### PR TITLE
doc/rados: Update stretch mode docs.

### DIFF
--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -121,8 +121,6 @@ your CRUSH map. This procedure shows how to do this.
 
       rule stretch_rule {
              id 1
-             min_size 1
-             max_size 10
              type replicated
              step take site1
              step chooseleaf firstn 2 type host
@@ -141,16 +139,35 @@ your CRUSH map. This procedure shows how to do this.
 
 #. Run the monitors in connectivity mode. See `Changing Monitor Elections`_.
 
+   .. prompt:: bash $
+
+      ceph mon set election_strategy connectivity
+
 #. Command the cluster to enter stretch mode. In this example, ``mon.e`` is the
    tiebreaker monitor and we are splitting across data centers. The tiebreaker
    monitor must be assigned a data center that is neither ``site1`` nor
-   ``site2``. For this purpose you can create another data-center bucket named
-   ``site3`` in your CRUSH and place ``mon.e`` there:
+   ``site2``. This data center **should not** be defined in your CRUSH map, here 
+   we are placing ``mon.e`` in a virtual data center called ``site3``:
 
    .. prompt:: bash $
 
       ceph mon set_location e datacenter=site3
       ceph mon enable_stretch_mode e stretch_rule datacenter
+
+#. Set the replication levels for each pool. Here we are setting the standard
+   replication levels for a stretch mode cluster. Where ``4`` copies will be kept
+   in total, with a minimum of ``2`` in each data center:
+
+   .. prompt:: bash $
+
+      ceph osd pool set ceph_data min_size 2
+      set pool 2 min_size to 2
+      ceph osd pool set ceph_data size 4
+      set pool 2 size to 4
+      ceph osd pool set ceph_metadata min_size 2
+      set pool 3 min_size to 2
+      ceph osd pool set ceph_metadata size 4
+      set pool 3 size to 4
 
 When stretch mode is enabled, PGs will become active only when they peer
 across data centers (or across whichever CRUSH bucket type was specified),


### PR DESCRIPTION
Update stretch mode docs, min_size and max_size are no longer defined in the CRUSH map and the example rule given will fail to compile.

Had a go installing a basic stretch mode cluster recently and it seems these docs are out of date. The provided rule would not compile until I removed the 'min_size' and 'max_size' lines. I believe this is due to these values now being set at the pool level, which I have also added generic examples for. I have also added an example for how to set your monitors to connectivity mode.

The exact steps of that installation can be viewed here: https://github.com/PC-Admin/cephfs-stress-test/blob/main/stretch_mode_setup.md#now-add-a-stretch_rule-to-the-end-of-the-crush-map-by-again-editing-it

The final cluster created by those installation steps worked well and replicated data as expected.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests