### PR TITLE
pacific: librbd: Append one journal event per image request 

### DIFF
--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -39,6 +39,7 @@ using util::create_async_context_callback;
 using util::create_context_callback;
 using journal::util::C_DecodeTag;
 using journal::util::C_DecodeTags;
+using io::Extents;
 
 namespace {
 
@@ -788,8 +789,8 @@ uint64_t Journal<I>::append_write_event(uint64_t offset, size_t length,
     bytes_remaining -= event_length;
   } while (bytes_remaining > 0);
 
-  return append_io_events(journal::EVENT_TYPE_AIO_WRITE, bufferlists, offset,
-                          length, flush_entry, 0);
+  return append_io_events(journal::EVENT_TYPE_AIO_WRITE, bufferlists,
+                          {{offset, length}}, flush_entry, 0);
 }
 
 template <typename I>
@@ -799,14 +800,14 @@ uint64_t Journal<I>::append_io_event(journal::EventEntry &&event_entry,
   bufferlist bl;
   event_entry.timestamp = ceph_clock_now();
   encode(event_entry, bl);
-  return append_io_events(event_entry.get_event_type(), {bl}, offset, length,
-                          flush_entry, filter_ret_val);
+  return append_io_events(event_entry.get_event_type(), {bl},
+                          {{offset, length}}, flush_entry, filter_ret_val);
 }
 
 template <typename I>
 uint64_t Journal<I>::append_io_events(journal::EventType event_type,
                                       const Bufferlists &bufferlists,
-                                      uint64_t offset, size_t length,
+                                      const Extents &image_extents,
                                       bool flush_entry, int filter_ret_val) {
   ceph_assert(!bufferlists.empty());
 
@@ -827,14 +828,13 @@ uint64_t Journal<I>::append_io_events(journal::EventType event_type,
 
   {
     std::lock_guard event_locker{m_event_lock};
-    m_events[tid] = Event(futures, offset, length, filter_ret_val);
+    m_events[tid] = Event(futures, image_extents, filter_ret_val);
   }
 
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << this << " " << __func__ << ": "
                  << "event=" << event_type << ", "
-                 << "offset=" << offset << ", "
-                 << "length=" << length << ", "
+                 << "image_extents=" << image_extents << ", "
                  << "flush=" << flush_entry << ", tid=" << tid << dendl;
 
   Context *on_safe = create_async_context_callback(

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -134,9 +134,15 @@ public:
 
   void user_flushed();
 
-  uint64_t append_write_event(uint64_t offset, size_t length,
+  uint64_t append_write_event(const io::Extents &image_extents,
                               const bufferlist &bl,
                               bool flush_entry);
+  uint64_t append_write_same_event(const io::Extents &image_extents,
+                                   const bufferlist &bl,
+                                   bool flush_entry);
+  uint64_t append_discard_event(const io::Extents &image_extents,
+                                uint32_t discard_granularity_bytes,
+                                bool flush_entry);
   uint64_t append_io_event(journal::EventEntry &&event_entry,
                            uint64_t offset, size_t length,
                            bool flush_entry, int filter_ret_val);
@@ -320,6 +326,10 @@ private:
   bool is_journal_replaying(const ceph::mutex &) const;
   bool is_tag_owner(const ceph::mutex &) const;
 
+  void add_write_event_entries(uint64_t offset, size_t length,
+                               const bufferlist &bl,
+                               uint64_t buffer_offset,
+                               Bufferlists *bufferlists);
   uint64_t append_io_events(journal::EventType event_type,
                             const Bufferlists &bufferlists,
                             const io::Extents &extents, bool flush_entry,

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -18,6 +18,7 @@
 #include "journal/ReplayHandler.h"
 #include "librbd/Utils.h"
 #include "librbd/asio/ContextWQ.h"
+#include "librbd/io/Types.h"
 #include "librbd/journal/Types.h"
 #include "librbd/journal/TypeTraits.h"
 
@@ -195,11 +196,13 @@ private:
 
     Event() {
     }
-    Event(const Futures &_futures, uint64_t offset, size_t length,
+    Event(const Futures &_futures, const io::Extents &image_extents,
           int filter_ret_val)
       : futures(_futures), filter_ret_val(filter_ret_val) {
-      if (length > 0) {
-        pending_extents.insert(offset, length);
+      for (auto &extent : image_extents) {
+        if (extent.second > 0) {
+          pending_extents.insert(extent.first, extent.second);
+        }
       }
     }
   };
@@ -319,7 +322,7 @@ private:
 
   uint64_t append_io_events(journal::EventType event_type,
                             const Bufferlists &bufferlists,
-                            uint64_t offset, size_t length, bool flush_entry,
+                            const io::Extents &extents, bool flush_entry,
                             int filter_ret_val);
   Future wait_event(ceph::mutex &lock, uint64_t tid, Context *on_safe);
 

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -469,7 +469,7 @@ void AbstractImageWriteRequest<I>::send_request() {
     if (journaling) {
       // in-flight ops are flushed prior to closing the journal
       ceph_assert(image_ctx.journal != NULL);
-      journal_tid = append_journal_event(m_synchronous);
+      journal_tid = append_journal_event();
     }
 
     // it's very important that IOContext is captured here instead of
@@ -514,7 +514,7 @@ void ImageWriteRequest<I>::assemble_extent(
 }
 
 template <typename I>
-uint64_t ImageWriteRequest<I>::append_journal_event(bool synchronous) {
+uint64_t ImageWriteRequest<I>::append_journal_event() {
   I &image_ctx = this->m_image_ctx;
 
   uint64_t tid = 0;
@@ -526,7 +526,7 @@ uint64_t ImageWriteRequest<I>::append_journal_event(bool synchronous) {
     buffer_offset += extent.second;
 
     tid = image_ctx.journal->append_write_event(extent.first, extent.second,
-                                                sub_bl, synchronous);
+                                                sub_bl, false);
   }
 
   return tid;
@@ -562,7 +562,7 @@ void ImageWriteRequest<I>::update_stats(size_t length) {
 }
 
 template <typename I>
-uint64_t ImageDiscardRequest<I>::append_journal_event(bool synchronous) {
+uint64_t ImageDiscardRequest<I>::append_journal_event() {
   I &image_ctx = this->m_image_ctx;
 
   uint64_t tid = 0;
@@ -574,7 +574,7 @@ uint64_t ImageDiscardRequest<I>::append_journal_event(bool synchronous) {
                                this->m_discard_granularity_bytes));
     tid = image_ctx.journal->append_io_event(std::move(event_entry),
                                              extent.first, extent.second,
-                                             synchronous, 0);
+                                             false, 0);
   }
 
   return tid;
@@ -713,7 +713,7 @@ void ImageFlushRequest<I>::send_request() {
 }
 
 template <typename I>
-uint64_t ImageWriteSameRequest<I>::append_journal_event(bool synchronous) {
+uint64_t ImageWriteSameRequest<I>::append_journal_event() {
   I &image_ctx = this->m_image_ctx;
 
   uint64_t tid = 0;
@@ -724,7 +724,7 @@ uint64_t ImageWriteSameRequest<I>::append_journal_event(bool synchronous) {
                                                                m_data_bl));
     tid = image_ctx.journal->append_io_event(std::move(event_entry),
                                              extent.first, extent.second,
-                                             synchronous, 0);
+                                             false, 0);
   }
 
   return tid;
@@ -764,8 +764,7 @@ void ImageWriteSameRequest<I>::update_stats(size_t length) {
 }
 
 template <typename I>
-uint64_t ImageCompareAndWriteRequest<I>::append_journal_event(
-    bool synchronous) {
+uint64_t ImageCompareAndWriteRequest<I>::append_journal_event() {
   I &image_ctx = this->m_image_ctx;
 
   uint64_t tid = 0;
@@ -776,7 +775,7 @@ uint64_t ImageCompareAndWriteRequest<I>::append_journal_event(
                                      m_bl));
   tid = image_ctx.journal->append_io_event(std::move(event_entry),
                                            extent.first, extent.second,
-                                           synchronous, -EILSEQ);
+                                           false, -EILSEQ);
 
   return tid;
 }

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -517,19 +517,9 @@ template <typename I>
 uint64_t ImageWriteRequest<I>::append_journal_event() {
   I &image_ctx = this->m_image_ctx;
 
-  uint64_t tid = 0;
-  uint64_t buffer_offset = 0;
   ceph_assert(!this->m_image_extents.empty());
-  for (auto &extent : this->m_image_extents) {
-    bufferlist sub_bl;
-    sub_bl.substr_of(m_bl, buffer_offset, extent.second);
-    buffer_offset += extent.second;
-
-    tid = image_ctx.journal->append_write_event(extent.first, extent.second,
-                                                sub_bl, false);
-  }
-
-  return tid;
+  return image_ctx.journal->append_write_event(
+    this->m_image_extents, m_bl, false);
 }
 
 template <typename I>
@@ -565,19 +555,9 @@ template <typename I>
 uint64_t ImageDiscardRequest<I>::append_journal_event() {
   I &image_ctx = this->m_image_ctx;
 
-  uint64_t tid = 0;
   ceph_assert(!this->m_image_extents.empty());
-  for (auto &extent : this->m_image_extents) {
-    journal::EventEntry event_entry(
-      journal::AioDiscardEvent(extent.first,
-                               extent.second,
-                               this->m_discard_granularity_bytes));
-    tid = image_ctx.journal->append_io_event(std::move(event_entry),
-                                             extent.first, extent.second,
-                                             false, 0);
-  }
-
-  return tid;
+  return image_ctx.journal->append_discard_event(
+    this->m_image_extents, m_discard_granularity_bytes, false);
 }
 
 template <typename I>
@@ -716,18 +696,9 @@ template <typename I>
 uint64_t ImageWriteSameRequest<I>::append_journal_event() {
   I &image_ctx = this->m_image_ctx;
 
-  uint64_t tid = 0;
   ceph_assert(!this->m_image_extents.empty());
-  for (auto &extent : this->m_image_extents) {
-    journal::EventEntry event_entry(journal::AioWriteSameEvent(extent.first,
-                                                               extent.second,
-                                                               m_data_bl));
-    tid = image_ctx.journal->append_io_event(std::move(event_entry),
-                                             extent.first, extent.second,
-                                             false, 0);
-  }
-
-  return tid;
+  return image_ctx.journal->append_write_same_event(
+    this->m_image_extents, m_data_bl, false);
 }
 
 template <typename I>

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -116,11 +116,6 @@ private:
 
 template <typename ImageCtxT = ImageCtx>
 class AbstractImageWriteRequest : public ImageRequest<ImageCtxT> {
-public:
-  inline void flag_synchronous() {
-    m_synchronous = true;
-  }
-
 protected:
   using typename ImageRequest<ImageCtxT>::ObjectRequests;
   using typename ImageRequest<ImageCtxT>::Extents;
@@ -130,8 +125,7 @@ protected:
                             const char *trace_name,
 			    const ZTracer::Trace &parent_trace)
     : ImageRequest<ImageCtxT>(image_ctx, aio_comp, std::move(image_extents),
-                              trace_name, parent_trace),
-      m_synchronous(false) {
+                              trace_name, parent_trace) {
   }
 
   void send_request() override;
@@ -147,11 +141,8 @@ protected:
       const LightweightObjectExtent &object_extent, IOContext io_context,
       uint64_t journal_tid, bool single_extent, Context *on_finish) = 0;
 
-  virtual uint64_t append_journal_event(bool synchronous) = 0;
+  virtual uint64_t append_journal_event() = 0;
   virtual void update_stats(size_t length) = 0;
-
-private:
-  bool m_synchronous;
 };
 
 template <typename ImageCtxT = ImageCtx>
@@ -185,7 +176,7 @@ protected:
       const LightweightObjectExtent &object_extent, IOContext io_context,
       uint64_t journal_tid, bool single_extent, Context *on_finish) override;
 
-  uint64_t append_journal_event(bool synchronous) override;
+  uint64_t append_journal_event() override;
   void update_stats(size_t length) override;
 
 private:
@@ -220,7 +211,7 @@ protected:
       const LightweightObjectExtent &object_extent, IOContext io_context,
       uint64_t journal_tid, bool single_extent, Context *on_finish) override;
 
-  uint64_t append_journal_event(bool synchronous) override;
+  uint64_t append_journal_event() override;
   void update_stats(size_t length) override;
 
   int prune_object_extents(
@@ -287,7 +278,7 @@ protected:
       const LightweightObjectExtent &object_extent, IOContext io_context,
       uint64_t journal_tid, bool single_extent, Context *on_finish) override;
 
-  uint64_t append_journal_event(bool synchronous) override;
+  uint64_t append_journal_event() override;
   void update_stats(size_t length) override;
 private:
   bufferlist m_data_bl;
@@ -319,7 +310,7 @@ protected:
       const LightweightObjectExtent &object_extent, IOContext io_context,
       uint64_t journal_tid, bool single_extent, Context *on_finish) override;
 
