### PR TITLE
test/neorados: Use two fewer GTest internals

### DIFF
--- a/src/test/neorados/common_tests.h
+++ b/src/test/neorados/common_tests.h
@@ -391,10 +391,14 @@ private:
   public:                                                                      \
     GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() = default;            \
     ~GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)() override = default;  \
-    GTEST_DISALLOW_COPY_AND_ASSIGN_(GTEST_TEST_CLASS_NAME_(test_suite_name,    \
-							   test_name));        \
-    GTEST_DISALLOW_MOVE_AND_ASSIGN_(GTEST_TEST_CLASS_NAME_(test_suite_name,    \
-							   test_name));        \
+    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)(			       \
+      const GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)&) = delete;     \
+    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)& operator =(	       \
+      const GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)&) = delete;     \
+    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)(			       \
+      GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)&&) = delete;	       \
+    GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)& operator =(	       \
+      GTEST_TEST_CLASS_NAME_(test_suite_name, test_name)&&) = delete;	       \
 									       \
   private:                                                                     \
     boost::asio::awaitable<void> CoTestBody() override;                        \


### PR DESCRIPTION
To get coroutine tests working, I used some internals. Two of these are no longer available in newer versions. Since they can be implemented with regular old C++ features, use those.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
