### PR TITLE
RGW/STS: adding role ownership and verify permission policy given a role action

### DIFF
--- a/src/rgw/driver/daos/rgw_sal_daos.cc
+++ b/src/rgw/driver/daos/rgw_sal_daos.cc
@@ -2075,7 +2075,7 @@ int DaosMultipartWriter::complete(
 }
 
 std::unique_ptr<RGWRole> DaosStore::get_role(
-    std::string name, std::string tenant, std::string path,
+    std::string name, std::string tenant, std::string owner, std::string path,
     std::string trust_policy, std::string max_session_duration_str,
     std::multimap<std::string, std::string> tags) {
   RGWRole* p = nullptr;
@@ -2095,6 +2095,7 @@ std::unique_ptr<RGWRole> DaosStore::get_role(std::string id) {
 int DaosStore::get_roles(const DoutPrefixProvider* dpp, optional_yield y,
                          const std::string& path_prefix,
                          const std::string& tenant,
+                         const std::string& owner,
                          vector<std::unique_ptr<RGWRole>>& roles) {
   return DAOS_NOT_IMPLEMENTED_LOG(dpp);
 }

--- a/src/rgw/driver/daos/rgw_sal_daos.h
+++ b/src/rgw/driver/daos/rgw_sal_daos.h
@@ -982,7 +982,7 @@ class DaosStore : public StoreDriver {
 
   std::unique_ptr<LuaManager> get_lua_manager(const DoutPrefixProvider *dpp = nullptr, const std::string& luarocks_path = "") override;
   virtual std::unique_ptr<RGWRole> get_role(
-      std::string name, std::string tenant, std::string path = "",
+      std::string name, std::string tenant, std::string owner = "", std::string path = "",
       std::string trust_policy = "", std::string max_session_duration_str = "",
       std::multimap<std::string, std::string> tags = {}) override;
   virtual std::unique_ptr<RGWRole> get_role(const RGWRoleInfo& info) override;
@@ -990,6 +990,7 @@ class DaosStore : public StoreDriver {
   virtual int get_roles(const DoutPrefixProvider* dpp, optional_yield y,
                         const std::string& path_prefix,
                         const std::string& tenant,
+                        const std::string& owner,
                         std::vector<std::unique_ptr<RGWRole>>& roles) override;
   virtual std::unique_ptr<RGWOIDCProvider> get_oidc_provider() override;
   virtual int get_oidc_providers(

--- a/src/rgw/driver/motr/rgw_sal_motr.cc
+++ b/src/rgw/driver/motr/rgw_sal_motr.cc
@@ -3024,6 +3024,7 @@ int MotrMultipartWriter::complete(size_t accounted_size, const std::string& etag
 
 std::unique_ptr<RGWRole> MotrStore::get_role(std::string name,
     std::string tenant,
+    std::string owner,
     std::string path,
     std::string trust_policy,
     std::string max_session_duration_str,
@@ -3049,6 +3050,7 @@ int MotrStore::get_roles(const DoutPrefixProvider *dpp,
     optional_yield y,
     const std::string& path_prefix,
     const std::string& tenant,
+    const std::string& owner,
     vector<std::unique_ptr<RGWRole>>& roles)
 {
   return 0;

--- a/src/rgw/driver/motr/rgw_sal_motr.h
+++ b/src/rgw/driver/motr/rgw_sal_motr.h
@@ -1043,6 +1043,7 @@ class MotrStore : public StoreDriver {
     std::unique_ptr<LuaManager> get_lua_manager(const DoutPrefixProvider *dpp = nullptr, const std::string& luarocks_path = "") override;
     virtual std::unique_ptr<RGWRole> get_role(std::string name,
         std::string tenant,
+        std::string owner="",
         std::string path="",
         std::string trust_policy="",
         std::string max_session_duration_str="",
@@ -1053,6 +1054,7 @@ class MotrStore : public StoreDriver {
         optional_yield y,
         const std::string& path_prefix,
         const std::string& tenant,
+        const std::string& owner,
         std::vector<std::unique_ptr<RGWRole>>& roles) override;
     virtual std::unique_ptr<RGWOIDCProvider> get_oidc_provider() override;
     virtual int get_oidc_providers(const DoutPrefixProvider *dpp,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -1340,6 +1340,10 @@ int RadosStore::get_roles(const DoutPrefixProvider *dpp,
       if (ret < 0) {
         return ret;
       }
+
+      if (! owner.empty() && role->get_owner() != owner) {
+        continue;
+      }
       roles.push_back(std::move(role));
     }
   }

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -1267,12 +1267,13 @@ std::unique_ptr<LuaManager> RadosStore::get_lua_manager(const std::string& luaro
 
 std::unique_ptr<RGWRole> RadosStore::get_role(std::string name,
 					      std::string tenant,
+					      std::string owner,
 					      std::string path,
 					      std::string trust_policy,
 					      std::string max_session_duration_str,
                 std::multimap<std::string,std::string> tags)
 {
-  return std::make_unique<RadosRole>(this, name, tenant, path, trust_policy, max_session_duration_str, tags);
+  return std::make_unique<RadosRole>(this, name, tenant, owner, path, trust_policy, max_session_duration_str, tags);
 }
 
 std::unique_ptr<RGWRole> RadosStore::get_role(std::string id)
@@ -1289,6 +1290,7 @@ int RadosStore::get_roles(const DoutPrefixProvider *dpp,
 			  optional_yield y,
 			  const std::string& path_prefix,
 			  const std::string& tenant,
+			  const std::string& owner,
 			  vector<std::unique_ptr<RGWRole>>& roles)
 {
   auto pool = svc()->zone->get_zone_params().roles_pool;

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -3674,6 +3674,8 @@ int RadosRole::delete_obj(const DoutPrefixProvider *dpp, optional_yield y)
   }
 
   if (! info.perm_policy_map.empty()) {
+    ldpp_dout(dpp, 0) << "ERROR: role id " << info.id
+                      << " still have permission policies attached" << dendl;
     return -ERR_DELETE_CONFLICT;
   }
 

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -192,6 +192,7 @@ class RadosStore : public StoreDriver {
     std::unique_ptr<LuaManager> get_lua_manager(const std::string& luarocks_path) override;
     virtual std::unique_ptr<RGWRole> get_role(std::string name,
 					      std::string tenant,
+					      std::string owner="",
 					      std::string path="",
 					      std::string trust_policy="",
 					      std::string max_session_duration_str="",
@@ -202,6 +203,7 @@ class RadosStore : public StoreDriver {
 			  optional_yield y,
 			  const std::string& path_prefix,
 			  const std::string& tenant,
+			  const std::string& owner,
 			  std::vector<std::unique_ptr<RGWRole>>& roles) override;
     virtual std::unique_ptr<RGWOIDCProvider> get_oidc_provider() override;
     virtual int get_oidc_providers(const DoutPrefixProvider *dpp,
@@ -909,10 +911,11 @@ class RadosRole : public RGWRole {
 public:
   RadosRole(RadosStore* _store, std::string name,
           std::string tenant,
+          std::string owner,
           std::string path,
           std::string trust_policy,
           std::string max_session_duration,
-          std::multimap<std::string,std::string> tags) : RGWRole(name, tenant, path, trust_policy, max_session_duration, tags), store(_store) {}
+          std::multimap<std::string,std::string> tags) : RGWRole(name, tenant, owner, path, trust_policy, max_session_duration, tags), store(_store) {}
   RadosRole(RadosStore* _store, std::string id) : RGWRole(id), store(_store) {}
   RadosRole(RadosStore* _store, const RGWRoleInfo& info) : RGWRole(info), store(_store) {}
   RadosRole(RadosStore* _store) : store(_store) {}

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6708,6 +6708,7 @@ int main(int argc, const char **argv)
       std::unique_ptr<rgw::sal::RGWRole> role = driver->get_role(role_name, tenant);
       ret = role->delete_obj(dpp(), null_yield);
       if (ret < 0) {
+        cerr << "failed to delete the role " <<  role_name << ": err_code " << ret << std::endl;
         return -ret;
       }
       cout << "role: " << role_name << " successfully deleted" << std::endl;

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -249,6 +249,7 @@ void RGWCreateRole::execute(optional_yield y)
   std::string user_tenant = s->user->get_tenant();
   std::unique_ptr<rgw::sal::RGWRole> role = driver->get_role(role_name,
 							    user_tenant,
+							    s->user->get_id().id,
 							    role_path,
 							    trust_policy,
 							    max_session_duration,
@@ -572,7 +573,7 @@ void RGWListRoles::execute(optional_yield y)
     return;
   }
   vector<std::unique_ptr<rgw::sal::RGWRole>> result;
-  op_ret = driver->get_roles(s, y, path_prefix, s->user->get_tenant(), result);
+  op_ret = driver->get_roles(s, y, path_prefix, s->user->get_tenant(), "", result);
 
   if (op_ret == 0) {
     s->formatter->open_array_section("ListRolesResponse");

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -91,8 +91,11 @@ int RGWRestRole::verify_permission(optional_yield y)
     return op_ret;
   }
 
-  if (int ret = check_caps(s->user->get_caps()); ret == 0) {
-    _role = std::move(role);
+  int ret;
+  if (s->auth.identity->get_identity_type() != TYPE_ROLE &&
+        (ret = check_caps(s->user->get_caps())) != 0) {
+    ldpp_dout(this, 20) << "ERROR: user " << s->user->get_id()
+      << " does not have the required capabilities" << dendl;
     return ret;
   }
 

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -99,6 +99,13 @@ int RGWRestRole::verify_permission(optional_yield y)
     return ret;
   }
 
+  // owner of the role doesn't need permission check
+  const auto& role_owner = role->get_owner();
+  if (! role_owner.empty() && role_owner == s->user->get_id().id) {
+    _role = std::move(role);
+    return 0;
+  }
+
   string resource_name = role->get_path() + role_name;
   uint64_t op = get_op();
   if (!verify_user_permission(this,

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -39,6 +39,7 @@ const string RGWRole::role_arn_prefix = "arn:aws:iam::";
 
 void RGWRoleInfo::dump(Formatter *f) const
 {
+  encode_json("Owner", owner , f);
   encode_json("RoleId", id , f);
   std::string role_name;
   if (tenant.empty()) {
@@ -118,6 +119,7 @@ void RGWRoleInfo::decode_json(JSONObj *obj)
 
 RGWRole::RGWRole(std::string name,
               std::string tenant,
+              std::string owner,
               std::string path,
               std::string trust_policy,
               std::string max_session_duration_str,
@@ -127,6 +129,7 @@ RGWRole::RGWRole(std::string name,
   info.path = std::move(path);
   info.trust_policy = std::move(trust_policy);
   info.tenant = std::move(tenant);
+  info.owner = std::move(owner);
   info.tags = std::move(tags);
   if (this->info.path.empty())
     this->info.path = "/";

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -25,6 +25,7 @@ struct RGWRoleInfo
   std::string trust_policy;
   std::map<std::string, std::string> perm_policy_map;
   std::string tenant;
+  std::string owner;
   uint64_t max_session_duration;
   std::multimap<std::string,std::string> tags;
   std::map<std::string, bufferlist> attrs;
@@ -36,7 +37,7 @@ struct RGWRoleInfo
   ~RGWRoleInfo() = default;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(3, 1, bl);
+    ENCODE_START(4, 1, bl);
     encode(id, bl);
     encode(name, bl);
     encode(path, bl);
@@ -46,11 +47,12 @@ struct RGWRoleInfo
     encode(perm_policy_map, bl);
     encode(tenant, bl);
     encode(max_session_duration, bl);
+    encode(owner, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(3, bl);
+    DECODE_START(4, bl);
     decode(id, bl);
     decode(name, bl);
     decode(path, bl);
@@ -63,6 +65,9 @@ struct RGWRoleInfo
     }
     if (struct_v >= 3) {
       decode(max_session_duration, bl);
+    }
+    if (struct_v >= 4) {
+      decode(owner, bl);
     }
     DECODE_FINISH(bl);
   }
@@ -98,6 +103,7 @@ public:
 
   RGWRole(std::string name,
               std::string tenant,
+              std::string owner,
               std::string path="",
               std::string trust_policy="",
               std::string max_session_duration_str="",
@@ -114,6 +120,7 @@ public:
   const std::string& get_id() const { return info.id; }
   const std::string& get_name() const { return info.name; }
   const std::string& get_tenant() const { return info.tenant; }
+  const std::string& get_owner() const { return info.owner; }
   const std::string& get_path() const { return info.path; }
   const std::string& get_create_date() const { return info.creation_date; }
   const std::string& get_assume_role_policy() const { return info.trust_policy;}

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -373,6 +373,7 @@ class Driver {
     /** Get an IAM Role by name etc. */
     virtual std::unique_ptr<RGWRole> get_role(std::string name,
 					      std::string tenant,
+					      std::string owner="",
 					      std::string path="",
 					      std::string trust_policy="",
 					      std::string max_session_duration_str="",
@@ -385,6 +386,7 @@ class Driver {
 			  optional_yield y,
 			  const std::string& path_prefix,
 			  const std::string& tenant,
+			  const std::string& owner,
 			  std::vector<std::unique_ptr<RGWRole>>& roles) = 0;
     /** Get an empty Open ID Connector provider */
     virtual std::unique_ptr<RGWOIDCProvider> get_oidc_provider() = 0;

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1403,6 +1403,7 @@ namespace rgw::sal {
 
   std::unique_ptr<RGWRole> DBStore::get_role(std::string name,
       std::string tenant,
+      std::string owner,
       std::string path,
       std::string trust_policy,
       std::string max_session_duration_str,
@@ -1428,6 +1429,7 @@ namespace rgw::sal {
       optional_yield y,
       const std::string& path_prefix,
       const std::string& tenant,
+      const std::string& owner,
       vector<std::unique_ptr<RGWRole>>& roles)
   {
     return 0;

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -808,6 +808,7 @@ public:
       std::unique_ptr<LuaManager> get_lua_manager(const std::string& luarocks_path) override;
       virtual std::unique_ptr<RGWRole> get_role(std::string name,
           std::string tenant,
+          std::string owner="",
           std::string path="",
           std::string trust_policy="",
           std::string max_session_duration_str="",
@@ -818,6 +819,7 @@ public:
           optional_yield y,
           const std::string& path_prefix,
           const std::string& tenant,
+          const std::string& owner,
           std::vector<std::unique_ptr<RGWRole>>& roles) override;
       virtual std::unique_ptr<RGWOIDCProvider> get_oidc_provider() override;
       virtual int get_oidc_providers(const DoutPrefixProvider *dpp,

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -390,12 +390,13 @@ std::unique_ptr<LuaManager> FilterDriver::get_lua_manager(const std::string& lua
 
 std::unique_ptr<RGWRole> FilterDriver::get_role(std::string name,
 					      std::string tenant,
+					      std::string owner,
 					      std::string path,
 					      std::string trust_policy,
 					      std::string max_session_duration_str,
                 std::multimap<std::string,std::string> tags)
 {
-  return next->get_role(name, tenant, path, trust_policy, max_session_duration_str, tags);
+  return next->get_role(name, tenant, owner, path, trust_policy, max_session_duration_str, tags);
 }
 
 std::unique_ptr<RGWRole> FilterDriver::get_role(std::string id)
@@ -412,9 +413,10 @@ int FilterDriver::get_roles(const DoutPrefixProvider *dpp,
 			   optional_yield y,
 			   const std::string& path_prefix,
 			   const std::string& tenant,
+			   const std::string& owner,
 			   std::vector<std::unique_ptr<RGWRole>>& roles)
 {
-  return next->get_roles(dpp, y, path_prefix, tenant, roles);
+  return next->get_roles(dpp, y, path_prefix, tenant, owner, roles);
 }
 
 std::unique_ptr<RGWOIDCProvider> FilterDriver::get_oidc_provider()

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -249,6 +249,7 @@ public:
   virtual std::unique_ptr<LuaManager> get_lua_manager(const std::string& luarocks_path) override;
   virtual std::unique_ptr<RGWRole> get_role(std::string name,
 					    std::string tenant,
+					    std::string owner="",
 					    std::string path="",
 					    std::string trust_policy="",
 					    std::string
@@ -260,6 +261,7 @@ public:
 			optional_yield y,
 			const std::string& path_prefix,
 			const std::string& tenant,
+			const std::string& owner,
 			std::vector<std::unique_ptr<RGWRole>>& roles) override;
   virtual std::unique_ptr<RGWOIDCProvider> get_oidc_provider() override;
   virtual int get_oidc_providers(const DoutPrefixProvider *dpp,


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/63751
Issue reproducer is added at https://github.com/ceph/s3-tests/pull/535 - the scenarios leading to the issue are provided there. To sum up, currently, a random s3 user can update/delete another user's role without given any permission policies which is a critical privacy/security gap.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
