### PR TITLE
crimson/osd: get SnapSetContext from head_obc

### DIFF
--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -808,7 +808,7 @@ PGBackend::rollback_iertr::future<> PGBackend::rollback(
   return obc_loader.with_clone_obc_only<RWState::RWWRITE>(
     head, target_coid,
     [this, &os, &txn, &delta_stats, &osd_op_params, &snapid]
-    (auto, auto resolved_obc) {
+    (auto head_obc, auto resolved_obc) {
     if (resolved_obc->obs.oi.soid.is_head()) {
       // no-op: The resolved oid returned the head object
       logger().debug("PGBackend::rollback: loaded head_obc: {}"
@@ -846,7 +846,7 @@ PGBackend::rollback_iertr::future<> PGBackend::rollback(
 
     // 3) Calculate clone_overlaps by following overlaps
     const auto& clone_overlap =
-      resolved_obc->ssc->snapset.clone_overlap;
+      head_obc->ssc->snapset.clone_overlap;
     auto iter = clone_overlap.lower_bound(snapid);
     ceph_assert(iter != clone_overlap.end());
     interval_set<uint64_t> overlaps = iter->second;

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -807,7 +807,7 @@ PGBackend::rollback_iertr::future<> PGBackend::rollback(
   target_coid.snap = snapid;
   return obc_loader.with_clone_obc_only<RWState::RWWRITE>(
     head, target_coid,
-    [this, &os, &txn, &delta_stats, &osd_op_params, &snapid]
+    [this, &os, &txn, &delta_stats, &osd_op_params, snapid]
     (auto head_obc, auto resolved_obc) {
     if (resolved_obc->obs.oi.soid.is_head()) {
       // no-op: The resolved oid returned the head object
@@ -869,7 +869,7 @@ PGBackend::rollback_iertr::future<> PGBackend::rollback(
     // if there's no snapshot, we delete the object;
     // otherwise, do nothing.
     crimson::ct_error::enoent::handle(
-    [this, &os, &snapid, &txn, &delta_stats, &snapc, &ss, &osd_op_params] {
+    [this, &os, snapid, &txn, &delta_stats, &snapc, &ss, &osd_op_params] {
       logger().debug("PGBackend::rollback: deleting head on {}"
                      " with snap_id of {}"
                      " because got ENOENT|whiteout on obc lookup",


### PR DESCRIPTION
resolved_obc is snap, it doesn't have ssc.
```
#5  0x00007f487a19271b in __assert_fail_base (fmt=0x7f487a347130 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x5647263b201d "px != 0", file=0x5647263b2025 "/home/zhangsong02/nv/ceph/build/boost/include/boost/smart_ptr/intrusive_ptr.hpp", line=201, function=<optimized out>) at ./assert/assert.c:92
#6  0x00007f487a1a3e96 in __GI___assert_fail (assertion=0x5647263b201d "px != 0", file=0x5647263b2025 "/home/zhangsong02/nv/ceph/build/boost/include/boost/smart_ptr/intrusive_ptr.hpp", line=201, function=0x5647264315ac "T *boost::intrusive_ptr<crimson::osd::SnapSetContext>::operator->() const [T = crimson::osd::SnapSetContext]") at ./assert/assert.c:101
#7  0x0000564723a17902 in boost::intrusive_ptr<crimson::osd::SnapSetContext>::operator-> (this=0x7f486fa21450) at boost/include/boost/smart_ptr/intrusive_ptr.hpp:201
#8  0x0000564723a16a28 in PGBackend::rollback(ObjectState&, SnapSet const&, OSDOp const&, ceph::os::Transaction&, osd_op_params_t&, object_stat_sum_t&, boost::intrusive_ptr<crimson::osd::ObjectContext>, crimson::osd::ObjectContextLoader&, SnapContext const&)::$_0::operator()<boost::intrusive_ptr<crimson::osd::ObjectContext>, boost::intrusive_ptr<crimson::osd::ObjectContext> >(boost::intrusive_ptr<crimson::osd::ObjectContext>, boost::intrusive_ptr<crimson::osd::ObjectContext>) const (this=0x7f486f8ccb10, resolved_obc=...) at /home/zhangsong02/nv/ceph/src/crimson/osd/pg_backend.cc:849
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
