### PR TITLE
reef: mgr/dashboard: Create realm sets to default

### DIFF
--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -956,7 +956,7 @@ class RgwMultisite:
     def create_realm(self, realm_name: str, default: bool):
         rgw_realm_create_cmd = ['realm', 'create']
         cmd_create_realm_options = ['--rgw-realm', realm_name]
-        if default != 'false':
+        if default:
             cmd_create_realm_options.append('--default')
         rgw_realm_create_cmd += cmd_create_realm_options
         try:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62575

---

backport of https://github.com/ceph/ceph/pull/53091
parent tracker: https://tracker.ceph.com/issues/62453

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh