### PR TITLE
osd: rename osd_delete_sleep to osd_pg_delete_sleep

### DIFF
--- a/doc/rados/configuration/mclock-config-ref.rst
+++ b/doc/rados/configuration/mclock-config-ref.rst
@@ -239,10 +239,10 @@ sleep options are disabled (set to 0),
 - :confval:`osd_recovery_sleep_ssd`
 - :confval:`osd_recovery_sleep_hybrid`
 - :confval:`osd_scrub_sleep`
-- :confval:`osd_delete_sleep`
-- :confval:`osd_delete_sleep_hdd`
-- :confval:`osd_delete_sleep_ssd`
-- :confval:`osd_delete_sleep_hybrid`
+- :confval:`osd_pg_delete_sleep`
+- :confval:`osd_pg_delete_sleep_hdd`
+- :confval:`osd_pg_delete_sleep_ssd`
+- :confval:`osd_pg_delete_sleep_hybrid`
 - :confval:`osd_snap_trim_sleep`
 - :confval:`osd_snap_trim_sleep_hdd`
 - :confval:`osd_snap_trim_sleep_ssd`

--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -429,10 +429,10 @@ Miscellaneous
 
 .. confval:: osd_default_notify_timeout
 .. confval:: osd_check_for_log_corruption
-.. confval:: osd_delete_sleep
-.. confval:: osd_delete_sleep_hdd
-.. confval:: osd_delete_sleep_ssd
-.. confval:: osd_delete_sleep_hybrid
+.. confval:: osd_pg_delete_sleep
+.. confval:: osd_pg_delete_sleep_hdd
+.. confval:: osd_pg_delete_sleep_ssd
+.. confval:: osd_pg_delete_sleep_hybrid
 .. confval:: osd_command_max_records
 .. confval:: osd_fast_fail_on_connection_refused
 

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -1377,7 +1377,7 @@ options:
   level: advanced
   default: 10
   with_legacy: true
-- name: osd_delete_sleep
+- name: osd_pg_delete_sleep
   type: float
   level: advanced
   desc: Time in seconds to sleep before next removal transaction. This setting
@@ -1387,21 +1387,21 @@ options:
   default: 0
   flags:
   - runtime
-- name: osd_delete_sleep_hdd
+- name: osd_pg_delete_sleep_hdd
   type: float
   level: advanced
   desc: Time in seconds to sleep before next removal transaction for HDDs
   default: 5
   flags:
   - runtime
-- name: osd_delete_sleep_ssd
+- name: osd_pg_delete_sleep_ssd
   type: float
   level: advanced
   desc: Time in seconds to sleep before next removal transaction for SSDs
   default: 1
   flags:
   - runtime
-- name: osd_delete_sleep_hybrid
+- name: osd_pg_delete_sleep_hybrid
   type: float
   level: advanced
   desc: Time in seconds to sleep before next removal transaction when OSD data is on HDD

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3563,16 +3563,16 @@ float OSD::get_osd_recovery_sleep()
     return cct->_conf->osd_recovery_sleep_hdd;
 }
 
-float OSD::get_osd_delete_sleep()
+float OSD::get_osd_pg_delete_sleep()
 {
-  float osd_delete_sleep = cct->_conf.get_val<double>("osd_delete_sleep");
-  if (osd_delete_sleep > 0)
-    return osd_delete_sleep;
+  float osd_pg_delete_sleep = cct->_conf.get_val<double>("osd_pg_delete_sleep");
+  if (osd_pg_delete_sleep > 0)
+    return osd_pg_delete_sleep;
   if (!store_is_rotational && !journal_is_rotational)
-    return cct->_conf.get_val<double>("osd_delete_sleep_ssd");
+    return cct->_conf.get_val<double>("osd_pg_delete_sleep_ssd");
   if (store_is_rotational && !journal_is_rotational)
-    return cct->_conf.get_val<double>("osd_delete_sleep_hybrid");
-  return cct->_conf.get_val<double>("osd_delete_sleep_hdd");
+    return cct->_conf.get_val<double>("osd_pg_delete_sleep_hybrid");
+  return cct->_conf.get_val<double>("osd_pg_delete_sleep_hdd");
 }
 
 int OSD::get_recovery_max_active()
