### PR TITLE
pacific: mgr/snap_schedule: add support for monthly snapshots

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -44,6 +44,11 @@
   a large buildup of session metadata resulting in the MDS going read-only due to
   the RADOS operation exceeding the size threshold. `mds_session_metadata_threshold`
   config controls the maximum size that a (encoded) session metadata can grow.
+* CephFS: For clusters with multiple CephFS file systems, all the snap-schedule
+  commands now expect the '--fs' argument.
+* CephFS: The period specifier ``m`` now implies minutes and the period specifier
+  ``M`` now implies months. This has been made consistent with the rest
+  of the system.
 
 * RADOS: `get_pool_is_selfmanaged_snaps_mode` C++ API has been deprecated
   due to being prone to false negative results.  It's safer replacement is

--- a/doc/cephfs/snap-schedule.rst
+++ b/doc/cephfs/snap-schedule.rst
@@ -30,9 +30,9 @@ assumed to be keyword arguments too.
 Snapshot schedules are identified by path, their repeat interval and their start
 time. The
 repeat interval defines the time between two subsequent snapshots. It is
-specified by a number and a period multiplier, one of `h(our)`, `d(ay)` and
-`w(eek)`. E.g. a repeat interval of `12h` specifies one snapshot every 12
-hours.
+specified by a number and a period multiplier, one of `h(our)`, `d(ay)`,
+`w(eek)`, `M(onth)` and `Y(ear)`. E.g. a repeat interval of `12h` specifies one
+snapshot every 12 hours.
 The start time is specified as a time string (more details about passing times
 below). By default
 the start time is last midnight. So when a snapshot schedule with repeat
@@ -52,8 +52,8 @@ space or concatenated pairs of `<number><time period>`.
 The semantics are that a spec will ensure `<number>` snapshots are kept that are
 at least `<time period>` apart. For Example `7d` means the user wants to keep 7
 snapshots that are at least one day (but potentially longer) apart from each other.
-The following time periods are recognized: `h(our), d(ay), w(eek), m(onth),
-y(ear)` and `n`. The latter is a special modifier where e.g. `10n` means keep
+The following time periods are recognized: `h(our)`, `d(ay)`, `w(eek)`, `M(onth)`, 
+`Y(ear)` and `n`. The latter is a special modifier where e.g. `10n` means keep
 the last 10 snapshots regardless of timing,
 
 All subcommands take optional `fs` argument to specify paths in

--- a/qa/tasks/cephfs/test_snap_schedules.py
+++ b/qa/tasks/cephfs/test_snap_schedules.py
@@ -89,7 +89,7 @@ class TestSnapSchedulesHelper(CephFSTestCase):
     def _schedule_to_timeout(self, schedule):
         mult = schedule[-1]
         period = int(schedule[0:-1])
-        if mult == 'M':
+        if mult == 'm':
             return period * 60
         elif mult == 'h':
             return period * 60 * 60
@@ -97,6 +97,10 @@ class TestSnapSchedulesHelper(CephFSTestCase):
             return period * 60 * 60 * 24
         elif mult == 'w':
             return period * 60 * 60 * 24 * 7
+        elif mult == 'M':
+            return period * 60 * 60 * 24 * 30
+        elif mult == 'Y':
+            return period * 60 * 60 * 24 * 365
         else:
             raise RuntimeError('schedule multiplier not recognized')
 
@@ -215,15 +219,15 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.mount_a.run_shell(['mkdir', '-p', TestSnapSchedules.TEST_DIRECTORY])
 
         # set a schedule on the dir
-        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='1m')
         exec_time = time.time()
 
-        timo, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1m')
         log.debug(f'expecting snap {TestSnapSchedules.TEST_DIRECTORY}/.snap/scheduled-{snap_sfx} in ~{timo}s...')
         to_wait = timo + 2 # some leeway to avoid false failures...
 
         # verify snapshot schedule
-        self.verify_schedule(TestSnapSchedules.TEST_DIRECTORY, ['1M'])
+        self.verify_schedule(TestSnapSchedules.TEST_DIRECTORY, ['1m'])
 
         def verify_added(snaps_added):
             log.debug(f'snapshots added={snaps_added}')
@@ -251,18 +255,18 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.mount_a.run_shell(['mkdir', '-p', TestSnapSchedules.TEST_DIRECTORY])
 
         # set schedules on the dir
-        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='1M')
-        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='2M')
+        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='1m')
+        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='2m')
         exec_time = time.time()
 
-        timo_1, snap_sfx_1 = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo_1, snap_sfx_1 = self.calc_wait_time_and_snap_name(exec_time, '1m')
         log.debug(f'expecting snap {TestSnapSchedules.TEST_DIRECTORY}/.snap/scheduled-{snap_sfx_1} in ~{timo_1}s...')
-        timo_2, snap_sfx_2 = self.calc_wait_time_and_snap_name(exec_time, '2M')
+        timo_2, snap_sfx_2 = self.calc_wait_time_and_snap_name(exec_time, '2m')
         log.debug(f'expecting snap {TestSnapSchedules.TEST_DIRECTORY}/.snap/scheduled-{snap_sfx_2} in ~{timo_2}s...')
         to_wait = timo_2 + 2 # use max timeout
 
         # verify snapshot schedule
-        self.verify_schedule(TestSnapSchedules.TEST_DIRECTORY, ['1M', '2M'])
+        self.verify_schedule(TestSnapSchedules.TEST_DIRECTORY, ['1m', '2m'])
 
         def verify_added_1(snaps_added):
             log.debug(f'snapshots added={snaps_added}')
@@ -300,16 +304,16 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.mount_a.run_shell(['mkdir', '-p', TestSnapSchedules.TEST_DIRECTORY])
 
         # set a schedule on the dir
-        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='1M')
-        self.fs_snap_schedule_cmd('retention', 'add', path=TestSnapSchedules.TEST_DIRECTORY, retention_spec_or_period='1M')
+        self.fs_snap_schedule_cmd('add', path=TestSnapSchedules.TEST_DIRECTORY, snap_schedule='1m')
+        self.fs_snap_schedule_cmd('retention', 'add', path=TestSnapSchedules.TEST_DIRECTORY, retention_spec_or_period='1m')
         exec_time = time.time()
 
-        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1m')
         log.debug(f'expecting snap {TestSnapSchedules.TEST_DIRECTORY}/.snap/scheduled-{snap_sfx} in ~{timo_1}s...')
         to_wait = timo_1 + 2 # some leeway to avoid false failures...
 
         # verify snapshot schedule
-        self.verify_schedule(TestSnapSchedules.TEST_DIRECTORY, ['1M'], retentions=[{'M':1}])
+        self.verify_schedule(TestSnapSchedules.TEST_DIRECTORY, ['1m'], retentions=[{'m':1}])
 
         def verify_added(snaps_added):
             log.debug(f'snapshots added={snaps_added}')
@@ -391,26 +395,26 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
 
         for d in testdirs:
             self.mount_a.run_shell(['mkdir', '-p', d[1:]])
-            self.fs_snap_schedule_cmd('add', path=d, snap_schedule='1M')
+            self.fs_snap_schedule_cmd('add', path=d, snap_schedule='1m')
 
         exec_time = time.time()
-        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1m')
 
         for d in testdirs:
-            self.fs_snap_schedule_cmd('activate', path=d, snap_schedule='1M')
+            self.fs_snap_schedule_cmd('activate', path=d, snap_schedule='1m')
 
         # we wait for 10 snaps to be taken
         wait_time = timo_1 + 10 * 60 + 15
         time.sleep(wait_time)
 
         for d in testdirs:
-            self.fs_snap_schedule_cmd('deactivate', path=d, snap_schedule='1M')
+            self.fs_snap_schedule_cmd('deactivate', path=d, snap_schedule='1m')
 
         for d in testdirs:
             self.verify_snap_stats(d)
 
         for d in testdirs:
-            self.fs_snap_schedule_cmd('remove', path=d, snap_schedule='1M')
+            self.fs_snap_schedule_cmd('remove', path=d, snap_schedule='1m')
             self.remove_snapshots(d[1:])
             self.mount_a.run_shell(['rmdir', d[1:]])
 
@@ -419,12 +423,12 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.mount_a.run_shell(['mkdir', '-p', TestSnapSchedules.TEST_DIRECTORY])
         testdir = os.path.join("/", TestSnapSchedules.TEST_DIRECTORY, "test_restart")
         self.mount_a.run_shell(['mkdir', '-p', testdir[1:]])
-        self.fs_snap_schedule_cmd('add', path=testdir, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('add', path=testdir, snap_schedule='1m')
 
         exec_time = time.time()
-        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1m')
 
-        self.fs_snap_schedule_cmd('activate', path=testdir, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('activate', path=testdir, snap_schedule='1m')
 
         # we wait for 10 snaps to be taken
         wait_time = timo_1 + 10 * 60 + 15
@@ -439,7 +443,7 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         log.debug(f'restarting active mgr: {active_mgr}')
         self.mgr_cluster.mon_manager.revive_mgr(active_mgr)
         time.sleep(300)  # sleep for 5 minutes
-        self.fs_snap_schedule_cmd('deactivate', path=testdir, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('deactivate', path=testdir, snap_schedule='1m')
 
         new_stats = self.get_snap_stats(testdir)
         self.assertTrue(new_stats['fs_count'] == new_stats['db_count'])
@@ -447,7 +451,7 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.assertTrue(new_stats['db_count'] > old_stats['db_count'])
 
         # cleanup
-        self.fs_snap_schedule_cmd('remove', path=testdir, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('remove', path=testdir, snap_schedule='1m')
         self.remove_snapshots(testdir[1:])
         self.mount_a.run_shell(['rmdir', testdir[1:]])    
 
@@ -455,7 +459,7 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         """
         Test that a non-existent path leads to schedule deactivation after a few retries.
         """
-        self.fs_snap_schedule_cmd('add', path="/bad-path", snap_schedule='1M')
+        self.fs_snap_schedule_cmd('add', path="/bad-path", snap_schedule='1m')
         start_time = time.time()
 
         while time.time() - start_time < 60.0:
@@ -482,15 +486,15 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.mount_a.run_shell(['mkdir', '-p', test_dir[1:]])
 
         # set a schedule on the dir
-        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1M')
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1m')
         self.fs_snap_schedule_cmd('retention', 'add', path=test_dir,
                                   retention_spec_or_period=f'{total_snaps}n')
         exec_time = time.time()
 
-        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo_1, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1m')
 
         # verify snapshot schedule
-        self.verify_schedule(test_dir, ['1M'])
+        self.verify_schedule(test_dir, ['1m'])
 
         # we wait for total_snaps snaps to be taken
         wait_time = timo_1 + total_snaps * 60 + 15
@@ -507,6 +511,61 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
         self.remove_snapshots(test_dir[1:])
 
         self.mount_a.run_shell(['rmdir', test_dir[1:]])
+
+    def test_snap_schedule_all_periods(self):
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/minutes"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1m')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/hourly"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1h')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/daily"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1d')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/weekly"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1w')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/monthly"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1M')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/yearly"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1Y')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/bad_period_spec"
+        self.mount_a.run_shell(['mkdir', '-p', test_dir])
+        with self.assertRaises(CommandFailedError):
+            self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1X')
+        with self.assertRaises(CommandFailedError):
+            self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1MM')
+        with self.assertRaises(CommandFailedError):
+            self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1')
+        with self.assertRaises(CommandFailedError):
+            self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='M')
+        with self.assertRaises(CommandFailedError):
+            self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='-1m')
+        with self.assertRaises(CommandFailedError):
+            self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='')
+
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/minutes"
+        self.mount_a.run_shell(['rmdir', test_dir])
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/hourly"
+        self.mount_a.run_shell(['rmdir', test_dir])
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/daily"
+        self.mount_a.run_shell(['rmdir', test_dir])
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/weekly"
+        self.mount_a.run_shell(['rmdir', test_dir])
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/monthly"
+        self.mount_a.run_shell(['rmdir', test_dir])
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/yearly"
+        self.mount_a.run_shell(['rmdir', test_dir])
+        test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/bad_period_spec"
+        self.mount_a.run_shell(['rmdir', test_dir])
 
 
 class TestSnapSchedulesSnapdir(TestSnapSchedulesHelper):
@@ -536,16 +595,16 @@ class TestSnapSchedulesSnapdir(TestSnapSchedulesHelper):
         self.mount_a.run_shell(['mkdir', '-p', TestSnapSchedulesSnapdir.TEST_DIRECTORY])
 
         # set a schedule on the dir
-        self.fs_snap_schedule_cmd('add', path=TestSnapSchedulesSnapdir.TEST_DIRECTORY, snap_schedule='1M')
-        self.fs_snap_schedule_cmd('retention', 'add', path=TestSnapSchedulesSnapdir.TEST_DIRECTORY, retention_spec_or_period='1M')
+        self.fs_snap_schedule_cmd('add', path=TestSnapSchedulesSnapdir.TEST_DIRECTORY, snap_schedule='1m')
+        self.fs_snap_schedule_cmd('retention', 'add', path=TestSnapSchedulesSnapdir.TEST_DIRECTORY, retention_spec_or_period='1m')
         exec_time = time.time()
 
-        timo, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1M')
+        timo, snap_sfx = self.calc_wait_time_and_snap_name(exec_time, '1m')
         sdn = self.get_snap_dir_name()
         log.info(f'expecting snap {TestSnapSchedulesSnapdir.TEST_DIRECTORY}/{sdn}/scheduled-{snap_sfx} in ~{timo}s...')
         
         # verify snapshot schedule
-        self.verify_schedule(TestSnapSchedulesSnapdir.TEST_DIRECTORY, ['1M'], retentions=[{'M':1}])
+        self.verify_schedule(TestSnapSchedulesSnapdir.TEST_DIRECTORY, ['1m'], retentions=[{'m':1}])
         
         # remove snapshot schedule
         self.fs_snap_schedule_cmd('remove', path=TestSnapSchedulesSnapdir.TEST_DIRECTORY)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62843

---

backport of https://github.com/ceph/ceph/pull/53070
parent tracker: https://tracker.ceph.com/issues/62494

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh