### PR TITLE
reef: DaemonServer.cc: fix config show command for RGW daemons

### DIFF
--- a/qa/suites/rados/singleton/all/mon-config.yaml
+++ b/qa/suites/rados/singleton/all/mon-config.yaml
@@ -6,7 +6,7 @@ roles:
   - osd.0
   - osd.1
   - osd.2
-  - client.0
+  - client.rgw
 openstack:
   - volumes: # attached to each instance
       count: 3
@@ -18,6 +18,7 @@ tasks:
       - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - \(POOL_APP_NOT_ENABLED\)
+- rgw: [client.rgw]
 - workunit:
     clients:
       all:

--- a/qa/workunits/mon/config.sh
+++ b/qa/workunits/mon/config.sh
@@ -111,6 +111,13 @@ do
 done
 ceph config rm osd.0 osd_scrub_cost
 
+#RGW daemons test config set
+ceph config set client.rgw debug_rgw 22
+while ! ceph config show client.rgw | grep debug_rgw | grep 22 | grep mon
+do
+    sleep 1
+done
+
 # show-with-defaults
 ceph config show-with-defaults osd.0 | grep debug_asok
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63946

---

backport of https://github.com/ceph/ceph/pull/48175
parent tracker: https://tracker.ceph.com/issues/63944

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh