### PR TITLE
ceph.spec.in: crimson: add nettle-devel

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -338,6 +338,7 @@ BuildRequires:  utf8proc-devel
 %if 0%{with seastar}
 BuildRequires:  c-ares-devel
 BuildRequires:  gnutls-devel
+BuildRequires:  nettle-devel
 BuildRequires:  hwloc-devel
 BuildRequires:  libpciaccess-devel
 BuildRequires:  lksctp-tools-devel


### PR DESCRIPTION
main FTBFS with c9+crimson:
https://shaman.ceph.com/builds/ceph/main/b41399bcbc062adc41a374a6dbf407ba88b44c21/crimson/369404/
```
/usr/bin/ld: /usr/lib64/libgnutls.so: undefined reference to `nettle_siv_gcm_aes256_decrypt_message@NETTLE_8'
/usr/bin/ld: /usr/lib64/libgnutls.so: undefined reference to `nettle_siv_gcm_aes128_decrypt_message@NETTLE_8'
/usr/bin/ld: /usr/lib64/libgnutls.so: undefined reference to `nettle_siv_gcm_aes256_encrypt_message@NETTLE_8'
/usr/bin/ld: /usr/lib64/libgnutls.so: undefined reference to `nettle_siv_gcm_aes128_encrypt_message@NETTLE_8'
collect2: error: ld returned 1 exit status
```

After this patch:
https://shaman.ceph.com/builds/ceph/wip-matanb-crimson-nettle/

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
