### PR TITLE
common: use inline for monostate dencoders

### DIFF
--- a/src/common/versioned_variant.h
+++ b/src/common/versioned_variant.h
@@ -28,8 +28,8 @@
 namespace ceph {
 
 // null encoding for std::monostate
-void encode(const std::monostate&, bufferlist& bl) {}
-void decode(std::monostate&, bufferlist::const_iterator& p) {}
+inline void encode(const std::monostate&, bufferlist& bl) {}
+inline void decode(std::monostate&, bufferlist::const_iterator& p) {}
 
 // largest value that can be represented by `__u8 struct_v`
 inline constexpr size_t max_version = std::numeric_limits<__u8>::max();


### PR DESCRIPTION
fix a 'multiple definition' error when included by multiple sources:

> src/common/versioned_variant.h:31: multiple definition of `ceph::encode(std::monostate const&, ceph::buffer::v15_2_0::list&)';
rgw_main.cc.o:src/common/versioned_variant.h:31: first defined here

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
