### PR TITLE
vstart: Pick only CIDR-formatted routes when cephadm enabled

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1587,7 +1587,7 @@ EOF
     fi
     if [ "$cephadm" -gt 0 ]; then
         debug echo Setting mon public_network ...
-        public_network=$(ip route list | grep -w "$IP" | grep -v default | awk '{print $1}')
+        public_network=$(ip route list | grep -w "$IP" | grep -v default | grep -E "/[0-9]+" | awk '{print $1}')
         ceph_adm config set mon public_network $public_network
     fi
 fi


### PR DESCRIPTION
When cephadm is enabled, the script for determining the public_network value from 'ip route list' output was previously capturing all routes associated with the specified IP. This included non-CIDR formatted entries such as specific IP routes (e.g., 8.8.8.8) and gateway addresses, leading to the selection of multiple, potentially irrelevant entries. This behavior resulted in an issue where vstart could not correctly identify the network, causing it to terminate unexpectedly.

This commit adds a grep command to ensure only CIDR network formats are identified.

> root@dskbd015:~/ydg/ceph/build# ../src/vstart.sh -n --nodaemon --redirect-output --cephadm
...
**Setting mon public_network ...
/root/ydg/ceph/build/bin/ceph -c /root/ydg/ceph/build/ceph.conf -k /root/ydg/ceph/build/keyring config set mon public_network 8.8.8.8 172.16.12.0/24 172.16.12.1 
172.16.12.0/24 not valid:  172.16.12.0/24 not one of 'true', 'false'
Invalid command: unused arguments: ['172.16.12.0/24', '172.16.12.1']**
config set <who> <name> <value> [--force] :  Set a configuration option for one or more entities
Error EINVAL: invalid command

> root@dskbd015:~/ydg/ceph/build# echo $IP # << selected by vstart.sh(ip addr)
172.16.12.35

> root@dskbd015:~/ydg/ceph# ip route list
default via 10.10.40.1 dev enp75s0f0 proto static 
default via 172.16.12.1 dev enp178s0f0 proto dhcp src 172.16.12.35 metric 100 
8.8.8.8 via 172.16.12.1 dev enp178s0f0 proto dhcp src 172.16.12.35 metric 100 
10.10.40.0/21 dev enp75s0f0 proto kernel scope link src 10.10.40.35 
172.16.12.0/24 dev enp178s0f0 proto kernel scope link src 172.16.12.35 metric 100 
172.16.12.1 dev enp178s0f0 proto dhcp scope link src 172.16.12.35 metric 100 
172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 

> root@dskbd015:~/ydg/ceph/build# ip route list | grep -w "$IP" | grep -v default | awk '{print $1}'
8.8.8.8
172.16.12.0/24
172.16.12.1
--


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
