### PR TITLE
common: LogClient do not output meaningless logs by default

### DIFF
--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -186,13 +186,11 @@ void LogChannel::do_log(clog_type prio, const std::string& s)
 
   // log to syslog?
   if (do_log_to_syslog()) {
-    ldout(cct,0) << __func__ << " log to syslog"  << dendl;
     e.log_to_syslog(get_log_prio(), get_syslog_facility());
   }
 
   // log to graylog?
   if (do_log_to_graylog()) {
-    ldout(cct,0) << __func__ << " log to graylog"  << dendl;
     graylog->log_log_entry(&e);
   }
 }


### PR DESCRIPTION
    common: LogClient do not output meaningless logs by default

    the default output log to syslog/graylog is meaningless
    it will consume a lot of log resources

    Fixes: https://tracker.ceph.com/issues/63727
    Signed-off-by: zhangjianwei <zhangjianwei2@cmss.chinamobile.com>