### PR TITLE
pacific: test/librbd: avoid config-related crashes in DiscardWithPruneWriteOverlap

### DIFF
--- a/src/test/librbd/journal/test_Stress.cc
+++ b/src/test/librbd/journal/test_Stress.cc
@@ -86,7 +86,7 @@ TEST_F(TestJournalStress, DiscardWithPruneWriteOverlap) {
           bufferlist payload_bl;
           payload_bl.append(payload);
           auto aio_comp = new librbd::io::AioCompletion();
-          api::Io<>::aio_write(*ictx, aio_comp, 0, payload.size(),
+          api::Io<>::aio_write(*ictx, aio_comp, offset, payload.size(),
                                std::move(payload_bl), 0, true);
           ASSERT_EQ(0, aio_comp->wait_for_complete());
           aio_comp->release();


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/54847 to pacific.  This is a follow-up for https://github.com/ceph/ceph/pull/54820, see https://github.com/ceph/ceph/pull/54377#issuecomment-1848677674 for details.

For quincy and reef, https://github.com/ceph/ceph/pull/54847 would be appended to respective backports of https://github.com/ceph/ceph/pull/54377 which are still outstanding.

cc @baergj