### PR TITLE
🧹build dependencies: centos9

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -213,6 +213,7 @@ BuildRequires:	selinux-policy-devel
 BuildRequires:	gperf
 BuildRequires:  cmake > 3.5
 BuildRequires:	fuse-devel
+BuildRequires:	git
 %if 0%{?fedora} || 0%{?suse_version} > 1500 || 0%{?rhel} == 9 || 0%{?openEuler}
 BuildRequires:	gcc-c++ >= 11
 %endif

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -545,6 +545,8 @@ else
                     $SUDO dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
                     $SUDO dnf config-manager --setopt=apt-mirror.front.sepia.ceph.com_lab-extras_8_.gpgcheck=0 --save
                     $SUDO dnf -y module enable javapackages-tools
+                elif test $ID = centos -a $MAJOR_VERSION = 9 ; then
+                    $SUDO dnf config-manager --set-enabled crb
                 elif test $ID = rhel -a $MAJOR_VERSION = 8 ; then
                     dts_ver=11
                     $SUDO dnf config-manager --set-enabled "codeready-builder-for-rhel-8-${ARCH}-rpms"


### PR DESCRIPTION
## build dependencies: centos9

- ceph.spec.in: declare git as build dependency [install-deps.error.git.log](https://github.com/ceph/ceph/files/14068895/install-deps.error.git.log)
- install-deps.sh: enable CRB repo [install-deps.error.crb.log](https://github.com/ceph/ceph/files/14068889/install-deps.error.crb.log)

Test procedure:
 -   docker run --rm -ti  -v /home/baum/ceph-ci:/home/ceph quay.io/centos/centos:stream9 bash
 -   [root@a3c4b1545e93 /]# cd /home/ceph/
 -   [root@a3c4b1545e93 ceph]# ./install-deps.sh 2>&1 tee install-deps.log

Successful log - with PR changes applied 
[install-deps.log](https://github.com/ceph/ceph/files/14068910/install-deps.log)
