### PR TITLE
src/pybind/mgr/pg_autoscaler/module.py: fix 'pg_autoscale_mode' output

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/module.py
+++ b/src/pybind/mgr/pg_autoscaler/module.py
@@ -231,7 +231,7 @@ class PgAutoscaler(MgrModule):
                     p['pg_num_target'],
 #                    p['pg_num_ideal'],
                     final,
-                    'off' if self.has_noautoscale_flag() else p['pg_autoscale_mode'],
+                    str(p['pg_autoscale_mode']),
                     str(p['bulk'])
                 ])
             return 0, table.get_string(), ''
@@ -662,6 +662,11 @@ class PgAutoscaler(MgrModule):
 
         ret, _, _ = self._get_pool_pg_targets(osdmap, even_pools, crush_map, root_map,
                                          pool_stats, ret, threshold, 'third', overlapped_roots)
+
+        # If noautoscale flag is set, we set pg_autoscale_mode to off
+        if self.has_noautoscale_flag():
+            for p in ret:
+                p['pg_autoscale_mode'] = 'off'
 
         return (ret, root_map)
 


### PR DESCRIPTION
Problem:
`ceph osd pool autoscale-status -f json`
and `ceph osd pool autoscale-status`
shows discrepeencies between each other
in the `pg_autoscale_mode` section,
when `no_autoscale` flag is set.

This is due to not showing
the output correctly.

Solution:

shows `false` in `pg_autoscale_mode` for
both `ceph osd pool autoscale-status` and
the json version of the command if `no_autoscale`
is set.

it sounds like a simple solution, but the problem
is more of a display problem rather than logic.

Fixes: https://tracker.ceph.com/issues/63860

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
