### PR TITLE
rgw: fix versioned bucket index logic so that incomplete index transactions can be fixed

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2672,6 +2672,28 @@ options:
   with_legacy: true
   services:
   - rgw
+- name: rgw_debug_inject_skip_index_clear_olh
+  type: bool
+  level: dev
+  desc: Whether to inject a condition to skip bucket index clear olh ops
+    when unlinking a bucket index entry. This is useful to simulate behavior
+    for testing cases where the op is lost due to a crash or other
+    abnormal scenario.
+  default: false
+  with_legacy: true
+  services:
+  - rgw
+- name: rgw_debug_inject_skip_index_complete_del
+  type: bool
+  level: dev
+  desc: Whether to inject a condition to skip bucket index complete_del ops
+    when removing a version bucket object instance. This is useful to simulate
+    behavior for testing cases where the op is lost due to a crash or other
+    abnormal scenario.
+  default: false
+  with_legacy: true
+  services:
+  - rgw
 - name: rgw_reshard_batch_size
   type: uint
   level: advanced


### PR DESCRIPTION
rgw: fix versioned bucket index logic so that incomplete index transactions can be fixed
    
When a versioned bucket index transaction does not complete normally,
it can leave behind index entries which cannot be cleaned up
by subsequent delete requests or by radosgw-admin commands. These
leftover index entries can also cause the bucket object count
to be incorrect in a manner that is not fixable by existing tooling.
This commit fixes the logic to allow those transactions to be
completed by subsequent deletes or by radosgw-admin commands.
    
Fixes: https://tracker.ceph.com/issues/64016
Signed-off-by: Cory Snyder <csnyder@1111systems.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
