### PR TITLE
quincy: doc/rados: repair stretch-mode.rst

### DIFF
--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -154,21 +154,6 @@ your CRUSH map. This procedure shows how to do this.
       ceph mon set_location e datacenter=site3
       ceph mon enable_stretch_mode e stretch_rule datacenter
 
-#. Set the replication levels for each pool. Here we are setting the standard
-   replication levels for a stretch mode cluster. Where ``4`` copies will be kept
-   in total, with a minimum of ``2`` in each data center:
-
-   .. prompt:: bash $
-
-      ceph osd pool set ceph_data min_size 2
-      set pool 2 min_size to 2
-      ceph osd pool set ceph_data size 4
-      set pool 2 size to 4
-      ceph osd pool set ceph_metadata min_size 2
-      set pool 3 min_size to 2
-      ceph osd pool set ceph_metadata size 4
-      set pool 3 size to 4
-
 When stretch mode is enabled, PGs will become active only when they peer
 across data centers (or across whichever CRUSH bucket type was specified),
 assuming both are alive. Pools will increase in size from the default ``3`` to


### PR DESCRIPTION
Remove a section of doc/rados/operations/stretch-mode.rst that I wrongly re-included after its removal. The request for this (re)-removal is here: https://github.com/ceph/ceph/pull/54689#discussion_r1413007655.

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit b73656787d618197c60372d1817eab35879fa478)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
