### PR TITLE
make-dist: don't use --continue option for wget

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -55,7 +55,7 @@ download_from() {
             exit
         fi
         url=$url_base/$fname
-        wget -c --no-verbose -O $fname $url
+        wget --no-verbose -O $fname $url
         if [ $? != 0 -o ! -e $fname ]; then
             echo "Download of $url failed"
         elif [ $(sha256sum $fname | awk '{print $1}') != $sha256 ]; then


### PR DESCRIPTION
the boost jfrog mirror is broken and returns an HTML error page instead of the archive. the file size of this page is 11534 bytes

when download_from() retries the download from download.ceph.com, the -c option tells it to resume the download of the existing file. the resulting boost_1_82_0.tar.bz2 ends up with the correct total file size of 121325129 bytes, but the first 11534 bytes still correspond to the HTML from jfrog. that causes the sha256sum mismatch

remove the -c option so that wget fetches the archive in its entirety
```
~/ceph$ ./make-dist
...
2024-01-08 08:14:08 URL:https://landing.jfrog.com/reactivate-server/boostorg [11534/11534] -> "boost_1_82_0.tar.bz2" [1]            
Error: failed to download boost_1_82_0.tar.bz2: SHA256 mismatch.                                                                    
2024-01-08 08:14:13 URL:https://download.ceph.com/qa/boost_1_82_0.tar.bz2 [121325129/121325129] -> "boost_1_82_0.tar.bz2" [1]       
Error: failed to download boost_1_82_0.tar.bz2: SHA256 mismatch.                                                                    
Error: failed to download boost_1_82_0.tar.bz2.

~/ceph$ ls -l boost_1_82_0.tar.bz2 
-rw-rw-r-- 1 cbodley cbodley 121325129 Jun 23  2023 boost_1_82_0.tar.bz2

~/ceph$ sha256sum boost_1_82_0.tar.bz2 
c924dd5cf654a3e72e0d61138406f150c3c17cfab8bf9c120682d4c0e5338c44  boost_1_82_0.tar.bz2

~/ceph$ head -n 1 boost_1_82_0.tar.bz2 
<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge"><meta name="viewport" content="width=device-width,initial-scale=1"><link rel="icon" href="/favicon.ico"><title>JFrog Landing</title><link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700,800&display=swap" rel="stylesheet"><script>VERSION = "2023.11.248";
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
