### PR TITLE
make-dist: update boost mirrors

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -193,8 +193,8 @@ tar cvf $outfile.version.tar $outfile/src/.git_version $outfile/ceph.spec
 # at the three URLs referenced below (may involve uploading to download.ceph.com)
 boost_version=1.82.0
 download_boost $boost_version a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6 \
-               https://boostorg.jfrog.io/artifactory/main/release/$boost_version/source \
-               https://download.ceph.com/qa
+               https://download.ceph.com/qa \
+               https://boostorg.jfrog.io/artifactory/main/release/$boost_version/source
 download_liburing 0.7 8e2842cfe947f3a443af301bdd6d034455536c38a455c7a700d0c1ad165a7543 \
                   https://github.com/axboe/liburing/archive \
                   https://git.kernel.dk/cgit/liburing/snapshot

--- a/make-dist
+++ b/make-dist
@@ -194,7 +194,7 @@ tar cvf $outfile.version.tar $outfile/src/.git_version $outfile/ceph.spec
 boost_version=1.82.0
 download_boost $boost_version a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6 \
                https://download.ceph.com/qa \
-               https://boostorg.jfrog.io/artifactory/main/release/$boost_version/source
+               https://archives.boost.io/release/$boost_version/source
 download_liburing 0.7 8e2842cfe947f3a443af301bdd6d034455536c38a455c7a700d0c1ad165a7543 \
                   https://github.com/axboe/liburing/archive \
                   https://git.kernel.dk/cgit/liburing/snapshot


### PR DESCRIPTION
* try the 'local' download.ceph.com mirror first
* change the jfrog mirror to the same one used by win32_deps_build.sh after https://github.com/ceph/ceph/commit/594d1e5e83e3d4c318ab1dd79660670a0852f7e6

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
