### PR TITLE
pacific: admin/doc-requirements: bump Sphinx to 5.0.2

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,4 +1,4 @@
-Sphinx == 4.4.0
+Sphinx == 5.0.2
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
 breathe >= 4.20.0
 Jinja2


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/55185 to pacific to unbreak docs checks.