### PR TITLE
rgw/multisite: forwarded requests always pass a bufferlist

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -132,6 +132,12 @@ int rgw_forward_request_to_master(const DoutPrefixProvider* dpp,
   }
   const RGWAccessKey& creds = site.get_zone_params().system_key;
 
+  bufferlist data;
+  if (indata == nullptr) {
+    // forward() needs an input bufferlist to set the content-length
+    indata = &data;
+  }
+
   // use the master zone's endpoints
   auto conn = RGWRESTConn{dpp->get_cct(), z->second.id, z->second.endpoints,
                           creds, zg->second.id, zg->second.api_name};


### PR DESCRIPTION
d2dbe7550296da6db885b5344c71f77f9acbfd8f added a rgw_forward_request_to_master() that took the input bufferlist by pointer instead of reference so it could be optional; however, RGWRESTSimpleRequest::forward_request() omits the Content-Length header when the data is nullptr. this was an unintended change and broke the forwarding of some requests

reported by @kchheda3 

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
