### PR TITLE
osd: add mclock queue perfcounter

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10827,7 +10827,8 @@ OSDShard::OSDShard(
     shard_lock{make_mutex(shard_lock_name)},
     scheduler(ceph::osd::scheduler::make_scheduler(
       cct, osd->whoami, osd->num_shards, id, osd->store->is_rotational(),
-      osd->store->get_type(), osd_op_queue, osd_op_queue_cut_off, osd->monc)),
+      osd->store->get_type(), osd_op_queue, osd_op_queue_cut_off, osd->monc,
+      osd->logger)),
     context_queue(sdata_wait_lock, sdata_cond)
 {
   dout(0) << "using op scheduler " << *scheduler << dendl;

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -338,6 +338,16 @@ PerfCounters *build_osd_logger(CephContext *cct) {
       l_osd_scrub_reservation_dur_hist, "scrub_resrv_repnum_vs_duration",
       rsrv_hist_x_axis_config, rsrv_hist_y_axis_config, "Histogram of scrub replicas reservation duration");
 
+  // mclock QoS queue op counter
+  osd_plb.add_u64_counter(l_osd_mclock_immediate_op, "mclock_immediate_op",
+    "osd op_scheduler_class::immediate type op count");
+  osd_plb.add_u64_counter(l_osd_mclock_client_op, "mclock_client_op",
+    "osd op_scheduler_class::client type op count");
+  osd_plb.add_u64_counter(l_osd_mclock_recovery_op, "mclock_recovery_op",
+    "osd op_scheduler_class::background_recovery type op count");
+  osd_plb.add_u64_counter(l_osd_mclock_best_effort_op, "mclock_best_effort_op",
+    "osd op_scheduler_class::background_best_effort type op count");
+
   return osd_plb.create_perf_counters();
 }
 

--- a/src/osd/osd_perf_counters.h
+++ b/src/osd/osd_perf_counters.h
@@ -136,6 +136,12 @@ enum {
   // are labeled, and histograms do not fully support labels.
   l_osd_scrub_reservation_dur_hist,
 
+  // mclock queue
+  l_osd_mclock_immediate_op,
+  l_osd_mclock_client_op,
+  l_osd_mclock_recovery_op,
+  l_osd_mclock_best_effort_op,
+
   l_osd_last,
 };
 

--- a/src/osd/scheduler/OpScheduler.cc
+++ b/src/osd/scheduler/OpScheduler.cc
@@ -24,7 +24,8 @@ namespace ceph::osd::scheduler {
 OpSchedulerRef make_scheduler(
   CephContext *cct, int whoami, uint32_t num_shards, int shard_id,
   bool is_rotational, std::string_view osd_objectstore,
-  op_queue_type_t osd_scheduler, unsigned op_queue_cut_off, MonClient *monc)
+  op_queue_type_t osd_scheduler, unsigned op_queue_cut_off, MonClient *monc,
+  PerfCounters *logger)
 {
   // Force the use of 'wpq' scheduler for filestore OSDs.
   // The 'mclock_scheduler' is not supported for filestore OSDs.
@@ -41,7 +42,7 @@ OpSchedulerRef make_scheduler(
     // default is 'mclock_scheduler'
     return std::make_unique<
       mClockScheduler>(cct, whoami, num_shards, shard_id, is_rotational,
-        op_queue_cut_off, monc);
+        op_queue_cut_off, monc, logger);
   } else {
     ceph_assert("Invalid choice of wq" == 0);
   }

--- a/src/osd/scheduler/OpScheduler.h
+++ b/src/osd/scheduler/OpScheduler.h
@@ -68,7 +68,8 @@ using OpSchedulerRef = std::unique_ptr<OpScheduler>;
 OpSchedulerRef make_scheduler(
   CephContext *cct, int whoami, uint32_t num_shards, int shard_id,
   bool is_rotational, std::string_view osd_objectstore,
-  op_queue_type_t osd_scheduler, unsigned op_queue_cut_off, MonClient *monc);
+  op_queue_type_t osd_scheduler, unsigned op_queue_cut_off, MonClient *monc,
+  PerfCounters *logger);
 
 /**
  * Implements OpScheduler in terms of OpQueue

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -98,6 +98,7 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
   const bool is_rotational;
   const unsigned cutoff_priority;
   MonClient *monc;
+  PerfCounters *logger = nullptr;
 
   /**
    * osd_bandwidth_cost_per_io
@@ -219,7 +220,7 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
 public: 
   mClockScheduler(CephContext *cct, int whoami, uint32_t num_shards,
     int shard_id, bool is_rotational, unsigned cutoff_priority,
-    MonClient *monc);
+    MonClient *monc, PerfCounters *logger);
   ~mClockScheduler() override;
 
   /// Calculate scaled cost per item

--- a/src/test/osd/TestMClockScheduler.cc
+++ b/src/test/osd/TestMClockScheduler.cc
@@ -47,7 +47,7 @@ public:
     cutoff_priority(12),
     monc(nullptr),
     q(g_ceph_context, whoami, num_shards, shard_id, is_rotational,
-      cutoff_priority, monc),
+      cutoff_priority, monc, nullptr),
     client1(1001),
     client2(9999),
     client3(100000001)


### PR DESCRIPTION
```
Easy to visualize the number of ops
in each subqueue of mclock.

Add request statistics for each
op_scheduler_class

ceph daemon osd.0 perf dump osd
{
    "osd": {
        "mclock_immdiate_op": 640,
        "mclock_client_op": 1229,
        "mclock_recovery_op": 887,
        "mclock_best_effort_op": 925
    }
}
```

https://tracker.ceph.com/issues/64167