### PR TITLE
rgw/multisite: error repo coroutines store raw_obj by value

### DIFF
--- a/src/rgw/driver/rados/rgw_sync_error_repo.cc
+++ b/src/rgw/driver/rados/rgw_sync_error_repo.cc
@@ -127,7 +127,7 @@ class RGWErrorRepoWriteCR : public RGWSimpleCoroutine {
   RGWErrorRepoWriteCR(librados::Rados* rados, const rgw_raw_obj& raw_obj,
                       const std::string& key, ceph::real_time timestamp)
     : RGWSimpleCoroutine(static_cast<CephContext*>(rados->cct())),
-      raw_obj(raw_obj),
+      rados(rados), raw_obj(raw_obj),
       key(key), timestamp(timestamp)
   {}
 
@@ -172,7 +172,7 @@ class RGWErrorRepoRemoveCR : public RGWSimpleCoroutine {
   RGWErrorRepoRemoveCR(librados::Rados* rados, const rgw_raw_obj& raw_obj,
                        const std::string& key, ceph::real_time timestamp)
     : RGWSimpleCoroutine(static_cast<CephContext*>(rados->cct())),
-      raw_obj(raw_obj),
+      rados(rados), raw_obj(raw_obj),
       key(key), timestamp(timestamp)
   {}
 

--- a/src/rgw/driver/rados/rgw_sync_error_repo.cc
+++ b/src/rgw/driver/rados/rgw_sync_error_repo.cc
@@ -118,7 +118,7 @@ int remove(librados::ObjectWriteOperation& op,
 
 class RGWErrorRepoWriteCR : public RGWSimpleCoroutine {
   librados::Rados* rados;
-  const rgw_raw_obj& raw_obj;
+  rgw_raw_obj raw_obj;
   std::string key;
   ceph::real_time timestamp;
 
@@ -163,7 +163,7 @@ RGWCoroutine* write_cr(librados::Rados* rados,
 
 class RGWErrorRepoRemoveCR : public RGWSimpleCoroutine {
   librados::Rados* rados;
-  const rgw_raw_obj& raw_obj;
+  rgw_raw_obj raw_obj;
   std::string key;
   ceph::real_time timestamp;
 


### PR DESCRIPTION
RGWErrorRepoWriteCR/RGWErrorRepoRemoveCR need to copy their rgw_raw_obj arguments to extend the lifetimes until send_request() is called

potential regression from https://github.com/ceph/ceph/pull/50359

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
