### PR TITLE
quincy: ceph-volume: use 'no workqueue' options with dmcrypt

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -889,6 +889,7 @@ Requires: parted
 Requires: util-linux
 Requires: xfsprogs
 Requires: python%{python3_pkgversion}-setuptools
+Requires: python%{python3_pkgversion}-packaging
 Requires: python%{python3_pkgversion}-ceph-common = %{_epoch_prefix}%{version}-%{release}
 %description volume
 This package contains a tool to deploy OSD with different devices like

--- a/src/ceph-volume/ceph_volume/__init__.py
+++ b/src/ceph-volume/ceph_volume/__init__.py
@@ -14,8 +14,9 @@ class UnloadedConfig(object):
     def __getattr__(self, *a):
         raise RuntimeError("No valid ceph configuration file was loaded.")
 
-conf = namedtuple('config', ['ceph', 'cluster', 'verbosity', 'path', 'log_path'])
+conf = namedtuple('config', ['ceph', 'cluster', 'verbosity', 'path', 'log_path', 'dmcrypt_no_workqueue'])
 conf.ceph = UnloadedConfig()
+conf.dmcrypt_no_workqueue = None
 
 __version__ = "1.0.0"
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -149,6 +149,8 @@ def activate_bluestore(osd_lvs, no_systemd=False, no_tmpfs=False):
         raise RuntimeError('could not find a bluestore OSD to activate')
 
     is_encrypted = osd_block_lv.tags.get('ceph.encrypted', '0') == '1'
