### PR TITLE
rgw/putobj: offload md5 calculations to the global execution context

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -81,6 +81,7 @@ set(librgw_common_srcs
   rgw_ldap.cc
   rgw_lc.cc
   rgw_lc_s3.cc
+  rgw_md5.cc
   rgw_metadata.cc
   rgw_multi.cc
   rgw_multi_del.cc

--- a/src/rgw/rgw_main.h
+++ b/src/rgw/rgw_main.h
@@ -83,9 +83,9 @@ class AppMain {
   std::unique_ptr<sal::ConfigStore> cfgstore;
   SiteConfig site;
   const DoutPrefixProvider* dpp;
-  RGWProcessEnv env;
   void need_context_pool();
-  std::optional<ceph::async::io_context_pool> context_pool;
+  ceph::async::io_context_pool context_pool;
+  RGWProcessEnv env;
 public:
   AppMain(const DoutPrefixProvider* dpp);
   ~AppMain();

--- a/src/rgw/rgw_md5.cc
+++ b/src/rgw/rgw_md5.cc
@@ -1,0 +1,40 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "rgw_md5.h"
+
+#include "common/ceph_crypto.h"
+
+#include "rgw_putobj_hash.h"
+
+namespace rgw {
+
+class MD5WithFIPS : public ceph::crypto::ssl::MD5 {
+ public:
+  MD5WithFIPS() {
+    // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
+    SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  }
+};
+
+auto create_md5_putobj_pipe(sal::DataProcessor* next,
+                            std::string& output)
+    -> std::unique_ptr<sal::DataProcessor>
+{
+  using Pipe = putobj::HashPipe<MD5WithFIPS>;
+  return std::make_unique<Pipe>(next, output);
+}
+
+} // namespace rgw

--- a/src/rgw/rgw_md5.h
+++ b/src/rgw/rgw_md5.h
@@ -1,0 +1,29 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include "rgw_sal_fwd.h"
+
+namespace rgw {
+
+/// Create a DataProcessor filter that calculates the md5sum of processed data
+auto create_md5_putobj_pipe(sal::DataProcessor* next,
+                            std::string& output)
+    -> std::unique_ptr<sal::DataProcessor>;
+
+} // namespace rgw

--- a/src/rgw/rgw_md5.h
+++ b/src/rgw/rgw_md5.h
@@ -17,12 +17,18 @@
 
 #include <memory>
 #include <string>
+#include <boost/asio/any_io_executor.hpp>
 #include "rgw_sal_fwd.h"
+
+class optional_yield;
 
 namespace rgw {
 
 /// Create a DataProcessor filter that calculates the md5sum of processed data
 auto create_md5_putobj_pipe(sal::DataProcessor* next,
+                            optional_yield y,
+                            boost::asio::any_io_executor hash_executor,
+                            size_t window_size,
                             std::string& output)
     -> std::unique_ptr<sal::DataProcessor>;
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4374,7 +4374,9 @@ void RGWPutObj::execute(optional_yield y)
       filter = &*run_lua;
     }
     if (need_calc_md5) {
-      md5_filter = rgw::create_md5_putobj_pipe(filter, etag);
+      auto ex = s->penv.io_context.get_executor();
+      const size_t window_size = s->cct->_conf->rgw_put_obj_min_window_size;
+      md5_filter = rgw::create_md5_putobj_pipe(filter, y, ex, window_size, etag);
       filter = md5_filter.get();
     }
   }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -34,6 +34,7 @@
 #include "rgw_user.h"
 #include "rgw_bucket.h"
 #include "rgw_log.h"
+#include "rgw_md5.h"
 #include "rgw_multi.h"
 #include "rgw_multi_del.h"
 #include "rgw_cors.h"
@@ -4139,14 +4140,9 @@ void RGWPutObj::execute(optional_yield y)
 {
   char supplied_md5_bin[CEPH_CRYPTO_MD5_DIGESTSIZE + 1];
   char supplied_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
-  char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
-  unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
-  MD5 hash;
-  // Allow use of MD5 digest in FIPS mode for non-cryptographic purposes
-  hash.SetFlags(EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
   bufferlist bl, aclbl, bs;
   int len;
-  
+
   off_t fst;
   off_t lst;
 
@@ -4340,6 +4336,7 @@ void RGWPutObj::execute(optional_yield y)
 
   std::unique_ptr<rgw::sal::DataProcessor> encrypt;
   std::unique_ptr<rgw::sal::DataProcessor> run_lua;
+  std::unique_ptr<rgw::sal::DataProcessor> md5_filter;
 
   if (!append) { // compression and encryption only apply to full object uploads
     op_ret = get_encrypt_filter(&encrypt, filter);
@@ -4376,6 +4373,10 @@ void RGWPutObj::execute(optional_yield y)
     if (run_lua) {
       filter = &*run_lua;
     }
+    if (need_calc_md5) {
+      md5_filter = rgw::create_md5_putobj_pipe(filter, etag);
+      filter = md5_filter.get();
+    }
   }
   tracepoint(rgw_op, before_data_transfer, s->req_id.c_str());
   do {
@@ -4399,10 +4400,6 @@ void RGWPutObj::execute(optional_yield y)
       return;
     } else if (len == 0) {
       break;
-    }
-
-    if (need_calc_md5) {
-      hash.Update((const unsigned char *)data.c_str(), data.length());
     }
 
     op_ret = filter->process(std::move(data), ofs);
@@ -4442,8 +4439,6 @@ void RGWPutObj::execute(optional_yield y)
     return;
   }
 
-  hash.Final(m);
-
   if (compressor && compressor->is_compressed()) {
     bufferlist tmp;
     RGWCompressionInfo cs_info;      
@@ -4470,11 +4465,9 @@ void RGWPutObj::execute(optional_yield y)
     }
   }
 
-  buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
-
-  etag = calc_md5;
-
-  if (supplied_md5_b64 && strcmp(calc_md5, supplied_md5)) {
+  if (supplied_md5_b64 && etag != supplied_md5) {
+    ldpp_dout(this, 4) << "content-md5 mismatch: calculated "
+        << etag << " != expected " << supplied_md5 << dendl;
     op_ret = -ERR_BAD_DIGEST;
     return;
   }
@@ -4496,11 +4489,14 @@ void RGWPutObj::execute(optional_yield y)
     emplace_attr(RGW_ATTR_SLO_MANIFEST, std::move(manifest_bl));
   }
 
-  if (supplied_etag && etag.compare(supplied_etag) != 0) {
+  if (supplied_etag && etag != supplied_etag) {
+    // compare against swift ETag request header
+    ldpp_dout(this, 4) << "etag mismatch: calculated "
+        << etag << " != expected " << supplied_etag << dendl;
     op_ret = -ERR_UNPROCESSABLE_ENTITY;
     return;
   }
-  bl.append(etag.c_str(), etag.size());
+  bl.append(etag);
   emplace_attr(RGW_ATTR_ETAG, std::move(bl));
 
   populate_with_generic_attrs(s, attrs);

--- a/src/rgw/rgw_process_env.h
+++ b/src/rgw/rgw_process_env.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <boost/asio/io_context.hpp>
 
 class ActiveRateLimiter;
 class OpsLogSink;
@@ -37,6 +38,9 @@ struct RGWLuaProcessEnv {
 };
 
 struct RGWProcessEnv {
+  // reference to the global thread pool context
+  boost::asio::io_context& io_context;
+
   RGWLuaProcessEnv lua;
   rgw::sal::ConfigStore* cfgstore = nullptr;
   rgw::sal::Driver* driver = nullptr;

--- a/src/rgw/rgw_putobj_hash.h
+++ b/src/rgw/rgw_putobj_hash.h
@@ -1,0 +1,77 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <string>
+
+#include "rgw_putobj.h"
+
+namespace rgw::putobj {
+
+/// Finalize a digest and return it as a hex-encoded string.
+template <typename Digest>
+std::string finalize(Digest& digest)
+{
+  unsigned char buf[Digest::digest_size];
+  digest.Final(buf);
+
+  std::string hex;
+  hex.resize(Digest::digest_size * 2);
+
+  auto out = hex.begin();
+  std::for_each(std::begin(buf), std::end(buf),
+      [&out] (unsigned char c) {
+        constexpr auto table = std::string_view{"0123456789abcdef"};
+        *out++ = table[c >> 4]; // high 4 bits
+        *out++ = table[c & 0xf]; // low 4 bits
+      });
+  return hex;
+}
+
+/// A streaming data processor that performs inline hashing of incoming
+/// bytes before forwarding them to the wrapped processor. When the processor
+/// is flushed by calling process() with an empty buffer, the final sum is
+/// copied to the given output string.
+template <typename Digest>
+class HashPipe : public putobj::Pipe {
+  std::string& output;
+  Digest digest;
+
+ public:
+  template <typename ...DigestArgs>
+  HashPipe(sal::DataProcessor* next, std::string& output, DigestArgs&& ...args)
+    : Pipe(next), output(output), digest(std::forward<DigestArgs>(args)...)
+  {}
+
+  int process(bufferlist&& data, uint64_t logical_offset) override
+  {
+    if (data.length() == 0) {
+      // flush the pipe and finalize the digest
+      output = finalize(digest);
+    } else {
+      // hash each buffer segment
+      for (const auto& ptr : data.buffers()) {
+        digest.Update(reinterpret_cast<const unsigned char*>(ptr.c_str()),
+                      ptr.length());
+      }
+    }
+
+    return Pipe::process(std::move(data), logical_offset);
+  }
+};
+
+} // namespace rgw::putobj


### PR DESCRIPTION
* uses the `sal::DataProcessor` interface to move etag calculation logic out of `RGWPutObj::execute()`
* adds an `Async` implementation that offloads etag calculations to another thread (the global thread pool executor) so they can run in parallel with `RGWPutObj::execute()`'s reads from the frontend socket and writes to rados

this offloading is conceptually similar to prior work in https://github.com/ceph/ceph/pull/52920, but without spawning a new thread for each request

this also relates to ongoing work in https://github.com/ceph/ceph/pull/52385 and https://github.com/ceph/ceph/pull/52488 to take advantage of vectorization (and potentially hardware acceleration) for etag calculation. however, that strategy involves a tradeoff between latency and batching, so is targetted at scaled-up workloads to reduce cpu usage. at smaller scales, we may prefer this PR's strategy to improve latency instead

depends on some asio-related commits from https://github.com/ceph/ceph/pull/50055 and https://github.com/ceph/ceph/pull/52496

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
