### PR TITLE
qa/workunits/rados/test.sh: fix GTEST_OUTPUT path

### DIFF
--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -427,7 +427,7 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
                         logger=log.getChild(role),
                         args=args + optional_args,
                         label="workunit test {workunit}".format(workunit=workunit),
-                        xml_path_regex=f'{testdir}/archive/gtest_xml_report-*.xml',
+                        xml_path_regex=f'{testdir}/archive/unit_test_xml_report/*.xml',
                         output_yaml=os.path.join(ctx.archive, 'unit_test_summary.yaml'),
                     )
                 else:

--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -12,7 +12,8 @@ function cleanup() {
 }
 trap cleanup EXIT ERR HUP INT QUIT
 
-GTEST_OUTPUT="xml:/home/ubuntu/cephtest/archive/gtest_xml_report"
+GTEST_OUTPUT_DIR=${TESTDIR:-$(mktemp -d)}/archive/unit_test_xml_report
+mkdir -p $GTEST_OUTPUT_DIR
 
 declare -A pids
 
@@ -39,7 +40,7 @@ do
     if [ $parallel -eq 1 ]; then
 	r=`printf '%25s' $f`
 	ff=`echo $f | awk '{print $1}'`
-	bash -o pipefail -exc "ceph_test_rados_$f --gtest_output=$GTEST_OUTPUT-$f.xml $color 2>&1 | tee ceph_test_rados_$ff.log | sed \"s/^/$r: /\"" &
+	bash -o pipefail -exc "ceph_test_rados_$f --gtest_output=xml:$GTEST_OUTPUT_DIR/$f.xml $color 2>&1 | tee ceph_test_rados_$ff.log | sed \"s/^/$r: /\"" &
 	pid=$!
 	echo "test $f on pid $pid"
 	pids[$f]=$pid


### PR DESCRIPTION
Currently, GTEST_OUTPUT is hardcoded to
'/home/ubuntu/cephtest/archive/gtest_xml_report'.
It causes errors on non-ubuntu OS.

This PR changes that to instead save all xml outputs to TESTDIR or new tmp directory. This still saves xml files in teuthology archive and fixes potential errors for local test runs on non-ubuntu based OS.

Bug introduced by commit: https://github.com/ceph/ceph/pull/54209/commits/ccf2bba418f2b10ea39d3699aea79baf9563a68f
Success teuthology output: https://pulpito.ceph.com/vallariag-2024-01-24_09:38:39-rados:monthrash-main-distro-default-smithi/
Teuthology run with error: https://pulpito.ceph.com/vallariag-2024-02-03_16:55:25-rados:monthrash-wip-vallariag-centos9-only-distro-default-smithi/


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
