### PR TITLE
client: fix copying bufferlist to iovec structures in Client::_read

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11269,7 +11269,7 @@ int64_t Client::_preadv_pwritev_locked(Fh *fh, const struct iovec *iov,
         }
 
         client_lock.unlock();
-        copy_bufferlist_to_iovec(iov, iovcnt, &bl, r);
+        copy_bufferlist_to_iovec(iov, iovcnt, blp ? blp : &bl, r);
         client_lock.lock();
         return r;
     }

--- a/src/test/client/nonblocking.cc
+++ b/src/test/client/nonblocking.cc
@@ -149,3 +149,62 @@ TEST_F(TestClient, LlreadvLlwritev) {
   ASSERT_EQ(0, client->ll_unlink(root, filename, myperm));
 }
 
+TEST_F(TestClient, LlreadvLlwritevNullContext) {
+  /* Test that if Client::ll_preadv_pwritev is called with nullptr context
+  then it performs a sync call. */
+
+  int mypid = getpid();
+  char filename[256];
+
+  client->unmount();
+  TearDown();
+  SetUp();
+
+  sprintf(filename, "test_llreadvllwritevnullcontextfile%u", mypid);
+
+  Inode *root, *file;
+  root = client->get_root();
+  ASSERT_NE(root, (Inode *)NULL);
+
+  Fh *fh;
+  struct ceph_statx stx;
+
+  ASSERT_EQ(0, client->ll_createx(root, filename, 0666,
+				  O_RDWR | O_CREAT | O_TRUNC,
+				  &file, &fh, &stx, 0, 0, myperm));
+
+  char out0[] = "hello ";
+  char out1[] = "world\n";  
+  struct iovec iov_out[2] = {
+	  {out0, sizeof(out0)},
+	  {out1, sizeof(out1)}
+  };
+
+  char in0[sizeof(out0)];
+  char in1[sizeof(out1)];
+  struct iovec iov_in[2] = {
+	  {in0, sizeof(in0)},
+	  {in1, sizeof(in1)}
+  };
+
+  ssize_t bytes_to_write = iov_out[0].iov_len + iov_out[1].iov_len;
+
+  int64_t rc;
+  bufferlist bl;
+  rc = client->ll_preadv_pwritev(fh, iov_out, 2, 0, true, nullptr, nullptr);
+  ASSERT_EQ(rc, bytes_to_write);
+
+  rc = client->ll_preadv_pwritev(fh, iov_in, 2, 0, false, nullptr, &bl);
+  ASSERT_EQ(rc, bytes_to_write);
+
+  copy_bufferlist_to_iovec(iov_in, 2, &bl, rc);
+  ASSERT_EQ(0, strncmp((const char*)iov_in[0].iov_base,
+                       (const char*)iov_out[0].iov_base,
+                       iov_out[0].iov_len));
+  ASSERT_EQ(0, strncmp((const char*)iov_in[1].iov_base,
+                       (const char*)iov_out[1].iov_base, 
+                       iov_out[1].iov_len));
+
+  client->ll_release(fh);
+  ASSERT_EQ(0, client->ll_unlink(root, filename, myperm));
+}


### PR DESCRIPTION
If the context is null then the async call(`Client::ll_preadv_pwritev`) should convert to sync call because both(sync and async call) makes use of the same internal interfaces. I tried testing sync calls and as expected they ran fine which made me to revert back to the test case i wrote (that fails when I provide a `nullptr` to `onfinish`) in hope of finding some combination of params that might've made the async call go  wayward but nothing seemed to be wrong, however there is a noticeable difference between the sync and async api i.e. __bufferlist__, the sync api doesn't accept bufferlist as an arg but the async api does, so when I went ahead and removed the bufferlist arg from async api call, (as i had the intuition) the test case passed (yay!). I also found that none of the the apis apart from `Client::ll_preadv_pwritev` accepts bufferlist (which pretty much explains why we never caught any bugs for this). While re-reading all the async code again i came across this:

https://github.com/ceph/ceph/blob/b4102be9e0e9a6421f3bab12ee1286d56a0154ec/src/client/Client.cc#L11257-L11274

Pay attention to line 11259 and 11272, things became clear :), `_read` is called with `blp ? blp : &bl` while `&bl` is being copied to iovec structures at line 11272. Now the reason why this crash never occured in async api is because we return 0 from here https://github.com/ceph/ceph/blob/b4102be9e0e9a6421f3bab12ee1286d56a0154ec/src/client/Client.cc#L10913 and so we never reach 11272 and `C_Read_Sync_NonBlocking` does the magic handling it nicely but in sync call, it is bound to fail.

Fixes: https://tracker.ceph.com/issues/63633





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
