### PR TITLE
rgw/rest: fix url decode of post params for iam/sts/sns

### DIFF
--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -152,7 +152,7 @@ class RGWPSCreateTopicOp : public RGWOp {
       return -EINVAL;
     }
     // Store topic Policy.
-    policy_text = url_decode(s->info.args.get("Policy"), true);
+    policy_text = s->info.args.get("Policy");
     if (!policy_text.empty() && !get_policy_from_text(s, policy_text)) {
       return -ERR_MALFORMED_DOC;
     }
@@ -562,7 +562,7 @@ class RGWPSSetTopicAttributesOp : public RGWOp {
         return -EINVAL;
       }
     } else if (attribute_name == "Policy") {
-      policy_text = url_decode(s->info.args.get("AttributeValue"), true);
+      policy_text = s->info.args.get("AttributeValue");
       if (!policy_text.empty() && !get_policy_from_text(s, policy_text)) {
         return -ERR_MALFORMED_DOC;
       }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5198,8 +5198,9 @@ void parse_post_action(const std::string& post_body, req_state* s)
           if (boost::starts_with(key, "Attributes.")) {
             update_attribute_map(t, map);
           } else {
+            constexpr bool in_query = true; // replace '+' with ' '
             s->info.args.append(t.substr(0, pos),
-                              url_decode(t.substr(pos+1, t.size() -1)));
+                              url_decode(t.substr(pos+1, t.size() -1), in_query));
           }
         }
       }

--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -92,9 +92,9 @@ uint64_t RGWPutUserPolicy::get_op()
 
 int RGWPutUserPolicy::get_params()
 {
-  policy_name = url_decode(s->info.args.get("PolicyName"), true);
-  user_name = url_decode(s->info.args.get("UserName"), true);
-  policy = url_decode(s->info.args.get("PolicyDocument"), true);
+  policy_name = s->info.args.get("PolicyName");
+  user_name = s->info.args.get("UserName");
+  policy = s->info.args.get("PolicyDocument");
 
   if (policy_name.empty() || user_name.empty() || policy.empty()) {
     ldpp_dout(this, 20) << "ERROR: one of policy name, user name or policy document is empty"


### PR DESCRIPTION
add the `in_query=true` argument to `url_decode()` to replace '+' with ' '

Fixes: https://tracker.ceph.com/issues/64189

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
