### PR TITLE
Revert "crimson/os/alienstore/alien_log: _flush concurrently"

### DIFF
--- a/src/crimson/os/alienstore/alien_log.cc
+++ b/src/crimson/os/alienstore/alien_log.cc
@@ -17,7 +17,8 @@ CnLog::~CnLog() {
 }
 
 void CnLog::_flush(EntryVector& q, bool crash) {
-  std::ignore = seastar::alien::submit_to(inst, shard, [&q] {
+  // XXX: the waiting here will block the thread for an indeterministic peroid
+  seastar::alien::submit_to(inst, shard, [&q] {
     for (auto& it : q) {
       crimson::get_logger(it.m_subsys).log(
         crimson::to_log_level(it.m_prio),
@@ -25,7 +26,7 @@ void CnLog::_flush(EntryVector& q, bool crash) {
         it.strv());
     }
     return seastar::make_ready_future<>();
-  });
+  }).wait();
   q.clear();
   return;
 }


### PR DESCRIPTION
Lifecycle on the EntryVector needs to be handled.  Let's revert for now.


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
