### PR TITLE
osd,mon,cli: collect and show stats for "meta" pool and pools being removed.

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -40,6 +40,25 @@
 * RGW: GetObject and HeadObject requests now return a x-rgw-replicated-at
   header for replicated objects. This timestamp can be compared against the
   Last-Modified header to determine how long the object took to replicate.
+* ceph df detail output has got META section in plain format:
+  * new column 'STORED' - amount of metadata the cluster keeps at main space
+    (as meta objects: osdmaps, snaptrim data, etc)
+  * new column 'USED' - total space allocated for metadata in STORED
+    column above.
+  * new column 'PGMETA' - amount of PG-related metadata the cluster keeps
+    in DB (PG logs and similar)
+  * new column 'OMAP' - amount of the remaining internal metadata the cluster
+    keeps in DB as OMAP records for meta objects.
+* ceph df detail output has got 'meta' object with the following fields
+  in json format:
+  * 'stored' field  - amount of metadata the cluster keeps at main space
+    (as meta objects: osdmaps, snaptrim data, etc)
+  * 'total_used' field - total space allocated for metadata in STORED
+    column above.
+  * 'total_pgmeta' field - amount of PG-related metadata the cluster keeps
+    in DB (PG logs and similar)
+  * 'other_omap' - amount of the remaining internal metadata the cluster
+    keeps in DB as OMAP records for meta objects.
 * The cephfs-shell utility is now packaged for RHEL 9 / CentOS 9 as required
   python dependencies are now available in EPEL9.
 * RGW: S3 multipart uploads using Server-Side Encryption now replicate correctly in

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -40,25 +40,21 @@
 * RGW: GetObject and HeadObject requests now return a x-rgw-replicated-at
   header for replicated objects. This timestamp can be compared against the
   Last-Modified header to determine how long the object took to replicate.
-* ceph df detail output has got META section in plain format:
-  * new column 'STORED' - amount of metadata the cluster keeps at main space
-    (as meta objects: osdmaps, snaptrim data, etc)
-  * new column 'USED' - total space allocated for metadata in STORED
-    column above.
-  * new column 'PGMETA' - amount of PG-related metadata the cluster keeps
-    in DB (PG logs and similar)
-  * new column 'OMAP' - amount of the remaining internal metadata the cluster
-    keeps in DB as OMAP records for meta objects.
-* ceph df detail output has got 'meta' object with the following fields
-  in json format:
-  * 'stored' field  - amount of metadata the cluster keeps at main space
-    (as meta objects: osdmaps, snaptrim data, etc)
-  * 'total_used' field - total space allocated for metadata in STORED
-    column above.
-  * 'total_pgmeta' field - amount of PG-related metadata the cluster keeps
-    in DB (PG logs and similar)
-  * 'other_omap' - amount of the remaining internal metadata the cluster
-    keeps in DB as OMAP records for meta objects.
+* ceph df detail output has got AUX section in plain format. It tracks internal
+  metadata pool and pools being wiped. The columns are:
+  * new column 'USED' - space allocated at main storage fo meta objects:
+    osdmaps, snaptrim data, etc.
+  * new column 'META' - amount of PG-related metadata the pool keeps
+    in DB (PG logs and similar).
+  * new column 'OMAP' - amount of OMAP data the pool contains.
+* ceph df detail output has got 'aux_pool_sum' array object in json format.
+  It tracks internal metadata pool and pools being wiped. The array entries
+  have the following fields in json format:
+  * 'bytes_used' field - space allocated at main storage fo meta objects:
+    osdmaps, snaptrim data, etc.
+  * 'meta' field - amount of PG-related metadata the pool keeps
+    in DB (PG logs and similar).
+  * 'omap' - amount of OMAP data the pool contains.
 * The cephfs-shell utility is now packaged for RHEL 9 / CentOS 9 as required
   python dependencies are now available in EPEL9.
 * RGW: S3 multipart uploads using Server-Side Encryption now replicate correctly in

--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -183,6 +183,12 @@ class HealthTest(DashboardTestCase):
                     'num_osds': int,
                     'num_per_pool_osds': int,
                     'num_per_pool_omap_osds': int
+                }),
+                'meta': JObj({
+                    'stored': int,
+                    'total_used': int,
+                    'total_pgmeta': int,
+                    'other_omap': int
                 })
             }),
             'fs_map': JObj({

--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -184,12 +184,13 @@ class HealthTest(DashboardTestCase):
                     'num_per_pool_osds': int,
                     'num_per_pool_omap_osds': int
                 }),
-                'meta': JObj({
-                    'stored': int,
-                    'total_used': int,
-                    'total_pgmeta': int,
-                    'other_omap': int
-                })
+                'aux_pool_sum': JList(JObj({
+                    'name': str,
+                    'id': int,
+                    'bytes_used': int,
+                    'meta': int,
+                    'omap': int
+                }))
             }),
             'fs_map': JObj({
                 'btime': str,

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -192,6 +192,7 @@ public:
 				   bool per_pool,
 				   bool per_pool_omap,
 				   const pg_pool_t *pool);
+  void dump_meta_pool_stats(std::stringstream* ss, ceph::Formatter* f) const;
 
   size_t get_num_pg_by_osd(int osd) const {
     auto p = num_pg_by_osd.find(osd);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7762,6 +7762,8 @@ MPGStats* OSD::collect_pg_stats()
 
   osd_stat_t cur_stat = service.get_osd_stat();
   cur_stat.os_perf_stat = store->get_cur_stats();
+  cur_stat.num_deletes_in_pgs = service.get_num_deletes_in_pgs();
+  cur_stat.num_deleting_pgs = logger->get(l_osd_pg_removing);
 
   auto m = new MPGStats(monc->get_fsid(), get_osdmap_epoch());
   m->osd_stat = cur_stat;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7787,6 +7787,8 @@ MPGStats* OSD::collect_pg_stats()
 	min_last_epoch_clean_pgs.push_back(pg->pg_id.pgid);
       });
   }
+  pool_set.emplace(-1); // add "meta" pool explicitly as
+                        //it's not retrievable from pg stats
   store_statfs_t st;
   bool per_pool_stats = true;
   bool per_pool_omap_stats = false;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -749,6 +749,14 @@ public:
     *pp = osd_stat.hb_pingtime;
     return;
   }
