### PR TITLE
mgr/rgwam: period doesn't have a realm_name anymore

### DIFF
--- a/src/python-common/ceph/rgw/types.py
+++ b/src/python-common/ceph/rgw/types.py
@@ -117,7 +117,6 @@ class RGWPeriod(JSONObj):
         self.epoch = period_dict['epoch']
         self.master_zone = period_dict['master_zone']
         self.master_zonegroup = period_dict['master_zonegroup']
-        self.realm_name = period_dict['realm_name']
         self.realm_id = period_dict['realm_id']
         pm = period_dict['period_map']
         self.zonegroups_by_id = {}


### PR DESCRIPTION
the `ceph rgw realm bootstrap` command fails to parse the period output after https://github.com/ceph/ceph/pull/54264 removed the `realm_name` field:
```
debug 2023-12-08T01:00:40.065+0000 7f7678af4700 -1 mgr handle_command module 'rgw' command handler threw exception: 'realm_name'
debug 2023-12-08T01:00:40.065+0000 7f7678af4700 -1 mgr.server reply reply (22) Invalid argument Traceback (most recent call last):
  File "/usr/share/ceph/mgr/mgr_module.py", line 1801, in _handle_command
    return CLICommand.COMMANDS[cmd['prefix']].call(self, cmd, inbuf)
  File "/usr/share/ceph/mgr/mgr_module.py", line 474, in call
    return self.func(mgr, **kwargs)
  File "/usr/share/ceph/mgr/rgw/module.py", line 96, in wrapper
    return func(self, *args, **kwargs)
  File "/usr/share/ceph/mgr/rgw/module.py", line 189, in _cmd_rgw_realm_bootstrap
    RGWAM(self.env).realm_bootstrap(spec, start_radosgw)
  File "/lib/python3.6/site-packages/ceph/rgw/rgwam_core.py", line 537, in realm_bootstrap
    self.update_period(realm, zonegroup)
  File "/lib/python3.6/site-packages/ceph/rgw/rgwam_core.py", line 514, in update_period
    period = RGWPeriod(period_info)
  File "/lib/python3.6/site-packages/ceph/rgw/types.py", line 120, in __init__
    self.realm_name = period_dict['realm_name']
KeyError: 'realm_name'
```
nothing else in this manager module seems to need the period's realm name, so stop trying to parse it

Fixes: https://tracker.ceph.com/issues/63783

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
