### PR TITLE
osd/scrub: allow replicas to scrub even if their OSDs have ongoing backfills

### DIFF
--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -819,11 +819,6 @@ ReplicaActive::ReservationAttemptRes ReplicaActive::get_remote_reservation()
 {
   using ReservationAttemptRes = ReplicaActive::ReservationAttemptRes;
   DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
-  if (!scrbr->get_pg_cct()->_conf.get_val<bool>("osd_scrub_during_recovery") &&
-      m_osds->is_recovery_active()) {
-    return ReservationAttemptRes{
-	MOSDScrubReserve::REJECT, "recovery is active", false};
-  }
 
   if (m_osds->get_scrub_services().inc_scrubs_remote(scrbr->get_spgid().pgid)) {
     return ReservationAttemptRes{MOSDScrubReserve::GRANT, "", true};


### PR DESCRIPTION
Limit the check ("not scrubbing if the OSD is performing recovery on some PG") to the primary OSD. Otherwise - a small number of backfills may prevent a large number of PGs from scrubbing.
