### PR TITLE
osd/scrub: check reservation replies for relevance

### DIFF
--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -440,6 +440,22 @@ struct PrimaryActive : sc::state<PrimaryActive, ScrubMachine, PrimaryIdle>,
   using reactions = mpl::list<
       // when the interval ends - we may not be a primary anymore
       sc::transition<IntervalChanged, NotActive>>;
+
+ /**
+  * Identifies a specific reservation request.
+  * The primary is permitted to cancel outstanding reservation requests without
+  * waiting for the pending response from the replica.  Thus, we may, in general,
+  * see responses from prior reservation attempts that we need to ignore.  Each
+  * reservation request is therefore associated with a nonce incremented within
+  * an interval with each reservation request.  Any response with a non-matching
+  * nonce must be from a reservation request we canceled.  Note that this check
+  * occurs after validating that the message is from the current interval, so
+  * reusing nonces between intervals is safe.
+  *
+  * 0 is a special value used to indicate that the sender did not include a nonce due
+  * to not being a sufficiently recent version.
+  */
+  reservation_nonce_t last_request_sent_nonce{1};
 };
 
 /**

--- a/src/osd/scrubber/scrub_reservations.h
+++ b/src/osd/scrubber/scrub_reservations.h
@@ -8,12 +8,15 @@
 #include <string_view>
 #include <vector>
 
+#include "messages/MOSDScrubReserve.h"
 #include "osd/scrubber_common.h"
 
 #include "osd_scrub_sched.h"
 #include "scrub_machine_lstnr.h"
 
 namespace Scrub {
+
+using reservation_nonce_t = MOSDScrubReserve::reservation_nonce_t;
 
 /**
  * Reserving/freeing scrub resources at the replicas.
@@ -44,6 +47,21 @@ namespace Scrub {
  *  that have been acquired until that moment.
  *  (Why? because we have encountered instances where a reservation request was
  *  lost - either due to a bug or due to a network issue.)
+ *
+ * Keeping primary & replica in sync:
+ *
+ * Reservation requests may be canceled by the primary independently of the
+ * replica's response. Depending on timing, a cancellation by the primary might
+ * or might not be processed by a replica prior to sending a response (either
+ * rejection or success).  Thus, we associate each reservation request with a
+ * nonce incremented with each reservation during an interval and drop any
+ * responses that do not match our current nonce.
+ * This check occurs after rejecting any messages from prior intervals, so
+ * reusing nonces between intervals is not a problem.  Note that epoch would
+ * not suffice as it is possible for this sequence to occur several times
+ * without a new map epoch.
+ * Note - 'release' messages, which are not replied to by the replica,
+ * do not need or use that field.
  */
 class ReplicaReservations {
   ScrubMachineListener& m_scrubber;
@@ -64,6 +82,14 @@ class ReplicaReservations {
   /// for logs, and for detecting slow peers
   ScrubTimePoint m_last_request_sent_at;
 
+  /**
+   * A ref to PrimaryActive::last_request_sent_nonce.
+   * Identifies a specific request sent, to verify against grant/deny
+   * responses.
+   * See PrimaryActive::last_request_sent_nonce for details.
+   */
+  reservation_nonce_t& m_last_request_sent_nonce;
+
   /// the 'slow response' timeout (in milliseconds) - as configured.
   /// Doubles as a 'do once' flag for the warning.
   std::chrono::milliseconds m_slow_response_warn_timeout;
@@ -77,7 +103,10 @@ class ReplicaReservations {
   std::optional<ScrubTimePoint> m_process_started_at;
 
  public:
-  ReplicaReservations(ScrubMachineListener& scrubber, PerfCounters& pc);
+  ReplicaReservations(
+      ScrubMachineListener& scrubber,
+      reservation_nonce_t& nonce,
+      PerfCounters& pc);
 
   ~ReplicaReservations();
 
@@ -90,18 +119,23 @@ class ReplicaReservations {
    * \returns true if there are no more replicas to send reservation requests
    * (i.e., the scrubber should proceed to the next phase), false otherwise.
    */
-  bool handle_reserve_grant(OpRequestRef op, pg_shard_t from);
+  bool handle_reserve_grant(const MOSDScrubReserve& msg, pg_shard_t from);
 
   /**
+   * React to an incoming reservation rejection.
+   *
    * Verify that the sender of the received rejection is the replica we
-   * were expecting a reply from.
-   * If this is so - just mark the fact that the specific peer need not
-   * be released.
+   * were expecting a reply from, and that the message isn't stale (see
+   * m_last_request_sent_nonce for details).
+   * If a valid rejection: log it, and mark the fact that the specific peer
+   * need not be released.
    *
    * Note - the actual handling of scrub session termination and of
    * releasing the reserved replicas is done by the caller (the FSM).
+   *
+   * Returns true if the rejection is valid, false otherwise.
    */
-  void verify_rejections_source(OpRequestRef op, pg_shard_t from);
+  bool handle_reserve_rejection(const MOSDScrubReserve& msg, pg_shard_t from);
 
   /**
    * Notifies implementation that it is no longer responsible for releasing
@@ -139,6 +173,20 @@ class ReplicaReservations {
    * - if there are no more replicas to send requests to, return true
    */
   bool send_next_reservation_or_complete();
+
+  /**
+   * is this is a reply to our last request?
+   * Checks response once against m_last_request_sent_nonce. See
+   * m_last_request_sent_nonce for details.
+   */
+  bool is_reservation_response_relevant(reservation_nonce_t msg_nonce) const;
+
+  /**
+   * is this reply coming from the expected replica?
+   * Now that we check the nonce before checking the sender - this
+   * check should never fail.
+   */
+  bool is_msg_source_correct(pg_shard_t from) const;
 
   // ---   perf counters helpers
 


### PR DESCRIPTION
Compare a token (nonce) carried in the reservation reply with the remembered
token of the reservation request.  If they don't match, the reply is stale and should
be ignored (and logged).

Fixes: https://tracker.ceph.com/issues/64052