-  uint64_t append_journal_event(bool synchronous) override;
+  uint64_t append_journal_event() override;
   void update_stats(size_t length) override;
 
   aio_type_t get_aio_type() const override {

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -20,7 +20,8 @@ set(librbd_test
   test_Operations.cc
   test_Trash.cc
   journal/test_Entries.cc
-  journal/test_Replay.cc)
+  journal/test_Replay.cc
+  journal/test_Stress.cc)
 add_library(rbd_test STATIC ${librbd_test})
 target_link_libraries(rbd_test PRIVATE
   rbd_test_support

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -16,8 +16,11 @@ namespace {
 struct MockTestImageCtx;
 
 struct MockTestJournal : public MockJournal {
-  MOCK_METHOD4(append_write_event, uint64_t(uint64_t, size_t,
+  MOCK_METHOD3(append_write_event, uint64_t(const io::Extents&,
                                             const bufferlist &, bool));
+  MOCK_METHOD3(append_write_same_event, uint64_t(const io::Extents&,
+                                                 const bufferlist &, bool));
+  MOCK_METHOD3(append_discard_event, uint64_t(const io::Extents&, uint32_t, bool));
   MOCK_METHOD5(append_io_event_mock, uint64_t(const journal::EventEntry&,
                                               uint64_t, size_t, bool, int));
   uint64_t append_io_event(journal::EventEntry &&event_entry,
@@ -111,9 +114,10 @@ struct TestMockIoImageRequest : public TestMockFixture {
     }
   }
 
-  void expect_journal_append_io_event(MockTestJournal &mock_journal, uint64_t journal_tid,
-                                      uint64_t offset, size_t length) {
-    EXPECT_CALL(mock_journal, append_io_event_mock(_, offset, length, _, _))
+  void expect_journal_append_discard_event(MockTestJournal &mock_journal,
+                                           uint64_t journal_tid,
+                                           const io::Extents& extents) {
+    EXPECT_CALL(mock_journal, append_discard_event(extents, _, _))
       .WillOnce(Return(journal_tid));
   }
 
@@ -378,8 +382,8 @@ TEST_F(TestMockIoImageRequest, PartialDiscardJournalAppendEnabled) {
   InSequence seq;
   expect_get_modify_timestamp(mock_image_ctx, false);
   expect_is_journal_appending(mock_journal, true);
-  expect_journal_append_io_event(mock_journal, 0, 16, 63);
-  expect_journal_append_io_event(mock_journal, 1, 84, 100);
+  expect_journal_append_discard_event(mock_journal, 0,
+                                      {{16, 63}, {84, 100}});
   expect_object_discard_request(mock_image_ctx, 0, 16, 63, 0);
   expect_object_discard_request(mock_image_ctx, 0, 84, 100, 0);
 
@@ -411,8 +415,8 @@ TEST_F(TestMockIoImageRequest, TailDiscardJournalAppendEnabled) {
   InSequence seq;
   expect_get_modify_timestamp(mock_image_ctx, false);
   expect_is_journal_appending(mock_journal, true);
-  expect_journal_append_io_event(
-    mock_journal, 0, ictx->layout.object_size - 1024, 1024);
+  expect_journal_append_discard_event(
+    mock_journal, 0, {{ictx->layout.object_size - 1024, 1024}});
   expect_object_discard_request(
     mock_image_ctx, 0, ictx->layout.object_size - 1024, 1024, 0);
 
@@ -444,7 +448,7 @@ TEST_F(TestMockIoImageRequest, PruneRequiredDiscardJournalAppendEnabled) {
   InSequence seq;
   expect_get_modify_timestamp(mock_image_ctx, false);
   expect_is_journal_appending(mock_journal, true);
-  EXPECT_CALL(mock_journal, append_io_event_mock(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(mock_journal, append_discard_event(_, _, _)).Times(0);
   EXPECT_CALL(*mock_image_ctx.io_object_dispatcher, send(_)).Times(0);
 
   C_SaferCond aio_comp_ctx;
@@ -474,7 +478,7 @@ TEST_F(TestMockIoImageRequest, LengthModifiedDiscardJournalAppendEnabled) {
   InSequence seq;
   expect_get_modify_timestamp(mock_image_ctx, false);
   expect_is_journal_appending(mock_journal, true);
-  expect_journal_append_io_event(mock_journal, 0, 32, 32);
+  expect_journal_append_discard_event(mock_journal, 0, {{32, 32}});
   expect_object_discard_request(mock_image_ctx, 0, 32, 32, 0);
 
   C_SaferCond aio_comp_ctx;
@@ -505,10 +509,9 @@ TEST_F(TestMockIoImageRequest, DiscardGranularityJournalAppendEnabled) {
   InSequence seq;
   expect_get_modify_timestamp(mock_image_ctx, false);
   expect_is_journal_appending(mock_journal, true);
-  expect_journal_append_io_event(mock_journal, 0, 32, 32);
-  expect_journal_append_io_event(mock_journal, 1, 96, 64);
-  expect_journal_append_io_event(
-    mock_journal, 2, ictx->layout.object_size - 32, 32);
+  expect_journal_append_discard_event(
+    mock_journal, 0,
+    {{32, 32}, {96, 64}, {ictx->layout.object_size - 32, 32}});
   expect_object_discard_request(mock_image_ctx, 0, 32, 32, 0);
   expect_object_discard_request(mock_image_ctx, 0, 96, 64, 0);
   expect_object_discard_request(

--- a/src/test/librbd/journal/test_Entries.cc
+++ b/src/test/librbd/journal/test_Entries.cc
@@ -195,6 +195,69 @@ TEST_F(TestJournalEntries, AioDiscard) {
   ASSERT_EQ(234U, aio_discard_event.length);
 }
 
+TEST_F(TestJournalEntries, AioDiscardWithPrune) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  // The discard path can create multiple image extents (ImageRequest.cc) in the
+  // case where the discard request needs to be pruned and multiple objects are
+  // involved in the request. This test ensures that journal event entries are
+  // queued up for each image extent.
+
+  // Create an image that is multiple objects so that we can force multiple
+  // image extents on the discard path.
+  CephContext* cct = reinterpret_cast<CephContext*>(_rados.cct());
+  auto object_size = 1ull << cct->_conf.get_val<uint64_t>("rbd_default_order");
+  auto image_size = 4 * object_size;
+
+  auto image_name = get_temp_image_name();
+  ASSERT_EQ(0, create_image_pp(m_rbd, m_ioctx, image_name, image_size));
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(image_name, &ictx));
+
+  ::journal::Journaler *journaler = create_journaler(ictx);
+  ASSERT_TRUE(journaler != NULL);
+
+  C_SaferCond cond_ctx;
+  auto c = librbd::io::AioCompletion::create(&cond_ctx);
+  c->get();
+  // We offset the discard by -4096 bytes and set discard granularity to 8192;
+  // this should cause two image extents to be formed in
+  // AbstractImageWriteRequest<I>::send_request().
+  api::Io<>::aio_discard(*ictx, c, object_size - 4096, 2 * object_size, 8192,
+                         true);
+  ASSERT_EQ(0, c->wait_for_complete());
+  c->put();
+
+  for (uint64_t chunk = 0; chunk < 2; chunk++) {
+    auto offset = object_size;
+    auto size = object_size;
+    if (chunk == 1) {
+      offset = object_size * 2;
+      size = object_size - 8192;
+    }
+
+    ::journal::ReplayEntry replay_entry;
+    if (!journaler->try_pop_front(&replay_entry)) {
+      ASSERT_TRUE(wait_for_entries_available(ictx));
+      ASSERT_TRUE(journaler->try_pop_front(&replay_entry));
+    }
+
+    librbd::journal::EventEntry event_entry;
+    ASSERT_TRUE(get_event_entry(replay_entry, &event_entry));
+
+    ASSERT_EQ(librbd::journal::EVENT_TYPE_AIO_DISCARD,
+              event_entry.get_event_type());
+
+    librbd::journal::AioDiscardEvent aio_discard_event =
+      boost::get<librbd::journal::AioDiscardEvent>(event_entry.event);
+    ASSERT_EQ(offset, aio_discard_event.offset);
+    ASSERT_EQ(size, aio_discard_event.length);
+
+    journaler->committed(replay_entry);
+  }
+}
+
 TEST_F(TestJournalEntries, AioFlush) {
   REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
 

--- a/src/test/librbd/journal/test_Stress.cc
+++ b/src/test/librbd/journal/test_Stress.cc
@@ -46,6 +46,10 @@ TEST_F(TestJournalStress, DiscardWithPruneWriteOverlap) {
   // Write-around cache required for overlapping I/O delays.
   cct->_conf.set_val_or_die("rbd_cache_writethrough_until_flush", "false");
   cct->_conf.set_val_or_die("rbd_cache_policy", "writearound");
+  // XXX: Work around https://tracker.ceph.com/issues/63681, which this test
+  // exposes when run under Valgrind.
+  cct->_conf.set_val_or_die("librados_thread_count", "15");
+  cct->_conf.apply_changes(nullptr);
 
   auto image_name = get_temp_image_name();
   ASSERT_EQ(0, create_image_pp(m_rbd, m_ioctx, image_name, image_size));

--- a/src/test/librbd/journal/test_Stress.cc
+++ b/src/test/librbd/journal/test_Stress.cc
@@ -1,0 +1,101 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_fixture.h"
+#include "test/librbd/test_support.h"
+#include "cls/rbd/cls_rbd_types.h"
+#include "cls/journal/cls_journal_types.h"
+#include "cls/journal/cls_journal_client.h"
+#include "journal/Journaler.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/ImageWatcher.h"
+#include "librbd/internal.h"
+#include "librbd/Journal.h"
+#include "librbd/Operations.h"
+#include "librbd/api/Io.h"
+#include "librbd/api/Snapshot.h"
+#include "librbd/io/AioCompletion.h"
+#include "librbd/io/ImageDispatchSpec.h"
+#include "librbd/io/ImageRequest.h"
+#include "librbd/io/ReadResult.h"
+#include "librbd/journal/Types.h"
+
+void register_test_journal_stress() {
+}
+
+namespace librbd {
+namespace journal {
+
+class TestJournalStress : public TestFixture {
+};
+
+TEST_F(TestJournalStress, DiscardWithPruneWriteOverlap) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  // Overlap discards and writes while discard pruning is occurring. This tests
+  // the conditions under which https://tracker.ceph.com/issues/63422 occurred.
+
+  // Create an image that is multiple objects so that we can force multiple
+  // image extents on the discard path.
+  CephContext* cct = reinterpret_cast<CephContext*>(_rados.cct());
+  auto object_size = 1ull << cct->_conf.get_val<uint64_t>("rbd_default_order");
+  auto image_size = 4 * object_size;
+
+  // Write-around cache required for overlapping I/O delays.
+  cct->_conf.set_val_or_die("rbd_cache_writethrough_until_flush", "false");
+  cct->_conf.set_val_or_die("rbd_cache_policy", "writearound");
+
+  auto image_name = get_temp_image_name();
+  ASSERT_EQ(0, create_image_pp(m_rbd, m_ioctx, image_name, image_size));
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(image_name, &ictx));
+
+  std::thread write_thread(
+    [ictx, object_size]() {
+      std::string payload(object_size, '1');
+
+      for (auto i = 0; i < 200; i++) {
+        // Alternate overlaps with the two objects that the discard below
+        // touches.
+        for (auto offset = object_size;
+             offset < object_size * 3;
+             offset += object_size) {
+          bufferlist payload_bl;
+          payload_bl.append(payload);
+          auto aio_comp = new librbd::io::AioCompletion();
+          api::Io<>::aio_write(*ictx, aio_comp, 0, payload.size(),
+                               std::move(payload_bl), 0, true);
+          ASSERT_EQ(0, aio_comp->wait_for_complete());
+          aio_comp->release();
+        }
+      }
+    }
+  );
+
+  auto discard_exit = false;
+  std::thread discard_thread(
+    [ictx, object_size, &discard_exit]() {
+      while (!discard_exit) {
+        // We offset the discard by -4096 bytes and set discard granularity to
+        // 8192; this should cause two image extents to be formed in
+        // AbstractImageWriteRequest<I>::send_request() on objects 1 and 2,
+        // overlapping with the writes above.
+        auto aio_comp = new librbd::io::AioCompletion();
+        api::Io<>::aio_discard(*ictx, aio_comp, object_size - 4096,
+                               2 * object_size, 8192, true);
+        ASSERT_EQ(0, aio_comp->wait_for_complete());
+        aio_comp->release();
+      }
+    }
+  );
+
+  write_thread.join();
+  discard_exit = true;
+  discard_thread.join();
+}
+
+} // namespace journal
+} // namespace librbd

--- a/src/test/librbd/test_main.cc
+++ b/src/test/librbd/test_main.cc
@@ -17,6 +17,7 @@ extern void register_test_image_watcher();
 extern void register_test_internal();
 extern void register_test_journal_entries();
 extern void register_test_journal_replay();
+extern void register_test_journal_stress();
 extern void register_test_migration();
 extern void register_test_mirroring();
 extern void register_test_mirroring_watcher();
@@ -37,6 +38,7 @@ int main(int argc, char **argv)
   register_test_internal();
   register_test_journal_entries();
   register_test_journal_replay();
+  register_test_journal_stress();
   register_test_migration();
   register_test_mirroring();
   register_test_mirroring_watcher();

--- a/src/test/librbd/test_mock_Journal.cc
+++ b/src/test/librbd/test_mock_Journal.cc
@@ -460,7 +460,7 @@ public:
     bl.append_zero(length);
 
     std::shared_lock owner_locker{mock_image_ctx.owner_lock};
-    return mock_journal->append_write_event(0, length, bl, false);
+    return mock_journal->append_write_event({{0, length}}, bl, false);
   }
 
   uint64_t when_append_io_event(MockJournalImageCtx &mock_image_ctx,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63745

---

backport of https://github.com/ceph/ceph/pull/54377
parent tracker: https://tracker.ceph.com/issues/63422

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh