### PR TITLE
librbd/migration: Move ImageCtx creation inside formats

### DIFF
--- a/src/librbd/Types.h
+++ b/src/librbd/Types.h
@@ -93,6 +93,8 @@ struct SnapInfo {
   }
 };
 
+typedef std::map<uint64_t, SnapInfo> SnapInfos;
+
 enum {
   OPEN_FLAG_SKIP_OPEN_PARENT = 1 << 0,
   OPEN_FLAG_OLD_FORMAT       = 1 << 1,

--- a/src/librbd/migration/FormatInterface.h
+++ b/src/librbd/migration/FormatInterface.h
@@ -6,6 +6,7 @@
 
 #include "include/buffer_fwd.h"
 #include "include/int_types.h"
+#include "include/rados/librados_fwd.hpp"
 #include "common/zipkin_trace.h"
 #include "librbd/Types.h"
 #include "librbd/io/Types.h"
@@ -15,6 +16,8 @@ struct Context;
 
 namespace librbd {
 
+struct ImageCtx;
+
 namespace io {
 struct AioCompletion;
 struct ReadResult;
@@ -22,13 +25,13 @@ struct ReadResult;
 
 namespace migration {
 
+template <typename ImageCtxT = ImageCtx>
 struct FormatInterface {
-  typedef std::map<uint64_t, SnapInfo> SnapInfos;
-
   virtual ~FormatInterface() {
   }
 
-  virtual void open(Context* on_finish) = 0;
+  virtual void open(librados::IoCtx& dst_io_ctx, ImageCtxT* dst_image_ctx,
+                    ImageCtxT** src_image_ctx, Context* on_finish) = 0;
   virtual void close(Context* on_finish) = 0;
 
   virtual void get_snapshots(SnapInfos* snap_infos, Context* on_finish) = 0;

--- a/src/librbd/migration/ImageDispatch.cc
+++ b/src/librbd/migration/ImageDispatch.cc
@@ -18,7 +18,7 @@ namespace migration {
 
 template <typename I>
 ImageDispatch<I>::ImageDispatch(I* image_ctx,
-                                std::unique_ptr<FormatInterface> format)
+                                std::unique_ptr<FormatInterface<I>> format)
   : m_image_ctx(image_ctx), m_format(std::move(format)) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 10) << "ictx=" << image_ctx << dendl;

--- a/src/librbd/migration/ImageDispatch.h
+++ b/src/librbd/migration/ImageDispatch.h
@@ -15,17 +15,20 @@ struct ImageCtx;
 
 namespace migration {
 
+template <typename ImageCtxT>
 struct FormatInterface;
 
 template <typename ImageCtxT>
 class ImageDispatch : public io::ImageDispatchInterface {
 public:
-  static ImageDispatch* create(ImageCtxT* image_ctx,
-                               std::unique_ptr<FormatInterface> source) {
+  static ImageDispatch* create(
+          ImageCtxT* image_ctx,
+          std::unique_ptr<FormatInterface<ImageCtxT>> source) {
     return new ImageDispatch(image_ctx, std::move(source));
   }
 
-  ImageDispatch(ImageCtxT* image_ctx, std::unique_ptr<FormatInterface> source);
+  ImageDispatch(ImageCtxT* image_ctx,
+                std::unique_ptr<FormatInterface<ImageCtxT>> source);
 
   void shut_down(Context* on_finish) override;
 
@@ -86,7 +89,7 @@ public:
 
 private:
   ImageCtxT* m_image_ctx;
-  std::unique_ptr<FormatInterface> m_format;
+  std::unique_ptr<FormatInterface<ImageCtxT>> m_format;
 
   void fail_io(int r, io::AioCompletion* aio_comp,
                io::DispatchResult* dispatch_result);

--- a/src/librbd/migration/NativeFormat.h
+++ b/src/librbd/migration/NativeFormat.h
@@ -20,25 +20,24 @@ struct ImageCtx;
 namespace migration {
 
 template <typename ImageCtxT>
-class NativeFormat : public FormatInterface {
+class NativeFormat : public FormatInterface<ImageCtxT> {
 public:
   static std::string build_source_spec(int64_t pool_id,
                                        const std::string& pool_namespace,
                                        const std::string& image_name,
                                        const std::string& image_id);
 
-  static NativeFormat* create(ImageCtxT* image_ctx,
-                              const json_spirit::mObject& json_object,
+  static NativeFormat* create(const json_spirit::mObject& json_object,
                               bool import_only) {
-    return new NativeFormat(image_ctx, json_object, import_only);
+    return new NativeFormat(json_object, import_only);
   }
 
-  NativeFormat(ImageCtxT* image_ctx, const json_spirit::mObject& json_object,
-               bool import_only);
+  NativeFormat(const json_spirit::mObject& json_object, bool import_only);
   NativeFormat(const NativeFormat&) = delete;
   NativeFormat& operator=(const NativeFormat&) = delete;
 
-  void open(Context* on_finish) override;
+  void open(librados::IoCtx& dst_io_ctx, ImageCtxT* dst_image_ctx,
+            ImageCtxT** src_image_ctx, Context* on_finish) override;
   void close(Context* on_finish) override;
 
   void get_snapshots(SnapInfos* snap_infos, Context* on_finish) override;

--- a/src/librbd/migration/OpenSourceImageRequest.cc
+++ b/src/librbd/migration/OpenSourceImageRequest.cc
@@ -40,19 +40,6 @@ template <typename I>
 void OpenSourceImageRequest<I>::open_source() {
   ldout(m_cct, 10) << dendl;
 
-  // note that all source image ctx properties are placeholders
-  *m_src_image_ctx = I::create("", "", CEPH_NOSNAP, m_io_ctx, true);
-  auto src_image_ctx = *m_src_image_ctx;
-  src_image_ctx->child = m_dst_image_ctx;
-
-  // use default layout values (can be overridden by source layers later)
-  src_image_ctx->order = 22;
-  src_image_ctx->layout = file_layout_t();
-  src_image_ctx->layout.stripe_count = 1;
-  src_image_ctx->layout.stripe_unit = 1ULL << src_image_ctx->order;
-  src_image_ctx->layout.object_size = 1Ull << src_image_ctx->order;
-  src_image_ctx->layout.pool_id = -1;
-
   bool import_only = true;
   auto source_spec = m_migration_info.source_spec;
   if (source_spec.empty()) {
@@ -67,14 +54,13 @@ void OpenSourceImageRequest<I>::open_source() {
                    << "source_snap_id=" << m_src_snap_id << ", "
                    << "import_only=" << import_only << dendl;
 
-  SourceSpecBuilder<I> source_spec_builder{src_image_ctx};
+  SourceSpecBuilder<I> source_spec_builder{m_cct};
   json_spirit::mObject source_spec_object;
   int r = source_spec_builder.parse_source_spec(source_spec,
                                                 &source_spec_object);
   if (r < 0) {
     lderr(m_cct) << "failed to parse migration source-spec:" << cpp_strerror(r)
                  << dendl;
-    (*m_src_image_ctx)->state->close();
     finish(r);
     return;
   }
@@ -84,7 +70,6 @@ void OpenSourceImageRequest<I>::open_source() {
   if (r < 0) {
     lderr(m_cct) << "failed to build migration format handler: "
                  << cpp_strerror(r) << dendl;
-    (*m_src_image_ctx)->state->close();
     finish(r);
     return;
   }
@@ -92,7 +77,7 @@ void OpenSourceImageRequest<I>::open_source() {
   auto ctx = util::create_context_callback<
     OpenSourceImageRequest<I>,
     &OpenSourceImageRequest<I>::handle_open_source>(this);
-  m_format->open(ctx);
+  m_format->open(m_io_ctx, m_dst_image_ctx, m_src_image_ctx, ctx);
 }
 
 template <typename I>

--- a/src/librbd/migration/OpenSourceImageRequest.h
+++ b/src/librbd/migration/OpenSourceImageRequest.h
@@ -17,6 +17,7 @@ struct ImageCtx;
 
 namespace migration {
 
+template <typename ImageCtxT>
 struct FormatInterface;
 
 template <typename ImageCtxT>
@@ -63,8 +64,6 @@ private:
    * @endverbatim
    */
 
-  typedef std::map<uint64_t, SnapInfo> SnapInfos;
-
   CephContext* m_cct;
   librados::IoCtx& m_io_ctx;
   ImageCtxT* m_dst_image_ctx;
@@ -73,7 +72,7 @@ private:
   ImageCtxT** m_src_image_ctx;
   Context* m_on_finish;
 
-  std::unique_ptr<FormatInterface> m_format;
+  std::unique_ptr<FormatInterface<ImageCtxT>> m_format;
 
   uint64_t m_image_size = 0;
   SnapInfos m_snap_infos;

--- a/src/librbd/migration/QCOWFormat.h
+++ b/src/librbd/migration/QCOWFormat.h
@@ -47,20 +47,21 @@ struct LookupTable {
 } // namespace qcow_format
 
 template <typename ImageCtxT>
-class QCOWFormat : public FormatInterface {
+class QCOWFormat : public FormatInterface<ImageCtxT> {
 public:
   static QCOWFormat* create(
-      ImageCtxT* image_ctx, const json_spirit::mObject& json_object,
+      const json_spirit::mObject& json_object,
       const SourceSpecBuilder<ImageCtxT>* source_spec_builder) {
-    return new QCOWFormat(image_ctx, json_object, source_spec_builder);
+    return new QCOWFormat(json_object, source_spec_builder);
   }
 
-  QCOWFormat(ImageCtxT* image_ctx, const json_spirit::mObject& json_object,
+  QCOWFormat(const json_spirit::mObject& json_object,
              const SourceSpecBuilder<ImageCtxT>* source_spec_builder);
   QCOWFormat(const QCOWFormat&) = delete;
   QCOWFormat& operator=(const QCOWFormat&) = delete;
 
-  void open(Context* on_finish) override;
+  void open(librados::IoCtx& dst_io_ctx, ImageCtxT* dst_image_ctx,
+            ImageCtxT** src_image_ctx, Context* on_finish) override;
   void close(Context* on_finish) override;
 
   void get_snapshots(SnapInfos* snap_infos, Context* on_finish) override;
@@ -143,7 +144,6 @@ private:
   json_spirit::mObject m_json_object;
   const SourceSpecBuilder<ImageCtxT>* m_source_spec_builder;
 
-  boost::asio::strand<boost::asio::io_context::executor_type> m_strand;
   std::shared_ptr<StreamInterface> m_stream;
 
   bufferlist m_bl;

--- a/src/librbd/migration/RawFormat.h
+++ b/src/librbd/migration/RawFormat.h
@@ -24,20 +24,21 @@ template <typename> struct SourceSpecBuilder;
 struct SnapshotInterface;
 
 template <typename ImageCtxT>
-class RawFormat : public FormatInterface {
+class RawFormat : public FormatInterface<ImageCtxT> {
 public:
   static RawFormat* create(
-      ImageCtxT* image_ctx, const json_spirit::mObject& json_object,
+      const json_spirit::mObject& json_object,
       const SourceSpecBuilder<ImageCtxT>* source_spec_builder) {
-    return new RawFormat(image_ctx, json_object, source_spec_builder);
+    return new RawFormat(json_object, source_spec_builder);
   }
 
-  RawFormat(ImageCtxT* image_ctx, const json_spirit::mObject& json_object,
+  RawFormat(const json_spirit::mObject& json_object,
             const SourceSpecBuilder<ImageCtxT>* source_spec_builder);
   RawFormat(const RawFormat&) = delete;
   RawFormat& operator=(const RawFormat&) = delete;
 
-  void open(Context* on_finish) override;
+  void open(librados::IoCtx& dst_io_ctx, ImageCtxT* dst_image_ctx,
+            ImageCtxT** src_image_ctx, Context* on_finish) override;
   void close(Context* on_finish) override;
 
   void get_snapshots(SnapInfos* snap_infos, Context* on_finish) override;

--- a/src/librbd/migration/RawSnapshot.cc
+++ b/src/librbd/migration/RawSnapshot.cc
@@ -151,7 +151,8 @@ void RawSnapshot<I>::open(SnapshotInterface* previous_snapshot,
 
   ldout(cct, 10) << "name=" << m_snap_info.name << dendl;
 
-  int r = m_source_spec_builder->build_stream(m_json_object, &m_stream);
+  int r = m_source_spec_builder->build_stream(m_image_ctx, m_json_object,
+                                              &m_stream);
   if (r < 0) {
     lderr(cct) << "failed to build migration stream handler" << cpp_strerror(r)
                << dendl;

--- a/src/librbd/migration/SourceSpecBuilder.h
+++ b/src/librbd/migration/SourceSpecBuilder.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_LIBRBD_MIGRATION_SOURCE_SPEC_BUILDER_H
 #define CEPH_LIBRBD_MIGRATION_SOURCE_SPEC_BUILDER_H
 
+#include "include/common_fwd.h"
 #include "include/int_types.h"
 #include <json_spirit/json_spirit.h>
 #include <memory>
@@ -18,32 +19,35 @@ struct ImageCtx;
 
 namespace migration {
 
+template <typename ImageCtxT>
 struct FormatInterface;
+
 struct SnapshotInterface;
 struct StreamInterface;
 
 template <typename ImageCtxT>
 class SourceSpecBuilder {
 public:
-  SourceSpecBuilder(ImageCtxT* image_ctx) : m_image_ctx(image_ctx) {
+  SourceSpecBuilder(CephContext* cct) : m_cct(cct) {
   }
 
   int parse_source_spec(const std::string& source_spec,
                         json_spirit::mObject* source_spec_object) const;
 
   int build_format(const json_spirit::mObject& format_object, bool import_only,
-                   std::unique_ptr<FormatInterface>* format) const;
+                   std::unique_ptr<FormatInterface<ImageCtxT>>* format) const;
 
-  int build_snapshot(const json_spirit::mObject& source_spec_object,
+  int build_snapshot(ImageCtxT* image_ctx,
+                     const json_spirit::mObject& source_spec_object,
                      uint64_t index,
                      std::shared_ptr<SnapshotInterface>* snapshot) const;
 
-  int build_stream(const json_spirit::mObject& source_spec_object,
+  int build_stream(ImageCtxT* image_ctx,
+                   const json_spirit::mObject& source_spec_object,
                    std::shared_ptr<StreamInterface>* stream) const;
 
 private:
-  ImageCtxT* m_image_ctx;
-
+  CephContext* m_cct;
 };
 
 } // namespace migration

--- a/src/test/librbd/migration/test_mock_RawSnapshot.cc
+++ b/src/test/librbd/migration/test_mock_RawSnapshot.cc
@@ -28,7 +28,8 @@ namespace migration {
 template<>
 struct SourceSpecBuilder<librbd::MockTestImageCtx> {
 
-  MOCK_CONST_METHOD2(build_stream, int(const json_spirit::mObject&,
+  MOCK_CONST_METHOD3(build_stream, int(librbd::MockTestImageCtx*,
+                                       const json_spirit::mObject&,
                                        std::shared_ptr<StreamInterface>*));
 
 };
@@ -67,8 +68,8 @@ public:
 
   void expect_build_stream(MockSourceSpecBuilder& mock_source_spec_builder,
                            MockStreamInterface* mock_stream_interface, int r) {
-    EXPECT_CALL(mock_source_spec_builder, build_stream(_, _))
-      .WillOnce(WithArgs<1>(Invoke([mock_stream_interface, r]
+    EXPECT_CALL(mock_source_spec_builder, build_stream(_, _, _))
+      .WillOnce(WithArgs<2>(Invoke([mock_stream_interface, r]
         (std::shared_ptr<StreamInterface>* ptr) {
           ptr->reset(mock_stream_interface);
           return r;


### PR DESCRIPTION
This PR moves the creation of the migration source image context from OpenSourceImageRequest into the FormatInterface::open function. This allows formats to more correctly define the image context, instead of patching an existing image context.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
