### PR TITLE
rgw: fix use of creds in forward_iam_request()

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1824,13 +1824,14 @@ static inline ssize_t rgw_unescape_str(const std::string& s, ssize_t ofs,
   return std::string::npos;
 }
 
-static inline std::string rgw_bl_str(ceph::buffer::list& raw)
+/// Return a string copy of the given bufferlist with trailing nulls removed
+static inline std::string rgw_bl_str(const ceph::buffer::list& bl)
 {
-  size_t len = raw.length();
-  std::string s(raw.c_str(), len);
-  while (len && !s[len - 1]) {
-    --len;
-    s.resize(len);
+  // use to_str() instead of c_str() so we don't reallocate a flat bufferlist
+  std::string s = bl.to_str();
+  // with to_str(), the result may include null characters. trim trailing nulls
+  while (!s.empty() && s.back() == '\0') {
+    s.pop_back();
   }
   return s;
 }

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -109,7 +109,7 @@ int RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_user& uid, con
   return req.forward_request(dpp, key, info, max_response, inbl, outbl, y);
 }
 
-int RGWRESTConn::forward_iam_request(const DoutPrefixProvider *dpp, const RGWAccessKey& key, const req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y)
+int RGWRESTConn::forward_iam_request(const DoutPrefixProvider *dpp, const req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y)
 {
   string url;
   int ret = get_url(url);

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -128,7 +128,7 @@ public:
   int forward(const DoutPrefixProvider *dpp, const rgw_user& uid, const req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y);
 
   /* sync request */
-  int forward_iam_request(const DoutPrefixProvider *dpp, const RGWAccessKey& key, const req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y);
+  int forward_iam_request(const DoutPrefixProvider *dpp, const req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y);
 
 
   /* async requests */

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -65,7 +65,7 @@ int forward_iam_request_to_master(const DoutPrefixProvider* dpp,
     return ret;
   }
 
-  std::string r = outdata.to_str();
+  std::string r = rgw_bl_str(outdata);
   boost::replace_all(r, "&quot;", "\"");
 
   if (!parser.parse(r.c_str(), r.length(), 1)) {

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -59,7 +59,7 @@ int forward_iam_request_to_master(const DoutPrefixProvider* dpp,
                           std::move(creds), zg->second.id, zg->second.api_name};
   bufferlist outdata;
   constexpr size_t max_response_size = 128 * 1024; // we expect a very small response
-  int ret = conn.forward_iam_request(dpp, creds, req, nullptr, max_response_size,
+  int ret = conn.forward_iam_request(dpp, req, nullptr, max_response_size,
                                      &indata, &outdata, y);
   if (ret < 0) {
     return ret;

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -131,7 +131,7 @@ def parse_meta_sync_status(meta_sync_status_json):
         else:
             markers[i] = sync_markers[i]['val']['marker']
 
-    return period, realm_epoch, num_shards, markers
+    return global_sync_status, period, realm_epoch, num_shards, markers
 
 def meta_sync_status(zone):
     for _ in range(config.checkpoint_retries):
@@ -182,8 +182,10 @@ def zone_meta_checkpoint(zone, meta_master_zone = None, master_status = None):
     log.info('starting meta checkpoint for zone=%s', zone.name)
 
     for _ in range(config.checkpoint_retries):
-        period, realm_epoch, num_shards, sync_status = meta_sync_status(zone)
-        if realm_epoch < current_realm_epoch:
+        global_status, period, realm_epoch, num_shards, sync_status = meta_sync_status(zone)
+        if global_status != 'sync':
+            log.warning('zone %s has not started sync yet, state=%s', zone.name, global_status)
+        elif realm_epoch < current_realm_epoch:
             log.warning('zone %s is syncing realm epoch=%d, behind current realm epoch=%d',
                         zone.name, realm_epoch, current_realm_epoch)
         else:


### PR DESCRIPTION
variable `creds` was moved into the `RGWRESTConn` constructor before being passed into `forward_iam_request()`. change `forward_iam_request()` so it uses the member variable from the constructor instead of taking it as an argument

Fixes: https://tracker.ceph.com/issues/63994

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
