### PR TITLE
pacific:  common/weighted_shuffle: don't feed std::discrete_distribution with all-zero weights

### DIFF
--- a/src/common/weighted_shuffle.h
+++ b/src/common/weighted_shuffle.h
@@ -14,6 +14,8 @@ void weighted_shuffle(RandomIt first, RandomIt last,
 {
   if (first == last) {
     return;
+  } else if (std::accumulate(weight_first, weight_last, 0) == 0) {
+    return;
   } else {
     std::discrete_distribution d{weight_first, weight_last};
     if (auto n = d(g); n > 0) {

--- a/src/test/test_weighted_shuffle.cc
+++ b/src/test/test_weighted_shuffle.cc
@@ -37,3 +37,55 @@ TEST(WeightedShuffle, Basic) {
 		epsilon);
   }
 }
+
+TEST(WeightedShuffle, ZeroedWeights) {
+  std::array<char, 5> choices{'a', 'b', 'c', 'd', 'e'};
+  std::array<int, 5> weights{0, 0, 0, 0, 0};
+  std::map<char, std::array<unsigned, 5>> frequency {
+    {'a', {0, 0, 0, 0, 0}},
+    {'b', {0, 0, 0, 0, 0}},
+    {'c', {0, 0, 0, 0, 0}},
+    {'d', {0, 0, 0, 0, 0}},
+    {'e', {0, 0, 0, 0, 0}}
+  }; // count each element appearing in each position
+  const int samples = 10000;
+  std::random_device rd;
+  for (auto i = 0; i < samples; i++) {
+    weighted_shuffle(begin(choices), end(choices),
+		     begin(weights), end(weights),
+		     std::mt19937{rd()});
+    for (size_t j = 0; j < choices.size(); ++j)
+      ++frequency[choices[j]][j];
+  }
+
+  for (char ch : choices) {
+    // all samples on the diagonal
+    ASSERT_EQ(std::accumulate(begin(frequency[ch]), end(frequency[ch]), 0),
+	      samples);
+    ASSERT_EQ(frequency[ch][ch-'a'], samples);
+  }
+}
+
+TEST(WeightedShuffle, SingleNonZeroWeight) {
+  std::array<char, 5> choices{'a', 'b', 'c', 'd', 'e'};
+  std::array<int, 5> weights{0, 42, 0, 0, 0};
+  std::map<char, std::array<unsigned, 5>> frequency {
+    {'a', {0, 0, 0, 0, 0}},
+    {'b', {0, 0, 0, 0, 0}},
+    {'c', {0, 0, 0, 0, 0}},
+    {'d', {0, 0, 0, 0, 0}},
+    {'e', {0, 0, 0, 0, 0}}
+  }; // count each element appearing in each position
+  const int samples = 10000;
+  std::random_device rd;
+  for (auto i = 0; i < samples; i++) {
+    weighted_shuffle(begin(choices), end(choices),
+		     begin(weights), end(weights),
+		     std::mt19937{rd()});
+    for (size_t j = 0; j < choices.size(); ++j)
+      ++frequency[choices[j]][j];
+  }
+
+  // 'b' is always first
+  ASSERT_EQ(frequency['b'][0], samples);
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64006

---

backport of https://github.com/ceph/ceph/pull/53228
parent tracker: https://tracker.ceph.com/issues/62645

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh