### PR TITLE
rgw/kafka: reply with an error when broker is down

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3983,7 +3983,8 @@ options:
     are sent to it for more than the time defined.
     Note that the connection will not be considered idle, even if it is down,
     as long as there are attempts to send messages to it.
-  default: 30
+    If set to zero, connections are never considered idle.
+  default: 300
   services:
   - rgw
   with_legacy: true
@@ -3991,11 +3992,41 @@ options:
   type: uint 
   level: advanced
   desc: Time in milliseconds to sleep while polling for kafka replies
-  long_desc: This will be used to prevent busy waiting for the kafka replies
+  long_desc: This will be used to prevent busy waiting for the kafka replies.
     As well as for the cases where the broker is down and we try to reconnect.
-    The same values times 3 will be used to sleep if there were no messages
-    sent or received across all kafka connections
+    The same values times 3, will be used to sleep if there were no messages
+    sent or received across all kafka connections.
+    If set to zero, poll will return immediatly, as well as the other sleeeps.
+    This may raise the CPU consumption of the kafka thread.
   default: 10
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_kafka_message_timeout
+  type: uint 
+  level: advanced
+  desc: This is the maximum time in milliseconds to deliver a message (including retries)
+  long_desc: Delivery error occurs when either the retry count or the message timeout are exceeded.
+    If set to zero, message will time out only based on retries.
+  default: 5000
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_kafka_check_broker
+  type: bool 
+  level: advanced
+  desc: Checking the state of the broker before sending the notification
+  long_desc: If set to "true" we will check the state of the broker before sending the
+    actual notification. If the broker is down we will reply with an error to the operation
+    that triggered the notification (S3, lifecycle, multisiet syncing). 
+    Note that the actual sending may still fail even if the state of the broker was ok.
+    If set to "true", (the current behavior, and the default) the state of the broker is not checked.
+    In both cases, failure to actually send the notification will not trigger failure 
+    of the operation that triggered the notification, and will only be logged.
+    Note that this is applicable only for non-persistent (synchronous) notifications.
+    Persistent notifications will reply with an error to the operation that triggered them 
+    only if their persistent queue is full, and ignore the state of the broker.
+  default: false
   services:
   - rgw
   with_legacy: true

--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -802,13 +802,7 @@ int RGWAsyncFetchRemoteObj::_send_request(const DoutPrefixProvider *dpp)
         // NOTE: we create a mutable copy of bucket.get_tenant as the get_notification function expects a std::string&, not const
         std::string tenant(dest_bucket.get_tenant());
 
