### PR TITLE
quincy: mgr: pin pytest to version 7.4.4

### DIFF
--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -2,3 +2,4 @@
 asyncssh==2.9
 kubernetes==11.0.0
 urllib3==1.26.15
+pytest==7.4.4


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64235

---

backport of https://github.com/ceph/ceph/pull/55342
parent tracker: https://tracker.ceph.com/issues/64200

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh