### PR TITLE
GCC 14 compatibility fixes

### DIFF
--- a/src/pybind/rbd/c_rbd.pxd
+++ b/src/pybind/rbd/c_rbd.pxd
@@ -2,6 +2,7 @@
 
 from libc.stdint cimport *
 from ctime cimport time_t, timespec
+cimport libcpp
 
 cdef extern from "rados/librados.h":
     enum:
@@ -525,7 +526,7 @@ cdef extern from "rbd/librbd.h" nogil:
     int rbd_snap_unprotect(rbd_image_t image, const char *snap_name)
     int rbd_snap_is_protected(rbd_image_t image, const char *snap_name,
                               int *is_protected)
-    int rbd_snap_exists(rbd_image_t image, const char *snapname, bint *exists)
+    int rbd_snap_exists(rbd_image_t image, const char *snapname, libcpp.bool *exists)
     int rbd_snap_get_limit(rbd_image_t image, uint64_t *limit)
     int rbd_snap_set_limit(rbd_image_t image, uint64_t limit)
     int rbd_snap_get_timestamp(rbd_image_t image, uint64_t snap_id, timespec *timestamp)
@@ -711,7 +712,7 @@ cdef extern from "rbd/librbd.h" nogil:
     int rbd_namespace_list(rados_ioctx_t io, char *namespace_names,
                            size_t *size)
     int rbd_namespace_exists(rados_ioctx_t io, const char *namespace_name,
-                             bint *exists)
+                             libcpp.bool *exists)
 
     int rbd_pool_init(rados_ioctx_t, bint force)
 

--- a/src/pybind/rbd/mock_rbd.pxi
+++ b/src/pybind/rbd/mock_rbd.pxi
@@ -3,6 +3,11 @@
 from libc.stdint cimport *
 from ctime cimport time_t, timespec
 
+# Make the bool type available as libcpp.bool, for both C and C++.
+cimport libcpp
+cdef extern from "<stdbool.h>":
+    pass
+
 cdef nogil:
     enum:
         _LIBRADOS_SNAP_HEAD "LIBRADOS_SNAP_HEAD"
@@ -637,7 +642,7 @@ cdef nogil:
     int rbd_snap_is_protected(rbd_image_t image, const char *snap_name,
                               int *is_protected):
         pass
-    int rbd_snap_exists(rbd_image_t image, const char *snapname, bint *exists):
+    int rbd_snap_exists(rbd_image_t image, const char *snapname, libcpp.bool *exists):
         pass
     int rbd_snap_get_limit(rbd_image_t image, uint64_t *limit):
         pass
@@ -896,7 +901,7 @@ cdef nogil:
                            size_t *size):
         pass
     int rbd_namespace_exists(rados_ioctx_t io, const char *namespace_name,
-                             bint *exists):
+                             libcpp.bool *exists):
         pass
     int rbd_pool_init(rados_ioctx_t io, bint force):
         pass

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -23,6 +23,7 @@ from libc cimport errno
 from libc.stdint cimport *
 from libc.stdlib cimport malloc, realloc, free
 from libc.string cimport strdup, memset
+cimport libcpp
 
 try:
     from collections.abc import Iterable
@@ -1935,12 +1936,12 @@ class RBD(object):
         cdef:
             rados_ioctx_t _ioctx = convert_ioctx(ioctx)
             const char *_name = name
-            bint _exists = False
+            libcpp.bool _exists = False
         with nogil:
             ret = rbd_namespace_exists(_ioctx, _name, &_exists)
         if ret != 0:
             raise make_ex(ret, 'error verifying namespace')
-        return bool(_exists != 0)
+        return _exists
 
     def namespace_list(self, ioctx):
         """
@@ -3679,12 +3680,12 @@ cdef class Image(object):
         name = cstr(name, 'name')
         cdef:
             char *_name = name
-            bint _exists = False
+            libcpp.bool _exists = False
         with nogil:
             ret = rbd_snap_exists(self.image, _name, &_exists)
         if ret != 0:
             raise make_ex(ret, 'error getting snapshot exists for %s' % self.name)
-        return bool(_exists != 0)
+        return _exists
 
     @requires_not_closed
     def get_snap_limit(self):

--- a/src/pybind/rgw/mock_rgw.pxi
+++ b/src/pybind/rgw/mock_rgw.pxi
@@ -1,5 +1,10 @@
 # cython: embedsignature=True
 
+# Make the bool type available as libcpp.bool, for both C and C++.
+cimport libcpp
+cdef extern from "<stdbool.h>":
+    pass
+
 cdef nogil:
     ctypedef void* librgw_t
 
@@ -111,8 +116,8 @@ cdef nogil:
 
     int rgw_readdir(rgw_fs *fs,
                     rgw_file_handle *parent_fh, uint64_t *offset,
-                    bint (*cb)(const char *name, void *arg, uint64_t offset, stat *st, uint32_t st_mask, uint32_t flags) nogil except? -9000,
-                    void *cb_arg, bint *eof, uint32_t flags) except? -9000:
+                    libcpp.bool (*cb)(const char *name, void *arg, uint64_t offset, stat *st, uint32_t st_mask, uint32_t flags) nogil except? -9000,
+                    void *cb_arg, libcpp.bool *eof, uint32_t flags) except? -9000:
         pass
 
     int rgw_getattr(rgw_fs *fs,

--- a/src/pybind/rgw/rgw.pyx
+++ b/src/pybind/rgw/rgw.pyx
@@ -7,6 +7,7 @@ from cpython cimport PyObject, ref, exc, array
 from libc.stdint cimport *
 from libc.stdlib cimport malloc, realloc, free
 from cstat cimport stat
+cimport libcpp
 
 IF BUILD_DOC:
     include "mock_rgw.pxi"
@@ -373,7 +374,7 @@ cdef class LibRGWFS(object):
         cdef:
             rgw_file_handle *_dir_handler = <rgw_file_handle*>dir_handler.handler
             uint64_t _offset = offset
-            bint _eof
+            libcpp.bool _eof
             uint32_t _flags = flags
         with nogil:
             ret = rgw_readdir(self.fs, _dir_handler, &_offset, &readdir_cb,

--- a/src/tracing/librados.tp
+++ b/src/tracing/librados.tp
@@ -2628,7 +2628,7 @@ TRACEPOINT_EVENT(librados, rados_watch3_enter,
     TP_FIELDS(
         ctf_integer_hex(rados_ioctx_t, ioctx, ioctx)
         ctf_string(oid, oid)
-        ctf_integer_hex(uint64_t, phandle, phandle)
+        ctf_integer_hex(uint64_t*, phandle, phandle)
         ctf_integer_hex(rados_watchcb2_t, callback, callback)
         ctf_integer(uint32_t, timeout, timeout)
         ctf_integer_hex(void*, arg, arg)
@@ -2658,7 +2658,7 @@ TRACEPOINT_EVENT(librados, rados_aio_watch2_enter,
         ctf_integer_hex(rados_ioctx_t, ioctx, ioctx)
         ctf_string(oid, oid)
         ctf_integer_hex(rados_completion_t, completion, completion)
-        ctf_integer_hex(uint64_t, phandle, phandle)
+        ctf_integer_hex(uint64_t*, phandle, phandle)
         ctf_integer_hex(rados_watchcb2_t, callback, callback)
         ctf_integer(uint32_t, timeout, timeout)
         ctf_integer_hex(void*, arg, arg)

--- a/src/tracing/tracing-common.h
+++ b/src/tracing/tracing-common.h
@@ -21,7 +21,7 @@
 // type should be an integer type
 // val should have type type*
 #define ceph_ctf_integerp(type, field, val) \
-    ctf_integer(type, field, (val) == NULL ? 0 : (val)) \
+    ctf_integer(type, field, (val) == NULL ? 0 : *(val)) \
     ctf_integer(uint8_t, field##_isnull, (val) == NULL)
 
 // val should have type char*


### PR DESCRIPTION
These changes should make it possible to build the C parts of Ceph with GCC 14.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
