### PR TITLE
pacific: [rgw][lc][rgw_lifecycle_work_time] adjust timing if the configured end time is less than the start time

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6034,7 +6034,12 @@ std::vector<Option> get_rgw_options() {
     Option("rgw_lifecycle_work_time", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("00:00-06:00")
     .set_description("Lifecycle allowed work time")
-    .set_long_description("Local time window in which the lifecycle maintenance thread can work."),
+    .set_long_description(
+        "Local time window in which the lifecycle maintenance thread can work. It expects "
+        "24-hour time notation. For example, "00:00-23:59" means starting at midnight lifecycle "
+        "is allowed to run for the whole day (24 hours). When lifecycle completes, it waits for the "
+        "next maintenance window. In this example, if it completes at 01:00, it will resume processing "
+        "23 hours later at the following midnight."),
 
     Option("rgw_lc_lock_max_time", Option::TYPE_INT, Option::LEVEL_DEV)
     .set_default(90)

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1899,6 +1899,12 @@ bool RGWLC::LCWorker::should_work(utime_t& now)
   time_t tt = now.sec();
   localtime_r(&tt, &bdt);
 
+  // next-day adjustment if the configured end_hour is less than start_hour
+  if (end_hour < start_hour) {
+    bdt.tm_hour = bdt.tm_hour > end_hour ? bdt.tm_hour : bdt.tm_hour + hours_in_a_day;
+    end_hour += hours_in_a_day;
+  }
+
   if (cct->_conf->rgw_lc_debug_interval > 0) {
 	  /* We're debugging, so say we can run */
 	  return true;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63787

---

backport of https://github.com/ceph/ceph/pull/54622
parent tracker: https://tracker.ceph.com/issues/63613

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh