### PR TITLE
osd/scrub: don't block high-priority scrubs on local resources

### DIFF
--- a/qa/standalone/scrub/osd-recovery-scrub.sh
+++ b/qa/standalone/scrub/osd-recovery-scrub.sh
@@ -33,7 +33,7 @@ function run() {
     done
 }
 
-# Simple test for "not scheduling scrubs due to active recovery"
+# Simple test for "recovery in progress. Only high priority scrubs allowed."
 # OSD::sched_scrub() called on all OSDs during ticks
 function TEST_recovery_scrub_1() {
     local dir=$1
@@ -99,11 +99,11 @@ function TEST_recovery_scrub_1() {
     kill_daemons $dir #|| return 1
 
     declare -a err_strings
-    err_strings[0]="not scheduling scrubs due to active recovery"
+    err_strings[0]="recovery in progress. Only high priority scrubs allowed."
 
     for osd in $(seq 0 $(expr $OSDS - 1))
     do
-        grep "not scheduling scrubs" $dir/osd.${osd}.log
+        grep "recovery in progress. Only high priority scrubs allowed." $dir/osd.${osd}.log
     done
     for err_string in "${err_strings[@]}"
     do

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -709,11 +709,16 @@ public:
   virtual void on_shutdown() = 0;
 
   bool get_must_scrub() const;
-  Scrub::schedule_result_t sched_scrub();
 
-  unsigned int scrub_requeue_priority(Scrub::scrub_prio_t with_priority, unsigned int suggested_priority) const;
+  Scrub::schedule_result_t start_scrubbing(
+      Scrub::OSDRestrictions osd_restrictions);
+
+  unsigned int scrub_requeue_priority(
+      Scrub::scrub_prio_t with_priority,
+      unsigned int suggested_priority) const;
   /// the version that refers to flags_.priority
   unsigned int scrub_requeue_priority(Scrub::scrub_prio_t with_priority) const;
+
 private:
   // auxiliaries used by sched_scrub():
   double next_deepscrub_interval() const;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -67,7 +67,6 @@ class ScrubBackend;
 namespace Scrub {
   class Store;
   class ReplicaReservations;
-  class LocalReservation;
   class ReservedByRemotePrimary;
   enum class schedule_result_t;
 }

--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -69,10 +69,11 @@ bool OsdScrub::scrub_random_backoff() const
 
 void OsdScrub::initiate_scrub(bool is_recovery_active)
 {
-  if (scrub_random_backoff()) {
-    // dice-roll says we should not scrub now
-    return;
-  }
+  const utime_t scrub_time = ceph_clock_now();
+  dout(10) << fmt::format(
+		  "time now:{}, recover is active?:{}", scrub_time,
+		  is_recovery_active)
+	   << dendl;
 
   if (auto blocked_pgs = get_blocked_pgs_count(); blocked_pgs > 0) {
     // some PGs managed by this OSD were blocked by a locked object during
@@ -84,35 +85,14 @@ void OsdScrub::initiate_scrub(bool is_recovery_active)
 	<< dendl;
   }
 
-  // fail fast if no resources are available
-  if (!m_resource_bookkeeper.can_inc_scrubs()) {
-    dout(20) << "too many scrubs already running on this OSD" << dendl;
-    return;
-  }
-
-  // if there is a PG that is just now trying to reserve scrub replica resources -
-  // we should wait and not initiate a new scrub
-  if (m_queue.is_reserving_now()) {
-    dout(10) << "scrub resources reservation in progress" << dendl;
-    return;
-  }
-
-  utime_t scrub_time = ceph_clock_now();
-  dout(10) << fmt::format(
-		  "time now:{}, recover is active?:{}", scrub_time,
-		  is_recovery_active)
-	   << dendl;
-
   // check the OSD-wide environment conditions (scrub resources, time, etc.).
   // These may restrict the type of scrubs we are allowed to start, or just
-  // prevent us from starting any scrub at all.
+  // prevent us from starting any non-operator-initiated scrub at all.
   auto env_restrictions =
       restrictions_on_scrubbing(is_recovery_active, scrub_time);
-  if (!env_restrictions) {
-    return;
-  }
 
-  if (g_conf()->subsys.should_gather<ceph_subsys_osd, 20>()) {
+  if (g_conf()->subsys.should_gather<ceph_subsys_osd, 20>() &&
+      !env_restrictions.high_priority_only) {
     dout(20) << "scrub scheduling (@tick) starts" << dendl;
     auto all_jobs = m_queue.list_registered_jobs();
     for (const auto& sj : all_jobs) {
@@ -124,7 +104,7 @@ void OsdScrub::initiate_scrub(bool is_recovery_active)
   // queue interface used here: we ask for a list of
   // eligible targets (based on the known restrictions).
   // We try all elements of this list until a (possibly temporary) success.
-  auto candidates = m_queue.ready_to_scrub(*env_restrictions, scrub_time);
+  auto candidates = m_queue.ready_to_scrub(env_restrictions, scrub_time);
   if (candidates.empty()) {
     dout(20) << "no PGs are ready for scrubbing" << dendl;
     return;
@@ -137,7 +117,7 @@ void OsdScrub::initiate_scrub(bool is_recovery_active)
     // scrub. For some failures - we can continue with the next candidate. For
     // others - we should stop trying to scrub at this tick.
     auto res = initiate_a_scrub(
-	candidate, env_restrictions->allow_requested_repair_only);
+	candidate, env_restrictions.allow_requested_repair_only);
 
     if (res == schedule_result_t::target_specific_failure) {
       // continue with the next job.
@@ -157,39 +137,51 @@ void OsdScrub::initiate_scrub(bool is_recovery_active)
 }
 
 
-std::optional<Scrub::OSDRestrictions> OsdScrub::restrictions_on_scrubbing(
+Scrub::OSDRestrictions OsdScrub::restrictions_on_scrubbing(
     bool is_recovery_active,
     utime_t scrub_clock_now) const
 {
-  // our local OSD may already be running too many scrubs
-  if (!m_resource_bookkeeper.can_inc_scrubs()) {
-    dout(10) << "OSD cannot inc scrubs" << dendl;
-    return std::nullopt;
-  }
-
-  // if there is a PG that is just now trying to reserve scrub replica resources
-  // - we should wait and not initiate a new scrub
-  if (m_queue.is_reserving_now()) {
-    dout(10) << "scrub resources reservation in progress" << dendl;
-    return std::nullopt;
-  }
-
   Scrub::OSDRestrictions env_conditions;
-  env_conditions.time_permit = scrub_time_permit(scrub_clock_now);
-  env_conditions.load_is_low = m_load_tracker.scrub_load_below_threshold();
-  env_conditions.only_deadlined =
-      !env_conditions.time_permit || !env_conditions.load_is_low;
 
-  if (is_recovery_active && !conf->osd_scrub_during_recovery) {
-    if (!conf->osd_repair_during_recovery) {
-      dout(15) << "not scheduling scrubs due to active recovery" << dendl;
-      return std::nullopt;
+  // some environmental conditions prevent all but high priority scrubs
+
+  if (!m_resource_bookkeeper.can_inc_scrubs()) {
+    // our local OSD is already running too many scrubs
+    dout(15) << "OSD cannot inc scrubs" << dendl;
+    env_conditions.high_priority_only = true;
+
+  } else if (scrub_random_backoff()) {
+    // dice-roll says we should not scrub now
+      dout(15) << "Lost in dice. Only high priority scrubs allowed."
+	       << dendl;
+      env_conditions.high_priority_only = true;
+
+  } else if (m_queue.is_reserving_now()) {
+    // if there is a PG that is just now trying to reserve scrub replica
+    // resources - we should wait and not initiate a new scrub
+    dout(10) << "scrub resources reservation in progress" << dendl;
+    env_conditions.high_priority_only = true;
+
+  } else if (is_recovery_active && !conf->osd_scrub_during_recovery) {
+    if (conf->osd_repair_during_recovery) {
+      dout(15)
+	  << "will only schedule explicitly requested repair due to active "
+	     "recovery"
+	  << dendl;
+      env_conditions.allow_requested_repair_only = true;
+
+    } else {
+      dout(15) << "recovery in progress. Only high priority scrubs allowed."
+	       << dendl;
+      env_conditions.high_priority_only = true;
     }
+  } else {
 
-    dout(10) << "will only schedule explicitly requested repair due to active "
-		"recovery"
-	     << dendl;
-    env_conditions.allow_requested_repair_only = true;
+    // regular, i.e. non-high-priority scrubs are allowed
+    env_conditions.time_permit = scrub_time_permit(scrub_clock_now);
+    env_conditions.load_is_low = m_load_tracker.scrub_load_below_threshold();
+    env_conditions.only_deadlined =
+	!env_conditions.time_permit || !env_conditions.load_is_low;
   }
 
   return env_conditions;

--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -407,9 +407,10 @@ void OsdScrub::remove_from_osd_queue(Scrub::ScrubJobRef sjob)
   m_queue.remove_from_osd_queue(sjob);
 }
 
-bool OsdScrub::inc_scrubs_local()
+std::unique_ptr<Scrub::LocalResourceWrapper> OsdScrub::inc_scrubs_local(
+    bool is_high_priority)
 {
-  return m_resource_bookkeeper.inc_scrubs_local();
+  return m_resource_bookkeeper.inc_scrubs_local(is_high_priority);
 }
 
 void OsdScrub::dec_scrubs_local()

--- a/src/osd/scrubber/osd_scrub.h
+++ b/src/osd/scrubber/osd_scrub.h
@@ -168,20 +168,17 @@ class OsdScrub {
 
   /**
    * check the OSD-wide environment conditions (scrub resources, time, etc.).
-   * These may restrict the type of scrubs we are allowed to start, or just
-   * prevent us from starting any scrub at all.
+   * These may restrict the type of scrubs we are allowed to start, maybe
+   * down to allowing only high-priority scrubs
    *
    * Specifically:
-   * a nullopt is returned if we are not allowed to scrub at all, for either of
+   * 'only high priority' flag is set for either of
    * the following reasons: no local resources (too many scrubs on this OSD);
    * a dice roll says we will not scrub in this tick;
    * a recovery is in progress, and we are not allowed to scrub while recovery;
    * a PG is trying to acquire replica resources.
-   *
-   * If we are allowed to scrub, the returned value specifies whether the only
-   * high priority scrubs or only overdue ones are allowed to go on.
    */
-  std::optional<Scrub::OSDRestrictions> restrictions_on_scrubbing(
+  Scrub::OSDRestrictions restrictions_on_scrubbing(
       bool is_recovery_active,
       utime_t scrub_clock_now) const;
 

--- a/src/osd/scrubber/osd_scrub.h
+++ b/src/osd/scrubber/osd_scrub.h
@@ -65,7 +65,8 @@ class OsdScrub {
   // ---------------------------------------------------------------
 
   // updating the resource counters
-  bool inc_scrubs_local();
+  std::unique_ptr<Scrub::LocalResourceWrapper> inc_scrubs_local(
+      bool is_high_priority);
   void dec_scrubs_local();
   bool inc_scrubs_remote(pg_t pgid);
   void dec_scrubs_remote(pg_t pgid);

--- a/src/osd/scrubber/osd_scrub.h
+++ b/src/osd/scrubber/osd_scrub.h
@@ -193,7 +193,7 @@ class OsdScrub {
    */
   Scrub::schedule_result_t initiate_a_scrub(
       spg_t pgid,
-      bool allow_requested_repair_only);
+      Scrub::OSDRestrictions restrictions);
 
   /// resource reservation management
   Scrub::ScrubResources m_resource_bookkeeper;

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -93,6 +93,8 @@ class ScrubJob final : public RefCountedObject {
 
   CephContext* cct;
 
+  bool high_priority{false};
+
   ScrubJob(CephContext* cct, const spg_t& pg, int node_id);
 
   utime_t get_sched_time() const { return schedule.scheduled_at; }
@@ -129,6 +131,12 @@ class ScrubJob final : public RefCountedObject {
    * and 'unregistering' is needed (both have in_queues() == true)
    */
   bool is_state_registered() const { return state == qu_state_t::registered; }
+
+  /**
+   * is this a high priority scrub job?
+   * High priority - (usually) a scrub that was initiated by the operator
+   */
+  bool is_high_priority() const { return high_priority; }
 
   /**
    * a text description of the "scheduling intentions" of this PG:

--- a/src/osd/scrubber/scrub_resources.cc
+++ b/src/osd/scrubber/scrub_resources.cc
@@ -13,6 +13,7 @@
 
 
 using ScrubResources = Scrub::ScrubResources;
+using LocalResourceWrapper = Scrub::LocalResourceWrapper;
 
 ScrubResources::ScrubResources(
     log_upwards_t log_access,
@@ -32,17 +33,18 @@ bool ScrubResources::can_inc_scrubs() const
   return can_inc_local_scrubs_unlocked();
 }
 
-bool ScrubResources::inc_scrubs_local()
+std::unique_ptr<LocalResourceWrapper> ScrubResources::inc_scrubs_local(
+    bool is_high_priority)
 {
   std::lock_guard lck{resource_lock};
-  if (can_inc_local_scrubs_unlocked()) {
+  if (is_high_priority || can_inc_local_scrubs_unlocked()) {
     ++scrubs_local;
     log_upwards(fmt::format(
 	"{}: {} -> {} (max {}, remote {})", __func__, (scrubs_local - 1),
 	scrubs_local, conf->osd_max_scrubs, granted_reservations.size()));
-    return true;
+    return std::make_unique<LocalResourceWrapper>(*this);
   }
-  return false;
+  return nullptr;
 }
 
 bool ScrubResources::can_inc_local_scrubs_unlocked() const
@@ -119,3 +121,16 @@ void ScrubResources::dump_scrub_reservations(ceph::Formatter* f) const
   f->dump_string("PGs being served", fmt::format("{}", granted_reservations));
   f->dump_int("osd_max_scrubs", conf->osd_max_scrubs);
 }
+
+// --------------- LocalResourceWrapper
+
+Scrub::LocalResourceWrapper::LocalResourceWrapper(
+    ScrubResources& resource_bookkeeper)
+    : m_resource_bookkeeper{resource_bookkeeper}
+{}
+
+Scrub::LocalResourceWrapper::~LocalResourceWrapper()
+{
+  m_resource_bookkeeper.dec_scrubs_local();
+}
+


### PR DESCRIPTION
A scrub can only be initiated if the number of active scrubs performed on the OSD when acting as a primary is below a certain configured limit. After this change - high priority scrubs are not blocked by this limit (although they are still counted towards it).
