### PR TITLE
osd: remove superfluous '>' in spg_t formatter

### DIFF
--- a/src/osd/osd_types_fmt.h
+++ b/src/osd/osd_types_fmt.h
@@ -131,7 +131,7 @@ struct fmt::formatter<spg_t> {
     if (shard_id_t::NO_SHARD == spg.shard.id) {
       return fmt::format_to(ctx.out(), "{}", spg.pgid);
     } else {
-      return fmt::format_to(ctx.out(), "{}s{}>", spg.pgid, spg.shard.id);
+      return fmt::format_to(ctx.out(), "{}s{}", spg.pgid, spg.shard.id);
     }
   }
 };


### PR DESCRIPTION
Fixing the formatting of EC spg_t's, from 'xx.yysz>' to 'xx.yysz'.