### PR TITLE
doc/cephfs/client-auth.rst: correct ``fs authorize cephfs1 /dir1 client.x rw``

### DIFF
--- a/doc/cephfs/client-auth.rst
+++ b/doc/cephfs/client-auth.rst
@@ -316,8 +316,8 @@ Changing rw permissions in caps
 It's not possible to modify caps by running ``fs authorize`` except for the
 case when read/write permissions have to be changed. This so because the
 ``fs authorize`` becomes ambiguous. For example, user runs ``fs authorize
-cephfs1 /dir1 client.x rw`` to create a client and then runs ``fs authorize
-cephfs1 /dir2 client.x rw`` (notice ``/dir1`` is changed to ``/dir2``).
+cephfs1 client.x /dir1 rw`` to create a client and then runs ``fs authorize
+cephfs1 client.x /dir2 rw`` (notice ``/dir1`` is changed to ``/dir2``).
 Running second command can be interpreted as changing ``/dir1`` to ``/dir2``
 in current cap or can also be interpreted as authorizing the client with a
 new cap for path ``/dir2``. As seen in previous sections, second

--- a/doc/cephfs/client-auth.rst
+++ b/doc/cephfs/client-auth.rst
@@ -314,7 +314,7 @@ Changing rw permissions in caps
 -------------------------------
 
 It's not possible to modify caps by running ``fs authorize`` except for the
-case when read/write permissions have to be changed. This so because the
+case when read/write permissions have to be changed. This is because the
 ``fs authorize`` becomes ambiguous. For example, user runs ``fs authorize
 cephfs1 client.x /dir1 rw`` to create a client and then runs ``fs authorize
 cephfs1 client.x /dir2 rw`` (notice ``/dir1`` is changed to ``/dir2``).


### PR DESCRIPTION
doc/cephfs/client-auth.rst: correct ``fs authorize cephfs1 /dir1 client.x rw``

Author: 叶海丰 <769358362@qq.com>
Date:   Fri Dec 15 17:05:38 2023 +0800

    doc/cephfs/client-auth.rst: correct ``fs authorize cephfs1 /dir1 client.x rw``
