### PR TITLE
quincy: mgr/snap_schedule: add support for monthly snapshots

### DIFF
--- a/doc/cephfs/snap-schedule.rst
+++ b/doc/cephfs/snap-schedule.rst
@@ -30,9 +30,9 @@ assumed to be keyword arguments too.
 Snapshot schedules are identified by path, their repeat interval and their start
 time. The
 repeat interval defines the time between two subsequent snapshots. It is
-specified by a number and a period multiplier, one of `h(our)`, `d(ay)` and
-`w(eek)`. E.g. a repeat interval of `12h` specifies one snapshot every 12
-hours.
+specified by a number and a period multiplier, one of `h(our)`, `d(ay)`,
+`w(eek)`, `M(onth)` and `Y(ear)`. E.g. a repeat interval of `12h` specifies one
+snapshot every 12 hours.
 The start time is specified as a time string (more details about passing times
 below). By default
 the start time is last midnight. So when a snapshot schedule with repeat
@@ -52,8 +52,8 @@ space or concatenated pairs of `<number><time period>`.
 The semantics are that a spec will ensure `<number>` snapshots are kept that are
 at least `<time period>` apart. For Example `7d` means the user wants to keep 7
 snapshots that are at least one day (but potentially longer) apart from each other.
-The following time periods are recognized: `h(our), d(ay), w(eek), m(onth),
-y(ear)` and `n`. The latter is a special modifier where e.g. `10n` means keep
+The following time periods are recognized: `h(our)`, `d(ay)`, `w(eek)`, `M(onth)`, 
+`Y(ear)` and `n`. The latter is a special modifier where e.g. `10n` means keep
 the last 10 snapshots regardless of timing,
 
 All subcommands take optional `fs` argument to specify paths in

--- a/qa/suites/fs/workload/tasks/3-snaps/yes.yaml
+++ b/qa/suites/fs/workload/tasks/3-snaps/yes.yaml
@@ -1,0 +1,30 @@
+overrides:
+  ceph:
+    conf:
+      mgr:
+        debug cephsqlite: 20
+  check-counter:
+    counters:
+      mds:
+        - mds.root_rsnaps
+        - mds_server.req_mksnap_latency.avgcount
+        - mds_server.req_rmsnap_latency.avgcount
+tasks:
+- exec:
+    mon.a:
+      - ceph mgr module enable snap_schedule
+      - ceph config set mgr mgr/snap_schedule/allow_m_granularity true
+      - ceph config set mgr mgr/snap_schedule/dump_on_update true
+      - ceph fs snap-schedule add --fs=cephfs --path=/ --snap_schedule=1m
+      - ceph fs snap-schedule retention add --fs=cephfs --path=/ --retention-spec-or-period=6m3h
+      - ceph fs snap-schedule status --fs=cephfs --path=/
+      - ceph fs snap-schedule list --fs=cephfs --path=/ --recursive=true
+      - date +%s > START_TIME
+- full_sequential_finally:
+  - exec:
+      mon.a:
+        # Ensure that we have some snaps which get deleted (so check-counters does not fail)
+        - date +%s > END_TIME
+        - START_TIME=$(cat START_TIME); END_TIME=$(cat END_TIME); DIFF_TIME=$((600-(END_TIME-START_TIME))); if [ "$DIFF_TIME" -gt 0 ]; then sleep "$DIFF_TIME"; fi
+        - ceph fs snap-schedule status --fs=cephfs --path=/
+        - ceph fs snap-schedule list --fs=cephfs --path=/ --recursive=true

--- a/qa/tasks/cephfs/test_snap_schedules.py
+++ b/qa/tasks/cephfs/test_snap_schedules.py
@@ -93,7 +93,7 @@ class TestSnapSchedulesHelper(CephFSTestCase):
     def _schedule_to_timeout(self, schedule):
         mult = schedule[-1]
         period = int(schedule[0:-1])
-        if mult == 'M':
+        if mult == 'm':
             return period * 60
         elif mult == 'h':
             return period * 60 * 60
@@ -101,6 +101,10 @@ class TestSnapSchedulesHelper(CephFSTestCase):
             return period * 60 * 60 * 24
         elif mult == 'w':
             return period * 60 * 60 * 24 * 7
