### PR TITLE
quincy: qa: run kernel_untar_build with newer tarball

### DIFF
--- a/qa/workunits/kernel_untar_build.sh
+++ b/qa/workunits/kernel_untar_build.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-wget -O linux.tar.gz http://download.ceph.com/qa/linux-5.4.tar.gz
+wget -O linux.tar.xz http://download.ceph.com/qa/linux-6.5.11.tar.xz
 
 mkdir t
 cd t
-tar xzf ../linux.tar.gz
+tar xJf ../linux.tar.xz
 cd linux*
 make defconfig
 make -j`grep -c processor /proc/cpuinfo`


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66636

---

backport of https://github.com/ceph/ceph/pull/54414
parent tracker: https://tracker.ceph.com/issues/57655

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh