### PR TITLE
quincy: rgw/rest: fix url decode of post params for iam/sts/sns

### DIFF
--- a/src/rgw/rgw_rest_iam.cc
+++ b/src/rgw/rgw_rest_iam.cc
@@ -30,8 +30,9 @@ void RGWHandler_REST_IAM::rgw_iam_parse_input()
       for (const auto& t : tokens) {
         auto pos = t.find("=");
         if (pos != string::npos) {
+          constexpr bool in_query = true; // replace '+' with ' '
           s->info.args.append(t.substr(0,pos),
-                              url_decode(t.substr(pos+1, t.size() -1)));
+                              url_decode(t.substr(pos+1, t.size() -1), in_query));
         }
       }
     }

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -358,7 +358,8 @@ void RGWHandler_REST_PSTopic_AWS::rgw_topic_parse_input() {
           if (key == "Action") {
             s->info.args.append(key, t.substr(pos + 1, t.size() - 1));
           } else if (key == "Name" || key == "TopicArn") {
-            const auto value = url_decode(t.substr(pos + 1, t.size() - 1));
+            constexpr bool in_query = true; // replace '+' with ' '
+            const auto value = url_decode(t.substr(pos + 1, t.size() - 1), in_query);
             s->info.args.append(key, value);
           } else {
             update_attribute_map(t, map);

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -759,8 +759,9 @@ void RGWHandler_REST_STS::rgw_sts_parse_input()
       for (const auto& t : tokens) {
         auto pos = t.find("=");
         if (pos != string::npos) {
+          constexpr bool in_query = true; // replace '+' with ' '
           s->info.args.append(t.substr(0,pos),
-                              url_decode(t.substr(pos+1, t.size() -1)));
+                              url_decode(t.substr(pos+1, t.size() -1), in_query));
         }
       }
     }

--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -93,9 +93,9 @@ uint64_t RGWPutUserPolicy::get_op()
 
 int RGWPutUserPolicy::get_params()
 {
-  policy_name = url_decode(s->info.args.get("PolicyName"), true);
-  user_name = url_decode(s->info.args.get("UserName"), true);
-  policy = url_decode(s->info.args.get("PolicyDocument"), true);
+  policy_name = s->info.args.get("PolicyName");
+  user_name = s->info.args.get("UserName");
+  policy = s->info.args.get("PolicyDocument");
 
   if (policy_name.empty() || user_name.empty() || policy.empty()) {
     ldpp_dout(this, 20) << "ERROR: one of policy name, user name or policy document is empty"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64227

---

backport of https://github.com/ceph/ceph/pull/55329
parent tracker: https://tracker.ceph.com/issues/64189

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh