### PR TITLE
mgr/cephadm: add support for prometheus web admin API

### DIFF
--- a/doc/cephadm/services/monitoring.rst
+++ b/doc/cephadm/services/monitoring.rst
@@ -423,6 +423,29 @@ In the following example spec we set the retention time to 1 year and the size t
   tell cephadm to redeploy the Prometheus daemon(s) to put this change into effect.
   This can be done with a ``ceph orch redeploy prometheus`` command.
 
+Enabling Web Admin API
+~~~~~~~~~~~~~~~~~~~~~~
+
+Cephadm supports enabling the web admin API by specifying the ``enable_admin_api``
+field as ``true`` in the Prometheus service spec.
+
+.. code-block:: yaml
+
+    service_type: prometheus
+    placement:
+      count: 1
+    spec:
+      enable_admin_api: true
+
+Like with retention time and size, this requires running ``ceph orch redeploy prometheus``
+for the setting to be picked up.
+
+.. note::
+
+  There are security concerns with enabling the admin API where anyone with
+  access to the HTTP endpoint may run arbitrary SQL against the Prometheus database.
+  Please see https://prometheus.io/docs/operating/security/#prometheus for more information
+
 Setting up Grafana
 ------------------
 

--- a/src/cephadm/cephadmlib/daemons/monitoring.py
+++ b/src/cephadm/cephadmlib/daemons/monitoring.py
@@ -260,8 +260,11 @@ class Monitoring(ContainerDaemonForm):
                 retention_size = config.get(
                     'retention_size', '0'
                 )  # default to disabled
+                enable_admin_api = config.get('enable_admin_api', False)
                 r += [f'--storage.tsdb.retention.time={retention_time}']
                 r += [f'--storage.tsdb.retention.size={retention_size}']
+                if enable_admin_api:
+                    r += ['--web.enable-admin-api']
                 scheme = 'http'
                 host = get_fqdn()
                 # in case host is not an fqdn then we use the IP to

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -422,6 +422,11 @@ class PrometheusService(CephadmService):
             # default to disabled
             retention_size = '0'
 
+        try:
+            enable_admin_api = spec.enable_admin_api
+        except AttributeError:
+            enable_admin_api = False
+
         # build service discovery end-point
         port = self.mgr.service_discovery_port
         mgr_addr = wrap_ipv6(self.mgr.get_mgr_ip())
@@ -493,6 +498,7 @@ class PrometheusService(CephadmService):
                     'retention_time': retention_time,
                     'retention_size': retention_size,
                     'ip_to_bind_to': ip_to_bind_to,
+                    'enable_admin_api': enable_admin_api,
                     'web_config': '/etc/prometheus/web.yml'
                 }
         else:
@@ -502,7 +508,8 @@ class PrometheusService(CephadmService):
                 },
                 'retention_time': retention_time,
                 'retention_size': retention_size,
-                'ip_to_bind_to': ip_to_bind_to
+                'ip_to_bind_to': ip_to_bind_to,
+                'enable_admin_api': enable_admin_api,
             }
 
         # include alerts, if present in the container

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -791,6 +791,7 @@ class TestMonitoring:
                             'retention_time': '15d',
                             'retention_size': '0',
                             'ip_to_bind_to': '1.2.3.1',
+                            'enable_admin_api': False,
                         },
                     }),
                 )
@@ -968,6 +969,7 @@ class TestMonitoring:
                             'retention_time': '15d',
                             'retention_size': '0',
                             'ip_to_bind_to': '',
+                            'enable_admin_api': False,
                             'web_config': '/etc/prometheus/web.yml',
                         },
                     }),

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1906,6 +1906,7 @@ class PrometheusSpec(MonitoringSpec):
                  retention_time: Optional[str] = None,
                  retention_size: Optional[str] = None,
                  targets: Optional[List[str]] = None,
+                 enable_admin_api: bool = False,
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
@@ -1921,6 +1922,7 @@ class PrometheusSpec(MonitoringSpec):
         self.retention_time = retention_time.strip() if retention_time else None
         self.retention_size = retention_size.strip() if retention_size else None
         self.only_bind_port_on_networks = only_bind_port_on_networks
+        self.enable_admin_api = enable_admin_api
 
     def validate(self) -> None:
         super(PrometheusSpec, self).validate()


### PR DESCRIPTION
Allows the user to enable the web admin API through
the prometheus service spec.

Fixes: https://tracker.ceph.com/issues/63983

Signed-off-by: Adam King <adking@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
