### PR TITLE
do_cmake.sh: cleanups using shellcheck

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -5,8 +5,8 @@ if [ -d .git ]; then
     git submodule update --init --recursive --progress
 fi
 
-: ${BUILD_DIR:=build}
-: ${CEPH_GIT_DIR:=..}
+: "${BUILD_DIR:=build}"
+: "${CEPH_GIT_DIR:=..}"
 
 if [ -e $BUILD_DIR ]; then
     echo "'$BUILD_DIR' dir already exists; either rm -rf '$BUILD_DIR' and re-run, or set BUILD_DIR env var to a different directory name"
@@ -67,7 +67,7 @@ cxx_compiler="g++"
 c_compiler="gcc"
 # 20 is used for more future-proof
 for i in $(seq 20 -1 11); do
-  if type -t gcc-$i > /dev/null; then
+  if type -t "gcc-$i" > /dev/null; then
     cxx_compiler="g++-$i"
     c_compiler="gcc-$i"
     break
@@ -83,7 +83,7 @@ if type cmake3 > /dev/null 2>&1 ; then
 else
     CMAKE=cmake
 fi
-${CMAKE} $ARGS "$@" $CEPH_GIT_DIR || exit 1
+${CMAKE} "$ARGS" "$@" "${CEPH_GIT_DIR}" || exit 1
 set +x
 
 # minimal config to find plugins
@@ -95,7 +95,7 @@ EOF
 
 echo done.
 
-if [[ ! "$ARGS $@" =~ "-DCMAKE_BUILD_TYPE" ]]; then
+if [[ ! "$ARGS $*" =~ "-DCMAKE_BUILD_TYPE" ]]; then
   cat <<EOF
 
 ****


### PR DESCRIPTION
Use shellcheck[1] to cleanup 'do_cmak.sh' script.

[1] https://github.com/koalaman/shellcheck





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
