### PR TITLE
crimson: clear obc_registry on interval change

### DIFF
--- a/src/common/intrusive_lru.h
+++ b/src/common/intrusive_lru.h
@@ -122,9 +122,9 @@ class intrusive_lru {
 
   // when the lru_set exceeds its target size, evict
   // only unreferenced elements from it (if any).
-  void evict() {
+  void evict(unsigned target_size) {
     while (!unreferenced_list.empty() &&
-	   lru_set.size() > lru_target_size) {
+	   lru_set.size() > target_size) {
       auto &evict_target = unreferenced_list.front();
       assert(evict_target.is_unreferenced());
       unreferenced_list.pop_front();
@@ -150,7 +150,7 @@ class intrusive_lru {
     assert(b.is_unreferenced());
     lru_set.insert(b);
     b.lru = this;
-    evict();
+    evict(lru_target_size);
   }
 
   // an element in the lru_set has no users,
@@ -159,7 +159,7 @@ class intrusive_lru {
     assert(b.is_referenced());
     unreferenced_list.push_back(b);
     b.lru = nullptr;
-    evict();
+    evict(lru_target_size);
   }
 
 public:
@@ -226,7 +226,7 @@ public:
 
   void set_target_size(size_t target_size) {
     lru_target_size = target_size;
-    evict();
+    evict(lru_target_size);
   }
 
   ~intrusive_lru() {

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -130,7 +130,7 @@ private:
     });
   }
 
-  boost::intrusive::list_member_hook<> list_hook;
+  boost::intrusive::list_member_hook<> obc_accessing_hook;
   uint64_t list_link_cnt = 0;
   bool fully_loaded = false;
 
@@ -154,7 +154,7 @@ public:
   using obc_accessing_option_t = boost::intrusive::member_hook<
     ObjectContext,
     boost::intrusive::list_member_hook<>,
-    &ObjectContext::list_hook>;
+    &ObjectContext::obc_accessing_hook>;
 
   template<RWState::State Type, typename InterruptCond = void, typename Func>
   auto with_lock(Func&& func) {

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -112,8 +112,8 @@ public:
     }
   }
 
-  bool is_fully_loaded() const {
-    return fully_loaded;
+  bool is_loaded_and_valid() const {
+    return fully_loaded && !invalidated_by_interval_change;
   }
 
 private:
@@ -133,7 +133,10 @@ private:
   boost::intrusive::list_member_hook<> obc_accessing_hook;
   uint64_t list_link_cnt = 0;
   bool fully_loaded = false;
+  bool invalidated_by_interval_change = false;
 
+  friend class ObjectContextRegistry;
+  friend class ObjectContextLoader;
 public:
 
   template <typename ListType>
@@ -265,6 +268,12 @@ public:
   void clear_range(const hobject_t &from,
                    const hobject_t &to) {
     obc_lru.clear_range(from, to);
+  }
+
+  void invalidate_on_interval_change() {
+    obc_lru.clear([](auto &obc) {
+      obc.invalidated_by_interval_change = true;
+    });
   }
 
   template <class F>

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -94,11 +94,13 @@ public:
     ceph_assert(is_head());
     obs = std::move(_obs);
     ssc = std::move(_ssc);
+    fully_loaded = true;
   }
 
   void set_clone_state(ObjectState &&_obs) {
     ceph_assert(!is_head());
     obs = std::move(_obs);
+    fully_loaded = true;
   }
 
   /// pass the provided exception to any waiting consumers of this ObjectContext
@@ -108,6 +110,10 @@ public:
     if (recovery_read_marker) {
       drop_recovery_read();
     }
+  }
+
+  bool is_fully_loaded() const {
+    return fully_loaded;
   }
 
 private:
@@ -126,6 +132,7 @@ private:
 
   boost::intrusive::list_member_hook<> list_hook;
   uint64_t list_link_cnt = 0;
+  bool fully_loaded = false;
 
 public:
 

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -168,7 +168,15 @@ using crimson::common::local_conf;
     auto loaded =
       load_obc_iertr::make_ready_future<ObjectContextRef>(obc);
     if (existed) {
-      ceph_assert(obc->is_fully_loaded());
+      if (!obc->is_loaded_and_valid()) {
+	ERRORDPP(
+	  "obc for {} invalid -- fully_loaded={}, "
+	  "invalidated_by_interval_change={}",
+	  dpp, obc->get_oid(),
+	  obc->fully_loaded, obc->invalidated_by_interval_change
+	);
+      }
+      ceph_assert(obc->is_loaded_and_valid());
       DEBUGDPP("cache hit on {}", dpp, obc->get_oid());
     } else {
       DEBUGDPP("cache miss on {}", dpp, obc->get_oid());

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -168,6 +168,7 @@ using crimson::common::local_conf;
     auto loaded =
       load_obc_iertr::make_ready_future<ObjectContextRef>(obc);
     if (existed) {
+      ceph_assert(obc->is_fully_loaded());
       DEBUGDPP("cache hit on {}", dpp, obc->get_oid());
     } else {
       DEBUGDPP("cache miss on {}", dpp, obc->get_oid());

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -449,7 +449,7 @@ public:
 
   version_t get_last_user_version() const;
 
-  std::pair<object_info_t, ObjectContextRef> prepare_clone(
+  ObjectContextRef prepare_clone(
     const hobject_t& coid);
 
   void apply_stats();

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1524,6 +1524,7 @@ void PG::on_change(ceph::os::Transaction &t) {
     client_request_orderer.clear_and_cancel(*this);
   }
   scrubber.on_interval_change();
+  obc_registry.invalidate_on_interval_change();
 }
 
 void PG::context_registry_on_change() {


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
