### PR TITLE
quincy: [rgw][lc][rgw_lifecycle_work_time] adjust timing if the configured end time is less than the start time

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -349,7 +349,11 @@ options:
   type: str
   level: advanced
   desc: Lifecycle allowed work time
-  long_desc: Local time window in which the lifecycle maintenance thread can work.
+  long_desc: Local time window in which the lifecycle maintenance thread can work. It expects
+    24-hour time notation. For example, "00:00-23:59" means starting at midnight lifecycle
+    is allowed to run for the whole day (24 hours). When lifecycle completes, it waits for the
+    next maintenance window. In this example, if it completes at 01:00, it will resume processing
+    23 hours later at the following midnight.
   default: 00:00-06:00
   services:
   - rgw

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2604,7 +2604,10 @@ public:
     RGWSI_BucketIndex *bi{nullptr};
   } svc;
 
-  RGWBucketInstanceMetadataHandler() {}
+  rgw::sal::Store* store;
+
+  RGWBucketInstanceMetadataHandler(rgw::sal::Store* store)
+    : store(store) {}
 
   void init(RGWSI_Zone *zone_svc,
 	    RGWSI_Bucket *bucket_svc,
@@ -2839,12 +2842,51 @@ int RGWMetadataHandlerPut_BucketInstance::put_post(const DoutPrefixProvider *dpp
     return ret;
   }
 
+  /* update lifecyle policy */
+  {
+    std::unique_ptr<rgw::sal::Bucket> bucket;
+    ret = bihandler->store->get_bucket(nullptr, bci.info, &bucket);
+    if (ret < 0) {
+      ldpp_dout(dpp, 0) << __func__ << " failed to get_bucket(...) for "
+			<< bci.info.bucket.name
+			<< dendl;
+      return ret;
+    }
+
+    auto lc = bihandler->store->get_rgwlc();
+
+    auto lc_it = bci.attrs.find(RGW_ATTR_LC);
+    if (lc_it != bci.attrs.end()) {
+      ldpp_dout(dpp, 20) << "set lc config for " << bci.info.bucket.name << dendl;
+      ret = lc->set_bucket_config(bucket.get(), bci.attrs, nullptr);
+      if (ret < 0) {
+	      ldpp_dout(dpp, 0) << __func__ << " failed to set lc config for "
+			<< bci.info.bucket.name
+			<< dendl;
+	      return ret;
+      }
+
+    } else {
+      ldpp_dout(dpp, 20) << "remove lc config for " << bci.info.bucket.name << dendl;
+      ret = lc->remove_bucket_config(bucket.get(), bci.attrs);
+      if (ret < 0) {
+	      ldpp_dout(dpp, 0) << __func__ << " failed to remove lc config for "
+			<< bci.info.bucket.name
+			<< dendl;
+	      return ret;
+      }
+    }
+  } /* update lc */
+
   return STATUS_APPLIED;
 }
 
 class RGWArchiveBucketInstanceMetadataHandler : public RGWBucketInstanceMetadataHandler {
 public:
-  RGWArchiveBucketInstanceMetadataHandler() {}
+  RGWArchiveBucketInstanceMetadataHandler(rgw::sal::Store* store)
+    : RGWBucketInstanceMetadataHandler(store) {}
+
+  // N.B. replication of lifecycle policy relies on logic in RGWBucketInstanceMetadataHandler::do_put(...), override with caution
 
   int do_remove(RGWSI_MetaBackend_Handler::Op *op, string& entry, RGWObjVersionTracker& objv_tracker, optional_yield y, const DoutPrefixProvider *dpp) override {
     ldpp_dout(dpp, 0) << "SKIP: bucket instance removal is not allowed on archive zone: bucket.instance:" << entry << dendl;
@@ -3404,24 +3446,24 @@ int RGWBucketCtl::bucket_imports_data(const rgw_bucket& bucket,
   return handler->bucket_imports_data();
 }
 
-RGWBucketMetadataHandlerBase *RGWBucketMetaHandlerAllocator::alloc()
+RGWBucketMetadataHandlerBase* RGWBucketMetaHandlerAllocator::alloc()
 {
   return new RGWBucketMetadataHandler();
 }
 
-RGWBucketInstanceMetadataHandlerBase *RGWBucketInstanceMetaHandlerAllocator::alloc()
+RGWBucketInstanceMetadataHandlerBase* RGWBucketInstanceMetaHandlerAllocator::alloc(rgw::sal::Store* store)
 {
-  return new RGWBucketInstanceMetadataHandler();
+  return new RGWBucketInstanceMetadataHandler(store);
 }
 
-RGWBucketMetadataHandlerBase *RGWArchiveBucketMetaHandlerAllocator::alloc()
+RGWBucketMetadataHandlerBase* RGWArchiveBucketMetaHandlerAllocator::alloc()
 {
   return new RGWArchiveBucketMetadataHandler();
 }
 
-RGWBucketInstanceMetadataHandlerBase *RGWArchiveBucketInstanceMetaHandlerAllocator::alloc()
+RGWBucketInstanceMetadataHandlerBase* RGWArchiveBucketInstanceMetaHandlerAllocator::alloc(rgw::sal::Store* store)
 {
-  return new RGWArchiveBucketInstanceMetadataHandler();
+  return new RGWArchiveBucketInstanceMetadataHandler(store);
 }
 
 

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -216,7 +216,7 @@ public:
 
 class RGWBucketInstanceMetaHandlerAllocator {
 public:
-  static RGWBucketInstanceMetadataHandlerBase *alloc();
+  static RGWBucketInstanceMetadataHandlerBase *alloc(rgw::sal::Store* store);
 };
 
 class RGWArchiveBucketMetaHandlerAllocator {
@@ -226,7 +226,7 @@ public:
 
 class RGWArchiveBucketInstanceMetaHandlerAllocator {
 public:
-  static RGWBucketInstanceMetadataHandlerBase *alloc();
+  static RGWBucketInstanceMetadataHandlerBase *alloc(rgw::sal::Store* store);
 };
 
 extern int rgw_remove_object(const DoutPrefixProvider *dpp, rgw::sal::Store* store, rgw::sal::Bucket* bucket, rgw_obj_key& key);

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -469,7 +469,7 @@ class RGWInitDataSyncStatusCoroutine : public RGWCoroutine {
   static constexpr uint32_t lock_duration = 30;
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
-  rgw::sal::RadosStore* store;
+  rgw::sal::RadosStore* store; // RGWDataSyncEnv also has a pointer to store
   const rgw_pool& pool;
   const uint32_t num_shards;
 
@@ -2490,8 +2490,8 @@ public:
   RGWMetadataHandler *alloc_bucket_meta_handler() override {
     return RGWArchiveBucketMetaHandlerAllocator::alloc();
   }
-  RGWBucketInstanceMetadataHandlerBase *alloc_bucket_instance_meta_handler() override {
-    return RGWArchiveBucketInstanceMetaHandlerAllocator::alloc();
+  RGWBucketInstanceMetadataHandlerBase *alloc_bucket_instance_meta_handler(rgw::sal::Store* store) override {
+    return RGWArchiveBucketInstanceMetaHandlerAllocator::alloc(store);
   }
 };
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -56,31 +56,6 @@ const char* LC_STATUS[] = {
 
 using namespace librados;
 
-static inline std::string_view sv_trim(std::string_view str) {
-  while (isspace(str.front())) {
-    str.remove_prefix(1);
-  }
-  while (isspace(str.back())) {
-    str.remove_suffix(1);
-  }
-  return str;
-}
-
-uint32_t LCFilter::recognize_flags(const std::string& flag_expr)
-{
-  uint32_t flags = 0;
-  ceph::split sp_flags(flag_expr); // default separators are ,;=\t\n
-  for (auto it = sp_flags.begin(); it != sp_flags.end(); ++it) {
-    auto token = sv_trim(string_view{*it});
-    for (auto& flag_tok : LCFilter::filter_flags) {
-      if (token == flag_tok.name) {
-	flags |= LCFilter::make_flag(flag_tok.bit);
-      }
-    }
-  }
-  return flags;
-}
-
 bool LCRule::valid() const
 {
   if (id.length() > MAX_ID_LEN) {

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -16,6 +16,7 @@
 #include "include/scope_guard.h"
 #include "common/Formatter.h"
 #include "common/containers.h"
+#include "common/split.h"
 #include <common/errno.h>
 #include "include/random.h"
 #include "cls/lock/cls_lock_client.h"
@@ -54,6 +55,31 @@ const char* LC_STATUS[] = {
 };
 
 using namespace librados;
+
+static inline std::string_view sv_trim(std::string_view str) {
+  while (isspace(str.front())) {
+    str.remove_prefix(1);
+  }
+  while (isspace(str.back())) {
+    str.remove_suffix(1);
+  }
+  return str;
+}
+
+uint32_t LCFilter::recognize_flags(const std::string& flag_expr)
+{
+  uint32_t flags = 0;
+  ceph::split sp_flags(flag_expr); // default separators are ,;=\t\n
+  for (auto it = sp_flags.begin(); it != sp_flags.end(); ++it) {
+    auto token = sv_trim(string_view{*it});
+    for (auto& flag_tok : LCFilter::filter_flags) {
+      if (token == flag_tok.name) {
+	flags |= LCFilter::make_flag(flag_tok.bit);
+      }
+    }
+  }
+  return flags;
+}
 
 bool LCRule::valid() const
 {

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -45,6 +45,9 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
+constexpr int32_t hours_in_a_day = 24;
+constexpr int32_t secs_in_a_day = hours_in_a_day * 60 * 60;
+
 using namespace std;
 
 const char* LC_STATUS[] = {
@@ -351,7 +354,7 @@ static bool obj_has_expired(const DoutPrefixProvider *dpp, CephContext *cct, cep
   utime_t base_time;
   if (cct->_conf->rgw_lc_debug_interval <= 0) {
     /* Normal case, run properly */
-    cmp = double(days)*24*60*60;
+    cmp = double(days) * secs_in_a_day;
     base_time = ceph_clock_now().round_to_day();
   } else {
     /* We're in debug mode; Treat each rgw_lc_debug_interval seconds as a day */
@@ -2035,8 +2038,7 @@ int RGWLC::process(LCWorker* worker,
 bool RGWLC::expired_session(time_t started)
 {
   time_t interval = (cct->_conf->rgw_lc_debug_interval > 0)
-    ? cct->_conf->rgw_lc_debug_interval
-    : 24*60*60;
+    ? cct->_conf->rgw_lc_debug_interval : secs_in_a_day;
 
   auto now = time(nullptr);
 
@@ -2052,8 +2054,7 @@ bool RGWLC::expired_session(time_t started)
 time_t RGWLC::thread_stop_at()
 {
   uint64_t interval = (cct->_conf->rgw_lc_debug_interval > 0)
-    ? cct->_conf->rgw_lc_debug_interval
-    : 24*60*60;
+    ? cct->_conf->rgw_lc_debug_interval : secs_in_a_day;
 
   return time(nullptr) + interval;
 }
@@ -2353,7 +2354,7 @@ int RGWLC::LCWorker::schedule_next_start_time(utime_t &start, utime_t& now)
   nt = mktime(&bdt);
   secs = nt - tt;
 
-  return secs>0 ? secs : secs+24*60*60;
+  return secs > 0 ? secs : secs + secs_in_a_day;
 }
 
 RGWLC::LCWorker::~LCWorker()
@@ -2639,7 +2640,7 @@ std::string s3_expiration_header(
       if (rule_expiration.has_days()) {
 	rule_expiration_date =
 	  boost::optional<ceph::real_time>(
-	    mtime + make_timespan(double(rule_expiration.get_days())*24*60*60 - ceph::real_clock::to_time_t(mtime)%(24*60*60) + 24*60*60));
+	    mtime + make_timespan(double(rule_expiration.get_days()) * secs_in_a_day - ceph::real_clock::to_time_t(mtime)%(secs_in_a_day) + secs_in_a_day));
       }
     }
 
@@ -2718,7 +2719,7 @@ bool s3_multipart_abort_header(
     std::optional<ceph::real_time> rule_abort_date;
     if (mp_expiration.has_days()) {
       rule_abort_date = std::optional<ceph::real_time>(
-              mtime + make_timespan(mp_expiration.get_days()*24*60*60 - ceph::real_clock::to_time_t(mtime)%(24*60*60) + 24*60*60));
+              mtime + make_timespan(mp_expiration.get_days() * secs_in_a_day - ceph::real_clock::to_time_t(mtime)%(secs_in_a_day) + secs_in_a_day));
     }
 
     // update earliest abort date

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -151,10 +151,10 @@ bool RGWLifecycleConfiguration::_add_rule(const LCRule& rule)
   } else {
     prefix = rule.get_prefix();
   }
-
   if (rule.get_filter().has_tags()){
     op.obj_tags = rule.get_filter().get_tags();
   }
+  op.rule_flags = rule.get_filter().get_flags();
   prefix_map.emplace(std::move(prefix), std::move(op));
   return true;
 }
@@ -976,7 +976,7 @@ int RGWLC::handle_multipart_expiration(rgw::sal::Bucket* target,
 
   worker->workpool->drain();
   return 0;
-}
+} /* RGWLC::handle_multipart_expiration */
 
 static int read_obj_tags(const DoutPrefixProvider *dpp, rgw::sal::Object* obj, RGWObjectCtx& ctx, bufferlist& tags_bl)
 {
@@ -994,6 +994,16 @@ static bool is_valid_op(const lc_op& op)
                || op.dm_expiration
                || !op.transitions.empty()
                || !op.noncur_transitions.empty()));
+}
+
+static bool zone_check(const lc_op& op, rgw::sal::Zone* zone)
+{
+
+  if (zone->get_tier_type() == "archive") {
+    return (op.rule_flags & uint32_t(LCFlagType::ArchiveZone));
+  } else {
+    return (! (op.rule_flags & uint32_t(LCFlagType::ArchiveZone)));
+  }
 }
 
 static inline bool has_all_tags(const lc_op& rule_action,
@@ -1769,6 +1779,9 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
       return -1;
     }
 
+  /* fetch information for zone checks */
+  rgw::sal::Zone* zone = store->get_zone();
+
   auto pf = [](RGWLC::LCWorker* wk, WorkQ* wq, WorkItem& wi) {
     auto wt =
       boost::get<std::tuple<LCOpRule, rgw_bucket_dir_entry>>(wi);
@@ -1821,11 +1834,17 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
     LCObjsLister ol(store, bucket.get());
     ol.set_prefix(prefix_iter->first);
 
+    if (! zone_check(op, zone)) {
+      ldpp_dout(this, 7) << "LC rule not executable in " << zone->get_tier_type()
+			 << " zone, skipping" << dendl;
+      continue;
+    }
+
     ret = ol.init(this);
     if (ret < 0) {
       if (ret == (-ENOENT))
         return 0;
-      ldpp_dout(this, 0) << "ERROR: store->list_objects():" <<dendl;
+      ldpp_dout(this, 0) << "ERROR: store->list_objects():" << dendl;
       return ret;
     }
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2314,6 +2314,12 @@ bool RGWLC::LCWorker::should_work(utime_t& now)
   time_t tt = now.sec();
   localtime_r(&tt, &bdt);
 
+  // next-day adjustment if the configured end_hour is less than start_hour
+  if (end_hour < start_hour) {
+    bdt.tm_hour = bdt.tm_hour > end_hour ? bdt.tm_hour : bdt.tm_hour + hours_in_a_day;
+    end_hour += hours_in_a_day;
+  }
+
   if (cct->_conf->rgw_lc_debug_interval > 0) {
 	  /* We're debugging, so say we can run */
 	  return true;

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2774,6 +2774,9 @@ void LCFilter::dump(Formatter *f) const
 {
   f->dump_string("prefix", prefix);
   f->dump_object("obj_tags", obj_tags);
+  if (have_flag(LCFlagType::ArchiveZone)) {
+    f->dump_string("archivezone", "");
+  }
 }
 
 void LCExpiration::dump(Formatter *f) const

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2422,16 +2422,21 @@ int RGWLC::set_bucket_config(rgw::sal::Bucket* bucket,
                          const rgw::sal::Attrs& bucket_attrs,
                          RGWLifecycleConfiguration *config)
 {
+  int ret{0};
   rgw::sal::Attrs attrs = bucket_attrs;
-  bufferlist lc_bl;
-  config->encode(lc_bl);
+  if (config) {
+    /* if no RGWLifecycleconfiguration provided, it means
+     * RGW_ATTR_LC is already valid and present */
+    bufferlist lc_bl;
+    config->encode(lc_bl);
+    attrs[RGW_ATTR_LC] = std::move(lc_bl);
 
-  attrs[RGW_ATTR_LC] = std::move(lc_bl);
-
-  int ret =
-    bucket->merge_and_store_attrs(this, attrs, null_yield);
-  if (ret < 0)
-    return ret;
+    ret =
+      bucket->merge_and_store_attrs(this, attrs, null_yield);
+    if (ret < 0) {
+      return ret;
+    }
+  }
 
   rgw_bucket& b = bucket->get_key();
 

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -213,7 +213,7 @@ public:
     return obj_tags;
   }
 
-  const uint32_t get_flags() {
+  const uint32_t get_flags() const {
     return flags;
   }
 
@@ -438,6 +438,7 @@ struct lc_op
   boost::optional<RGWObjTags> obj_tags;
   std::map<std::string, transition_action> transitions;
   std::map<std::string, transition_action> noncur_transitions;
+  uint32_t rule_flags;
 
   /* ctors are nice */
   lc_op() = delete;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -201,7 +201,6 @@ protected:
   uint32_t flags;
 
 public:
-static uint32_t recognize_flags(const std::string& flag_expr);
 
   LCFilter() : flags(make_flag(LCFlagType::none))
     {}

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -218,12 +218,12 @@ public:
   }
 
   bool empty() const {
-    return !(has_prefix() || has_tags());
+    return !(has_prefix() || has_tags() || has_flags());
   }
 
   // Determine if we need AND tag when creating xml
   bool has_multi_condition() const {
-    if (obj_tags.count() > 1)
+    if (obj_tags.count() + int(has_prefix()) > 1) // Prefix is a member of Filter
       return true;
     return false;
   }
@@ -234,6 +234,14 @@ public:
 
   bool has_tags() const {
     return !obj_tags.empty();
+  }
+
+  bool has_flags() const {
+    return !(flags == uint32_t(LCFlagType::none));
+  }
+
+  bool have_flag(LCFlagType flag) const {
+    return flags & make_flag(flag);
   }
 
   void encode(bufferlist& bl) const {

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -223,7 +223,7 @@ public:
 
   // Determine if we need AND tag when creating xml
   bool has_multi_condition() const {
-    if (obj_tags.count() + int(has_prefix()) > 1) // Prefix is a member of Filter
+    if (obj_tags.count() + int(has_prefix()) + int(has_flags()) > 1) // Prefix is a member of Filter
       return true;
     return false;
   }

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -112,19 +112,24 @@ void RGWLifecycleConfiguration_S3::decode_xml(XMLObj *obj)
 
 void LCFilter_S3::dump_xml(Formatter *f) const
 {
-  if (has_prefix()) {
-    encode_xml("Prefix", prefix, f);
-  }
   bool multi = has_multi_condition();
   if (multi) {
     f->open_array_section("And");
+  }
+  if (has_prefix()) {
+    encode_xml("Prefix", prefix, f);
   }
   if (has_tags()) {
     const auto& tagset_s3 = static_cast<const RGWObjTagSet_S3 &>(obj_tags);
     tagset_s3.dump_xml(f);
   }
+  if (has_flags()) {
+    if (have_flag(LCFlagType::ArchiveZone)) {
+      encode_xml("ArchiveZone", "", f);
+    }
+  }
   if (multi) {
-    f->close_section();
+    f->close_section(); // And
   }
 }
 

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -146,10 +146,9 @@ void LCFilter_S3::decode_xml(XMLObj *obj)
 
   RGWXMLDecoder::decode_xml("Prefix", prefix, o);
 
-  /* parse optional flags (extension) */
-  auto flags_iter = o->find("Flag");
-  while (auto flag_xml = flags_iter.get_next()){
-    flags |= LCFilter::recognize_flags(flag_xml->get_data());
+  /* parse optional ArchiveZone flag (extension) */
+  if (o->find_first("ArchiveZone")) {
+    flags |= make_flag(LCFlagType::ArchiveZone);
   }
 
   obj_tags.clear(); // why is this needed?

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -139,15 +139,22 @@ void LCFilter_S3::decode_xml(XMLObj *obj)
    * Empty filters are allowed:
    * https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html
    */
-  XMLObj *o = obj->find_first("And");
+  XMLObj* o = obj->find_first("And");
   if (o == nullptr){
     o = obj;
   }
 
   RGWXMLDecoder::decode_xml("Prefix", prefix, o);
+
+  /* parse optional flags (extension) */
+  auto flags_iter = o->find("Flag");
+  while (auto flag_xml = flags_iter.get_next()){
+    flags |= LCFilter::recognize_flags(flag_xml->get_data());
+  }
+
+  obj_tags.clear(); // why is this needed?
   auto tags_iter = o->find("Tag");
-  obj_tags.clear();
-  while (auto tag_xml =tags_iter.get_next()){
+  while (auto tag_xml = tags_iter.get_next()){
     std::string _key,_val;
     RGWXMLDecoder::decode_xml("Key", _key, tag_xml);
     RGWXMLDecoder::decode_xml("Value", _val, tag_xml);

--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -14,6 +14,7 @@
 #include "rgw_xml.h"
 #include "rgw_tag_s3.h"
 
+
 class LCFilter_S3 : public LCFilter
 {
 public:

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1423,6 +1423,8 @@ class Zone {
     virtual bool has_zonegroup_api(const std::string& api) const = 0;
     /** Get the current period ID for this zone */
     virtual const std::string& get_current_period_id() = 0;
+    /** Get the tier type for the zone */
+    virtual const std::string& get_tier_type() = 0;
 };
 
 /**

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1424,7 +1424,7 @@ class Zone {
     /** Get the current period ID for this zone */
     virtual const std::string& get_current_period_id() = 0;
     /** Get the tier type for the zone */
-    virtual const std::string& get_tier_type() = 0;
+    virtual const std::string_view get_tier_type() = 0;
 };
 
 /**

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -270,6 +270,7 @@ protected:
       virtual bool get_redirect_endpoint(std::string* endpoint) override;
       virtual bool has_zonegroup_api(const std::string& api) const override;
       virtual const std::string& get_current_period_id() override;
+      virtual const std::string& get_tier_type() override { return "fixme"; }
   };
 
   class DBLuaScriptManager : public LuaScriptManager {

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -270,7 +270,7 @@ protected:
       virtual bool get_redirect_endpoint(std::string* endpoint) override;
       virtual bool has_zonegroup_api(const std::string& api) const override;
       virtual const std::string& get_current_period_id() override;
-      virtual const std::string& get_tier_type() override { return "rgw"; }
+      virtual const std::string_view get_tier_type() override { return "rgw"; }
   };
 
   class DBLuaScriptManager : public LuaScriptManager {

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -270,7 +270,7 @@ protected:
       virtual bool get_redirect_endpoint(std::string* endpoint) override;
       virtual bool has_zonegroup_api(const std::string& api) const override;
       virtual const std::string& get_current_period_id() override;
-      virtual const std::string& get_tier_type() override { return "fixme"; }
+      virtual const std::string& get_tier_type() override { return "rgw"; }
   };
 
   class DBLuaScriptManager : public LuaScriptManager {

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -2817,7 +2817,7 @@ const std::string& RadosZone::get_current_period_id()
   return store->svc()->zone->get_current_period_id();
 }
 
-const std::string& RadosZone::get_tier_type()
+const std::string_view RadosZone::get_tier_type()
 {
   return store->svc()->zone->get_zone().tier_type;
 }

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -2817,6 +2817,11 @@ const std::string& RadosZone::get_current_period_id()
   return store->svc()->zone->get_current_period_id();
 }
 
+const std::string& RadosZone::get_tier_type()
+{
+  return store->svc()->zone->get_zone().tier_type;
+}
+
 int RadosLuaScriptManager::get(const DoutPrefixProvider* dpp, optional_yield y, const std::string& key, std::string& script)
 {
   auto obj_ctx = store->svc()->sysobj->init_obj_ctx();

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -358,7 +358,7 @@ class RadosZone : public Zone {
     virtual bool get_redirect_endpoint(std::string* endpoint) override;
     virtual bool has_zonegroup_api(const std::string& api) const override;
     virtual const std::string& get_current_period_id() override;
-    virtual const std::string& get_tier_type() override;
+    virtual const std::string_view get_tier_type() override;
 };
 
 class RadosStore : public Store {

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -358,6 +358,7 @@ class RadosZone : public Zone {
     virtual bool get_redirect_endpoint(std::string* endpoint) override;
     virtual bool has_zonegroup_api(const std::string& api) const override;
     virtual const std::string& get_current_period_id() override;
+    virtual const std::string& get_tier_type() override;
 };
 
 class RadosStore : public Store {

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -365,10 +365,10 @@ int RGWCtlDef::init(RGWServices& svc, rgw::sal::Store* store, const DoutPrefixPr
   auto sync_module = svc.sync_modules->get_sync_module();
   if (sync_module) {
     meta.bucket.reset(sync_module->alloc_bucket_meta_handler());
-    meta.bucket_instance.reset(sync_module->alloc_bucket_instance_meta_handler());
+    meta.bucket_instance.reset(sync_module->alloc_bucket_instance_meta_handler(store));
   } else {
     meta.bucket.reset(RGWBucketMetaHandlerAllocator::alloc());
-    meta.bucket_instance.reset(RGWBucketInstanceMetaHandlerAllocator::alloc());
+    meta.bucket_instance.reset(RGWBucketInstanceMetaHandlerAllocator::alloc(store));
   }
 
   meta.otp.reset(RGWOTPMetaHandlerAllocator::alloc());

--- a/src/rgw/rgw_sync_module.cc
+++ b/src/rgw/rgw_sync_module.cc
@@ -22,9 +22,9 @@ RGWMetadataHandler *RGWSyncModuleInstance::alloc_bucket_meta_handler()
   return RGWBucketMetaHandlerAllocator::alloc();
 }
 
-RGWBucketInstanceMetadataHandlerBase *RGWSyncModuleInstance::alloc_bucket_instance_meta_handler()
+RGWBucketInstanceMetadataHandlerBase* RGWSyncModuleInstance::alloc_bucket_instance_meta_handler(rgw::sal::Store* store)
 {
-  return RGWBucketInstanceMetaHandlerAllocator::alloc();
+  return RGWBucketInstanceMetaHandlerAllocator::alloc(store);
 }
 
 RGWStatRemoteObjCBCR::RGWStatRemoteObjCBCR(RGWDataSyncCtx *_sc,

--- a/src/rgw/rgw_sync_module.h
+++ b/src/rgw/rgw_sync_module.h
@@ -53,7 +53,7 @@ public:
     return false;
   }
   virtual RGWMetadataHandler *alloc_bucket_meta_handler();
-  virtual RGWBucketInstanceMetadataHandlerBase *alloc_bucket_instance_meta_handler();
+  virtual RGWBucketInstanceMetadataHandlerBase *alloc_bucket_instance_meta_handler(rgw::sal::Store* store);
 
   // indication whether the sync module start with full sync (default behavior)
   // incremental sync would follow anyway

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -190,6 +190,14 @@ add_ceph_unittest(unittest_rgw_xml)
 
 target_link_libraries(unittest_rgw_xml ${rgw_libs} ${EXPAT_LIBRARIES})
 
+# unittest_rgw_lc
+add_executable(unittest_rgw_lc test_rgw_lc.cc)
+add_ceph_unittest(unittest_rgw_lc)
+target_include_directories(unittest_rgw_lc SYSTEM PRIVATE
+  "${CMAKE_SOURCE_DIR}/src/rgw")
+target_link_libraries(unittest_rgw_lc
+  rgw_common ${rgw_libs} ${EXPAT_LIBRARIES})
+
 # unittest_rgw_arn
 add_executable(unittest_rgw_arn test_rgw_arn.cc)
 add_ceph_unittest(unittest_rgw_arn)

--- a/src/test/rgw/test_rgw_lc.cc
+++ b/src/test/rgw/test_rgw_lc.cc
@@ -1,0 +1,114 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "rgw_xml.h"
+#include "rgw_lc.h"
+#include "rgw_lc_s3.h"
+#include <gtest/gtest.h>
+//#include <spawn/spawn.hpp>
+#include <string>
+#include <vector>
+#include <stdexcept>
+
+static const char* xmldoc_1 =
+R"(<Filter>
+   <And>
+      <Prefix>tax/</Prefix>
+      <Tag>
+         <Key>key1</Key>
+         <Value>value1</Value>
+      </Tag>
+      <Tag>
+         <Key>key2</Key>
+         <Value>value2</Value>
+      </Tag>
+    </And>
+</Filter>
+)";
+
+TEST(TestLCFilterDecoder, XMLDoc1)
+{
+  RGWXMLDecoder::XMLParser parser;
+  ASSERT_TRUE(parser.init());
+  ASSERT_TRUE(parser.parse(xmldoc_1, strlen(xmldoc_1), 1));
+  LCFilter_S3 filter;
+  auto result = RGWXMLDecoder::decode_xml("Filter", filter, &parser, true);
+  ASSERT_TRUE(result);
+  /* check repeated Tag element */
+  auto tag_map = filter.get_tags().get_tags();
+  auto val1 = tag_map.find("key1");
+  ASSERT_EQ(val1->second, "value1");
+  auto val2 = tag_map.find("key2");
+  ASSERT_EQ(val2->second, "value2");
+  /* check our flags */
+  ASSERT_EQ(filter.get_flags(), 0);
+}
+
+static const char* xmldoc_2 =
+R"(<Filter>
+   <And>
+      <Flag>
+         ArchiveZone
+      </Flag>
+      <Flag>
+         ArchiveZone
+      </Flag>
+      <Tag>
+         <Key>spongebob</Key>
+         <Value>squarepants</Value>
+      </Tag>
+    </And>
+</Filter>
+)";
+
+TEST(TestLCFilterDecoder, XMLDoc2)
+{
+  RGWXMLDecoder::XMLParser parser;
+  ASSERT_TRUE(parser.init());
+  ASSERT_TRUE(parser.parse(xmldoc_2, strlen(xmldoc_2), 1));
+  LCFilter_S3 filter;
+  auto result = RGWXMLDecoder::decode_xml("Filter", filter, &parser, true);
+  ASSERT_TRUE(result);
+  /* check repeated Tag element */
+  auto tag_map = filter.get_tags().get_tags();
+  auto val1 = tag_map.find("spongebob");
+  ASSERT_EQ(val1->second, "squarepants");
+  /* check our flags */
+  ASSERT_EQ(filter.get_flags(), uint32_t(LCFlagType::ArchiveZone));
+}
+
+// invalid And element placement
+static const char* xmldoc_3 =
+R"(<Filter>
+    <And>
+      <Tag>
+         <Key>miles</Key>
+         <Value>davis</Value>
+      </Tag>
+    </And>
+      <Tag>
+         <Key>spongebob</Key>
+         <Value>squarepants</Value>
+      </Tag>
+</Filter>
+)";
+
+TEST(TestLCFilterInvalidAnd, XMLDoc3)
+{
+  RGWXMLDecoder::XMLParser parser;
+  ASSERT_TRUE(parser.init());
+  ASSERT_TRUE(parser.parse(xmldoc_3, strlen(xmldoc_3), 1));
+  LCFilter_S3 filter;
+  auto result = RGWXMLDecoder::decode_xml("Filter", filter, &parser, true);
+  ASSERT_TRUE(result);
+  /* check repeated Tag element */
+  auto tag_map = filter.get_tags().get_tags();
+  auto val1 = tag_map.find("spongebob");
+  ASSERT_TRUE(val1 == tag_map.end());
+  /* because the invalid 2nd tag element was not recognized,
+   * we cannot access it:
+  ASSERT_EQ(val1->second, "squarepants");
+  */
+  /* check our flags */
+  ASSERT_EQ(filter.get_flags(), uint32_t(LCFlagType::none));
+}

--- a/src/test/rgw/test_rgw_lc.cc
+++ b/src/test/rgw/test_rgw_lc.cc
@@ -47,12 +47,7 @@ TEST(TestLCFilterDecoder, XMLDoc1)
 static const char* xmldoc_2 =
 R"(<Filter>
    <And>
-      <Flag>
-         ArchiveZone
-      </Flag>
-      <Flag>
-         ArchiveZone
-      </Flag>
+      <ArchiveZone />
       <Tag>
          <Key>spongebob</Key>
          <Value>squarepants</Value>
@@ -69,12 +64,12 @@ TEST(TestLCFilterDecoder, XMLDoc2)
   LCFilter_S3 filter;
   auto result = RGWXMLDecoder::decode_xml("Filter", filter, &parser, true);
   ASSERT_TRUE(result);
-  /* check repeated Tag element */
+  /* check tags */
   auto tag_map = filter.get_tags().get_tags();
   auto val1 = tag_map.find("spongebob");
   ASSERT_EQ(val1->second, "squarepants");
   /* check our flags */
-  ASSERT_EQ(filter.get_flags(), uint32_t(LCFlagType::ArchiveZone));
+  ASSERT_EQ(filter.get_flags(), LCFilter::make_flag(LCFlagType::ArchiveZone));
 }
 
 // invalid And element placement

--- a/src/test/rgw/test_rgw_lc.cc
+++ b/src/test/rgw/test_rgw_lc.cc
@@ -106,3 +106,238 @@ TEST(TestLCFilterInvalidAnd, XMLDoc3)
   /* check our flags */
   ASSERT_EQ(filter.get_flags(), uint32_t(LCFlagType::none));
 }
+
+struct LCWorkTimeTests : ::testing::Test
+{
+   CephContext* cct;
+   std::unique_ptr<RGWLC::LCWorker> worker;
+
+   // expects input in the form of "%m/%d/%y %H:%M:%S"; e.g., "01/15/23 23:59:01"
+   utime_t get_utime_by_date_time_string(const std::string& date_time_str)
+   {
+      struct tm tm{};
+      struct timespec ts = {0};
+
+      strptime(date_time_str.c_str(), "%m/%d/%y %H:%M:%S", &tm);
+      ts.tv_sec = mktime(&tm);
+
+      return utime_t(ts);
+   }
+
+   // expects a map from input value (date & time string) to expected result (boolean)
+   void run_should_work_test(const std::unordered_map<std::string, bool>& test_values_to_expectations_map) {
+      for (const auto& [date_time_str, expected_value] : test_values_to_expectations_map) {
+         auto ut = get_utime_by_date_time_string(date_time_str);
+         auto should_work = worker->should_work(ut);
+
+         ASSERT_EQ(should_work, expected_value)
+            << "input time: " << ut
+            << " expected: " << expected_value
+            << " should_work: " << should_work
+            << " work-time-window: " << cct->_conf->rgw_lifecycle_work_time << std::endl;
+      }
+   }
+
+   // expects a map from input value (a tuple of date & time strings) to expected result (seconds)
+   void run_schedule_next_start_time_test(const std::map<std::tuple<std::string, std::string>, int>& test_values_to_expectations_map) {
+      for (const auto& [date_time_str_tuple, expected_value] : test_values_to_expectations_map) {
+         auto work_started_at = get_utime_by_date_time_string(std::get<0>(date_time_str_tuple));
+         auto work_completed_at = get_utime_by_date_time_string(std::get<1>(date_time_str_tuple));
+         auto wait_secs_till_next_start = worker->schedule_next_start_time(work_started_at, work_completed_at);
+
+         ASSERT_EQ(wait_secs_till_next_start, expected_value)
+            << "work_started_at: " << work_started_at
+            << " work_completed_at: " << work_completed_at
+            << " expected: " << expected_value
+            << " wait_secs_till_next_start: " << wait_secs_till_next_start
+            << " work-time-window: " << cct->_conf->rgw_lifecycle_work_time << std::endl;
+      }
+   }
+
+protected:
+
+   void SetUp() override {
+      cct = (new CephContext(CEPH_ENTITY_TYPE_ANY))->get();
+
+      cct->_conf->set_value("rgw_lc_max_wp_worker", 0, 0); // no need to create a real workpool
+      worker = std::make_unique<RGWLC::LCWorker>(nullptr, cct, nullptr, 0);
+   }
+
+   void TearDown() override {
+      worker.reset();
+      cct->put();
+   }
+};
+
+TEST_F(LCWorkTimeTests, ShouldWorkDefaultWorkTime)
+{
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 00:00:00", true},
+      {"01/01/24 00:00:00", true}, // date is not relevant, but only the time-window
+      {"01/01/23 00:00:01", true},
+      {"01/01/23 03:00:00", true},
+      {"01/01/23 05:59:59", true},
+      {"01/01/23 06:00:00", true},
+      {"01/01/23 06:00:59", true}, // seconds don't matter, but only hours and minutes
+      {"01/01/23 06:01:00", false},
+      {"01/01/23 23:59:59", false},
+      {"01/02/23 23:59:59", false},
+      {"01/01/23 12:00:00", false},
+      {"01/01/23 14:00:00", false}
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheSameDay)
+{
+   cct->_conf->rgw_lifecycle_work_time = "14:00-16:00";
+
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 00:00:00", false},
+      {"01/01/23 12:00:00", false},
+      {"01/01/24 13:59:59", false},
+      {"01/01/23 14:00:00", true},
+      {"01/01/23 16:00:00", true},
+      {"01/01/23 16:00:59", true},
+      {"01/01/23 16:01:00", false},
+      {"01/01/23 17:00:00", false},
+      {"01/01/23 23:59:59", false},
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheSameDay24Hours)
+{
+   cct->_conf->rgw_lifecycle_work_time = "00:00-23:59";
+
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 23:59:00", true},
+      {"01/01/23 23:59:59", true},
+      {"01/01/23 00:00:00", true},
+      {"01/01/23 00:00:01", true},
+      {"01/01/23 00:01:00", true},
+      {"01/01/23 01:00:00", true},
+      {"01/01/23 12:00:00", true},
+      {"01/01/23 17:00:00", true},
+      {"01/01/23 23:00:00", true}
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+
+TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheNextDay)
+{
+   cct->_conf->rgw_lifecycle_work_time = "14:00-01:00";
+
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 13:59:00", false},
+      {"01/01/23 13:59:59", false},
+      {"01/01/24 14:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 17:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 23:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 00:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 00:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 01:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 01:00:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 01:01:00", false},
+      {"01/01/23 05:00:00", false},
+      {"01/01/23 12:00:00", false},
+      {"01/01/23 13:00:00", false}
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheNextDay24Hours)
+{
+   cct->_conf->rgw_lifecycle_work_time = "14:00-13:59";
+
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 00:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 00:00:01", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 00:01:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 01:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 12:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 13:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 13:59:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 13:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 14:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 14:00:01", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 14:01:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 16:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 23:59:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 23:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheNextDayIrregularMins)
+{
+   cct->_conf->rgw_lifecycle_work_time = "22:15-03:33";
+
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 22:14:59", false},
+      {"01/01/23 22:15:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 00:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 01:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 02:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 03:33:00", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 03:33:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 03:34:00", false},
+      {"01/01/23 04:00:00", false},
+      {"01/01/23 12:00:00", false},
+      {"01/01/23 22:00:00", false},
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeStartEndSameHour)
+{
+   cct->_conf->rgw_lifecycle_work_time = "22:15-22:45";
+
+   std::unordered_map<std::string, bool> test_values_to_expectations = {
+      {"01/01/23 22:14:59", false},
+      {"01/01/23 22:15:00", true},
+      {"01/01/24 22:44:59", true},
+      {"01/01/24 22:45:59", true},
+      {"01/01/24 22:46:00", false},
+      {"01/01/23 23:00:00", false},
+      {"01/01/23 00:00:00", false},
+      {"01/01/23 12:00:00", false},
+      {"01/01/23 21:00:00", false},
+   };
+
+   run_should_work_test(test_values_to_expectations);
+}
+
+TEST_F(LCWorkTimeTests, ScheduleNextStartTime)
+{
+   cct->_conf->rgw_lifecycle_work_time = "22:15-03:33";
+
+   // items of the map: [ (work_started_time, work_completed_time), expected_value (seconds) ]
+   //
+   // expected_value is the difference between configured start time (i.e, 22:15:00) and
+   // the second item of the tuple (i.e., work_completed_time).
+   //
+   // Note that "seconds" of work completion time is taken into account but date is not relevant.
+   // e.g., the first testcase: 75713 == 01:13:07 - 22:15:00 (https://tinyurl.com/ydm86752)
+   std::map<std::tuple<std::string, std::string>, int> test_values_to_expectations = {
+      {{"01/01/23 22:15:05", "01/01/23 01:13:07"}, 75713},
+      {{"01/01/23 22:15:05", "01/02/23 01:13:07"}, 75713},
+      {{"01/01/23 22:15:05", "01/01/23 22:17:07"}, 86273},
+      {{"01/01/23 22:15:05", "01/02/23 22:17:07"}, 86273},
+      {{"01/01/23 22:15:05", "01/01/23 22:14:00"}, 60},
+      {{"01/01/23 22:15:05", "01/02/23 22:14:00"}, 60},
+      {{"01/01/23 22:15:05", "01/01/23 22:15:00"}, 24 * 60 * 60},
+      {{"01/01/23 22:15:05", "01/02/23 22:15:00"}, 24 * 60 * 60},
+      {{"01/01/23 22:15:05", "01/01/23 22:15:01"}, 24 * 60 * 60 - 1},
+      {{"01/01/23 22:15:05", "01/02/23 22:15:01"}, 24 * 60 * 60 - 1},
+   };
+
+   run_schedule_next_start_time_test(test_values_to_expectations);
+}

--- a/src/test/rgw/test_rgw_lc.cc
+++ b/src/test/rgw/test_rgw_lc.cc
@@ -5,7 +5,6 @@
 #include "rgw_lc.h"
 #include "rgw_lc_s3.h"
 #include <gtest/gtest.h>
-//#include <spawn/spawn.hpp>
 #include <string>
 #include <vector>
 #include <stdexcept>

--- a/src/test/rgw/test_rgw_lc.cc
+++ b/src/test/rgw/test_rgw_lc.cc
@@ -235,13 +235,13 @@ TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheNextDay)
    std::unordered_map<std::string, bool> test_values_to_expectations = {
       {"01/01/23 13:59:00", false},
       {"01/01/23 13:59:59", false},
-      {"01/01/24 14:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 17:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 23:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 00:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 00:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 01:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 01:00:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/24 14:00:00", true}, // used-to-fail
+      {"01/01/24 17:00:00", true}, // used-to-fail
+      {"01/01/24 23:59:59", true}, // used-to-fail
+      {"01/01/23 00:00:00", true}, // used-to-fail
+      {"01/01/23 00:59:59", true}, // used-to-fail
+      {"01/01/23 01:00:00", true}, // used-to-fail
+      {"01/01/23 01:00:59", true}, // used-to-fail
       {"01/01/23 01:01:00", false},
       {"01/01/23 05:00:00", false},
       {"01/01/23 12:00:00", false},
@@ -255,21 +255,22 @@ TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheNextDay24Hours)
 {
    cct->_conf->rgw_lifecycle_work_time = "14:00-13:59";
 
+   // all of the below cases used-to-fail
    std::unordered_map<std::string, bool> test_values_to_expectations = {
-      {"01/01/23 00:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 00:00:01", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 00:01:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 01:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 12:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 13:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 13:59:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 13:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 14:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 14:00:01", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 14:01:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 16:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 23:59:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 23:59:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 00:00:00", true},
+      {"01/01/23 00:00:01", true},
+      {"01/01/23 00:01:00", true},
+      {"01/01/24 01:00:00", true},
+      {"01/01/24 12:00:00", true},
+      {"01/01/24 13:00:00", true},
+      {"01/01/24 13:59:00", true},
+      {"01/01/24 13:59:59", true},
+      {"01/01/23 14:00:00", true},
+      {"01/01/23 14:00:01", true},
+      {"01/01/23 14:01:00", true},
+      {"01/01/23 16:00:00", true},
+      {"01/01/23 23:59:00", true},
+      {"01/01/23 23:59:59", true},
    };
 
    run_should_work_test(test_values_to_expectations);
@@ -281,12 +282,12 @@ TEST_F(LCWorkTimeTests, ShouldWorkCustomWorkTimeEndTimeInTheNextDayIrregularMins
 
    std::unordered_map<std::string, bool> test_values_to_expectations = {
       {"01/01/23 22:14:59", false},
-      {"01/01/23 22:15:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 00:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 01:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/24 02:00:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 03:33:00", false}, // should have been true, expected to fail due to tracker issue #63613
-      {"01/01/23 03:33:59", false}, // should have been true, expected to fail due to tracker issue #63613
+      {"01/01/23 22:15:00", true}, // used-to-fail
+      {"01/01/24 00:00:00", true}, // used-to-fail
+      {"01/01/24 01:00:00", true}, // used-to-fail
+      {"01/01/24 02:00:00", true}, // used-to-fail
+      {"01/01/23 03:33:00", true}, // used-to-fail
+      {"01/01/23 03:33:59", true}, // used-to-fail
       {"01/01/23 03:34:00", false},
       {"01/01/23 04:00:00", false},
       {"01/01/23 12:00:00", false},


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63776

---

backport of https://github.com/ceph/ceph/pull/54622
parent tracker: https://tracker.ceph.com/issues/63613

This PR is based on https://github.com/ceph/ceph/pull/54873 backport to avoid unnecessary conflicts. So it will need rebase when that PR is merged.

Also if PR https://github.com/ceph/ceph/pull/49527 is merged before this PR, then  the conflict in "rgw/lc: [non-functional change] use const expr to represent seconds in a day" could be resolved.


this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh