### PR TITLE
quincy: client/fuse: handle case of renameat2 with non-zero flags

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -753,6 +753,15 @@ static void fuse_ll_rename(fuse_req_t req, fuse_ino_t parent, const char *name,
 #endif
                            )
 {
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+  // cephfs does not support renameat2 flavors; follow same logic as done in
+  // kclient's ceph_rename()
+  if (flags) {
+    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    return;
+  }
+#endif
+
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
   UserPerm perm(ctx->uid, ctx->gid);


### PR DESCRIPTION
(Backport)

When user issues renameat(2) with non-zero flags (RENAME_EXCHANGE or RENAME_NOREPALCE) the current code ignores those flags and treat the call as ordinary rename. This, in turn, may yield successful rename with wrong semantics then those expected by the caller.

Follow the same semantics as kernel's cephfs client: return -EINVAL when having non-zero flags to renameat2 (see 'ceph_rename' at fs/ceph/dir.c).

Fixes: https://tracker.ceph.com/issues/63823
Original-Issue: https://tracker.ceph.com/issues/63722
Original-PR: https://github.com/ceph/ceph/pull/54733
Signed-off-by: Leonid Usov <leonid.usov@ibm.com>
Signed-off-by: Shachar Sharon <ssharon@redhat.com>
(cherry picked from commit 19509ce650367de8dfb979d3c6a40d5752c822f2)


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
