### PR TITLE
qa/suites/rados/thrash: modify selection of max-scrubs configuration values

### DIFF
--- a/qa/suites/rados/thrash/3-scrub-overrides/max-simultaneous-scrubs-1.yaml
+++ b/qa/suites/rados/thrash/3-scrub-overrides/max-simultaneous-scrubs-1.yaml
@@ -2,4 +2,4 @@ overrides:
   ceph:
     conf:
       osd:
-        osd max scrubs: 2
+        osd max scrubs: 1

--- a/qa/suites/rados/thrash/3-scrub-overrides/max-simultaneous-scrubs-5.yaml
+++ b/qa/suites/rados/thrash/3-scrub-overrides/max-simultaneous-scrubs-5.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd max scrubs: 5


### PR DESCRIPTION
As the osd-max-scrubs default was increased from 1 to (currently) 3, the original set of optional values under `rados/thrash/3-scrub-overrides` are no longer useful.  Here we change the set of optional values to reflect the current default.

