### PR TITLE
reef: win32_deps_build.sh: change Boost URL

### DIFF
--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -20,7 +20,7 @@ sslDir="${depsToolsetDir}/openssl"
 sslSrcDir="${depsSrcDir}/openssl"
 
 # For now, we'll keep the version number within the file path when not using git.
-boostUrl="https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz"
+boostUrl="https://archives.boost.io/release/1.79.0/source/boost_1_79_0.tar.gz"
 boostSrcDir="${depsSrcDir}/boost_1_79_0"
 boostDir="${depsToolsetDir}/boost"
 zlibDir="${depsToolsetDir}/zlib"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63955

---

backport of https://github.com/ceph/ceph/pull/55081
parent tracker: https://tracker.ceph.com/issues/63952

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh