### PR TITLE
quincy: mon: add exception handling to ceph health mute

### DIFF
--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -300,13 +300,19 @@ bool HealthMonitor::prepare_command(MonOpRequestRef op)
     cmd_getval(cmdmap, "sticky", sticky);
     string ttl_str;
     utime_t ttl;
+    std::chrono::seconds secs;
     if (cmd_getval(cmdmap, "ttl", ttl_str)) {
-      auto secs = parse_timespan(ttl_str);
-      if (secs == 0s) {
-	r = -EINVAL;
-	ss << "not a valid duration: " << ttl_str;
-	goto out;
+      try {
+        secs = parse_timespan(ttl_str);
+        if (secs == 0s) {
+          throw std::invalid_argument("timespan = 0");
+        }
+      } catch (const std::invalid_argument& e) {
+        ss << "invalid duration: " << ttl_str << " (" << e.what() << ")";
+        r = -EINVAL;
+        goto out;
       }
+      
       ttl = ceph_clock_now();
       ttl += std::chrono::duration<double>(secs).count();
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63986

---

backport of https://github.com/ceph/ceph/pull/48799
parent tracker: https://tracker.ceph.com/issues/58003

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh