### PR TITLE
rbd-nbd: fix resize of images mapped using netlink

### DIFF
--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -202,8 +202,11 @@ provisioned=`rbd -p ${POOL} --format xml du ${IMAGE} |
 used=`rbd -p ${POOL} --format xml du ${IMAGE} |
   $XMLSTARLET sel -t -m "//stats/images/image/used_size" -v .`
 [ "${used}" -lt "${provisioned}" ]
+unmap_device ${DEV} ${PID}
 
 # resize test
+DEV=`_sudo rbd device -t nbd -o try-netlink map ${POOL}/${IMAGE}`
+get_pid ${POOL}
 devname=$(basename ${DEV})
 blocks=$(awk -v dev=${devname} '$4 == dev {print $3}' /proc/partitions)
 test -n "${blocks}"
@@ -216,9 +219,9 @@ rbd resize ${POOL}/${IMAGE} --allow-shrink --size ${SIZE}M
 blocks2=$(awk -v dev=${devname} '$4 == dev {print $3}' /proc/partitions)
 test -n "${blocks2}"
 test ${blocks2} -eq ${blocks}
+unmap_device ${DEV} ${PID}
 
 # read-only option test
-unmap_device ${DEV} ${PID}
 DEV=`_sudo rbd --device-type nbd map --read-only ${POOL}/${IMAGE}`
 PID=$(rbd device --device-type nbd list | awk -v pool=${POOL} -v img=${IMAGE} -v dev=${DEV} \
     '$2 == pool && $3 == img && $5 == dev {print $1}')

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -1332,21 +1332,21 @@ static int netlink_resize(int nbd_index, const std::string& cookie,
 
   sock = netlink_init(&nl_id);
   if (!sock) {
-    cerr << "rbd-nbd: Netlink interface not supported." << std::endl;
-    return 1;
+    derr << __func__ << ": netlink interface not supported" << dendl;
+    return -EINVAL;
   }
 
   nl_socket_modify_cb(sock, NL_CB_VALID, NL_CB_CUSTOM, genl_handle_msg, NULL);
 
   msg = nlmsg_alloc();
   if (!msg) {
-    cerr << "rbd-nbd: Could not allocate netlink message." << std::endl;
+    derr << __func__ << ": could not allocate netlink message" << dendl;
     goto free_sock;
   }
 
   if (!genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, nl_id, 0, 0,
                    NBD_CMD_RECONFIGURE, 0)) {
-    cerr << "rbd-nbd: Could not setup message." << std::endl;
+    derr << __func__ << ": could not setup netlink message" << dendl;
     goto free_msg;
   }
 
@@ -1357,7 +1357,8 @@ static int netlink_resize(int nbd_index, const std::string& cookie,
 
   ret = nl_send_sync(sock, msg);
   if (ret < 0) {
-    cerr << "rbd-nbd: netlink resize failed: " << nl_geterror(ret) << std::endl;
+    derr << __func__ << ": netlink resize failed: " << nl_geterror(ret)
+         << dendl;
     goto free_sock;
   }
 

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -194,7 +194,8 @@ static EventSocket terminate_event_sock;
 static int parse_args(vector<const char*>& args, std::ostream *err_msg,
                       Config *cfg);
 static int netlink_disconnect(int index);
-static int netlink_resize(int nbd_index, uint64_t size);
+static int netlink_resize(int nbd_index, const std::string& cookie,
+                          uint64_t size);
 
 static int run_quiesce_hook(const std::string &quiesce_hook,
                             const std::string &devpath,
@@ -744,6 +745,7 @@ private:
   ceph::mutex lock = ceph::make_mutex("NBDWatchCtx::Locker");
   bool notify = false;
   bool terminated = false;
+  std::string cookie;
 
   bool wait_notify() {
     dout(10) << __func__ << dendl;
@@ -779,11 +781,11 @@ private:
              << dendl;
       }
       if (use_netlink) {
-        ret = netlink_resize(nbd_index, new_size);
+        ret = netlink_resize(nbd_index, cookie, new_size);
       } else {
         ret = ioctl(fd, NBD_SET_SIZE, new_size);
         if (ret < 0) {
-          derr << "resize failed: " << cpp_strerror(errno) << dendl;
+          derr << "ioctl resize failed: " << cpp_strerror(errno) << dendl;
         }
       }
       if (!ret) {
@@ -805,13 +807,15 @@ public:
               bool _use_netlink,
               librados::IoCtx &_io_ctx,
               librbd::Image &_image,
-              unsigned long _size)
+              unsigned long _size,
+              std::string _cookie)
     : fd(_fd)
     , nbd_index(_nbd_index)
     , use_netlink(_use_netlink)
     , io_ctx(_io_ctx)
     , image(_image)
     , size(_size)
+    , cookie(std::move(_cookie))
   {
     handle_notify_thread = make_named_thread("rbd_handle_notify",
                                              &NBDWatchCtx::handle_notify_entry,
@@ -1319,7 +1323,8 @@ static int netlink_disconnect_by_path(const std::string& devpath)
   return netlink_disconnect(index);
 }
 
-static int netlink_resize(int nbd_index, uint64_t size)
+static int netlink_resize(int nbd_index, const std::string& cookie,
+                          uint64_t size)
 {
   struct nl_sock *sock;
   struct nl_msg *msg;
@@ -1347,6 +1352,8 @@ static int netlink_resize(int nbd_index, uint64_t size)
 
   NLA_PUT_U32(msg, NBD_ATTR_INDEX, nbd_index);
   NLA_PUT_U64(msg, NBD_ATTR_SIZE_BYTES, size);
+  if (!cookie.empty())
+    NLA_PUT_STRING(msg, NBD_ATTR_BACKEND_IDENTIFIER, cookie.c_str());
 
   ret = nl_send_sync(sock, msg);
   if (ret < 0) {
@@ -1896,7 +1903,7 @@ static int do_map(int argc, const char *argv[], Config *cfg, bool reconnect)
     uint64_t handle;
 
     NBDWatchCtx watch_ctx(nbd, nbd_index, use_netlink, io_ctx, image,
-                          info.size);
+                          info.size, cfg->cookie);
     r = image.update_watch(&watch_ctx, &handle);
     if (r < 0)
       goto close_nbd;


### PR DESCRIPTION
Include device identifier or cookie in the message sent to the kernel
to resize images mapped to NBD devices using netlink. Otherwise,
netlink_resize() fails and the size of the device isn't updated.

Fixes: https://tracker.ceph.com/issues/64139
Signed-off-by: Ramana Raja <rraja@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
