### PR TITLE
Solution 2: osd/OSD: reply pg_created when pg is peered

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1264,8 +1264,15 @@ void OSDService::send_pg_created(pg_t pgid)
   dout(20) << __func__ << dendl;
   auto o = get_osdmap();
   if (o->require_osd_release >= ceph_release_t::luminous) {
-    pg_created.insert(pgid);
-    monc->send_mon_message(new MOSDPGCreated(pgid));
+    if (pg_created.count(pgid)) {
+      dout(20) << __func__ << " already reply to mon "
+               << pgid << " pg_created." << dendl;
+    } else {
+      pg_created.insert(pgid);
+      dout(20) << __func__ << " reply to mon "
+               << pgid << " pg_created." << dendl;
+      monc->send_mon_message(new MOSDPGCreated(pgid));
+    }
   }
 }
 
@@ -1276,6 +1283,8 @@ void OSDService::send_pg_created()
   auto o = get_osdmap();
   if (o->require_osd_release >= ceph_release_t::luminous) {
     for (auto pgid : pg_created) {
+      dout(20) << __func__ << " re-reply to mon "
+               << pgid << " pg_created!" << dendl;
       monc->send_mon_message(new MOSDPGCreated(pgid));
     }
   }


### PR DESCRIPTION
```
    osd/OSD: reply pg_created when pg is peered

    Problem:
      when PG is active+clean
      ceph osd force-create-pg 1.0 --yes-i-really-mean-it
      because osd is not reply pg_created to mon.
    Affects:
      pool remains creating flags,
      mon creating_pgs.pg is not empty,
      lead to mon cannot trim OSDMaps
    Solution:
      After receiving the new OSDMap, when delivering
      the ActMap event to the PG state machine,
      if pg Active and is_peered, reply pg_created to mon.

    Fixes: https://tracker.ceph.com/issues/63912
    Signed-off-by: zhangjianwei2 <zhangjianwei2@cmss.chinamobile.com>
```
Fixes: https://tracker.ceph.com/issues/63912

- Solution 1: Add PgCreateEvt https://github.com/ceph/ceph/pull/55239
- Solution 2: Use Active::react(ActMap) https://github.com/ceph/ceph/pull/55041