### PR TITLE
Solution 1: osd/OSD: reply pg_created when pg is peered

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1265,6 +1265,7 @@ void OSDService::send_pg_created(pg_t pgid)
   auto o = get_osdmap();
   if (o->require_osd_release >= ceph_release_t::luminous) {
     pg_created.insert(pgid);
+    dout(20) << __func__ << " reply to mon " << pgid << " created." << dendl;
     monc->send_mon_message(new MOSDPGCreated(pgid));
   }
 }
@@ -1276,6 +1277,7 @@ void OSDService::send_pg_created()
   auto o = get_osdmap();
   if (o->require_osd_release >= ceph_release_t::luminous) {
     for (auto pgid : pg_created) {
+      dout(20) << __func__ << " reply to mon " << pgid << " created!" << dendl;
       monc->send_mon_message(new MOSDPGCreated(pgid));
     }
   }
@@ -9222,7 +9224,7 @@ void OSD::handle_fast_pg_create(MOSDPGCreate2 *m)
 	    std::make_shared<PGPeeringEvent>(
 	      m->epoch,
 	      m->epoch,
-	      NullEvt(),
+	      PgCreateEvt(),
 	      true,
 	      new PGCreateInfo(
 		pgid,

--- a/src/osd/PGPeeringEvent.h
+++ b/src/osd/PGPeeringEvent.h
@@ -193,6 +193,7 @@ struct RequestRecoveryPrio : boost::statechart::event< RequestRecoveryPrio > {
   };
 
 TrivialEvent(NullEvt)
+TrivialEvent(PgCreateEvt)
 TrivialEvent(RemoteBackfillReserved)
 TrivialEvent(RemoteReservationRejectedTooFull)
 TrivialEvent(RemoteReservationRevokedTooFull)

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -6332,6 +6332,22 @@ boost::statechart::result PeeringState::Active::react(const CheckReadable &evt)
   return discard_event();
 }
 
+boost::statechart::result PeeringState::Active::react(const PgCreateEvt &evt)
+{
+  DECLARE_LOCALS;
+  pg_t pgid = context< PeeringMachine >().spgid.pgid;
+
+  psdout(10) << __func__ << " receive PgCreateEvt"
+             << " is_peered=" << ps->is_peered() << dendl;
+
+  if (ps->is_peered()) {
+    psdout(10) << __func__ << " pg is peered, reply pg_created" << dendl;
+    pl->send_pg_created(pgid);
+  }
+
+  return discard_event();
+}
+
 /*
  * update info.history.last_epoch_started ONLY after we and all
  * replicas have activated AND committed the activate transaction

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -690,6 +690,7 @@ public:
     typedef boost::mpl::list <
       boost::statechart::transition< Initialize, Reset >,
       boost::statechart::custom_reaction< NullEvt >,
+      boost::statechart::custom_reaction< PgCreateEvt >,
       boost::statechart::transition< boost::statechart::event_base, Crashed >
       > reactions;
 
@@ -711,6 +712,7 @@ public:
       boost::statechart::custom_reaction< AdvMap >,
       boost::statechart::custom_reaction< ActMap >,
       boost::statechart::custom_reaction< NullEvt >,
+      boost::statechart::custom_reaction< PgCreateEvt >,
       boost::statechart::custom_reaction< IntervalFlush >,
       boost::statechart::transition< boost::statechart::event_base, Crashed >
       > reactions;
@@ -737,6 +739,7 @@ public:
       boost::statechart::custom_reaction< IntervalFlush >,
       // ignored
       boost::statechart::custom_reaction< NullEvt >,
+      boost::statechart::custom_reaction< PgCreateEvt >,
       boost::statechart::custom_reaction<SetForceRecovery>,
       boost::statechart::custom_reaction<UnsetForceRecovery>,
       boost::statechart::custom_reaction<SetForceBackfill>,
@@ -867,7 +870,8 @@ public:
       boost::statechart::custom_reaction< DoRecovery>,
       boost::statechart::custom_reaction< RenewLease>,
       boost::statechart::custom_reaction< MLeaseAck>,
-      boost::statechart::custom_reaction< CheckReadable>
+      boost::statechart::custom_reaction< CheckReadable>,
+      boost::statechart::custom_reaction< PgCreateEvt >
       > reactions;
     boost::statechart::result react(const QueryState& q);
     boost::statechart::result react(const QueryUnfound& q);
@@ -906,6 +910,7 @@ public:
       return discard_event();
     }
     boost::statechart::result react(const CheckReadable&);
+    boost::statechart::result react(const PgCreateEvt&);
     void all_activated_and_committed();
   };
 


### PR DESCRIPTION
```
Problem:
  when PG is active+clean
  ceph osd force-create-pg 1.0 --yes-i-really-mean-it
  because osd is not reply pg_created to mon.
Affects:
  pool remains creating flags,
  mon creating_pgs.pg is not empty,
  lead to mon cannot trim OSDMaps
Solution:
  add PgCreateEvt for pg create
  if pg Active and is_peered,
  reply pg_created to mon.

Fixes: https://tracker.ceph.com/issues/63912
```

- Solution 1: Add PgCreateEvt https://github.com/ceph/ceph/pull/55239
- Solution 2: Use Active::react(ActMap) https://github.com/ceph/ceph/pull/55041

