### PR TITLE
MgrMonitor: consider the build config when defining the always-on modules

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -70,77 +70,31 @@ static ostream& _prefix(std::ostream *_dout, Monitor &mon,
 
 // the system treats always_on_modules as if they provide built-in functionality
 // by ensuring that they are always enabled.
-const static std::map<uint32_t, std::set<std::string>> always_on_modules = {
-  {
-    CEPH_RELEASE_OCTOPUS, {
-      "crash",
-      "status",
-      "progress",
-      "balancer",
-      "devicehealth",
-      "orchestrator",
-      "rbd_support",
-      "volumes",
-      "pg_autoscaler",
-      "telemetry",
-    }
-  },
-  {
-    CEPH_RELEASE_PACIFIC, {
-      "crash",
-      "status",
-      "progress",
-      "balancer",
-      "devicehealth",
-      "orchestrator",
-      "rbd_support",
-      "volumes",
-      "pg_autoscaler",
-      "telemetry",
-    }
-  },
-  {
-    CEPH_RELEASE_QUINCY, {
-      "crash",
-      "status",
-      "progress",
-      "balancer",
-      "devicehealth",
-      "orchestrator",
-      "rbd_support",
-      "volumes",
-      "pg_autoscaler",
-      "telemetry",
-    }
-  },
-  {
-    CEPH_RELEASE_REEF, {
-      "crash",
-      "status",
-      "progress",
-      "balancer",
-      "devicehealth",
-      "orchestrator",
-      "rbd_support",
-      "volumes",
-      "pg_autoscaler",
-      "telemetry",
-    }
-  },
-  {
-    CEPH_RELEASE_SQUID, {
-      "crash",
-      "status",
-      "progress",
-      "balancer",
-      "devicehealth",
-      "orchestrator",
-      "rbd_support",
-      "volumes",
-      "pg_autoscaler",
-      "telemetry",
-    }
-  },
+static const std::map<uint32_t, std::set<std::string>>& always_on_modules() {
+  static const std::set<std::string> octopus_modules = {
+    "crash",
+    "status",
+    "progress",
+    "balancer",
+    "devicehealth",
+    "orchestrator",
+#ifdef WITH_RBD
+    "rbd_support",
+#endif
+#ifdef WITH_CEPHFS
+    "volumes",
+#endif
+    "pg_autoscaler",
+    "telemetry",
+  };
+  static const std::map<uint32_t, std::set<std::string>> always_on_modules_map = {
+    { CEPH_RELEASE_OCTOPUS, octopus_modules },
+    { CEPH_RELEASE_PACIFIC, octopus_modules },
+    { CEPH_RELEASE_QUINCY, octopus_modules },
+    { CEPH_RELEASE_REEF, octopus_modules },
+    { CEPH_RELEASE_SQUID, octopus_modules },
+  };
+  return always_on_modules_map;
 };
 
 // Prefix for mon store of active mgr's command descriptions
@@ -190,7 +144,7 @@ void MgrMonitor::create_initial()
   for (auto& m : tok) {
     pending_map.modules.insert(m);
   }
-  pending_map.always_on_modules = always_on_modules;
+  pending_map.always_on_modules = always_on_modules();
   pending_command_descs = mgr_commands;
   dout(10) << __func__ << " initial modules " << pending_map.modules
 	   << ", always on modules " << pending_map.get_always_on_modules()
@@ -769,13 +723,13 @@ void MgrMonitor::on_active()
   }
   mon.clog->debug() << "mgrmap e" << map.epoch << ": " << map;
   assert(HAVE_FEATURE(mon.get_quorum_con_features(), SERVER_NAUTILUS));
-  if (pending_map.always_on_modules == always_on_modules) {
+  if (pending_map.always_on_modules == always_on_modules()) {
     return;
   }
   dout(4) << "always on modules changed, pending "
           << pending_map.always_on_modules << " != wanted "
-          << always_on_modules << dendl;
-  pending_map.always_on_modules = always_on_modules;
+          << always_on_modules() << dendl;
+  pending_map.always_on_modules = always_on_modules();
   propose_pending();
 }
 


### PR DESCRIPTION
Following a [discussion on slack](https://ceph-storage.slack.com/archives/C1HFZTW81/p1702900067810509)

> When ceph is built `WITH_RBD=OFF` shouldn’t we also disable the `rbd_support` mgr module? I suspect that this causes the health warning for me:
> ```
> "Module 'rbd_support' has failed dependency: module 'rbd' has no attribute 'Image'"
> ```


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