+  uint64_t get_num_deletes_in_pgs() const {
+    return num_deletes_in_pgs;
+  }
+  void inc_num_deletes_in_pgs(uint64_t delta) {
+    num_deletes_in_pgs += delta;
+  }
+private:
+  std::atomic<uint64_t> num_deletes_in_pgs = 0;
 
   // -- OSD Full Status --
 private:

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2374,6 +2374,7 @@ std::pair<ghobject_t, bool> PG::do_delete_work(
     dout(20) << __func__ << " deleting " << num << " objects" << dendl;
     Context *fin = new C_DeleteMore(this, get_osdmap_epoch(), num);
     t.register_on_commit(fin);
+    osd->inc_num_deletes_in_pgs(num);
   } else {
     if (cct->_conf->osd_inject_failure_on_pg_removal) {
       _exit(1);

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -407,6 +407,8 @@ void osd_stat_t::dump(Formatter *f, bool with_net) const
   f->dump_unsigned("num_osds", num_osds);
   f->dump_unsigned("num_per_pool_osds", num_per_pool_osds);
   f->dump_unsigned("num_per_pool_omap_osds", num_per_pool_omap_osds);
+  f->dump_unsigned("num_deletes_in_pgs", num_deletes_in_pgs);
+  f->dump_unsigned("num_deleting_pgs", num_deleting_pgs);
 
   /// dump legacy stats fields to ensure backward compatibility.
   f->dump_unsigned("kb", statfs.kb());
@@ -502,7 +504,7 @@ void osd_stat_t::dump_ping_time(Formatter *f) const
 
 void osd_stat_t::encode(ceph::buffer::list &bl, uint64_t features) const
 {
-  ENCODE_START(14, 2, bl);
+  ENCODE_START(15, 2, bl);
 
   //////// for compatibility ////////
   int64_t kb = statfs.kb();
@@ -564,6 +566,8 @@ void osd_stat_t::encode(ceph::buffer::list &bl, uint64_t features) const
     encode(i.second.front_max[2], bl);
     encode(i.second.front_last, bl);
   }
+  encode(num_deletes_in_pgs, bl);
+  encode(num_deleting_pgs, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -674,6 +678,13 @@ void osd_stat_t::decode(ceph::buffer::list::const_iterator &bl)
       decode(ifs.front_last, bl);
       hb_pingtime[osd] = ifs;
     }
+  }
+  if (struct_v >= 15) {
+    decode(num_deletes_in_pgs, bl);
+    decode(num_deleting_pgs, bl);
+  } else {
+    num_deletes_in_pgs = 0;
+    num_deleting_pgs = 0;
   }
   DECODE_FINISH(bl);
 }

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2534,6 +2534,9 @@ struct osd_stat_t {
   uint32_t num_per_pool_osds = 0;
   uint32_t num_per_pool_omap_osds = 0;
 
+  uint64_t num_deletes_in_pgs = 0;
+  uint64_t num_deleting_pgs = 0;
+
   struct Interfaces {
     uint32_t last_update;  // in seconds
     uint32_t back_pingtime[3];
@@ -2561,6 +2564,8 @@ struct osd_stat_t {
     num_osds += o.num_osds;
     num_per_pool_osds += o.num_per_pool_osds;
     num_per_pool_omap_osds += o.num_per_pool_omap_osds;
+    num_deletes_in_pgs += o.num_deletes_in_pgs;
+    num_deleting_pgs += o.num_deleting_pgs;
     for (const auto& a : o.os_alerts) {
       auto& target = os_alerts[a.first];
       for (auto& i : a.second) {
@@ -2579,6 +2584,8 @@ struct osd_stat_t {
     num_osds -= o.num_osds;
     num_per_pool_osds -= o.num_per_pool_osds;
     num_per_pool_omap_osds -= o.num_per_pool_omap_osds;
+    num_deletes_in_pgs -= o.num_deletes_in_pgs;
+    num_deleting_pgs -= o.num_deleting_pgs;
     for (const auto& a : o.os_alerts) {
       auto& target = os_alerts[a.first];
       for (auto& i : a.second) {
@@ -2608,7 +2615,9 @@ inline bool operator==(const osd_stat_t& l, const osd_stat_t& r) {
     l.num_pgs == r.num_pgs &&
     l.num_osds == r.num_osds &&
     l.num_per_pool_osds == r.num_per_pool_osds &&
-    l.num_per_pool_omap_osds == r.num_per_pool_omap_osds;
+    l.num_per_pool_omap_osds == r.num_per_pool_omap_osds &&
+    l.num_deletes_in_pgs == r.num_deletes_in_pgs &&
+    l.num_deleting_pgs == r.num_deleting_pgs;
 }
 inline bool operator!=(const osd_stat_t& l, const osd_stat_t& r) {
   return !(l == r);


### PR DESCRIPTION
This could be helpful to troubleshoot unexpectedly high space usage reported by the cluster.

"ceph df detail" output has been extended with AUX section:
--- RAW STORAGE ---
CLASS     SIZE    AVAIL     USED  RAW USED  %RAW USED
hdd    303 GiB  300 GiB  3.0 GiB   3.0 GiB       0.99
TOTAL  303 GiB  300 GiB  3.0 GiB   3.0 GiB       0.99

--- POOLS ---
\<no changes in this section\>

---  AUX  ---
POOL         ID     USED    META     OMAP
meta          -1  4.4 MiB  41 MiB  4.8 KiB
<wiping>    4  1.1 GiB     0 B      0 B_**

"io" section of "ceph -s" output has been extended with information on cleanup operations rate,
showing amount of objects being removed per second for background delete PG operation(s).

cluster:
    id:     6a7e4791-c295-4d17-bf99-4b55bee33515
    health: HEALTH_WARN
            3 OSD(s) experiencing BlueFS spillover

 \<no changes in this section\>

io:
    recovery: 13 KiB/s, 0 objects/s
    cleanup:  126 PGs, 543 objects/s



Signed-off-by: Igor Fedotov <igor.fedotov@croit.io>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
