### PR TITLE
quincy: doc/install: update "update submodules"

### DIFF
--- a/doc/install/clone-source.rst
+++ b/doc/install/clone-source.rst
@@ -98,59 +98,7 @@ repository.
 Updating Submodules
 -------------------
 
-#. Determine whether your submodules are out of date:
-
-   .. prompt:: bash $
-
-      git status
-
-   A. If your submodules are up to date 
-         If your submodules are up to date, the following console output will
-         appear: 
-
-         ::
-   
-           On branch main
-           Your branch is up to date with 'origin/main'.
-           
-           nothing to commit, working tree clean
-   
-         If you see this console output, then your submodules are up to date.
-         You do not need this procedure.
-
-
-   B. If your submodules are not up to date 
-         If your submodules are not up to date, you will see a message that
-         includes a list of "untracked files". The example here shows such a
-         list, which was generated from a real situation in which the
-         submodules were no longer current. Your list of files will not be the
-         same as this list of files, but this list is provided as an example.
-         If in your case any untracked files are listed, then you should
-         continue to the next step of this procedure.
-
-         ::
-
-            On branch main
-            Your branch is up to date with 'origin/main'.
-            
-            Untracked files:
-              (use "git add <file>..." to include in what will be committed)
-            src/pybind/cephfs/build/
-            src/pybind/cephfs/cephfs.c
-            src/pybind/cephfs/cephfs.egg-info/
-            src/pybind/rados/build/
-            src/pybind/rados/rados.c
-            src/pybind/rados/rados.egg-info/
-            src/pybind/rbd/build/
-            src/pybind/rbd/rbd.c
-            src/pybind/rbd/rbd.egg-info/
-            src/pybind/rgw/build/
-            src/pybind/rgw/rgw.c
-            src/pybind/rgw/rgw.egg-info/
-            
-            nothing added to commit but untracked files present (use "git add" to track)
-
-#. If your submodules are out of date, run the following commands:
+If your submodules are out of date, run the following commands:
 
    .. prompt:: bash $
 
@@ -158,24 +106,10 @@ Updating Submodules
       git clean -fdx
       git submodule foreach git clean -fdx
 
-   If you still have problems with a submodule directory, use ``rm -rf
-   [directory name]`` to remove the directory. Then run ``git submodule update
-   --init --recursive`` again.
+If you still have problems with a submodule directory, use ``rm -rf [directory
+name]`` to remove the directory. Then run ``git submodule update --init
+--recursive --progress`` again.
 
-#. Run ``git status`` again:
-
-   .. prompt:: bash $
-
-      git status
-   
-   Your submodules are up to date if you see the following message:
-
-   ::
-
-     On branch main
-     Your branch is up to date with 'origin/main'.
-     
-     nothing to commit, working tree clean
 
 Choose a Branch
 ===============


### PR DESCRIPTION
Remove misleading material that would give readers the wrong idea about when stale submodules are present. This commit is made in response to information given to me by Ilya Dryomov here: https://github.com/ceph/ceph/pull/54929#issuecomment-1859237986.

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit f5c87693abcfc9a6a3869a3f52549384807fba9d)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
