### PR TITLE
mgr/dashboard: Allow the user to add the access/secret key on zone edit and not on zone creation

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-zone-form/rgw-multisite-zone-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-zone-form/rgw-multisite-zone-form.component.html
@@ -110,7 +110,7 @@
         </div>
       </div>
       <div class="form-group row">
-        <label class="cd-col-form-label required"
+        <label class="cd-col-form-label"
                for="access_key"
                i18n>S3 access key
           <cd-helper>
@@ -118,29 +118,41 @@
           </cd-helper>
         </label>
         <div class="cd-col-form-input">
-          <input class="form-control"
-                 type="text"
-                 placeholder="DiPt4V7WWvy2njL1z6aC"
-                 id="access_key"
-                 name="access_key"
-                 formControlName="access_key">
+          <div class="input-group">
+            <input class="form-control"
+                   type="password"
+                   placeholder="DiPt4V7WWvy2njL1z6aC"
+                   id="access_key"
+                   name="access_key"
+                   formControlName="access_key">
+            <button type="button"
+                    class="btn btn-light"
+                    cdPasswordButton="access_key">
+            </button>
+          </div>
         </div>
       </div>
       <div class="form-group row">
-        <label class="cd-col-form-label required"
-               for="access_key"
+        <label class="cd-col-form-label"
+               for="secret_key"
                i18n>S3 secret key
           <cd-helper>
             <span>To see or copy your S3 access key, go to <b>Object Gateway > Users</b> and click on your user name. In <b>Keys</b>, click <b>Show</b>. View the secret key by clicking Show and copy the key by clicking <b>Copy to Clipboard</b>.</span>
           </cd-helper>
         </label>
         <div class="cd-col-form-input">
-          <input class="form-control"
-                 type="text"
-                 placeholder="xSZUdYky0bTctAdCEEW8ikhfBVKsBV5LFYL82vvh"
-                 id="secret_key"
-                 name="secret_key"
-                 formControlName="secret_key">
+          <div class="input-group">
+            <input class="form-control"
+                   type="password"
+                   placeholder="xSZUdYky0bTctAdCEEW8ikhfBVKsBV5LFYL82vvh"
+                   id="secret_key"
+                   name="secret_key"
+                   formControlName="secret_key">
+            <button type="button"
+                    class="btn btn-light"
+                    cdPasswordButton="secret_key">
+            </button>
+          </div>
         </div>
       </div>
       <div class="form-group row"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-zone-form/rgw-multisite-zone-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-zone-form/rgw-multisite-zone-form.component.ts
@@ -112,8 +112,8 @@ export class RgwMultisiteZoneFormComponent implements OnInit {
           Validators.required
         ]
       }),
-      access_key: new UntypedFormControl(null, Validators.required),
-      secret_key: new UntypedFormControl(null, Validators.required),
+      access_key: new UntypedFormControl('', {}),
+      secret_key: new UntypedFormControl('', {}),
       placementTarget: new UntypedFormControl(null),
       placementDataPool: new UntypedFormControl(''),
       placementIndexPool: new UntypedFormControl(null),


### PR DESCRIPTION

[Screencast from 2024-02-13 14-01-53.webm](https://github.com/ceph/ceph/assets/66050535/ecc6b126-e372-4fef-8535-979789a99d2f)



In current design access/secret key is compulsory while creating zone from a dashboard
so as a workflow we cannot use any replication user(dedicated user) access/secret keys during zone creation since that user will not be accessible post creating new default real/zg/zones.
due to this reason we have to use "default dashboard user" while creating zone and then need to edit the zone with any specific replication user details.

Fixes: https://tracker.ceph.com/issues/64080





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
