### PR TITLE
bluestore: silence some unused function warnings

### DIFF
--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -219,7 +219,6 @@ std::ostream& operator<<(std::ostream& out, const bluefs_fnode_delta_t& delta)
 
 // bluefs_transaction_t
 
-DENC_HELPERS
 void bluefs_transaction_t::bound_encode(size_t &s) const {
   uint32_t crc = op_bl.crc32c(-1);
   DENC_START(1, 1, s);


### PR DESCRIPTION
```
[205/650] Building CXX object src/os/CMakeFiles/os.dir/bluestore/bluefs_types.cc.o
In file included from src/include/encoding.h:42,
                 from src/include/compact_map.h:16,
                 from src/include/mempool.h:32,
                 from src/os/bluestore/bluestore_types.h:23,
                 from src/os/bluestore/bluefs_types.h:8,
                 from src/os/bluestore/bluefs_types.cc:5:
src/include/denc.h:1826:15: warning: ‘void _denc_finish(ceph::buffer::v15_2_0::ptr::const_iterator&, __u8*, __u8*, char**, uint32_t*)’ defined but not used [-Wunused-function]
 1826 |   static void _denc_finish(::ceph::buffer::ptr::const_iterator& p,      \
      |               ^~~~~~~~~~~~
src/os/bluestore/bluefs_types.cc:222:1: note: in expansion of macro ‘DENC_HELPERS’
  222 | DENC_HELPERS
      | ^~~~~~~~~~~~
src/include/denc.h:1816:15: warning: ‘void _denc_start(ceph::buffer::v15_2_0::ptr::const_iterator&, __u8*, __u8*, char**, uint32_t*)’ defined but not used [-Wunused-function]
 1816 |   static void _denc_start(::ceph::buffer::ptr::const_iterator& p,       \
      |               ^~~~~~~~~~~
src/os/bluestore/bluefs_types.cc:222:1: note: in expansion of macro ‘DENC_HELPERS’
  222 | DENC_HELPERS
      | ^~~~~~~~~~~~
src/include/denc.h:1807:15: warning: ‘void _denc_finish(ceph::buffer::v15_2_0::list::contiguous_appender&, __u8*, __u8*, char**, uint32_t*) defined but not used [-Wunused-function]
 1807 |   static void _denc_finish(::ceph::buffer::list::contiguous_appender& p, \
      |               ^~~~~~~~~~~~
src/os/bluestore/bluefs_types.cc:222:1: note: in expansion of macro ‘DENC_HELPERS’
  222 | DENC_HELPERS
      | ^~~~~~~~~~~~
src/include/denc.h:1797:15: warning: ‘void _denc_start(ceph::buffer::v15_2_0::list::contiguous_appender&, __u8*, __u8*, char**, uint32_t*)’ defined but not used [-Wunused-function]
 1797 |   static void _denc_start(::ceph::buffer::list::contiguous_appender& p, \
      |               ^~~~~~~~~~~
src/os/bluestore/bluefs_types.cc:222:1: note: in expansion of macro ‘DENC_HELPERS’
  222 | DENC_HELPERS
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
