### PR TITLE
pybind/mgr/mirroring: drop mon_host from peer_list

### DIFF
--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -798,7 +798,6 @@ class TestMirroring(CephFSTestCase):
         peer_uuid = self.get_peer_uuid("client.mirror_peer_bootstrap@site-remote")
         res = json.loads(self.get_ceph_cmd_stdout("fs", "snapshot", "mirror", "peer_list", self.primary_fs_name))
         self.assertTrue(peer_uuid in res)
-        self.assertTrue('mon_host' in res[peer_uuid] and res[peer_uuid]['mon_host'] != '')
 
         # remove peer
         self.peer_remove(self.primary_fs_name, self.primary_fs_id, "client.mirror_peer_bootstrap@site-remote")

--- a/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
+++ b/src/pybind/mgr/mirroring/fs/snapshot_mirror.py
@@ -558,14 +558,11 @@ class FSSnapshotMirror:
                 peers = self.get_filesystem_peers(filesystem)
                 peer_res = {}
                 for peer_uuid, rem in peers.items():
-                    conf = self.config_get(FSSnapshotMirror.peer_config_key(filesystem, peer_uuid))
                     remote = rem['remote']
                     peer_res[peer_uuid] = {'client_name': remote['client_name'],
                                            'site_name': remote['cluster_name'],
                                            'fs_name': remote['fs_name']
                                            }
-                    if 'mon_host' in conf:
-                        peer_res[peer_uuid]['mon_host'] = conf['mon_host']
                 return 0, json.dumps(peer_res), ''
         except MirrorException as me:
             return me.args[0], '', me.args[1]


### PR DESCRIPTION
Drop mon_host from peer_list to make it similar to rbd_mirror peer_list.

Fixes: https://tracker.ceph.com/issues/63614