+    if is_encrypted and conf.dmcrypt_no_workqueue is None:
+        encryption_utils.set_dmcrypt_no_workqueue()
     dmcrypt_secret = None
     osd_id = osd_block_lv.tags['ceph.osd_id']
     conf.cluster = osd_block_lv.tags['ceph.cluster_name']

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -269,7 +269,7 @@ class Batch(object):
         )
         parser.add_argument(
             '--dmcrypt',
-            action='store_true',
+            action=arg_validators.DmcryptAction,
             help='Enable device encryption via dm-crypt',
         )
         parser.add_argument(

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -73,7 +73,7 @@ common_args = {
         'default': "",
     },
     '--dmcrypt': {
-        'action': 'store_true',
+        'action': arg_validators.DmcryptAction,
         'help': 'Enable device encryption via dm-crypt',
     },
     '--no-systemd': {

--- a/src/ceph-volume/ceph_volume/devices/raw/common.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/common.py
@@ -46,7 +46,7 @@ def create_parser(prog, description):
     )
     parser.add_argument(
         '--dmcrypt',
-        action='store_true',
+        action=arg_validators.DmcryptAction,
         help='Enable device encryption via dm-crypt',
     )
     parser.add_argument(

--- a/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
@@ -1,6 +1,44 @@
 from ceph_volume.util import encryption
-from mock.mock import patch
+from mock.mock import patch, Mock
 import base64
+import pytest
+
+
+class TestNoWorkqueue:
+    def setup_method(self):
+        encryption.conf.dmcrypt_no_workqueue = None
+
+    @patch('ceph_volume.util.encryption.process.call',
+           Mock(return_value=(['cryptsetup 2.7.2 flags: UDEV BLKID KEYRING' \
+                               'FIPS KERNEL_CAPI PWQUALITY '], [''], 0)))
+    def test_set_dmcrypt_no_workqueue_true(self):
+        encryption.set_dmcrypt_no_workqueue()
+        assert encryption.conf.dmcrypt_no_workqueue
+
+    @patch('ceph_volume.util.encryption.process.call',
+           Mock(return_value=(['cryptsetup 2.0.0'], [''], 0)))
+    def test_set_dmcrypt_no_workqueue_false(self):
+        encryption.set_dmcrypt_no_workqueue()
+        assert encryption.conf.dmcrypt_no_workqueue is None
+
+    @patch('ceph_volume.util.encryption.process.call',
+           Mock(return_value=([''], ['fake error'], 1)))
+    def test_set_dmcrypt_no_workqueue_cryptsetup_version_fails(self):
+        with pytest.raises(RuntimeError):
+            encryption.set_dmcrypt_no_workqueue()
+
+    @patch('ceph_volume.util.encryption.process.call',
+           Mock(return_value=(['unexpected output'], [''], 0)))
+    def test_set_dmcrypt_no_workqueue_pattern_not_found(self):
+        with pytest.raises(RuntimeError):
+            encryption.set_dmcrypt_no_workqueue()
+
+    @patch('ceph_volume.util.encryption.process.call',
+           Mock(return_value=([], [''], 0)))
+    def test_set_dmcrypt_no_workqueue_index_error(self):
+        with pytest.raises(RuntimeError):
+            encryption.set_dmcrypt_no_workqueue()
+
 
 class TestGetKeySize(object):
     def test_get_size_from_conf_default(self, conf_ceph_stub):

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -4,10 +4,19 @@ import math
 from ceph_volume import terminal, decorators, process
 from ceph_volume.util.device import Device
 from ceph_volume.util import disk
-
+from ceph_volume.util.encryption import set_dmcrypt_no_workqueue
+from ceph_volume import process, conf
 
 def valid_osd_id(val):
     return str(int(val))
+
+class DmcryptAction(argparse._StoreTrueAction):
+    def __init__(self, *args, **kwargs):
+        super(DmcryptAction, self).__init__(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        set_dmcrypt_no_workqueue()
+        super(DmcryptAction, self).__call__(*args, **kwargs)
 
 class ValidDevice(object):
 

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -137,7 +137,8 @@ class Device(object):
         self._is_lvm_member = None
         self.ceph_device = False
         self._parse()
-        self.device_nodes = sys_info.devices[self.path]['device_nodes']
+        if self.path in sys_info.devices.keys():
+            self.device_nodes = sys_info.devices[self.path]['device_nodes']
         self.lsm_data = self.fetch_lsm(with_lsm)
 
         self.available_lvm, self.rejected_reasons_lvm = self._check_lvm_reject_reasons()

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -120,13 +120,8 @@ class Device(object):
             # check if we are not a device mapper
             if "dm-" not in real_path:
                 self.path = real_path
-        if not sys_info.devices:
-            if self.path:
-                sys_info.devices = disk.get_devices(device=self.path)
-            else:
-                sys_info.devices = disk.get_devices()
-        if sys_info.devices.get(self.path, {}):
-            self.device_nodes = sys_info.devices[self.path]['device_nodes']
+        if not sys_info.devices.get(self.path):
+            sys_info.devices = disk.get_devices()
         self.sys_api = sys_info.devices.get(self.path, {})
         self.partitions = self._get_partitions()
         self.lv_api = None
@@ -142,6 +137,7 @@ class Device(object):
         self._is_lvm_member = None
         self.ceph_device = False
         self._parse()
+        self.device_nodes = sys_info.devices[self.path]['device_nodes']
         self.lsm_data = self.fetch_lsm(with_lsm)
 
         self.available_lvm, self.rejected_reasons_lvm = self._check_lvm_reject_reasons()

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -839,6 +839,7 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         sysdir = os.path.join(_sys_block_path, devname)
         if block[2] == 'part':
             sysdir = os.path.join(_sys_block_path, block[3], devname)
+        metadata = {}
 
         # If the device is ceph rbd it gets excluded
         if is_ceph_rbd(diskname):

--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -41,13 +41,13 @@ def set_dmcrypt_no_workqueue(target_version: str = '2.3.4') -> None:
 
     # This regex extracts the version number from
     # the `cryptsetup --version` output
-    pattern: str = r'\b\d+(\.\d+)*\b'
+    pattern: str = r'(\d+\.?)+'
 
     if rc:
         raise RuntimeError(f"Can't retrieve cryptsetup version: {err}")
 
     try:
-        cryptsetup_version = re.match(pattern, out[0])
+        cryptsetup_version = re.search(pattern, out[0])
 
         if cryptsetup_version is None:
             _output: str = "\n".join(out)

--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -1,6 +1,7 @@
 import base64
 import os
 import logging
+import re
 from ceph_volume import process, conf, terminal
 from ceph_volume.util import constants, system
 from ceph_volume.util.device import Device
@@ -12,14 +13,49 @@ logger = logging.getLogger(__name__)
 mlogger = terminal.MultiLogger(__name__)
 
 def set_dmcrypt_no_workqueue(target_version: str = '2.3.4') -> None:
-    """
-    set `conf.dmcrypt_no_workqueue` to `True` if the available
-    version of `cryptsetup` is greater or equal to `version`
+    """Set `conf.dmcrypt_no_workqueue` to `True` if the installed version
+    of `cryptsetup` is greater than or equal to the specified `target_version`.
+
+    Depending on the crypsetup version, `cryptsetup --version` output can be different.
+    Eg:
+
+    CentOS Stream9:
+    $ cryptsetup --version
+    cryptsetup 2.6.0 flags: UDEV BLKID KEYRING FIPS KERNEL_CAPI PWQUALITY
+
+    CentOS Stream8:
+    $ cryptsetup --version
+    cryptsetup 2.3.7
+
+    Args:
+        target_version (str, optional): The minimum version required for setting
+            `conf.dmcrypt_no_workqueue` to `True`. Defaults to '2.3.4'.
+
+    Raises:
+        RuntimeError: If failed to retrieve the cryptsetup version.
+        RuntimeError: If failed to parse the cryptsetup version.
+        RuntimeError: If failed to compare the cryptsetup version with the target version.
     """
     command = ["cryptsetup", "--version"]
     out, err, rc = process.call(command)
+
+    # This regex extracts the version number from
+    # the `cryptsetup --version` output
+    pattern: str = r'\b\d+(\.\d+)*\b'
+
+    if rc:
+        raise RuntimeError(f"Can't retrieve cryptsetup version: {err}")
+
     try:
-        if version.parse(out[0]) >= version.parse(f'cryptsetup {target_version}'):
+        cryptsetup_version = re.match(pattern, out[0])
+
+        if cryptsetup_version is None:
+            _output: str = "\n".join(out)
+            raise RuntimeError('Error while checking cryptsetup version.\n',
+                               '`cryptsetup --version` output:\n',
+                               f'{_output}')
+
+        if version.parse(cryptsetup_version.group(0)) >= version.parse(target_version):
             conf.dmcrypt_no_workqueue = True
     except IndexError:
         mlogger.debug(f'cryptsetup version check: rc={rc} out={out} err={err}')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64196

---

backport of https://github.com/ceph/ceph/pull/54423
parent tracker: https://tracker.ceph.com/issues/64195

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh