### PR TITLE
reef: mds: scrub repair does not clear earlier damage health status

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -3752,6 +3752,7 @@ bool CDir::scrub_local()
     mdcache->repair_dirfrag_stats(this);
     scrub_infop->header->set_repaired();
     good = true;
+    mdcache->mds->damage_table.remove_dentry_damage_entry(this);
   }
   return good;
 }

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4788,6 +4788,7 @@ next:
                            false);
         // Flag that we repaired this BT so that it won't go into damagetable
         results->backtrace.repaired = true;
+        in->mdcache->mds->damage_table.remove_backtrace_damage_entry(in->ino());
         if (in->mdcache->mds->logger)
           in->mdcache->mds->logger->inc(l_mds_scrub_backtrace_repaired);
       }
@@ -4926,6 +4927,9 @@ next:
 	    << "freshly-calculated rstats don't match existing ones (will be fixed)";
 	  in->mdcache->repair_inode_stats(in);
           results->raw_stats.repaired = true;
+          for (const auto &p : in->dirfrags){
+            in->mdcache->mds->damage_table.remove_dirfrag_damage_entry(p.second);
+          }
 	} else {
 	  results->raw_stats.error_str
 	    << "freshly-calculated rstats don't match existing ones";

--- a/src/mds/DamageTable.cc
+++ b/src/mds/DamageTable.cc
@@ -15,6 +15,7 @@
 #include "common/debug.h"
 
 #include "mds/CDir.h"
+#include "mds/CInode.h"
 
 #include "DamageTable.h"
 
@@ -198,6 +199,33 @@ bool DamageTable::notify_remote_damaged(inodeno_t ino, std::string_view path)
   }
 
   return false;
+}
+
+void DamageTable::remove_dentry_damage_entry(CDir *dir)
+{
+  if (dentries.count(
+        DirFragIdent(dir->inode->ino(), dir->frag)
+        ) > 0){
+          const auto frag_dentries =
+            dentries.at(DirFragIdent(dir->inode->ino(), dir->frag));
+          for(const auto &i : frag_dentries) {
+            erase(i.second->id);
+          }
+        }
+}
+
+void DamageTable::remove_dirfrag_damage_entry(CDir *dir)
+{
+  if (is_dirfrag_damaged(dir)){
+    erase(dirfrags.find(DirFragIdent(dir->inode->ino(), dir->frag))->second->id);
+  }
+}
+
+void DamageTable::remove_backtrace_damage_entry(inodeno_t ino)
+{  
+  if (is_remote_damaged(ino)){
+    erase(remotes.find(ino)->second->id);
+  }  
 }
 
 bool DamageTable::oversized() const

--- a/src/mds/DamageTable.h
+++ b/src/mds/DamageTable.h
@@ -22,6 +22,7 @@
 #include "include/random.h"
 
 class CDir;
+class CInode;
 
 typedef uint64_t damage_entry_id_t;
 
@@ -154,6 +155,12 @@ class DamageTable
      * Indicate that a particular Inode could not be loaded by number
      */
     bool notify_remote_damaged(inodeno_t ino, std::string_view path);
+
+    void remove_dentry_damage_entry(CDir *dir);
+
+    void remove_dirfrag_damage_entry(CDir *dir);
+
+    void remove_backtrace_damage_entry(inodeno_t ino);
 
     bool is_dentry_damaged(
       const CDir *dir_frag,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63810

---

backport of https://github.com/ceph/ceph/pull/48895
parent tracker: https://tracker.ceph.com/issues/54557

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh