### PR TITLE
mgr/dashboard:  Code refactor rgw migrate component for using correctly the MIGRATE action verb

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-migrate/rgw-multisite-migrate.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-migrate/rgw-multisite-migrate.component.html
@@ -146,7 +146,7 @@
     </div>
     <div class="modal-footer">
       <cd-form-button-panel (submitActionEvent)="submit()"
-                            [submitText]="actionLabels.MIGRATE"
+                            [submitText]="actionLabels.MIGRATE + ' ' + 'to Multi-site'"
                             [form]="multisiteMigrateForm"></cd-form-button-panel>
     </div>
     </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-migrate/rgw-multisite-migrate.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-migrate/rgw-multisite-migrate.component.ts
@@ -181,7 +181,7 @@ export class RgwMultisiteMigrateComponent implements OnInit {
       () => {
         this.notificationService.show(
           NotificationType.success,
-          $localize`${this.actionLabels.MIGRATE} done successfully`
+          $localize`Migration done successfully`
         );
         this.submitAction.emit();
         this.activeModal.close();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
@@ -150,7 +150,7 @@ export class ActionLabelsI18n {
 
     this.IMPORT = $localize`Import`;
 
-    this.MIGRATE = $localize`Migrate to Multi-site`;
+    this.MIGRATE = $localize`Migrate`;
 
     /* Destroy an existing item */
     this.DELETE = $localize`Delete`;


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/64152, a followup from https://github.com/ceph/ceph/pull/55270#discussion_r1464338212

this.MIGRATE = $localize`Migrate to Multi-Site`;

Just like other action verbs we should set this.Migrate = "MIGRATE" only. This will require rephrasing in the following places as well:
1. https://github.com/ceph/ceph/blob/d3256c484136a1b32b79a904861f681a9248ba3c/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-details/rgw-multisite-details.component.ts#L223-L228

2. https://github.com/ceph/ceph/blob/d3256c484136a1b32b79a904861f681a9248ba3c/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-migrate/rgw-multisite-migrate.component.ts#L180-L18

![Screenshot from 2024-01-25 17-19-35](https://github.com/ceph/ceph/assets/25664409/c22096ca-faaf-4f35-b346-5c293b067af9)
![Screenshot from 2024-01-25 17-19-46](https://github.com/ceph/ceph/assets/25664409/69ae28df-48c6-4ccd-9e0c-300413a8489d)


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
