### PR TITLE
quincy: rbd-nbd: fix resize of images mapped using netlink

### DIFF
--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -202,8 +202,11 @@ provisioned=`rbd -p ${POOL} --format xml du ${IMAGE} |
 used=`rbd -p ${POOL} --format xml du ${IMAGE} |
   $XMLSTARLET sel -t -m "//stats/images/image/used_size" -v .`
 [ "${used}" -lt "${provisioned}" ]
+unmap_device ${DEV} ${PID}
 
 # resize test
+DEV=`_sudo rbd device -t nbd -o try-netlink map ${POOL}/${IMAGE}`
+get_pid ${POOL}
 devname=$(basename ${DEV})
 blocks=$(awk -v dev=${devname} '$4 == dev {print $3}' /proc/partitions)
 test -n "${blocks}"
@@ -216,9 +219,9 @@ rbd resize ${POOL}/${IMAGE} --allow-shrink --size ${SIZE}M
 blocks2=$(awk -v dev=${devname} '$4 == dev {print $3}' /proc/partitions)
 test -n "${blocks2}"
 test ${blocks2} -eq ${blocks}
+unmap_device ${DEV} ${PID}
 
 # read-only option test
-unmap_device ${DEV} ${PID}
 DEV=`_sudo rbd --device-type nbd map --read-only ${POOL}/${IMAGE}`
 PID=$(rbd device --device-type nbd list | awk -v pool=${POOL} -v img=${IMAGE} -v dev=${DEV} \
     '$2 == pool && $3 == img && $5 == dev {print $1}')

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -1295,21 +1295,21 @@ static int netlink_resize(int nbd_index, const std::string& cookie,
 
   sock = netlink_init(&nl_id);
   if (!sock) {
-    cerr << "rbd-nbd: Netlink interface not supported." << std::endl;
-    return 1;
+    derr << __func__ << ": netlink interface not supported" << dendl;
+    return -EINVAL;
   }
 
   nl_socket_modify_cb(sock, NL_CB_VALID, NL_CB_CUSTOM, genl_handle_msg, NULL);
 
   msg = nlmsg_alloc();
   if (!msg) {
-    cerr << "rbd-nbd: Could not allocate netlink message." << std::endl;
+    derr << __func__ << ": could not allocate netlink message" << dendl;
     goto free_sock;
   }
 
   if (!genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, nl_id, 0, 0,
                    NBD_CMD_RECONFIGURE, 0)) {
-    cerr << "rbd-nbd: Could not setup message." << std::endl;
+    derr << __func__ << ": could not setup netlink message" << dendl;
     goto free_msg;
   }
 
@@ -1320,7 +1320,8 @@ static int netlink_resize(int nbd_index, const std::string& cookie,
 
   ret = nl_send_sync(sock, msg);
   if (ret < 0) {
-    cerr << "rbd-nbd: netlink resize failed: " << nl_geterror(ret) << std::endl;
+    derr << __func__ << ": netlink resize failed: " << nl_geterror(ret)
+         << dendl;
     goto free_sock;
   }
 

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -194,7 +194,8 @@ static EventSocket terminate_event_sock;
 static int parse_args(vector<const char*>& args, std::ostream *err_msg,
                       Config *cfg);
 static int netlink_disconnect(int index);
-static int netlink_resize(int nbd_index, uint64_t size);
+static int netlink_resize(int nbd_index, const std::string& cookie,
+                          uint64_t size);
 
 static int run_quiesce_hook(const std::string &quiesce_hook,
                             const std::string &devpath,
@@ -744,6 +745,7 @@ private:
   ceph::mutex lock = ceph::make_mutex("NBDWatchCtx::Locker");
   bool notify = false;
   bool terminated = false;
+  std::string cookie;
 
   bool wait_notify() {
     dout(10) << __func__ << dendl;
@@ -779,11 +781,11 @@ private:
              << dendl;
       }
       if (use_netlink) {
-        ret = netlink_resize(nbd_index, new_size);
+        ret = netlink_resize(nbd_index, cookie, new_size);
       } else {
         ret = ioctl(fd, NBD_SET_SIZE, new_size);
         if (ret < 0) {
-          derr << "resize failed: " << cpp_strerror(errno) << dendl;
+          derr << "ioctl resize failed: " << cpp_strerror(errno) << dendl;
         }
       }
       if (!ret) {
@@ -805,13 +807,15 @@ public:
               bool _use_netlink,
               librados::IoCtx &_io_ctx,
               librbd::Image &_image,
-              unsigned long _size)
+              unsigned long _size,
+              std::string _cookie)
     : fd(_fd)
     , nbd_index(_nbd_index)
     , use_netlink(_use_netlink)
     , io_ctx(_io_ctx)
     , image(_image)
     , size(_size)
+    , cookie(std::move(_cookie))
   {
     handle_notify_thread = make_named_thread("rbd_handle_notify",
                                              &NBDWatchCtx::handle_notify_entry,
@@ -1282,7 +1286,8 @@ static int netlink_disconnect_by_path(const std::string& devpath)
   return netlink_disconnect(index);
 }
 
-static int netlink_resize(int nbd_index, uint64_t size)
+static int netlink_resize(int nbd_index, const std::string& cookie,
+                          uint64_t size)
 {
   struct nl_sock *sock;
   struct nl_msg *msg;
@@ -1310,6 +1315,8 @@ static int netlink_resize(int nbd_index, uint64_t size)
 
   NLA_PUT_U32(msg, NBD_ATTR_INDEX, nbd_index);
   NLA_PUT_U64(msg, NBD_ATTR_SIZE_BYTES, size);
+  if (!cookie.empty())
+    NLA_PUT_STRING(msg, NBD_ATTR_BACKEND_IDENTIFIER, cookie.c_str());
 
   ret = nl_send_sync(sock, msg);
   if (ret < 0) {
@@ -1852,7 +1859,7 @@ static int do_map(int argc, const char *argv[], Config *cfg, bool reconnect)
     uint64_t handle;
 
     NBDWatchCtx watch_ctx(nbd, nbd_index, use_netlink, io_ctx, image,
-                          info.size);
+                          info.size, cfg->cookie);
     r = image.update_watch(&watch_ctx, &handle);
     if (r < 0)
       goto close_nbd;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64180

---

backport of https://github.com/ceph/ceph/pull/55287
parent tracker: https://tracker.ceph.com/issues/64139

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh