### PR TITLE
rgw/multisite: reduce the log volume when syncing

### DIFF
--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -460,12 +460,23 @@ done:
   if (latency) {
     *latency = lat;
   }
-  dout(1) << "====== req done req=" << hex << req << dec
-	  << " op status=" << op_ret
-	  << " http_status=" << s->err.http_ret
-	  << " latency=" << lat
-	  << " ======"
-	  << dendl;
+  // admin and system users ops log the 'req done' line at log level 2
+  if(s->user->get_info().admin || s->user->get_info().system) {
+    req_done_output<2>(req, op_ret, s->err.http_ret, lat);
+  } else {
+    req_done_output<1>(req, op_ret, s->err.http_ret, lat);
+  }
 
   return (ret < 0 ? ret : s->err.ret);
 } /* process_request */
+
+template <const int LogLevelV>
+void req_done_output(RGWRequest *const req, const int op_status, const int http_status, const ceph::coarse_real_clock::duration latency)
+{
+  dout(LogLevelV) << "====== req done req=" << hex << req << dec
+    << " op status=" << op_status
+    << " http_status=" << http_status
+    << " latency=" << latency
+    << " ======"
+    << dendl;
+}

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -148,6 +148,9 @@ extern int process_request(const RGWProcessEnv& penv,
                            ceph::coarse_real_clock::duration* latency,
                            int* http_ret = nullptr);
 
+template <const int LogLevelV>
+void req_done_output(RGWRequest *const req, const int op_status, const int http_status, const ceph::coarse_real_clock::duration latency);
+
 extern int rgw_process_authenticated(RGWHandler_REST* handler,
                                      RGWOp*& op,
                                      RGWRequest* req,


### PR DESCRIPTION
change the 'req done' log line
`2024-01-23T17:05:35.886+0200 7ffeca1ac640  1 ====== req done req=0x7ffec01977a8 op status=0 http_status=200 latency=0.000000000s ======` 
of multisite sync operations from log level 1 to log level 2, eliding those logs at the default log level 1 reduced the disk space utilization of RGW logs of the MS syncing RGWs with the test workload by 10.8% (on secondary zone) and by 31.1% on the primary

example data collection of logs disk size utilization reduction  (with `ncdu`) of the logs generated after the test workload 
 if syncing 100K objects spread over 10 buckets:

Primary zone:
```
 160.9 MiB [###########################] /lvl-before                                                                                                                                        
 110.8 MiB [##################         ] /lvl-after
```
Secondary zone:
```
   12.0 MiB [###########################] /lvl-before                                                                                                                                        
   10.7 MiB [########################   ] /lvl-after
```


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
