### PR TITLE
reef: doc/rados/configuration/bluestore-config-ref: Fix lowcase typo

### DIFF
--- a/doc/rados/configuration/bluestore-config-ref.rst
+++ b/doc/rados/configuration/bluestore-config-ref.rst
@@ -358,7 +358,7 @@ OSD and run the following command:
 
        ceph-bluestore-tool \
         --path <data path> \
-        --sharding="m(3) p(3,0-12) o(3,0-13)=block_cache={type=binned_lru} l p" \
+        --sharding="m(3) p(3,0-12) O(3,0-13)=block_cache={type=binned_lru} l p" \
         reshard
 
 .. confval:: bluestore_rocksdb_cf


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63661

---

backport of https://github.com/ceph/ceph/pull/54339
parent tracker: https://tracker.ceph.com/issues/63436

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh