### PR TITLE
reef: doc/rados: update "stretch mode"

### DIFF
--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -121,8 +121,6 @@ your CRUSH map. This procedure shows how to do this.
 
       rule stretch_rule {
              id 1
-             min_size 1
-             max_size 10
              type replicated
              step take site1
              step chooseleaf firstn 2 type host
@@ -141,16 +139,35 @@ your CRUSH map. This procedure shows how to do this.
 
 #. Run the monitors in connectivity mode. See `Changing Monitor Elections`_.
 
+   .. prompt:: bash $
+
+      ceph mon set election_strategy connectivity
+
 #. Command the cluster to enter stretch mode. In this example, ``mon.e`` is the
    tiebreaker monitor and we are splitting across data centers. The tiebreaker
    monitor must be assigned a data center that is neither ``site1`` nor
-   ``site2``. For this purpose you can create another data-center bucket named
-   ``site3`` in your CRUSH and place ``mon.e`` there:
+   ``site2``. This data center **should not** be defined in your CRUSH map, here 
+   we are placing ``mon.e`` in a virtual data center called ``site3``:
 
    .. prompt:: bash $
 
       ceph mon set_location e datacenter=site3
       ceph mon enable_stretch_mode e stretch_rule datacenter
+
+#. Set the replication levels for each pool. Here we are setting the standard
+   replication levels for a stretch mode cluster. Where ``4`` copies will be kept
+   in total, with a minimum of ``2`` in each data center:
+
+   .. prompt:: bash $
+
+      ceph osd pool set ceph_data min_size 2
+      set pool 2 min_size to 2
+      ceph osd pool set ceph_data size 4
+      set pool 2 size to 4
+      ceph osd pool set ceph_metadata min_size 2
+      set pool 3 min_size to 2
+      ceph osd pool set ceph_metadata size 4
+      set pool 3 size to 4
 
 When stretch mode is enabled, PGs will become active only when they peer
 across data centers (or across whichever CRUSH bucket type was specified),


### PR DESCRIPTION
Update stretch mode docs, min_size and max_size are no longer defined in the CRUSH map and the example rule given will fail to compile.

Specify that the tiebreaker data centre cannot be defined in CRUSH as this produces an error.

Signed-off-by: Michael Collins <perthserverplus@gmail.com>
(cherry picked from commit 28551b41f878e7ad8f43e85bcbc8c9f64c07346c)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
