### PR TITLE
quincy: qa: remove vstart runner from radosgw_admin task

### DIFF
--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -7,8 +7,9 @@ Rgw admin testing against a running instance
 #   grep '^ *# TESTCASE' | sed 's/^ *# TESTCASE //'
 #
 # to run this standalone:
-#	python qa/tasks/radosgw_admin.py [--user=uid] --host=host --port=port
-#
+#   1. uncomment vstart_runner lines to run locally against a vstart cluster
+#   2. run:
+#        $ python qa/tasks/radosgw_admin.py [--user=uid] --host=host --port=port
 
 import json
 import logging
@@ -27,7 +28,7 @@ import httplib2
 
 #import pdb
 
-import tasks.vstart_runner
+#import tasks.vstart_runner
 from tasks.rgw import RGWEndpoint
 from tasks.util.rgw import rgwadmin as tasks_util_rgw_rgwadmin
 from tasks.util.rgw import get_user_summary, get_user_successful_ops
@@ -1107,7 +1108,7 @@ def task(ctx, config):
     (err, out) = rgwadmin(ctx, client, ['zonegroup', 'get'], check_status=True)
 
 from teuthology.config import config
-from teuthology.orchestra import cluster
+from teuthology.orchestra import cluster, remote
 
 import argparse;
 
@@ -1124,7 +1125,9 @@ def main():
     else:
         port = 80
 
-    client0 = tasks.vstart_runner.LocalRemote()
+    client0 = remote.Remote(host)
+    #client0 = tasks.vstart_runner.LocalRemote()
+
     ctx = config
     ctx.cluster=cluster.Cluster(remotes=[(client0,
         [ 'ceph.client.rgw.%s' % (port),  ]),])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63840

---

backport of https://github.com/ceph/ceph/pull/54618
parent tracker: https://tracker.ceph.com/issues/63583

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh