### PR TITLE
osd/scrub: partial implementation of scrub reserver

### DIFF
--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -473,6 +473,11 @@ bool OsdScrub::inc_scrubs_remote(pg_t pgid)
   return m_resource_bookkeeper.inc_scrubs_remote(pgid);
 }
 
+void OsdScrub::enqueue_remote_reservation(pg_t pgid)
+{
+  m_resource_bookkeeper.enqueue_remote_reservation(pgid);
+}
+
 void OsdScrub::dec_scrubs_remote(pg_t pgid)
 {
   m_resource_bookkeeper.dec_scrubs_remote(pgid);

--- a/src/osd/scrubber/osd_scrub.h
+++ b/src/osd/scrubber/osd_scrub.h
@@ -70,6 +70,7 @@ class OsdScrub {
       bool is_high_priority);
   void dec_scrubs_local();
   bool inc_scrubs_remote(pg_t pgid);
+  void enqueue_remote_reservation(pg_t pgid);
   void dec_scrubs_remote(pg_t pgid);
 
   // counting the number of PGs stuck while scrubbing, waiting for objects


### PR DESCRIPTION
This is a partial implementation of a change in the way scrub resource reservation
requests (sent by a primary to its replicas) are handled. In the complete implementation,
scrub reservation requests are no longer granted or refused immediately, but rather are queued in an
asynch reserver (similar to the way backfill reservations are handled).

In this partial implementation - all requests are treated as 'legacy', i.e. - the reserver
is never actually used. But the scrubber state-machine is already modified to handle
asynch requests.