### PR TITLE
inline_memory: optimized mem_is_zero for aarch64 by neon intrinsic

### DIFF
--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -294,6 +294,13 @@ add_executable(unittest_perf_histogram
 add_ceph_unittest(unittest_perf_histogram)
 target_link_libraries(unittest_perf_histogram ceph-common)
 
+# unittest_memory
+add_executable(unittest_memory
+  test_memory.cc
+  )
+add_ceph_unittest(unittest_memory)
+target_link_libraries(unittest_memory ceph-common)
+
 # unittest_perf_cache_key
 add_executable(unittest_perf_counters_key test_perf_counters_key.cc)
 add_ceph_unittest(unittest_perf_counters_key)

--- a/src/test/common/test_memory.cc
+++ b/src/test/common/test_memory.cc
@@ -30,7 +30,7 @@ TEST_P(MemoryIsZeroBigTest, MemoryIsZeroTestBig) {
 TEST_P(MemoryIsZeroSmallTest, MemoryIsZeroTestSmall) {
   size_t size = GetParam();
   for (size_t i = 0; i < size; i++) {
-    char data[size] = { 0 };
+    char* data = new char[size]();
     EXPECT_TRUE(mem_is_zero(data, size));
 
     data[i] = 'a';
@@ -63,11 +63,11 @@ TEST_P(MemoryIsZeroPerformance, MemoryIsZeroPerformanceTest) {
   free(data);
 }
 
-INSTANTIATE_TEST_CASE_P(Default, MemoryIsZeroSmallTest,
+INSTANTIATE_TEST_SUITE_P(MemoryIsZeroSmallTests, MemoryIsZeroSmallTest,
                         ::testing::Values(1, 4, 7, 8, 12, 28, 60, 64));
 
-INSTANTIATE_TEST_CASE_P(Default, MemoryIsZeroBigTest,
+INSTANTIATE_TEST_SUITE_P(MemoryIsZeroBigTests, MemoryIsZeroBigTest,
                         ::testing::Values(1024, 4096, 8192, 64 * 1024));
 
-INSTANTIATE_TEST_CASE_P(Default, MemoryIsZeroPerformance,
+INSTANTIATE_TEST_SUITE_P(MemoryIsZeroPerformanceTests, MemoryIsZeroPerformance,
                         ::testing::Values(1024, 2048, 4096, 8192, 64 * 1024));

--- a/src/test/common/test_memory.cc
+++ b/src/test/common/test_memory.cc
@@ -1,0 +1,73 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <iostream>
+#include <vector>
+#include <string.h>
+
+#include "include/inline_memory.h"
+#include "include/utime.h"
+#include "common/Clock.h"
+#include "gtest/gtest.h"
+
+class MemoryIsZeroBigTest : public ::testing::TestWithParam<size_t> {};
+class MemoryIsZeroSmallTest : public ::testing::TestWithParam<size_t> {};
+class MemoryIsZeroPerformance : public ::testing::TestWithParam<size_t> {};
+
+TEST_P(MemoryIsZeroBigTest, MemoryIsZeroTestBig) {
+  size_t size = GetParam();
+  char *data = (char *)malloc(sizeof(char) * size);
+  memset(data, 0, sizeof(char) * size);
+  EXPECT_TRUE(mem_is_zero(data, size));
+
+  size_t pos = rand() % size;
+  data[pos] = 'a';
+  EXPECT_FALSE(mem_is_zero(data, size));
+
+  free(data);
+}
+
+TEST_P(MemoryIsZeroSmallTest, MemoryIsZeroTestSmall) {
+  size_t size = GetParam();
+  for (size_t i = 0; i < size; i++) {
+    char data[size] = { 0 };
+    EXPECT_TRUE(mem_is_zero(data, size));
+
+    data[i] = 'a';
+    EXPECT_FALSE(mem_is_zero(data, size));
+  }
+}
+
+TEST_P(MemoryIsZeroPerformance, MemoryIsZeroPerformanceTest) {
+  constexpr size_t ITER = 1000000;
+  utime_t start;
+  utime_t end;
+
+  size_t size = GetParam();
+  char *data = (char *)malloc(size);
+  memset(data, 0, size);
+  
+  bool res = false;
+  start = ceph_clock_now();
+  for (size_t i = 0; i < ITER; i++) {
+    res = mem_is_zero(data, size);
+  }
+  end = ceph_clock_now();
+
+  std::cout << "iterators=" << ITER 
+            << " size= " << size 
+            << " time=" << (double)(end - start)
+            << std::endl;
+
+  ASSERT_TRUE(res);
+  free(data);
+}
+
+INSTANTIATE_TEST_CASE_P(Default, MemoryIsZeroSmallTest,
+                        ::testing::Values(1, 4, 7, 8, 12, 28, 60, 64));
+
+INSTANTIATE_TEST_CASE_P(Default, MemoryIsZeroBigTest,
+                        ::testing::Values(1024, 4096, 8192, 64 * 1024));
+
+INSTANTIATE_TEST_CASE_P(Default, MemoryIsZeroPerformance,
+                        ::testing::Values(1024, 2048, 4096, 8192, 64 * 1024));


### PR DESCRIPTION
The Neon instruction can be used to optimize mem_is_Zero. The Neon instruction can load 128-bit data. Most ARM CPU architectures have 2 LD loading channels. Therefore, two 128-bit data can be loaded at the same time, which is good for block data.

We did a set of performance tests with different sizes compare TSV110 with default implementation, it shows about 50% improvement.

loop: 1,000,000
used time:

|size    |    default      |     neon|
| ------ | ------ | ------ |
|1024    |    0.091       |     0.044|
|2048    |    0.177       |     0.092|
|4096    |    0.348       |     0.175|
|8192    |    0.689       |     0.345|
|65536   |    5.471       |     2.746|


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
