### PR TITLE
reef: rgw/rest: fix url decode of post params for iam/sts/sns

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5192,8 +5192,9 @@ void parse_post_action(const std::string& post_body, req_state* s)
           if (boost::starts_with(key, "Attributes.")) {
             update_attribute_map(t, map);
           } else {
+            constexpr bool in_query = true; // replace '+' with ' '
             s->info.args.append(t.substr(0, pos),
-                              url_decode(t.substr(pos+1, t.size() -1)));
+                              url_decode(t.substr(pos+1, t.size() -1), in_query));
           }
         }
       }

--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -91,9 +91,9 @@ uint64_t RGWPutUserPolicy::get_op()
 
 int RGWPutUserPolicy::get_params()
 {
-  policy_name = url_decode(s->info.args.get("PolicyName"), true);
-  user_name = url_decode(s->info.args.get("UserName"), true);
-  policy = url_decode(s->info.args.get("PolicyDocument"), true);
+  policy_name = s->info.args.get("PolicyName");
+  user_name = s->info.args.get("UserName");
+  policy = s->info.args.get("PolicyDocument");
 
   if (policy_name.empty() || user_name.empty() || policy.empty()) {
     ldpp_dout(this, 20) << "ERROR: one of policy name, user name or policy document is empty"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64228

---

backport of https://github.com/ceph/ceph/pull/55329
parent tracker: https://tracker.ceph.com/issues/64189

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh