### PR TITLE
OSD: oldest_map and newest_map should be displayed directly

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -713,6 +713,8 @@ void OSD::dump_status(Formatter* f) const
   f->dump_unsigned("whoami", superblock.whoami);
   f->dump_string("state", pg_shard_manager.get_osd_state_string());
   f->dump_stream("maps") << superblock.maps;
+  f->dump_stream("oldest_map") << superblock.get_oldest_map();
+  f->dump_stream("newest_map") << superblock.get_newest_map();
   f->dump_unsigned("cluster_osdmap_trim_lower_bound",
                    superblock.cluster_osdmap_trim_lower_bound);
   f->dump_unsigned("num_pgs", pg_shard_manager.get_num_pgs());

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2696,6 +2696,8 @@ void OSD::asok_command(
     f->dump_unsigned("whoami", superblock.whoami);
     f->dump_string("state", get_state_name(get_state()));
     f->dump_stream("maps") << superblock.maps;
+    f->dump_stream("oldest_map") << superblock.get_oldest_map();
+    f->dump_stream("newest_map") << superblock.get_newest_map();
     f->dump_unsigned("cluster_osdmap_trim_lower_bound",
                      superblock.cluster_osdmap_trim_lower_bound);
     f->dump_unsigned("num_pgs", num_pgs);


### PR DESCRIPTION
    OSD: oldest_map and newest_map should be displayed directly

    9215996586ba79302c07e5cf586ec2add1ac159e delete these,
    ceph daemon osd.x status
    when osd status is displayed, only superblock.maps (begin ~ len) can be seen.
    this need calculate maps to get oldest_map/newest_map held by the current osd.
    moreover, it cannot be simply calculate. need pay attention to the boundaries。
    this is not very friendly.

    Fixes: https://tracker.ceph.com/issues/63836
    Signed-off-by: zhangjianwei2 <zhangjianwei2@cmss.chinamobile.com>

Fixes: https://tracker.ceph.com/issues/63836

due to 9215996586ba79302c07e5cf586ec2add1ac159e:
<img width="694" alt="图片" src="https://github.com/ceph/ceph/assets/19184136/8357fdf6-4683-48ce-b177-f88aeb8e576d">
