### PR TITLE
reef: mgr/dashboard: fix e2e failure related to landing page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/04-osds.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/04-osds.e2e-spec.ts
@@ -1,9 +1,19 @@
 import { OSDsPageHelper } from '../cluster/osds.po';
 import { DashboardPageHelper } from '../ui/dashboard.po';
+import { ManagerModulesPageHelper } from '../cluster/mgr-modules.po';
 
 describe('OSDs page', () => {
   const osds = new OSDsPageHelper();
   const dashboard = new DashboardPageHelper();
+  const mgrmodules = new ManagerModulesPageHelper();
+
+  before(() => {
+    cy.login();
+    mgrmodules.navigateTo();
+    mgrmodules.navigateEdit('dashboard');
+    cy.get('#FEATURE_TOGGLE_DASHBOARD').uncheck();
+    cy.contains('button', 'Update').click();
+  });
 
   beforeEach(() => {
     cy.login();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59470

---

backport of https://github.com/ceph/ceph/pull/54965
parent tracker: https://tracker.ceph.com/issues/59142

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh