### PR TITLE
rgw/sysobj: pool_list_objects_init() initializes marker

### DIFF
--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -517,9 +517,7 @@ int rgw_list_pool(const DoutPrefixProvider *dpp,
   if (iter == ioctx.nobjects_end())
     return -ENOENT;
 
-  uint32_t i;
-
-  for (i = 0; i < max && iter != ioctx.nobjects_end(); ++i, ++iter) {
+  for (; oids->size() < max && iter != ioctx.nobjects_end(); ++iter) {
     string oid = iter->get_oid();
     ldpp_dout(dpp, 20) << "RGWRados::pool_iterate: got " << oid << dendl;
 

--- a/src/rgw/services/svc_sys_obj_core.cc
+++ b/src/rgw/services/svc_sys_obj_core.cc
@@ -612,7 +612,7 @@ int RGWSI_SysObj_Core::pool_list_objects_init(const DoutPrefixProvider *dpp,
                                               const string& prefix,
                                               RGWSI_SysObj::Pool::ListCtx *_ctx)
 {
-  _ctx->impl.emplace<PoolListImplInfo>(prefix);
+  _ctx->impl.emplace<PoolListImplInfo>(prefix, marker);
 
   auto& ctx = static_cast<PoolListImplInfo&>(*_ctx->impl);
 

--- a/src/rgw/services/svc_sys_obj_core_types.h
+++ b/src/rgw/services/svc_sys_obj_core_types.h
@@ -30,6 +30,7 @@ struct RGWSI_SysObj_Core_PoolListImplInfo : public RGWSI_SysObj_Pool_ListInfo {
   rgw::AccessListFilter filter;
   std::string marker;
 
-  RGWSI_SysObj_Core_PoolListImplInfo(const std::string& prefix)
-    : filter(rgw::AccessListFilterPrefix(prefix)) {}
+  RGWSI_SysObj_Core_PoolListImplInfo(const std::string& prefix,
+                                     const std::string& marker)
+    : filter(rgw::AccessListFilterPrefix(prefix)), marker(marker) {}
 };


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/63717

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
