### PR TITLE
cephadm: add check for haproxy tcp backends

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/ingress/haproxy.cfg.j2
+++ b/src/pybind/mgr/cephadm/templates/services/ingress/haproxy.cfg.j2
@@ -85,6 +85,6 @@ backend backend
     default-server {{ default_server_opts|join(" ") }}
 {% endif %}
     {% for server in servers %}
-    server {{ server.name }} {{ server.ip }}:{{ server.port }}
+    server {{ server.name }} {{ server.ip }}:{{ server.port }} check weight 100
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
When deploying the ingress service for an NFS cluster the resulting haproxy.cfg does not contain any checks for the backend servers.

This commit adds checks. This enables haproxy to avoid failed backends.