### PR TITLE
reef: qa: add centos_latest (9.stream) and ubuntu_20.04 yamls to supported-all-distro

### DIFF
--- a/qa/distros/supported-all-distro/centos_latest.yaml
+++ b/qa/distros/supported-all-distro/centos_latest.yaml
@@ -1,0 +1,1 @@
+../all/centos_latest.yaml

--- a/qa/distros/supported-all-distro/ubuntu_20.04.yaml
+++ b/qa/distros/supported-all-distro/ubuntu_20.04.yaml
@@ -1,0 +1,1 @@
+../all/ubuntu_20.04.yaml

--- a/qa/distros/supported-all-distro/ubuntu_latest.yaml
+++ b/qa/distros/supported-all-distro/ubuntu_latest.yaml
@@ -1,1 +1,1 @@
-../all/ubuntu_20.04.yaml
+../all/ubuntu_latest.yaml

--- a/qa/suites/smoke/basic/supported-all-distro
+++ b/qa/suites/smoke/basic/supported-all-distro
@@ -1,0 +1,1 @@
+.qa/distros/supported-all-distro

--- a/qa/suites/smoke/basic/supported-random-distro$
+++ b/qa/suites/smoke/basic/supported-random-distro$
@@ -1,1 +1,0 @@
-../../../distros/supported-random-distro$/

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -68,7 +68,10 @@ class KernelMount(CephFSMount):
                 self.enable_dynamic_debug()
             self.ctx[f'kmount_count.{self.client_remote.hostname}'] = kmount_count + 1
 
-        self.gather_mount_info()
+        try:
+            self.gather_mount_info()
+        except:
+            log.warn('failed to fetch mount info - tests depending on mount addr/inst may fail!')
 
     def gather_mount_info(self):
         self.id = self._get_global_id()

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -186,6 +186,12 @@ class CephFSMount(object):
                               sudo=True).decode())
 
     def is_blocked(self):
+        if not self.addr:
+            # can't infer if our addr is blocklisted - let the caller try to
+            # umount without lazy/force. If the client was blocklisted, then
+            # the umount would be stuck and the test would fail on timeout.
+            # happens only with Ubuntu 20.04 (missing kclient patches :/).
+            return False
         self.fs = Filesystem(self.ctx, name=self.cephfs_name)
 
         try:


### PR DESCRIPTION
    A bug in Ceph MDS (MDS crash!) is seen with distos using a not-so-recent kernel
    (5.4ish). This crash was first seen in quincy smoke run and the problematic
    backport change was reverted. The smoke suite chooses a random distro for each
    job, so to hit this bug, the appropriate distro needs to be (randomly) get chosen.

    This change point the smoke suite to run against all supported distros.

    This effects suites that point to supported-all-distro (powercycle) since it
    bloats up the nuymber of jobs. E.g., currently, without --subset, powercycle:osd

              INFO:teuthology.suite.run:0/336 jobs were filtered out.

    vs

    (with this change)

              Unable to schedule 560 jobs, too many jobs, when maximum 500 jobs allowed.

    For smoke suite

              INFO:teuthology.suite.run:Scheduled 24 jobs in total.

    vs

    (with this change)

               INFO:teuthology.suite.run:Scheduled 120 jobs in total.

    Eventually, with PR #46882, then testing kernel will no longer override the
    distro kernel in fs suite, so we should get good coverage then.

--

This isn't really reef only change BTW.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
