### PR TITLE
[DNM]install-deps: add -f flag to apt-get while installing gcc

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -74,7 +74,7 @@ for i in $(seq 20 -1 11); do
   fi
 done
 ARGS+=" -DCMAKE_CXX_COMPILER=$cxx_compiler"
-ARGS+=" -DCMAKE_C_COMPILER=$c_compiler"
+ARGS+=" -DCMAKE_C_COMPILER=$c_compiler --trace-expand"
 
 mkdir $BUILD_DIR
 cd $BUILD_DIR

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -11,7 +11,7 @@
 #  License as published by the Free Software Foundation; either
 #  version 2.1 of the License, or (at your option) any later version.
 #
-set -e
+set -ex
 
 if ! [ "${_SOURCED_LIB_BUILD}" = 1 ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -461,7 +461,10 @@ else
                 ;;
             *Jammy*)
                 [ ! $NO_BOOST_PKGS ] && install_boost_on_ubuntu jammy
-                $SUDO apt-get install -y gcc
+		dpkg -l | grep libisl
+		dpkg -l | grep san
+		dpkg -l | grep gcc
+                $SUDO apt-get install -f -y gcc
                 ;;
             *)
                 $SUDO apt-get install -y gcc


### PR DESCRIPTION
while installing gcc, error log shows:
`
The following packages have unmet dependencies:
 cpp-11 : Depends: libisl19 (>= 0.15) but it is not installable
 gcc-11 : Depends: libisl19 (>= 0.15) but it is not installable
E: Unable to correct problems, you have held broken packages. 
`
Add -f, --fix-broken to fix unmet dependencies.

Fixes: https://tracker.ceph.com/issues/64121





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
