### PR TITLE
reef: add checking for rgw frontend init

### DIFF
--- a/src/rgw/rgw_lib.cc
+++ b/src/rgw/rgw_lib.cc
@@ -468,6 +468,7 @@ namespace rgw {
 
   int RGWLib::init(vector<const char*>& args)
   {
+    int r{0};
     /* alternative default for module */
     map<std::string,std::string> defaults = {
       { "debug_rgw", "1/5" },
@@ -524,7 +525,13 @@ namespace rgw {
     register_async_signal_handler(SIGUSR1, rgw::signal::handle_sigterm);
 
     main.init_tracepoints();
-    main.init_frontends2(this /* rgwlib */);
+    r = main.init_frontends2(this /* rgwlib */);
+    if (r != 0) {
+      derr << "ERROR: unable to initialize frontend, r = " << r << dendl;
+      main.shutdown();
+      return r;
+    }
+
     main.init_notification_endpoints();
     main.init_lua();
 

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -157,7 +157,12 @@ int main(int argc, char *argv[])
   main.init_opslog();
   main.init_tracepoints();
   main.init_lua();
-  main.init_frontends2(nullptr /* RGWLib */);
+  r = main.init_frontends2(nullptr /* RGWLib */);
+  if (r != 0) {
+    derr << "ERROR:  initialize frontend fail, r = " << r << dendl;
+    main.shutdown();
+    return r;
+  }
   main.init_notification_endpoints();
 
 #if defined(HAVE_SYS_PRCTL_H)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63775

---

backport of https://github.com/ceph/ceph/pull/54668
parent tracker: https://tracker.ceph.com/issues/63644

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh