### PR TITLE
osd/OSD: rewrite track_pools_and_pg_num_changes logic

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1675,8 +1675,11 @@ protected:
 
   void handle_osd_map(class MOSDMap *m);
   void track_pools_and_pg_num_changes(const std::map<epoch_t,OSDMapRef>& added_maps,
-                                      ObjectStore::Transaction& t,
-                                      epoch_t last);
+                                      ObjectStore::Transaction& t);
+  void _track_pools_and_pg_num_changes(ObjectStore::Transaction& t,
+                                       const OSDMapRef& lastmap,
+                                       const OSDMapRef& current_added_map,
+                                       epoch_t current_added_map_epoch);
   void _committed_osd_maps(epoch_t first, epoch_t last, class MOSDMap *m);
   void trim_maps(epoch_t oldest);
   void note_down_osd(int osd);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1674,6 +1674,9 @@ protected:
   friend struct send_map_on_destruct;
 
   void handle_osd_map(class MOSDMap *m);
+  void track_pools_and_pg_num_changes(const std::map<epoch_t,OSDMapRef>& added_maps,
+                                      ObjectStore::Transaction& t,
+                                      epoch_t last);
   void _committed_osd_maps(epoch_t first, epoch_t last, class MOSDMap *m);
   void trim_maps(epoch_t oldest);
   void note_down_osd(int osd);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1666,6 +1666,12 @@ protected:
     return osdmap ? osdmap->get_epoch() : 0;
   }
 
+  /* When handling OSDMaps pg_num_history is used to
+   * track any changes to number of PGs of each pool
+   * to be used later in order to identify PG splits and merges.
+   * See: OSD::track_pools_and_pg_num_changes
+   *      and OSDService::identify_splits_and_merges.
+   */
   pool_pg_num_history_t pg_num_history;
 
   ceph::shared_mutex map_lock = ceph::make_shared_mutex("OSD::map_lock");


### PR DESCRIPTION
* `track_pools_and_pg_num_changes()` is moved into a separate method
* `track_pools_and_pg_num_changes()` inner logic is moved into a separate method 

* Map gap case is now properly handled, `last_map` should start with the newest map we have.
Fixes: https://tracker.ceph.com/issues/63881

  _Example fix usage after letting osd.2 hit a map gap while creating 2 pools and changing pg_num in the meanwhile:_
  ```
  2023-12-21T14:23:22.252+0000 7faea797f700 10 osd.2 23 track_pools_and_pg_num_changes can't get previous map 122 first start of this osd after a map gap
  2023-12-21T14:23:22.252+0000 7faea797f700 10 osd.2 23 track_pools_and_pg_num_changes recording pool 2 pg_num 1 -> 3
  2023-12-21T14:23:22.252+0000 7faea797f700 10 osd.2 23 track_pools_and_pg_num_changes recording new pool 3 pg_num 1
  2023-12-21T14:23:22.252+0000 7faea797f700 10 osd.2 23 track_pools_and_pg_num_changes recording new pool 4 pg_num 1
  ```

---



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
