### PR TITLE
quincy: pybind/mgr/devicehealth: replace SMART data if exists for same DATETIME

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -492,8 +492,8 @@ CREATE TABLE DeviceHealthMetrics (
 
     def put_device_metrics(self, devid: str, data: Any) -> None:
         SQL = """
-        INSERT INTO DeviceHealthMetrics (devid, raw_smart)
-            VALUES (?, ?);
+        INSERT OR REPLACE INTO DeviceHealthMetrics (devid, raw_smart, time)
+            VALUES (?, ?, strftime('%s', 'now'));
         """
 
         with self._db_lock, self.db:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63797

---

backport of https://github.com/ceph/ceph/pull/54337
parent tracker: https://tracker.ceph.com/issues/63433

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh