### PR TITLE
mon: zero-initialize MonCommand::flags

### DIFF
--- a/src/mon/MonCommand.h
+++ b/src/mon/MonCommand.h
@@ -22,7 +22,7 @@ struct MonCommand {
   std::string helpstring;
   std::string module;
   std::string req_perms;
-  uint64_t flags;
+  uint64_t flags = 0;
 
   // MonCommand flags
   static const uint64_t FLAG_NONE       = 0;


### PR DESCRIPTION
causing failures in check-generated.sh:
```
2 MonCommand
/tmp/typ-qmnDZ1ahR /tmp/typ-lIgJTZiUe differ: byte 100, line 6 **** MonCommand test 1 dump_json check failed ****
   ceph-dencoder type MonCommand select_test 1 dump_json > /tmp/typ-qmnDZ1ahR
   ceph-dencoder type MonCommand select_test 1 encode decode dump_json > /tmp/typ-lIgJTZiUe
6c6
<     "flags": 94661933599904
---
>     "flags": 94342467308704
```
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
