### PR TITLE
quincy: librbd: don't report HOLE_UPDATED when diffing against a hole

### DIFF
--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -150,11 +150,12 @@ private:
 };
 
 int simple_diff_cb(uint64_t off, size_t len, int exists, void *arg) {
-  // it's possible for a discard to create a hole in the parent image -- ignore
-  if (exists) {
-    interval_set<uint64_t> *diff = static_cast<interval_set<uint64_t> *>(arg);
-    diff->insert(off, len);
-  }
+  // This reads the existing extents in a parent from the beginning
+  // of time.  Since images are thin-provisioned, the extents will
+  // always represent data, not holes.
+  ceph_assert(exists);
+  auto diff = static_cast<interval_set<uint64_t>*>(arg);
+  diff->insert(off, len);
   return 0;
 }
 

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -249,7 +249,7 @@ int DiffIterate<I>::execute() {
   if (m_whole_object) {
     C_SaferCond ctx;
     auto req = object_map::DiffRequest<I>::create(&m_image_ctx, from_snap_id,
-                                                  end_snap_id,
+                                                  end_snap_id, true,
                                                   &object_diff_state, &ctx);
     req->send();
 

--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -101,9 +101,10 @@ void ImageCopyRequest<I>::compute_diff() {
 
   auto ctx = create_context_callback<
     ImageCopyRequest<I>, &ImageCopyRequest<I>::handle_compute_diff>(this);
-  auto req = object_map::DiffRequest<I>::create(m_src_image_ctx, m_src_snap_id_start,
-                                                m_src_snap_id_end, &m_object_diff_state,
-                                                ctx);
+  auto req = object_map::DiffRequest<I>::create(m_src_image_ctx,
+                                                m_src_snap_id_start,
+                                                m_src_snap_id_end, false,
+                                                &m_object_diff_state, ctx);
   req->send();
 }
 

--- a/src/librbd/object_map/DiffRequest.cc
+++ b/src/librbd/object_map/DiffRequest.cc
@@ -266,7 +266,11 @@ void DiffRequest<I>::handle_load_object_map(int r) {
         }
       } else {
         // diffing against a snapshot, this is its object map
-        *diff_it = DIFF_STATE_DATA;
+        if (object_map_state != OBJECT_PENDING) {
+          *diff_it = DIFF_STATE_DATA;
+        } else {
+          *diff_it = DIFF_STATE_DATA_UPDATED;
+        }
       }
 
       ldout(cct, 20) << "object state: " << i << " "

--- a/src/librbd/object_map/DiffRequest.cc
+++ b/src/librbd/object_map/DiffRequest.cc
@@ -195,16 +195,34 @@ void DiffRequest<I>::handle_load_object_map(int r) {
   for (; it != overlap_end_it; ++it, ++diff_it, ++i) {
     uint8_t object_map_state = *it;
     uint8_t prev_object_diff_state = *diff_it;
-    if (object_map_state == OBJECT_EXISTS ||
-        object_map_state == OBJECT_PENDING ||
-        (object_map_state == OBJECT_EXISTS_CLEAN &&
-         prev_object_diff_state != DIFF_STATE_DATA &&
-         prev_object_diff_state != DIFF_STATE_DATA_UPDATED)) {
-      *diff_it = DIFF_STATE_DATA_UPDATED;
-    } else if (object_map_state == OBJECT_NONEXISTENT &&
-               prev_object_diff_state != DIFF_STATE_HOLE &&
-               prev_object_diff_state != DIFF_STATE_HOLE_UPDATED) {
-      *diff_it = DIFF_STATE_HOLE_UPDATED;
+    switch (prev_object_diff_state) {
+    case DIFF_STATE_HOLE:
+      if (object_map_state != OBJECT_NONEXISTENT) {
+        // stay in HOLE on intermediate snapshots for diff-iterate
+        if (!m_diff_iterate_range || m_current_snap_id == m_snap_id_end) {
+          *diff_it = DIFF_STATE_DATA_UPDATED;
+        }
+      }
+      break;
+    case DIFF_STATE_DATA:
+      if (object_map_state == OBJECT_NONEXISTENT) {
+        *diff_it = DIFF_STATE_HOLE_UPDATED;
+      } else if (object_map_state != OBJECT_EXISTS_CLEAN) {
+        *diff_it = DIFF_STATE_DATA_UPDATED;
+      }
+      break;
+    case DIFF_STATE_HOLE_UPDATED:
+      if (object_map_state != OBJECT_NONEXISTENT) {
+        *diff_it = DIFF_STATE_DATA_UPDATED;
+      }
+      break;
+    case DIFF_STATE_DATA_UPDATED:
+      if (object_map_state == OBJECT_NONEXISTENT) {
+        *diff_it = DIFF_STATE_HOLE_UPDATED;
+      }
+      break;
+    default:
+      ceph_abort();
     }
 
     ldout(cct, 20) << "object state: " << i << " "
@@ -225,8 +243,29 @@ void DiffRequest<I>::handle_load_object_map(int r) {
       } else if (diff_from_start ||
                  (m_object_diff_state_valid &&
                   object_map_state != OBJECT_EXISTS_CLEAN)) {
-        *diff_it = DIFF_STATE_DATA_UPDATED;
+        // diffing against the beginning of time or image was grown
+        // (implicit) starting state is HOLE, this is the first object
+        // map after
+        if (m_diff_iterate_range) {
+          // for diff-iterate, if the object is discarded prior to or
+          // in the end version, result should be HOLE
+          // since DATA_UPDATED can transition only to HOLE_UPDATED,
+          // stay in HOLE on intermediate snapshots -- another way to
+          // put this is that when starting with a hole, intermediate
+          // snapshots can be ignored as the result depends only on the
+          // end version
+          if (m_current_snap_id == m_snap_id_end) {
+            *diff_it = DIFF_STATE_DATA_UPDATED;
+          } else {
+            *diff_it = DIFF_STATE_HOLE;
+          }
+        } else {
+          // for deep-copy, if the object is discarded prior to or
+          // in the end version, result should be HOLE_UPDATED
+          *diff_it = DIFF_STATE_DATA_UPDATED;
+        }
       } else {
+        // diffing against a snapshot, this is its object map
         *diff_it = DIFF_STATE_DATA;
       }
 

--- a/src/librbd/object_map/DiffRequest.h
+++ b/src/librbd/object_map/DiffRequest.h
@@ -22,19 +22,19 @@ template <typename ImageCtxT>
 class DiffRequest {
 public:
   static DiffRequest* create(ImageCtxT* image_ctx, uint64_t snap_id_start,
-                             uint64_t snap_id_end,
+                             uint64_t snap_id_end, bool diff_iterate_range,
                              BitVector<2>* object_diff_state,
                              Context* on_finish) {
     return new DiffRequest(image_ctx, snap_id_start, snap_id_end,
-                           object_diff_state, on_finish);
+                           diff_iterate_range, object_diff_state, on_finish);
   }
 
   DiffRequest(ImageCtxT* image_ctx, uint64_t snap_id_start,
-              uint64_t snap_id_end, BitVector<2>* object_diff_state,
-              Context* on_finish)
+              uint64_t snap_id_end, bool diff_iterate_range,
+              BitVector<2>* object_diff_state, Context* on_finish)
     : m_image_ctx(image_ctx), m_snap_id_start(snap_id_start),
-      m_snap_id_end(snap_id_end), m_object_diff_state(object_diff_state),
-      m_on_finish(on_finish) {
+      m_snap_id_end(snap_id_end), m_diff_iterate_range(diff_iterate_range),
+      m_object_diff_state(object_diff_state), m_on_finish(on_finish) {
   }
 
   void send();
@@ -58,6 +58,7 @@ private:
   ImageCtxT* m_image_ctx;
   uint64_t m_snap_id_start;
   uint64_t m_snap_id_end;
+  bool m_diff_iterate_range;
   BitVector<2>* m_object_diff_state;
   Context* m_on_finish;
 

--- a/src/librbd/object_map/Types.h
+++ b/src/librbd/object_map/Types.h
@@ -8,10 +8,17 @@ namespace librbd {
 namespace object_map {
 
 enum DiffState {
-  DIFF_STATE_HOLE         = 0, /* unchanged hole */
-  DIFF_STATE_DATA         = 1, /* unchanged data */
-  DIFF_STATE_HOLE_UPDATED = 2, /* new hole */
-  DIFF_STATE_DATA_UPDATED = 3  /* new data */
+  // diff-iterate: hole with or without data captured in intermediate snapshot
+  // deep-copy: hole without data captured in intermediate snapshot
+  DIFF_STATE_HOLE         = 0,
+  // diff-iterate, deep-copy: unchanged data
+  DIFF_STATE_DATA         = 1,
+  // diff-iterate: new hole (data -> hole)
+  // deep-copy: new hole (data -> hole) or hole with data captured in
+  //            intermediate snapshot
+  DIFF_STATE_HOLE_UPDATED = 2,
+  // diff-iterate, deep-copy: new data (hole -> data) or changed data
+  DIFF_STATE_DATA_UPDATED = 3
 };
 
 } // namespace object_map

--- a/src/test/cli-integration/rbd/snap-diff.t
+++ b/src/test/cli-integration/rbd/snap-diff.t
@@ -39,10 +39,14 @@
   $ rbd diff --from-snap=snap1 xrbddiff1/xtestdiff1 --format json
   []
   $ rbd snap rollback xrbddiff1/xtestdiff1@snap1 --no-progress
+  $ rbd diff --from-snap=allzeroes xrbddiff1/xtestdiff1 --format json
+  [{"offset":0,"length":1048576,"exists":"true"}]
   $ rbd diff --from-snap=snap1 xrbddiff1/xtestdiff1 --format json
   []
   $ rbd snap rollback xrbddiff1/xtestdiff1@allzeroes --no-progress
   $ rbd diff --from-snap=allzeroes xrbddiff1/xtestdiff1 --format json
+  []
+  $ rbd diff --from-snap=snap1 xrbddiff1/xtestdiff1 --format json
   [{"offset":0,"length":1048576,"exists":"false"}]
   $ ceph osd pool rm xrbddiff1 xrbddiff1 --yes-i-really-really-mean-it
   pool 'xrbddiff1' removed

--- a/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
@@ -92,6 +92,7 @@ struct DiffRequest<MockTestImageCtx> {
   static DiffRequest* s_instance;
   static DiffRequest* create(MockTestImageCtx *image_ctx,
                              uint64_t snap_id_start, uint64_t snap_id_end,
+                             bool diff_iterate_range,
                              BitVector<2>* object_diff_state,
                              Context* on_finish) {
     ceph_assert(s_instance != nullptr);

--- a/src/test/librbd/object_map/test_mock_DiffRequest.cc
+++ b/src/test/librbd/object_map/test_mock_DiffRequest.cc
@@ -42,6 +42,10 @@ public:
     ASSERT_EQ(0, open_image(m_image_name, &m_image_ctx));
   }
 
+  bool is_diff_iterate() const {
+    return true;
+  }
+
   void expect_get_flags(MockTestImageCtx& mock_image_ctx, uint64_t snap_id,
                         int32_t flags, int r) {
     EXPECT_CALL(mock_image_ctx, get_flags(snap_id, _))
@@ -87,7 +91,8 @@ TEST_F(TestMockObjectMapDiffRequest, InvalidStartSnap) {
 
   C_SaferCond ctx;
   auto req = new MockDiffRequest(&mock_image_ctx, CEPH_NOSNAP, 0,
-                                 &m_object_diff_state, &ctx);
+                                 is_diff_iterate(), &m_object_diff_state,
+                                 &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -98,7 +103,7 @@ TEST_F(TestMockObjectMapDiffRequest, StartEndSnapEqual) {
   InSequence seq;
 
   C_SaferCond ctx;
-  auto req = new MockDiffRequest(&mock_image_ctx, 1, 1,
+  auto req = new MockDiffRequest(&mock_image_ctx, 1, 1, is_diff_iterate(),
                                  &m_object_diff_state, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
@@ -115,7 +120,8 @@ TEST_F(TestMockObjectMapDiffRequest, FastDiffDisabled) {
 
   C_SaferCond ctx;
   auto req = new MockDiffRequest(&mock_image_ctx, 0, CEPH_NOSNAP,
-                                 &m_object_diff_state, &ctx);
+                                 is_diff_iterate(), &m_object_diff_state,
+                                 &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -133,7 +139,8 @@ TEST_F(TestMockObjectMapDiffRequest, FastDiffInvalid) {
 
   C_SaferCond ctx;
   auto req = new MockDiffRequest(&mock_image_ctx, 0, CEPH_NOSNAP,
-                                 &m_object_diff_state, &ctx);
+                                 is_diff_iterate(), &m_object_diff_state,
+                                 &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -180,7 +187,8 @@ TEST_F(TestMockObjectMapDiffRequest, FullDelta) {
 
   C_SaferCond ctx;
   auto req = new MockDiffRequest(&mock_image_ctx, 0, CEPH_NOSNAP,
-                                 &m_object_diff_state, &ctx);
+                                 is_diff_iterate(), &m_object_diff_state,
+                                 &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 
@@ -188,7 +196,7 @@ TEST_F(TestMockObjectMapDiffRequest, FullDelta) {
   expected_diff_state.resize(object_count);
   expected_diff_state[1] = DIFF_STATE_DATA_UPDATED;
   expected_diff_state[2] = DIFF_STATE_DATA_UPDATED;
-  expected_diff_state[3] = DIFF_STATE_HOLE_UPDATED;
+  expected_diff_state[3] = DIFF_STATE_HOLE;
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 
@@ -226,7 +234,7 @@ TEST_F(TestMockObjectMapDiffRequest, IntermediateDelta) {
   expect_load_map(mock_image_ctx, 2U, object_map_2, 0);
 
   C_SaferCond ctx;
-  auto req = new MockDiffRequest(&mock_image_ctx, 1, 2,
+  auto req = new MockDiffRequest(&mock_image_ctx, 1, 2, is_diff_iterate(),
                                  &m_object_diff_state, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
@@ -274,7 +282,8 @@ TEST_F(TestMockObjectMapDiffRequest, EndDelta) {
 
   C_SaferCond ctx;
   auto req = new MockDiffRequest(&mock_image_ctx, 2, CEPH_NOSNAP,
-                                 &m_object_diff_state, &ctx);
+                                 is_diff_iterate(), &m_object_diff_state,
+                                 &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 
@@ -302,7 +311,8 @@ TEST_F(TestMockObjectMapDiffRequest, StartSnapDNE) {
 
   C_SaferCond ctx;
   auto req = new MockDiffRequest(&mock_image_ctx, 1, CEPH_NOSNAP,
-                                 &m_object_diff_state, &ctx);
+                                 is_diff_iterate(), &m_object_diff_state,
+                                 &ctx);
   req->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -328,7 +338,7 @@ TEST_F(TestMockObjectMapDiffRequest, EndSnapDNE) {
   expect_load_map(mock_image_ctx, 1U, object_map_1, 0);
 
   C_SaferCond ctx;
-  auto req = new MockDiffRequest(&mock_image_ctx, 1, 2,
+  auto req = new MockDiffRequest(&mock_image_ctx, 1, 2, is_diff_iterate(),
                                  &m_object_diff_state, &ctx);
   req->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
@@ -367,7 +377,8 @@ TEST_F(TestMockObjectMapDiffRequest, IntermediateSnapDNE) {
 
   C_SaferCond ctx;
   auto req = new MockDiffRequest(&mock_image_ctx, 0, CEPH_NOSNAP,
-                                 &m_object_diff_state, &ctx);
+                                 is_diff_iterate(), &m_object_diff_state,
+                                 &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 
@@ -394,7 +405,8 @@ TEST_F(TestMockObjectMapDiffRequest, LoadObjectMapDNE) {
 
   C_SaferCond ctx;
   auto req = new MockDiffRequest(&mock_image_ctx, 0, CEPH_NOSNAP,
-                                 &m_object_diff_state, &ctx);
+                                 is_diff_iterate(), &m_object_diff_state,
+                                 &ctx);
   req->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -427,7 +439,8 @@ TEST_F(TestMockObjectMapDiffRequest, LoadIntermediateObjectMapDNE) {
 
   C_SaferCond ctx;
   auto req = new MockDiffRequest(&mock_image_ctx, 0, CEPH_NOSNAP,
-                                 &m_object_diff_state, &ctx);
+                                 is_diff_iterate(), &m_object_diff_state,
+                                 &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 
@@ -458,7 +471,8 @@ TEST_F(TestMockObjectMapDiffRequest, LoadObjectMapError) {
 
   C_SaferCond ctx;
   auto req = new MockDiffRequest(&mock_image_ctx, 0, CEPH_NOSNAP,
-                                 &m_object_diff_state, &ctx);
+                                 is_diff_iterate(), &m_object_diff_state,
+                                 &ctx);
   req->send();
   ASSERT_EQ(-EPERM, ctx.wait());
 }
@@ -484,7 +498,8 @@ TEST_F(TestMockObjectMapDiffRequest, ObjectMapTooSmall) {
 
   C_SaferCond ctx;
   auto req = new MockDiffRequest(&mock_image_ctx, 0, CEPH_NOSNAP,
-                                 &m_object_diff_state, &ctx);
+                                 is_diff_iterate(), &m_object_diff_state,
+                                 &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }

--- a/src/test/librbd/object_map/test_mock_DiffRequest.cc
+++ b/src/test/librbd/object_map/test_mock_DiffRequest.cc
@@ -32,6 +32,122 @@ using ::testing::WithArg;
 namespace librbd {
 namespace object_map {
 
+static constexpr uint8_t from_beginning_table[][2] = {
+  //        to                expected
+  { OBJECT_NONEXISTENT,   DIFF_STATE_HOLE },
+  { OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED }
+};
+
+static constexpr uint8_t from_beginning_intermediate_table[][4] = {
+  //   intermediate               to             diff-iterate expected       deep-copy expected
+  { OBJECT_NONEXISTENT,   OBJECT_NONEXISTENT,   DIFF_STATE_HOLE,          DIFF_STATE_HOLE },
+  { OBJECT_NONEXISTENT,   OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_NONEXISTENT,   DIFF_STATE_HOLE,          DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_NONEXISTENT,   DIFF_STATE_HOLE,          DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_PENDING,       OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_NONEXISTENT,   DIFF_STATE_HOLE,          DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED }
+};
+
+static constexpr uint8_t from_snap_table[][3] = {
+  //       from                   to                expected
+  { OBJECT_NONEXISTENT,   OBJECT_NONEXISTENT,   DIFF_STATE_HOLE },
+  { OBJECT_NONEXISTENT,   OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA },
+  { OBJECT_PENDING,       OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_PENDING,       OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA }
+};
+
+static constexpr uint8_t from_snap_intermediate_table[][5] = {
+  //       from              intermediate               to             diff-iterate expected       deep-copy expected
+  { OBJECT_NONEXISTENT,   OBJECT_NONEXISTENT,   OBJECT_NONEXISTENT,   DIFF_STATE_HOLE,          DIFF_STATE_HOLE },
+  { OBJECT_NONEXISTENT,   OBJECT_NONEXISTENT,   OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_NONEXISTENT,   OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_NONEXISTENT,   OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_EXISTS,        OBJECT_NONEXISTENT,   DIFF_STATE_HOLE,          DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_EXISTS,        OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_EXISTS,        OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_EXISTS,        OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_PENDING,       OBJECT_NONEXISTENT,   DIFF_STATE_HOLE,          DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_PENDING,       OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_PENDING,       OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_PENDING,       OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_EXISTS_CLEAN,  OBJECT_NONEXISTENT,   DIFF_STATE_HOLE,          DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_EXISTS_CLEAN,  OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_NONEXISTENT,   OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_NONEXISTENT,   OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED,  DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_NONEXISTENT,   OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_NONEXISTENT,   OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_NONEXISTENT,   OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_EXISTS,        OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED,  DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_EXISTS,        OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_EXISTS,        OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_EXISTS,        OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_PENDING,       OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED,  DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_PENDING,       OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_PENDING,       OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_PENDING,       OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_EXISTS_CLEAN,  OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED,  DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_EXISTS_CLEAN,  OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS,        OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA,          DIFF_STATE_DATA },
+  { OBJECT_PENDING,       OBJECT_NONEXISTENT,   OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED,  DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_PENDING,       OBJECT_NONEXISTENT,   OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_NONEXISTENT,   OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_NONEXISTENT,   OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_EXISTS,        OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED,  DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_PENDING,       OBJECT_EXISTS,        OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_EXISTS,        OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_EXISTS,        OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_PENDING,       OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED,  DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_PENDING,       OBJECT_PENDING,       OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_PENDING,       OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_PENDING,       OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_EXISTS_CLEAN,  OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED,  DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_PENDING,       OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_EXISTS_CLEAN,  OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_PENDING,       OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_NONEXISTENT,   OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED,  DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_NONEXISTENT,   OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_NONEXISTENT,   OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_NONEXISTENT,   OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS,        OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED,  DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS,        OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS,        OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS,        OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_PENDING,       OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED,  DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_PENDING,       OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_PENDING,       OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_PENDING,       OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS_CLEAN,  OBJECT_NONEXISTENT,   DIFF_STATE_HOLE_UPDATED,  DIFF_STATE_HOLE_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS,        DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS_CLEAN,  OBJECT_PENDING,       DIFF_STATE_DATA_UPDATED,  DIFF_STATE_DATA_UPDATED },
+  { OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS_CLEAN,  OBJECT_EXISTS_CLEAN,  DIFF_STATE_DATA,          DIFF_STATE_DATA }
+};
+
 class TestMockObjectMapDiffRequest : public TestMockFixture,
                                      public ::testing::WithParamInterface<bool> {
 public:
@@ -146,10 +262,45 @@ TEST_P(TestMockObjectMapDiffRequest, FastDiffInvalid) {
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
 
-TEST_P(TestMockObjectMapDiffRequest, FullDelta) {
+TEST_P(TestMockObjectMapDiffRequest, FromBeginningToSnap) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
-  uint32_t object_count = 5;
+  uint32_t object_count = std::size(from_beginning_table);
+  m_image_ctx->size = object_count * (1 << m_image_ctx->order);
+
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
+  mock_image_ctx.snap_info = {
+    {1U, {"snap1", {cls::rbd::UserSnapshotNamespace{}}, mock_image_ctx.size, {},
+          {}, {}, {}}}
+  };
+
+  BitVector<2> object_map_1;
+  object_map_1.resize(object_count);
+  BitVector<2> expected_diff_state;
+  expected_diff_state.resize(object_count);
+  for (uint32_t i = 0; i < object_count; i++) {
+    object_map_1[i] = from_beginning_table[i][0];
+    expected_diff_state[i] = from_beginning_table[i][1];
+  }
+
+  InSequence seq;
+
+  expect_get_flags(mock_image_ctx, 1U, 0, 0);
+  expect_load_map(mock_image_ctx, 1U, object_map_1, 0);
+
+  C_SaferCond ctx;
+  auto req = new MockDiffRequest(&mock_image_ctx, 0, 1, is_diff_iterate(),
+                                 &m_object_diff_state, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  ASSERT_EQ(expected_diff_state, m_object_diff_state);
+}
+
+TEST_P(TestMockObjectMapDiffRequest, FromBeginningToSnapIntermediateSnap) {
+  REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
+
+  uint32_t object_count = std::size(from_beginning_intermediate_table);
   m_image_ctx->size = object_count * (1 << m_image_ctx->order);
 
   MockTestImageCtx mock_image_ctx(*m_image_ctx);
@@ -160,30 +311,59 @@ TEST_P(TestMockObjectMapDiffRequest, FullDelta) {
           {}, {}, {}}}
   };
 
+  BitVector<2> object_map_1;
+  object_map_1.resize(object_count);
+  BitVector<2> object_map_2;
+  object_map_2.resize(object_count);
+  BitVector<2> expected_diff_state;
+  expected_diff_state.resize(object_count);
+  for (uint32_t i = 0; i < object_count; i++) {
+    object_map_1[i] = from_beginning_intermediate_table[i][0];
+    object_map_2[i] = from_beginning_intermediate_table[i][1];
+    if (is_diff_iterate()) {
+      expected_diff_state[i] = from_beginning_intermediate_table[i][2];
+    } else {
+      expected_diff_state[i] = from_beginning_intermediate_table[i][3];
+    }
+  }
+
   InSequence seq;
 
   expect_get_flags(mock_image_ctx, 1U, 0, 0);
-
-  BitVector<2> object_map_1;
-  object_map_1.resize(object_count);
-  object_map_1[1] = OBJECT_EXISTS_CLEAN;
   expect_load_map(mock_image_ctx, 1U, object_map_1, 0);
 
   expect_get_flags(mock_image_ctx, 2U, 0, 0);
-
-  BitVector<2> object_map_2;
-  object_map_2.resize(object_count);
-  object_map_2[1] = OBJECT_EXISTS_CLEAN;
-  object_map_2[2] = OBJECT_EXISTS;
-  object_map_2[3] = OBJECT_EXISTS;
   expect_load_map(mock_image_ctx, 2U, object_map_2, 0);
 
-  expect_get_flags(mock_image_ctx, CEPH_NOSNAP, 0, 0);
+  C_SaferCond ctx;
+  auto req = new MockDiffRequest(&mock_image_ctx, 0, 2, is_diff_iterate(),
+                                 &m_object_diff_state, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  ASSERT_EQ(expected_diff_state, m_object_diff_state);
+}
+
+TEST_P(TestMockObjectMapDiffRequest, FromBeginningToHead) {
+  REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
+
+  uint32_t object_count = std::size(from_beginning_table);
+  m_image_ctx->size = object_count * (1 << m_image_ctx->order);
+
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
 
   BitVector<2> object_map_head;
   object_map_head.resize(object_count);
-  object_map_head[1] = OBJECT_EXISTS_CLEAN;
-  object_map_head[2] = OBJECT_EXISTS_CLEAN;
+  BitVector<2> expected_diff_state;
+  expected_diff_state.resize(object_count);
+  for (uint32_t i = 0; i < object_count; i++) {
+    object_map_head[i] = from_beginning_table[i][0];
+    expected_diff_state[i] = from_beginning_table[i][1];
+  }
+
+  InSequence seq;
+
+  expect_get_flags(mock_image_ctx, CEPH_NOSNAP, 0, 0);
   expect_load_map(mock_image_ctx, CEPH_NOSNAP, object_map_head, 0);
 
   C_SaferCond ctx;
@@ -193,18 +373,59 @@ TEST_P(TestMockObjectMapDiffRequest, FullDelta) {
   req->send();
   ASSERT_EQ(0, ctx.wait());
 
-  BitVector<2> expected_diff_state;
-  expected_diff_state.resize(object_count);
-  expected_diff_state[1] = DIFF_STATE_DATA_UPDATED;
-  expected_diff_state[2] = DIFF_STATE_DATA_UPDATED;
-  expected_diff_state[3] = DIFF_STATE_HOLE;
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 
-TEST_P(TestMockObjectMapDiffRequest, IntermediateDelta) {
+TEST_P(TestMockObjectMapDiffRequest, FromBeginningToHeadIntermediateSnap) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
-  uint32_t object_count = 5;
+  uint32_t object_count = std::size(from_beginning_intermediate_table);
+  m_image_ctx->size = object_count * (1 << m_image_ctx->order);
+
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
+  mock_image_ctx.snap_info = {
+    {1U, {"snap1", {cls::rbd::UserSnapshotNamespace{}}, mock_image_ctx.size, {},
+          {}, {}, {}}}
+  };
+
+  BitVector<2> object_map_1;
+  object_map_1.resize(object_count);
+  BitVector<2> object_map_head;
+  object_map_head.resize(object_count);
+  BitVector<2> expected_diff_state;
+  expected_diff_state.resize(object_count);
+  for (uint32_t i = 0; i < object_count; i++) {
+    object_map_1[i] = from_beginning_intermediate_table[i][0];
+    object_map_head[i] = from_beginning_intermediate_table[i][1];
+    if (is_diff_iterate()) {
+      expected_diff_state[i] = from_beginning_intermediate_table[i][2];
+    } else {
+      expected_diff_state[i] = from_beginning_intermediate_table[i][3];
+    }
+  }
+
+  InSequence seq;
+
+  expect_get_flags(mock_image_ctx, 1U, 0, 0);
+  expect_load_map(mock_image_ctx, 1U, object_map_1, 0);
+
+  expect_get_flags(mock_image_ctx, CEPH_NOSNAP, 0, 0);
+  expect_load_map(mock_image_ctx, CEPH_NOSNAP, object_map_head, 0);
+
+  C_SaferCond ctx;
+  auto req = new MockDiffRequest(&mock_image_ctx, 0, CEPH_NOSNAP,
+                                 is_diff_iterate(), &m_object_diff_state,
+                                 &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  ASSERT_EQ(expected_diff_state, m_object_diff_state);
+}
+
+TEST_P(TestMockObjectMapDiffRequest, FromSnapToSnap) {
+  REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
+
+  uint32_t object_count = std::size(from_snap_table);
   m_image_ctx->size = object_count * (1 << m_image_ctx->order);
 
   MockTestImageCtx mock_image_ctx(*m_image_ctx);
@@ -215,23 +436,24 @@ TEST_P(TestMockObjectMapDiffRequest, IntermediateDelta) {
           {}, {}, {}}}
   };
 
+  BitVector<2> object_map_1;
+  object_map_1.resize(object_count);
+  BitVector<2> object_map_2;
+  object_map_2.resize(object_count);
+  BitVector<2> expected_diff_state;
+  expected_diff_state.resize(object_count);
+  for (uint32_t i = 0; i < object_count; i++) {
+    object_map_1[i] = from_snap_table[i][0];
+    object_map_2[i] = from_snap_table[i][1];
+    expected_diff_state[i] = from_snap_table[i][2];
+  }
+
   InSequence seq;
 
   expect_get_flags(mock_image_ctx, 1U, 0, 0);
-
-  BitVector<2> object_map_1;
-  object_map_1.resize(object_count);
-  object_map_1[1] = OBJECT_EXISTS;
-  object_map_1[2] = OBJECT_EXISTS_CLEAN;
   expect_load_map(mock_image_ctx, 1U, object_map_1, 0);
 
   expect_get_flags(mock_image_ctx, 2U, 0, 0);
-
-  BitVector<2> object_map_2;
-  object_map_2.resize(object_count);
-  object_map_2[1] = OBJECT_EXISTS_CLEAN;
-  object_map_2[2] = OBJECT_EXISTS;
-  object_map_2[3] = OBJECT_EXISTS;
   expect_load_map(mock_image_ctx, 2U, object_map_2, 0);
 
   C_SaferCond ctx;
@@ -240,18 +462,110 @@ TEST_P(TestMockObjectMapDiffRequest, IntermediateDelta) {
   req->send();
   ASSERT_EQ(0, ctx.wait());
 
-  BitVector<2> expected_diff_state;
-  expected_diff_state.resize(object_count);
-  expected_diff_state[1] = DIFF_STATE_DATA;
-  expected_diff_state[2] = DIFF_STATE_DATA_UPDATED;
-  expected_diff_state[3] = DIFF_STATE_DATA_UPDATED;
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 
-TEST_P(TestMockObjectMapDiffRequest, EndDelta) {
+TEST_P(TestMockObjectMapDiffRequest, FromSnapToSnapIntermediateSnap) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
-  uint32_t object_count = 5;
+  uint32_t object_count = std::size(from_snap_intermediate_table);
+  m_image_ctx->size = object_count * (1 << m_image_ctx->order);
+
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
+  mock_image_ctx.snap_info = {
+    {1U, {"snap1", {cls::rbd::UserSnapshotNamespace{}}, mock_image_ctx.size, {},
+          {}, {}, {}}},
+    {2U, {"snap2", {cls::rbd::UserSnapshotNamespace{}}, mock_image_ctx.size, {},
+          {}, {}, {}}},
+    {3U, {"snap3", {cls::rbd::UserSnapshotNamespace{}}, mock_image_ctx.size, {},
+          {}, {}, {}}}
+  };
+
+  BitVector<2> object_map_1;
+  object_map_1.resize(object_count);
+  BitVector<2> object_map_2;
+  object_map_2.resize(object_count);
+  BitVector<2> object_map_3;
+  object_map_3.resize(object_count);
+  BitVector<2> expected_diff_state;
+  expected_diff_state.resize(object_count);
+  for (uint32_t i = 0; i < object_count; i++) {
+    object_map_1[i] = from_snap_intermediate_table[i][0];
+    object_map_2[i] = from_snap_intermediate_table[i][1];
+    object_map_3[i] = from_snap_intermediate_table[i][2];
+    if (is_diff_iterate()) {
+      expected_diff_state[i] = from_snap_intermediate_table[i][3];
+    } else {
+      expected_diff_state[i] = from_snap_intermediate_table[i][4];
+    }
+  }
+
+  InSequence seq;
+
+  expect_get_flags(mock_image_ctx, 1U, 0, 0);
+  expect_load_map(mock_image_ctx, 1U, object_map_1, 0);
+
+  expect_get_flags(mock_image_ctx, 2U, 0, 0);
+  expect_load_map(mock_image_ctx, 2U, object_map_2, 0);
+
+  expect_get_flags(mock_image_ctx, 3U, 0, 0);
+  expect_load_map(mock_image_ctx, 3U, object_map_3, 0);
+
+  C_SaferCond ctx;
+  auto req = new MockDiffRequest(&mock_image_ctx, 1, 3, is_diff_iterate(),
+                                 &m_object_diff_state, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  ASSERT_EQ(expected_diff_state, m_object_diff_state);
+}
+
+TEST_P(TestMockObjectMapDiffRequest, FromSnapToHead) {
+  REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
+
+  uint32_t object_count = std::size(from_snap_table);
+  m_image_ctx->size = object_count * (1 << m_image_ctx->order);
+
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
+  mock_image_ctx.snap_info = {
+    {1U, {"snap1", {cls::rbd::UserSnapshotNamespace{}}, mock_image_ctx.size, {},
+          {}, {}, {}}}
+  };
+
+  BitVector<2> object_map_1;
+  object_map_1.resize(object_count);
+  BitVector<2> object_map_head;
+  object_map_head.resize(object_count);
+  BitVector<2> expected_diff_state;
+  expected_diff_state.resize(object_count);
+  for (uint32_t i = 0; i < object_count; i++) {
+    object_map_1[i] = from_snap_table[i][0];
+    object_map_head[i] = from_snap_table[i][1];
+    expected_diff_state[i] = from_snap_table[i][2];
+  }
+
+  InSequence seq;
+
+  expect_get_flags(mock_image_ctx, 1U, 0, 0);
+  expect_load_map(mock_image_ctx, 1U, object_map_1, 0);
+
+  expect_get_flags(mock_image_ctx, CEPH_NOSNAP, 0, 0);
+  expect_load_map(mock_image_ctx, CEPH_NOSNAP, object_map_head, 0);
+
+  C_SaferCond ctx;
+  auto req = new MockDiffRequest(&mock_image_ctx, 1, CEPH_NOSNAP,
+                                 is_diff_iterate(), &m_object_diff_state,
+                                 &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  ASSERT_EQ(expected_diff_state, m_object_diff_state);
+}
+
+TEST_P(TestMockObjectMapDiffRequest, FromSnapToHeadIntermediateSnap) {
+  REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
+
+  uint32_t object_count = std::size(from_snap_intermediate_table);
   m_image_ctx->size = object_count * (1 << m_image_ctx->order);
 
   MockTestImageCtx mock_image_ctx(*m_image_ctx);
@@ -262,37 +576,43 @@ TEST_P(TestMockObjectMapDiffRequest, EndDelta) {
           {}, {}, {}}}
   };
 
-  InSequence seq;
-
-  expect_get_flags(mock_image_ctx, 2U, 0, 0);
-
+  BitVector<2> object_map_1;
+  object_map_1.resize(object_count);
   BitVector<2> object_map_2;
   object_map_2.resize(object_count);
-  object_map_2[1] = OBJECT_EXISTS_CLEAN;
-  object_map_2[2] = OBJECT_EXISTS;
-  object_map_2[3] = OBJECT_EXISTS;
+  BitVector<2> object_map_head;
+  object_map_head.resize(object_count);
+  BitVector<2> expected_diff_state;
+  expected_diff_state.resize(object_count);
+  for (uint32_t i = 0; i < object_count; i++) {
+    object_map_1[i] = from_snap_intermediate_table[i][0];
+    object_map_2[i] = from_snap_intermediate_table[i][1];
+    object_map_head[i] = from_snap_intermediate_table[i][2];
+    if (is_diff_iterate()) {
+      expected_diff_state[i] = from_snap_intermediate_table[i][3];
+    } else {
+      expected_diff_state[i] = from_snap_intermediate_table[i][4];
+    }
+  }
+
+  InSequence seq;
+
+  expect_get_flags(mock_image_ctx, 1U, 0, 0);
+  expect_load_map(mock_image_ctx, 1U, object_map_1, 0);
+
+  expect_get_flags(mock_image_ctx, 2U, 0, 0);
   expect_load_map(mock_image_ctx, 2U, object_map_2, 0);
 
   expect_get_flags(mock_image_ctx, CEPH_NOSNAP, 0, 0);
-
-  BitVector<2> object_map_head;
-  object_map_head.resize(object_count);
-  object_map_head[1] = OBJECT_EXISTS_CLEAN;
-  object_map_head[2] = OBJECT_EXISTS_CLEAN;
   expect_load_map(mock_image_ctx, CEPH_NOSNAP, object_map_head, 0);
 
   C_SaferCond ctx;
-  auto req = new MockDiffRequest(&mock_image_ctx, 2, CEPH_NOSNAP,
+  auto req = new MockDiffRequest(&mock_image_ctx, 1, CEPH_NOSNAP,
                                  is_diff_iterate(), &m_object_diff_state,
                                  &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 
-  BitVector<2> expected_diff_state;
-  expected_diff_state.resize(object_count);
-  expected_diff_state[1] = DIFF_STATE_DATA;
-  expected_diff_state[2] = DIFF_STATE_DATA;
-  expected_diff_state[3] = DIFF_STATE_HOLE_UPDATED;
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 

--- a/src/test/librbd/object_map/test_mock_DiffRequest.cc
+++ b/src/test/librbd/object_map/test_mock_DiffRequest.cc
@@ -32,7 +32,8 @@ using ::testing::WithArg;
 namespace librbd {
 namespace object_map {
 
-class TestMockObjectMapDiffRequest : public TestMockFixture {
+class TestMockObjectMapDiffRequest : public TestMockFixture,
+                                     public ::testing::WithParamInterface<bool> {
 public:
   typedef DiffRequest<MockTestImageCtx> MockDiffRequest;
 
@@ -43,7 +44,7 @@ public:
   }
 
   bool is_diff_iterate() const {
-    return true;
+    return GetParam();
   }
 
   void expect_get_flags(MockTestImageCtx& mock_image_ctx, uint64_t snap_id,
@@ -84,7 +85,7 @@ public:
   BitVector<2> m_object_diff_state;
 };
 
-TEST_F(TestMockObjectMapDiffRequest, InvalidStartSnap) {
+TEST_P(TestMockObjectMapDiffRequest, InvalidStartSnap) {
   MockTestImageCtx mock_image_ctx(*m_image_ctx);
 
   InSequence seq;
@@ -97,7 +98,7 @@ TEST_F(TestMockObjectMapDiffRequest, InvalidStartSnap) {
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
 
-TEST_F(TestMockObjectMapDiffRequest, StartEndSnapEqual) {
+TEST_P(TestMockObjectMapDiffRequest, StartEndSnapEqual) {
   MockTestImageCtx mock_image_ctx(*m_image_ctx);
 
   InSequence seq;
@@ -110,7 +111,7 @@ TEST_F(TestMockObjectMapDiffRequest, StartEndSnapEqual) {
   ASSERT_EQ(0U, m_object_diff_state.size());
 }
 
-TEST_F(TestMockObjectMapDiffRequest, FastDiffDisabled) {
+TEST_P(TestMockObjectMapDiffRequest, FastDiffDisabled) {
   // negative test -- object-map implicitly enables fast-diff
   REQUIRE(!is_feature_enabled(RBD_FEATURE_OBJECT_MAP));
 
@@ -126,7 +127,7 @@ TEST_F(TestMockObjectMapDiffRequest, FastDiffDisabled) {
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
 
-TEST_F(TestMockObjectMapDiffRequest, FastDiffInvalid) {
+TEST_P(TestMockObjectMapDiffRequest, FastDiffInvalid) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   MockTestImageCtx mock_image_ctx(*m_image_ctx);
@@ -145,7 +146,7 @@ TEST_F(TestMockObjectMapDiffRequest, FastDiffInvalid) {
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
 
-TEST_F(TestMockObjectMapDiffRequest, FullDelta) {
+TEST_P(TestMockObjectMapDiffRequest, FullDelta) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   uint32_t object_count = 5;
@@ -200,7 +201,7 @@ TEST_F(TestMockObjectMapDiffRequest, FullDelta) {
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 
-TEST_F(TestMockObjectMapDiffRequest, IntermediateDelta) {
+TEST_P(TestMockObjectMapDiffRequest, IntermediateDelta) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   uint32_t object_count = 5;
@@ -247,7 +248,7 @@ TEST_F(TestMockObjectMapDiffRequest, IntermediateDelta) {
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 
-TEST_F(TestMockObjectMapDiffRequest, EndDelta) {
+TEST_P(TestMockObjectMapDiffRequest, EndDelta) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   uint32_t object_count = 5;
@@ -295,7 +296,7 @@ TEST_F(TestMockObjectMapDiffRequest, EndDelta) {
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 
-TEST_F(TestMockObjectMapDiffRequest, StartSnapDNE) {
+TEST_P(TestMockObjectMapDiffRequest, StartSnapDNE) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   uint32_t object_count = 5;
@@ -317,7 +318,7 @@ TEST_F(TestMockObjectMapDiffRequest, StartSnapDNE) {
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
 
-TEST_F(TestMockObjectMapDiffRequest, EndSnapDNE) {
+TEST_P(TestMockObjectMapDiffRequest, EndSnapDNE) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   uint32_t object_count = 5;
@@ -344,7 +345,7 @@ TEST_F(TestMockObjectMapDiffRequest, EndSnapDNE) {
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
 
-TEST_F(TestMockObjectMapDiffRequest, IntermediateSnapDNE) {
+TEST_P(TestMockObjectMapDiffRequest, IntermediateSnapDNE) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   uint32_t object_count = 5;
@@ -388,7 +389,7 @@ TEST_F(TestMockObjectMapDiffRequest, IntermediateSnapDNE) {
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 
-TEST_F(TestMockObjectMapDiffRequest, LoadObjectMapDNE) {
+TEST_P(TestMockObjectMapDiffRequest, LoadObjectMapDNE) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   uint32_t object_count = 5;
@@ -411,7 +412,7 @@ TEST_F(TestMockObjectMapDiffRequest, LoadObjectMapDNE) {
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
 
-TEST_F(TestMockObjectMapDiffRequest, LoadIntermediateObjectMapDNE) {
+TEST_P(TestMockObjectMapDiffRequest, LoadIntermediateObjectMapDNE) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   uint32_t object_count = 5;
@@ -450,7 +451,7 @@ TEST_F(TestMockObjectMapDiffRequest, LoadIntermediateObjectMapDNE) {
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 
-TEST_F(TestMockObjectMapDiffRequest, LoadObjectMapError) {
+TEST_P(TestMockObjectMapDiffRequest, LoadObjectMapError) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   uint32_t object_count = 5;
@@ -477,7 +478,7 @@ TEST_F(TestMockObjectMapDiffRequest, LoadObjectMapError) {
   ASSERT_EQ(-EPERM, ctx.wait());
 }
 
-TEST_F(TestMockObjectMapDiffRequest, ObjectMapTooSmall) {
+TEST_P(TestMockObjectMapDiffRequest, ObjectMapTooSmall) {
   REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   uint32_t object_count = 5;
@@ -503,6 +504,9 @@ TEST_F(TestMockObjectMapDiffRequest, ObjectMapTooSmall) {
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
+
+INSTANTIATE_TEST_SUITE_P(MockObjectMapDiffRequestTests,
+                         TestMockObjectMapDiffRequest, ::testing::Bool());
 
 } // namespace object_map
 } // librbd

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -6325,12 +6325,14 @@ TYPED_TEST(DiffIterateTest, DiffIterateDeterministicPP)
 
 TYPED_TEST(DiffIterateTest, DiffIterateDiscard)
 {
+  REQUIRE(!is_feature_enabled(RBD_FEATURE_STRIPINGV2));
+
   librados::IoCtx ioctx;
   ASSERT_EQ(0, this->_rados.ioctx_create(this->m_pool_name.c_str(), ioctx));
 
   librbd::RBD rbd;
   librbd::Image image;
-  int order = 0;
+  int order = 22;
   std::string name = this->get_temp_image_name();
   uint64_t size = 20 << 20;
 
@@ -6341,61 +6343,127 @@ TYPED_TEST(DiffIterateTest, DiffIterateDiscard)
   if (this->whole_object) {
     object_size = 1 << order;
   }
-  vector<diff_extent> extents;
-  ceph::bufferlist bl;
 
+  std::vector<diff_extent> extents;
   ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
-      			           vector_iterate_cb, (void *) &extents));
+                                   vector_iterate_cb, &extents));
   ASSERT_EQ(0u, extents.size());
 
-  char data[256];
-  memset(data, 1, sizeof(data));
-  bl.append(data, 256);
+  ceph::bufferlist bl;
+  bl.append(std::string(256, '1'));
   ASSERT_EQ(256, image.write(0, 256, bl));
+  ASSERT_EQ(256, image.write(1 << order, 256, bl));
   ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
-      			           vector_iterate_cb, (void *) &extents));
-  ASSERT_EQ(1u, extents.size());
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(2u, extents.size());
   ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-
-  int obj_ofs = 256;
-  ASSERT_EQ(1 << order, image.discard(0, 1 << order));
-
+  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
   extents.clear();
+
+  ASSERT_EQ(size, image.discard(0, size));
   ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
-      			           vector_iterate_cb, (void *) &extents));
+                                   vector_iterate_cb, &extents));
   ASSERT_EQ(0u, extents.size());
 
   ASSERT_EQ(0, image.snap_create("snap1"));
+
   ASSERT_EQ(256, image.write(0, 256, bl));
+  ASSERT_EQ(256, image.write(1 << order, 256, bl));
   ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
-      			           vector_iterate_cb, (void *) &extents));
-  ASSERT_EQ(1u, extents.size());
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(2u, extents.size());
   ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
+  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
+  extents.clear();
+
   ASSERT_EQ(0, image.snap_create("snap2"));
 
-  ASSERT_EQ(obj_ofs, image.discard(0, obj_ofs));
-
-  extents.clear();
-  ASSERT_EQ(0, image.snap_set("snap2"));
-  ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, this->whole_object,
-      			           vector_iterate_cb, (void *) &extents));
-  ASSERT_EQ(1u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-
-  ASSERT_EQ(0, image.snap_set(NULL));
   ASSERT_EQ(1 << order, image.discard(0, 1 << order));
-  ASSERT_EQ(0, image.snap_create("snap3"));
-  ASSERT_EQ(0, image.snap_set("snap3"));
-
+  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(1u, extents.size());
+  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[0]);
   extents.clear();
-  ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, this->whole_object,
-      			           vector_iterate_cb, (void *) &extents));
-  ASSERT_EQ(0u, extents.size());
 
+  ASSERT_EQ(0, image.snap_create("snap3"));
+
+  // 1. beginning of time -> HEAD
+  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(1u, extents.size());
+  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[0]);
+  extents.clear();
+
+  // 2. snap1 -> HEAD
+  ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(1u, extents.size());
+  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[0]);
+  extents.clear();
+
+  // 3. snap2 -> HEAD
   ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, this->whole_object,
-                                   vector_iterate_cb, (void *) &extents));
+                                   vector_iterate_cb, &extents));
   ASSERT_EQ(1u, extents.size());
   ASSERT_EQ(diff_extent(0, 256, false, object_size), extents[0]);
+  extents.clear();
+
+  // 4. snap3 -> HEAD
+  ASSERT_EQ(0, image.diff_iterate2("snap3", 0, size, true, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(0u, extents.size());
+
+  ASSERT_PASSED(this->validate_object_map, image);
+  ASSERT_EQ(0, image.snap_set("snap3"));
+
+  // 5. beginning of time -> snap3
+  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(1u, extents.size());
+  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[0]);
+  extents.clear();
+
+  // 6. snap1 -> snap3
+  ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(1u, extents.size());
+  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[0]);
+  extents.clear();
+
+  // 7. snap2 -> snap3
+  ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(1u, extents.size());
+  ASSERT_EQ(diff_extent(0, 256, false, object_size), extents[0]);
+  extents.clear();
+
+  ASSERT_PASSED(this->validate_object_map, image);
+  ASSERT_EQ(0, image.snap_set("snap2"));
+
+  // 8. beginning of time -> snap2
+  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(2u, extents.size());
+  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
+  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
+  extents.clear();
+
+  // 9. snap1 -> snap2
+  ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(2u, extents.size());
+  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
+  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
+  extents.clear();
+
+  ASSERT_PASSED(this->validate_object_map, image);
+  ASSERT_EQ(0, image.snap_set("snap1"));
+
+  // 10. beginning of time -> snap1
+  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(0u, extents.size());
+
   ASSERT_PASSED(this->validate_object_map, image);
 }
 

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -6390,6 +6390,10 @@ TYPED_TEST(DiffIterateTest, DiffIterateDiscard)
   extents.clear();
   ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, this->whole_object,
       			           vector_iterate_cb, (void *) &extents));
+  ASSERT_EQ(0u, extents.size());
+
+  ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, this->whole_object,
+                                   vector_iterate_cb, (void *) &extents));
   ASSERT_EQ(1u, extents.size());
   ASSERT_EQ(diff_extent(0, 256, false, object_size), extents[0]);
   ASSERT_PASSED(this->validate_object_map, image);

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -1437,7 +1437,7 @@ def check_diff(image, offset, length, from_snapshot, expected):
     extents = []
     def cb(offset, length, exists):
         extents.append((offset, length, exists))
-    image.diff_iterate(0, IMG_SIZE, None, cb)
+    image.diff_iterate(0, IMG_SIZE, from_snapshot, cb)
     eq(extents, expected)
 
 class TestClone(object):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63847

---

backport of https://github.com/ceph/ceph/pull/54547
parent tracker: https://tracker.ceph.com/issues/53897