### PR TITLE
Various mypy related updates

### DIFF
--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -26,7 +26,7 @@ deps =
   types-cryptography
   types-python-dateutil
   -c{toxinidir}/../src/mypy-constrains.txt
-commands = mypy {posargs:.}
+commands = mypy --no-namespace-packages {posargs:.}
 
 [testenv:py3]
 basepython = python3

--- a/qa/workunits/windows/test_rbd_wnbd.py
+++ b/qa/workunits/windows/test_rbd_wnbd.py
@@ -75,7 +75,7 @@ parser.add_argument('--skip-cleanup-on-error', action='store_true',
 class CephTestException(Exception):
     msg_fmt = "An exception has been encountered."
 
-    def __init__(self, message: str = None, **kwargs):
+    def __init__(self, message: str = '', **kwargs):
         self.kwargs = kwargs
         if not message:
             message = self.msg_fmt % kwargs
@@ -520,7 +520,7 @@ class RbdTest(object):
     @classmethod
     def print_results(cls,
                       title: str = "Test results",
-                      description: str = None):
+                      description: str = ''):
         pass
 
 
@@ -551,7 +551,7 @@ class RbdFioTest(RbdTest):
 
     def __init__(self,
                  *args,
-                 fio_size_mb: int = None,
+                 fio_size_mb: int = 0,
                  iterations: int = 1,
                  workers: int = 1,
                  bs: str = "2M",
@@ -603,7 +603,7 @@ class RbdFioTest(RbdTest):
         return self.image.path
 
     @Tracer.trace
-    def _run_fio(self, fio_size_mb=None):
+    def _run_fio(self, fio_size_mb: int = 0) -> None:
         LOG.info("Starting FIO test.")
         cmd = [
             "fio", "--thread", "--output-format=json",
@@ -628,7 +628,7 @@ class RbdFioTest(RbdTest):
     @classmethod
     def print_results(cls,
                       title: str = "Benchmark results",
-                      description: str = None):
+                      description: str = ''):
         if description:
             title = "%s (%s)" % (title, description)
 

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -6,6 +6,10 @@ check_untyped_defs = True
 show_error_context = True
 allow_redefinition = True
 disallow_untyped_defs = True
+# Disable namespace packages as the cephfs, rados, rbd, etc. dirs lack an
+# __init__.py and thus confuse mypy 0.990 (and up) into thinking these are
+# empty namespaces causing the ignore_missing_imports rules to stop working.
+namespace_packages = False
 
 [mypy-rados]
 # This would require a rados.pyi file

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from cephadm.module import CephadmOrchestrator
 
 
-def cherrypy_filter(record: logging.LogRecord) -> int:
+def cherrypy_filter(record: logging.LogRecord) -> bool:
     blocked = [
         'TLSV1_ALERT_DECRYPT_ERROR'
     ]

--- a/src/pybind/mgr/cephadm/configchecks.py
+++ b/src/pybind/mgr/cephadm/configchecks.py
@@ -150,7 +150,7 @@ class CephadmCheckDefinition:
             "description": self.description,
             "name": self.name,
             "status": self.status,
-            "valid": True if self.func else False
+            "valid": True if getattr(self, 'func', None) else False
         }
 
 

--- a/src/pybind/mgr/cephadm/http_server.py
+++ b/src/pybind/mgr/cephadm/http_server.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from cephadm.module import CephadmOrchestrator
 
 
-def cherrypy_filter(record: logging.LogRecord) -> int:
+def cherrypy_filter(record: logging.LogRecord) -> bool:
     blocked = [
         'TLSV1_ALERT_DECRYPT_ERROR'
     ]

--- a/src/pybind/mgr/cephadm/service_discovery.py
+++ b/src/pybind/mgr/cephadm/service_discovery.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from cephadm.module import CephadmOrchestrator
 
 
-def cherrypy_filter(record: logging.LogRecord) -> int:
+def cherrypy_filter(record: logging.LogRecord) -> bool:
     blocked = [
         'TLSV1_ALERT_DECRYPT_ERROR'
     ]

--- a/src/pybind/mgr/dashboard/controllers/_crud.py
+++ b/src/pybind/mgr/dashboard/controllers/_crud.py
@@ -332,7 +332,7 @@ class CRUDEndpoint:
     CRUDClassMetadata: Optional[RESTController] = None
 
     def __init__(self, router: APIRouter, doc: APIDoc,
-                 set_column: Optional[Dict[str, Dict[str, str]]] = None,
+                 set_column: Optional[Dict[str, Dict[str, Union[str, bool]]]] = None,
                  actions: Optional[List[TableAction]] = None,
                  permissions: Optional[List[str]] = None, forms: Optional[List[Form]] = None,
                  column_key: Optional[str] = None,

--- a/src/pybind/mgr/dashboard/rest_client.py
+++ b/src/pybind/mgr/dashboard/rest_client.py
@@ -23,7 +23,7 @@ from requests.exceptions import ConnectionError, InvalidURL, Timeout
 from .settings import Settings
 
 try:
-    from requests.packages.urllib3.exceptions import SSLError
+    from requests.packages.urllib3.exceptions import SSLError  # type: ignore
 except ImportError:
     from urllib3.exceptions import SSLError  # type: ignore
 
@@ -433,6 +433,7 @@ class RestClient(object):
                              method.upper(), str(ex))
             raise RequestException(str(ex))
         except Timeout as ex:
+            assert ex.request
             msg = "{} REST API {} timed out after {} seconds (url={}).".format(
                 self.client_name, ex.request.method, Settings.REST_REQUESTS_TIMEOUT,
                 ex.request.url)

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1277,7 +1277,7 @@ class DaemonDescription(object):
         return DaemonDescription.from_json(self.to_json())
 
     @staticmethod
-    def yaml_representer(dumper: 'yaml.SafeDumper', data: 'DaemonDescription') -> Any:
+    def yaml_representer(dumper: 'yaml.Dumper', data: 'DaemonDescription') -> yaml.Node:
         return dumper.represent_dict(cast(Mapping, data.to_json().items()))
 
 
@@ -1410,7 +1410,7 @@ class ServiceDescription(object):
         return cls(spec=spec, events=events, **c_status)
 
     @staticmethod
-    def yaml_representer(dumper: 'yaml.SafeDumper', data: 'ServiceDescription') -> Any:
+    def yaml_representer(dumper: 'yaml.Dumper', data: 'ServiceDescription') -> yaml.Node:
         return dumper.represent_dict(cast(Mapping, data.to_json().items()))
 
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -129,7 +129,7 @@ class HostDetails:
         return _cls
 
     @staticmethod
-    def yaml_representer(dumper: 'yaml.SafeDumper', data: 'HostDetails') -> Any:
+    def yaml_representer(dumper: 'yaml.Dumper', data: 'HostDetails') -> yaml.Node:
         return dumper.represent_dict(cast(Mapping, data.to_json().items()))
 
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -139,7 +139,7 @@ yaml.add_representer(HostDetails, HostDetails.yaml_representer)
 class DaemonFields(enum.Enum):
     service_name = 'service_name'
     daemon_type = 'daemon_type'
-    name = 'name'
+    name = 'name'  # type: ignore
     host = 'host'
     status = 'status'
     refreshed = 'refreshed'

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -33,7 +33,11 @@ from ceph.deployment.service_spec import (
     HostPattern,
 )
 from ceph.utils import datetime_now
-from ceph.deployment.drive_selection.matchers import SizeMatcher
+from ceph.deployment.drive_selection.matchers import (
+    AllMatcher,
+    Matcher,
+    SizeMatcher,
+)
 from nfs.cluster import create_ganesha_pool
 from nfs.module import Module
 from nfs.export import NFSRados
@@ -416,7 +420,7 @@ class DefaultCreator():
     def filter_devices(self, rook_pods: KubernetesResource, drive_group: DriveGroupSpec, matching_hosts: List[str]) -> List[Device]:
         device_list = []
         assert drive_group.data_devices is not None
-        sizematcher: Optional[SizeMatcher] = None
+        sizematcher: Matcher = AllMatcher('', None)
         if drive_group.data_devices.size:
             sizematcher = SizeMatcher('size', drive_group.data_devices.size)
         limit = getattr(drive_group.data_devices, 'limit', None)
@@ -444,7 +448,7 @@ class DefaultCreator():
                             all 
                             or (
                                 device.sys_api['node'] in matching_hosts
-                                and ((sizematcher != None) or sizematcher.compare(device))
+                                and sizematcher.compare(device)
                                 and (
                                     not drive_group.data_devices.paths
                                     or (device.path in paths)
@@ -481,7 +485,7 @@ class LSOCreator(DefaultCreator):
     def filter_devices(self, rook_pods: KubernetesResource, drive_group: DriveGroupSpec, matching_hosts: List[str]) -> List[Device]:
         device_list = []
         assert drive_group.data_devices is not None
-        sizematcher = None
+        sizematcher: Matcher = AllMatcher('', None)
         if drive_group.data_devices.size:
             sizematcher = SizeMatcher('size', drive_group.data_devices.size)
         limit = getattr(drive_group.data_devices, 'limit', None)
@@ -511,7 +515,7 @@ class LSOCreator(DefaultCreator):
                             all 
                             or (
                                 device.sys_api['node'] in matching_hosts
-                                and ((sizematcher != None) or sizematcher.compare(device))
+                                and sizematcher.compare(device)
                                 and (
                                     not drive_group.data_devices.paths
                                     or device.path in paths

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -425,7 +425,7 @@ class DefaultCreator():
             sizematcher = SizeMatcher('size', drive_group.data_devices.size)
         limit = getattr(drive_group.data_devices, 'limit', None)
         count = 0
-        all = getattr(drive_group.data_devices, 'all', None)
+        _all = getattr(drive_group.data_devices, 'all', None)
         paths = [device.path for device in drive_group.data_devices.paths]
         osd_list = []
         for pod in rook_pods.items:
@@ -445,7 +445,7 @@ class DefaultCreator():
                 if not limit or (count < limit):
                     if device.available:
                         if (
-                            all 
+                            _all
                             or (
                                 device.sys_api['node'] in matching_hosts
                                 and sizematcher.compare(device)
@@ -489,7 +489,7 @@ class LSOCreator(DefaultCreator):
         if drive_group.data_devices.size:
             sizematcher = SizeMatcher('size', drive_group.data_devices.size)
         limit = getattr(drive_group.data_devices, 'limit', None)
-        all = getattr(drive_group.data_devices, 'all', None)
+        _all = getattr(drive_group.data_devices, 'all', None)
         paths = [device.path for device in drive_group.data_devices.paths]
         vendor = getattr(drive_group.data_devices, 'vendor', None)
         model = getattr(drive_group.data_devices, 'model', None)
@@ -512,7 +512,7 @@ class LSOCreator(DefaultCreator):
                 if not limit or (count < limit):
                     if device.available:
                         if (
-                            all 
+                            _all
                             or (
                                 device.sys_api['node'] in matching_hosts
                                 and sizematcher.compare(device)


### PR DESCRIPTION
While working on one task I ran into some mypy related issue that I thought may be fixed in newer versions of mypy. But I was not easily able to try a newer version because the version is pinned in a "global" mypy constraints file - and updating the version there caused various new issues to appear.

After a period of groaning I decided that trying to make the codebase work on newer versions of mypy was worthwhile and something I had thought of doing previously anyway. I've tested on versions of mypy from 0.990 - 1.8.0. This PR *does not* change the pinned version of mypy it just makes it easier to make that change in the future.

Most everything the newer versions of mypy found were valid, with the exception of the detecting the cython based extension sources as empty namespace packages forcing me the turn off namespace package support. However, this seems to have had no negative side effects so it seems like a valid workaround for now.

One change (currently prefixed by `xxx` in the commit message) in the rook module seems to have a legit logical error. But I wasn't clear if my fix is correct. So I may need some help verifying it before taking the PR out of draft.



## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
  - [x] Touches a number of different components, so you tell me if you really really want a ticket.
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
  - [x] This is not a feature. Existing tests ought to be sufficient.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