@@ -9690,10 +9690,10 @@ const char** OSD::get_tracked_conf_keys() const
     "osd_recovery_sleep_hdd",
     "osd_recovery_sleep_ssd",
     "osd_recovery_sleep_hybrid",
-    "osd_delete_sleep",
-    "osd_delete_sleep_hdd",
-    "osd_delete_sleep_ssd",
-    "osd_delete_sleep_hybrid",
+    "osd_pg_delete_sleep",
+    "osd_pg_delete_sleep_hdd",
+    "osd_pg_delete_sleep_ssd",
+    "osd_pg_delete_sleep_hybrid",
     "osd_snap_trim_sleep",
     "osd_snap_trim_sleep_hdd",
     "osd_snap_trim_sleep_ssd",
@@ -9744,10 +9744,10 @@ void OSD::handle_conf_change(const ConfigProxy& conf,
       service.remote_reserver.set_max(cct->_conf->osd_max_backfills);
     }
   }
-  if (changed.count("osd_delete_sleep") ||
-      changed.count("osd_delete_sleep_hdd") ||
-      changed.count("osd_delete_sleep_ssd") ||
-      changed.count("osd_delete_sleep_hybrid") ||
+  if (changed.count("osd_pg_delete_sleep") ||
+      changed.count("osd_pg_delete_sleep_hdd") ||
+      changed.count("osd_pg_delete_sleep_ssd") ||
+      changed.count("osd_pg_delete_sleep_hybrid") ||
       changed.count("osd_snap_trim_sleep") ||
       changed.count("osd_snap_trim_sleep_hdd") ||
       changed.count("osd_snap_trim_sleep_ssd") ||
@@ -10082,10 +10082,10 @@ void OSD::maybe_override_sleep_options_for_qos()
     cct->_conf.set_val("osd_recovery_sleep_hybrid", std::to_string(0));
 
     // Disable delete sleep
-    cct->_conf.set_val("osd_delete_sleep", std::to_string(0));
-    cct->_conf.set_val("osd_delete_sleep_hdd", std::to_string(0));
-    cct->_conf.set_val("osd_delete_sleep_ssd", std::to_string(0));
-    cct->_conf.set_val("osd_delete_sleep_hybrid", std::to_string(0));
+    cct->_conf.set_val("osd_pg_delete_sleep", std::to_string(0));
+    cct->_conf.set_val("osd_pg_delete_sleep_hdd", std::to_string(0));
+    cct->_conf.set_val("osd_pg_delete_sleep_ssd", std::to_string(0));
+    cct->_conf.set_val("osd_pg_delete_sleep_hybrid", std::to_string(0));
 
     // Disable snap trim sleep
     cct->_conf.set_val("osd_snap_trim_sleep", std::to_string(0));

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1966,7 +1966,7 @@ private:
   int get_num_op_threads();
 
   float get_osd_recovery_sleep();
-  float get_osd_delete_sleep();
+  float get_osd_pg_delete_sleep();
   float get_osd_snap_trim_sleep();
 
   int get_recovery_max_active();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2630,8 +2630,8 @@ std::pair<ghobject_t, bool> PG::do_delete_work(
   dout(10) << __func__ << dendl;
 
   {
-    float osd_delete_sleep = osd->osd->get_osd_delete_sleep();
-    if (osd_delete_sleep > 0 && delete_needs_sleep) {
+    float osd_pg_delete_sleep = osd->osd->get_osd_pg_delete_sleep();
+    if (osd_pg_delete_sleep > 0 && delete_needs_sleep) {
       epoch_t e = get_osdmap()->get_epoch();
       PGRef pgref(this);
       auto delete_requeue_callback = new LambdaContext([this, pgref, e](int r) {
@@ -2646,7 +2646,7 @@ std::pair<ghobject_t, bool> PG::do_delete_work(
       });
 
       auto delete_schedule_time = ceph::real_clock::now();
-      delete_schedule_time += ceph::make_timespan(osd_delete_sleep);
+      delete_schedule_time += ceph::make_timespan(osd_pg_delete_sleep);
       std::lock_guard l{osd->sleep_lock};
       osd->sleep_timer.add_event_at(delete_schedule_time,
 				    delete_requeue_callback);


### PR DESCRIPTION
osd_delete_sleep is actually controlling the sleep time when deleting pg, osd_pg_delete_sleep makes it easier for people to understand this configuration.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
