### PR TITLE
osd/scrub: use an AsyncReserver to handle scrub reservations on the replica side

### DIFF
--- a/src/common/AsyncReserver.h
+++ b/src/common/AsyncReserver.h
@@ -16,6 +16,9 @@
 #define ASYNC_RESERVER_H
 
 #include "common/Formatter.h"
+#include "common/ceph_context.h"
+#include "common/ceph_mutex.h"
+#include "include/Context.h"
 
 #define rdout(x) lgeneric_subdout(cct,reserver,x)
 

--- a/src/common/AsyncReserver.h
+++ b/src/common/AsyncReserver.h
@@ -113,8 +113,10 @@ class AsyncReserver {
       if (it->second.empty()) {
 	queues.erase(it);
       }
-      f->queue(p.grant);
-      p.grant = nullptr;
+      if (p.grant) {
+	f->queue(p.grant);
+	p.grant = nullptr;
+      }
       in_progress[p.item] = p;
       if (p.preempt) {
 	preempt_by_prio.insert(std::make_pair(p.prio, p.item));
@@ -274,8 +276,7 @@ public:
    * active reservations.
    */
   bool request_reservation_or_fail(
-      T item,		     ///< [in] reservation key
-      Context *on_reserved   ///< [in] callback to be called on reservation
+      T item		     ///< [in] reservation key
   )
   {
     std::lock_guard l(lock);
@@ -288,7 +289,7 @@ public:
     }
 
     const unsigned prio = UINT_MAX;
-    Reservation r(item, prio, on_reserved, nullptr);
+    Reservation r(item, prio, nullptr, nullptr);
     queues[prio].push_back(r);
     queue_pointers.insert(std::make_pair(
 	item, std::make_pair(prio, --(queues[prio]).end())));

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -535,6 +535,16 @@ options:
   see_also:
   - osd_scrub_slow_reservation_response
   with_legacy: false
+- name: osd_scrub_disable_reservation_queuing
+  type: bool
+  level: advanced
+  desc: Disable queuing of scrub reservations
+  long_desc: When set - scrub replica reservations are responded to immediately, with
+    either success or failure (the pre-Squid version behaviour). This configuration
+    option is introduced to support mixed-version clusters and debugging, and will
+    be removed in the next release.
+  default: false
+  with_legacy: false
 # where rados plugins are stored
 - name: osd_class_dir
   type: str

--- a/src/messages/MOSDScrubReserve.h
+++ b/src/messages/MOSDScrubReserve.h
@@ -37,7 +37,7 @@ public:
   reservation_nonce_t reservation_nonce{0};
   /// 'false' if the (legacy) primary is expecting an immediate
   /// granted / denied response
-  bool wait_for_resources{false};
+  bool wait_for_resources{true};
 
   epoch_t get_map_epoch() const override {
     return map_epoch;
@@ -63,23 +63,23 @@ public:
   }
 
   void print(std::ostream& out) const {
-    out << "MOSDScrubReserve(" << pgid << " ";
+    out << "MOSDScrubReserve(" << pgid << ",";
     switch (type) {
     case REQUEST:
-      out << (wait_for_resources ? "QREQUEST " : "REQUEST ");
+      out << (wait_for_resources ? "QREQUEST" : "REQUEST");
       break;
     case GRANT:
-      out << "GRANT ";
+      out << "GRANT";
       break;
     case REJECT:
-      out << "REJECT ";
+      out << "REJECT";
       break;
     case RELEASE:
-      out << "RELEASE ";
+      out << "RELEASE";
       break;
     }
-    out << "e" << map_epoch << " from: " << from
-	<< " reservation_nonce: " << reservation_nonce << ")";
+    out << ",e:" << map_epoch << ",from:" << from
+	<< ",reservation_nonce:" << reservation_nonce << ")";
     return;
   }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -273,6 +273,8 @@ OSDService::OSDService(OSD *osd, ceph::async::io_context_pool& poolctx) :
 		  cct->_conf->osd_min_recovery_priority),
   snap_reserver(cct, &reserver_finisher,
 		cct->_conf->osd_max_trimming_pgs),
+  scrub_reserver(cct, &reserver_finisher,
+		cct->_conf->osd_max_scrubs),
   recovery_ops_active(0),
   recovery_ops_reserved(0),
   recovery_paused(false),
@@ -9888,6 +9890,9 @@ void OSD::handle_conf_change(const ConfigProxy& conf,
   }
   if (changed.count("osd_max_trimming_pgs")) {
     service.snap_reserver.set_max(cct->_conf->osd_max_trimming_pgs);
+  }
+  if (changed.count("osd_max_scrubs")) {
+    service.scrub_reserver.set_max(cct->_conf->osd_max_scrubs);
   }
   if (changed.count("osd_op_complaint_time") ||
       changed.count("osd_op_log_threshold")) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2893,7 +2893,7 @@ will start to track new ops received afterwards.";
     f->close_section();
   } else if (prefix == "dump_scrub_reservations") {
     f->open_object_section("scrub_reservations");
-    service.get_scrub_services().resource_bookkeeper().dump_scrub_reservations(f);
+    service.get_scrub_services().dump_scrub_reservations(f);
     f->close_section();
   } else if (prefix == "get_latest_osdmap") {
     get_latest_osdmap();

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -251,6 +251,14 @@ public:
    */
   std::optional<PGLockWrapper> get_locked_pg(spg_t pgid) final;
 
+  /**
+   * the entity that counts the number of active replica scrub
+   * operations, and grant scrub reservation requests asynchronously.
+   */
+  AsyncReserver<spg_t, Finisher>& get_scrub_reserver() {
+    return scrub_reserver;
+  }
+
  private:
   // -- agent shared state --
   ceph::mutex agent_lock = ceph::make_mutex("OSDService::agent_lock");
@@ -494,6 +502,8 @@ public:
   void send_pg_created();
 
   AsyncReserver<spg_t, Finisher> snap_reserver;
+  /// keeping track of replicas being reserved for scrubbing
+  AsyncReserver<spg_t, Finisher> scrub_reserver;
   void queue_recovery_context(PG *pg,
                               GenContext<ThreadPool::TPHandle&> *c,
                               uint64_t cost,

--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -57,6 +57,14 @@ void OsdScrub::dump_scrubs(ceph::Formatter* f) const
   m_queue.dump_scrubs(f);
 }
 
+void OsdScrub::dump_scrub_reservations(ceph::Formatter* f) const
+{
+  m_resource_bookkeeper.dump_scrub_reservations(f);
+  f->open_array_section("remote_scrub_reservations");
+  m_osd_svc.get_scrub_reserver().dump(f);
+  f->close_section();
+}
+
 void OsdScrub::log_fwd(std::string_view text)
 {
   dout(20) << text << dendl;

--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -468,21 +468,6 @@ void OsdScrub::dec_scrubs_local()
   m_resource_bookkeeper.dec_scrubs_local();
 }
 
-bool OsdScrub::inc_scrubs_remote(pg_t pgid)
-{
-  return m_resource_bookkeeper.inc_scrubs_remote(pgid);
-}
-
-void OsdScrub::enqueue_remote_reservation(pg_t pgid)
-{
-  m_resource_bookkeeper.enqueue_remote_reservation(pgid);
-}
-
-void OsdScrub::dec_scrubs_remote(pg_t pgid)
-{
-  m_resource_bookkeeper.dec_scrubs_remote(pgid);
-}
-
 void OsdScrub::mark_pg_scrub_blocked(spg_t blocked_pg)
 {
   m_queue.mark_pg_scrub_blocked(blocked_pg);

--- a/src/osd/scrubber/osd_scrub.h
+++ b/src/osd/scrubber/osd_scrub.h
@@ -51,6 +51,8 @@ class OsdScrub {
 
   void dump_scrubs(ceph::Formatter* f) const;  ///< fwd to the queue
 
+  void dump_scrub_reservations(ceph::Formatter* f) const;
+
   /**
    * on_config_change() (the refactored "OSD::sched_all_scrubs()")
    *

--- a/src/osd/scrubber/osd_scrub.h
+++ b/src/osd/scrubber/osd_scrub.h
@@ -69,9 +69,6 @@ class OsdScrub {
   std::unique_ptr<Scrub::LocalResourceWrapper> inc_scrubs_local(
       bool is_high_priority);
   void dec_scrubs_local();
-  bool inc_scrubs_remote(pg_t pgid);
-  void enqueue_remote_reservation(pg_t pgid);
-  void dec_scrubs_remote(pg_t pgid);
 
   // counting the number of PGs stuck while scrubbing, waiting for objects
   void mark_pg_scrub_blocked(spg_t blocked_pg);

--- a/src/osd/scrubber/osd_scrub_sched.h
+++ b/src/osd/scrubber/osd_scrub_sched.h
@@ -108,6 +108,7 @@ ScrubQueue interfaces (main functions):
 // clang-format on
 
 #include <optional>
+#include "common/AsyncReserver.h"
 #include "utime.h"
 #include "osd/scrubber/scrub_job.h"
 #include "osd/PG.h"
@@ -134,6 +135,12 @@ class ScrubSchedListener {
    * returns nullopt if failing to lock.
    */
   virtual std::optional<PGLockWrapper> get_locked_pg(spg_t pgid) = 0;
+
+  /**
+   * allow access to the scrub_reserver, the AsyncReserver that keeps track
+   * of 'remote replica reservations'.
+   */
+  virtual AsyncReserver<spg_t, Finisher>& get_scrub_reserver() = 0;
 
   virtual ~ScrubSchedListener() {}
 };

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -397,6 +397,15 @@ void PgScrubber::send_scrub_is_finished(epoch_t epoch_queued)
   dout(10) << "scrubber event --<< " << __func__ << dendl;
 }
 
+void PgScrubber::send_granted_by_reserver(const AsyncScrubResData& req)
+{
+  dout(10) << "scrubber event -->> granted_by_reserver" << dendl;
+  if (check_interval(req.request_epoch)) {
+    m_fsm->process_event(Scrub::ReserverGranted{req});
+  }
+  dout(10) << "scrubber event --<< granted_by_reserver" << dendl;
+}
+
 // -----------------
 
 bool PgScrubber::is_reserving() const

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -227,6 +227,8 @@ class PgScrubber : public ScrubPgIF,
 
   void send_scrub_is_finished(epoch_t epoch_queued) final;
 
+  void send_granted_by_reserver(const AsyncScrubResData& req) final;
+
   /**
    *  we allow some number of preemptions of the scrub, which mean we do
    *  not block.  Then we start to block.  Once we start blocking, we do

--- a/src/osd/scrubber/scrub_resources.cc
+++ b/src/osd/scrubber/scrub_resources.cc
@@ -40,8 +40,8 @@ std::unique_ptr<LocalResourceWrapper> ScrubResources::inc_scrubs_local(
   if (is_high_priority || can_inc_local_scrubs_unlocked()) {
     ++scrubs_local;
     log_upwards(fmt::format(
-	"{}: {} -> {} (max {}, remote {})", __func__, (scrubs_local - 1),
-	scrubs_local, conf->osd_max_scrubs, granted_reservations.size()));
+	"{}: {} -> {} (max {})", __func__, (scrubs_local - 1), scrubs_local,
+	conf->osd_max_scrubs));
     return std::make_unique<LocalResourceWrapper>(*this);
   }
   return nullptr;
@@ -62,63 +62,17 @@ void ScrubResources::dec_scrubs_local()
 {
   std::lock_guard lck{resource_lock};
   log_upwards(fmt::format(
-      "{}:  {} -> {} (max {}, remote {})",
-      __func__, scrubs_local, (scrubs_local - 1), conf->osd_max_scrubs,
-      granted_reservations.size()));
+      "{}:  {} -> {} (max {})", __func__, scrubs_local, (scrubs_local - 1),
+      conf->osd_max_scrubs));
   --scrubs_local;
   ceph_assert(scrubs_local >= 0);
 }
 
-// ------------------------- scrubbing on this OSD as replicas ----------------
-
-bool ScrubResources::inc_scrubs_remote(pg_t pgid)
-{
-  std::lock_guard lck{resource_lock};
-
-  // if this PG is already reserved - it's probably a benign bug.
-  // report it, but do not fail the reservation.
-  if (granted_reservations.contains(pgid)) {
-    log_upwards(fmt::format("{}: pg[{}] already reserved", __func__, pgid));
-    return true;
-  }
-
-  auto pre_op_cnt = granted_reservations.size();
-  if (std::cmp_less(pre_op_cnt, conf->osd_max_scrubs)) {
-    granted_reservations.insert(pgid);
-    log_upwards(fmt::format(
-	"{}: pg[{}] reserved. Remote scrubs count changed from {} -> {} (max "
-	"{}, local {})",
-	__func__, pgid, pre_op_cnt, granted_reservations.size(),
-	conf->osd_max_scrubs, scrubs_local));
-    return true;
-  }
-
-  log_upwards(fmt::format(
-      "{}: pg[{}] failed. Too many concurrent replica scrubs ({} >= max ({}))",
-      __func__, pgid, pre_op_cnt, conf->osd_max_scrubs));
-  return false;
-}
-
-void ScrubResources::dec_scrubs_remote(pg_t pgid)
-{
-  std::lock_guard lck{resource_lock};
-  // we might not have this PG in the set (e.g. if we are concluding a
-  // high priority scrub, one that does not require reservations)
-  auto cnt = granted_reservations.erase(pgid);
-  if (cnt) {
-    log_upwards(fmt::format(
-	"{}: remote reservation for {} removed -> {} (max {}, local {})",
-	__func__, pgid, granted_reservations.size(), conf->osd_max_scrubs,
-	scrubs_local));
-  }
-}
 
 void ScrubResources::dump_scrub_reservations(ceph::Formatter* f) const
 {
   std::lock_guard lck{resource_lock};
   f->dump_int("scrubs_local", scrubs_local);
-  f->dump_int("granted_reservations", granted_reservations.size());
-  f->dump_string("PGs being served", fmt::format("{}", granted_reservations));
   f->dump_int("osd_max_scrubs", conf->osd_max_scrubs);
 }
 

--- a/src/osd/scrubber/scrub_resources.h
+++ b/src/osd/scrubber/scrub_resources.h
@@ -10,33 +10,6 @@
 #include "common/Formatter.h"
 #include "osd/osd_types.h"
 
-/*
- * AsyncReserver for scrub 'remote' reservations
- * -----------------------------------------------
- *
- * On the replica side, all reservations are treated as having the same priority.
- * Note that 'high priority' scrubs, e.g. user-initiated scrubs, are not required
- * to perform any reservations, and are never handled by the replicas' OSD.
- *
- * A queued scrub reservation request is cancelled by any of the following events:
- *
- * - a new interval: in this case, we do not expect to see a cancellation request
- *   from the primary, and we can simply remove the request from the queue;
- *
- * - a cancellation request from the primary: probably a result of timing out on
- *   the reservation process. Here, we can simply remove the request from the queue.
- *
- * - a new reservation request for the same PG: which means we had missed the
- *   previous cancellation request. We cancel the previous request, and replace
- *   it with the new one. We would also issue an error log message.
- *
- * Primary/Replica with differing versions:
- *
- * The updated version of MOSDScrubReserve contains a new 'OK to queue' field.
- * For legacy Primary OSDs, this field is decoded as 'false', and the replica
- * responds immediately, with grant/rejection.
-*/
-
 namespace Scrub {
 
 /**
@@ -50,8 +23,8 @@ class LocalResourceWrapper;
 /**
  * The number of concurrent scrub operations performed on an OSD is limited
  * by a configuration parameter. The 'ScrubResources' class is responsible for
- * maintaining a count of the number of scrubs currently performed, both
- * acting as primary and acting as a replica, and for enforcing the limit.
+ * maintaining a count of the number of scrubs currently performed by primary
+ * PGs on this OSD, and for enforcing the limit.
  */
 class ScrubResources {
   friend class LocalResourceWrapper;
@@ -64,10 +37,6 @@ class ScrubResources {
    * regular scrubs will be allowed to start.
    */
   int scrubs_local{0};
-
-  /// the set of PGs that have active scrub reservations as replicas
-  /// \todo come C++23 - consider std::flat_set<pg_t>
-  std::set<pg_t> granted_reservations;
 
   mutable ceph::mutex resource_lock =
       ceph::make_mutex("ScrubQueue::resource_lock");
@@ -96,15 +65,6 @@ class ScrubResources {
 
   /// decrements the number of scrubs acting as a Primary
   void dec_scrubs_local();
-
-  /// increments the number of scrubs acting as a Replica
-  bool inc_scrubs_remote(pg_t pgid);
-
-  /// queue a request with the scrub reserver
-  void enqueue_remote_reservation(pg_t pgid) {}
-
-  /// decrements the number of scrubs acting as a Replica
-  void dec_scrubs_remote(pg_t pgid);
 
   void dump_scrub_reservations(ceph::Formatter* f) const;
 };

--- a/src/test/osd/test_scrub_sched.cc
+++ b/src/test/osd/test_scrub_sched.cc
@@ -10,6 +10,7 @@
 
 #include "common/async/context_pool.h"
 #include "common/ceph_argparse.h"
+#include "common/Finisher.h"
 #include "global/global_context.h"
 #include "global/global_init.h"
 #include "include/utime_fmt.h"
@@ -109,9 +110,17 @@ class FakeOsd : public Scrub::ScrubSchedListener {
     return std::nullopt;
   }
 
+  AsyncReserver<spg_t, Finisher>& get_scrub_reserver() final
+  {
+    return m_scrub_reserver;
+  }
+
  private:
   int m_osd_num;
   std::map<spg_t, schedule_result_t> m_next_response;
+  Finisher reserver_finisher{g_ceph_context};
+  AsyncReserver<spg_t, Finisher> m_scrub_reserver{
+      g_ceph_context, &reserver_finisher, 1};
 };
 
 


### PR DESCRIPTION
That means that when trying to reserve its replicas for scrubbing, the primary sends a reservation request
with a 'queue this request' flag set. That request is queued at the scrub-reserver, and granted once
the number of concurrent 'remote reservations' falls below the configured threshold.
