### PR TITLE
mgr/dashboard: Create subvol of same name in different group

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-form/cephfs-subvolume-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-form/cephfs-subvolume-form.component.ts
@@ -108,7 +108,8 @@ export class CephfsSubvolumeFormComponent extends CdForm implements OnInit {
             this.cephFsSubvolumeService,
             null,
             null,
-            this.fsName
+            this.fsName,
+            this.subVolumeGroupName
           )
         ]
       }),

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs-subvolume.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs-subvolume.service.ts
@@ -75,8 +75,8 @@ export class CephfsSubvolumeService {
     });
   }
 
-  exists(subVolumeName: string, fsName: string) {
-    return this.info(fsName, subVolumeName).pipe(
+  exists(subVolumeName: string, fsName: string, subVolumeGroupName: string = '') {
+    return this.info(fsName, subVolumeName, subVolumeGroupName).pipe(
       mapTo(true),
       catchError((error: Event) => {
         if (_.isFunction(error.preventDefault)) {


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/64112

Issue:
Currently, we are unable to create subvolume of same name in different subvolume group

Fix:
We are validating only the filesystem name of subvolume which is stopping the creation a subvolume of same name. Added more granularity , by adding the subvolumegroup name.

[fix-64112.webm](https://github.com/ceph/ceph/assets/25664409/2225fb0a-95a8-461e-8669-edf3171cab38)


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
