### PR TITLE
pacific: tools/ceph_objectstore_tool: action_on_all_objects_in_pg to skip pgmeta

### DIFF
--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -107,7 +107,7 @@ int _action_on_all_objects_in_pg(ObjectStore *store, coll_t coll, action_on_obje
       if (obj->is_pgmeta())
 	continue;
       object_info_t oi;
-      if (coll != coll_t::meta()) {
+      if (coll != coll_t::meta() && !obj->is_pgmeta()) {
         bufferlist attr;
         r = store->getattr(ch, *obj, OI_ATTR, attr);
         if (r < 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63649

---

backport of https://github.com/ceph/ceph/pull/54663
parent tracker: https://tracker.ceph.com/issues/63640

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh