### PR TITLE
reef: qa: use correct imports to resolve fuse_mount and kernel_mount

### DIFF
--- a/qa/tasks/cephfs/test_snap_schedules.py
+++ b/qa/tasks/cephfs/test_snap_schedules.py
@@ -529,8 +529,8 @@ class TestSnapSchedulesSnapdir(TestSnapSchedulesHelper):
             self.mount_a.run_shell(['rmdir', snapshot_path])
 
     def get_snap_dir_name(self):
-        from tasks.cephfs.fuse_mount import FuseMount
-        from tasks.cephfs.kernel_mount import KernelMount
+        from .fuse_mount import FuseMount
+        from .kernel_mount import KernelMount
 
         if isinstance(self.mount_a, KernelMount):
             sdn = self.mount_a.client_config.get('snapdirname', '.snap')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63575

---

backport of https://github.com/ceph/ceph/pull/54471
parent tracker: https://tracker.ceph.com/issues/62706

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh