### PR TITLE
reef: src/mount: kernel mount command returning misleading error message

### DIFF
--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -912,7 +912,8 @@ static int do_mount(const char *dev, const char *node,
 			fprintf(stderr, "mount error: ceph filesystem not supported by the system\n");
 			break;
 		case EHOSTUNREACH:
-			fprintf(stderr, "mount error: no mds server is up or the cluster is laggy\n");
+			fprintf(stderr, "mount error: no mds (Metadata Server) is up. "
+			"The cluster might be laggy, or you may not be authorized\n");
 			break;
 		default:
 			fprintf(stderr, "mount error %d = %s\n", errno, strerror(errno));


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64098

---

backport of https://github.com/ceph/ceph/pull/54972
parent tracker: https://tracker.ceph.com/issues/63866

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh