### PR TITLE
quincy: librbd: improve rbd_diff_iterate2() performance in fast-diff mode

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -4,6 +4,11 @@
 * RADOS: `get_pool_is_selfmanaged_snaps_mode` C++ API has been deprecated
   due to being prone to false negative results.  It's safer replacement is
   `pool_is_in_selfmanaged_snaps_mode`.
+* RBD: When diffing against the beginning of time (`fromsnapname == NULL`) in
+  fast-diff mode (`whole_object == true` with `fast-diff` image feature enabled
+  and valid), diff-iterate is now guaranteed to execute locally if exclusive
+  lock is available.  This brings a dramatic performance improvement for QEMU
+  live disk synchronization and backup use cases.
 
 >=17.2.7
 --------

--- a/src/common/bit_vector.hpp
+++ b/src/common/bit_vector.hpp
@@ -129,7 +129,7 @@ public:
 
     inline IteratorImpl operator++(int) {
       IteratorImpl iterator_impl(*this);
-      ++iterator_impl;
+      ++*this;
       return iterator_impl;
     }
     inline IteratorImpl operator+(uint64_t offset) {

--- a/src/common/bit_vector.hpp
+++ b/src/common/bit_vector.hpp
@@ -83,7 +83,7 @@ public:
   };
 
 public:
-  template <typename BitVectorT, typename DataIterator>
+  template <typename BitVectorT, typename DataIteratorT, typename ReferenceT>
   class IteratorImpl {
   private:
     friend class BitVector;
@@ -94,7 +94,7 @@ public:
     // cached derived values
     uint64_t m_index = 0;
     uint64_t m_shift = 0;
-    DataIterator m_data_iterator;
+    DataIteratorT m_data_iterator;
 
     IteratorImpl(BitVectorT *bit_vector, uint64_t offset)
       : m_bit_vector(bit_vector),
@@ -145,17 +145,15 @@ public:
       return (m_offset != rhs.m_offset || m_bit_vector != rhs.m_bit_vector);
     }
 
-    inline ConstReference operator*() const {
-      return ConstReference(m_data_iterator, m_shift);
-    }
-    inline Reference operator*() {
-      return Reference(m_data_iterator, m_shift);
+    inline ReferenceT operator*() const {
+      return ReferenceT(m_data_iterator, m_shift);
     }
   };
 
   typedef IteratorImpl<const BitVector,
-                       bufferlist::const_iterator> ConstIterator;
-  typedef IteratorImpl<BitVector, bufferlist::iterator> Iterator;
+                       bufferlist::const_iterator,
+                       ConstReference> ConstIterator;
+  typedef IteratorImpl<BitVector, bufferlist::iterator, Reference> Iterator;
 
   static const uint32_t BLOCK_SIZE;
   static const uint8_t BIT_COUNT = _bit_count;

--- a/src/include/intarith.h
+++ b/src/include/intarith.h
@@ -22,6 +22,10 @@ constexpr inline std::make_unsigned_t<std::common_type_t<T, U>> div_round_up(T n
   return (n + d - 1) / d;
 }
 
+template<typename T, typename U>
+constexpr inline std::make_unsigned_t<std::common_type_t<T, U>> round_down_to(T n, U d) {
+  return n - n % d;
+}
 
 template<typename T, typename U>
 constexpr inline std::make_unsigned_t<std::common_type_t<T, U>> round_up_to(T n, U d) {

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -146,6 +146,7 @@ namespace librbd {
                        // parent_md and parent
 
     ceph::shared_mutex timestamp_lock; // protects (create/access/modify)_timestamp
+                                       // and internal diff_iterate_lock_timestamp
     ceph::mutex async_ops_lock; // protects async_ops and async_requests
     ceph::mutex copyup_list_lock; // protects copyup_waiting_list
 
@@ -171,6 +172,7 @@ namespace librbd {
     utime_t create_timestamp;
     utime_t access_timestamp;
     utime_t modify_timestamp;
+    utime_t diff_iterate_lock_timestamp;
 
     file_layout_t layout;
 

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -45,6 +45,12 @@ public:
     return m_object_map.size();
   }
 
+  template <typename F, typename... Args>
+  auto with_object_map(F&& f, Args&&... args) const {
+    std::shared_lock locker(m_lock);
+    return std::forward<F>(f)(m_object_map, std::forward<Args>(args)...);
+  }
+
   inline void set_state(uint64_t object_no, uint8_t new_state,
                         const boost::optional<uint8_t> &current_state) {
     std::unique_lock locker{m_lock};

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "librbd/api/DiffIterate.h"
+#include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
 #include "librbd/ObjectMap.h"
@@ -29,6 +30,8 @@ namespace librbd {
 namespace api {
 
 namespace {
+
+constexpr uint32_t LOCK_INTERVAL_SECONDS = 5;
 
 struct DiffContext {
   DiffIterate<>::Callback callback;
@@ -149,6 +152,35 @@ private:
   }
 };
 
+template <typename I>
+bool should_try_acquire_lock(I* image_ctx) {
+  if (image_ctx->exclusive_lock == nullptr ||
+      image_ctx->exclusive_lock->is_lock_owner()) {
+    return false;
+  }
+  if ((image_ctx->features & RBD_FEATURE_FAST_DIFF) == 0) {
+    return false;
+  }
+
+  utime_t now = ceph_clock_now();
+  utime_t cutoff = now - utime_t(LOCK_INTERVAL_SECONDS, 0);
+
+  {
+    std::shared_lock timestamp_locker{image_ctx->timestamp_lock};
+    if (image_ctx->diff_iterate_lock_timestamp > cutoff) {
+      return false;
+    }
+  }
+
+  std::unique_lock timestamp_locker{image_ctx->timestamp_lock};
+  if (image_ctx->diff_iterate_lock_timestamp > cutoff) {
+    return false;
+  }
+
+  image_ctx->diff_iterate_lock_timestamp = now;
+  return true;
+}
+
 int simple_diff_cb(uint64_t off, size_t len, int exists, void *arg) {
   // This reads the existing extents in a parent from the beginning
   // of time.  Since images are thin-provisioned, the extents will
@@ -168,10 +200,14 @@ int DiffIterate<I>::diff_iterate(I *ictx,
                                  uint64_t off, uint64_t len,
                                  bool include_parent, bool whole_object,
                                  int (*cb)(uint64_t, size_t, int, void *),
-                                 void *arg)
-{
-  ldout(ictx->cct, 20) << "diff_iterate " << ictx << " off = " << off
-      		 << " len = " << len << dendl;
+                                 void *arg) {
+  ldout(ictx->cct, 10) << "from_snap_namespace=" << from_snap_namespace
+                       << ", fromsnapname=" << (fromsnapname ?: "")
+                       << ", off=" << off
+                       << ", len=" << len
+                       << ", include_parent=" << include_parent
+                       << ", whole_object=" << whole_object
+                       << dendl;
 
   if (!ictx->data_ctx.is_valid()) {
     return -ENODEV;
@@ -198,11 +234,28 @@ int DiffIterate<I>::diff_iterate(I *ictx,
     return r;
   }
 
-  ictx->image_lock.lock_shared();
-  r = clip_io(ictx, off, &len);
-  ictx->image_lock.unlock_shared();
-  if (r < 0) {
-    return r;
+  {
+    std::shared_lock owner_locker{ictx->owner_lock};
+    std::shared_lock image_locker{ictx->image_lock};
+
+    r = clip_io(ictx, off, &len);
+    if (r < 0) {
+      return r;
+    }
+
+    // optimization: hang onto the only object map needed to run fast
+    // diff against the beginning of time -- it's loaded when exclusive
+    // lock is acquired
+    // acquire exclusive lock only if not busy (i.e. don't request),
+    // throttle acquisition attempts and ignore errors
+    if (fromsnapname == nullptr && whole_object &&
+        should_try_acquire_lock(ictx)) {
+      C_SaferCond lock_ctx;
+      ictx->exclusive_lock->try_acquire_lock(&lock_ctx);
+      image_locker.unlock();
+      owner_locker.unlock();
+      lock_ctx.wait();
+    }
   }
 
   DiffIterate command(*ictx, from_snap_namespace, fromsnapname, off, len,

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -291,7 +291,7 @@ int DiffIterate<I>::execute() {
   uint64_t left = m_length;
 
   while (left > 0) {
-    uint64_t period_off = off - (off % period);
+    uint64_t period_off = round_down_to(off, period);
     uint64_t read_len = std::min(period_off + period - off, left);
 
     if (fast_diff_enabled) {

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -293,10 +293,14 @@ int DiffIterate<I>::execute() {
         std::shared_lock image_locker{m_image_ctx.image_lock};
         uint64_t overlap = 0;
         m_image_ctx.get_parent_overlap(m_image_ctx.snap_id, &overlap);
-        if (m_image_ctx.parent && overlap > 0) {
+        io::Extents parent_extents = {{m_offset, m_length}};
+        if (m_image_ctx.parent &&
+            m_image_ctx.prune_parent_extents(parent_extents, overlap) > 0) {
           ldout(cct, 10) << " first getting parent diff" << dendl;
-          DiffIterate diff_parent(*m_image_ctx.parent, {}, nullptr, 0, overlap,
-                                  true, true, &simple_diff_cb, &parent_diff);
+          DiffIterate diff_parent(*m_image_ctx.parent, {}, nullptr,
+                                  parent_extents[0].first,
+                                  parent_extents[0].second, true, true,
+                                  &simple_diff_cb, &parent_diff);
           r = diff_parent.execute();
           if (r < 0) {
             return r;

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -212,6 +212,29 @@ int DiffIterate<I>::diff_iterate(I *ictx,
 }
 
 template <typename I>
+std::pair<uint64_t, uint64_t> DiffIterate<I>::calc_object_diff_range() {
+  uint64_t period = m_image_ctx.get_stripe_period();
+  uint64_t first_period_off = round_down_to(m_offset, period);
+  uint64_t last_period_off = round_down_to(m_offset + m_length - 1, period);
+
+  striper::LightweightObjectExtents object_extents;
+  if (first_period_off != last_period_off) {
+    // map only the tail of the first period and the front of the last
+    // period instead of the entire range for efficiency
+    Striper::file_to_extents(m_image_ctx.cct, &m_image_ctx.layout,
+                             m_offset, first_period_off + period - m_offset,
+                             0, 0, &object_extents);
+    Striper::file_to_extents(m_image_ctx.cct, &m_image_ctx.layout,
+                        last_period_off, m_offset + m_length - last_period_off,
+                        0, 0, &object_extents);
+  } else {
+    Striper::file_to_extents(m_image_ctx.cct, &m_image_ctx.layout, m_offset,
+                             m_length, 0, 0, &object_extents);
+  }
+  return {object_extents.front().object_no, object_extents.back().object_no + 1};
+}
+
+template <typename I>
 int DiffIterate<I>::execute() {
   CephContext* cct = m_image_ctx.cct;
 
@@ -245,20 +268,24 @@ int DiffIterate<I>::execute() {
 
   int r;
   bool fast_diff_enabled = false;
+  uint64_t start_object_no, end_object_no;
   BitVector<2> object_diff_state;
   interval_set<uint64_t> parent_diff;
   if (m_whole_object) {
+    std::tie(start_object_no, end_object_no) = calc_object_diff_range();
+
     C_SaferCond ctx;
     auto req = object_map::DiffRequest<I>::create(&m_image_ctx, from_snap_id,
-                                                  end_snap_id, true,
+                                                  end_snap_id, start_object_no,
+                                                  end_object_no,
                                                   &object_diff_state, &ctx);
     req->send();
-
     r = ctx.wait();
     if (r < 0) {
       ldout(cct, 5) << "fast diff disabled" << dendl;
     } else {
       ldout(cct, 5) << "fast diff enabled" << dendl;
+      ceph_assert(object_diff_state.size() == end_object_no - start_object_no);
       fast_diff_enabled = true;
 
       // check parent overlap only if we are comparing to the beginning of time
@@ -306,7 +333,8 @@ int DiffIterate<I>::execute() {
       io::SparseExtents aggregate_sparse_extents;
       for (auto& [object, extents] : object_extents) {
         const uint64_t object_no = extents.front().objectno;
-        uint8_t diff_state = object_diff_state[object_no];
+        ceph_assert(object_no >= start_object_no && object_no < end_object_no);
+        uint8_t diff_state = object_diff_state[object_no - start_object_no];
         ldout(cct, 20) << "object " << object << ": diff_state="
                        << (int)diff_state << dendl;
 

--- a/src/librbd/api/DiffIterate.h
+++ b/src/librbd/api/DiffIterate.h
@@ -7,6 +7,7 @@
 #include "include/int_types.h"
 #include "common/bit_vector.hpp"
 #include "cls/rbd/cls_rbd_types.h"
+#include <utility>
 
 namespace librbd {
 
@@ -50,6 +51,8 @@ private:
       m_callback_arg(callback_arg)
   {
   }
+
+  std::pair<uint64_t, uint64_t> calc_object_diff_range();
 
   int execute();
 

--- a/src/librbd/api/DiffIterate.h
+++ b/src/librbd/api/DiffIterate.h
@@ -55,10 +55,6 @@ private:
   std::pair<uint64_t, uint64_t> calc_object_diff_range();
 
   int execute();
-
-  int diff_object_map(uint64_t from_snap_id, uint64_t to_snap_id,
-                      BitVector<2>* object_diff_state);
-
 };
 
 } // namespace api

--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -103,7 +103,7 @@ void ImageCopyRequest<I>::compute_diff() {
     ImageCopyRequest<I>, &ImageCopyRequest<I>::handle_compute_diff>(this);
   auto req = object_map::DiffRequest<I>::create(m_src_image_ctx,
                                                 m_src_snap_id_start,
-                                                m_src_snap_id_end, false,
+                                                m_src_snap_id_end, 0, UINT64_MAX,
                                                 &m_object_diff_state, ctx);
   req->send();
 }

--- a/src/librbd/object_map/DiffRequest.cc
+++ b/src/librbd/object_map/DiffRequest.cc
@@ -233,15 +233,12 @@ void DiffRequest<I>::handle_load_object_map(int r) {
   }
   ldout(cct, 20) << "computed overlap diffs" << dendl;
 
-  bool diff_from_start = (m_snap_id_start == 0);
   auto end_it = m_object_map.end();
   for (; it != end_it; ++it, ++diff_it, ++i) {
     uint8_t object_map_state = *it;
     if (object_map_state == OBJECT_NONEXISTENT) {
       *diff_it = DIFF_STATE_HOLE;
-    } else if (diff_from_start ||
-               (m_object_diff_state_valid &&
-                object_map_state != OBJECT_EXISTS_CLEAN)) {
+    } else if (m_current_snap_id != m_snap_id_start) {
       // diffing against the beginning of time or image was grown
       // (implicit) starting state is HOLE, this is the first object
       // map after
@@ -277,8 +274,6 @@ void DiffRequest<I>::handle_load_object_map(int r) {
                    << static_cast<uint32_t>(*it) << ")" << dendl;
   }
   ldout(cct, 20) << "computed resize diffs" << dendl;
-
-  m_object_diff_state_valid = true;
 
   std::shared_lock image_locker{m_image_ctx->image_lock};
   load_object_map(&image_locker);

--- a/src/librbd/object_map/DiffRequest.cc
+++ b/src/librbd/object_map/DiffRequest.cc
@@ -38,16 +38,19 @@ void DiffRequest<I>::send() {
 
   m_object_diff_state->clear();
 
-  // collect all the snap ids in the provided range (inclusive)
-  if (m_snap_id_start != 0) {
-    m_snap_ids.insert(m_snap_id_start);
-  }
-
+  // collect all the snap ids in the provided range (inclusive) unless
+  // this is diff-iterate against the beginning of time, in which case
+  // only the end version matters
   std::shared_lock image_locker{m_image_ctx->image_lock};
-  auto snap_info_it = m_image_ctx->snap_info.upper_bound(m_snap_id_start);
-  auto snap_info_it_end = m_image_ctx->snap_info.lower_bound(m_snap_id_end);
-  for (; snap_info_it != snap_info_it_end; ++snap_info_it) {
-    m_snap_ids.insert(snap_info_it->first);
+  if (!m_diff_iterate_range || m_snap_id_start != 0) {
+    if (m_snap_id_start != 0) {
+      m_snap_ids.insert(m_snap_id_start);
+    }
+    auto snap_info_it = m_image_ctx->snap_info.upper_bound(m_snap_id_start);
+    auto snap_info_it_end = m_image_ctx->snap_info.lower_bound(m_snap_id_end);
+    for (; snap_info_it != snap_info_it_end; ++snap_info_it) {
+      m_snap_ids.insert(snap_info_it->first);
+    }
   }
   m_snap_ids.insert(m_snap_id_end);
 

--- a/src/librbd/object_map/DiffRequest.cc
+++ b/src/librbd/object_map/DiffRequest.cc
@@ -176,15 +176,21 @@ void DiffRequest<I>::handle_load_object_map(int r) {
   }
 
   uint64_t prev_object_diff_state_size = m_object_diff_state->size();
-  if (prev_object_diff_state_size < num_objs) {
-    // the diff state should be the largest of all snapshots in the set
-    m_object_diff_state->resize(num_objs);
-  }
-  if (m_object_map.size() < m_object_diff_state->size()) {
-    // the image was shrunk so expanding the object map will flag end objects
-    // as non-existent and they will be compared against the previous object
-    // diff state
-    m_object_map.resize(m_object_diff_state->size());
+  if (m_diff_iterate_range) {
+    if (m_object_diff_state->size() != m_object_map.size()) {
+      m_object_diff_state->resize(m_object_map.size());
+    }
+  } else {
+    // for deep-copy, the object diff state should be the largest of
+    // all versions in the set, so it's only ever grown
+    if (m_object_diff_state->size() < m_object_map.size()) {
+      m_object_diff_state->resize(m_object_map.size());
+    } else if (m_object_diff_state->size() > m_object_map.size()) {
+      // the image was shrunk so expanding the object map will flag end objects
+      // as non-existent and they will be compared against the previous object
+      // diff state
+      m_object_map.resize(m_object_diff_state->size());
+    }
   }
 
   uint64_t overlap = std::min(m_object_map.size(), prev_object_diff_state_size);

--- a/src/librbd/object_map/DiffRequest.h
+++ b/src/librbd/object_map/DiffRequest.h
@@ -21,21 +21,20 @@ namespace object_map {
 template <typename ImageCtxT>
 class DiffRequest {
 public:
-  static DiffRequest* create(ImageCtxT* image_ctx, uint64_t snap_id_start,
-                             uint64_t snap_id_end, bool diff_iterate_range,
+  static DiffRequest* create(ImageCtxT* image_ctx,
+                             uint64_t snap_id_start, uint64_t snap_id_end,
+                             uint64_t start_object_no, uint64_t end_object_no,
                              BitVector<2>* object_diff_state,
                              Context* on_finish) {
     return new DiffRequest(image_ctx, snap_id_start, snap_id_end,
-                           diff_iterate_range, object_diff_state, on_finish);
+                           start_object_no, end_object_no, object_diff_state,
+                           on_finish);
   }
 
-  DiffRequest(ImageCtxT* image_ctx, uint64_t snap_id_start,
-              uint64_t snap_id_end, bool diff_iterate_range,
-              BitVector<2>* object_diff_state, Context* on_finish)
-    : m_image_ctx(image_ctx), m_snap_id_start(snap_id_start),
-      m_snap_id_end(snap_id_end), m_diff_iterate_range(diff_iterate_range),
-      m_object_diff_state(object_diff_state), m_on_finish(on_finish) {
-  }
+  DiffRequest(ImageCtxT* image_ctx,
+              uint64_t snap_id_start, uint64_t snap_id_end,
+              uint64_t start_object_no, uint64_t end_object_no,
+              BitVector<2>* object_diff_state, Context* on_finish);
 
   void send();
 
@@ -58,7 +57,8 @@ private:
   ImageCtxT* m_image_ctx;
   uint64_t m_snap_id_start;
   uint64_t m_snap_id_end;
-  bool m_diff_iterate_range;
+  uint64_t m_start_object_no;
+  uint64_t m_end_object_no;
   BitVector<2>* m_object_diff_state;
   Context* m_on_finish;
 
@@ -71,6 +71,8 @@ private:
   BitVector<2> m_object_map;
 
   bufferlist m_out_bl;
+
+  bool is_diff_iterate() const;
 
   void load_object_map(std::shared_lock<ceph::shared_mutex>* image_locker);
   void handle_load_object_map(int r);

--- a/src/librbd/object_map/DiffRequest.h
+++ b/src/librbd/object_map/DiffRequest.h
@@ -69,7 +69,6 @@ private:
   uint64_t m_current_size = 0;
 
   BitVector<2> m_object_map;
-  bool m_object_diff_state_valid = false;
 
   bufferlist m_out_bl;
 

--- a/src/librbd/object_map/DiffRequest.h
+++ b/src/librbd/object_map/DiffRequest.h
@@ -68,8 +68,6 @@ private:
 
   uint64_t m_current_size = 0;
 
-  BitVector<2> m_object_map;
-
   bufferlist m_out_bl;
 
   bool is_diff_iterate() const;

--- a/src/librbd/object_map/DiffRequest.h
+++ b/src/librbd/object_map/DiffRequest.h
@@ -72,6 +72,9 @@ private:
 
   bool is_diff_iterate() const;
 
+  int prepare_for_object_map();
+  int process_object_map(const BitVector<2>& object_map);
+
   void load_object_map(std::shared_lock<ceph::shared_mutex>* image_locker);
   void handle_load_object_map(int r);
 

--- a/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
@@ -92,7 +92,7 @@ struct DiffRequest<MockTestImageCtx> {
   static DiffRequest* s_instance;
   static DiffRequest* create(MockTestImageCtx *image_ctx,
                              uint64_t snap_id_start, uint64_t snap_id_end,
-                             bool diff_iterate_range,
+                             uint64_t start_object_no, uint64_t end_object_no,
                              BitVector<2>* object_diff_state,
                              Context* on_finish) {
     ceph_assert(s_instance != nullptr);

--- a/src/test/librbd/mock/MockObjectMap.h
+++ b/src/test/librbd/mock/MockObjectMap.h
@@ -4,18 +4,26 @@
 #ifndef CEPH_TEST_LIBRBD_MOCK_OBJECT_MAP_H
 #define CEPH_TEST_LIBRBD_MOCK_OBJECT_MAP_H
 
+#include "common/bit_vector.hpp"
 #include "librbd/Utils.h"
 #include "gmock/gmock.h"
 
 namespace librbd {
 
 struct MockObjectMap {
-  MOCK_METHOD1(at, uint8_t(uint64_t));
-  uint8_t operator[](uint64_t object_no) {
+  MOCK_CONST_METHOD1(at, uint8_t(uint64_t));
+  uint8_t operator[](uint64_t object_no) const {
     return at(object_no);
   }
 
   MOCK_CONST_METHOD0(size, uint64_t());
+
+  MOCK_CONST_METHOD0(with, ceph::BitVector<2>());
+  template <typename F, typename... Args>
+  auto with_object_map(F&& f, Args&&... args) const {
+    const ceph::BitVector<2> object_map = with();
+    return std::forward<F>(f)(object_map, std::forward<Args>(args)...);
+  }
 
   MOCK_METHOD1(open, void(Context *on_finish));
   MOCK_METHOD1(close, void(Context *on_finish));

--- a/src/test/librbd/object_map/test_mock_DiffRequest.cc
+++ b/src/test/librbd/object_map/test_mock_DiffRequest.cc
@@ -207,7 +207,7 @@ TEST_P(TestMockObjectMapDiffRequest, InvalidStartSnap) {
   InSequence seq;
 
   C_SaferCond ctx;
-  auto req = new MockDiffRequest(&mock_image_ctx, CEPH_NOSNAP, 0,
+  auto req = new MockDiffRequest(&mock_image_ctx, CEPH_NOSNAP, CEPH_NOSNAP,
                                  is_diff_iterate(), &m_object_diff_state,
                                  &ctx);
   req->send();

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -6812,6 +6812,83 @@ TYPED_TEST(DiffIterateTest, DiffIterateUnaligned)
   ioctx.close();
 }
 
+TYPED_TEST(DiffIterateTest, DiffIterateTryAcquireLock)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, this->_rados.ioctx_create(this->m_pool_name.c_str(), ioctx));
+
+  {
+    librbd::RBD rbd;
+    int order = 22;
+    std::string name = this->get_temp_image_name();
+    ssize_t size = 20 << 20;
+
+    uint64_t object_size = 0;
+    if (this->whole_object) {
+      object_size = 1 << order;
+    }
+
+    ASSERT_EQ(0, create_image_pp(rbd, ioctx, name.c_str(), size, &order));
+
+    librbd::Image image1;
+    ASSERT_EQ(0, rbd.open(ioctx, image1, name.c_str(), NULL));
+
+    ceph::bufferlist bl;
+    bl.append(std::string(256, '1'));
+    ASSERT_EQ(256, image1.write(0, 256, bl));
+    ASSERT_EQ(0, image1.flush());
+
+    bool lock_owner;
+    ASSERT_EQ(0, image1.is_exclusive_lock_owner(&lock_owner));
+    ASSERT_TRUE(lock_owner);
+
+    librbd::Image image2;
+    ASSERT_EQ(0, rbd.open(ioctx, image2, name.c_str(), NULL));
+
+    std::vector<diff_extent> extents;
+    ASSERT_EQ(0, image2.diff_iterate2(NULL, 0, size, true, this->whole_object,
+                                      vector_iterate_cb, &extents));
+    ASSERT_EQ(1u, extents.size());
+    ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
+    extents.clear();
+
+    ASSERT_EQ(0, image2.is_exclusive_lock_owner(&lock_owner));
+    ASSERT_FALSE(lock_owner);
+
+    ASSERT_EQ(0, image1.close());
+    ASSERT_EQ(0, image2.diff_iterate2(NULL, 0, size, true, this->whole_object,
+                                      vector_iterate_cb, &extents));
+    ASSERT_EQ(1u, extents.size());
+    ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
+    extents.clear();
+
+    ASSERT_EQ(0, image2.is_exclusive_lock_owner(&lock_owner));
+    ASSERT_FALSE(lock_owner);
+
+    sleep(5);
+    ASSERT_EQ(0, image2.diff_iterate2(NULL, 0, size, true, this->whole_object,
+                                      vector_iterate_cb, &extents));
+    ASSERT_EQ(1u, extents.size());
+    ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
+    extents.clear();
+
+    ASSERT_EQ(0, image2.is_exclusive_lock_owner(&lock_owner));
+    if (this->whole_object &&
+        (is_feature_enabled(RBD_FEATURE_OBJECT_MAP) ||
+         is_feature_enabled(RBD_FEATURE_FAST_DIFF))) {
+      ASSERT_TRUE(lock_owner);
+    } else {
+      ASSERT_FALSE(lock_owner);
+    }
+
+    ASSERT_PASSED(this->validate_object_map, image2);
+  }
+
+  ioctx.close();
+}
+
 TYPED_TEST(DiffIterateTest, DiffIterateStriping)
 {
   REQUIRE_FEATURE(RBD_FEATURE_STRIPINGV2);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64106

---

backport of https://github.com/ceph/ceph/pull/55127
parent tracker: https://tracker.ceph.com/issues/63341