### PR TITLE
osd/scrubber: fix signed comparison warning

### DIFF
--- a/src/osd/scrubber/scrub_resources.cc
+++ b/src/osd/scrubber/scrub_resources.cc
@@ -81,7 +81,7 @@ bool ScrubResources::inc_scrubs_remote(pg_t pgid)
   }
 
   auto pre_op_cnt = granted_reservations.size();
-  if (pre_op_cnt < conf->osd_max_scrubs) {
+  if (std::cmp_less(pre_op_cnt, conf->osd_max_scrubs)) {
     granted_reservations.insert(pgid);
     log_upwards(fmt::format(
 	"{}: pg[{}] reserved. Remote scrubs count changed from {} -> {} (max "


### PR DESCRIPTION
using gcc 13.2.1:
```
[681/1140] Building CXX object src/osd/CMakeFiles/osd.dir/scrubber/scrub_resources.cc.o
src/osd/scrubber/scrub_resources.cc: In member function ‘bool Scrub::ScrubResources::inc_scrubs_remote(pg_t)’:
src/osd/scrubber/scrub_resources.cc:84:18: warning: comparison of integer expressions of different signedness: ‘long unsigned int’ and ‘const int64_t’ {aka ‘const long int’} [-Wsign-compare]
   84 |   if (pre_op_cnt < conf->osd_max_scrubs) {
      |       ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
