### PR TITLE
reef: mgr/dashboard: get rgw port from ssl_endpoint

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -134,6 +134,16 @@ class RgwDaemon(RESTController):
             for service in server['services']:
                 metadata = service['metadata']
 
+                frontend_config = metadata['frontend_config#0']
+                port_match = re.search(r"port=(\d+)", frontend_config)
+                port = None
+                if port_match:
+                    port = port_match.group(1)
+                else:
+                    match_from_endpoint = re.search(r"endpoint=\S+:(\d+)", frontend_config)
+                    if match_from_endpoint:
+                        port = match_from_endpoint.group(1)
+
                 # extract per-daemon service data and health
                 daemon = {
                     'id': metadata['id'],
@@ -144,7 +154,7 @@ class RgwDaemon(RESTController):
                     'zonegroup_name': metadata['zonegroup_name'],
                     'zone_name': metadata['zone_name'],
                     'default': instance.daemon.name == metadata['id'],
-                    'port': int(re.findall(r'port=(\d+)', metadata['frontend_config#0'])[0])
+                    'port': int(port) if port else None
                 }
 
                 daemons.append(daemon)

--- a/src/pybind/mgr/dashboard/tests/test_rgw.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw.py
@@ -79,7 +79,13 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
         RgwStub.get_settings()
         mgr.list_servers.return_value = [{
             'hostname': 'host1',
-            'services': [{'id': '4832', 'type': 'rgw'}, {'id': '5356', 'type': 'rgw'}]
+            'services': [
+                {'id': '4832', 'type': 'rgw'},
+                {'id': '5356', 'type': 'rgw'},
+                {'id': '5357', 'type': 'rgw'},
+                {'id': '5358', 'type': 'rgw'},
+                {'id': '5359', 'type': 'rgw'}
+            ]
         }]
         mgr.get_metadata.side_effect = [
             {
@@ -96,8 +102,34 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
                 'realm_name': 'realm2',
                 'zonegroup_name': 'zg2',
                 'zone_name': 'zone2',
-                'frontend_config#0': 'beast port=80 ssl_port=443 ssl_certificate=config:/config'
-            }]
+                'frontend_config#0': 'beast ssl_port=443 ssl_certificate=config:/config'
+            },
+            {
+                'ceph_version': 'ceph version master (dev)',
+                'id': 'daemon3',
+                'realm_name': 'realm3',
+                'zonegroup_name': 'zg3',
+                'zone_name': 'zone3',
+                'frontend_config#0':
+                    'beast ssl_endpoint=0.0.0.0:8080 ssl_certificate=config:/config'
+            },
+            {
+                'ceph_version': 'ceph version master (dev)',
+                'id': 'daemon4',
+                'realm_name': 'realm4',
+                'zonegroup_name': 'zg4',
+                'zone_name': 'zone4',
+                'frontend_config#0': 'beast ssl_certificate=config:/config'
+            },
+            {
+                'ceph_version': 'ceph version master (dev)',
+                'id': 'daemon5',
+                'realm_name': 'realm5',
+                'zonegroup_name': 'zg5',
+                'zone_name': 'zone5',
+                'frontend_config#0':
+                    'beast endpoint=0.0.0.0:8445 ssl_certificate=config:/config'
+            }, ]
         self._get('/test/api/rgw/daemon')
         self.assertStatus(200)
         self.assertJsonBody([{
@@ -119,7 +151,40 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'zonegroup_name': 'zg2',
             'zone_name': 'zone2',
             'default': False,
-            'port': 80
+            'port': 443,
+        },
+            {
+            'id': 'daemon3',
+            'service_map_id': '5357',
+            'version': 'ceph version master (dev)',
+            'server_hostname': 'host1',
+            'realm_name': 'realm3',
+            'zonegroup_name': 'zg3',
+            'zone_name': 'zone3',
+            'default': False,
+            'port': 8080,
+        },
+            {
+            'id': 'daemon4',
+            'service_map_id': '5358',
+            'version': 'ceph version master (dev)',
+            'server_hostname': 'host1',
+            'realm_name': 'realm4',
+            'zonegroup_name': 'zg4',
+            'zone_name': 'zone4',
+            'default': False,
+            'port': None,
+        },
+            {
+            'id': 'daemon5',
+            'service_map_id': '5359',
+            'version': 'ceph version master (dev)',
+            'server_hostname': 'host1',
+            'realm_name': 'realm5',
+            'zonegroup_name': 'zg5',
+            'zone_name': 'zone5',
+            'default': False,
+            'port': 8445,
         }])
 
     def test_list_empty(self):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63652

---

backport of https://github.com/ceph/ceph/pull/54531
parent tracker: https://tracker.ceph.com/issues/63564

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh