### PR TITLE
rgw/notifications/lc: handle publish_commit() failures as warnings

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -574,13 +574,12 @@ static int remove_expired_obj(
       fmt::format("ERROR: {} failed, with error: {}", __func__, ret) << dendl;
   } else {
     // send request to notification manager
-    ret = notify->publish_commit(dpp, obj_state->size,
+    int publish_ret = notify->publish_commit(dpp, obj_state->size,
 				 ceph::real_clock::now(),
 				 obj_state->attrset[RGW_ATTR_ETAG].to_str(),
 				 version_id);
-    if (ret < 0) {
-      ldpp_dout(dpp, 1) << "ERROR: notify publish_commit failed, with error: "
-												<< ret << dendl;
+    if (publish_ret < 0) {
+      ldpp_dout(dpp, 5) << "WARNING: notify publish_commit failed, with error: " << publish_ret << dendl;
     }
   }
 
@@ -860,13 +859,13 @@ int RGWLC::handle_multipart_expiration(rgw::sal::Bucket* target,
 
       ret = mpu->abort(this, cct, null_yield);
       if (ret == 0) {
-        ret = notify->publish_commit(
+        int publish_ret = notify->publish_commit(
             this, sal_obj->get_obj_size(), ceph::real_clock::now(),
             sal_obj->get_attrs()[RGW_ATTR_ETAG].to_str(),
 						version_id);
-        if (ret < 0) {
-          ldpp_dout(wk->get_lc(), 1)
-              << "ERROR: notify publish_commit failed, with error: " << ret
+        if (publish_ret < 0) {
+          ldpp_dout(wk->get_lc(), 5)
+              << "WARNING: notify publish_commit failed, with error: " << publish_ret
               << dendl;
         }
         if (perfcounter) {
@@ -1366,13 +1365,13 @@ public:
       return ret;
     } else {
       // send request to notification manager
-      ret =  notify->publish_commit(oc.dpp, obj->get_obj_size(),
+      int publish_ret = notify->publish_commit(oc.dpp, obj->get_obj_size(),
 				    ceph::real_clock::now(),
 				    obj->get_attrs()[RGW_ATTR_ETAG].to_str(),
 				    version_id);
-      if (ret < 0) {
-	ldpp_dout(oc.dpp, 1) <<
-	  "ERROR: notify publish_commit failed, with error: " << ret << dendl;
+      if (publish_ret < 0) {
+	ldpp_dout(oc.dpp, 5) <<
+	  "WARNING: notify publish_commit failed, with error: " << publish_ret << dendl;
       }
     }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/63859

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
