### PR TITLE
rgw: logging of additional fields in process_request

### DIFF
--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -464,6 +464,12 @@ done:
 	  << " op status=" << op_ret
 	  << " http_status=" << s->err.http_ret
 	  << " latency=" << lat
+	  << " trans_id=" << s->trans_id
+	  << " user=" << (s->user ? s->user->get_id().id : "<none>")
+	  << " tenant=" << (!s->bucket_tenant.empty() ? s->bucket_tenant : "<none>")
+	  << " bucket=" << (s->bucket ? s->bucket->get_name() : "<none>")
+	  << " object=" << (s->object ? s->object->get_name() : "<none>")
+	  << " path=" << s->info.request_uri << (s->info.request_params.empty() ? "" : "?") << s->info.request_params
 	  << " ======"
 	  << dendl;
 


### PR DESCRIPTION
With default logging levels it is complicated to find request details in the logs. I propose adding this fields in the logging event after request is done. This will also make it easier to extract this information by parsing them.

Added logging for:
	
- transaction id
- username
- tenant
- bucket
- object
- query params

This is how it is going to look like:
`
2024-01-23T13:15:27.942+0300 7f9c6fff7640  1 ====== req done req=0x7f9d7a6c6600 op status=0 http_status=200 latency=0.016000219s trans_id=tx000000faab93764214243-0065af91bf-1624-default user=johndoe tenant=<none> bucket=test object=<none> path=/test?delimiter=%2F&list-type=2&prefix= ======
`

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
