### PR TITLE
cephadm: build with wheels, enabling pyyaml dependency

### DIFF
--- a/src/cephadm/build.py
+++ b/src/cephadm/build.py
@@ -31,6 +31,23 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
+# Fill in the package requirements for the zipapp build below. The PY36_REQUIREMENTS
+# list applies *only* to python 3.6. The PY_REQUIREMENTS list applies to all other
+# python versions. Python lower than 3.6 is not supported by this script.
+#
+# Each item must be a dict with the following fields:
+# - package_spec (REQUIRED, str): A python package requirement in the same style as
+#   requirements.txt and pip.
+# - from_source (bool): Try to force a clean no-binaries build using source packages.
+# - unique (bool): If true, this requirement should not be combined with any other
+#   on the pip command line.
+# - ignore_suffixes (list of str): A list of file and directory suffixes to EXCLUDE
+#   from the final zipapp.
+# - ignore_exact (list of str): A list of exact file and directory names to EXCLUDE
+#   from the final zipapp.
+# - custom_pip_args (list of str): A list of additional custom arguments to pass
+#   to pip when installing this dependency.
+#
 PY36_REQUIREMENTS = [
     {
         'package_spec': 'MarkupSafe >= 2.0.1, <2.2',
@@ -54,6 +71,11 @@ PY36_REQUIREMENTS = [
 PY_REQUIREMENTS = [
     {'package_spec': 'MarkupSafe >= 2.1.3, <2.2', 'from_source': True},
     {'package_spec': 'Jinja2 >= 3.1.2, <3.2', 'from_source': True},
+    # We can not install PyYAML using sources. Unlike MarkupSafe it requires
+    # Cython to build and Cython must be compiled and there's not clear way past
+    # the requirement in pyyaml's pyproject.toml. Instead, rely on fetching
+    # a platform specific pyyaml wheel and then stripping of the binary shared
+    # object.
     {
         'package_spec': 'PyYAML >= 6.0, <6.1',
         # do not include the stub package for compatibility with

--- a/src/cephadm/build.py
+++ b/src/cephadm/build.py
@@ -33,16 +33,18 @@ log = logging.getLogger(__name__)
 PY36_REQUIREMENTS = [
     {
         'package_spec': 'MarkupSafe >= 2.0.1, <2.2',
+        'from_source': True,
         'unique': True,
     },
     {
         'package_spec': 'Jinja2 >= 3.0.2, <3.2',
+        'from_source': True,
         'unique': True,
     },
 ]
 PY_REQUIREMENTS = [
-    {'package_spec': 'MarkupSafe >= 2.1.3, <2.2'},
-    {'package_spec': 'Jinja2 >= 3.1.2, <3.2'},
+    {'package_spec': 'MarkupSafe >= 2.1.3, <2.2', 'from_source': True},
+    {'package_spec': 'Jinja2 >= 3.1.2, <3.2', 'from_source': True},
 ]
 # IMPORTANT to be fully compatible with all the distros ceph is built for we
 # need to work around various old versions of python/pip. As such it's easier
@@ -61,17 +63,27 @@ _VALID_VERS_VARS = [
 
 class InstallSpec:
     def __init__(
-        self, package_spec, custom_pip_args=None, unique=False, **kwargs
+        self,
+        package_spec,
+        custom_pip_args=None,
+        unique=False,
+        from_source=False,
+        **kwargs,
     ):
         self.package_spec = package_spec
         self.name = package_spec.split()[0]
         self.custom_pip_args = custom_pip_args or []
         self.unique = unique
+        self.from_source = from_source
         self.extra = kwargs
 
     @property
     def pip_args(self):
-        return self.custom_pip_args
+        args = []
+        if self.from_source:
+            args.append("--no-binary")
+            args.append(":all:")
+        return args + self.custom_pip_args
 
     @property
     def pip_args_and_package(self):
@@ -306,8 +318,6 @@ def _install_pip_deps(tempdir, config):
                 "-m",
                 "pip",
                 "install",
-                "--no-binary",
-                ":all:",
                 "--target",
                 tempdir,
             ]

--- a/src/cephadm/build.py
+++ b/src/cephadm/build.py
@@ -165,7 +165,9 @@ class DependencyInfo:
     def __init__(self, config):
         self._config = config
         self._deps = []
-        self._reqs = {s.name: s.package_spec for s in self._config.requirements}
+        self._reqs = {
+            s.name: s.package_spec for s in self._config.requirements
+        }
 
     @property
     def requirements(self):
@@ -184,7 +186,6 @@ class DependencyInfo:
         """Record bundled dependency meta-data to the supplied file."""
         with open(path, 'w') as fh:
             json.dump(self._deps, fh)
-
 
 
 def _run(command, *args, **kwargs):
@@ -255,7 +256,9 @@ def _build(dest, src, config):
         shutil.rmtree(tempdir)
 
 
-def _ignore_cephadmlib(source_dir, names, ignore_suffixes=None, ignore_exact=None):
+def _ignore_cephadmlib(
+    source_dir, names, ignore_suffixes=None, ignore_exact=None
+):
     # shutil.copytree callback: return the list of names *to ignore*
     suffixes = ["~", ".old", ".swp", ".pyc", ".pyo", ".so", "__pycache__"]
     exact = []

--- a/src/cephadm/tests/build/test_cephadm_build.py
+++ b/src/cephadm/tests/build/test_cephadm_build.py
@@ -25,12 +25,12 @@ CONTAINERS = {
     'centos-8-plusdeps': {
         'name': 'cephadm-build-test:centos8-py36-deps',
         'base_image': 'quay.io/centos/centos:stream8',
-        'script': 'dnf install -y python36 python3-jinja2',
+        'script': 'dnf install -y python36 python3-jinja2 python3-pyyaml',
     },
     'centos-9-plusdeps': {
         'name': 'cephadm-build-test:centos9-py3-deps',
         'base_image': 'quay.io/centos/centos:stream9',
-        'script': 'dnf install -y python3 python3-jinja2',
+        'script': 'dnf install -y python3 python3-jinja2 python3-pyyaml',
     },
     'ubuntu-20.04': {
         'name': 'cephadm-build-test:ubuntu-20-04-py3',
@@ -122,7 +122,7 @@ def test_cephadm_build(env, source_dir, tmp_path):
     assert 'bundled_packages' in data
     assert all(v['package_source'] == 'pip' for v in data['bundled_packages'])
     assert all(
-        v['name'] in ('Jinja2', 'MarkupSafe')
+        v['name'] in ('Jinja2', 'MarkupSafe', 'PyYAML')
         for v in data['bundled_packages']
     )
     assert all('requirements_entry' in v for v in data['bundled_packages'])
@@ -178,7 +178,7 @@ def test_cephadm_build_from_rpms(env, source_dir, tmp_path):
     assert 'bundled_packages' in data
     assert all(v['package_source'] == 'rpm' for v in data['bundled_packages'])
     assert all(
-        v['name'] in ('Jinja2', 'MarkupSafe')
+        v['name'] in ('Jinja2', 'MarkupSafe', 'PyYAML')
         for v in data['bundled_packages']
     )
     assert all('requirements_entry' in v for v in data['bundled_packages'])


### PR DESCRIPTION
Continue over-engineering the build.py script so that some dependencies can be installed from wheels  (with binary builds). Unlike markupsafe, the pyyaml pure-python fallback is difficult to install due to how that project's pyproject.toml/setup.py are arranged. More details in the individual commit messages.

Update the build.py script to have more per-dependency options so that we can work around the difficulties of python packaging and continue to install the pure-python parts of a limited set of dependencies into the cephadm zipapp.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
