### PR TITLE
erasure-code/isa/xor_op: add neon-based region_xor implementation

### DIFF
--- a/src/erasure-code/isa/xor_op.cc
+++ b/src/erasure-code/isa/xor_op.cc
@@ -197,6 +197,7 @@ region_sse2_xor(char** src,
   return;
 }
 
+#if defined(__aarch64__) && defined(__ARM_NEON)
 void
 // -----------------------------------------------------------------------------
 region_neon_xor(char **src,
@@ -205,7 +206,6 @@ region_neon_xor(char **src,
                 unsigned size)
 // -----------------------------------------------------------------------------
 {
-#if defined(__aarch64__) && defined(__ARM_NEON)
   ceph_assert(!(size % EC_ISA_VECTOR_NEON_WORDSIZE));
   unsigned char *p = (unsigned char *)parity;
   unsigned char *vbuf[256] = { NULL };
@@ -232,6 +232,6 @@ region_neon_xor(char **src,
     vst1q_u64((uint64_t *)(p + 16), d0_2);
     p += EC_ISA_VECTOR_NEON_WORDSIZE;
   }
-#endif // __aarch64__ && __ARM_NEON
   return;
 }
+#endif // __aarch64__ && __ARM_NEON

--- a/src/erasure-code/isa/xor_op.cc
+++ b/src/erasure-code/isa/xor_op.cc
@@ -15,6 +15,11 @@
 #include <stdio.h>
 #include <string.h>
 #include "arch/intel.h"
+#include "arch/arm.h"
+
+#if defined(__aarch64__) && defined(__ARM_NEON)
+  #include <arm_neon.h>
+#endif
 
 #include "include/ceph_assert.h"
 
@@ -101,6 +106,16 @@ region_xor(unsigned char** src,
       // 64-byte region xor
       region_sse2_xor((char**) src, (char*) parity, src_size, region_size);
     } else
+#elif defined (__aarch64__) && defined(__ARM_NEON)
+    if (ceph_arch_neon) {
+      // -----------------------------
+      // use NEON region xor function
+      // -----------------------------
+      unsigned region_size = 
+        (size / EC_ISA_VECTOR_NEON_WORDSIZE) * EC_ISA_VECTOR_NEON_WORDSIZE;
+      size_left -= region_size;
+      region_neon_xor((char**) src, (char *) parity, src_size, region_size);
+    } else
 #endif
     {
       // --------------------------------------------
@@ -179,5 +194,44 @@ region_sse2_xor(char** src,
 
   asm volatile("sfence" : : : "memory");
 #endif // __x86_64__
+  return;
+}
+
+void
+// -----------------------------------------------------------------------------
+region_neon_xor(char **src,
+                char *parity,
+                int src_size,
+                unsigned size)
+// -----------------------------------------------------------------------------
+{
+#if defined(__aarch64__) && defined(__ARM_NEON)
+  ceph_assert(!(size % EC_ISA_VECTOR_NEON_WORDSIZE));
+  unsigned char *p = (unsigned char *)parity;
+  unsigned char *vbuf[256] = { NULL };
+  for (int v = 0; v < src_size; v++) {
+    vbuf[v] = (unsigned char *)src[v];
+  }
+
+  // ----------------------------------------------------------------------------------------
+  // NEON load instructions can load 128bits of data each time, and there are 2 load channels
+  // ----------------------------------------------------------------------------------------
+  for (unsigned i = 0; i < size; i += EC_ISA_VECTOR_NEON_WORDSIZE) {
+    uint64x2_t d0_1 = vld1q_u64((uint64_t *)(&(vbuf[0][i])));
+    uint64x2_t d0_2 = vld1q_u64((uint64_t *)(&(vbuf[0][i + 16])));
+
+    for (int d = 1; d < src_size; d++) {
+      uint64x2_t di_1 = vld1q_u64((uint64_t *)(&(vbuf[d][i])));
+      uint64x2_t di_2 = vld1q_u64((uint64_t *)(&(vbuf[d][i + 16])));
+
+      d0_1 = veorq_u64(d0_1, di_1);
+      d0_2 = veorq_u64(d0_2, di_2);
+    }
+
+    vst1q_u64((uint64_t *)p, d0_1);
+    vst1q_u64((uint64_t *)(p + 16), d0_2);
+    p += EC_ISA_VECTOR_NEON_WORDSIZE;
+  }
+#endif // __aarch64__ && __ARM_NEON
   return;
 }

--- a/src/erasure-code/isa/xor_op.h
+++ b/src/erasure-code/isa/xor_op.h
@@ -27,7 +27,7 @@
 
 #define EC_ISA_ADDRESS_ALIGNMENT 32u
 #define EC_ISA_VECTOR_SSE2_WORDSIZE 64u
-
+#define EC_ISA_VECTOR_NEON_WORDSIZE 32u
 #if __GNUC__ > 4 || \
   ( (__GNUC__ == 4) && (__GNUC_MINOR__ >= 4) ) ||\
   (__clang__ == 1 )
@@ -83,5 +83,14 @@ region_sse2_xor(char** src /* array of 64-byte aligned source pointer to xor */,
                 int src_size /* size of the source pointer array */,
                 unsigned size /* size of the region to xor */);
 
+// -------------------------------------------------------------------------
+// compute region XOR like parity = src[0] ^ src[1] ... ^ src[src_size-1]
+// using NEON 32-byte operations
+// -------------------------------------------------------------------------
+void
+region_neon_xor(char** src    /* array of 64-byte aligned source pointer to xor */,
+                char* parity  /* 32-byte aligned output pointer containing the parity */,
+                int src_size  /* size of the source pointer array */,
+                unsigned size /* size of the region to xor */);
 
 #endif // EC_ISA_XOR_OP_H

--- a/src/erasure-code/isa/xor_op.h
+++ b/src/erasure-code/isa/xor_op.h
@@ -83,6 +83,7 @@ region_sse2_xor(char** src /* array of 64-byte aligned source pointer to xor */,
                 int src_size /* size of the source pointer array */,
                 unsigned size /* size of the region to xor */);
 
+#if defined(__aarch64__) && defined(__ARM_NEON)
 // -------------------------------------------------------------------------
 // compute region XOR like parity = src[0] ^ src[1] ... ^ src[src_size-1]
 // using NEON 32-byte operations
@@ -92,5 +93,5 @@ region_neon_xor(char** src    /* array of 64-byte aligned source pointer to xor 
                 char* parity  /* 32-byte aligned output pointer containing the parity */,
                 int src_size  /* size of the source pointer array */,
                 unsigned size /* size of the region to xor */);
-
+#endif // __aarch64__ && __ARM_NEON
 #endif // EC_ISA_XOR_OP_H


### PR DESCRIPTION
The load instruction of NEON can load 128 bits. Generally, the CPU has two load channels. Therefore, the 32-byte Region_xor can be implemented. According to the test by ceph_erasure_code_benchmark, the performance is improved by more than 20% ~ 50% on average.

loop = 10000

| (k, m, size) | base(s) | neon(s) |
| -------- | -------- | -------- |
| (4, 1, 16384) | 0.018 | 0.015 |
| (4, 1, 65536) | 0.043 | 0.037 |
| (4, 1, 102400) | 0.058 | 0.049 |
| (8, 1, 32768) | 0.034 | 0.029 |
| (8, 1, 65536) | 0.052 | 0.045 |
| (8, 1, 102400) | 0.068 | 0.061 |
| (8, 1, 524288) | 0.631 | 0.420 |
| (8, 1, 1048576) | 1.561 | 0.931 |
| (8, 1, 8388608) | 16.70 | 8.244 |





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
