### PR TITLE
pacific: rgw/auth: Fix the return code returned by AuthStrategy,

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -171,7 +171,7 @@ strategy_handle_rejected(rgw::auth::Engine::result_t&& engine_result,
 
     case Control::FALLBACK:
       /* Don't try next. */
-      return std::make_pair(false, std::move(strategy_result));
+      return std::make_pair(false, std::move(engine_result));
 
     default:
       /* Huh, memory corruption? */

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5756,7 +5756,7 @@ rgw::auth::s3::LocalEngine::authenticate(
   if (rgw_get_user_info_by_access_key(dpp, ctl->user, access_key_id, user_info, y) < 0) {
       ldpp_dout(dpp, 5) << "error reading user info, uid=" << access_key_id
               << " can't authenticate" << dendl;
-      return result_t::deny(-ERR_INVALID_ACCESS_KEY);
+      return result_t::reject(-ERR_INVALID_ACCESS_KEY);
   }
   //TODO: Uncomment, when we have a migration plan in place.
   /*else {
@@ -5770,7 +5770,7 @@ rgw::auth::s3::LocalEngine::authenticate(
   const auto iter = user_info.access_keys.find(access_key_id);
   if (iter == std::end(user_info.access_keys)) {
     ldpp_dout(dpp, 0) << "ERROR: access key not encoded in user info" << dendl;
-    return result_t::deny(-EPERM);
+    return result_t::reject(-EPERM);
   }
   const RGWAccessKey& k = iter->second;
 
@@ -5786,7 +5786,7 @@ rgw::auth::s3::LocalEngine::authenticate(
   ldpp_dout(dpp, 15) << "compare=" << compare << dendl;
 
   if (compare != 0) {
-    return result_t::deny(-ERR_SIGNATURE_NO_MATCH);
+    return result_t::reject(-ERR_SIGNATURE_NO_MATCH);
   }
 
   auto apl = apl_factory->create_apl_local(cct, s, user_info, k.subuser, boost::none, access_key_id);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62413

---

backport of https://github.com/ceph/ceph/pull/52510
parent tracker: https://tracker.ceph.com/issues/61916

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh