### PR TITLE
script/build-integration-branch: minor improvements around github api access & tokens

### DIFF
--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -7,7 +7,12 @@ Builds integration branches. Something similar to
   >   git pull b
   > done
 
-Requires `~/.github_token`.
+Requires either `~/.github_token` containing ONLY the token
+OR adding an entry like the following to `~/.netrc`:
+  ```
+  machine github.com
+  password ghp_E7ln0tAR34LtoK3nIsw34RyTve2moM3BvK
+  ```
 
 
 Usage:
@@ -24,6 +29,7 @@ import os
 import requests
 import sys
 import time
+import netrc
 
 from subprocess import call, check_output
 from urllib.parse import urljoin
@@ -52,9 +58,28 @@ except ImportError:
     assert len(sys.argv) == 2
     branch = label + postfix
 
-
-with open(os.path.expanduser('~/.github_token')) as myfile:
-    token = myfile.readline().strip()
+token = ''
+try:
+    nrc = netrc.netrc()
+    nrauth = nrc.authenticators("api.github.com")
+    if nrauth:
+        token = nrauth[2]
+    if not token:
+        nrauth = nrc.authenticators("github.com")
+        if nrauth:
+            token = nrauth[2]
+except FileNotFoundError:
+    pass
+if not token:
+    try:
+        with open(os.path.expanduser('~/.github_token')) as myfile:
+            token = myfile.readline().strip()
+    except FileNotFoundError:
+        pass
+if not token:
+    print('No github api access token found')
+    print('  Add a token to .netrc for [api.]github.com')
+    print('  OR add a token to $HOME/.github_token')
 
 # get prs
 baseurl = urljoin('https://api.github.com',

--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -65,7 +65,11 @@ url = baseurl.format(label=label,
                      repo=repo)
 r = requests.get(url,
                  headers={'Authorization': 'token %s' % token})
-assert(r.ok)
+if not r.ok:
+    print("Failed to access github api")
+    print("(Do you have a valid, unexpired github api token?)")
+    sys.exit(1)
+
 j = json.loads(r.text or r.content)
 print("--- found %d issues tagged with %s" % (len(j), label))
 


### PR DESCRIPTION

Try to fix some of the annoyances I have with this script wrt token handling. This should be fully backwards compatible with current workflows but allow one to migrate the token to .netrc that may also be used by other tools.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
