### PR TITLE
osd/PeeringState: set DELETING state and send to MPGStats

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2494,6 +2494,10 @@ void PGMap::get_health_checks(
       const auto &pg_id = i.first;
       const auto &pg_info = i.second;
 
+      // skip pg of deleting state, avoid health warn caused by deleting pg
+      if (pg_info.state == PG_STATE_DELETING)
+        continue;
+
       for (const auto &j : state_to_response) {
         const auto &pg_response_state = j.first;
         const auto &pg_response = j.second;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -480,6 +480,15 @@ public:
   void clear_sent_ready_to_merge();
   void prune_sent_ready_to_merge(const OSDMapRef& osdmap);
 
+  // -- pg deleting --
+  ceph::mutex pg_delete = ceph::make_mutex("OSDService::pg_delete");
+  std::map<pg_t, pg_stat_t> osd_deleting_pgs;
+  std::map<pg_t, pg_stat_t> osd_deleted_pgs;
+  std::map<pg_t, pg_stat_t>& get_osd_deleting_pgs() { return osd_deleting_pgs; }
+  std::map<pg_t, pg_stat_t>& get_osd_deleted_pgs() { return osd_deleted_pgs; }
+  void update_deleting_pgs(const pg_t pgid);
+  void update_deleted_pgs(const pg_t pgid);
+
   // -- pg_temp --
 private:
   ceph::mutex pg_temp_lock = ceph::make_mutex("OSDService::pg_temp_lock");

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2395,6 +2395,9 @@ std::pair<ghobject_t, bool> PG::do_delete_work(
     ++num;
   }
   bool running = true;
+
+  osd->update_deleting_pgs(pg_id.pgid);
+
   if (num) {
     dout(20) << __func__ << " deleting " << num << " objects" << dendl;
     Context *fin = new C_DeleteMore(this, get_osdmap_epoch(), num);
@@ -2425,6 +2428,7 @@ std::pair<ghobject_t, bool> PG::do_delete_work(
       init_pg_ondisk(t, info.pgid, &pool.info);
       recovery_state.reset_last_persisted();
     } else {
+      osd->update_deleted_pgs(pg_id.pgid);
       recovery_state.set_delete_complete();
 
       // cancel reserver here, since the PG is about to get deleted and the

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1185,6 +1185,10 @@ std::string pg_state_string(uint64_t state)
     *css << "laggy+";
   if (state & PG_STATE_WAIT)
     *css << "wait+";
+  if (state & PG_STATE_DELETING)
+    *css << "deleting+";
+  if (state & PG_STATE_DELETED)
+    *css << "deleted+";
   auto ret = css->str();
   if (ret.length() > 0)
     ret.resize(ret.length() - 1);
@@ -1262,6 +1266,10 @@ std::optional<uint64_t> pg_string_state(const std::string& state)
     type = PG_STATE_LAGGY;
   else if (state == "wait")
     type = PG_STATE_WAIT;
+  else if (state == "deleting")
+    type = PG_STATE_DELETING;
+  else if (state == "deleted")
+    type = PG_STATE_DELETED;
   else if (state == "unknown")
     type = 0;
   else

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1041,6 +1041,8 @@ WRITE_CLASS_ENCODER_FEATURES(objectstore_perf_stat_t)
 #define PG_STATE_FAILED_REPAIR      (1ULL << 32) // A repair failed to fix all errors
 #define PG_STATE_LAGGY              (1ULL << 33) // PG is laggy/unreabable due to slow/delayed pings
 #define PG_STATE_WAIT               (1ULL << 34) // PG is waiting for prior intervals' readable period to expire
+#define PG_STATE_DELETING           (1ULL << 35) // pg is deleting
+#define PG_STATE_DELETED            (1ULL << 36) // pg is deleted
 
 std::string pg_state_string(uint64_t state);
 std::string pg_vector_string(const std::vector<int32_t> &a);


### PR DESCRIPTION
When deleting a pool containing a large amount of data, OSD incurs
significant overhead and lasts for a long time. The pg deleting status
can easily let us know what osd is doing.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
