### PR TITLE
common: fix ambiguous error when using gcc 13

### DIFF
--- a/src/common/scrub_types.h
+++ b/src/common/scrub_types.h
@@ -220,7 +220,7 @@ struct fmt::formatter<librados::object_id_t> {
   template <typename FormatContext>
   auto format(const auto &oid, FormatContext& ctx) const
   {
-    return format_to(ctx.out(), "{}/{}/{}", oid.locator, oid.nspace, oid.name);
+    return fmt::format_to(ctx.out(), "{}/{}/{}", oid.locator, oid.nspace, oid.name);
   }
 };
 


### PR DESCRIPTION
<details>
<summary>compiler output</summary>

```
FAILED: src/crimson/osd/CMakeFiles/crimson-osd.dir/scrub/pg_scrubber.cc.o
/usr/bin/ccache /usr/lib64/ccache/clang++ -DBOOST_ASIO_DISABLE_CONCEPTS -DBOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION -DBOOST_ASIO_HAS_IO_URING -DBOOST_ASIO_NO_TS_EXECUTORS -DBOOST_MPL_CFG_NO_PREPROCESSED_HEADERS -DBOOST_MPL_LIMIT_LIST_SIZE=30 -DHAVE_CONFIG_H -DSEASTAR_API_LEVEL=6 -DSEASTAR_DEBUG -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_TYPE_ERASE_MORE -DWITH_SEASTAR=1 -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE -D__CEPH__ -D__STDC_FORMAT_MACROS -D__linux__ -I/home/zhscn/project/ceph/build/src/include -I/home/zhscn/project/ceph/src -I/home/zhscn/project/ceph/src/seastar/include -I/home/zhscn/project/ceph/build/src/seastar/gen/include -I/home/zhscn/project/ceph/src/dmclock/src -I/home/zhscn/project/ceph/src/dmclock/support/src -isystem /home/zhscn/project/ceph/build/boost/include -isystem /home/zhscn/project/ceph/build/include -isystem /home/zhscn/project/ceph/src/xxHash -isystem /home/zhscn/project/ceph/src/fmt/include -isystem /home/zhscn/project/ceph/src/jaegertracing/opentelemetry-cpp/api/include -isystem /home/zhscn/project/ceph/src/jaegertracing/opentelemetry-cpp/exporters/jaeger/include -isystem /home/zhscn/project/ceph/src/jaegertracing/opentelemetry-cpp/ext/include -isystem /home/zhscn/project/ceph/src/jaegertracing/opentelemetry-cpp/sdk/include -g -g -O0 -std=c++20 -fPIE -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -DBOOST_PHOENIX_STL_TUPLE_H_ -Wall -fno-strict-aliasing -fsigned-char -Wtype-limits -Wignored-qualifiers -Wpointer-arith -Werror=format-security -Winit-self -Wno-unknown-pragmas -Wnon-virtual-dtor -Wno-ignored-qualifiers -ftemplate-depth-1024 -Wpessimizing-move -Wredundant-move -Wno-inconsistent-missing-override -Wno-mismatched-tags -Wno-unused-private-field -Wno-address-of-packed-member -Wno-unused-function -Wno-unused-local-typedef -Wno-varargs -Wno-gnu-designator -Wno-missing-braces -Wno-parentheses -Wno-deprecated-register -DCEPH_DEBUG_MUTEX -D_GLIBCXX_ASSERTIONS -fdiagnostics-color=auto -Wno-non-virtual-dtor -U_FORTIFY_SOURCE -DSEASTAR_SSTRING -Wno-error=unused-result "-Wno-error=#warnings" -fstack-clash-protection -ftemplate-backtrace-limit=0 -MD -MT src/crimson/osd/CMakeFiles/crimson-osd.dir/scrub/pg_scrubber.cc.o -MF src/crimson/osd/CMakeFiles/crimson-osd.dir/scrub/pg_scrubber.cc.o.d -o src/crimson/osd/CMakeFiles/crimson-osd.dir/scrub/pg_scrubber.cc.o -c /home/zhscn/project/ceph/src/crimson/osd/scrub/pg_scrubber.cc
In file included from /home/zhscn/project/ceph/src/crimson/osd/scrub/pg_scrubber.cc:7:
In file included from /home/zhscn/project/ceph/src/crimson/osd/pg.h:22:
In file included from /home/zhscn/project/ceph/src/osd/SnapMapper.h:34:
In file included from /home/zhscn/project/ceph/src/osd/SnapMapReaderI.h:11:
/home/zhscn/project/ceph/src/common/scrub_types.h:223:12: error: call to 'format_to' is ambiguous
  223 |     return format_to(ctx.out(), "{}/{}/{}", oid.locator, oid.nspace, oid.name);
      |            ^~~~~~~~~
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:813:64: note: in instantiation of function template specialization 'fmt::formatter<librados::object_id_t>::format<fmt::basic_format_context<fmt::appender, char>, librados::object_id_t>' requested here
  813 |     -> decltype(typename Context::template formatter_type<T>().format(
      |                                                                ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:824:10: note: while substituting deduced template arguments into function template 'has_const_formatter_impl' [with Context = fmt::basic_format_context<fmt::appender, char>, T = librados::object_id_t]
  824 |   return has_const_formatter_impl<Context>(static_cast<T*>(nullptr));
      |          ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1485:23: note: in instantiation of function template specialization 'fmt::detail::has_const_formatter<librados::object_id_t, fmt::basic_format_context<fmt::appender, char>>' requested here
 1485 |       : bool_constant<has_const_formatter<U, Context>() ||
      |                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1496:39: note: in instantiation of template class 'fmt::detail::arg_mapper<fmt::basic_format_context<fmt::appender, char>>::formattable<const librados::object_id_t &>' requested here
 1496 |   template <typename T, FMT_ENABLE_IF(formattable<T>::value)>
      |                                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1497:33: note: while substituting prior template arguments into non-type template parameter [with T = const librados::object_id_t &]
 1497 |   FMT_CONSTEXPR FMT_INLINE auto do_map(T&& val) -> T& {
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~
 1498 |     return val;
      |     ~~~~~~~~~~~
 1499 |   }
      |   ~
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1514:25: note: while substituting deduced template arguments into function template 'do_map' [with T = const librados::object_id_t &, $1 = (no value)]
 1514 |       -> decltype(this->do_map(std::forward<T>(val))) {
      |                         ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1530:50: note: while substituting deduced template arguments into function template 'map' [with T = const librados::object_id_t &, U = (no value), $2 = (no value)]
 1530 |     type_constant<decltype(arg_mapper<Context>().map(std::declval<const T&>())),
      |                                                  ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:2740:7: note: in instantiation of template type alias 'mapped_type_constant' requested here
 2740 |       mapped_type_constant<T, context>::value != type::custom_type,
      |       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:2954:23: note: in instantiation of function template specialization 'fmt::detail::parse_format_specs<librados::object_id_t, fmt::detail::compile_parse_context<char>>' requested here
 2954 |         parse_funcs_{&parse_format_specs<Args, parse_context_type>...},
      |                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:3159:47: note: in instantiation of member function 'fmt::detail::format_string_checker<char, fmt::detail::error_handler, librados::object_id_t, std::vector<unsigned long>, std::vector<unsigned long>>::format_string_checker' requested here
 3159 |       detail::parse_format_string<true>(str_, checker(s, {}));
      |                                               ^
/home/zhscn/project/ceph/src/common/scrub_types.h:400:7: note: in instantiation of function template specialization 'fmt::basic_format_string<char, const librados::object_id_t &, const std::vector<unsigned long> &, const std::vector<unsigned long> &>::basic_format_string<char[38], 0>' requested here
  400 |       ", object: {}, clones: {}, missing: {}",
      |       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:813:64: note: in instantiation of function template specialization 'fmt::formatter<librados::inconsistent_snapset_t>::format<fmt::basic_format_context<fmt::appender, char>, inconsistent_snapset_wrapper>' requested here
  813 |     -> decltype(typename Context::template formatter_type<T>().format(
      |                                                                ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:824:10: note: while substituting deduced template arguments into function template 'has_const_formatter_impl' [with Context = fmt::basic_format_context<fmt::appender, char>, T = inconsistent_snapset_wrapper]
  824 |   return has_const_formatter_impl<Context>(static_cast<T*>(nullptr));
      |          ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1485:23: note: in instantiation of function template specialization 'fmt::detail::has_const_formatter<inconsistent_snapset_wrapper, fmt::basic_format_context<fmt::appender, char>>' requested here
 1485 |       : bool_constant<has_const_formatter<U, Context>() ||
      |                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1496:39: note: in instantiation of template class 'fmt::detail::arg_mapper<fmt::basic_format_context<fmt::appender, char>>::formattable<inconsistent_snapset_wrapper>' requested here
 1496 |   template <typename T, FMT_ENABLE_IF(formattable<T>::value)>
      |                                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1497:33: note: while substituting prior template arguments into non-type template parameter [with T = inconsistent_snapset_wrapper]
 1497 |   FMT_CONSTEXPR FMT_INLINE auto do_map(T&& val) -> T& {
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~
 1498 |     return val;
      |     ~~~~~~~~~~~
 1499 |   }
      |   ~
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1514:25: note: while substituting deduced template arguments into function template 'do_map' [with T = inconsistent_snapset_wrapper, $1 = (no value)]
 1514 |       -> decltype(this->do_map(std::forward<T>(val))) {
      |                         ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1853:74: note: while substituting deduced template arguments into function template 'map' [with T = inconsistent_snapset_wrapper, U = (no value), $2 = (no value)]
 1853 |                      decltype(detail::arg_mapper<buffer_context<Char>>().map(
      |                                                                          ^
/home/zhscn/project/ceph/src/fmt/include/fmt/ranges.h:417:11: note: in instantiation of template type alias 'is_formattable' requested here
  417 |           is_formattable<uncvref_type<maybe_const_range<R>>, Char>,
      |           ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:320:47: note: in instantiation of template class 'fmt::detail::is_formattable_delayed<std::vector<inconsistent_snapset_wrapper>, char>' requested here
  320 | template <typename P> struct conjunction<P> : P {};
      |                                               ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:323:7: note: in instantiation of template class 'fmt::conjunction<fmt::detail::is_formattable_delayed<std::vector<inconsistent_snapset_wrapper>, char>>' requested here
  323 |     : conditional_t<bool(P1::value), conjunction<Pn...>, P1> {};
      |       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/ranges.h:584:17: note: in instantiation of template class 'fmt::conjunction<std::integral_constant<bool, true>, fmt::detail::is_formattable_delayed<std::vector<inconsistent_snapset_wrapper>, char>>' requested here
  584 |     enable_if_t<conjunction<bool_constant<range_format_kind<R, Char>::value !=
      |                 ^
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/type_traits:1040:25: note: during template argument deduction for class template partial specialization 'formatter<R, Char, enable_if_t<conjunction<bool_constant<range_format_kind<R, Char>::value != range_format::disabled>, detail::is_formattable_delayed<R, Char>>::value>>' [with R = std::vector<inconsistent_snapset_wrapper>, Char = char]
 1040 |       = __bool_constant<__is_constructible(_Tp, _Args...)>;
      |                         ^
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/type_traits:1040:25: note: in instantiation of template class 'fmt::formatter<std::vector<inconsistent_snapset_wrapper>>' requested here
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/type_traits:1046:16: note: in instantiation of template type alias '__is_constructible_impl' requested here
 1046 |       : public __is_constructible_impl<_Tp, _Args...>
      |                ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1420:42: note: in instantiation of template class 'std::is_constructible<fmt::formatter<std::vector<inconsistent_snapset_wrapper>>>' requested here
 1420 |                 !is_string<T>::value && !has_formatter<T, Context>::value &&
      |                                          ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1422:33: note: while substituting prior template arguments into non-type template parameter [with T = std::vector<inconsistent_snapset_wrapper>]
 1422 |   FMT_CONSTEXPR FMT_INLINE auto map(const T& val)
      |                                 ^~~~~~~~~~~~~~~~~
 1423 |       -> basic_string_view<char_type> {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1424 |     return basic_string_view<char_type>(val);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1425 |   }
      |   ~
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1530:50: note: while substituting deduced template arguments into function template 'map' [with T = std::vector<inconsistent_snapset_wrapper>, $1 = (no value)]
 1530 |     type_constant<decltype(arg_mapper<Context>().map(std::declval<const T&>())),
      |                                                  ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:2740:7: note: in instantiation of template type alias 'mapped_type_constant' requested here
 2740 |       mapped_type_constant<T, context>::value != type::custom_type,
      |       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:2954:23: note: in instantiation of function template specialization 'fmt::detail::parse_format_specs<std::vector<inconsistent_snapset_wrapper>, fmt::detail::compile_parse_context<char>>' requested here
 2954 |         parse_funcs_{&parse_format_specs<Args, parse_context_type>...},
      |                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:3159:47: note: in instantiation of member function 'fmt::detail::format_string_checker<char, fmt::detail::error_handler, long, long, std::vector<inconsistent_snapset_wrapper>, std::vector<inconsistent_obj_wrapper>>::format_string_checker' requested here
 3159 |       detail::parse_format_string<true>(str_, checker(s, {}));
      |                                               ^
/home/zhscn/project/ceph/src/crimson/osd/scrub/scrub_validator.h:169:7: note: in instantiation of function template specialization 'fmt::basic_format_string<char, const long &, const long &, const std::vector<inconsistent_snapset_wrapper> &, const std::vector<inconsistent_obj_wrapper> &>::basic_format_string<char[107], 0>' requested here
  169 |       "chunk_result_t("
      |       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:813:64: note: in instantiation of function template specialization 'fmt::formatter<crimson::osd::scrub::chunk_result_t>::format<fmt::basic_format_context<fmt::appender, char>>' requested here
  813 |     -> decltype(typename Context::template formatter_type<T>().format(
      |                                                                ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:824:10: note: while substituting deduced template arguments into function template 'has_const_formatter_impl' [with Context = fmt::basic_format_context<fmt::appender, char>, T = crimson::osd::scrub::chunk_result_t]
  824 |   return has_const_formatter_impl<Context>(static_cast<T*>(nullptr));
      |          ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1485:23: note: in instantiation of function template specialization 'fmt::detail::has_const_formatter<crimson::osd::scrub::chunk_result_t, fmt::basic_format_context<fmt::appender, char>>' requested here
 1485 |       : bool_constant<has_const_formatter<U, Context>() ||
      |                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1496:39: note: in instantiation of template class 'fmt::detail::arg_mapper<fmt::basic_format_context<fmt::appender, char>>::formattable<const crimson::osd::scrub::chunk_result_t &>' requested here
 1496 |   template <typename T, FMT_ENABLE_IF(formattable<T>::value)>
      |                                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1497:33: note: while substituting prior template arguments into non-type template parameter [with T = const crimson::osd::scrub::chunk_result_t &]
 1497 |   FMT_CONSTEXPR FMT_INLINE auto do_map(T&& val) -> T& {
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~
 1498 |     return val;
      |     ~~~~~~~~~~~
 1499 |   }
      |   ~
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1514:25: note: while substituting deduced template arguments into function template 'do_map' [with T = const crimson::osd::scrub::chunk_result_t &, $1 = (no value)]
 1514 |       -> decltype(this->do_map(std::forward<T>(val))) {
      |                         ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1530:50: note: while substituting deduced template arguments into function template 'map' [with T = const crimson::osd::scrub::chunk_result_t &, U = (no value), $2 = (no value)]
 1530 |     type_constant<decltype(arg_mapper<Context>().map(std::declval<const T&>())),
      |                                                  ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:2740:7: note: in instantiation of template type alias 'mapped_type_constant' requested here
 2740 |       mapped_type_constant<T, context>::value != type::custom_type,
      |       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:2954:23: note: in instantiation of function template specialization 'fmt::detail::parse_format_specs<crimson::osd::scrub::chunk_result_t, fmt::detail::compile_parse_context<char>>' requested here
 2954 |         parse_funcs_{&parse_format_specs<Args, parse_context_type>...},
      |                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:3159:47: note: in instantiation of member function 'fmt::detail::format_string_checker<char, fmt::detail::error_handler, crimson::osd::scrub::ScrubContext::request_range_result_t, crimson::osd::scrub::chunk_result_t>::format_string_checker' requested here
 3159 |       detail::parse_format_string<true>(str_, checker(s, {}));
      |                                               ^
/home/zhscn/project/ceph/src/crimson/osd/scrub/pg_scrubber.cc:266:7: note: in instantiation of function template specialization 'fmt::basic_format_string<char, const crimson::osd::scrub::ScrubContext::request_range_result_t &, crimson::osd::scrub::chunk_result_t &>::basic_format_string<char[42], 0>' requested here
  266 |       "Scrub errors found. range: {}, result: {}",
      |       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:3233:17: note: candidate function [with OutputIt = fmt::appender, T = <const std::basic_string<char> &, const std::basic_string<char> &, const std::basic_string<char> &>, $2 = 0]
 3233 | FMT_INLINE auto format_to(OutputIt out, format_string<T...> fmt, T&&... args)
      |                 ^
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/format:3828:5: note: candidate function [with _Out = fmt::appender, _Args = <const std::basic_string<char> &, const std::basic_string<char> &, const std::basic_string<char> &>]
 3828 |     format_to(_Out __out, format_string<_Args...> __fmt, _Args&&... __args)
      |     ^
In file included from /home/zhscn/project/ceph/src/crimson/osd/scrub/pg_scrubber.cc:7:
In file included from /home/zhscn/project/ceph/src/crimson/osd/pg.h:22:
In file included from /home/zhscn/project/ceph/src/osd/SnapMapper.h:34:
In file included from /home/zhscn/project/ceph/src/osd/SnapMapReaderI.h:11:
/home/zhscn/project/ceph/src/common/scrub_types.h:223:12: error: call to 'format_to' is ambiguous
  223 |     return format_to(ctx.out(), "{}/{}/{}", oid.locator, oid.nspace, oid.name);
      |            ^~~~~~~~~
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:813:64: note: in instantiation of function template specialization 'fmt::formatter<librados::object_id_t>::format<fmt::basic_format_context<char *, char>, librados::object_id_t>' requested here
  813 |     -> decltype(typename Context::template formatter_type<T>().format(
      |                                                                ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:824:10: note: while substituting deduced template arguments into function template 'has_const_formatter_impl' [with Context = fmt::basic_format_context<char *, char>, T = librados::object_id_t]
  824 |   return has_const_formatter_impl<Context>(static_cast<T*>(nullptr));
      |          ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1485:23: note: in instantiation of function template specialization 'fmt::detail::has_const_formatter<librados::object_id_t, fmt::basic_format_context<char *, char>>' requested here
 1485 |       : bool_constant<has_const_formatter<U, Context>() ||
      |                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1496:39: note: in instantiation of template class 'fmt::detail::arg_mapper<fmt::basic_format_context<char *, char>>::formattable<const librados::object_id_t &>' requested here
 1496 |   template <typename T, FMT_ENABLE_IF(formattable<T>::value)>
      |                                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1497:33: note: while substituting prior template arguments into non-type template parameter [with T = const librados::object_id_t &]
 1497 |   FMT_CONSTEXPR FMT_INLINE auto do_map(T&& val) -> T& {
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~
 1498 |     return val;
      |     ~~~~~~~~~~~
 1499 |   }
      |   ~
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1514:25: note: while substituting deduced template arguments into function template 'do_map' [with T = const librados::object_id_t &, $1 = (no value)]
 1514 |       -> decltype(this->do_map(std::forward<T>(val))) {
      |                         ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1530:50: note: while substituting deduced template arguments into function template 'map' [with T = const librados::object_id_t &, U = (no value), $2 = (no value)]
 1530 |     type_constant<decltype(arg_mapper<Context>().map(std::declval<const T&>())),
      |                                                  ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:2956:13: note: in instantiation of template type alias 'mapped_type_constant' requested here
 2956 |             mapped_type_constant<Args,
      |             ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:3159:47: note: in instantiation of member function 'fmt::detail::format_string_checker<char, fmt::detail::error_handler, librados::object_id_t, std::vector<unsigned long>, std::vector<unsigned long>>::format_string_checker' requested here
 3159 |       detail::parse_format_string<true>(str_, checker(s, {}));
      |                                               ^
/home/zhscn/project/ceph/src/common/scrub_types.h:400:7: note: in instantiation of function template specialization 'fmt::basic_format_string<char, const librados::object_id_t &, const std::vector<unsigned long> &, const std::vector<unsigned long> &>::basic_format_string<char[38], 0>' requested here
  400 |       ", object: {}, clones: {}, missing: {}",
      |       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:813:64: note: in instantiation of function template specialization 'fmt::formatter<librados::inconsistent_snapset_t>::format<fmt::basic_format_context<fmt::appender, char>, inconsistent_snapset_wrapper>' requested here
  813 |     -> decltype(typename Context::template formatter_type<T>().format(
      |                                                                ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:824:10: note: while substituting deduced template arguments into function template 'has_const_formatter_impl' [with Context = fmt::basic_format_context<fmt::appender, char>, T = inconsistent_snapset_wrapper]
  824 |   return has_const_formatter_impl<Context>(static_cast<T*>(nullptr));
      |          ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1485:23: note: in instantiation of function template specialization 'fmt::detail::has_const_formatter<inconsistent_snapset_wrapper, fmt::basic_format_context<fmt::appender, char>>' requested here
 1485 |       : bool_constant<has_const_formatter<U, Context>() ||
      |                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1496:39: note: in instantiation of template class 'fmt::detail::arg_mapper<fmt::basic_format_context<fmt::appender, char>>::formattable<inconsistent_snapset_wrapper>' requested here
 1496 |   template <typename T, FMT_ENABLE_IF(formattable<T>::value)>
      |                                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1497:33: note: while substituting prior template arguments into non-type template parameter [with T = inconsistent_snapset_wrapper]
 1497 |   FMT_CONSTEXPR FMT_INLINE auto do_map(T&& val) -> T& {
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~
 1498 |     return val;
      |     ~~~~~~~~~~~
 1499 |   }
      |   ~
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1514:25: note: while substituting deduced template arguments into function template 'do_map' [with T = inconsistent_snapset_wrapper, $1 = (no value)]
 1514 |       -> decltype(this->do_map(std::forward<T>(val))) {
      |                         ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1853:74: note: while substituting deduced template arguments into function template 'map' [with T = inconsistent_snapset_wrapper, U = (no value), $2 = (no value)]
 1853 |                      decltype(detail::arg_mapper<buffer_context<Char>>().map(
      |                                                                          ^
/home/zhscn/project/ceph/src/fmt/include/fmt/ranges.h:417:11: note: in instantiation of template type alias 'is_formattable' requested here
  417 |           is_formattable<uncvref_type<maybe_const_range<R>>, Char>,
      |           ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:320:47: note: in instantiation of template class 'fmt::detail::is_formattable_delayed<std::vector<inconsistent_snapset_wrapper>, char>' requested here
  320 | template <typename P> struct conjunction<P> : P {};
      |                                               ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:323:7: note: in instantiation of template class 'fmt::conjunction<fmt::detail::is_formattable_delayed<std::vector<inconsistent_snapset_wrapper>, char>>' requested here
  323 |     : conditional_t<bool(P1::value), conjunction<Pn...>, P1> {};
      |       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/ranges.h:584:17: note: in instantiation of template class 'fmt::conjunction<std::integral_constant<bool, true>, fmt::detail::is_formattable_delayed<std::vector<inconsistent_snapset_wrapper>, char>>' requested here
  584 |     enable_if_t<conjunction<bool_constant<range_format_kind<R, Char>::value !=
      |                 ^
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/type_traits:1040:25: note: during template argument deduction for class template partial specialization 'formatter<R, Char, enable_if_t<conjunction<bool_constant<range_format_kind<R, Char>::value != range_format::disabled>, detail::is_formattable_delayed<R, Char>>::value>>' [with R = std::vector<inconsistent_snapset_wrapper>, Char = char]
 1040 |       = __bool_constant<__is_constructible(_Tp, _Args...)>;
      |                         ^
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/type_traits:1040:25: note: in instantiation of template class 'fmt::formatter<std::vector<inconsistent_snapset_wrapper>>' requested here
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/type_traits:1046:16: note: in instantiation of template type alias '__is_constructible_impl' requested here
 1046 |       : public __is_constructible_impl<_Tp, _Args...>
      |                ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1420:42: note: in instantiation of template class 'std::is_constructible<fmt::formatter<std::vector<inconsistent_snapset_wrapper>>>' requested here
 1420 |                 !is_string<T>::value && !has_formatter<T, Context>::value &&
      |                                          ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1422:33: note: while substituting prior template arguments into non-type template parameter [with T = std::vector<inconsistent_snapset_wrapper>]
 1422 |   FMT_CONSTEXPR FMT_INLINE auto map(const T& val)
      |                                 ^~~~~~~~~~~~~~~~~
 1423 |       -> basic_string_view<char_type> {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1424 |     return basic_string_view<char_type>(val);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1425 |   }
      |   ~
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1530:50: note: while substituting deduced template arguments into function template 'map' [with T = std::vector<inconsistent_snapset_wrapper>, $1 = (no value)]
 1530 |     type_constant<decltype(arg_mapper<Context>().map(std::declval<const T&>())),
      |                                                  ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:2740:7: note: in instantiation of template type alias 'mapped_type_constant' requested here
 2740 |       mapped_type_constant<T, context>::value != type::custom_type,
      |       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:2954:23: note: in instantiation of function template specialization 'fmt::detail::parse_format_specs<std::vector<inconsistent_snapset_wrapper>, fmt::detail::compile_parse_context<char>>' requested here
 2954 |         parse_funcs_{&parse_format_specs<Args, parse_context_type>...},
      |                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:3159:47: note: in instantiation of member function 'fmt::detail::format_string_checker<char, fmt::detail::error_handler, long, long, std::vector<inconsistent_snapset_wrapper>, std::vector<inconsistent_obj_wrapper>>::format_string_checker' requested here
 3159 |       detail::parse_format_string<true>(str_, checker(s, {}));
      |                                               ^
/home/zhscn/project/ceph/src/crimson/osd/scrub/scrub_validator.h:169:7: note: in instantiation of function template specialization 'fmt::basic_format_string<char, const long &, const long &, const std::vector<inconsistent_snapset_wrapper> &, const std::vector<inconsistent_obj_wrapper> &>::basic_format_string<char[107], 0>' requested here
  169 |       "chunk_result_t("
      |       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:813:64: note: in instantiation of function template specialization 'fmt::formatter<crimson::osd::scrub::chunk_result_t>::format<fmt::basic_format_context<fmt::appender, char>>' requested here
  813 |     -> decltype(typename Context::template formatter_type<T>().format(
      |                                                                ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:824:10: note: while substituting deduced template arguments into function template 'has_const_formatter_impl' [with Context = fmt::basic_format_context<fmt::appender, char>, T = crimson::osd::scrub::chunk_result_t]
  824 |   return has_const_formatter_impl<Context>(static_cast<T*>(nullptr));
      |          ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1485:23: note: in instantiation of function template specialization 'fmt::detail::has_const_formatter<crimson::osd::scrub::chunk_result_t, fmt::basic_format_context<fmt::appender, char>>' requested here
 1485 |       : bool_constant<has_const_formatter<U, Context>() ||
      |                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1496:39: note: in instantiation of template class 'fmt::detail::arg_mapper<fmt::basic_format_context<fmt::appender, char>>::formattable<const crimson::osd::scrub::chunk_result_t &>' requested here
 1496 |   template <typename T, FMT_ENABLE_IF(formattable<T>::value)>
      |                                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1497:33: note: while substituting prior template arguments into non-type template parameter [with T = const crimson::osd::scrub::chunk_result_t &]
 1497 |   FMT_CONSTEXPR FMT_INLINE auto do_map(T&& val) -> T& {
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~
 1498 |     return val;
      |     ~~~~~~~~~~~
 1499 |   }
      |   ~
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1514:25: note: while substituting deduced template arguments into function template 'do_map' [with T = const crimson::osd::scrub::chunk_result_t &, $1 = (no value)]
 1514 |       -> decltype(this->do_map(std::forward<T>(val))) {
      |                         ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1530:50: note: while substituting deduced template arguments into function template 'map' [with T = const crimson::osd::scrub::chunk_result_t &, U = (no value), $2 = (no value)]
 1530 |     type_constant<decltype(arg_mapper<Context>().map(std::declval<const T&>())),
      |                                                  ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:2740:7: note: in instantiation of template type alias 'mapped_type_constant' requested here
 2740 |       mapped_type_constant<T, context>::value != type::custom_type,
      |       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:2954:23: note: in instantiation of function template specialization 'fmt::detail::parse_format_specs<crimson::osd::scrub::chunk_result_t, fmt::detail::compile_parse_context<char>>' requested here
 2954 |         parse_funcs_{&parse_format_specs<Args, parse_context_type>...},
      |                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:3159:47: note: in instantiation of member function 'fmt::detail::format_string_checker<char, fmt::detail::error_handler, crimson::osd::scrub::ScrubContext::request_range_result_t, crimson::osd::scrub::chunk_result_t>::format_string_checker' requested here
 3159 |       detail::parse_format_string<true>(str_, checker(s, {}));
      |                                               ^
/home/zhscn/project/ceph/src/crimson/osd/scrub/pg_scrubber.cc:266:7: note: in instantiation of function template specialization 'fmt::basic_format_string<char, const crimson::osd::scrub::ScrubContext::request_range_result_t &, crimson::osd::scrub::chunk_result_t &>::basic_format_string<char[42], 0>' requested here
  266 |       "Scrub errors found. range: {}, result: {}",
      |       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:3233:17: note: candidate function [with OutputIt = char *, T = <const std::basic_string<char> &, const std::basic_string<char> &, const std::basic_string<char> &>, $2 = 0]
 3233 | FMT_INLINE auto format_to(OutputIt out, format_string<T...> fmt, T&&... args)
      |                 ^
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/format:3828:5: note: candidate function [with _Out = char *, _Args = <const std::basic_string<char> &, const std::basic_string<char> &, const std::basic_string<char> &>]
 3828 |     format_to(_Out __out, format_string<_Args...> __fmt, _Args&&... __args)
      |     ^
In file included from /home/zhscn/project/ceph/src/crimson/osd/scrub/pg_scrubber.cc:4:
In file included from /home/zhscn/project/ceph/src/fmt/include/fmt/ranges.h:19:
In file included from /home/zhscn/project/ceph/src/fmt/include/fmt/format.h:48:
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1743:17: error: static assertion failed due to requirement 'formattable_const': Cannot format a const argument.
 1743 |   static_assert(formattable_const, "Cannot format a const argument.");
      |                 ^~~~~~~~~~~~~~~~~
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1777:10: note: in instantiation of function template specialization 'fmt::detail::make_value<fmt::basic_format_context<fmt::appender, char>, const librados::object_id_t &>' requested here
 1777 |   return make_value<Context>(val);
      |          ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1899:23: note: in instantiation of function template specialization 'fmt::detail::make_arg<true, fmt::basic_format_context<fmt::appender, char>, fmt::detail::type::custom_type, const librados::object_id_t &, 0>' requested here
 1899 |         data_{detail::make_arg<
      |                       ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:1918:10: note: in instantiation of function template specialization 'fmt::format_arg_store<fmt::basic_format_context<fmt::appender, char>, librados::object_id_t, std::vector<unsigned long>, std::vector<unsigned long>>::format_arg_store<const librados::object_id_t &, const std::vector<unsigned long> &, const std::vector<unsigned long> &>' requested here
 1918 |   return {FMT_FORWARD(args)...};
      |          ^
/home/zhscn/project/ceph/src/fmt/include/fmt/core.h:3235:36: note: in instantiation of function template specialization 'fmt::make_format_args<fmt::basic_format_context<fmt::appender, char>, const librados::object_id_t &, const std::vector<unsigned long> &, const std::vector<unsigned long> &>' requested here
 3235 |   return vformat_to(out, fmt, fmt::make_format_args(args...));
      |                                    ^
/home/zhscn/project/ceph/src/common/scrub_types.h:398:17: note: in instantiation of function template specialization 'fmt::format_to<fmt::appender, const librados::object_id_t &, const std::vector<unsigned long> &, const std::vector<unsigned long> &, 0>' requested here
  398 |     return fmt::format_to(
      |                 ^
3 errors generated.
```
</details>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
