### PR TITLE
quincy: pybind/mgr/pg_autoscaler: Cut back osdmap.get_pools calls

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/tests/test_overlapping_roots.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_overlapping_roots.py
@@ -52,8 +52,9 @@ class TestPgAutoscaler(object):
         overlapped_roots = set()
         osdmap = OSDMAP(pools)
         crush = CRUSH(rules, osd_dic)
-        roots, overlapped_roots = self.autoscaler.identify_subtrees_and_overlaps(osdmap,
-                                                                                 crush, result, overlapped_roots, roots)
+        roots, overlapped_roots = self.autoscaler.identify_subtrees_and_overlaps(
+            osdmap, pools, crush, result, overlapped_roots, roots
+        )
         assert overlapped_roots == expected_overlapped_roots
 
     def test_subtrees_and_overlaps(self):
@@ -93,7 +94,8 @@ class TestPgAutoscaler(object):
             },
         ]
         pools = {
-            0: {
+            "data": {
+                "pool": 0,
                 "pool_name": "data",
                 "pg_num_target": 1024,
                 "size": 3,
@@ -104,7 +106,8 @@ class TestPgAutoscaler(object):
                 },
                 "expected_final_pg_target": 1024,
             },
-            1: {
+            "metadata": {
+                "pool": 1,
                 "pool_name": "metadata",
                 "pg_num_target": 64,
                 "size": 3,
@@ -115,7 +118,8 @@ class TestPgAutoscaler(object):
                 },
                 "expected_final_pg_target": 64,
             },
-            4: {
+            "libvirt-pool": {
+                "pool": 4,
                 "pool_name": "libvirt-pool",
                 "pg_num_target": 32,
                 "size": 3,
@@ -124,7 +128,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 128,
             },
-            93: {
+            ".rgw.root": {
+                "pool": 93,
                 "pool_name": ".rgw.root",
                 "pg_num_target": 32,
                 "size": 3,
@@ -133,7 +138,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 32,
             },
-            94: {
+            "default.rgw.control": {
+                "pool": 94,
                 "pool_name": "default.rgw.control",
                 "pg_num_target": 32,
                 "size": 3,
@@ -142,7 +148,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 32,
             },
-            95: {
+            "default.rgw.meta": {
+                "pool": 95,
                 "pool_name": "default.rgw.meta",
                 "pg_num_target": 32,
                 "size": 3,
@@ -151,7 +158,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 32,
             },
-            96: {
+            "default.rgw.log": {
+                "pool": 96,
                 "pool_name": "default.rgw.log",
                 "pg_num_target": 32,
                 "size": 3,
@@ -160,7 +168,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 32,
             },
-            97: {
+            "default.rgw.buckets.index": {
+                "pool": 97,
                 "pool_name": "default.rgw.buckets.index",
                 "pg_num_target": 32,
                 "size": 3,
@@ -169,7 +178,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 32,
             },
-            98: {
+            "default.rgw.buckets.data": {
+                "pool": 98,
                 "pool_name": "default.rgw.buckets.data",
                 "pg_num_target": 32,
                 "size": 3,
@@ -178,7 +188,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 128,
             },
-            99: {
+            "default.rgw.buckets.non-ec": {
+                "pool": 99,
                 "pool_name": "default.rgw.buckets.non-ec",
                 "pg_num_target": 32,
                 "size": 3,
@@ -187,7 +198,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 32,
             },
-            100: {
+            "device_health_metrics": {
+                "pool": 100,
                 "pool_name": "device_health_metrics",
                 "pg_num_target": 1,
                 "size": 3,
@@ -198,7 +210,8 @@ class TestPgAutoscaler(object):
                 },
                 "expected_final_pg_target": 1,
             },
-            113: {
+            "cephfs.teuthology.meta": {
+                "pool": 113,
                 "pool_name": "cephfs.teuthology.meta",
                 "pg_num_target": 64,
                 "size": 3,
@@ -210,7 +223,8 @@ class TestPgAutoscaler(object):
                 },
                 "expected_final_pg_target": 512,
             },
-            114: {
+            "cephfs.teuthology.data": {
+                "pool": 114,
                 "pool_name": "cephfs.teuthology.data",
                 "pg_num_target": 256,
                 "size": 3,
@@ -222,7 +236,8 @@ class TestPgAutoscaler(object):
                 "expected_final_pg_target": 1024,
                 "expected_final_pg_target": 256,
             },
-            117: {
+            "cephfs.scratch.meta": {
+                "pool": 117,
                 "pool_name": "cephfs.scratch.meta",
                 "pg_num_target": 32,
                 "size": 3,
@@ -234,7 +249,8 @@ class TestPgAutoscaler(object):
                 },
                 "expected_final_pg_target": 64,
             },
-            118: {
+            "cephfs.scratch.data": {
+                "pool": 118,
                 "pool_name": "cephfs.scratch.data",
                 "pg_num_target": 32,
                 "size": 3,
@@ -243,7 +259,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 128,
             },
-            119: {
+            "cephfs.teuthology.data-ec": {
+                "pool": 119,
                 "pool_name": "cephfs.teuthology.data-ec",
                 "pg_num_target": 1024,
                 "size": 6,
@@ -254,7 +271,8 @@ class TestPgAutoscaler(object):
                 },
                 "expected_final_pg_target": 1024,
             },
-            121: {
+            "cephsqlite": {
+                "pool": 121,
                 "pool_name": "cephsqlite",
                 "pg_num_target": 32,
                 "size": 3,
@@ -304,7 +322,8 @@ class TestPgAutoscaler(object):
             },
         ]
         pools = {
-            0: {
+            "data": {
+                "pool": 0,
                 "pool_name": "data",
                 "pg_num_target": 1024,
                 "size": 3,
@@ -315,7 +334,8 @@ class TestPgAutoscaler(object):
                 },
                 "expected_final_pg_target": 1024,
             },
-            1: {
+            "metadata": {
+                "pool": 1,
                 "pool_name": "metadata",
                 "pg_num_target": 64,
                 "size": 3,
@@ -326,7 +346,8 @@ class TestPgAutoscaler(object):
                 },
                 "expected_final_pg_target": 64,
             },
-            4: {
+            "libvirt-pool": {
+                "pool": 4,
                 "pool_name": "libvirt-pool",
                 "pg_num_target": 32,
                 "size": 3,
@@ -335,7 +356,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 128,
             },
-            93: {
+            ".rgw.root": {
+                "pool": 93,
                 "pool_name": ".rgw.root",
                 "pg_num_target": 32,
                 "size": 3,
@@ -344,7 +366,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 32,
             },
-            94: {
+            "default.rgw.control": {
+                "pool": 94,
                 "pool_name": "default.rgw.control",
                 "pg_num_target": 32,
                 "size": 3,
@@ -353,7 +376,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 32,
             },
-            95: {
+            "default.rgw.meta": {
+                "pool": 95,
                 "pool_name": "default.rgw.meta",
                 "pg_num_target": 32,
                 "size": 3,
@@ -362,7 +386,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 32,
             },
-            96: {
+            "default.rgw.log": {
+                "pool": 96,
                 "pool_name": "default.rgw.log",
                 "pg_num_target": 32,
                 "size": 3,
@@ -371,7 +396,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 32,
             },
-            97: {
+            "default.rgw.buckets.index": {
+                "pool": 97,
                 "pool_name": "default.rgw.buckets.index",
                 "pg_num_target": 32,
                 "size": 3,
@@ -380,7 +406,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 32,
             },
-            98: {
+            "default.rgw.buckets.data": {
+                "pool": 98,
                 "pool_name": "default.rgw.buckets.data",
                 "pg_num_target": 32,
                 "size": 3,
@@ -389,7 +416,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 128,
             },
-            99: {
+            "default.rgw.buckets.non-ec": {
+                "pool": 99,
                 "pool_name": "default.rgw.buckets.non-ec",
                 "pg_num_target": 32,
                 "size": 3,
@@ -398,7 +426,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 32,
             },
-            100: {
+            "device_health_metrics": {
+                "pool": 100,
                 "pool_name": "device_health_metrics",
                 "pg_num_target": 1,
                 "size": 3,
@@ -409,7 +438,8 @@ class TestPgAutoscaler(object):
                 },
                 "expected_final_pg_target": 1,
             },
-            113: {
+            "cephfs.teuthology.meta": {
+                "pool": 113,
                 "pool_name": "cephfs.teuthology.meta",
                 "pg_num_target": 64,
                 "size": 3,
@@ -421,7 +451,8 @@ class TestPgAutoscaler(object):
                 },
                 "expected_final_pg_target": 512,
             },
-            114: {
+            "cephfs.teuthology.data": {
+                "pool": 114,
                 "pool_name": "cephfs.teuthology.data",
                 "pg_num_target": 256,
                 "size": 3,
@@ -433,7 +464,8 @@ class TestPgAutoscaler(object):
                 "expected_final_pg_target": 1024,
                 "expected_final_pg_target": 256,
             },
-            117: {
+            "cephfs.scratch.meta": {
+                "pool": 117,
                 "pool_name": "cephfs.scratch.meta",
                 "pg_num_target": 32,
                 "size": 3,
@@ -445,7 +477,8 @@ class TestPgAutoscaler(object):
                 },
                 "expected_final_pg_target": 64,
             },
-            118: {
+            "cephfs.scratch.data": {
+                "pool": 118,
                 "pool_name": "cephfs.scratch.data",
                 "pg_num_target": 32,
                 "size": 3,
@@ -454,7 +487,8 @@ class TestPgAutoscaler(object):
                 "options": {},
                 "expected_final_pg_target": 128,
             },
-            119: {
+            "cephfs.teuthology.data-ec": {
+                "pool": 119,
                 "pool_name": "cephfs.teuthology.data-ec",
                 "pg_num_target": 1024,
                 "size": 6,
@@ -465,7 +499,8 @@ class TestPgAutoscaler(object):
                 },
                 "expected_final_pg_target": 1024,
             },
-            121: {
+            "cephsqlite": {
+                "pool": 121,
                 "pool_name": "cephsqlite",
                 "pg_num_target": 32,
                 "size": 3,


### PR DESCRIPTION
**Problem:**

we have been extravagantly using osdmap get calls
which has led to performance issue when `pg_num`
is around ~3000.
    
**Solution:**

Limit the use of osdmap get calls by calling it once
and use the data for both functions `maybe_adjust`
and `update_progress_events`.
 
 Fixes: https://tracker.ceph.com/issues/62165
 
Signed-off-by: Kamoltat <ksirivad@redhat.com>

**Before Fix:**
![pg_autoscaler-reef-5s-scrape-1000-osds-32768pg](https://github.com/ceph/ceph/assets/22287000/9afa84b1-c6ce-4699-97e4-35a685aa0eea)

**After Fix:**
![pg_autoscaler-reef-patched-5s-scrape-1000-osds-32768pg](https://github.com/ceph/ceph/assets/22287000/6feca4d4-22d8-460f-a979-4b7cfdd9a88e)

Backport tracker: https://tracker.ceph.com/issues/62886


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