-        std::unique_ptr<rgw::sal::Notification> notify 
-                 = store->get_notification(dpp, &dest_obj, nullptr, rgw::notify::ObjectSyncedCreate,
-                  &dest_bucket, user_id,
-                  tenant,
-                  req_id, null_yield);
-
-        auto notify_res = static_cast<rgw::sal::RadosNotification*>(notify.get())->get_reservation();
+        rgw::notify::reservation_t notify_res(dpp, store, &dest_obj, nullptr, &dest_bucket, user_id,  tenant, req_id, null_yield);
         int ret = rgw::notify::publish_reserve(dpp, rgw::notify::ObjectSyncedCreate, notify_res, &obj_tags);
         if (ret < 0) {
           ldpp_dout(dpp, 1) << "ERROR: reserving notification failed, with error: " << ret << dendl;

--- a/src/rgw/driver/rados/rgw_notify.h
+++ b/src/rgw/driver/rados/rgw_notify.h
@@ -19,6 +19,7 @@ namespace rgw::sal {
 
 class RGWRados;
 struct rgw_obj_key;
+class RGWPubSubEndpoint;
 
 namespace rgw::notify {
 
@@ -72,6 +73,7 @@ struct reservation_t {
   const std::string user_tenant;
   const std::string req_id;
   optional_yield yield;
+  std::unique_ptr<RGWPubSubEndpoint> endpoint;
 
   /* ctor for rgw_op callers */
   reservation_t(const DoutPrefixProvider* _dpp,

--- a/src/rgw/driver/rados/rgw_pubsub_push.h
+++ b/src/rgw/driver/rados/rgw_pubsub_push.h
@@ -22,16 +22,16 @@ public:
   RGWPubSubEndpoint(const RGWPubSubEndpoint&) = delete;
   const RGWPubSubEndpoint& operator=(const RGWPubSubEndpoint&) = delete;
 
-  typedef std::unique_ptr<RGWPubSubEndpoint> Ptr;
-
   // factory method for the actual notification endpoint
   // derived class specific arguments are passed in http args format
   // may throw a configuration_error if creation fails
-  static Ptr create(const std::string& endpoint, const std::string& topic, const RGWHTTPArgs& args, CephContext *cct=nullptr);
+  static RGWPubSubEndpoint* create(const std::string& endpoint, const std::string& topic, const RGWHTTPArgs& args, CephContext *cct=nullptr);
  
-  // this method is used in order to send notification (S3 compliant) and wait for completion 
-  // in async manner via a coroutine when invoked in the frontend environment
-  virtual int send_to_completion_async(CephContext* cct, const rgw_pubsub_s3_event& event, optional_yield y) = 0;
+  // this method is used in order to send notification to the endpoint
+  virtual int send(CephContext* cct, const rgw_pubsub_s3_event& event, optional_yield y) = 0;
+
+  // this method is used in order to verify connectivity with the endpoint
+  virtual int is_alive(CephContext* cct, optional_yield y) = 0;
 
   // present as string
   virtual std::string to_str() const { return ""; }

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -713,10 +713,6 @@ class RadosNotification : public StoreNotification {
 
     ~RadosNotification() = default;
 
-    rgw::notify::reservation_t& get_reservation(void) {
-      return res;
-    }
-
     virtual int publish_reserve(const DoutPrefixProvider *dpp, RGWObjTags* obj_tags = nullptr) override;
     virtual int publish_commit(const DoutPrefixProvider* dpp, uint64_t size,
 			       const ceph::real_time& mtime, const std::string& etag, const std::string& version) override;

--- a/src/rgw/rgw_kafka.cc
+++ b/src/rgw/rgw_kafka.cc
@@ -2,9 +2,13 @@
 // vim: ts=8 sw=2 smarttab ft=cpp
 
 #include "rgw_kafka.h"
+#include "common/Clock.h"
 #include "rgw_url.h"
+#include <algorithm>
+#include <cstddef>
 #include <librdkafka/rdkafka.h>
 #include "include/ceph_assert.h"
+#include <memory>
 #include <sstream>
 #include <cstring>
 #include <unordered_map>
@@ -18,29 +22,78 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-// TODO investigation, not necessarily issues:
-// (1) in case of single threaded writer context use spsc_queue
-// (2) check performance of emptying queue to local list, and go over the list and publish
-// (3) use std::shared_mutex (c++17) or equivalent for the connections lock
 
 // comparison operator between topic pointer and name
 bool operator==(const rd_kafka_topic_t* rkt, const std::string& name) {
     return name == std::string_view(rd_kafka_topic_name(rkt)); 
 }
 
+// this is the inverse of rd_kafka_errno2err
+// see: https://github.com/confluentinc/librdkafka/blob/master/src/rdkafka.c
+inline int rd_kafka_err2errno(rd_kafka_resp_err_t err) {
+  if (err == 0) return 0;
+  switch (err) {
+    case RD_KAFKA_RESP_ERR__INVALID_ARG:
+    return EINVAL;
+  case RD_KAFKA_RESP_ERR__CONFLICT:
+    return EBUSY;
+  case RD_KAFKA_RESP_ERR__UNKNOWN_TOPIC:
+    return ENOENT;
+  case RD_KAFKA_RESP_ERR__UNKNOWN_PARTITION:
+    return ESRCH;
+  case RD_KAFKA_RESP_ERR__TIMED_OUT:
+  case RD_KAFKA_RESP_ERR__MSG_TIMED_OUT:
+    return ETIMEDOUT;
+  case RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE:
+    return EMSGSIZE;
+  case RD_KAFKA_RESP_ERR__QUEUE_FULL:
+    return ENOBUFS;
+  default:
+    return EIO;
+  }
+}
+
 namespace rgw::kafka {
 
-// status codes for publishing
-static const int STATUS_CONNECTION_CLOSED =      -0x1002;
-static const int STATUS_QUEUE_FULL =             -0x1003;
-static const int STATUS_MAX_INFLIGHT =           -0x1004;
-static const int STATUS_MANAGER_STOPPED =        -0x1005;
-static const int STATUS_CONNECTION_IDLE =        -0x1006;
-// status code for connection opening
-static const int STATUS_CONF_ALLOC_FAILED      = -0x2001;
-static const int STATUS_CONF_REPLCACE          = -0x2002;
+enum Status {
+  STATUS_CONNECTION_CLOSED = -0x1002,
+  STATUS_CONNECTION_IDLE   = -0x1006,
+  STATUS_CONF_ALLOC_FAILED = -0x2001,
+  STATUS_CONF_REPLCACE     = -0x2002,
+};
 
-static const int STATUS_OK =                     0x0;
+// convert int status to string - both RGW and librdkafka values
+inline std::string status_to_string(int s) {
+  switch (s) {
+    case STATUS_CONNECTION_CLOSED:
+      return "Kafka connection closed";
+    case STATUS_CONF_ALLOC_FAILED:
+      return "Kafka configuration allocation failed";
+    case STATUS_CONF_REPLCACE:
+      return "Kafka configuration changed";
+    case STATUS_CONNECTION_IDLE:
+      return "Kafka connection idle";
+    default:
+      return std::string(rd_kafka_err2str(static_cast<rd_kafka_resp_err_t>(s)));
+  }
+}
+
+// convert int status to errno - both RGW and librdkafka values
+inline int status_to_errno(int s) {
+  if (s == 0) return 0;
+  switch (s) {
+    case STATUS_CONNECTION_CLOSED:
+      return -EIO;
+    case STATUS_CONF_ALLOC_FAILED:
+      return -ENOMEM;
+    case STATUS_CONF_REPLCACE:
+      return -EAGAIN;
+    case STATUS_CONNECTION_IDLE:
+      return -EIO;
+    default:
+      return -rd_kafka_err2errno(static_cast<rd_kafka_resp_err_t>(s));
+  }
+}
 
 // struct for holding the callback and its tag in the callback list
 struct reply_callback_with_tag_t {
@@ -64,7 +117,7 @@ struct connection_t {
   rd_kafka_conf_t* temp_conf = nullptr;
   std::vector<rd_kafka_topic_t*> topics;
   uint64_t delivery_tag = 1;
-  int status = STATUS_OK;
+  int status = 0;
   CephContext* const cct;
   CallbackList callbacks;
   const std::string broker;
@@ -75,42 +128,41 @@ struct connection_t {
   const std::string password;
   const boost::optional<std::string> mechanism;
   utime_t timestamp = ceph_clock_now();
+  utime_t last_status = ceph_clock_now();
+
+  // fire all callbacks
+  void clear_callbacks() {
+    std::for_each(callbacks.begin(), callbacks.end(), [this](auto& cb_tag) {
+        cb_tag.cb(status_to_errno(status));
+        ldout(cct, 20) << "Kafka clear callbacks: invoking callback with tag = "
+                       << cb_tag.tag << " for: " << broker
+                       << " with status = " << status_to_string(status) << dendl;
+      });
+    callbacks.clear();
+  }
 
   // cleanup of all internal connection resource
   // the object can still remain, and internal connection
   // resources created again on successful reconnection
-  void destroy(int s) {
-    status = s;
+  void destroy() {
     // destroy temporary conf (if connection was never established)
     if (temp_conf) {
         rd_kafka_conf_destroy(temp_conf);
         return;
     }
-    if (!is_ok()) {
+    if (!producer) {
       // no producer, nothing to destroy
       return;
     }
-    // wait for all remaining acks/nacks
-    rd_kafka_flush(producer, 5*1000 /* wait for max 5 seconds */);
     // destroy all topics
     std::for_each(topics.begin(), topics.end(), [](auto topic) {rd_kafka_topic_destroy(topic);});
+    topics.clear();
     // destroy producer
     rd_kafka_destroy(producer);
     producer = nullptr;
-    // fire all remaining callbacks (if not fired by rd_kafka_flush)
-    std::for_each(callbacks.begin(), callbacks.end(), [this](auto& cb_tag) {
-        cb_tag.cb(status);
-        ldout(cct, 20) << "Kafka destroy: invoking callback with tag="
-                       << cb_tag.tag << " for: " << broker
-                       << " with status: " << status << dendl;
-      });
-    callbacks.clear();
+    clear_callbacks();
     delivery_tag = 1;
     ldout(cct, 20) << "Kafka destroy: complete for: " << broker << dendl;
-  }
-
-  bool is_ok() const {
-    return (producer != nullptr);
   }
 
   // ctor for setting immutable values
@@ -121,31 +173,11 @@ struct connection_t {
 
   // dtor also destroys the internals
   ~connection_t() {
-    destroy(status);
+    destroy();
   }
 };
 
-// convert int status to string - including RGW specific values
-std::string status_to_string(int s) {
-  switch (s) {
-    case STATUS_OK:
-        return "STATUS_OK";
-    case STATUS_CONNECTION_CLOSED:
-      return "RGW_KAFKA_STATUS_CONNECTION_CLOSED";
-    case STATUS_QUEUE_FULL:
-      return "RGW_KAFKA_STATUS_QUEUE_FULL";
-    case STATUS_MAX_INFLIGHT:
-      return "RGW_KAFKA_STATUS_MAX_INFLIGHT";
-    case STATUS_MANAGER_STOPPED:
-      return "RGW_KAFKA_STATUS_MANAGER_STOPPED";
-    case STATUS_CONF_ALLOC_FAILED:
-      return "RGW_KAFKA_STATUS_CONF_ALLOC_FAILED";
-    case STATUS_CONF_REPLCACE:
-      return "RGW_KAFKA_STATUS_CONF_REPLCACE";
-    case STATUS_CONNECTION_IDLE:
-      return "RGW_KAFKA_STATUS_CONNECTION_IDLE";
-  }
-  return std::string(rd_kafka_err2str((rd_kafka_resp_err_t)s));
+void status_cb(int status) {
 }
 
 void message_callback(rd_kafka_t* rk, const rd_kafka_message_t* rkmessage, void* opaque) {
@@ -153,6 +185,8 @@ void message_callback(rd_kafka_t* rk, const rd_kafka_message_t* rkmessage, void*
 
   const auto conn = reinterpret_cast<connection_t*>(opaque);
   const auto result = rkmessage->err;
+  conn->status = result;
+  conn->last_status = ceph_clock_now();
 
   if (!rkmessage->_private) {
     ldout(conn->cct, 20) << "Kafka run: n/ack received, (no callback) with result=" << result << dendl;
@@ -164,9 +198,9 @@ void message_callback(rd_kafka_t* rk, const rd_kafka_message_t* rkmessage, void*
   const auto& callbacks_begin = conn->callbacks.begin();
   const auto tag_it = std::find(callbacks_begin, callbacks_end, *tag);
   if (tag_it != callbacks_end) {
-      ldout(conn->cct, 20) << "Kafka run: n/ack received, invoking callback with tag=" << 
-          *tag << " and result=" << rd_kafka_err2str(result) << dendl;
-      tag_it->cb(result);
+      ldout(conn->cct, 20) << "Kafka run: n/ack received, invoking callback with tag = " << 
+          *tag << " and result = " << rd_kafka_err2str(result) << "(" << result << ")"  << dendl;
+      tag_it->cb(-rd_kafka_err2errno(result));
       conn->callbacks.erase(tag_it);
   } else {
     // TODO add counter for acks with no callback
@@ -194,24 +228,91 @@ void log_callback(const rd_kafka_t* rk, int level, const char *fac, const char *
 void poll_err_callback(rd_kafka_t *rk, int err, const char *reason, void *opaque) {
   const auto conn = reinterpret_cast<connection_t*>(rd_kafka_opaque(rk));
   ldout(conn->cct, 10) << "Kafka run: poll error(" << err << "): " << reason << dendl;
+  if (conn->cct->_conf->rgw_kafka_check_broker) {
+    conn->status = err;
+    conn->last_status = ceph_clock_now();
+    conn->clear_callbacks();
+  }
 }
 
 using connection_t_ptr = std::unique_ptr<connection_t>;
 
+void update_connection_status(connection_t* conn) {
+  if (!conn->cct->_conf->rgw_kafka_check_broker) {
+    conn->status = 0;
+    conn->last_status = ceph_clock_now();
+  }
+  
+  ceph_assert(conn->producer);
+  const std::string topic_name{"dummy"};
+  // create a new dummy topic unless it was already created
+  auto topic_it = std::find(conn->topics.begin(), conn->topics.end(), topic_name);
+  rd_kafka_topic_t* topic = nullptr;
+  if (topic_it == conn->topics.end()) {
+    topic = rd_kafka_topic_new(conn->producer, topic_name.c_str(), nullptr);
+    if (!topic) {
+      const auto err = rd_kafka_last_error();
+      ldout(conn->cct, 1) << "Kafka connection status: failed to create topic: " << topic_name << " error: " 
+        << rd_kafka_err2str(err) << "(" << err << ")" << dendl;
+      conn->status = err;
+      conn->last_status = ceph_clock_now();
+      return;
+    }
+    conn->topics.push_back(topic);
+    ldout(conn->cct, 20) << "Kafka connection status: created new topic: " << topic_name << dendl;
+  } else {
+    topic = *topic_it;
+    ldout(conn->cct, 20) << "Kafka connection status: reused existing topic: " << topic_name << dendl;
+  }
+    
+  const auto tag = new uint64_t(conn->delivery_tag++);
+  const auto rc = rd_kafka_produce(
+      topic,
+      RD_KAFKA_PARTITION_UA,
+      RD_KAFKA_MSG_F_FREE,
+      // data and length
+      nullptr,
+      0,
+      // key and length
+      nullptr, 
+      0,
+      tag);
+    if (rc == -1) {
+      const auto err = rd_kafka_last_error();
+      ldout(conn->cct, 10) << "Kafka connection status: failed to produce. error: " 
+        << rd_kafka_err2str(err) << "(" << err << ")" << dendl;
+      conn->status = err;
+      conn->last_status = ceph_clock_now();
+      delete tag;
+      return;
+    }
+    conn->callbacks.emplace_back(*tag, status_cb);
+ 
+    // since rd_kafka_produce is async we call rd_kafka_poll to get the status
+    rd_kafka_poll(conn->producer, -1);
+}
+
 // utility function to create a producer, when the connection object already exists
 bool new_producer(connection_t* conn) {
   // reset all status codes
-  conn->status = STATUS_OK; 
-  char errstr[512] = {0};
+  conn->status = STATUS_CONNECTION_CLOSED; 
+  conn->last_status = ceph_clock_now();
+
+  ceph_assert(!conn->producer);
 
   conn->temp_conf = rd_kafka_conf_new();
   if (!conn->temp_conf) {
     conn->status = STATUS_CONF_ALLOC_FAILED;
+    conn->last_status = ceph_clock_now();
     return false;
   }
 
+  char errstr[512] = {0};
   // get list of brokers based on the bootstrap broker
   if (rd_kafka_conf_set(conn->temp_conf, "bootstrap.servers", conn->broker.c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
+  // set message timeout
+  if (rd_kafka_conf_set(conn->temp_conf, "message.timeout.ms", 
+        std::to_string(conn->cct->_conf->rgw_kafka_message_timeout).c_str(), errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) goto conf_error;
 
   if (conn->use_ssl) {
     if (!conn->user.empty()) {
@@ -262,22 +363,18 @@ bool new_producer(connection_t* conn) {
 
   // set the global callback for delivery success/fail
   rd_kafka_conf_set_dr_msg_cb(conn->temp_conf, message_callback);
-
   // set the global opaque pointer to be the connection itself
   rd_kafka_conf_set_opaque(conn->temp_conf, conn);
-
   // redirect kafka logs to RGW
   rd_kafka_conf_set_log_cb(conn->temp_conf, log_callback);
   // define poll callback to allow reconnect
   rd_kafka_conf_set_error_cb(conn->temp_conf, poll_err_callback);
   // create the producer
-  if (conn->producer) {
-    ldout(conn->cct, 5) << "Kafka connect: producer already exists. detroying the existing before creating a new one" << dendl;
-    conn->destroy(STATUS_CONF_REPLCACE);
-  }
   conn->producer = rd_kafka_new(RD_KAFKA_PRODUCER, conn->temp_conf, errstr, sizeof(errstr));
+  conn->temp_conf = nullptr;
   if (!conn->producer) {
     conn->status = rd_kafka_last_error();
+    conn->last_status = ceph_clock_now();
     ldout(conn->cct, 1) << "Kafka connect: failed to create producer: " << errstr << dendl;
     return false;
   }
@@ -296,11 +393,12 @@ bool new_producer(connection_t* conn) {
   }
 
   // conf ownership passed to producer
-  conn->temp_conf = nullptr;
+  update_connection_status(conn);
   return true;
 
 conf_error:
   conn->status = rd_kafka_last_error();
+  conn->last_status = ceph_clock_now();
   ldout(conn->cct, 1) << "Kafka connect: configuration failed: " << errstr << dendl;
   return false;
 }
@@ -329,7 +427,6 @@ public:
 private:
   std::atomic<size_t> connection_count;
   bool stopped;
-  int read_timeout_ms;
   ConnectionList connections;
   MessageQueue messages;
   std::atomic<size_t> queued;
@@ -343,9 +440,9 @@ private:
     const std::unique_ptr<message_wrapper_t> msg_deleter(message);
     const auto conn_it = connections.find(message->conn_name);
     if (conn_it == connections.end()) {
-      ldout(cct, 1) << "Kafka publish: connection was deleted while message was in the queue. error: " << STATUS_CONNECTION_CLOSED << dendl;
+      ldout(cct, 1) << "Kafka publish: connection was deleted while message was in the queue" << dendl;
       if (message->cb) {
-        message->cb(STATUS_CONNECTION_CLOSED);
+        message->cb(status_to_errno(STATUS_CONNECTION_CLOSED));
       }
       return;
     }
@@ -353,12 +450,13 @@ private:
 
     conn->timestamp = ceph_clock_now(); 
 
-    if (!conn->is_ok()) {
+    ceph_assert(conn->producer);
+    if (conn->status != 0) {
       // connection had an issue while message was in the queue
       // TODO add error stats
-      ldout(conn->cct, 1) << "Kafka publish: producer was closed while message was in the queue. error: " << status_to_string(conn->status) << dendl;
+      ldout(conn->cct, 1) << "Kafka publish: producer had error while message was in the queue. error: " << status_to_string(conn->status) << dendl;
       if (message->cb) {
-        message->cb(conn->status);
+        message->cb(status_to_errno(conn->status));
       }
       return;
     }
@@ -370,19 +468,19 @@ private:
       topic = rd_kafka_topic_new(conn->producer, message->topic.c_str(), nullptr);
       if (!topic) {
         const auto err = rd_kafka_last_error();
-        ldout(conn->cct, 1) << "Kafka publish: failed to create topic: " << message->topic << " error: " << status_to_string(err) << dendl;
+        ldout(conn->cct, 1) << "Kafka publish: failed to create topic: " << message->topic << " error: " 
+          << rd_kafka_err2str(err) << "(" << err << ")" << dendl;
         if (message->cb) {
-          message->cb(err);
+          message->cb(-rd_kafka_err2errno(err));
         }
-        conn->destroy(err);
         return;
       }
       // TODO use the topics list as an LRU cache
       conn->topics.push_back(topic);
       ldout(conn->cct, 20) << "Kafka publish: successfully created topic: " << message->topic << dendl;
     } else {
-        topic = *topic_it;
-        ldout(conn->cct, 20) << "Kafka publish: reused existing topic: " << message->topic << dendl;
+      topic = *topic_it;
+      ldout(conn->cct, 20) << "Kafka publish: reused existing topic: " << message->topic << dendl;
     }
 
     const auto tag = (message->cb == nullptr ? nullptr : new uint64_t(conn->delivery_tag++));
@@ -404,13 +502,12 @@ private:
             tag);
     if (rc == -1) {
       const auto err = rd_kafka_last_error();
-      ldout(conn->cct, 10) << "Kafka publish: failed to produce: " << rd_kafka_err2str(err) << dendl;
-      // TODO: dont error on full queue, and don't destroy connection, retry instead
+      ldout(conn->cct, 10) << "Kafka publish: failed to produce: " 
+        << rd_kafka_err2str(err) << "(" << err << ")" << dendl;
       // immediatly invoke callback on error if needed
       if (message->cb) {
-        message->cb(err);
+        message->cb(-rd_kafka_err2errno(err));
       }
-      conn->destroy(err);
       delete tag;
       return;
     }
@@ -425,7 +522,7 @@ private:
       } else {
         // immediately invoke callback with error - this is not a connection error
         ldout(conn->cct, 1) << "Kafka publish (with callback): failed with error: callback queue full" << dendl;
-        message->cb(STATUS_MAX_INFLIGHT);
+        message->cb(-EBUSY);
         // tag will be deleted when the global callback is invoked
       }
     } else {
@@ -438,14 +535,18 @@ private:
   // (1) empty the queue of messages to be published
   // (2) loop over all connections and read acks
   // (3) manages deleted connections
-  // (4) TODO reconnect on connection errors
-  // (5) TODO cleanup timedout callbacks
   void run() noexcept {
+    auto no_activity_count = 10;
+
     while (!stopped) {
 
       // publish all messages in the queue
       auto reply_count = 0U;
-      const auto send_count = messages.consume_all(std::bind(&Manager::publish_internal, this, std::placeholders::_1));
+      std::vector<message_wrapper_t*> local_messages;
+      const auto send_count = messages.consume_all([&local_messages](auto message) {local_messages.push_back(message);});
+      std::for_each(local_messages.begin(), local_messages.end(), 
+          [this](auto message){this->publish_internal(message);}
+      );
       dequeued += send_count;
       ConnectionList::iterator conn_it;
       ConnectionList::const_iterator end_it;
@@ -458,6 +559,7 @@ private:
       }
 
       const auto read_timeout = cct->_conf->rgw_kafka_sleep_timeout;
+
       // loop over all connections to read acks
       for (;conn_it != end_it;) {
         
@@ -465,38 +567,40 @@ private:
 
         // Checking the connection idleness
         if(conn->timestamp.sec() + conn->cct->_conf->rgw_kafka_connection_idle < ceph_clock_now()) {
-          ldout(conn->cct, 20) << "kafka run: deleting a connection due to idle behaviour: " << ceph_clock_now() << dendl;
+          ldout(conn->cct, 20) << "kafka run: deleting a connection due to idle behaviour at: " << ceph_clock_now() << dendl;
           std::lock_guard lock(connections_lock);
           conn->status = STATUS_CONNECTION_IDLE;
+          conn->last_status = ceph_clock_now();
           conn_it = connections.erase(conn_it);
-          --connection_count; \
+          --connection_count;
           continue;
         }
 
-        // try to reconnect the connection if it has an error
-        if (!conn->is_ok()) {
-          ldout(conn->cct, 10) << "Kafka run: connection status is: " << status_to_string(conn->status) << dendl;
+        const auto status_check_time = read_timeout*10;
+        // check connection status
+        if (conn->status != 0 && conn->last_status.sec() + status_check_time < ceph_clock_now()) {
           const auto& broker = conn_it->first;
-          ldout(conn->cct, 20) << "Kafka run: retry connection" << dendl;
-          if (new_producer(conn.get()) == false) {
-            ldout(conn->cct, 10) << "Kafka run: connection (" << broker << ") retry failed" << dendl;
-            // TODO: add error counter for failed retries
-            // TODO: add exponential backoff for retries
-          } else {
-            ldout(conn->cct, 10) << "Kafka run: connection (" << broker << ") retry successful" << dendl;
-          }
+          ldout(conn->cct, 10) << "Kafka run: check status for: " << broker 
+            << ". connection status is: " << status_to_string(conn->status) << dendl;
+          update_connection_status(conn.get());
           ++conn_it;
           continue;
         }
 
+        ceph_assert(conn->producer);
         reply_count += rd_kafka_poll(conn->producer, read_timeout);
 
         // just increment the iterator
         ++conn_it;
       }
-      // sleep if no messages were received or published across all connection
+      // sleep if no messages were published across all connection
       if (send_count == 0 && reply_count == 0) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(read_timeout*3));
+        if (no_activity_count == 0) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(read_timeout*3));
+          no_activity_count = 10;
+        } else {
+          --no_activity_count;
+        }
       }
     }
   }
@@ -575,7 +679,7 @@ public:
     if (it != connections.end()) {
       // connection found - return even if non-ok
       ldout(cct, 20) << "Kafka connect: connection found" << dendl;
-      return it->second.get();
+      return true;
     }
 
     // connection not found, creating a new one
@@ -584,15 +688,15 @@ public:
       ldout(cct, 1) << "Kafka connect: max connections exceeded" << dendl;
       return false;
     }
-    // create_connection must always return a connection object
-    // even if error occurred during creation. 
-    // in such a case the creation will be retried in the main thread
-    ++connection_count;
-    ldout(cct, 10) << "Kafka connect: new connection is created. Total connections: " << connection_count << dendl;
-    auto conn = connections.emplace(broker, std::make_unique<connection_t>(cct, broker, use_ssl, verify_ssl, ca_location, user, password, mechanism)).first->second.get();
-    if (!new_producer(conn)) {
-      ldout(cct, 10) << "Kafka connect: new connection is created. But producer creation failed. will retry" << dendl;
+
+    auto conn = std::make_unique<connection_t>(cct, broker, use_ssl, verify_ssl, ca_location, user, password, mechanism);
+    if (!new_producer(conn.get())) {
+      ldout(cct, 10) << "Kafka connect: producer creation failed in new connection" << dendl;
+      return false;
     }
+    ++connection_count;
+    connections.emplace(broker, std::move(conn));
+    ldout(cct, 10) << "Kafka connect: new connection is created. Total connections: " << connection_count << dendl;
     return true;
   }
 
@@ -601,15 +705,30 @@ public:
     const std::string& topic,
     const std::string& message) {
     if (stopped) {
-      return STATUS_MANAGER_STOPPED;
+      return -ESRCH;
     }
     auto message_wrapper = std::make_unique<message_wrapper_t>(conn_name, topic, message, nullptr);
     if (messages.push(message_wrapper.get())) {
       std::ignore = message_wrapper.release();
       ++queued;
-      return STATUS_OK;
+      return 0;
     }
-    return STATUS_QUEUE_FULL;
+    return -EBUSY;
+  }
+
+  int check_broker(const std::string& conn_name,
+    const std::string& topic) {
+    if (!cct->_conf->rgw_kafka_check_broker) {
+      return 0;
+    }
+    std::lock_guard lock(connections_lock);
+    if (const auto it = connections.find(conn_name); it != connections.end()) {
+      ldout(cct, 10) << "Kafka broker: " << conn_name << " status is: " << it->second->status << dendl;
+      it->second->timestamp = ceph_clock_now(); 
+      return it->second->status;
+    }
+    ldout(cct, 10) << "Kafka broker: " << conn_name << " not found" << dendl;
+    return STATUS_CONNECTION_CLOSED;
   }
   
   int publish_with_confirm(const std::string& conn_name, 
@@ -617,15 +736,15 @@ public:
     const std::string& message,
     reply_callback_t cb) {
     if (stopped) {
-      return STATUS_MANAGER_STOPPED;
+      return -ESRCH;
     }
     auto message_wrapper = std::make_unique<message_wrapper_t>(conn_name, topic, message, cb);
     if (messages.push(message_wrapper.get())) {
       std::ignore = message_wrapper.release();
       ++queued;
-      return STATUS_OK;
+      return 0;
     }
-    return STATUS_QUEUE_FULL;
+    return -EBUSY;
   }
 
   // dtor wait for thread to stop
@@ -695,7 +814,7 @@ bool connect(std::string& broker, const std::string& url, bool use_ssl, bool ver
 int publish(const std::string& conn_name,
     const std::string& topic,
     const std::string& message) {
-  if (!s_manager) return STATUS_MANAGER_STOPPED;
+  if (!s_manager) return -ESRCH;
   return s_manager->publish(conn_name, topic, message);
 }
 
@@ -703,8 +822,14 @@ int publish_with_confirm(const std::string& conn_name,
     const std::string& topic,
     const std::string& message,
     reply_callback_t cb) {
-  if (!s_manager) return STATUS_MANAGER_STOPPED;
+  if (!s_manager) return -ESRCH;
   return s_manager->publish_with_confirm(conn_name, topic, message, cb);
+}
+
+int check_broker(const std::string& conn_name,
+    const std::string& topic) {
+  if (!s_manager) return -ESRCH;
+  return s_manager->check_broker(conn_name, topic);
 }
 
 size_t get_connection_count() {

--- a/src/rgw/rgw_kafka.h
+++ b/src/rgw/rgw_kafka.h
@@ -22,7 +22,12 @@ bool init(CephContext* cct);
 void shutdown();
 
 // connect to a kafka endpoint
-bool connect(std::string& broker, const std::string& url, bool use_ssl, bool verify_ssl, boost::optional<const std::string&> ca_location, boost::optional<const std::string&> mechanism);
+bool connect(std::string& broker, 
+    const std::string& url, 
+    bool use_ssl, 
+    bool verify_ssl, 
+    boost::optional<const std::string&> ca_location, 
+    boost::optional<const std::string&> mechanism);
 
 // publish a message over a connection that was already created
 int publish(const std::string& conn_name,
@@ -37,7 +42,12 @@ int publish_with_confirm(const std::string& conn_name,
     const std::string& message,
     reply_callback_t cb);
 
+// verify that broker is up and that topic exists
+int check_broker(const std::string& conn_name,
+    const std::string& topic);
+
 // convert the integer status returned from the "publish" function to a string
+//
 std::string status_to_string(int s);
 
 // number of connections


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/63915

test: https://gist.github.com/yuvalif/33487bff19883e3409caa8a843a0b353

**TODO**: implement ``amqp::check_broker()``

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