+        elif mult == 'M':
+            return period * 60 * 60 * 24 * 30
+        elif mult == 'Y':
+            return period * 60 * 60 * 24 * 365
         else:
             raise RuntimeError('schedule multiplier not recognized')
 
@@ -223,15 +227,15 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.mount_a.run_shell(['mkdir', '-p', TestSnapSchedules.TEST_DIRECTORY])
 
         # set a schedule on the dir
-        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='1m')
         exec_time = time.time()
 
-        timo, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1m')
         log.debug(f'expecting snap {TestSnapSchedules.TEST_DIRECTORY}/.snap/scheduled-{snap_sfx} in ~{timo}s...')
         to_wait = timo + 2 # some leeway to avoid false failures...
 
         # verify snapshot schedule
-        self.verify_schedule(TestSnapSchedules.TEST_DIRECTORY, ['1M'])
+        self.verify_schedule(TestSnapSchedules.TEST_DIRECTORY, ['1m'])
 
         def verify_added(snaps_added):
             log.debug(f'snapshots added={snaps_added}')
@@ -259,18 +263,18 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.mount_a.run_shell(['mkdir', '-p', TestSnapSchedules.TEST_DIRECTORY])
 
         # set schedules on the dir
-        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='1M')
-        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='2M')
+        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='1m')
+        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='2m')
         exec_time = time.time()
 
-        timo_1, snap_sfx_1 = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo_1, snap_sfx_1 = self.calc_wait_time_and_snap_name(exec_time, '1m')
         log.debug(f'expecting snap {TestSnapSchedules.TEST_DIRECTORY}/.snap/scheduled-{snap_sfx_1} in ~{timo_1}s...')
-        timo_2, snap_sfx_2 = self.calc_wait_time_and_snap_name(exec_time, '2M')
+        timo_2, snap_sfx_2 = self.calc_wait_time_and_snap_name(exec_time, '2m')
         log.debug(f'expecting snap {TestSnapSchedules.TEST_DIRECTORY}/.snap/scheduled-{snap_sfx_2} in ~{timo_2}s...')
         to_wait = timo_2 + 2 # use max timeout
 
         # verify snapshot schedule
-        self.verify_schedule(TestSnapSchedules.TEST_DIRECTORY, ['1M', '2M'])
+        self.verify_schedule(TestSnapSchedules.TEST_DIRECTORY, ['1m', '2m'])
 
         def verify_added_1(snaps_added):
             log.debug(f'snapshots added={snaps_added}')
@@ -308,16 +312,16 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.mount_a.run_shell(['mkdir', '-p', TestSnapSchedules.TEST_DIRECTORY])
 
         # set a schedule on the dir
-        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='1M')
-        self.fs_snap_schedule_cmd('retention', 'add', path=TestSnapSchedules.TEST_DIRECTORY, retention_spec_or_period='1M')
+        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='1m')
+        self.fs_snap_schedule_cmd('retention', 'add', path=TestSnapSchedules.TEST_DIRECTORY, retention_spec_or_period='1m')
         exec_time = time.time()
 
-        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1m')
         log.debug(f'expecting snap {TestSnapSchedules.TEST_DIRECTORY}/.snap/scheduled-{snap_sfx} in ~{timo_1}s...')
         to_wait = timo_1 + 2 # some leeway to avoid false failures...
 
         # verify snapshot schedule
-        self.verify_schedule(TestSnapSchedules.TEST_DIRECTORY, ['1M'], retentions=[{'M':1}])
+        self.verify_schedule(TestSnapSchedules.TEST_DIRECTORY, ['1m'], retentions=[{'m':1}])
 
         def verify_added(snaps_added):
             log.debug(f'snapshots added={snaps_added}')
@@ -399,26 +403,26 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
 
         for d in testdirs:
             self.mount_a.run_shell(['mkdir', '-p', d[1:]])
-            self.fs_snap_schedule_cmd('add', path=d, snap_schedule='1M')
+            self.fs_snap_schedule_cmd('add', path=d, snap_schedule='1m')
 
         exec_time = time.time()
-        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1m')
 
         for d in testdirs:
-            self.fs_snap_schedule_cmd('activate', path=d, snap_schedule='1M')
+            self.fs_snap_schedule_cmd('activate', path=d, snap_schedule='1m')
 
         # we wait for 10 snaps to be taken
         wait_time = timo_1 + 10 * 60 + 15
         time.sleep(wait_time)
 
         for d in testdirs:
-            self.fs_snap_schedule_cmd('deactivate', path=d, snap_schedule='1M')
+            self.fs_snap_schedule_cmd('deactivate', path=d, snap_schedule='1m')
 
         for d in testdirs:
             self.verify_snap_stats(d)
 
         for d in testdirs:
-            self.fs_snap_schedule_cmd('remove', path=d, snap_schedule='1M')
+            self.fs_snap_schedule_cmd('remove', path=d, snap_schedule='1m')
             self.remove_snapshots(d[1:])
             self.mount_a.run_shell(['rmdir', d[1:]])
 
@@ -427,12 +431,12 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.mount_a.run_shell(['mkdir', '-p', TestSnapSchedules.TEST_DIRECTORY])
         testdir = os.path.join("/", TestSnapSchedules.TEST_DIRECTORY, "test_restart")
         self.mount_a.run_shell(['mkdir', '-p', testdir[1:]])
-        self.fs_snap_schedule_cmd('add', path=testdir, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('add', path=testdir, snap_schedule='1m')
 
         exec_time = time.time()
-        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1m')
 
-        self.fs_snap_schedule_cmd('activate', path=testdir, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('activate', path=testdir, snap_schedule='1m')
 
         # we wait for 10 snaps to be taken
         wait_time = timo_1 + 10 * 60 + 15
@@ -447,7 +451,7 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         log.debug(f'restarting active mgr: {active_mgr}')
         self.mgr_cluster.mon_manager.revive_mgr(active_mgr)
         time.sleep(300)  # sleep for 5 minutes
-        self.fs_snap_schedule_cmd('deactivate', path=testdir, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('deactivate', path=testdir, snap_schedule='1m')
 
         new_stats = self.get_snap_stats(testdir)
         self.assertTrue(new_stats['fs_count'] == new_stats['db_count'])
@@ -455,7 +459,7 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.assertTrue(new_stats['db_count'] > old_stats['db_count'])
 
         # cleanup
-        self.fs_snap_schedule_cmd('remove', path=testdir, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('remove', path=testdir, snap_schedule='1m')
         self.remove_snapshots(testdir[1:])
         self.mount_a.run_shell(['rmdir', testdir[1:]])    
 
@@ -463,7 +467,7 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         """
         Test that a non-existent path leads to schedule deactivation after a few retries.
         """
-        self.fs_snap_schedule_cmd('add', path="/bad-path", snap_schedule='1M')
+        self.fs_snap_schedule_cmd('add', path="/bad-path", snap_schedule='1m')
         start_time = time.time()
 
         while time.time() - start_time < 60.0:
@@ -490,15 +494,15 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.mount_a.run_shell(['mkdir', '-p', test_dir[1:]])
 
         # set a schedule on the dir
-        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1m')
         self.fs_snap_schedule_cmd('retention', 'add', path=test_dir,
                                   retention_spec_or_period=f'{total_snaps}n')
         exec_time = time.time()
 
-        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1m')
 
         # verify snapshot schedule
-        self.verify_schedule(test_dir, ['1M'])
+        self.verify_schedule(test_dir, ['1m'])
 
         # we wait for total_snaps snaps to be taken
         wait_time = timo_1 + total_snaps * 60 + 15
@@ -515,6 +519,61 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.remove_snapshots(test_dir[1:])
 
         self.mount_a.run_shell(['rmdir', test_dir[1:]])
+
+    def test_snap_schedule_all_periods(self):
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/minutes"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1m')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/hourly"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1h')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/daily"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1d')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/weekly"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1w')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/monthly"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1M')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/yearly"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1Y')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/bad_period_spec"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        with self.assertRaises(CommandFailedError):
+            self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1X')
+        with self.assertRaises(CommandFailedError):
+            self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1MM')
+        with self.assertRaises(CommandFailedError):
+            self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1')
+        with self.assertRaises(CommandFailedError):
+            self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='M')
+        with self.assertRaises(CommandFailedError):
+            self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='-1m')
+        with self.assertRaises(CommandFailedError):
+            self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/minutes"
+        self.mount_a.run_shell(['rmdir', test_dir])
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/hourly"
+        self.mount_a.run_shell(['rmdir', test_dir])
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/daily"
+        self.mount_a.run_shell(['rmdir', test_dir])
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/weekly"
+        self.mount_a.run_shell(['rmdir', test_dir])
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/monthly"
+        self.mount_a.run_shell(['rmdir', test_dir])
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/yearly"
+        self.mount_a.run_shell(['rmdir', test_dir])
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/bad_period_spec"
+        self.mount_a.run_shell(['rmdir', test_dir])
 
 
 class TestSnapSchedulesSnapdir(TestSnapSchedulesHelper):
@@ -544,16 +603,16 @@ class TestSnapSchedulesSnapdir(TestSnapSchedulesHelper):
         self.mount_a.run_shell(['mkdir', '-p', TestSnapSchedulesSnapdir.TEST_DIRECTORY])
 
         # set a schedule on the dir
-        self.fs_snap_schedule_cmd('add', path=TestSnapSchedulesSnapdir.TEST_DIRECTORY, snap_schedule='1M')
-        self.fs_snap_schedule_cmd('retention', 'add', path=TestSnapSchedulesSnapdir.TEST_DIRECTORY, retention_spec_or_period='1M')
+        self.fs_snap_schedule_cmd('add', path=TestSnapSchedulesSnapdir.TEST_DIRECTORY, snap_schedule='1m')
+        self.fs_snap_schedule_cmd('retention', 'add', path=TestSnapSchedulesSnapdir.TEST_DIRECTORY, retention_spec_or_period='1m')
         exec_time = time.time()
 
-        timo, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1m')
         sdn = self.get_snap_dir_name()
         log.info(f'expecting snap {TestSnapSchedulesSnapdir.TEST_DIRECTORY}/{sdn}/scheduled-{snap_sfx} in ~{timo}s...')
         
         # verify snapshot schedule
-        self.verify_schedule(TestSnapSchedulesSnapdir.TEST_DIRECTORY, ['1M'], retentions=[{'M':1}])
+        self.verify_schedule(TestSnapSchedulesSnapdir.TEST_DIRECTORY, ['1m'], retentions=[{'m':1}])
         
         # remove snapshot schedule
         self.fs_snap_schedule_cmd('remove', path=TestSnapSchedulesSnapdir.TEST_DIRECTORY)

--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -79,12 +79,12 @@ def get_prune_set(candidates: Set[Tuple[cephfs.DirEntry, datetime]],
         # NOTE: prune set has tz suffix stripped out.
         ("n", SNAPSHOT_TS_FORMAT),
         # TODO remove M for release
-        ("M", '%Y-%m-%d-%H_%M'),
+        ("m", '%Y-%m-%d-%H_%M'),
         ("h", '%Y-%m-%d-%H'),
         ("d", '%Y-%m-%d'),
         ("w", '%G-%V'),
-        ("m", '%Y-%m'),
-        ("y", '%Y'),
+        ("M", '%Y-%m'),
+        ("Y", '%Y'),
     ])
     keep = []
     if not retention:
@@ -212,7 +212,7 @@ class SnapSchedClient(CephfsClient):
         return DBConnectionManager(dbinfo)
 
     def _is_allowed_repeat(self, exec_row: Dict[str, str], path: str) -> bool:
-        if Schedule.parse_schedule(exec_row['schedule'])[1] == 'M':
+        if Schedule.parse_schedule(exec_row['schedule'])[1] == 'm':
             if self.allow_minute_snaps:
                 log.debug(('Minute repeats allowed, '
                            f'scheduling snapshot on path {path}'))
@@ -373,9 +373,10 @@ class SnapSchedClient(CephfsClient):
                                         Optional[str], Optional[str]]) -> None:
         sched = Schedule(*args)
         log.debug(f'repeat is {sched.repeat}')
-        if sched.parse_schedule(sched.schedule)[1] == 'M' and not self.allow_minute_snaps:
+        if sched.parse_schedule(sched.schedule)[1] == 'm' and not self.allow_minute_snaps:
             log.error('not allowed')
-            raise ValueError('no minute snaps allowed')
+            raise ValueError('invalid schedule specified - multiplier should '
+                             'be one of h,d,w,M,Y')
         log.debug(f'attempting to add schedule {sched}')
         with self.get_schedule_db(fs) as conn_mgr:
             db = conn_mgr.dbinfo.db


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62841

---

backport of https://github.com/ceph/ceph/pull/53070
parent tracker: https://tracker.ceph.com/issues/62494

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh