### PR TITLE
mgr/dashboard: Fixes multisite topology page breadcrumb

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -183,6 +183,7 @@ const routes: Routes = [
   },
   {
     path: 'multisite',
+    data: { breadcrumbs: 'Multi-site' },
     children: [{ path: '', component: RgwMultisiteDetailsComponent }]
   }
 ];


### PR DESCRIPTION
The multi-site topology page just says object in breadcrumb. The fix adds the missing "multi-site" breadcrumb.

Fixes https://tracker.ceph.com/issues/63635

Signed-off-by: Afreen Misbah <afreen23.git@gmail.com>
(cherry picked from commit f75a9da2871113a156092ff28f29b9d12f465975)

--------

Backport tracker: https://tracker.ceph.com/issues/64036
original Pr: #55143 

--------

Before:
![image](https://github.com/ceph/ceph/assets/25664409/ff3a73e8-8e47-47f0-ad4a-790b42fc3a1d)


After:
![Screenshot from 2024-01-10 15-53-15](https://github.com/ceph/ceph/assets/25664409/ed0a292b-b341-4dc5-ba07-912e3069ae1c)




## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
