### PR TITLE
common/perf_counters_key: avoid compiler warnings for requesting the impossible

### DIFF
--- a/src/common/perf_counters_key.h
+++ b/src/common/perf_counters_key.h
@@ -63,7 +63,9 @@ class label_iterator {
   reference operator*() const { return state->label; }
   pointer operator->() const { return &state->label; }
 
-  auto operator<=>(const label_iterator& rhs) const = default;
+  // can't request a default spaceship operator (<=>)
+  // because of the optional member `state`
+  bool operator==(const label_iterator& rhs) const = default;
 
  private:
   struct iterator_state {


### PR DESCRIPTION
The requested default spaceship operator for the type is not possible due to an optional member that doesn't support a three-way comparison

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
