### PR TITLE
osd/osd_types: fix spelling of osd_op_flag_name

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -133,7 +133,7 @@ const char * ceph_osd_op_flag_name(unsigned flag)
       name = "fadvise_sequential";
       break;
     case CEPH_OSD_OP_FLAG_FADVISE_WILLNEED:
-      name = "favise_willneed";
+      name = "fadvise_willneed";
       break;
     case CEPH_OSD_OP_FLAG_FADVISE_DONTNEED:
       name = "fadvise_dontneed";


### PR DESCRIPTION
osd/osd_types: fix spelling of osd_op_flag_name

fix "CEPH_OSD_OP_FLAG_FADVISE_WILLNEED" op name "favise_willneed" as "fadvise_willneed"

Signed-off-by: shimin shimin@kuaishou.com