### PR TITLE
doc/radosgw: format commands in role.rst

### DIFF
--- a/doc/radosgw/role.rst
+++ b/doc/radosgw/role.rst
@@ -58,9 +58,11 @@ For example::
 Delete a Role
 -------------
 
-To delete a role, execute the following::
+To delete a role, run a command of the following form:
 
-	radosgw-admin role delete --role-name={role-name}
+.. prompt:: bash
+
+   radosgw-admin role delete --role-name={role-name}
 
 Request Parameters
 ~~~~~~~~~~~~~~~~~~
@@ -70,18 +72,23 @@ Request Parameters
 :Description: Name of the role.
 :Type: String
 
-For example:: 	
-	
-  radosgw-admin role delete --role-name=S3Access1
+For example:
 
-Note: A role can be deleted only when it doesn't have any permission policy attached to it.
+.. prompt:: bash
+	
+   radosgw-admin role delete --role-name=S3Access1
+
+Note: A role can be deleted only when it has no permission policy attached to
+it.
 
 Get a Role
 ----------
 
-To get information about a role, execute the following::
+To get information about a role, run a command of the following form:
 
-	radosgw-admin role get --role-name={role-name}
+.. prompt:: bash
+
+   radosgw-admin role get --role-name={role-name}
 
 Request Parameters
 ~~~~~~~~~~~~~~~~~~
@@ -91,9 +98,11 @@ Request Parameters
 :Description: Name of the role.
 :Type: String
 
-For example:: 	
+For example:
+
+.. prompt:: bash
 	
-  radosgw-admin role get --role-name=S3Access1
+   radosgw-admin role get --role-name=S3Access1
   
 .. code-block:: javascript
   
@@ -111,21 +120,26 @@ For example::
 List Roles
 ----------
 
-To list roles with a specified path prefix, execute the following::
+To list roles with a specified path prefix, run a command of the following form:
 
-	radosgw-admin role list [--path-prefix ={path prefix}]
+.. prompt:: bash
+
+   radosgw-admin role list [--path-prefix ={path prefix}]
 
 Request Parameters
 ~~~~~~~~~~~~~~~~~~
 
 ``path-prefix``
 
-:Description: Path prefix for filtering roles. If this is not specified, all roles are listed.
+:Description: Path prefix for filtering roles. If this is not specified, all
+              roles are listed.
 :Type: String
 
-For example:: 	
+For example:
+
+.. prompt:: bash
 	
-  radosgw-admin role list --path-prefix="/application"
+   radosgw-admin role list --path-prefix="/application"
   
 .. code-block:: javascript
   
@@ -140,7 +154,6 @@ For example::
         "assume_role_policy_document": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/TESTER\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
     }
   ]
-
 
 Update Assume Role Policy Document of a role
 --------------------------------------------
@@ -364,7 +377,9 @@ Example::
 
   POST "<hostname>?Action=DeleteRole&RoleName=S3Access"
 
-Note: A role can be deleted only when it doesn't have any permission policy attached to it.
+Note: A role can be deleted only when it doesn't have any permission policy
+attached to it. If you intend to delete a role, you must first delete any
+policies attached to it.
 
 Get a Role
 ----------


### PR DESCRIPTION
Format approximately one-hundred lines of doc/radosgw/role.rst to include proper command prompts. I also made one small English usage improvement.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
