### PR TITLE
dependabot: ignore major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       - "dashboard"
     pull-request-branch-name:
       separator: "-"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -20,3 +23,6 @@ updates:
       prefix: ".github:"
     pull-request-branch-name:
       separator: "-"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Following a breakage in the pr-triage following #55326, this suggests a change to limit the automatic updates proposed by the dependabot to minor and patch versions of the dependencies.

However, it's not yet clear whether this approach is better than just ignoring the PRs if we aren't sure we want to upgrade

This will be discussed in the [corresponding slack thread](https://ceph-storage.slack.com/archives/C1HFJ4VTN/p1706556971580939)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
