### PR TITLE
rgw/zone: remove check for (very) old pools config

### DIFF
--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -33,7 +33,6 @@ std::string zonegroup_names_oid_prefix = "zonegroups_names.";
 std::string RGW_DEFAULT_ZONE_ROOT_POOL = "rgw.root";
 std::string RGW_DEFAULT_ZONEGROUP_ROOT_POOL = "rgw.root";
 std::string RGW_DEFAULT_PERIOD_ROOT_POOL = "rgw.root";
-std::string avail_pools = ".pools.avail";
 std::string default_storage_pool_suffix = "rgw.buckets.data";
 
 }
@@ -412,22 +411,14 @@ int RGWZoneParams::set_as_default(const DoutPrefixProvider *dpp, optional_yield 
 
 int RGWZoneParams::create(const DoutPrefixProvider *dpp, optional_yield y, bool exclusive)
 {
-  /* check for old pools config */
-  rgw_raw_obj obj(domain_root, avail_pools);
-  auto sysobj = sysobj_svc->get_obj(obj);
-  int r = sysobj.rop().stat(y, dpp);
-  if (r < 0) {
-    ldpp_dout(dpp, 10) << "couldn't find old data placement pools config, setting up new ones for the zone" << dendl;
-    /* a new system, let's set new placement info */
-    RGWZonePlacementInfo default_placement;
-    default_placement.index_pool = name + "." + default_bucket_index_pool_suffix;
-    rgw_pool pool = name + "." + default_storage_pool_suffix;
-    default_placement.storage_classes.set_storage_class(RGW_STORAGE_CLASS_STANDARD, &pool, nullptr);
-    default_placement.data_extra_pool = name + "." + default_storage_extra_pool_suffix;
-    placement_pools["default-placement"] = default_placement;
-  }
+  RGWZonePlacementInfo default_placement;
+  default_placement.index_pool = name + "." + default_bucket_index_pool_suffix;
+  rgw_pool pool = name + "." + default_storage_pool_suffix;
+  default_placement.storage_classes.set_storage_class(RGW_STORAGE_CLASS_STANDARD, &pool, nullptr);
+  default_placement.data_extra_pool = name + "." + default_storage_extra_pool_suffix;
+  placement_pools["default-placement"] = default_placement;
 
-  r = fix_pool_names(dpp, y);
+  int r = fix_pool_names(dpp, y);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "ERROR: fix_pool_names returned r=" << r << dendl;
     return r;


### PR DESCRIPTION
i'm not sure how this was meant to work originally, but now it's obviously broken - it tries to stat an object from the domain_root pool before the domain_root pool name gets filled in

https://github.com/ceph/ceph/pull/50359 added a new error message that makes this clear:

> ERROR: creating ioctx (pool=); r=-22

the commit that calls this the 'old pools config' goes all the way back to https://github.com/ceph/ceph/pull/415 for the dumpling release, so i think it's finally safe to remove :)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
