### PR TITLE
reef: mgr/dashboard: Fixes multisite topology page breadcrumb

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -183,6 +183,7 @@ const routes: Routes = [
   },
   {
     path: 'multisite',
+    data: { breadcrumbs: 'Multi-site' },
     children: [{ path: '', component: RgwMultisiteDetailsComponent }]
   }
 ];


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64036

---

backport of https://github.com/ceph/ceph/pull/55143
parent tracker: https://tracker.ceph.com/issues/63635

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh