### PR TITLE
quincy: win32_deps_build.sh: change Boost URL

### DIFF
--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -24,7 +24,7 @@ curlSrcDir="${depsSrcDir}/curl"
 curlDir="${depsToolsetDir}/curl"
 
 # For now, we'll keep the version number within the file path when not using git.
-boostUrl="https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz"
+boostUrl="https://archives.boost.io/release/1.75.0/source/boost_1_75_0.tar.gz"
 boostSrcDir="${depsSrcDir}/boost_1_75_0"
 boostDir="${depsToolsetDir}/boost"
 zlibDir="${depsToolsetDir}/zlib"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63956

---

backport of https://github.com/ceph/ceph/pull/55081
parent tracker: https://tracker.ceph.com/issues/63952

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh