### PR TITLE
quincy: rgw: d3n: fix valgrind reported leak related to libaio worker threads

### DIFF
--- a/src/rgw/rgw_d3n_datacache.cc
+++ b/src/rgw/rgw_d3n_datacache.cc
@@ -102,7 +102,7 @@ void D3nDataCache::init(CephContext *_cct) {
   struct aioinit ainit{0};
   ainit.aio_threads = cct->_conf.get_val<int64_t>("rgw_d3n_libaio_aio_threads");
   ainit.aio_num = cct->_conf.get_val<int64_t>("rgw_d3n_libaio_aio_num");
-  ainit.aio_idle_time = 120;
+  ainit.aio_idle_time = 5;
   aio_init(&ainit);
 #endif
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63752

---

backport of https://github.com/ceph/ceph/pull/54810
parent tracker: https://tracker.ceph.com/issues/63445

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh