### PR TITLE
tools/cephfs-journal-tool: add command to autorepair journal header

### DIFF
--- a/doc/cephfs/cephfs-journal-tool.rst
+++ b/doc/cephfs/cephfs-journal-tool.rst
@@ -24,7 +24,7 @@ Syntax
 ::
 
     cephfs-journal-tool journal <inspect|import|export|reset>
-    cephfs-journal-tool header <get|set>
+    cephfs-journal-tool header <get|set|{autorepair> [--force]}
     cephfs-journal-tool event <get|splice|apply> [filter] <list|json|summary|binary>
 
 
@@ -95,8 +95,17 @@ Header mode
 * ``set`` modifies an attribute of the header.  Allowed attributes are
   ``trimmed_pos``, ``expire_pos`` and ``write_pos``.
 
-Example: header get/set
-~~~~~~~~~~~~~~~~~~~~~~~
+* ``autorepair`` provides a best effort to fix corrupted journal pointers of
+  the mdlog. Events are enumerated and the:
+  * trimmed_pos is set to the first event in the log segment
+  * expire_pos and read_pos are set to the first major segment event
+  * write_pos is set to the the first position immediately after the last event
+  A log is emitted to the console listing the proposed changes to the offsets
+  in the header. Only if a --force argument is found that the proposed header
+  fields are committed to the disk.
+
+Example: header get/set/autorepair
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
@@ -115,6 +124,8 @@ Example: header get/set
     # cephfs-journal-tool header set trimmed_pos 4194303
     Updating trimmed_pos 0x400000 -> 0x3fffff
     Successfully updated header.
+
+    # cephfs-journal-tool --rank a:0 header autorepair [--force]
 
 
 Event mode

--- a/qa/workunits/suites/cephfs_journal_tool_smoke.sh
+++ b/qa/workunits/suites/cephfs_journal_tool_smoke.sh
@@ -62,6 +62,7 @@ $BIN header get
 $BIN header set write_pos 123
 $BIN header set expire_pos 123
 $BIN header set trimmed_pos 123
+$BIN header autorepair
 
 echo "Rolling back journal to original state..."
 $BIN journal import $JOURNAL_FILE

--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -1363,13 +1363,13 @@ void Journaler::_trim()
   }
 
   // trim
-  ceph_assert(trim_to <= write_pos);
-  ceph_assert(trim_to <= expire_pos);
-  ceph_assert(trim_to > trimming_pos);
   ldout(cct, 10) << "trim trimming to " << trim_to
 		 << ", trimmed/trimming/expire are "
 		 << trimmed_pos << "/" << trimming_pos << "/" << expire_pos
 		 << dendl;
+  ceph_assert(trim_to <= write_pos);
+  ceph_assert(trim_to <= expire_pos);
+  ceph_assert(trim_to >= trimming_pos);
 
   // delete range of objects
   uint64_t first = trimming_pos / period;

--- a/src/tools/cephfs/JournalTool.h
+++ b/src/tools/cephfs/JournalTool.h
@@ -57,6 +57,7 @@ class JournalTool : public MDSUtility
 
     // Header operations
     int header_set();
+    int header_autorepair(bool dry_run);
 
     // I/O handles
     librados::Rados rados;


### PR DESCRIPTION
PR provides a best attempt effort to fix mdlog journal pointers in the header.

Fixes: https://tracker.ceph.com/issues/64101
Signed-off-by: Milind Changire <mchangir@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
