### PR TITLE
mgr/snap_schedule: handle volume delete

### DIFF
--- a/doc/cephfs/snap-schedule.rst
+++ b/doc/cephfs/snap-schedule.rst
@@ -197,6 +197,15 @@ this happens, the next snapshot will be schedule as if the previous one was not
 delayed, i.e. one or more delayed snapshots will not cause drift in the overall
 schedule.
 
+If a volume is deleted while snapshot schedules are active on the volume, then
+there might be cases when Python Tracebacks are seen in the log file or on the
+command-line when commands are executed on such volumes. Although measures have
+been taken to take note of the fs_map changes and delete active timers and
+close database connections to avoid Python Tracebacks, it is not possible to
+completely mute the tracebacks due to the inherent nature of problem. In the
+event that such tracebacks are seen, the only solution to get the system to a
+stable state is the disable and re-enable the snap_schedule Manager Module.
+
 In order to somewhat limit the overall number of snapshots in a file system, the
 module will only keep a maximum of 50 snapshots per directory. If the retention
 policy results in more then 50 retained snapshots, the retention list will be

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -1211,6 +1211,11 @@ class RemoveFilesystemHandler : public FileSystemCommandHandler
 
     fsmap.erase_filesystem(fsp->get_fscid());
 
+    ss << "If there are active snapshot schedules associated with this "
+       << "file-system, you might see EIO errors in the mgr logs or at the "
+       << "snap-schedule command-line due to the missing file-system. "
+       << "However, these errors are transient and will get auto-resolved.";
+
     return 0;
   }
 };

--- a/src/pybind/mgr/volumes/fs/operations/volume.py
+++ b/src/pybind/mgr/volumes/fs/operations/volume.py
@@ -133,7 +133,11 @@ def delete_volume(mgr, volname, metadata_pool, data_pools):
         r, outb, outs = remove_pool(mgr, data_pool)
         if r != 0:
             return r, outb, outs
-    result_str = "metadata pool: {0} data pool: {1} removed".format(metadata_pool, str(data_pools))
+    result_str = f"metadata pool: {metadata_pool} data pool: {str(data_pools)} removed.\n"
+    result_str += "If there are active snapshot schedules associated with this "
+    result_str += "volume, you might see EIO errors in the mgr logs or at the "
+    result_str += "snap-schedule command-line due to the missing volume. "
+    result_str += "However, these errors are transient and will get auto-resolved."
     return r, result_str, ""
 
 def rename_volume(mgr, volname: str, newvolname: str) -> Tuple[int, str, str]:


### PR DESCRIPTION
Remove references to timers and db connection that refer to paths in the deleted volume.

This is a best case effort and not 100% safe. There can be race conditions where the db connection is closed while the module is executing a query on the db while the volume itself is deleted.

Hopefully there won't be many tracebacks seen.

Fixes: https://tracker.ceph.com/issues/63999
Signed-off-by: Milind Changire <mchangir@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
