### PR TITLE
pacific: make-dist: don't use --continue option for wget

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -55,7 +55,7 @@ download_from() {
             exit
         fi
         url=$url_base/$fname
-        wget -c --no-verbose -O $fname $url
+        wget --no-verbose -O $fname $url
         if [ $? != 0 -o ! -e $fname ]; then
             echo "Download of $url failed"
         elif [ $(sha256sum $fname | awk '{print $1}') != $sha256 ]; then


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63963

---

backport of https://github.com/ceph/ceph/pull/55088
parent tracker: https://tracker.ceph.com/issues/63959

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh