### PR TITLE
pacific: Tools/rados: Improve Error Messaging for Object Name Resolution

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2955,7 +2955,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     for (const auto& oid : oids) {
       ret = io_ctx.omap_clear(oid);
       if (ret < 0) {
-        cerr << "error clearing omap keys " << pool_name << "/" << prettify(*obj_name) << "/"
+        cerr << "error clearing omap keys " << pool_name << "/" << prettify(oid) << "/"
              << cpp_strerror(ret) << std::endl;
         return 1;
       }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63975

---

backport of https://github.com/ceph/ceph/pull/54518
parent tracker: https://tracker.ceph.com/issues/63541

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh