### PR TITLE
reef: [rgw][lc][rgw_lifecycle_work_time] adjust timing if the configured end time is less than the start time

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -359,7 +359,11 @@ options:
   type: str
   level: advanced
   desc: Lifecycle allowed work time
-  long_desc: Local time window in which the lifecycle maintenance thread can work.
+  long_desc: Local time window in which the lifecycle maintenance thread can work. It expects
+    24-hour time notation. For example, "00:00-23:59" means starting at midnight lifecycle
+    is allowed to run for the whole day (24 hours). When lifecycle completes, it waits for the
+    next maintenance window. In this example, if it completes at 01:00, it will resume processing
+    23 hours later at the following midnight.
   default: 00:00-06:00
   services:
   - rgw

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2347,6 +2347,12 @@ bool RGWLC::LCWorker::should_work(utime_t& now)
   time_t tt = now.sec();
   localtime_r(&tt, &bdt);
 
+  // next-day adjustment if the configured end_hour is less than start_hour
+  if (end_hour < start_hour) {
+    bdt.tm_hour = bdt.tm_hour > end_hour ? bdt.tm_hour : bdt.tm_hour + hours_in_a_day;
+    end_hour += hours_in_a_day;
+  }
+
   if (cct->_conf->rgw_lc_debug_interval > 0) {
 	  /* We're debugging, so say we can run */
 	  return true;

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -41,6 +41,9 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
+constexpr int32_t hours_in_a_day = 24;
+constexpr int32_t secs_in_a_day = hours_in_a_day * 60 * 60;
+
 using namespace std;
 
 const char* LC_STATUS[] = {
@@ -289,7 +292,7 @@ static bool obj_has_expired(const DoutPrefixProvider *dpp, CephContext *cct, cep
   utime_t base_time;
   if (cct->_conf->rgw_lc_debug_interval <= 0) {
     /* Normal case, run properly */
-    cmp = double(days)*24*60*60;
+    cmp = double(days) * secs_in_a_day;
     base_time = ceph_clock_now().round_to_day();
   } else {
     /* We're in debug mode; Treat each rgw_lc_debug_interval seconds as a day */
@@ -1874,8 +1877,7 @@ bool RGWLC::expired_session(time_t started)
   }
 
   time_t interval = (cct->_conf->rgw_lc_debug_interval > 0)
-    ? cct->_conf->rgw_lc_debug_interval
-    : 24*60*60;
+    ? cct->_conf->rgw_lc_debug_interval : secs_in_a_day;
 
   auto now = time(nullptr);
 
@@ -1891,8 +1893,7 @@ bool RGWLC::expired_session(time_t started)
 time_t RGWLC::thread_stop_at()
 {
   uint64_t interval = (cct->_conf->rgw_lc_debug_interval > 0)
-    ? cct->_conf->rgw_lc_debug_interval
-    : 24*60*60;
+    ? cct->_conf->rgw_lc_debug_interval : secs_in_a_day;
 
   return time(nullptr) + interval;
 }
@@ -1983,7 +1984,7 @@ static inline bool allow_shard_rollover(CephContext* cct, time_t now, time_t sha
    *    - the current shard has not rolled over in the last 24 hours
    */
   if (((shard_rollover_date < now) &&
-       (now - shard_rollover_date > 24*60*60)) ||
+       (now - shard_rollover_date > secs_in_a_day)) ||
       (! shard_rollover_date /* no rollover date stored */) ||
       (cct->_conf->rgw_lc_debug_interval > 0 /* defaults to -1 == disabled */)) {
     return true;
@@ -2009,7 +2010,7 @@ static inline bool already_run_today(CephContext* cct, time_t start_date)
   bdt.tm_min = 0;
   bdt.tm_sec = 0;
   begin_of_day = mktime(&bdt);
-  if (now - begin_of_day < 24*60*60)
+  if (now - begin_of_day < secs_in_a_day)
     return true;
   else
     return false;
@@ -2386,7 +2387,7 @@ int RGWLC::LCWorker::schedule_next_start_time(utime_t &start, utime_t& now)
   nt = mktime(&bdt);
   secs = nt - tt;
 
-  return secs>0 ? secs : secs+24*60*60;
+  return secs > 0 ? secs : secs + secs_in_a_day;
 }
 
 RGWLC::LCWorker::~LCWorker()
@@ -2677,7 +2678,7 @@ std::string s3_expiration_header(
       if (rule_expiration.has_days()) {
 	rule_expiration_date =
 	  boost::optional<ceph::real_time>(
-	    mtime + make_timespan(double(rule_expiration.get_days())*24*60*60 - ceph::real_clock::to_time_t(mtime)%(24*60*60) + 24*60*60));
+	    mtime + make_timespan(double(rule_expiration.get_days()) * secs_in_a_day - ceph::real_clock::to_time_t(mtime)%(secs_in_a_day) + secs_in_a_day));
       }
     }
 
@@ -2756,7 +2757,7 @@ bool s3_multipart_abort_header(
     std::optional<ceph::real_time> rule_abort_date;
     if (mp_expiration.has_days()) {
       rule_abort_date = std::optional<ceph::real_time>(
-              mtime + make_timespan(mp_expiration.get_days()*24*60*60 - ceph::real_clock::to_time_t(mtime)%(24*60*60) + 24*60*60));
+              mtime + make_timespan(mp_expiration.get_days() * secs_in_a_day - ceph::real_clock::to_time_t(mtime)%(secs_in_a_day) + secs_in_a_day));
     }
 
     // update earliest abort date

--- a/src/test/rgw/test_rgw_lc.cc
+++ b/src/test/rgw/test_rgw_lc.cc
@@ -106,3 +106,238 @@ TEST(TestLCFilterInvalidAnd, XMLDoc3)
   /* check our flags */
   ASSERT_EQ(filter.get_flags(), uint32_t(LCFlagType::none));
 }
+
+struct LCWorkTimeTests : ::testing::Test
+{
+   CephContext* cct;
+   std::unique_ptr<RGWLC::LCWorker> worker;
+
+   // expects input in the form of "%m/%d/%y %H:%M:%S"; e.g., "01/15/23 23:59:01"
+   utime_t get_utime_by_date_time_string(const std::string& date_time_str)
+   {
+      struct tm tm{};
+      struct timespec ts = {0};
+
+      strptime(date_time_str.c_str(), "%m/%d/%y %H:%M:%S", &tm);
+      ts.tv_sec = mktime(&tm);
+
+      return utime_t(ts);
+   }
+
+   // expects a map from input value (date & time string) to expected result (boolean)
+   void run_should_work_test(const auto& test_values_to_expectations_map) {
+      for (const auto& [date_time_str, expected_value] : test_values_to_expectations_map) {
+         auto ut = get_utime_by_date_time_string(date_time_str);
+         auto should_work = worker->should_work(ut);
+
+         ASSERT_EQ(should_work, expected_value)
+            << "input time: " << ut
+            << " expected: " << expected_value
+            << " should_work: " << should_work
+            << " work-time-window: " << cct->_conf->rgw_lifecycle_work_time << std::endl;
+      }
+   }
+
+   // expects a map from input value (a tuple of date & time strings) to expected result (seconds)
+   void run_schedule_next_start_time_test(const auto& test_values_to_expectations_map) {
+      for (const auto& [date_time_str_tuple, expected_value] : test_values_to_expectations_map) {
+         auto work_started_at = get_utime_by_date_time_string(std::get<0>(date_time_str_tuple));
+         auto work_completed_at = get_utime_by_date_time_string(std::get<1>(date_time_str_tuple));
+         auto wait_secs_till_next_start = worker->schedule_next_start_time(work_started_at, work_completed_at);
+
+         ASSERT_EQ(wait_secs_till_next_start, expected_value)
+            << "work_started_at: " << work_started_at
+            << " work_completed_at: " << work_completed_at
+            << " expected: " << expected_value
+            << " wait_secs_till_next_start: " << wait_secs_till_next_start
+            << " work-time-window: " << cct->_conf->rgw_lifecycle_work_time << std::endl;
+      }
+   }
+
+protected:
+
+   void SetUp() override {
+      cct = (new CephContext(CEPH_ENTITY_TYPE_ANY))->get();
+
+      cct->_conf->set_value("rgw_lc_max_wp_worker", 0, 0); // no need to create a real workpool
+      worker = std::make_unique<RGWLC::LCWorker>(nullptr, cct, nullptr, 0);
+   }
+
+   void TearDown() override {
+      worker.reset();
+      cct->put();
+   }
+};
+
+TEST_F(LCWorkTimeTests, ShouldWorkDefaultWorkTime)
+{
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 00:00:00", true},
+      {"01/01/24 00:00:00", true}, // date is not relevant, but only the time-window
+      {"01/01/23 00:00:01", true},
+      {"01/01/23 03:00:00", true},
+      {"01/01/23 05:59:59", true},
+      {"01/01/23 06:00:00", true},
+      {"01/01/23 06:00:59", true}, // seconds don't matter, but only hours and minutes
+      {"01/01/23 06:01:00", false},
+      {"01/01/23 23:59:59", false},
+      {"01/02/23 23:59:59", false},
+      {"01/01/23 12:00:00", false},
+      {"01/01/23 14:00:00", false}
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheSameDay)
+{
+   cct->_conf->rgw_lifecycle_work_time = "14:00-16:00";
+
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 00:00:00", false},
+      {"01/01/23 12:00:00", false},
+      {"01/01/24 13:59:59", false},
+      {"01/01/23 14:00:00", true},
+      {"01/01/23 16:00:00", true},
+      {"01/01/23 16:00:59", true},
+      {"01/01/23 16:01:00", false},
+      {"01/01/23 17:00:00", false},
+      {"01/01/23 23:59:59", false},
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheSameDay24Hours)
+{
+   cct->_conf->rgw_lifecycle_work_time = "00:00-23:59";
+
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 23:59:00", true},
+      {"01/01/23 23:59:59", true},
+      {"01/01/23 00:00:00", true},
+      {"01/01/23 00:00:01", true},
+      {"01/01/23 00:01:00", true},
+      {"01/01/23 01:00:00", true},
+      {"01/01/23 12:00:00", true},
+      {"01/01/23 17:00:00", true},
+      {"01/01/23 23:00:00", true}
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+
+TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheNextDay)
+{
+   cct->_conf->rgw_lifecycle_work_time = "14:00-01:00";
+
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 13:59:00", false},
+      {"01/01/23 13:59:59", false},
+      {"01/01/24 14:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 17:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 23:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 00:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 00:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 01:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 01:00:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 01:01:00", false},
+      {"01/01/23 05:00:00", false},
+      {"01/01/23 12:00:00", false},
+      {"01/01/23 13:00:00", false}
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheNextDay24Hours)
+{
+   cct->_conf->rgw_lifecycle_work_time = "14:00-13:59";
+
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 00:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 00:00:01", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 00:01:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 01:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 12:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 13:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 13:59:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 13:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 14:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 14:00:01", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 14:01:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 16:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 23:59:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 23:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheNextDayIrregularMins)
+{
+   cct->_conf->rgw_lifecycle_work_time = "22:15-03:33";
+
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 22:14:59", false},
+      {"01/01/23 22:15:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 00:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 01:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 02:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 03:33:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 03:33:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 03:34:00", false},
+      {"01/01/23 04:00:00", false},
+      {"01/01/23 12:00:00", false},
+      {"01/01/23 22:00:00", false},
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeStartEndSameHour)
+{
+   cct->_conf->rgw_lifecycle_work_time = "22:15-22:45";
+
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 22:14:59", false},
+      {"01/01/23 22:15:00", true},
+      {"01/01/24 22:44:59", true},
+      {"01/01/24 22:45:59", true},
+      {"01/01/24 22:46:00", false},
+      {"01/01/23 23:00:00", false},
+      {"01/01/23 00:00:00", false},
+      {"01/01/23 12:00:00", false},
+      {"01/01/23 21:00:00", false},
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+TEST_F(LCWorkTimeTests, ScheduleNextStartTime)
+{
+   cct->_conf->rgw_lifecycle_work_time = "22:15-03:33";
+
+   // items of the map: [ (work_started_time, work_completed_time), expected_value (seconds) ]
+   //
+   // expected_value is the difference between configured start time (i.e, 22:15:00) and
+   // the second item of the tuple (i.e., work_completed_time).
+   //
+   // Note that "seconds" of work completion time is taken into account but date is not relevant.
+   // e.g., the first testcase: 75713 == 01:13:07 - 22:15:00 (https://tinyurl.com/ydm86752)
+   std::map<std::tuple<std::string, std::string>, int> test_values_to_expectations = {
+      {{"01/01/23 22:15:05", "01/01/23 01:13:07"}, 75713},
+      {{"01/01/23 22:15:05", "01/02/23 01:13:07"}, 75713},
+      {{"01/01/23 22:15:05", "01/01/23 22:17:07"}, 86273},
+      {{"01/01/23 22:15:05", "01/02/23 22:17:07"}, 86273},
+      {{"01/01/23 22:15:05", "01/01/23 22:14:00"}, 60},
+      {{"01/01/23 22:15:05", "01/02/23 22:14:00"}, 60},
+      {{"01/01/23 22:15:05", "01/01/23 22:15:00"}, 24 * 60 * 60},
+      {{"01/01/23 22:15:05", "01/02/23 22:15:00"}, 24 * 60 * 60},
+      {{"01/01/23 22:15:05", "01/01/23 22:15:01"}, 24 * 60 * 60 - 1},
+      {{"01/01/23 22:15:05", "01/02/23 22:15:01"}, 24 * 60 * 60 - 1},
+   };
+
+   run_schedule_next_start_time_test(test_values_to_expectations);
+}

--- a/src/test/rgw/test_rgw_lc.cc
+++ b/src/test/rgw/test_rgw_lc.cc
@@ -5,7 +5,6 @@
 #include "rgw_lc.h"
 #include "rgw_lc_s3.h"
 #include <gtest/gtest.h>
-//#include <spawn/spawn.hpp>
 #include <string>
 #include <vector>
 #include <stdexcept>

--- a/src/test/rgw/test_rgw_lc.cc
+++ b/src/test/rgw/test_rgw_lc.cc
@@ -235,13 +235,13 @@ TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheNextDay)
    std::unordered_map<std::string, bool> test_values_to_expectations = {
       {"01/01/23 13:59:00", false},
       {"01/01/23 13:59:59", false},
-      {"01/01/24 14:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 17:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 23:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 00:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 00:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 01:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 01:00:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 14:00:00", true}, // used-to-fail
+      {"01/01/24 17:00:00", true}, // used-to-fail
+      {"01/01/24 23:59:59", true}, // used-to-fail
+      {"01/01/23 00:00:00", true}, // used-to-fail
+      {"01/01/23 00:59:59", true}, // used-to-fail
+      {"01/01/23 01:00:00", true}, // used-to-fail
+      {"01/01/23 01:00:59", true}, // used-to-fail
       {"01/01/23 01:01:00", false},
       {"01/01/23 05:00:00", false},
       {"01/01/23 12:00:00", false},
@@ -255,21 +255,22 @@ TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheNextDay24Hours)
 {
    cct->_conf->rgw_lifecycle_work_time = "14:00-13:59";
 
+   // all of the below cases used-to-fail
    std::unordered_map<std::string, bool> test_values_to_expectations = {
-      {"01/01/23 00:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 00:00:01", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 00:01:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 01:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 12:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 13:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 13:59:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 13:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 14:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 14:00:01", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 14:01:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 16:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 23:59:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 23:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 00:00:00", true},
+      {"01/01/23 00:00:01", true},
+      {"01/01/23 00:01:00", true},
+      {"01/01/24 01:00:00", true},
+      {"01/01/24 12:00:00", true},
+      {"01/01/24 13:00:00", true},
+      {"01/01/24 13:59:00", true},
+      {"01/01/24 13:59:59", true},
+      {"01/01/23 14:00:00", true},
+      {"01/01/23 14:00:01", true},
+      {"01/01/23 14:01:00", true},
+      {"01/01/23 16:00:00", true},
+      {"01/01/23 23:59:00", true},
+      {"01/01/23 23:59:59", true},
    };
 
    run_should_work_test(test_values_to_expectations);
@@ -281,12 +282,12 @@ TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheNextDayIrregularMins
 
    std::unordered_map<std::string, bool> test_values_to_expectations = {
       {"01/01/23 22:14:59", false},
-      {"01/01/23 22:15:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 00:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 01:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 02:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 03:33:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 03:33:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 22:15:00", true}, // used-to-fail
+      {"01/01/24 00:00:00", true}, // used-to-fail
+      {"01/01/24 01:00:00", true}, // used-to-fail
+      {"01/01/24 02:00:00", true}, // used-to-fail
+      {"01/01/23 03:33:00", true}, // used-to-fail
+      {"01/01/23 03:33:59", true}, // used-to-fail
       {"01/01/23 03:34:00", false},
       {"01/01/23 04:00:00", false},
       {"01/01/23 12:00:00", false},


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63777

---

backport of https://github.com/ceph/ceph/pull/54622
parent tracker: https://tracker.ceph.com/issues/63613

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh