### PR TITLE
mgr/dashboard: use pyopenssl as cherrypy ssl_module

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -44,6 +44,7 @@ except ImportError:
     # To be picked up and reported by .can_run()
     cherrypy = None
 
+from cheroot.ssl.pyopenssl import pyOpenSSLAdapter
 from .services.sso import load_sso_db
 
 if cherrypy is not None:
@@ -150,6 +151,7 @@ class CherryPyConfig(object):
             'tools.json_in.on': True,
             'tools.json_in.force': True,
             'tools.plugin_hooks_filter_request.on': True,
+            'response.stream': True,
         }
 
         if use_ssl:
@@ -188,10 +190,13 @@ class CherryPyConfig(object):
                 else:
                     context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_TLSv1_2
 
-            config['server.ssl_module'] = 'builtin'
+            config['server.ssl_module'] = 'pyopenssl'
             config['server.ssl_certificate'] = cert_fname
             config['server.ssl_private_key'] = pkey_fname
-            config['server.ssl_context'] = context
+            config['server.ssl_adapter'] = pyOpenSSLAdapter(
+                certificate=cert_fname,
+                private_key=pkey_fname
+            )
 
         self.update_cherrypy_config(config)
 


### PR DESCRIPTION
This migration will fix the cherrypy issues when the user uses some security scanners which interrupts the cherrypy module when the ssl is enabled.

Steps used to verify:
- Install tlsfuzzer . The instructions are:

		git clone https://github.com/tlsfuzzer/tlsfuzzer.git
		cd tlsfuzzer
		git clone https://github.com/warner/python-ecdsa .python-ecdsa
		ln -s .python-ecdsa/src/ecdsa/ ecdsa
		git clone https://github.com/tlsfuzzer/tlslite-ng .tlslite-ng
		ln -s .tlslite-ng/tlslite/ tlslite

**(This tool works only with tls1.2 so need to enable `UNSAFE_TLS1_2` flag in dashboard setting.)**
- Run the script `test-fuzzed-ciphertext.py`

        PYTHONPATH=. python3 scripts/test-fuzzed-ciphertext.py -p 8443 -h <mgr host>

once you run the script the mgr will hung which you can verify through dashboard. You need to restart mgr to fix it.


Fixes: https://tracker.ceph.com/issues/55837





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
