### PR TITLE
osd: fix scheduling of OSD::trim_maps is not timely

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -751,6 +751,14 @@ options:
   services:
   - osd
   with_legacy: true
+# osd trim osdmaps periodicity
+- name: osd_map_trim_min_interval
+  type: int
+  level: advanced
+  desc: The desired interval seconds between trim_maps of OSD::tick.
+  default: 10_min
+  min: 1_min
+  with_legacy: false
 # cap on # of inc maps we send to peers, clients
 - name: osd_map_share_max_epochs
   type: int

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6329,6 +6329,18 @@ void OSD::tick()
     }
   }
 
+  // periodic trim osdmaps
+  {
+    auto map_trim_min_interval = cct->_conf.get_val<int64_t>(
+                                            "osd_map_trim_min_interval");
+    auto now = ceph::coarse_mono_clock::now();
+    const auto elapsed = now - last_trim_maps;
+    if (std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
+      > map_trim_min_interval) {
+      trim_maps(superblock.cluster_osdmap_trim_lower_bound);
+    }
+  }
+
   tick_timer.add_event_after(get_tick_interval(), new C_Tick(this));
 }
 
@@ -7917,6 +7929,7 @@ void OSD::osdmap_subscribe(version_t epoch, bool force_request)
 
 void OSD::trim_maps(epoch_t oldest)
 {
+  last_trim_maps = ceph::coarse_mono_clock::now();
   epoch_t min = std::min(oldest, service.map_cache.cached_key_lower_bound());
   dout(20) <<  __func__ << ": min=" << min << " oldest_map="
            << superblock.get_oldest_map() << dendl;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6337,7 +6337,7 @@ void OSD::tick()
     const auto elapsed = now - last_trim_maps;
     if (std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
       > map_trim_min_interval) {
-      trim_maps(superblock.cluster_osdmap_trim_lower_bound);
+      trim_maps();
     }
   }
 
@@ -7927,12 +7927,20 @@ void OSD::osdmap_subscribe(version_t epoch, bool force_request)
   }
 }
 
-void OSD::trim_maps(epoch_t oldest)
+void OSD::trim_maps()
 {
   last_trim_maps = ceph::coarse_mono_clock::now();
-  epoch_t min = std::min(oldest, service.map_cache.cached_key_lower_bound());
-  dout(20) <<  __func__ << ": min=" << min << " oldest_map="
-           << superblock.get_oldest_map() << dendl;
+
+  auto cluster_osdmap_tlb = superblock.cluster_osdmap_trim_lower_bound;
+  auto cache_key_lb = service.map_cache.cached_key_lower_bound();
+  epoch_t min = std::min(cluster_osdmap_tlb, cache_key_lb);
+  dout(5) <<  __func__ << ": min=" << min
+          << " oldest_map=" << superblock.get_oldest_map()
+          << " superblock.cluster_osdmap_trim_lower_bound="
+          << cluster_osdmap_tlb
+          << " service.map_cache.cached_key_lower_bound=" << cache_key_lb
+          << dendl;
+
   if (min <= superblock.get_oldest_map())
     return;
 
@@ -8244,7 +8252,7 @@ void OSD::handle_osd_map(MOSDMap *m)
   }
 
   if (!superblock.maps.empty()) {
-    trim_maps(m->cluster_osdmap_trim_lower_bound);
+    trim_maps();
     pg_num_history.prune(superblock.get_oldest_map());
   }
   superblock.insert_osdmap_epochs(first, last);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1666,7 +1666,7 @@ protected:
 
   void handle_osd_map(class MOSDMap *m);
   void _committed_osd_maps(epoch_t first, epoch_t last, class MOSDMap *m);
-  void trim_maps(epoch_t oldest);
+  void trim_maps();
   void note_down_osd(int osd);
   void note_up_osd(int osd);
   friend struct C_OnMapCommit;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1194,6 +1194,7 @@ private:
 
   // -- superblock --
   OSDSuperblock superblock;
+  ceph::coarse_mono_clock::time_point last_trim_maps;
 
   static void write_superblock(CephContext* cct,
                                OSDSuperblock& sb,


### PR DESCRIPTION
QUESTION:
OSD::trim_maps will only be scheduled by OSD::handle_osd_map, And only trim 30 osdmap epochs at a time,
When osd has stored a large number of osdmaps,
This will result in a large number of osdmaps
not being cleaned up in time.

SOLUTION:
scheduling OSD::trim_maps periodically
(osd_map_trim_min_interval) in OSD::tick,
use superblock.cluster_osdmap_trim_lower_bound
as trim lower boundary.

https://tracker.ceph.com/issues/63658


My recent code contributions about osdmap handle and osdmap trim:
1. Speed up osdmap processing : https://github.com/ceph/ceph/pull/51444
2. Speed up osdmap processing : https://github.com/ceph/ceph/pull/54612
3. Involving osdmap trim:  https://github.com/ceph/ceph/pull/54491
4. Involving osdmap trim:  https://github.com/ceph/ceph/pull/54686
