### PR TITLE
mon/AuthMonitor: fix potential repeated global id

### DIFF
--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -614,6 +614,13 @@ void AuthMonitor::_set_mon_num_rank(int num, int rank)
   mon_rank = rank;
 }
 
+void AuthMonitor::_reset_last_allocated_id()
+{
+  dout(10) << __func__ << " last_allocated_id " << last_allocated_id << " max_global_id " << max_global_id << dendl;
+  ceph_assert(ceph_mutex_is_locked(mon.auth_lock));
+  last_allocated_id = 0;
+}
+
 uint64_t AuthMonitor::_assign_global_id()
 {
   ceph_assert(ceph_mutex_is_locked(mon.auth_lock));

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -159,6 +159,7 @@ private:
 public:
   uint64_t _assign_global_id(); ///< called under mon->auth_lock
   void _set_mon_num_rank(int num, int rank); ///< called under mon->auth_lock
+  void _reset_last_allocated_id();
 
 private:
   bool prepare_used_pending_keys(MonOpRequestRef op);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2393,6 +2393,7 @@ void Monitor::finish_election()
   {
     std::lock_guard l(auth_lock);
     authmon()->_set_mon_num_rank(monmap->size(), rank);
+    authmon()->_reset_last_allocated_id();
   }
 
   // am i named and located properly?


### PR DESCRIPTION
When we expand or shrink monitors, there is the possibility of repeatedly allocating global ids. Because the calculation of last_allocated_id depends on mon_num and mon_rank, and expand or shrink monitors changes mon_num and mon_rank. A simple fix is to reset last_allocated_id when the election is complete, and that make all monitor' last_allocated_id start at max_global_id.

Fixs: https://tracker.ceph.com/issues/63891
Signed-off-by: shimin shimin@kuaishou.com