### PR TITLE
mon: fix health store size growing infinitely

### DIFF
--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -400,7 +400,7 @@ void HealthMonitor::tick()
 
 bool HealthMonitor::check_mutes()
 {
-  bool changed = true;
+  bool changed = false;
   auto now = ceph_clock_now();
   health_check_map_t all;
   gather_all_health_checks(&all);


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/64236

We have recently encountered `MON_DISK_BIG` in a large production cluster with all pg `active+clean`. The paxos log shows that the first committed version of health store stay at `1`, while last committed version grows periodically.

> 2024-01-29T03:01:49.831+0000 7f3260ce3700 10 mon.yj-bstoreceph01rack01meta-01@1(peon).paxosservice(health 1..7481140) refresh
2024-01-29T03:01:49.831+0000 7f3260ce3700 10 mon.yj-bstoreceph01rack01meta-01@1(peon).paxosservice(health 1..7481140) post_refresh
2024-01-29T03:01:50.408+0000 7f3260ce3700 10 mon.yj-bstoreceph01rack01meta-01@1(peon).paxosservice(health 1..7481141) refresh
2024-01-29T03:01:50.408+0000 7f3260ce3700 10 mon.yj-bstoreceph01rack01meta-01@1(peon).paxosservice(health 1..7481141) post_refresh

We then found `HealthMonitor::check_mutes` wrongly marks `changed` to true, trigger `propose_pending` and block following `maybe_trim` logic (`have_pending` will be always be false); as a result, the health store will never be trimmed.
This also cause unnecessary paxos propose even no change has been found.

https://github.com/ceph/ceph/blob/93c567e8aebc282f98f9f7826529defeb0d4fec7/src/mon/HealthMonitor.cc#L393-L399

https://github.com/ceph/ceph/blob/93c567e8aebc282f98f9f7826529defeb0d4fec7/src/mon/Monitor.cc#L5892-L5894

https://github.com/ceph/ceph/blob/93c567e8aebc282f98f9f7826529defeb0d4fec7/src/mon/PaxosService.cc#L385-L388

https://github.com/ceph/ceph/blob/93c567e8aebc282f98f9f7826529defeb0d4fec7/src/mon/PaxosService.h#L548-L550

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
