### PR TITLE
python-common: fix osdspec_affinity check

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -132,7 +132,7 @@ class DriveSelection(object):
                 other_osdspec_affinity = ''
                 for lv in disk.lvs:
                     if 'osdspec_affinity' in lv.keys():
-                        if lv['osdspec_affinity'] != self.spec.service_id:
+                        if lv['osdspec_affinity'] != str(self.spec.service_id):
                             other_osdspec_affinity = lv['osdspec_affinity']
                             break
                 if other_osdspec_affinity:


### PR DESCRIPTION
When no `service_id` is provided to service spec (osd) it results in OSDs created with "osdspec_affinity" attribute set to a string containing "None".

The DriveSelection class relies on the comparison of the actual value of this attribute with the value of the service_id which has the python type `None` in that case.

If any existing deployments were created without the service_id attribute, we now have to support this case and make sure the check won't filter out devices unexpectedly.

Fixes: https://tracker.ceph.com/issues/63729
