### PR TITLE
os/bluestore: Multiple bdev labels on main block device

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5305,12 +5305,6 @@ options:
   level: dev
   default: false
   with_legacy: true
-- name: bluestore_debug_prefill
-  type: float
-  level: dev
-  desc: simulate fragmentation
-  default: 0
-  with_legacy: true
 - name: bluestore_debug_prefragment_max
   type: size
   level: dev

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4383,6 +4383,30 @@ options:
   flags:
   - create
   with_legacy: true
+- name: bluestore_bdev_label_multi
+  type: bool
+  level: advanced
+  desc: Keep multiple copies of block device label.
+  long_desc: Having multiple labels is only useful in error conditions.
+    The label located at offset 0 has been known to be sometimes overwritten by unknown causes,
+    but without it OSD cannot run.
+  default: true
+  flags:
+  - create
+  with_legacy: false
+- name: bluestore_bdev_label_require_all
+  type: bool
+  level: advanced
+  desc: Require all copies to match.
+  long_desc: Under normal conditions, all copies should be the same.
+    Clearing this flag allows to run OSD if at least one of labels
+    could be properly read.
+  default: true
+  see_also:
+  - bluestore_bdev_label_multi
+  flags:
+  - runtime
+  with_legacy: false
 # whether preallocate space if block/db_path/wal_path is file rather that block device.
 - name: bluestore_block_preallocate_file
   type: bool

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4407,6 +4407,16 @@ options:
   flags:
   - runtime
   with_legacy: false
+- name: bluestore_bdev_label_multi_upgrade
+  type: bool
+  level: advanced
+  desc: Let repair upgrade to multi label.
+  long_desc: By default single label is preserved.
+    Setting this variable before running fsck-repair upgrades single label into multi label.
+  default: false
+  flags:
+  - startup
+  with_legacy: false
 # whether preallocate space if block/db_path/wal_path is file rather that block device.
 - name: bluestore_block_preallocate_file
   type: bool

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -546,6 +546,13 @@ uint64_t BlueFS::get_block_device_size(unsigned id) const
   return 0;
 }
 
+BlockDevice* BlueFS::get_block_device(unsigned id) const
+{
+  if (id < bdev.size() && bdev[id])
+    return bdev[id];
+  return nullptr;
+}
+
 void BlueFS::handle_discard(unsigned id, interval_set<uint64_t>& to_release)
 {
   dout(10) << __func__ << " bdev " << id << dendl;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -490,7 +490,7 @@ int BlueFS::add_block_device(unsigned id, const string& path, bool trim,
       break;
     case BDEV_DB:
     case BDEV_NEWDB:
-      reserved = DB_SUPER_RESERVED;
+      reserved = SUPER_RESERVED;
       break;
     case BDEV_SLOW:
       reserved = 0;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -743,6 +743,7 @@ public:
 		       bluefs_shared_alloc_context_t* _shared_alloc = nullptr);
   bool bdev_support_label(unsigned id);
   uint64_t get_block_device_size(unsigned bdev) const;
+  BlockDevice* get_block_device(unsigned bdev) const;
 
   // handler for discard event
   void handle_discard(unsigned dev, interval_set<uint64_t>& to_release);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6013,16 +6013,15 @@ int BlueStore::write_meta(const std::string& key, const std::string& value)
 {
   string p = path + "/block";
   if (bdev_label_valid_locations.empty()) {
-    int r = _read_main_bdev_label(cct, p, &bdev_label,
+    _read_main_bdev_label(cct, p, &bdev_label,
       &bdev_label_valid_locations, &bdev_label_multi, &bdev_label_epoch);
-    ceph_assert(r == 0);
   }
   if (!bdev_label_valid_locations.empty()) {
     bdev_label.meta[key] = value;
     if (bdev_label_multi) {
       bdev_label.meta["epoch"] = std::to_string(bdev_label_epoch);
     }
-    int r = _write_bdev_label(cct, p, bdev_label);
+    int r = _write_bdev_label(cct, p, bdev_label, bdev_label_valid_locations);
     ceph_assert(r == 0);
   }
   return ObjectStore::write_meta(key, value);
@@ -6032,9 +6031,8 @@ int BlueStore::read_meta(const std::string& key, std::string *value)
 {
   string p = path + "/block";
   if (bdev_label_valid_locations.empty()) {
-    int r = _read_main_bdev_label(cct, p, &bdev_label,
+    _read_main_bdev_label(cct, p, &bdev_label,
       &bdev_label_valid_locations, &bdev_label_multi, &bdev_label_epoch);
-    ceph_assert(r == 0);
   }
   if (!bdev_label_valid_locations.empty()) {
     auto i = bdev_label.meta.find(key);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6752,6 +6752,7 @@ void BlueStore::_main_bdev_label_try_reserve()
   alloc->foreach(look_for_bdev);
   for (auto& location : accepted_positions) {
     alloc->init_rm_free(location, lsize);
+    bdev_label_valid_locations.push_back(location);
   }
 
   for (size_t i = 0; i < candidate_positions.size(); i++) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6018,7 +6018,7 @@ int BlueStore::write_meta(const std::string& key, const std::string& value)
   }
   string p = path + "/block";
   if (bdev_label_valid_locations.empty()) {
-    _read_main_bdev_label(&bdev_label, &bdev_label_valid_locations,
+    _read_main_bdev_label(cct, bdev, p, fsid, &bdev_label, &bdev_label_valid_locations,
       &bdev_label_multi, &bdev_label_epoch);
   }
   if (!bdev_label_valid_locations.empty()) {
@@ -6027,7 +6027,7 @@ int BlueStore::write_meta(const std::string& key, const std::string& value)
       bdev_label_epoch++;
       bdev_label.meta["epoch"] = std::to_string(bdev_label_epoch);
     }
-    int r = _write_bdev_label(cct, p, bdev_label, bdev_label_valid_locations);
+    int r = _write_bdev_label(cct, bdev, p, bdev_label, bdev_label_valid_locations);
     ceph_assert(r == 0);
   }
   return ObjectStore::write_meta(key, value);
@@ -6041,7 +6041,7 @@ int BlueStore::read_meta(const std::string& key, std::string *value)
   }
   string p = path + "/block";
   if (bdev_label_valid_locations.empty()) {
-    _read_main_bdev_label(&bdev_label, &bdev_label_valid_locations,
+    _read_main_bdev_label(cct, bdev, p, fsid, &bdev_label, &bdev_label_valid_locations,
       &bdev_label_multi, &bdev_label_epoch);
   }
   if (!bdev_label_valid_locations.empty()) {
@@ -6483,11 +6483,17 @@ int BlueStore::get_block_device_fsid(CephContext* cct, const string& path,
 				     uuid_d *fsid)
 {
   bluestore_bdev_label_t label;
-  int r = _read_bdev_label(cct, path, &label);
-  if (r < 0)
-    return r;
-  *fsid = label.osd_uuid;
-  return 0;
+  string bdev_path = path + "/block";
+  unique_ptr<BlockDevice> bdev(BlockDevice::create(cct, bdev_path, nullptr, nullptr, nullptr, nullptr));
+  int r = bdev->open(bdev_path);
+  if (r == 0) {
+    r = _read_main_bdev_label(cct, bdev.get(), bdev_path, uuid_d(), &label);
+  }
+  if (r == 0) {
+    *fsid = label.osd_uuid;
+  }
+  bdev->close();
+  return r;
 }
 
 int BlueStore::_open_path()
@@ -6512,11 +6518,13 @@ void BlueStore::_close_path()
 
 int BlueStore::_write_bdev_label(
   CephContext *cct,
+  BlockDevice* bdev,
   const string &path,
   bluestore_bdev_label_t label,
   std::vector<uint64_t> locations)
 {
-  dout(10) << __func__ << " path " << path << " label " << label << dendl;
+  dout(10) << __func__ << " path " << path << " label " << label
+    << " locations " << locations << dendl;
   bufferlist bl;
   encode(label, bl);
   uint32_t crc = bl.crc32c(-1);
@@ -6526,29 +6534,15 @@ int BlueStore::_write_bdev_label(
   z.zero();
   bl.append(std::move(z));
 
-  int fd = TEMP_FAILURE_RETRY(::open(path.c_str(), O_WRONLY|O_CLOEXEC|O_DIRECT));
-  if (fd < 0) {
-    fd = -errno;
-    derr << __func__ << " failed to open " << path << ": " << cpp_strerror(fd)
-	 << dendl;
-    return fd;
-  }
   bl.rebuild_aligned_size_and_memory(BDEV_LABEL_BLOCK_SIZE, BDEV_LABEL_BLOCK_SIZE, IOV_MAX);
   int r = 0;
   ceph_assert(locations.size() > 0);
-  struct stat st;
-  r = ::fstat(fd, &st);
-  if (r < 0) {
-    r = -errno;
-    derr << __func__ << " failed to fstat " << path << ": " << cpp_strerror(r) << dendl;
-    VOID_TEMP_FAILURE_RETRY(::close(fd));
-    return r;
-  }
+  uint64_t dev_size = bdev->get_size();
   int failed_r = 0;
   bool wrote_at_least_one = false;
   for (uint64_t position : locations) {
-    if (int64_t(position + BDEV_LABEL_BLOCK_SIZE) <= st.st_size) {
-      r = bl.write_fd(fd, position);
+    if (position + BDEV_LABEL_BLOCK_SIZE <= dev_size) {
+      r = bdev->write(position, bl, false);
       if (r == 0) {
         wrote_at_least_one = true;
       } else {
@@ -6560,17 +6554,16 @@ int BlueStore::_write_bdev_label(
     }
   }
   if (!wrote_at_least_one) {
-    derr << __func__ << " failed to write to any bdev of locations" << dendl;
+    derr << __func__ << " failed to write to any of bdev locations" << dendl;
     r = failed_r;
     goto out;
   }
-  r = ::fsync(fd);
+  r = bdev->flush();
   if (r < 0) {
     derr << __func__ << " failed to fsync " << path
       << ": " << cpp_strerror(r) << dendl;
   }
 out:
-  VOID_TEMP_FAILURE_RETRY(::close(fd));
   return r;
 }
 /*
@@ -6583,44 +6576,28 @@ out:
 */
 int BlueStore::_read_bdev_label(
   CephContext* cct,
+  BlockDevice* bdev,
   const std::string &path,
   bluestore_bdev_label_t *label,
   uint64_t disk_position)
 {
   dout(10) << __func__ << " position=0x" << std::hex << disk_position << std::dec << dendl;
-  int fd = TEMP_FAILURE_RETRY(::open(path.c_str(), O_RDONLY|O_CLOEXEC));
-  if (fd < 0) {
-    fd = -errno;
-    derr << __func__ << " failed to open " << path << ": " << cpp_strerror(fd)
-	 << dendl;
-    return fd;
-  }
+  ceph_assert(bdev);
   bufferlist bl;
   unique_ptr<char> buf(new char[BDEV_LABEL_BLOCK_SIZE]);
-  struct stat st;
-  int r = ::fstat(fd, &st);
-  if (r < 0) {
-    r = -errno;
-    derr << __func__ << " failed to fstat " << path << ": " << cpp_strerror(r) << dendl;
-    VOID_TEMP_FAILURE_RETRY(::close(fd));
-    return r;
-  }
-  if (st.st_size <= int64_t(disk_position + BDEV_LABEL_BLOCK_SIZE)) {
+  uint64_t dev_size = bdev->get_size();
+  if (dev_size <= disk_position + BDEV_LABEL_BLOCK_SIZE) {
     dout(10) << __func__ << " position=0x" << std::hex << disk_position
-      << " dev size=0x" << st.st_size << std::dec << dendl;
+      << " dev size=0x" << dev_size << std::dec << dendl;
     return 1;
   }
-
-  r = safe_pread_exact(fd, buf.get(), BDEV_LABEL_BLOCK_SIZE, disk_position);
+  int r = bdev->read_random(disk_position, BDEV_LABEL_BLOCK_SIZE, buf.get(), false);
   if (r < 0) {
     derr << __func__ << " failed to read from " << path
          << " at 0x" << std::hex << disk_position << std::dec
          <<": " << cpp_strerror(r) << dendl;
   }
-  VOID_TEMP_FAILURE_RETRY(::close(fd));
-  if (r < 0) {
-    return r;
-  }
+
   bl.append(buf.get(), BDEV_LABEL_BLOCK_SIZE);
   uint32_t crc, expected_crc;
   auto p = bl.cbegin();
@@ -6649,6 +6626,7 @@ int BlueStore::_read_bdev_label(
 
 /**
   Reads device label.
+  fsid            - Fsid to look for. If zero, accept any.
   *out_label      - Filled if reading of label is considered successful.
   *out_valid_positions - List of locations that contained valid labels.
   *out_is_multi  -  Whether the label is regular or multi label with epoch.
@@ -6658,15 +6636,19 @@ int BlueStore::_read_bdev_label(
   0    When all label are read
   1    When some, but not all labels are read
   -ENOENT Otherwise
-
 */
 int BlueStore::_read_main_bdev_label(
+  CephContext* cct,
+  BlockDevice* bdev,
+  const string& path,
+  uuid_d fsid,
   bluestore_bdev_label_t *out_label,
   std::vector<uint64_t>* out_valid_positions,
   bool* out_is_multi,
   int64_t* out_epoch)
 {
   dout(10) << __func__ << dendl;
+  ceph_assert(bdev);
   ceph_assert(out_label);
   // go and try read all possible bdev labels.
   // if only first bdev label is correct, it must not have "multi=yes" key.
@@ -6674,7 +6656,7 @@ int BlueStore::_read_main_bdev_label(
   bool all_labels_valid = true;
   for (uint64_t position : bdev_label_positions) {
     bluestore_bdev_label_t label;
-    int r = _read_bdev_label(cct, path + "/block", &label, position);
+    int r = _read_bdev_label(cct, bdev, path, &label, position);
     if (r == 0 && (fsid.is_zero() || label.osd_uuid == fsid)) {
       auto i = label.meta.find("multi");
       bool is_multi = i != label.meta.end() && i->second == "yes";
@@ -6694,6 +6676,7 @@ int BlueStore::_read_main_bdev_label(
         // for not base bdev position, it has to be cloned to be considered
         continue;
       }
+      fsid = label.osd_uuid; //from now on, only accept same fsid
       i = label.meta.find("epoch");
       if (i != label.meta.end()) {
         int64_t v = atoll(i->second.c_str());
@@ -6719,6 +6702,7 @@ int BlueStore::_read_main_bdev_label(
     } else if (r == 0) {
       derr << __func__ << " label at 0x" << std::hex << position << std::dec
         << " correct, but osd_uuid=" << label.osd_uuid << " need=" << fsid << dendl;
+      all_labels_valid = false;
     } else if (r == 1) {
       // tried to read but no disk
     } else {
@@ -6793,7 +6777,8 @@ void BlueStore::_main_bdev_label_remove(Allocator* an_alloc)
 }
 
 int BlueStore::_check_or_set_bdev_label(
-  const string& path, uint64_t size, const string& desc, bool create)
+  const string& path, BlockDevice* bdev,
+  uint64_t size, const string& desc, bool create)
 {
   bluestore_bdev_label_t label;
   if (create) {
@@ -6801,11 +6786,11 @@ int BlueStore::_check_or_set_bdev_label(
     label.size = size;
     label.btime = ceph_clock_now();
     label.description = desc;
-    int r = _write_bdev_label(cct, path, label);
+    int r = _write_bdev_label(cct, bdev, path, label);
     if (r < 0)
       return r;
   } else {
-    int r = _read_bdev_label(cct, path, &label);
+    int r = _read_bdev_label(cct, bdev, path, &label);
     if (r < 0)
       return r;
     if (cct->_conf->bluestore_debug_permit_any_bdev_label) {
@@ -6842,7 +6827,7 @@ int BlueStore::_set_main_bdev_label()
   } else {
     bdev_label_valid_locations.push_back(BDEV_FIRST_LABEL_POSITION);
   }
-  int r = _write_bdev_label(cct, path + "/block", label, bdev_label_valid_locations);
+  int r = _write_bdev_label(cct, bdev, path + "/block", label, bdev_label_valid_locations);
   if (r < 0)
     return r;
   return 0;
@@ -6851,8 +6836,8 @@ int BlueStore::_set_main_bdev_label()
 int BlueStore::_check_main_bdev_label()
 {
   string block_path = path + "/block";
-  int r = _read_main_bdev_label(&bdev_label, &bdev_label_valid_locations,
-    &bdev_label_multi, &bdev_label_epoch);
+  int r = _read_main_bdev_label(cct, bdev, block_path, fsid, &bdev_label,
+    &bdev_label_valid_locations, &bdev_label_multi, &bdev_label_epoch);
   if (r < 0)
     return r;
   if (cct->_conf->bluestore_debug_permit_any_bdev_label) {
@@ -7405,6 +7390,7 @@ int BlueStore::_minimal_open_bluefs(bool create)
     if (bluefs->bdev_support_label(BlueFS::BDEV_DB)) {
       r = _check_or_set_bdev_label(
 	bfn,
+        bluefs->get_block_device(BlueFS::BDEV_DB),
 	bluefs->get_block_device_size(BlueFS::BDEV_DB),
         "bluefs db", create);
       if (r < 0) {
@@ -7452,6 +7438,7 @@ int BlueStore::_minimal_open_bluefs(bool create)
     if (bluefs->bdev_support_label(BlueFS::BDEV_WAL)) {
       r = _check_or_set_bdev_label(
 	bfn,
+        bluefs->get_block_device(BlueFS::BDEV_WAL),
 	bluefs->get_block_device_size(BlueFS::BDEV_WAL),
         "bluefs wal", create);
       if (r < 0) {
@@ -8574,6 +8561,7 @@ int BlueStore::add_new_bluefs_device(int id, const string& dev_path)
     if (bluefs->bdev_support_label(BlueFS::BDEV_NEWWAL)) {
       r = _check_or_set_bdev_label(
 	p,
+        bluefs->get_block_device(BlueFS::BDEV_NEWWAL),
 	bluefs->get_block_device_size(BlueFS::BDEV_NEWWAL),
         "bluefs wal",
 	true);
@@ -8595,6 +8583,7 @@ int BlueStore::add_new_bluefs_device(int id, const string& dev_path)
     if (bluefs->bdev_support_label(BlueFS::BDEV_NEWDB)) {
       r = _check_or_set_bdev_label(
 	p,
+        bluefs->get_block_device(BlueFS::BDEV_NEWDB),
 	bluefs->get_block_device_size(BlueFS::BDEV_NEWDB),
         "bluefs db",
 	true);
@@ -8724,6 +8713,7 @@ int BlueStore::migrate_to_new_bluefs_device(const set<int>& devs_source,
     if (bluefs->bdev_support_label(BlueFS::BDEV_NEWWAL)) {
       r = _check_or_set_bdev_label(
 	dev_path,
+        bluefs->get_block_device(BlueFS::BDEV_NEWWAL),
 	bluefs->get_block_device_size(BlueFS::BDEV_NEWWAL),
         "bluefs wal",
 	true);
@@ -8742,6 +8732,7 @@ int BlueStore::migrate_to_new_bluefs_device(const set<int>& devs_source,
     if (bluefs->bdev_support_label(BlueFS::BDEV_NEWDB)) {
       r = _check_or_set_bdev_label(
 	dev_path,
+        bluefs->get_block_device(BlueFS::BDEV_NEWDB),
 	bluefs->get_block_device_size(BlueFS::BDEV_NEWDB),
         "bluefs db",
 	true);
@@ -8804,13 +8795,13 @@ string BlueStore::get_device_path(unsigned id)
 int BlueStore::_set_bdev_label_size(const string& path, uint64_t size)
 {
   bluestore_bdev_label_t label;
-  int r = _read_bdev_label(cct, path, &label);
+  int r = _read_bdev_label(cct, bdev, path, &label);
   if (r < 0) {
     derr << "unable to read label for " << path << ": "
           << cpp_strerror(r) << dendl;
   } else {
     label.size = size;
-    r = _write_bdev_label(cct, path, label);
+    r = _write_bdev_label(cct, bdev, path, label);
     if (r < 0) {
       derr << "unable to write label for " << path << ": "
             << cpp_strerror(r) << dendl;
@@ -11368,7 +11359,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     ceph_assert(bdev->supported_bdev_label());
     // Now fix bdev_labels that were detected to be broken & repairable.
     string p = path + "/block";
-    _write_bdev_label(cct, p, bdev_label, bdev_labels_in_repair);
+    _write_bdev_label(cct, bdev, p, bdev_label, bdev_labels_in_repair);
     repaired += bdev_labels_in_repair.size();
   }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6489,8 +6489,11 @@ void BlueStore::_close_path()
   path_fd = -1;
 }
 
-int BlueStore::_write_bdev_label(CephContext *cct,
-				 const string &path, bluestore_bdev_label_t label)
+int BlueStore::_write_bdev_label(
+  CephContext *cct,
+  const string &path,
+  bluestore_bdev_label_t label,
+  std::vector<uint64_t> locations)
 {
   dout(10) << __func__ << " path " << path << " label " << label << dendl;
   bufferlist bl;
@@ -6510,26 +6513,43 @@ int BlueStore::_write_bdev_label(CephContext *cct,
     return fd;
   }
   bl.rebuild_aligned_size_and_memory(BDEV_LABEL_BLOCK_SIZE, BDEV_LABEL_BLOCK_SIZE, IOV_MAX);
-  int r = bl.write_fd(fd);
-  if (r < 0) {
-    derr << __func__ << " failed to write to " << path
-	 << ": " << cpp_strerror(r) << dendl;
-    goto out;
+  int r = 0;
+  if (std::find(locations.begin(), locations.end(), BDEV_LABEL_POSITION) ==
+      locations.end()) {
+    locations.push_back(BDEV_LABEL_POSITION);
+  }
+  for (uint64_t position : locations) {
+    r = bl.write_fd(fd, position);
+    if (r < 0) {
+      derr << __func__ << " failed to write to " << path
+        << ": " << cpp_strerror(r) << dendl;
+      goto out;
+    }
   }
   r = ::fsync(fd);
   if (r < 0) {
     derr << __func__ << " failed to fsync " << path
-	 << ": " << cpp_strerror(r) << dendl;
+      << ": " << cpp_strerror(r) << dendl;
   }
 out:
   VOID_TEMP_FAILURE_RETRY(::close(fd));
   return r;
 }
+/*
+  Reads bdev label at specific position.
 
-int BlueStore::_read_bdev_label(CephContext* cct, const string &path,
-				bluestore_bdev_label_t *label)
+  Returns:
+  0 - label read successful
+  1 - position outside device
+  <0 - error
+*/
+int BlueStore::_read_bdev_label(
+  CephContext* cct,
+  const std::string &path,
+  bluestore_bdev_label_t *label,
+  uint64_t disk_position)
 {
-  dout(10) << __func__ << dendl;
+  dout(10) << __func__ << " position=0x" << std::hex << disk_position << std::dec << dendl;
   int fd = TEMP_FAILURE_RETRY(::open(path.c_str(), O_RDONLY|O_CLOEXEC));
   if (fd < 0) {
     fd = -errno;
@@ -6538,14 +6558,32 @@ int BlueStore::_read_bdev_label(CephContext* cct, const string &path,
     return fd;
   }
   bufferlist bl;
-  int r = bl.read_fd(fd, BDEV_LABEL_BLOCK_SIZE);
-  VOID_TEMP_FAILURE_RETRY(::close(fd));
+  unique_ptr<char> buf(new char[BDEV_LABEL_BLOCK_SIZE]);
+  struct stat st;
+  int r = ::fstat(fd, &st);
   if (r < 0) {
-    derr << __func__ << " failed to read from " << path
-	 << ": " << cpp_strerror(r) << dendl;
+    r = -errno;
+    derr << __func__ << " failed to fstat " << path << ": " << cpp_strerror(r) << dendl;
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
     return r;
   }
+  if (st.st_size <= int64_t(disk_position + BDEV_LABEL_BLOCK_SIZE)) {
+    dout(10) << __func__ << " position=0x" << std::hex << disk_position
+      << " dev size=0x" << st.st_size << std::dec << dendl;
+    return 1;
+  }
 
+  r = safe_pread_exact(fd, buf.get(), BDEV_LABEL_BLOCK_SIZE, disk_position);
+  if (r < 0) {
+    derr << __func__ << " failed to read from " << path
+         << " at 0x" << std::hex << disk_position << std::dec
+         <<": " << cpp_strerror(r) << dendl;
+  }
+  VOID_TEMP_FAILURE_RETRY(::close(fd));
+  if (r < 0) {
+    return r;
+  }
+  bl.append(buf.get(), BDEV_LABEL_BLOCK_SIZE);
   uint32_t crc, expected_crc;
   auto p = bl.cbegin();
   try {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6804,8 +6804,8 @@ int BlueStore::_check_or_set_bdev_label(
 int BlueStore::_check_or_set_main_bdev_label(
   string path, uint64_t size, bool create)
 {
-  bluestore_bdev_label_t label;
   if (create) {
+    bluestore_bdev_label_t label;
     label.osd_uuid = fsid;
     label.size = size;
     label.btime = ceph_clock_now();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6609,6 +6609,91 @@ int BlueStore::_read_bdev_label(
   return 0;
 }
 
+/**
+  Reads device label.
+  cct             - CephContext, as usual
+  path            - Path to block device, as conf.bluestore_block_path defines.
+  *out_label      - Filled if reading of label is considered successful.
+  *out_valid_positions - List of locations that contained valid labels.
+  *out_is_multi  -  Whether the label is regular or multi label with epoch.
+  *out_epoch     -  Epoch of label.
+
+  Returns:
+  0    When all label are read
+  1    When some, but not all labels are read
+  -ENOENT Otherwise
+
+*/
+int BlueStore::_read_main_bdev_label(
+  CephContext* cct,
+  const string &path,
+  bluestore_bdev_label_t *out_label,
+  std::vector<uint64_t>* out_valid_positions,
+  bool* out_is_multi,
+  int64_t* out_epoch)
+{
+  dout(10) << __func__ << dendl;
+  ceph_assert(out_label);
+  // go and try read all possible bdev labels.
+  // if only first bdev label is correct, it must not have "multi=yes" key.
+  int64_t epoch = -1;
+  bool all_labels_valid = true;
+  for (uint64_t position : bdev_label_positions) {
+    bluestore_bdev_label_t label;
+    int r = _read_bdev_label(cct, path, &label, position);
+    if (r == 0) {
+      auto i = label.meta.find("multi");
+      bool is_multi = i != label.meta.end() && i->second == "yes";
+      if (position == BDEV_LABEL_POSITION && !is_multi) {
+        // we have a single-label case
+        *out_label = label;
+        is_multi = false;
+        if (out_is_multi) {
+          *out_is_multi = false;
+        }
+        if(out_valid_positions) {
+          out_valid_positions->push_back(position);
+        }
+        goto done;
+      }
+      if (!is_multi) {
+        // for not base bdev position, it has to be cloned to be considered
+        continue;
+      }
+      i = label.meta.find("epoch");
+      if (i != label.meta.end()) {
+        int64_t v = atoll(i->second.c_str());
+        if (v > epoch) {
+          epoch = v;
+          *out_label = label;
+          if (out_epoch) {
+            *out_epoch = epoch;
+          }
+          is_multi = true;
+          if (out_is_multi) {
+            *out_is_multi = true;
+          }
+          if(out_valid_positions) {
+            out_valid_positions->push_back(position);
+          }
+        }
+      }
+    } else if (r == 1) {
+      // tried to read but no disk
+    } else {
+      all_labels_valid = false;
+    }
+  }
+  if (epoch == -1) {
+    // not even one label read properly
+    derr << "No valid bdev label found" << dendl;
+    return -ENOENT;
+  }
+  done:
+  dout(10) << __func__ << " got " << *out_label << dendl;
+  return all_labels_valid ? 0 : 1;
+}
+
 int BlueStore::_check_or_set_bdev_label(
   string path, uint64_t size, string desc, bool create)
 {
@@ -6632,6 +6717,44 @@ int BlueStore::_check_or_set_bdev_label(
       derr << __func__ << " bdev " << path << " fsid " << label.osd_uuid
 	   << " does not match our fsid " << fsid << dendl;
       return -EIO;
+    }
+  }
+  return 0;
+}
+
+int BlueStore::_check_or_set_main_bdev_label(
+  string path, uint64_t size, bool create)
+{
+  bluestore_bdev_label_t label;
+  if (create) {
+    label.osd_uuid = fsid;
+    label.size = size;
+    label.btime = ceph_clock_now();
+    label.description = "main";
+    if (cct->_conf.get_val<bool>("bluestore_bdev_label_multi")) {
+      label.meta["multi"] = "yes";
+      label.meta["epoch"] = "1";
+    }
+    int r = _write_bdev_label(cct, path, label, bdev_label_positions);
+    if (r < 0)
+      return r;
+  } else {
+    int r = _read_main_bdev_label(cct, path, &bdev_label, &bdev_label_valid_locations);
+    if (r < 0)
+      return r;
+    if (cct->_conf->bluestore_debug_permit_any_bdev_label) {
+      dout(20) << __func__ << " bdev " << path << " fsid " << label.osd_uuid
+	   << " and fsid " << fsid << " check bypassed" << dendl;
+    } else if (label.osd_uuid != fsid) {
+      derr << __func__ << " bdev " << path << " fsid " << label.osd_uuid
+	   << " does not match our fsid " << fsid << dendl;
+      return -EIO;
+    }
+    if (cct->_conf.get_val<bool>("bluestore_bdev_label_require_all")) {
+      if (r != 0) {
+        derr << __func__ << "not all labels read properly" << dendl;
+        return -EIO;
+      }
     }
   }
   return 0;
@@ -6686,7 +6809,7 @@ int BlueStore::_open_bdev(bool create)
   }
 
   if (bdev->supported_bdev_label()) {
-    r = _check_or_set_bdev_label(p, bdev->get_size(), "main", create);
+    r = _check_or_set_main_bdev_label(p, bdev->get_size(), create);
     if (r < 0)
       goto fail_close;
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6012,6 +6012,10 @@ int BlueStore::_set_cache_sizes()
 
 int BlueStore::write_meta(const std::string& key, const std::string& value)
 {
+    if (bdev && !bdev->supported_bdev_label()) {
+    // skip bdev label section if not supported
+    return ObjectStore::write_meta(key, value);
+  }
   string p = path + "/block";
   if (bdev_label_valid_locations.empty()) {
     _read_main_bdev_label(cct, p, &bdev_label,
@@ -6031,6 +6035,10 @@ int BlueStore::write_meta(const std::string& key, const std::string& value)
 
 int BlueStore::read_meta(const std::string& key, std::string *value)
 {
+  if (bdev && !bdev->supported_bdev_label()) {
+    // skip bdev label section if not supported
+    return ObjectStore::read_meta(key, value);
+  }
   string p = path + "/block";
   if (bdev_label_valid_locations.empty()) {
     _read_main_bdev_label(cct, p, &bdev_label,
@@ -6816,7 +6824,7 @@ int BlueStore::_check_or_set_main_bdev_label(
       bdev_label_multi = true;
       bdev_label_epoch = 1;
       for (uint64_t position : bdev_label_positions) {
-        if (int64_t(position + BDEV_LABEL_BLOCK_SIZE) <= size) {
+        if (position + BDEV_LABEL_BLOCK_SIZE <= size) {
           bdev_label_valid_locations.push_back(position);
         }
       }
@@ -10457,18 +10465,8 @@ int BlueStore::_fsck(BlueStore::FSCKDepth depth, bool repair)
       depth == FSCK_SHALLOW ? " (shallow)" : " (regular)")
     << dendl;
 
-  {
-    string p = path + "/block";
-    int r = _read_main_bdev_label(cct, p, &bdev_label,
-      &bdev_label_valid_locations, &bdev_label_multi);
-    if (r < 0) {
-      derr << __func__ << " fsck error: no valid block device label found" << dendl;
-      return r;
-    }
-    // hack - sanitize check for bdev label
-    bluestore_bdev_label_require_all = false;
-  }
-
+  // hack - sanitize check for bdev label
+  bluestore_bdev_label_require_all = false;
   auto restore_option = make_scope_guard([&] {
     bluestore_bdev_label_require_all = cct->_conf.get_val<bool>("bluestore_bdev_label_require_all");
   });
@@ -10563,8 +10561,13 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
 
   auto alloc_size = fm->get_alloc_size();
 
+  if (bdev->supported_bdev_label() && bdev_label_multi
+    && bdev_label_valid_locations.empty()) {
+    derr << __func__ << " fsck error: no valid block device label found" << dendl;
+    return -EIO;
+  }
   // Delayed action, we could not do it in _fsck().
-  if (repair && !bdev_label_multi &&
+  if (bdev->supported_bdev_label() && repair && !bdev_label_multi &&
     cct->_conf.get_val<bool>("bluestore_bdev_label_multi_upgrade")) {
     // upgrade to multi
     bdev_label.meta["multi"] = "yes";
@@ -10573,7 +10576,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     bdev_labels_broken.push_back(BDEV_LABEL_POSITION);
     errors++;
   }
-  if (bdev_label_multi) {
+  if (bdev->supported_bdev_label() && bdev_label_multi) {
     for (size_t i = 0; i < bdev_label_positions.size(); i++) {
       uint64_t location = bdev_label_positions[i];
       if (location + BDEV_LABEL_BLOCK_SIZE > bdev->get_size()) {
@@ -10615,7 +10618,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
 
   bluefs_used_blocks = used_blocks;
 
-  if (bdev_label_multi) {
+  if (bdev->supported_bdev_label() && bdev_label_multi) {
     // Forcibly mark regions of bdev label clones as used.
     // If an object happens to be using it we will get an error and a repair applied.
     // We can move away data only if it was allocated for object in BlueStore,
@@ -11244,6 +11247,10 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     // skip freelist vs allocated compare when we have Null fm
     if (!fm->is_null_manager()) {
       dout(1) << __func__ << " checking freelist vs allocated" << dendl;
+      if (!bdev->supported_bdev_label()) {
+        // it should be 0 labels if labels are not supported
+        ceph_assert(bdev_label_valid_locations.empty());
+      }
       //unmark extra bdev copies, will collide with the check
       for (uint64_t location : bdev_label_valid_locations) {
         uint64_t length = std::max<uint64_t>(BDEV_LABEL_BLOCK_SIZE, alloc_size);
@@ -11339,6 +11346,8 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     dout(5) << __func__ << " repair applied" << dendl;
   }
   if (repair && bdev_labels_in_repair.size() > 0) {
+    // should not happen when labels are disabled
+    ceph_assert(bdev->supported_bdev_label());
     // Now fix bdev_labels that were detected to be broken & repairable.
     string p = path + "/block";
     _write_bdev_label(cct, p, bdev_label, bdev_labels_in_repair);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6012,7 +6012,7 @@ int BlueStore::_set_cache_sizes()
 
 int BlueStore::write_meta(const std::string& key, const std::string& value)
 {
-    if (bdev && !bdev->supported_bdev_label()) {
+  if (!bdev || !bdev->supported_bdev_label()) {
     // skip bdev label section if not supported
     return ObjectStore::write_meta(key, value);
   }
@@ -6035,7 +6035,7 @@ int BlueStore::write_meta(const std::string& key, const std::string& value)
 
 int BlueStore::read_meta(const std::string& key, std::string *value)
 {
-  if (bdev && !bdev->supported_bdev_label()) {
+  if (!bdev || !bdev->supported_bdev_label()) {
     // skip bdev label section if not supported
     return ObjectStore::read_meta(key, value);
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6750,7 +6750,6 @@ void BlueStore::_main_bdev_label_try_reserve()
   alloc->foreach(look_for_bdev);
   for (auto& location : accepted_positions) {
     alloc->init_rm_free(location, lsize);
-    bdev_label_valid_locations.push_back(location);
   }
 
   for (size_t i = 0; i < candidate_positions.size(); i++) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6695,8 +6695,12 @@ int BlueStore::_read_main_bdev_label(
             *out_is_multi = true;
           }
           if(out_valid_positions) {
-            out_valid_positions->push_back(position);
+            // clear out old versions
+            out_valid_positions->clear();
           }
+        }
+        if(v == epoch && out_valid_positions) {
+          out_valid_positions->push_back(position);
         }
       }
     } else if (r == 1) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6652,18 +6652,18 @@ int BlueStore::_read_main_bdev_label(
   ceph_assert(out_label);
   // go and try read all possible bdev labels.
   // if only first bdev label is correct, it must not have "multi=yes" key.
+  bool any_fsid = cct->_conf->bluestore_debug_permit_any_bdev_label;
   int64_t epoch = -1;
   bool all_labels_valid = true;
   for (uint64_t position : bdev_label_positions) {
     bluestore_bdev_label_t label;
     int r = _read_bdev_label(cct, bdev, path, &label, position);
-    if (r == 0 && (fsid.is_zero() || label.osd_uuid == fsid)) {
+    if (r == 0 && (fsid.is_zero() || label.osd_uuid == fsid || any_fsid)) {
       auto i = label.meta.find("multi");
       bool is_multi = i != label.meta.end() && i->second == "yes";
       if (position == BDEV_FIRST_LABEL_POSITION && !is_multi) {
         // we have a single-label case
         *out_label = label;
-        is_multi = false;
         if (out_is_multi) {
           *out_is_multi = false;
         }
@@ -6676,28 +6676,28 @@ int BlueStore::_read_main_bdev_label(
         // for not base bdev position, it has to be cloned to be considered
         continue;
       }
-      fsid = label.osd_uuid; //from now on, only accept same fsid
+      //from now on, only accept same fsid, unless overriden by config
+      fsid = label.osd_uuid;
       i = label.meta.find("epoch");
       if (i != label.meta.end()) {
         int64_t v = atoll(i->second.c_str());
         if (v > epoch) {
           epoch = v;
           *out_label = label;
-          if (out_epoch) {
-            *out_epoch = epoch;
-          }
-          is_multi = true;
-          if (out_is_multi) {
-            *out_is_multi = true;
-          }
           if(out_valid_positions) {
             // clear out old versions
             out_valid_positions->clear();
           }
+        } else if (v < epoch) {
+          derr << __func__ << " label at 0x" << std::hex << position << std::dec
+               << " has outdated epoch=" << v << " current=" << epoch << dendl;
         }
         if(v == epoch && out_valid_positions) {
           out_valid_positions->push_back(position);
         }
+      } else {
+        derr << __func__ << " label at 0x" << std::hex << position << std::dec
+             << " is multi=yes but no epoch=" << dendl;
       }
     } else if (r == 0) {
       derr << __func__ << " label at 0x" << std::hex << position << std::dec
@@ -6709,7 +6709,14 @@ int BlueStore::_read_main_bdev_label(
       all_labels_valid = false;
     }
   }
-  if (epoch == -1) {
+  if (epoch != -1) {
+    if (out_epoch) {
+      *out_epoch = epoch;
+    }
+    if (out_is_multi) {
+      *out_is_multi = true;
+    }
+  } else {
     // not even one label read properly
     derr << "No valid bdev label found" << dendl;
     return -ENOENT;
@@ -6777,13 +6784,13 @@ void BlueStore::_main_bdev_label_remove(Allocator* an_alloc)
 }
 
 int BlueStore::_check_or_set_bdev_label(
-  const string& path, BlockDevice* bdev,
-  uint64_t size, const string& desc, bool create)
+  BlockDevice* bdev, const string& path,
+  const string& desc, bool create)
 {
   bluestore_bdev_label_t label;
   if (create) {
     label.osd_uuid = fsid;
-    label.size = size;
+    label.size = bdev->get_size();
     label.btime = ceph_clock_now();
     label.description = desc;
     int r = _write_bdev_label(cct, bdev, path, label);
@@ -7419,14 +7426,12 @@ int BlueStore::_minimal_open_bluefs(bool create)
 
     if (bluefs->bdev_support_label(BlueFS::BDEV_DB)) {
       r = _check_or_set_bdev_label(
-	bfn,
         bluefs->get_block_device(BlueFS::BDEV_DB),
-	bluefs->get_block_device_size(BlueFS::BDEV_DB),
+        bfn,
         "bluefs db", create);
       if (r < 0) {
-        derr << __func__
-	      << " check block device(" << bfn << ") label returned: "
-              << cpp_strerror(r) << dendl;
+        derr << __func__ << " check block device(" << bfn
+             << ") label returned: " << cpp_strerror(r) << dendl;
         goto free_bluefs;
       }
     }
@@ -7467,13 +7472,12 @@ int BlueStore::_minimal_open_bluefs(bool create)
 
     if (bluefs->bdev_support_label(BlueFS::BDEV_WAL)) {
       r = _check_or_set_bdev_label(
-	bfn,
         bluefs->get_block_device(BlueFS::BDEV_WAL),
-	bluefs->get_block_device_size(BlueFS::BDEV_WAL),
+        bfn,
         "bluefs wal", create);
       if (r < 0) {
         derr << __func__ << " check block device(" << bfn
-              << ") label returned: " << cpp_strerror(r) << dendl;
+             << ") label returned: " << cpp_strerror(r) << dendl;
         goto free_bluefs;
       }
     }
@@ -8588,9 +8592,8 @@ int BlueStore::add_new_bluefs_device(int id, const string& dev_path)
 
     if (bluefs->bdev_support_label(BlueFS::BDEV_NEWWAL)) {
       r = _check_or_set_bdev_label(
-	p,
         bluefs->get_block_device(BlueFS::BDEV_NEWWAL),
-	bluefs->get_block_device_size(BlueFS::BDEV_NEWWAL),
+        p,
         "bluefs wal",
 	true);
       ceph_assert(r == 0);
@@ -8610,9 +8613,8 @@ int BlueStore::add_new_bluefs_device(int id, const string& dev_path)
 
     if (bluefs->bdev_support_label(BlueFS::BDEV_NEWDB)) {
       r = _check_or_set_bdev_label(
-	p,
         bluefs->get_block_device(BlueFS::BDEV_NEWDB),
-	bluefs->get_block_device_size(BlueFS::BDEV_NEWDB),
+        p,
         "bluefs db",
 	true);
       ceph_assert(r == 0);
@@ -8740,9 +8742,8 @@ int BlueStore::migrate_to_new_bluefs_device(const set<int>& devs_source,
 
     if (bluefs->bdev_support_label(BlueFS::BDEV_NEWWAL)) {
       r = _check_or_set_bdev_label(
-	dev_path,
         bluefs->get_block_device(BlueFS::BDEV_NEWWAL),
-	bluefs->get_block_device_size(BlueFS::BDEV_NEWWAL),
+        dev_path,
         "bluefs wal",
 	true);
       ceph_assert(r == 0);
@@ -8759,9 +8760,8 @@ int BlueStore::migrate_to_new_bluefs_device(const set<int>& devs_source,
 
     if (bluefs->bdev_support_label(BlueFS::BDEV_NEWDB)) {
       r = _check_or_set_bdev_label(
-	dev_path,
         bluefs->get_block_device(BlueFS::BDEV_NEWDB),
-	bluefs->get_block_device_size(BlueFS::BDEV_NEWDB),
+        dev_path,
         "bluefs db",
 	true);
       ceph_assert(r == 0);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6665,7 +6665,7 @@ int BlueStore::_read_main_bdev_label(
   for (uint64_t position : bdev_label_positions) {
     bluestore_bdev_label_t label;
     int r = _read_bdev_label(cct, path + "/block", &label, position);
-    if (r == 0) {
+    if (r == 0 && (fsid.is_zero() || label.osd_uuid == fsid)) {
       auto i = label.meta.find("multi");
       bool is_multi = i != label.meta.end() && i->second == "yes";
       if (position == BDEV_LABEL_POSITION && !is_multi) {
@@ -6706,6 +6706,9 @@ int BlueStore::_read_main_bdev_label(
           out_valid_positions->push_back(position);
         }
       }
+    } else if (r == 0) {
+      derr << __func__ << " label at 0x" << std::hex << position << std::dec
+        << " correct, but osd_uuid=" << label.osd_uuid << " need=" << fsid << dendl;
     } else if (r == 1) {
       // tried to read but no disk
     } else {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6806,7 +6806,8 @@ int BlueStore::_check_or_set_main_bdev_label(
   string path, uint64_t size, bool create)
 {
   if (create) {
-    bluestore_bdev_label_t label;
+    bdev_label_valid_locations.clear();
+    bluestore_bdev_label_t& label = bdev_label;
     label.osd_uuid = fsid;
     label.size = size;
     label.btime = ceph_clock_now();
@@ -6814,8 +6815,17 @@ int BlueStore::_check_or_set_main_bdev_label(
     if (cct->_conf.get_val<bool>("bluestore_bdev_label_multi")) {
       label.meta["multi"] = "yes";
       label.meta["epoch"] = "1";
+      bdev_label_multi = true;
+      bdev_label_epoch = 1;
+      for (uint64_t position : bdev_label_positions) {
+        if (int64_t(position + BDEV_LABEL_BLOCK_SIZE) <= size) {
+          bdev_label_valid_locations.push_back(position);
+        }
+      }
+    } else {
+      bdev_label_valid_locations.push_back(BDEV_LABEL_POSITION);
     }
-    int r = _write_bdev_label(cct, path, label, bdev_label_positions);
+    int r = _write_bdev_label(cct, path, label, bdev_label_valid_locations);
     if (r < 0)
       return r;
   } else {
@@ -6823,10 +6833,10 @@ int BlueStore::_check_or_set_main_bdev_label(
     if (r < 0)
       return r;
     if (cct->_conf->bluestore_debug_permit_any_bdev_label) {
-      dout(20) << __func__ << " bdev " << path << " fsid " << label.osd_uuid
+      dout(20) << __func__ << " bdev " << path << " fsid " << bdev_label.osd_uuid
 	   << " and fsid " << fsid << " check bypassed" << dendl;
-    } else if (label.osd_uuid != fsid) {
-      derr << __func__ << " bdev " << path << " fsid " << label.osd_uuid
+    } else if (bdev_label.osd_uuid != fsid) {
+      derr << __func__ << " bdev " << path << " fsid " << bdev_label.osd_uuid
 	   << " does not match our fsid " << fsid << dendl;
       return -EIO;
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10563,6 +10563,15 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
   auto alloc_size = fm->get_alloc_size();
 
   // Delayed action, we could not do it in _fsck().
+  if (repair && !bdev_label_multi &&
+    cct->_conf.get_val<bool>("bluestore_bdev_label_multi_upgrade")) {
+    // upgrade to multi
+    bdev_label.meta["multi"] = "yes";
+    bdev_label.meta["epoch"] = "1";
+    bdev_label_multi = true;
+    bdev_labels_broken.push_back(BDEV_LABEL_POSITION);
+    errors++;
+  }
   if (bdev_label_multi) {
     for (size_t i = 0; i < bdev_label_positions.size(); i++) {
       uint64_t location = bdev_label_positions[i];

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6035,13 +6035,29 @@ int BlueStore::write_meta(const std::string& key, const std::string& value)
 
 int BlueStore::read_meta(const std::string& key, std::string *value)
 {
-  if (!bdev || !bdev->supported_bdev_label()) {
+  BlockDevice* local_bdev = bdev;
+  auto close_bdev = make_scope_guard([&] {
+    if (!bdev && local_bdev) {
+      local_bdev->close();
+      delete local_bdev;
+    }
+  });
+  if (!local_bdev) {
+    string p = path + "/block";
+    local_bdev = BlockDevice::create(cct, p, nullptr, nullptr, nullptr, nullptr);
+    int r = local_bdev->open(p);
+    if (r < 0) {
+      delete local_bdev;
+      local_bdev = nullptr;
+    }
+  }
+  if (!local_bdev || !local_bdev->supported_bdev_label()) {
     // skip bdev label section if not supported
     return ObjectStore::read_meta(key, value);
   }
   string p = path + "/block";
   if (bdev_label_valid_locations.empty()) {
-    _read_multi_bdev_label(cct, bdev, p, fsid, &bdev_label, &bdev_label_valid_locations,
+    _read_multi_bdev_label(cct, local_bdev, p, fsid, &bdev_label, &bdev_label_valid_locations,
       &bdev_label_multi, &bdev_label_epoch);
   }
   if (!bdev_label_valid_locations.empty()) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10681,10 +10681,8 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
         dout(1) << "fsck bdev label at 0x" << std::hex << position << std::dec
                 <<  "taken by bluefs, cannot be fixed" << dendl;
       } else {
-        if (repair) {
-          // Mark blocks so we could move offending objects away.
-          bdev_labels_in_repair.push_back(position);
-        }
+        // Mark blocks so we could move offending objects away.
+        bdev_labels_in_repair.push_back(position);
       }
     }
     // Mark locations of those bdev labels that are not taken by bluefs.
@@ -11295,7 +11293,10 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
         ceph_assert(bdev_label_valid_locations.empty());
       }
       //unmark extra bdev copies, will collide with the check
-      for (uint64_t location : bdev_label_valid_locations) {
+
+      std::vector<uint64_t> sum = bdev_label_valid_locations;
+      sum.insert(sum.end(), bdev_labels_in_repair.begin(), bdev_labels_in_repair.end());
+      for (uint64_t location : sum) {
         uint64_t length = std::max<uint64_t>(BDEV_LABEL_BLOCK_SIZE, alloc_size);
         if (location != BDEV_FIRST_LABEL_POSITION) {
           apply_for_bitset_range(location, length, alloc_size, used_blocks,
@@ -11394,6 +11395,11 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     // Now fix bdev_labels that were detected to be broken & repairable.
     string p = path + "/block";
     _write_bdev_label(cct, bdev, p, bdev_label, bdev_labels_in_repair);
+    for (uint64_t pos : bdev_labels_in_repair) {
+      if (pos != BDEV_FIRST_LABEL_POSITION) {
+        bdev_label_valid_locations.push_back(pos);
+      }
+    }
     repaired += bdev_labels_in_repair.size();
   }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7139,9 +7139,6 @@ int BlueStore::_init_alloc(std::map<uint64_t, uint64_t> *zone_adjustments)
       }
     }
   }
-  if (bdev_label_multi) {
-    _main_bdev_label_try_reserve();
-  }
   dout(1) << __func__
           << " loaded " << byte_u_t(bytes) << " in " << num << " extents"
           << std::hex
@@ -7637,6 +7634,10 @@ int BlueStore::_open_db_and_around(bool read_only, bool to_repair)
 
   if (!read_only) {
     _post_init_alloc(zone_adjustments);
+  }
+
+  if (bdev_label_multi) {
+    _main_bdev_label_try_reserve();
   }
 
   // when function is called in repair mode (to_repair=true) we skip db->open()/create()

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -132,6 +132,16 @@ const string PREFIX_SHARED_BLOB = "X"; // u64 SB id -> shared_blob_t
 
 const string BLUESTORE_GLOBAL_STATFS_KEY = "bluestore_statfs";
 
+// Label offsets where they might be replicated. It is possible on previous versions where these offsets
+// were already used so labels won't exist there.
+static constexpr uint64_t _1G = uint64_t(1024)*1024*1024;
+const vector<uint64_t> bdev_label_positions = {
+  BDEV_LABEL_POSITION,
+  _1G,
+  10*_1G,
+  100*_1G,
+  1000*_1G};
+
 #define OBJECT_MAX_SIZE 0xffffffff // 32 bits
 
 
@@ -6694,6 +6704,60 @@ int BlueStore::_read_main_bdev_label(
   return all_labels_valid ? 0 : 1;
 }
 
+void BlueStore::_main_bdev_label_try_reserve()
+{
+  // Try to mark bdev label locations as used.
+  // This is possible if location is not allocated.
+  // If location us used, remove it from list of places to write label.
+  // We operate on BlueStore's main device allocator `alloc`.
+  ceph_assert(alloc);
+  ceph_assert(bdev);
+  ceph_assert(bdev_label_multi == true);
+  vector<uint64_t> candidate_positions;
+  vector<uint64_t> accepted_positions;
+  uint64_t lsize = std::max(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
+  for (size_t i = 1; i < bdev_label_positions.size(); i++) {
+    uint64_t location = bdev_label_positions[i];
+    if (location + lsize <= bdev->get_size()) {
+      candidate_positions.push_back(location);
+    }
+  }
+  auto look_for_bdev = [&](uint64_t free_location, uint64_t free_length) {
+    for (size_t i = 0; i < candidate_positions.size();) {
+      uint64_t location = candidate_positions[i];
+      if (free_location <= location &&
+          location + lsize <= free_location + free_length) {
+        accepted_positions.push_back(location);
+        candidate_positions.erase(candidate_positions.begin() + i);
+      } else {
+        ++i;
+      }
+    }
+  };
+  alloc->foreach(look_for_bdev);
+  for (auto& location : accepted_positions) {
+    alloc->init_rm_free(location, lsize);
+  }
+
+  for (size_t i = 0; i < candidate_positions.size(); i++) {
+    uint64_t location = candidate_positions[i];
+    derr << __func__ << " bdev label location 0x" << std::hex << location << std::dec
+         << " occupied by BlueStore object or BlueFS file, disabling" << dendl;
+    std::erase(bdev_label_valid_locations, candidate_positions[i]);
+  }
+}
+
+void BlueStore::_main_bdev_label_remove(Allocator* an_alloc)
+{
+  ceph_assert(bdev_label_multi == true);
+  uint64_t lsize = std::max(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
+
+  for (size_t location : bdev_label_valid_locations) {
+    if (location != BDEV_LABEL_POSITION)
+      an_alloc->init_add_free(location, lsize);
+  }
+}
+
 int BlueStore::_check_or_set_bdev_label(
   string path, uint64_t size, string desc, bool create)
 {
@@ -6901,19 +6965,15 @@ int BlueStore::_open_fm(KeyValueDB::Transaction t,
 
     fm->create(bdev->get_size(), alloc_size, t);
 
-    // allocate superblock reserved space.  note that we do not mark
-    // bluefs space as allocated in the freelist; we instead rely on
-    // bluefs doing that itself.
     auto reserved = _get_ondisk_reserved();
     if (fm_restore) {
       // we need to allocate the full space in restore case
       // as later we will add free-space marked in the allocator file
       fm->allocate(0, bdev->get_size(), t);
     } else {
-      // allocate superblock reserved space.  note that we do not mark
-      // bluefs space as allocated in the freelist; we instead rely on
-      // bluefs doing that itself.
-      fm->allocate(0, reserved, t);
+      // allocate bdev label + bluefs superblock reserved space.
+      fm->allocate(BDEV_LABEL_POSITION, reserved, t);
+      // we do not mark other label positions
     }
     r = _write_out_fm_meta(0);
     ceph_assert(r == 0);
@@ -7054,6 +7114,9 @@ int BlueStore::_init_alloc(std::map<uint64_t, uint64_t> *zone_adjustments)
 	return -ENOTRECOVERABLE;
       }
     }
+  }
+  if (bdev_label_multi) {
+    _main_bdev_label_try_reserve();
   }
   dout(1) << __func__
           << " loaded " << byte_u_t(bytes) << " in " << num << " extents"
@@ -8315,9 +8378,24 @@ int BlueStore::mkfs()
     goto out_close_bdev;
   }
 
+  // initialize alloc, remove regions taken
   reserved = _get_ondisk_reserved();
-  alloc->init_add_free(reserved,
-    p2align(bdev->get_size(), min_alloc_size) - reserved);
+  // full free
+  alloc->init_add_free(0, p2align(bdev->get_size(), min_alloc_size));
+  // allocate bdev label + bluefs superblock reserved space.
+  alloc->init_rm_free(BDEV_LABEL_POSITION, reserved);
+
+  // take possible bdev locations, so it will not be used
+  if (cct->_conf.get_val<bool>("bluestore_bdev_label_multi")) {
+    // take space for other bdev label copies
+    for (size_t i = 1; i < bdev_label_positions.size(); i++) {
+    uint64_t location = bdev_label_positions[i];
+    uint64_t size = p2roundup(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
+    if (location + size > bdev->get_size()) continue;
+    ceph_assert(p2align(location, min_alloc_size) == location);
+    alloc->init_rm_free(location, size);
+    }
+  }
 
   r = _open_db(true);
   if (r < 0)
@@ -19384,6 +19462,10 @@ int BlueStore::store_allocator(Allocator* src_allocator)
   if (!allocator) {
     bluefs->close_writer(p_handle);
     return -1;
+  }
+  // remove allocations that are used by bdev label copies
+  if (bdev_label_multi == true) {
+    _main_bdev_label_remove(allocator.get());
   }
 
   // store all extents (except for the bluefs extents we removed) in a single flat file

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11627,7 +11627,7 @@ void BlueStore::inject_bluefs_file(std::string_view dir, std::string_view name, 
   auto ret = bluefs->open_for_write(dir, name, &p_handle, false);
   ceph_assert(ret == 0);
 
-  std::string s('0', new_size);
+  std::string s(new_size, '0');
   bufferlist bl;
   bl.append(s);
   p_handle->append(bl);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6586,7 +6586,7 @@ int BlueStore::_read_bdev_label(
   bufferlist bl;
   unique_ptr<char> buf(new char[BDEV_LABEL_BLOCK_SIZE]);
   uint64_t dev_size = bdev->get_size();
-  if (dev_size <= disk_position + BDEV_LABEL_BLOCK_SIZE) {
+  if (dev_size < disk_position + BDEV_LABEL_BLOCK_SIZE) {
     dout(10) << __func__ << " position=0x" << std::hex << disk_position
       << " dev size=0x" << dev_size << std::dec << dendl;
     return 1;
@@ -6596,6 +6596,7 @@ int BlueStore::_read_bdev_label(
     derr << __func__ << " failed to read from " << path
          << " at 0x" << std::hex << disk_position << std::dec
          <<": " << cpp_strerror(r) << dendl;
+    return -EIO;
   }
 
   bl.append(buf.get(), BDEV_LABEL_BLOCK_SIZE);
@@ -8464,11 +8465,11 @@ int BlueStore::mkfs()
   if (cct->_conf.get_val<bool>("bluestore_bdev_label_multi")) {
     // take space for other bdev label copies
     for (size_t i = 1; i < bdev_label_positions.size(); i++) {
-    uint64_t location = bdev_label_positions[i];
-    uint64_t size = p2roundup(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
-    if (location + size > bdev->get_size()) continue;
-    ceph_assert(p2align(location, min_alloc_size) == location);
-    alloc->init_rm_free(location, size);
+      uint64_t location = bdev_label_positions[i];
+      uint64_t size = p2roundup(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
+      if (location + size > bdev->get_size()) continue;
+      ceph_assert(p2align(location, min_alloc_size) == location);
+      alloc->init_rm_free(location, size);
     }
   }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6754,48 +6754,6 @@ int BlueStore::_open_fm(KeyValueDB::Transaction t,
       // bluefs doing that itself.
       fm->allocate(0, reserved, t);
     }
-    // debug code - not needed for NULL FM
-    if (cct->_conf->bluestore_debug_prefill > 0) {
-      uint64_t end = bdev->get_size() - reserved;
-      dout(1) << __func__ << " pre-fragmenting freespace, using "
-	      << cct->_conf->bluestore_debug_prefill << " with max free extent "
-	      << cct->_conf->bluestore_debug_prefragment_max << dendl;
-      uint64_t start = p2roundup(reserved, min_alloc_size);
-      uint64_t max_b = cct->_conf->bluestore_debug_prefragment_max / min_alloc_size;
-      float r = cct->_conf->bluestore_debug_prefill;
-      r /= 1.0 - r;
-      bool stop = false;
-
-      while (!stop && start < end) {
-	uint64_t l = (rand() % max_b + 1) * min_alloc_size;
-	if (start + l > end) {
-	  l = end - start;
-          l = p2align(l, min_alloc_size);
-        }
-        ceph_assert(start + l <= end);
-
-	uint64_t u = 1 + (uint64_t)(r * (double)l);
-	u = p2roundup(u, min_alloc_size);
-        if (start + l + u > end) {
-          u = end - (start + l);
-          // trim to align so we don't overflow again
-          u = p2align(u, min_alloc_size);
-          stop = true;
-        }
-        ceph_assert(start + l + u <= end);
-
-	dout(20) << __func__ << " free 0x" << std::hex << start << "~" << l
-		 << " use 0x" << u << std::dec << dendl;
-
-        if (u == 0) {
-          // break if u has been trimmed to nothing
-          break;
-        }
-
-	fm->allocate(start + l, u, t);
-	start += l + u;
-      }
-    }
     r = _write_out_fm_meta(0);
     ceph_assert(r == 0);
   } else {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6529,12 +6529,22 @@ int BlueStore::_write_bdev_label(
       locations.end()) {
     locations.push_back(BDEV_LABEL_POSITION);
   }
+  struct stat st;
+  r = ::fstat(fd, &st);
+  if (r < 0) {
+    r = -errno;
+    derr << __func__ << " failed to fstat " << path << ": " << cpp_strerror(r) << dendl;
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
+    return r;
+  }
   for (uint64_t position : locations) {
-    r = bl.write_fd(fd, position);
-    if (r < 0) {
-      derr << __func__ << " failed to write to " << path
-        << ": " << cpp_strerror(r) << dendl;
-      goto out;
+    if (int64_t(position + BDEV_LABEL_BLOCK_SIZE) <= st.st_size) {
+      r = bl.write_fd(fd, position);
+      if (r < 0) {
+        derr << __func__ << " failed to write to " << path
+          << ": " << cpp_strerror(r) << dendl;
+        goto out;
+      }
     }
   }
   r = ::fsync(fd);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6018,7 +6018,7 @@ int BlueStore::write_meta(const std::string& key, const std::string& value)
   }
   string p = path + "/block";
   if (bdev_label_valid_locations.empty()) {
-    _read_main_bdev_label(cct, bdev, p, fsid, &bdev_label, &bdev_label_valid_locations,
+    _read_multi_bdev_label(cct, bdev, p, fsid, &bdev_label, &bdev_label_valid_locations,
       &bdev_label_multi, &bdev_label_epoch);
   }
   if (!bdev_label_valid_locations.empty()) {
@@ -6041,7 +6041,7 @@ int BlueStore::read_meta(const std::string& key, std::string *value)
   }
   string p = path + "/block";
   if (bdev_label_valid_locations.empty()) {
-    _read_main_bdev_label(cct, bdev, p, fsid, &bdev_label, &bdev_label_valid_locations,
+    _read_multi_bdev_label(cct, bdev, p, fsid, &bdev_label, &bdev_label_valid_locations,
       &bdev_label_multi, &bdev_label_epoch);
   }
   if (!bdev_label_valid_locations.empty()) {
@@ -6487,7 +6487,7 @@ int BlueStore::get_block_device_fsid(CephContext* cct, const string& path,
   unique_ptr<BlockDevice> bdev(BlockDevice::create(cct, bdev_path, nullptr, nullptr, nullptr, nullptr));
   int r = bdev->open(bdev_path);
   if (r == 0) {
-    r = _read_main_bdev_label(cct, bdev.get(), bdev_path, uuid_d(), &label);
+    r = _read_multi_bdev_label(cct, bdev.get(), bdev_path, uuid_d(), &label);
   }
   if (r == 0) {
     *fsid = label.osd_uuid;
@@ -6637,7 +6637,7 @@ int BlueStore::_read_bdev_label(
   1    When some, but not all labels are read
   -ENOENT Otherwise
 */
-int BlueStore::_read_main_bdev_label(
+int BlueStore::_read_multi_bdev_label(
   CephContext* cct,
   BlockDevice* bdev,
   const string& path,
@@ -6697,7 +6697,7 @@ int BlueStore::_read_main_bdev_label(
         }
       } else {
         derr << __func__ << " label at 0x" << std::hex << position << std::dec
-             << " is multi=yes but no epoch=" << dendl;
+             << " is multi=yes but no epoch" << dendl;
       }
     } else if (r == 0) {
       derr << __func__ << " label at 0x" << std::hex << position << std::dec
@@ -6843,7 +6843,7 @@ int BlueStore::_set_main_bdev_label()
 int BlueStore::_check_main_bdev_label()
 {
   string block_path = path + "/block";
-  int r = _read_main_bdev_label(cct, bdev, block_path, fsid, &bdev_label,
+  int r = _read_multi_bdev_label(cct, bdev, block_path, fsid, &bdev_label,
     &bdev_label_valid_locations, &bdev_label_multi, &bdev_label_epoch);
   if (r < 0)
     return r;
@@ -6863,16 +6863,21 @@ int BlueStore::_check_main_bdev_label()
 }
 
 int BlueStore::read_bdev_label(
-  CephContext* cct, const std::string &path,
-  bluestore_bdev_label_t *label, uint64_t disk_position)
+  CephContext* cct,
+  const std::string &path,
+  bluestore_bdev_label_t* out_label,
+  std::vector<uint64_t>* out_valid_positions,
+  bool* out_is_multi,
+  int64_t* out_epoch)
 {
   unique_ptr<BlockDevice> bdev(BlockDevice::create(
     cct, path, nullptr, nullptr, nullptr, nullptr));
   int r = bdev->open(path);
   if (r < 0)
     return r;
-  r = BlueStore::_read_bdev_label(
-    cct, bdev.get(), path, label, disk_position);
+  uuid_d fsid;
+  r = BlueStore::_read_multi_bdev_label(
+    cct, bdev.get(), path, fsid, out_label, out_valid_positions, out_is_multi, out_epoch);
   bdev->close();
   return r;
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6526,10 +6526,7 @@ int BlueStore::_write_bdev_label(
   }
   bl.rebuild_aligned_size_and_memory(BDEV_LABEL_BLOCK_SIZE, BDEV_LABEL_BLOCK_SIZE, IOV_MAX);
   int r = 0;
-  if (std::find(locations.begin(), locations.end(), BDEV_LABEL_POSITION) ==
-      locations.end()) {
-    locations.push_back(BDEV_LABEL_POSITION);
-  }
+  ceph_assert(locations.size() > 0);
   struct stat st;
   r = ::fstat(fd, &st);
   if (r < 0) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5666,6 +5666,7 @@ BlueStore::BlueStore(CephContext *cct,
   _init_logger();
   cct->_conf.add_observer(this);
   set_cache_shards(1);
+  bluestore_bdev_label_require_all = cct->_conf.get_val<bool>("bluestore_bdev_label_require_all");
 }
 
 BlueStore::~BlueStore()
@@ -6837,7 +6838,7 @@ int BlueStore::_check_or_set_main_bdev_label(
 	   << " does not match our fsid " << fsid << dendl;
       return -EIO;
     }
-    if (cct->_conf.get_val<bool>("bluestore_bdev_label_require_all")) {
+    if (bluestore_bdev_label_require_all) {
       if (r != 0) {
         derr << __func__ << "not all labels read properly" << dendl;
         return -EIO;
@@ -10463,7 +10464,13 @@ int BlueStore::_fsck(BlueStore::FSCKDepth depth, bool repair)
       derr << __func__ << " fsck error: no valid block device label found" << dendl;
       return r;
     }
+    // hack - sanitize check for bdev label
+    bluestore_bdev_label_require_all = false;
   }
+
+  auto restore_option = make_scope_guard([&] {
+    bluestore_bdev_label_require_all = cct->_conf.get_val<bool>("bluestore_bdev_label_require_all");
+  });
 
   // in deep mode we need R/W write access to be able to replay deferred ops
   const bool read_only = !(repair || depth == FSCK_DEEP);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11244,6 +11244,17 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     // skip freelist vs allocated compare when we have Null fm
     if (!fm->is_null_manager()) {
       dout(1) << __func__ << " checking freelist vs allocated" << dendl;
+      //unmark extra bdev copies, will collide with the check
+      for (uint64_t location : bdev_label_valid_locations) {
+        uint64_t length = std::max<uint64_t>(BDEV_LABEL_BLOCK_SIZE, alloc_size);
+        if (location != BDEV_LABEL_POSITION) {
+          apply_for_bitset_range(location, length, alloc_size, used_blocks,
+            [&](uint64_t pos, mempool_dynamic_bitset& bs) {
+              bs.reset(pos);
+            }
+          );
+        }
+      }
       fm->enumerate_reset();
       uint64_t offset, length;
       while (fm->enumerate_next(db, &offset, &length)) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6018,8 +6018,8 @@ int BlueStore::write_meta(const std::string& key, const std::string& value)
   }
   string p = path + "/block";
   if (bdev_label_valid_locations.empty()) {
-    _read_main_bdev_label(cct, p, &bdev_label,
-      &bdev_label_valid_locations, &bdev_label_multi, &bdev_label_epoch);
+    _read_main_bdev_label(&bdev_label, &bdev_label_valid_locations,
+      &bdev_label_multi, &bdev_label_epoch);
   }
   if (!bdev_label_valid_locations.empty()) {
     bdev_label.meta[key] = value;
@@ -6041,8 +6041,8 @@ int BlueStore::read_meta(const std::string& key, std::string *value)
   }
   string p = path + "/block";
   if (bdev_label_valid_locations.empty()) {
-    _read_main_bdev_label(cct, p, &bdev_label,
-      &bdev_label_valid_locations, &bdev_label_multi, &bdev_label_epoch);
+    _read_main_bdev_label(&bdev_label, &bdev_label_valid_locations,
+      &bdev_label_multi, &bdev_label_epoch);
   }
   if (!bdev_label_valid_locations.empty()) {
     auto i = bdev_label.meta.find(key);
@@ -6639,8 +6639,6 @@ int BlueStore::_read_bdev_label(
 
 /**
   Reads device label.
-  cct             - CephContext, as usual
-  path            - Path to block device, as conf.bluestore_block_path defines.
   *out_label      - Filled if reading of label is considered successful.
   *out_valid_positions - List of locations that contained valid labels.
   *out_is_multi  -  Whether the label is regular or multi label with epoch.
@@ -6653,8 +6651,6 @@ int BlueStore::_read_bdev_label(
 
 */
 int BlueStore::_read_main_bdev_label(
-  CephContext* cct,
-  const string &path,
   bluestore_bdev_label_t *out_label,
   std::vector<uint64_t>* out_valid_positions,
   bool* out_is_multi,
@@ -6668,7 +6664,7 @@ int BlueStore::_read_main_bdev_label(
   bool all_labels_valid = true;
   for (uint64_t position : bdev_label_positions) {
     bluestore_bdev_label_t label;
-    int r = _read_bdev_label(cct, path, &label, position);
+    int r = _read_bdev_label(cct, path + "/block", &label, position);
     if (r == 0) {
       auto i = label.meta.find("multi");
       bool is_multi = i != label.meta.end() && i->second == "yes";
@@ -6808,49 +6804,53 @@ int BlueStore::_check_or_set_bdev_label(
   return 0;
 }
 
-int BlueStore::_check_or_set_main_bdev_label(
-  const string& path, uint64_t size, bool create)
+int BlueStore::_set_main_bdev_label()
 {
-  if (create) {
-    bdev_label_valid_locations.clear();
-    bluestore_bdev_label_t& label = bdev_label;
-    label.osd_uuid = fsid;
-    label.size = size;
-    label.btime = ceph_clock_now();
-    label.description = "main";
-    if (cct->_conf.get_val<bool>("bluestore_bdev_label_multi")) {
-      label.meta["multi"] = "yes";
-      label.meta["epoch"] = "1";
-      bdev_label_multi = true;
-      bdev_label_epoch = 1;
-      for (uint64_t position : bdev_label_positions) {
-        if (position + BDEV_LABEL_BLOCK_SIZE <= size) {
-          bdev_label_valid_locations.push_back(position);
-        }
+  uint64_t size = bdev->get_size();
+  bdev_label_valid_locations.clear();
+  bluestore_bdev_label_t& label = bdev_label;
+  label.osd_uuid = fsid;
+  label.size = size;
+  label.btime = ceph_clock_now();
+  label.description = "main";
+  if (cct->_conf.get_val<bool>("bluestore_bdev_label_multi")) {
+    label.meta["multi"] = "yes";
+    label.meta["epoch"] = "1";
+    bdev_label_multi = true;
+    bdev_label_epoch = 1;
+    for (uint64_t position : bdev_label_positions) {
+      if (position + BDEV_LABEL_BLOCK_SIZE <= size) {
+        bdev_label_valid_locations.push_back(position);
       }
-    } else {
-      bdev_label_valid_locations.push_back(BDEV_LABEL_POSITION);
     }
-    int r = _write_bdev_label(cct, path, label, bdev_label_valid_locations);
-    if (r < 0)
-      return r;
   } else {
-    int r = _read_main_bdev_label(cct, path, &bdev_label, &bdev_label_valid_locations);
-    if (r < 0)
-      return r;
-    if (cct->_conf->bluestore_debug_permit_any_bdev_label) {
-      dout(20) << __func__ << " bdev " << path << " fsid " << bdev_label.osd_uuid
-	   << " and fsid " << fsid << " check bypassed" << dendl;
-    } else if (bdev_label.osd_uuid != fsid) {
-      derr << __func__ << " bdev " << path << " fsid " << bdev_label.osd_uuid
-	   << " does not match our fsid " << fsid << dendl;
+    bdev_label_valid_locations.push_back(BDEV_LABEL_POSITION);
+  }
+  int r = _write_bdev_label(cct, path + "/block", label, bdev_label_valid_locations);
+  if (r < 0)
+    return r;
+  return 0;
+}
+
+int BlueStore::_check_main_bdev_label()
+{
+  string block_path = path + "/block";
+  int r = _read_main_bdev_label(&bdev_label, &bdev_label_valid_locations,
+    &bdev_label_multi, &bdev_label_epoch);
+  if (r < 0)
+    return r;
+  if (cct->_conf->bluestore_debug_permit_any_bdev_label) {
+    dout(20) << __func__ << " bdev " << block_path << " fsid " << bdev_label.osd_uuid
+      << " and fsid " << fsid << " check bypassed" << dendl;
+  } else if (bdev_label.osd_uuid != fsid) {
+    derr << __func__ << " bdev " << block_path << " fsid " << bdev_label.osd_uuid
+      << " does not match our fsid " << fsid << dendl;
+    return -EIO;
+  }
+  if (bluestore_bdev_label_require_all) {
+    if (r != 0) {
+      derr << __func__ << "not all labels read properly" << dendl;
       return -EIO;
-    }
-    if (bluestore_bdev_label_require_all) {
-      if (r != 0) {
-        derr << __func__ << "not all labels read properly" << dendl;
-        return -EIO;
-      }
     }
   }
   return 0;
@@ -6905,7 +6905,11 @@ int BlueStore::_open_bdev(bool create)
   }
 
   if (bdev->supported_bdev_label()) {
-    r = _check_or_set_main_bdev_label(p, bdev->get_size(), create);
+    if (create) {
+      r = _set_main_bdev_label();
+    } else {
+      r = _check_main_bdev_label();
+    }
     if (r < 0)
       goto fail_close;
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6019,6 +6019,7 @@ int BlueStore::write_meta(const std::string& key, const std::string& value)
   if (!bdev_label_valid_locations.empty()) {
     bdev_label.meta[key] = value;
     if (bdev_label_multi) {
+      bdev_label_epoch++;
       bdev_label.meta["epoch"] = std::to_string(bdev_label_epoch);
     }
     int r = _write_bdev_label(cct, p, bdev_label, bdev_label_valid_locations);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6855,6 +6855,36 @@ int BlueStore::_check_main_bdev_label()
   return 0;
 }
 
+int BlueStore::read_bdev_label(
+  CephContext* cct, const std::string &path,
+  bluestore_bdev_label_t *label, uint64_t disk_position)
+{
+  unique_ptr<BlockDevice> bdev(BlockDevice::create(
+    cct, path, nullptr, nullptr, nullptr, nullptr));
+  int r = bdev->open(path);
+  if (r < 0)
+    return r;
+  r = BlueStore::_read_bdev_label(
+    cct, bdev.get(), path, label, disk_position);
+  bdev->close();
+  return r;
+}
+int BlueStore::write_bdev_label(
+  CephContext* cct, const std::string &path,
+  const bluestore_bdev_label_t& label, uint64_t disk_position)
+{
+  unique_ptr<BlockDevice> bdev(BlockDevice::create(
+    cct, path, nullptr, nullptr, nullptr, nullptr));
+  int r = bdev->open(path);
+  if (r < 0)
+    return r;
+  r = BlueStore::_write_bdev_label(
+    cct, bdev.get(), path, label, {disk_position});
+  bdev->close();
+  return r;
+}
+
+
 void BlueStore::_set_alloc_sizes(void)
 {
   max_alloc_size = cct->_conf->bluestore_max_alloc_size;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10562,7 +10562,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
   if (bdev_label_multi) {
     for (size_t i = 0; i < bdev_label_positions.size(); i++) {
       uint64_t location = bdev_label_positions[i];
-      if (location > bdev->get_size()) {
+      if (location + BDEV_LABEL_BLOCK_SIZE > bdev->get_size()) {
         continue;
       }
       if (std::find(
@@ -10631,11 +10631,13 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     for (size_t i = 0; i < bdev_label_positions.size(); i++) {
       uint64_t position = bdev_label_positions[i];
       uint64_t length = std::max<uint64_t>(BDEV_LABEL_BLOCK_SIZE, alloc_size);
-      apply_for_bitset_range(position, length, alloc_size, used_blocks,
-        [&](uint64_t pos, mempool_dynamic_bitset& bs) {
-          bs.set(pos);
-        }
-      );
+      if (position + length <= bdev->get_size()) {
+        apply_for_bitset_range(position, length, alloc_size, used_blocks,
+          [&](uint64_t pos, mempool_dynamic_bitset& bs) {
+            bs.set(pos);
+          }
+        );
+      }
     }
   }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -137,7 +137,7 @@ const string BLUESTORE_GLOBAL_STATFS_KEY = "bluestore_statfs";
 // were already used so labels won't exist there.
 static constexpr uint64_t _1G = uint64_t(1024)*1024*1024;
 const vector<uint64_t> bdev_label_positions = {
-  BDEV_LABEL_POSITION,
+  BDEV_FIRST_LABEL_POSITION,
   _1G,
   10*_1G,
   100*_1G,
@@ -6544,15 +6544,25 @@ int BlueStore::_write_bdev_label(
     VOID_TEMP_FAILURE_RETRY(::close(fd));
     return r;
   }
+  int failed_r = 0;
+  bool wrote_at_least_one = false;
   for (uint64_t position : locations) {
     if (int64_t(position + BDEV_LABEL_BLOCK_SIZE) <= st.st_size) {
       r = bl.write_fd(fd, position);
-      if (r < 0) {
+      if (r == 0) {
+        wrote_at_least_one = true;
+      } else {
         derr << __func__ << " failed to write to " << path
+          << " at location 0x" << std::hex << position << std::dec
           << ": " << cpp_strerror(r) << dendl;
-        goto out;
+        failed_r = r;
       }
     }
+  }
+  if (!wrote_at_least_one) {
+    derr << __func__ << " failed to write to any bdev of locations" << dendl;
+    r = failed_r;
+    goto out;
   }
   r = ::fsync(fd);
   if (r < 0) {
@@ -6668,7 +6678,7 @@ int BlueStore::_read_main_bdev_label(
     if (r == 0 && (fsid.is_zero() || label.osd_uuid == fsid)) {
       auto i = label.meta.find("multi");
       bool is_multi = i != label.meta.end() && i->second == "yes";
-      if (position == BDEV_LABEL_POSITION && !is_multi) {
+      if (position == BDEV_FIRST_LABEL_POSITION && !is_multi) {
         // we have a single-label case
         *out_label = label;
         is_multi = false;
@@ -6755,6 +6765,10 @@ void BlueStore::_main_bdev_label_try_reserve()
       }
     }
   };
+  // Iterating over free is very inefficient.
+  // We can do it here only because its only on init, otherwise it would be unacceptable.
+  // Here we could use some API like: alloc->allocate_at().
+  // When we create it, replace code.
   alloc->foreach(look_for_bdev);
   for (auto& location : accepted_positions) {
     alloc->init_rm_free(location, lsize);
@@ -6772,15 +6786,14 @@ void BlueStore::_main_bdev_label_remove(Allocator* an_alloc)
 {
   ceph_assert(bdev_label_multi == true);
   uint64_t lsize = std::max(BDEV_LABEL_BLOCK_SIZE, min_alloc_size);
-
   for (size_t location : bdev_label_valid_locations) {
-    if (location != BDEV_LABEL_POSITION)
+    if (location != BDEV_FIRST_LABEL_POSITION)
       an_alloc->init_add_free(location, lsize);
   }
 }
 
 int BlueStore::_check_or_set_bdev_label(
-  const string& path, uint64_t size, string desc, bool create)
+  const string& path, uint64_t size, const string& desc, bool create)
 {
   bluestore_bdev_label_t label;
   if (create) {
@@ -6827,7 +6840,7 @@ int BlueStore::_set_main_bdev_label()
       }
     }
   } else {
-    bdev_label_valid_locations.push_back(BDEV_LABEL_POSITION);
+    bdev_label_valid_locations.push_back(BDEV_FIRST_LABEL_POSITION);
   }
   int r = _write_bdev_label(cct, path + "/block", label, bdev_label_valid_locations);
   if (r < 0)
@@ -6850,11 +6863,9 @@ int BlueStore::_check_main_bdev_label()
       << " does not match our fsid " << fsid << dendl;
     return -EIO;
   }
-  if (bluestore_bdev_label_require_all) {
-    if (r != 0) {
-      derr << __func__ << "not all labels read properly" << dendl;
-      return -EIO;
-    }
+  if (bluestore_bdev_label_require_all && r != 0) {
+    derr << __func__ << " not all labels read properly" << dendl;
+    return -EIO;
   }
   return 0;
 }
@@ -7011,7 +7022,7 @@ int BlueStore::_open_fm(KeyValueDB::Transaction t,
       fm->allocate(0, bdev->get_size(), t);
     } else {
       // allocate bdev label + bluefs superblock reserved space.
-      fm->allocate(BDEV_LABEL_POSITION, reserved, t);
+      fm->allocate(BDEV_FIRST_LABEL_POSITION, reserved, t);
       // we do not mark other label positions
     }
     r = _write_out_fm_meta(0);
@@ -8423,7 +8434,7 @@ int BlueStore::mkfs()
   // full free
   alloc->init_add_free(0, p2align(bdev->get_size(), min_alloc_size));
   // allocate bdev label + bluefs superblock reserved space.
-  alloc->init_rm_free(BDEV_LABEL_POSITION, reserved);
+  alloc->init_rm_free(BDEV_FIRST_LABEL_POSITION, reserved);
 
   // take possible bdev locations, so it will not be used
   if (cct->_conf.get_val<bool>("bluestore_bdev_label_multi")) {
@@ -10580,7 +10591,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     bdev_label.meta["multi"] = "yes";
     bdev_label.meta["epoch"] = "1";
     bdev_label_multi = true;
-    bdev_labels_broken.push_back(BDEV_LABEL_POSITION);
+    bdev_labels_broken.push_back(BDEV_FIRST_LABEL_POSITION);
     errors++;
   }
   if (bdev->supported_bdev_label() && bdev_label_multi) {
@@ -10637,7 +10648,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
       bool is_taken_by_bluefs = false;
       apply_for_bitset_range(position, length, alloc_size, bluefs_used_blocks,
         [&](uint64_t pos, mempool_dynamic_bitset& bs) {
-          is_taken_by_bluefs |= bs.test_set(pos);
+          is_taken_by_bluefs |= bs.test(pos);
         }
       );
       if (is_taken_by_bluefs) {
@@ -10651,7 +10662,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
         }
       }
     }
-    // Mark bits or locations of all bdev labels.
+    // Mark locations of those bdev labels that are not taken by bluefs.
     for (size_t i = 0; i < bdev_label_positions.size(); i++) {
       uint64_t position = bdev_label_positions[i];
       uint64_t length = std::max<uint64_t>(BDEV_LABEL_BLOCK_SIZE, alloc_size);
@@ -10666,7 +10677,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
   }
 
   apply_for_bitset_range(
-    BDEV_LABEL_POSITION, std::max<uint64_t>(min_alloc_size, SUPER_RESERVED), alloc_size, used_blocks,
+    BDEV_FIRST_LABEL_POSITION, std::max<uint64_t>(min_alloc_size, SUPER_RESERVED), alloc_size, used_blocks,
     [&](uint64_t pos, mempool_dynamic_bitset &bs) {
       bs.set(pos);
     }
@@ -11261,7 +11272,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
       //unmark extra bdev copies, will collide with the check
       for (uint64_t location : bdev_label_valid_locations) {
         uint64_t length = std::max<uint64_t>(BDEV_LABEL_BLOCK_SIZE, alloc_size);
-        if (location != BDEV_LABEL_POSITION) {
+        if (location != BDEV_FIRST_LABEL_POSITION) {
           apply_for_bitset_range(location, length, alloc_size, used_blocks,
             [&](uint64_t pos, mempool_dynamic_bitset& bs) {
               bs.reset(pos);
@@ -13582,9 +13593,9 @@ ObjectMap::ObjectMapIterator BlueStore::get_omap_iterator(
 // write helpers
 
 uint64_t BlueStore::_get_ondisk_reserved() const {
-  static_assert(BDEV_LABEL_POSITION == 0);
+  static_assert(BDEV_FIRST_LABEL_POSITION == 0);
   ceph_assert(min_alloc_size);
-  uint64_t size = p2roundup(BDEV_LABEL_BLOCK_SIZE + BLUEFS_SUPER_BLOCK_SIZE, min_alloc_size);
+  uint64_t size = p2roundup(SUPER_RESERVED, min_alloc_size);
   return size;
 }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -30,6 +30,7 @@
 
 #include "BlueStore.h"
 #include "bluestore_common.h"
+#include "os/bluestore/bluestore_types.h"
 #include "simple_bitmap.h"
 #include "os/kv.h"
 #include "include/compat.h"
@@ -6011,14 +6012,16 @@ int BlueStore::_set_cache_sizes()
 int BlueStore::write_meta(const std::string& key, const std::string& value)
 {
   string p = path + "/block";
-  if (!bdev_label_valid) {
-    int r = _read_bdev_label(cct, p, &bdev_label);
-    if (r == 0) {
-      bdev_label_valid = true;
-    }
+  if (bdev_label_valid_locations.empty()) {
+    int r = _read_main_bdev_label(cct, p, &bdev_label,
+      &bdev_label_valid_locations, &bdev_label_multi, &bdev_label_epoch);
+    ceph_assert(r == 0);
   }
-  if (bdev_label_valid) {
+  if (!bdev_label_valid_locations.empty()) {
     bdev_label.meta[key] = value;
+    if (bdev_label_multi) {
+      bdev_label.meta["epoch"] = std::to_string(bdev_label_epoch);
+    }
     int r = _write_bdev_label(cct, p, bdev_label);
     ceph_assert(r == 0);
   }
@@ -6027,20 +6030,20 @@ int BlueStore::write_meta(const std::string& key, const std::string& value)
 
 int BlueStore::read_meta(const std::string& key, std::string *value)
 {
-  if (!bdev_label_valid) {
-    string p = path + "/block";
-    int r = _read_bdev_label(cct, p, &bdev_label);
-    if (r < 0) {
-      return ObjectStore::read_meta(key, value);
+  string p = path + "/block";
+  if (bdev_label_valid_locations.empty()) {
+    int r = _read_main_bdev_label(cct, p, &bdev_label,
+      &bdev_label_valid_locations, &bdev_label_multi, &bdev_label_epoch);
+    ceph_assert(r == 0);
+  }
+  if (!bdev_label_valid_locations.empty()) {
+    auto i = bdev_label.meta.find(key);
+    if (i != bdev_label.meta.end()) {
+      *value = i->second;
+      return 0;
     }
-    bdev_label_valid = true;
   }
-  auto i = bdev_label.meta.find(key);
-  if (i == bdev_label.meta.end()) {
-    return ObjectStore::read_meta(key, value);
-  }
-  *value = i->second;
-  return 0;
+  return ObjectStore::read_meta(key, value);
 }
 
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8329,22 +8329,6 @@ int BlueStore::mkfs()
       return r; // idempotent
     }
   }
-
-  {
-    string type;
-    r = read_meta("type", &type);
-    if (r == 0) {
-      if (type != "bluestore") {
-	derr << __func__ << " expected bluestore, but type is " << type << dendl;
-	return -EIO;
-      }
-    } else {
-      r = write_meta("type", "bluestore");
-      if (r < 0)
-        return r;
-    }
-  }
-
   r = _open_path();
   if (r < 0)
     return r;
@@ -8397,6 +8381,20 @@ int BlueStore::mkfs()
   r = _open_bdev(true);
   if (r < 0)
     goto out_close_fsid;
+  {
+    string type;
+    r = read_meta("type", &type);
+    if (r == 0) {
+      if (type != "bluestore") {
+	derr << __func__ << " expected bluestore, but type is " << type << dendl;
+	return -EIO;
+      }
+    } else {
+      r = write_meta("type", "bluestore");
+      if (r < 0)
+        return r;
+    }
+  }
 
   freelist_type = "bitmap";
   dout(10) << " freelist_type " << freelist_type << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11326,7 +11326,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     repaired = repairer.apply(db);
     dout(5) << __func__ << " repair applied" << dendl;
   }
-  if (repair) {
+  if (repair && bdev_labels_in_repair.size() > 0) {
     // Now fix bdev_labels that were detected to be broken & repairable.
     string p = path + "/block";
     _write_bdev_label(cct, p, bdev_label, bdev_labels_in_repair);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6776,7 +6776,7 @@ void BlueStore::_main_bdev_label_remove(Allocator* an_alloc)
 }
 
 int BlueStore::_check_or_set_bdev_label(
-  string path, uint64_t size, string desc, bool create)
+  const string& path, uint64_t size, string desc, bool create)
 {
   bluestore_bdev_label_t label;
   if (create) {
@@ -6804,7 +6804,7 @@ int BlueStore::_check_or_set_bdev_label(
 }
 
 int BlueStore::_check_or_set_main_bdev_label(
-  string path, uint64_t size, bool create)
+  const string& path, uint64_t size, bool create)
 {
   if (create) {
     bdev_label_valid_locations.clear();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6600,7 +6600,7 @@ int BlueStore::_read_bdev_label(
   dout(10) << __func__ << " position=0x" << std::hex << disk_position << std::dec << dendl;
   ceph_assert(bdev);
   bufferlist bl;
-  unique_ptr<char> buf(new char[BDEV_LABEL_BLOCK_SIZE]);
+  unique_ptr<char[]> buf(new char[BDEV_LABEL_BLOCK_SIZE]);
   uint64_t dev_size = bdev->get_size();
   if (dev_size < disk_position + BDEV_LABEL_BLOCK_SIZE) {
     dout(10) << __func__ << " position=0x" << std::hex << disk_position

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6000,28 +6000,33 @@ int BlueStore::_set_cache_sizes()
 
 int BlueStore::write_meta(const std::string& key, const std::string& value)
 {
-  bluestore_bdev_label_t label;
   string p = path + "/block";
-  int r = _read_bdev_label(cct, p, &label);
-  if (r < 0) {
-    return ObjectStore::write_meta(key, value);
+  if (!bdev_label_valid) {
+    int r = _read_bdev_label(cct, p, &bdev_label);
+    if (r == 0) {
+      bdev_label_valid = true;
+    }
   }
-  label.meta[key] = value;
-  r = _write_bdev_label(cct, p, label);
-  ceph_assert(r == 0);
+  if (bdev_label_valid) {
+    bdev_label.meta[key] = value;
+    int r = _write_bdev_label(cct, p, bdev_label);
+    ceph_assert(r == 0);
+  }
   return ObjectStore::write_meta(key, value);
 }
 
 int BlueStore::read_meta(const std::string& key, std::string *value)
 {
-  bluestore_bdev_label_t label;
-  string p = path + "/block";
-  int r = _read_bdev_label(cct, p, &label);
-  if (r < 0) {
-    return ObjectStore::read_meta(key, value);
+  if (!bdev_label_valid) {
+    string p = path + "/block";
+    int r = _read_bdev_label(cct, p, &bdev_label);
+    if (r < 0) {
+      return ObjectStore::read_meta(key, value);
+    }
+    bdev_label_valid = true;
   }
-  auto i = label.meta.find(key);
-  if (i == label.meta.end()) {
+  auto i = bdev_label.meta.find(key);
+  if (i == bdev_label.meta.end()) {
     return ObjectStore::read_meta(key, value);
   }
   *value = i->second;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10435,6 +10435,16 @@ int BlueStore::_fsck(BlueStore::FSCKDepth depth, bool repair)
       depth == FSCK_SHALLOW ? " (shallow)" : " (regular)")
     << dendl;
 
+  {
+    string p = path + "/block";
+    int r = _read_main_bdev_label(cct, p, &bdev_label,
+      &bdev_label_valid_locations, &bdev_label_multi);
+    if (r < 0) {
+      derr << __func__ << " fsck error: no valid block device label found" << dendl;
+      return r;
+    }
+  }
+
   // in deep mode we need R/W write access to be able to replay deferred ops
   const bool read_only = !(repair || depth == FSCK_DEEP);
   int r = _open_db_and_around(read_only);
@@ -10495,6 +10505,8 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
   int64_t warnings = 0;
   unsigned repaired = 0;
 
+  std::vector<uint64_t> bdev_labels_broken;
+  std::vector<uint64_t> bdev_labels_in_repair;
   uint64_t_btree_t used_omap_head;
   uint64_t_btree_t used_sbids;
 
@@ -10523,6 +10535,26 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
 
   auto alloc_size = fm->get_alloc_size();
 
+  // Delayed action, we could not do it in _fsck().
+  if (bdev_label_multi) {
+    for (size_t i = 0; i < bdev_label_positions.size(); i++) {
+      uint64_t location = bdev_label_positions[i];
+      if (location > bdev->get_size()) {
+        continue;
+      }
+      if (std::find(
+        bdev_label_valid_locations.begin(),
+        bdev_label_valid_locations.end(),
+        location) == bdev_label_valid_locations.end()) {
+        derr << "fsck error: bdev label at 0x" << std::hex << location << std::dec
+             << " corrupted" << dendl;
+        errors++;
+        bdev_labels_broken.push_back(location);
+      }
+    }
+    // We have to wait for allocations check to know if we can fix.
+  }
+
   utime_t start = ceph_clock_now();
 
   _fsck_collections(&errors);
@@ -10546,8 +10578,46 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
 
   bluefs_used_blocks = used_blocks;
 
+  if (bdev_label_multi) {
+    // Forcibly mark regions of bdev label clones as used.
+    // If an object happens to be using it we will get an error and a repair applied.
+    // We can move away data only if it was allocated for object in BlueStore,
+    // we are unable to move away BlueFS data.
+
+    // skip first bdev label in this check
+    for (uint64_t position : bdev_labels_broken) {
+      uint64_t length = std::max<uint64_t>(BDEV_LABEL_BLOCK_SIZE, alloc_size);
+      bool is_taken_by_bluefs = false;
+      apply_for_bitset_range(position, length, alloc_size, bluefs_used_blocks,
+        [&](uint64_t pos, mempool_dynamic_bitset& bs) {
+          is_taken_by_bluefs |= bs.test_set(pos);
+        }
+      );
+      if (is_taken_by_bluefs) {
+        // We are unable to fix it.
+        dout(1) << "fsck bdev label at 0x" << std::hex << position << std::dec
+                <<  "taken by bluefs, cannot be fixed" << dendl;
+      } else {
+        if (repair) {
+          // Mark blocks so we could move offending objects away.
+          bdev_labels_in_repair.push_back(position);
+        }
+      }
+    }
+    // Mark bits or locations of all bdev labels.
+    for (size_t i = 0; i < bdev_label_positions.size(); i++) {
+      uint64_t position = bdev_label_positions[i];
+      uint64_t length = std::max<uint64_t>(BDEV_LABEL_BLOCK_SIZE, alloc_size);
+      apply_for_bitset_range(position, length, alloc_size, used_blocks,
+        [&](uint64_t pos, mempool_dynamic_bitset& bs) {
+          bs.set(pos);
+        }
+      );
+    }
+  }
+
   apply_for_bitset_range(
-    0, std::max<uint64_t>(min_alloc_size, DB_SUPER_RESERVED), alloc_size, used_blocks,
+    BDEV_LABEL_POSITION, std::max<uint64_t>(min_alloc_size, SUPER_RESERVED), alloc_size, used_blocks,
     [&](uint64_t pos, mempool_dynamic_bitset &bs) {
       bs.set(pos);
     }
@@ -11144,14 +11214,14 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
           [&](uint64_t pos, mempool_dynamic_bitset &bs) {
             ceph_assert(pos < bs.size());
             if (bs.test(pos) && !bluefs_used_blocks.test(pos)) {
-              if (offset == DB_SUPER_RESERVED &&
-                  length == min_alloc_size - DB_SUPER_RESERVED) {
+              if (offset == SUPER_RESERVED &&
+                  length == min_alloc_size - SUPER_RESERVED) {
                 // this is due to the change just after luminous to min_alloc_size
                 // granularity allocations, and our baked in assumption at the top
-                // of _fsck that 0~round_up_to(DB_SUPER_RESERVED,min_alloc_size) is used
-                // (vs luminous's round_up_to(DB_SUPER_RESERVED,block_size)).  harmless,
+                // of _fsck that 0~round_up_to(SUPER_RESERVED,min_alloc_size) is used
+                // (vs luminous's round_up_to(SUPER_RESERVED,block_size)).  harmless,
                 // since we will never allocate this region below min_alloc_size.
-                dout(10) << __func__ << " ignoring free extent between DB_SUPER_RESERVED"
+                dout(10) << __func__ << " ignoring free extent between SUPER_RESERVED"
                          << " and min_alloc_size, 0x" << std::hex << offset << "~"
                          << length << std::dec << dendl;
               } else {
@@ -11217,6 +11287,12 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     dout(5) << __func__ << " applying repair results" << dendl;
     repaired = repairer.apply(db);
     dout(5) << __func__ << " repair applied" << dendl;
+  }
+  if (repair) {
+    // Now fix bdev_labels that were detected to be broken & repairable.
+    string p = path + "/block";
+    _write_bdev_label(cct, p, bdev_label, bdev_labels_in_repair);
+    repaired += bdev_labels_in_repair.size();
   }
 
 out_scan:
@@ -13440,9 +13516,10 @@ ObjectMap::ObjectMapIterator BlueStore::get_omap_iterator(
 // write helpers
 
 uint64_t BlueStore::_get_ondisk_reserved() const {
+  static_assert(BDEV_LABEL_POSITION == 0);
   ceph_assert(min_alloc_size);
-  return round_up_to(
-    std::max<uint64_t>(DB_SUPER_RESERVED, min_alloc_size), min_alloc_size);
+  uint64_t size = p2roundup(BDEV_LABEL_BLOCK_SIZE + BLUEFS_SUPER_BLOCK_SIZE, min_alloc_size);
+  return size;
 }
 
 void BlueStore::_prepare_ondisk_format_super(KeyValueDB::Transaction& t)
@@ -20012,7 +20089,7 @@ int BlueStore::read_allocation_from_onodes(SimpleBitmap *sbmap, read_alloc_stats
 int BlueStore::reconstruct_allocations(SimpleBitmap *sbmap, read_alloc_stats_t &stats)
 {
   // first set space used by superblock
-  auto super_length = std::max<uint64_t>(min_alloc_size, DB_SUPER_RESERVED);
+  auto super_length = std::max<uint64_t>(min_alloc_size, SUPER_RESERVED);
   set_allocation_in_simple_bmap(sbmap, 0, super_length);
   stats.extent_count++;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2763,7 +2763,7 @@ private:
   static int _read_bdev_label(
     CephContext* cct, BlockDevice* bdev, const std::string &path,
     bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_FIRST_LABEL_POSITION);
-  int _check_or_set_bdev_label(const std::string& path, BlockDevice* bdev, uint64_t size,
+  int _check_or_set_bdev_label(BlockDevice* bdev, const std::string& path,
                                const std::string& desc, bool create);
   int _set_main_bdev_label();
   int _check_main_bdev_label();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2767,14 +2767,14 @@ private:
                                const std::string& desc, bool create);
   int _set_main_bdev_label();
   int _check_main_bdev_label();
-  static int _read_main_bdev_label(
+  static int _read_multi_bdev_label(
     CephContext* cct,
     BlockDevice* bdev,
     const std::string& path,
     uuid_d fsid,
     bluestore_bdev_label_t *out_label,
     std::vector<uint64_t>* out_valid_positions = nullptr,
-    bool* out_is_cloned = nullptr,
+    bool* out_is_multi = nullptr,
     int64_t* out_epoch = nullptr);
   int _set_bdev_label_size(const std::string& path, uint64_t size);
   void _main_bdev_label_try_reserve();
@@ -3454,8 +3454,12 @@ public:
         std::vector<uint64_t>({disk_position}));
     }
   static int read_bdev_label(
-    CephContext* cct, const std::string &path,
-    bluestore_bdev_label_t *label, uint64_t disk_position = 0);
+    CephContext* cct,
+    const std::string &path,
+    bluestore_bdev_label_t *out_label,
+    std::vector<uint64_t>* out_valid_positions = nullptr,
+    bool* out_is_cloned = nullptr,
+    int64_t* out_epoch = nullptr);
   static int write_bdev_label(
     CephContext* cct, const std::string &path,
     const bluestore_bdev_label_t& label, uint64_t disk_position = 0);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2762,10 +2762,10 @@ public:
     CephContext* cct, const std::string &path,
     bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_LABEL_POSITION);
 private:
-  int _check_or_set_bdev_label(std::string path, uint64_t size, std::string desc,
+  int _check_or_set_bdev_label(const std::string& path, uint64_t size, std::string desc,
 			       bool create);
   int _check_or_set_main_bdev_label(
-    std::string path,
+    const std::string& path,
     uint64_t size,
     bool create);
   static int _read_main_bdev_label(

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2432,6 +2432,7 @@ private:
   std::vector<uint64_t>  bdev_label_valid_locations; // this has any elements
   bool bdev_label_multi = false;
   int64_t bdev_label_epoch = -1;
+  bool bluestore_bdev_label_require_all = false;
 
   typedef std::map<uint64_t, volatile_statfs> osd_pools_map;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3381,6 +3381,9 @@ public:
   KeyValueDB* get_kv() {
     return db;
   }
+  BlockDevice* get_bdev() {
+    return bdev;
+  }
 
   int queue_transactions(
     CollectionHandle& ch,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2757,7 +2757,7 @@ public:
     CephContext* cct,
     const std::string &path,
     bluestore_bdev_label_t label,
-    std::vector<uint64_t> locations = std::vector<uint64_t>(BDEV_LABEL_POSITION));
+    std::vector<uint64_t> locations = std::vector<uint64_t>({BDEV_LABEL_POSITION}));
   static int _read_bdev_label(
     CephContext* cct, const std::string &path,
     bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_LABEL_POSITION);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2758,12 +2758,12 @@ public:
     CephContext* cct,
     const std::string &path,
     bluestore_bdev_label_t label,
-    std::vector<uint64_t> locations = std::vector<uint64_t>({BDEV_LABEL_POSITION}));
+    std::vector<uint64_t> locations = std::vector<uint64_t>({BDEV_FIRST_LABEL_POSITION}));
   static int _read_bdev_label(
     CephContext* cct, const std::string &path,
-    bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_LABEL_POSITION);
+    bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_FIRST_LABEL_POSITION);
 private:
-  int _check_or_set_bdev_label(const std::string& path, uint64_t size, std::string desc,
+  int _check_or_set_bdev_label(const std::string& path, uint64_t size, const std::string& desc,
 			       bool create);
   int _set_main_bdev_label();
   int _check_main_bdev_label();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2427,8 +2427,10 @@ private:
   std::atomic<uint32_t> config_changed = {0}; ///< Counter to determine if there is a configuration change.
 
   // caching of bdev_label
-  bool                   bdev_label_valid = false; // indicator if
-  bluestore_bdev_label_t bdev_label;               // this value is valid
+  bluestore_bdev_label_t bdev_label;                 // this value is valid if
+  std::vector<uint64_t>  bdev_label_valid_locations; // this has any elements
+  bool bdev_label_multi = false;
+  int64_t bdev_label_epoch = -1;
 
   typedef std::map<uint64_t, volatile_statfs> osd_pools_map;
 
@@ -2761,6 +2763,17 @@ public:
 private:
   int _check_or_set_bdev_label(std::string path, uint64_t size, std::string desc,
 			       bool create);
+  int _check_or_set_main_bdev_label(
+    std::string path,
+    uint64_t size,
+    bool create);
+  static int _read_main_bdev_label(
+    CephContext* cct,
+    const std::string &path,
+    bluestore_bdev_label_t *out_label,
+    std::vector<uint64_t>* out_valid_positions = nullptr,
+    bool* out_is_cloned = nullptr,
+    int64_t* out_epoch = nullptr);
   int _set_bdev_label_size(const std::string& path, uint64_t size);
 
   int _open_super_meta();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -53,6 +53,7 @@
 #include "os/ObjectStore.h"
 
 #include "bluestore_types.h"
+#include "bluestore_common.h"
 #include "BlueFS.h"
 #include "common/EventTrace.h"
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3438,6 +3438,18 @@ public:
     _wctx_finish(&txc, c, o, &wctx, nullptr);
   }
 
+  static int debug_read_bdev_label(
+    CephContext* cct, const std::string &path,
+    bluestore_bdev_label_t *label, uint64_t disk_position) {
+      return _read_bdev_label(cct, path, label, disk_position);
+    }
+  static int debug_write_bdev_label(
+    CephContext* cct, const std::string &path,
+    const bluestore_bdev_label_t& label, uint64_t disk_position) {
+      return _write_bdev_label(cct, path, label,
+        std::vector<uint64_t>({disk_position}));
+    }
+
   inline void log_latency(const char* name,
     int idx,
     const ceph::timespan& lat,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2765,13 +2765,9 @@ public:
 private:
   int _check_or_set_bdev_label(const std::string& path, uint64_t size, std::string desc,
 			       bool create);
-  int _check_or_set_main_bdev_label(
-    const std::string& path,
-    uint64_t size,
-    bool create);
-  static int _read_main_bdev_label(
-    CephContext* cct,
-    const std::string &path,
+  int _set_main_bdev_label();
+  int _check_main_bdev_label();
+  int _read_main_bdev_label(
     bluestore_bdev_label_t *out_label,
     std::vector<uint64_t>* out_valid_positions = nullptr,
     bool* out_is_cloned = nullptr,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2426,6 +2426,10 @@ private:
   double max_defer_interval = 0; ///< Time to wait between last deferred submit
   std::atomic<uint32_t> config_changed = {0}; ///< Counter to determine if there is a configuration change.
 
+  // caching of bdev_label
+  bool                   bdev_label_valid = false; // indicator if
+  bluestore_bdev_label_t bdev_label;               // this value is valid
+
   typedef std::map<uint64_t, volatile_statfs> osd_pools_map;
 
   ceph::mutex vstatfs_lock = ceph::make_mutex("BlueStore::vstatfs_lock");

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2753,7 +2753,7 @@ public:
     std::lock_guard l(deferred_lock);
     return deferred_last_submitted;
   }
-
+private:
   static int _write_bdev_label(
     CephContext* cct,
     BlockDevice* bdev,
@@ -2763,7 +2763,6 @@ public:
   static int _read_bdev_label(
     CephContext* cct, BlockDevice* bdev, const std::string &path,
     bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_FIRST_LABEL_POSITION);
-private:
   int _check_or_set_bdev_label(const std::string& path, BlockDevice* bdev, uint64_t size,
                                const std::string& desc, bool create);
   int _set_main_bdev_label();
@@ -3454,6 +3453,12 @@ public:
       return _write_bdev_label(cct, bdev, path, label,
         std::vector<uint64_t>({disk_position}));
     }
+  static int read_bdev_label(
+    CephContext* cct, const std::string &path,
+    bluestore_bdev_label_t *label, uint64_t disk_position = 0);
+  static int write_bdev_label(
+    CephContext* cct, const std::string &path,
+    const bluestore_bdev_label_t& label, uint64_t disk_position = 0);
 
   inline void log_latency(const char* name,
     int idx,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2756,18 +2756,23 @@ public:
 
   static int _write_bdev_label(
     CephContext* cct,
+    BlockDevice* bdev,
     const std::string &path,
     bluestore_bdev_label_t label,
     std::vector<uint64_t> locations = std::vector<uint64_t>({BDEV_FIRST_LABEL_POSITION}));
   static int _read_bdev_label(
-    CephContext* cct, const std::string &path,
+    CephContext* cct, BlockDevice* bdev, const std::string &path,
     bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_FIRST_LABEL_POSITION);
 private:
-  int _check_or_set_bdev_label(const std::string& path, uint64_t size, const std::string& desc,
-			       bool create);
+  int _check_or_set_bdev_label(const std::string& path, BlockDevice* bdev, uint64_t size,
+                               const std::string& desc, bool create);
   int _set_main_bdev_label();
   int _check_main_bdev_label();
-  int _read_main_bdev_label(
+  static int _read_main_bdev_label(
+    CephContext* cct,
+    BlockDevice* bdev,
+    const std::string& path,
+    uuid_d fsid,
     bluestore_bdev_label_t *out_label,
     std::vector<uint64_t>* out_valid_positions = nullptr,
     bool* out_is_cloned = nullptr,
@@ -3439,14 +3444,14 @@ public:
   }
 
   static int debug_read_bdev_label(
-    CephContext* cct, const std::string &path,
+    CephContext* cct, BlockDevice* bdev, const std::string &path,
     bluestore_bdev_label_t *label, uint64_t disk_position) {
-      return _read_bdev_label(cct, path, label, disk_position);
+      return _read_bdev_label(cct, bdev, path, label, disk_position);
     }
   static int debug_write_bdev_label(
-    CephContext* cct, const std::string &path,
+    CephContext* cct, BlockDevice* bdev, const std::string &path,
     const bluestore_bdev_label_t& label, uint64_t disk_position) {
-      return _write_bdev_label(cct, path, label,
+      return _write_bdev_label(cct, bdev, path, label,
         std::vector<uint64_t>({disk_position}));
     }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2775,6 +2775,8 @@ private:
     bool* out_is_cloned = nullptr,
     int64_t* out_epoch = nullptr);
   int _set_bdev_label_size(const std::string& path, uint64_t size);
+  void _main_bdev_label_try_reserve();
+  void _main_bdev_label_remove(Allocator* alloc);
 
   int _open_super_meta();
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2750,10 +2750,14 @@ public:
     return deferred_last_submitted;
   }
 
-  static int _write_bdev_label(CephContext* cct,
-			       const std::string &path, bluestore_bdev_label_t label);
-  static int _read_bdev_label(CephContext* cct, const std::string &path,
-			      bluestore_bdev_label_t *label);
+  static int _write_bdev_label(
+    CephContext* cct,
+    const std::string &path,
+    bluestore_bdev_label_t label,
+    std::vector<uint64_t> locations = std::vector<uint64_t>(BDEV_LABEL_POSITION));
+  static int _read_bdev_label(
+    CephContext* cct, const std::string &path,
+    bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_LABEL_POSITION);
 private:
   int _check_or_set_bdev_label(std::string path, uint64_t size, std::string desc,
 			       bool create);

--- a/src/os/bluestore/bluestore_common.h
+++ b/src/os/bluestore/bluestore_common.h
@@ -65,7 +65,8 @@ struct Int64ArrayMergeOperator : public KeyValueDB::MergeOperator {
 // write a label in the first block.  always use this size.  note that
 // bluefs makes a matching assumption about the location of its
 // superblock (always the second block of the device).
-#define BDEV_LABEL_BLOCK_SIZE  4096
+static constexpr uint64_t BDEV_LABEL_POSITION = 0;
+static constexpr uint64_t BDEV_LABEL_BLOCK_SIZE = 4096;
 
 // reserved for standalone DB volume:
 // label (4k) + bluefs super (4k), which means we start at 8k.

--- a/src/os/bluestore/bluestore_common.h
+++ b/src/os/bluestore/bluestore_common.h
@@ -65,7 +65,7 @@ struct Int64ArrayMergeOperator : public KeyValueDB::MergeOperator {
 // write a label in the first block.  always use this size.  note that
 // bluefs makes a matching assumption about the location of its
 // superblock (always the second block of the device).
-static constexpr uint64_t BDEV_LABEL_POSITION = 0;
+static constexpr uint64_t BDEV_FIRST_LABEL_POSITION = 0;
 static constexpr uint64_t BDEV_LABEL_BLOCK_SIZE = 4096;
 
 // reserved for standalone DB volume:

--- a/src/os/bluestore/bluestore_common.h
+++ b/src/os/bluestore/bluestore_common.h
@@ -70,7 +70,9 @@ static constexpr uint64_t BDEV_LABEL_BLOCK_SIZE = 4096;
 
 // reserved for standalone DB volume:
 // label (4k) + bluefs super (4k), which means we start at 8k.
-#define DB_SUPER_RESERVED  (BDEV_LABEL_BLOCK_SIZE + 4096)
+static constexpr uint64_t BLUEFS_SUPER_POSITION = 4096;
+static constexpr uint64_t BLUEFS_SUPER_BLOCK_SIZE = 4096;
+static constexpr uint64_t SUPER_RESERVED = BDEV_LABEL_BLOCK_SIZE + BLUEFS_SUPER_BLOCK_SIZE;
 
 
 #endif

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -79,7 +79,7 @@ const char* find_device_path(
 {
   for (auto& i : devs) {
     bluestore_bdev_label_t label;
-    int r = BlueStore::_read_bdev_label(cct, i, &label);
+    int r = BlueStore::read_bdev_label(cct, i, &label);
     if (r < 0) {
       cerr << "unable to read label for " << i << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -111,7 +111,7 @@ void parse_devices(
   }
   for (auto& d : devs) {
     bluestore_bdev_label_t label;
-    int r = BlueStore::_read_bdev_label(cct, d, &label);
+    int r = BlueStore::read_bdev_label(cct, d, &label);
     if (r < 0) {
       cerr << "unable to read label for " << d << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -677,7 +677,7 @@ int main(int argc, char **argv)
   }
   else if (action == "prime-osd-dir") {
     bluestore_bdev_label_t label;
-    int r = BlueStore::_read_bdev_label(cct.get(), devs.front(), &label);
+    int r = BlueStore::read_bdev_label(cct.get(), devs.front(), &label);
     if (r < 0) {
       cerr << "failed to read label for " << devs.front() << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -731,7 +731,7 @@ int main(int argc, char **argv)
     jf.open_object_section("devices");
     for (auto& i : devs) {
       bluestore_bdev_label_t label;
-      int r = BlueStore::_read_bdev_label(cct.get(), i, &label);
+      int r = BlueStore::read_bdev_label(cct.get(), i, &label);
       if (r < 0) {
 	cerr << "unable to read label for " << i << ": "
 	     << cpp_strerror(r) << std::endl;
@@ -746,7 +746,7 @@ int main(int argc, char **argv)
   }
   else if (action == "set-label-key") {
     bluestore_bdev_label_t label;
-    int r = BlueStore::_read_bdev_label(cct.get(), devs.front(), &label);
+    int r = BlueStore::read_bdev_label(cct.get(), devs.front(), &label);
     if (r < 0) {
       cerr << "unable to read label for " << devs.front() << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -768,7 +768,7 @@ int main(int argc, char **argv)
     } else {
       label.meta[key] = value;
     }
-    r = BlueStore::_write_bdev_label(cct.get(), devs.front(), label);
+    r = BlueStore::write_bdev_label(cct.get(), devs.front(), label);
     if (r < 0) {
       cerr << "unable to write label for " << devs.front() << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -777,7 +777,7 @@ int main(int argc, char **argv)
   }
   else if (action == "rm-label-key") {
     bluestore_bdev_label_t label;
-    int r = BlueStore::_read_bdev_label(cct.get(), devs.front(), &label);
+    int r = BlueStore::read_bdev_label(cct.get(), devs.front(), &label);
     if (r < 0) {
       cerr << "unable to read label for " << devs.front() << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -788,7 +788,7 @@ int main(int argc, char **argv)
       exit(EXIT_FAILURE);
     }
     label.meta.erase(key);
-    r = BlueStore::_write_bdev_label(cct.get(), devs.front(), label);
+    r = BlueStore::write_bdev_label(cct.get(), devs.front(), label);
     if (r < 0) {
       cerr << "unable to write label for " << devs.front() << ": "
 	   << cpp_strerror(r) << std::endl;

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -746,7 +746,11 @@ int main(int argc, char **argv)
   }
   else if (action == "set-label-key") {
     bluestore_bdev_label_t label;
-    int r = BlueStore::read_bdev_label(cct.get(), devs.front(), &label);
+    std::vector<uint64_t> valid_positions;
+    bool is_multi = false;
+    int64_t epoch = -1;
+    int r = BlueStore::read_bdev_label(cct.get(), devs.front(), &label,
+      &valid_positions, &is_multi, &epoch);
     if (r < 0) {
       cerr << "unable to read label for " << devs.front() << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -768,16 +772,32 @@ int main(int argc, char **argv)
     } else {
       label.meta[key] = value;
     }
-    r = BlueStore::write_bdev_label(cct.get(), devs.front(), label);
-    if (r < 0) {
-      cerr << "unable to write label for " << devs.front() << ": "
-	   << cpp_strerror(r) << std::endl;
-      exit(EXIT_FAILURE);
+    if (is_multi) {
+      epoch++;
+      label.meta["epoch"] = std::to_string(epoch);
+    }
+    bool wrote_at_least_one = false;
+    for (uint64_t position : valid_positions) {
+      r = BlueStore::write_bdev_label(cct.get(), devs.front(), label, position);
+      if (r < 0) {
+        cerr << "unable to write label for " << devs.front()
+             << " at 0x" << std::hex << position << std::dec
+             << ": " << cpp_strerror(r) << std::endl;
+      } else {
+        wrote_at_least_one = true;
+      }
+    }
+    if (!wrote_at_least_one) {
+        exit(EXIT_FAILURE);
     }
   }
   else if (action == "rm-label-key") {
     bluestore_bdev_label_t label;
-    int r = BlueStore::read_bdev_label(cct.get(), devs.front(), &label);
+    std::vector<uint64_t> valid_positions;
+    bool is_multi = false;
+    int64_t epoch = -1;
+    int r = BlueStore::read_bdev_label(cct.get(), devs.front(), &label,
+      &valid_positions, &is_multi, &epoch);
     if (r < 0) {
       cerr << "unable to read label for " << devs.front() << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -788,11 +808,23 @@ int main(int argc, char **argv)
       exit(EXIT_FAILURE);
     }
     label.meta.erase(key);
-    r = BlueStore::write_bdev_label(cct.get(), devs.front(), label);
-    if (r < 0) {
-      cerr << "unable to write label for " << devs.front() << ": "
-	   << cpp_strerror(r) << std::endl;
-      exit(EXIT_FAILURE);
+    if (is_multi) {
+      epoch++;
+      label.meta["epoch"] = std::to_string(epoch);
+    }
+    bool wrote_at_least_one = false;
+    for (uint64_t position : valid_positions) {
+      r = BlueStore::write_bdev_label(cct.get(), devs.front(), label, position);
+      if (r < 0) {
+        cerr << "unable to write label for " << devs.front()
+             << " at 0x" << std::hex << position << std::dec
+             << ": " << cpp_strerror(r) << std::endl;
+      } else {
+        wrote_at_least_one = true;
+      }
+    }
+    if (!wrote_at_least_one) {
+        exit(EXIT_FAILURE);
     }
   }
   else if (action == "bluefs-bdev-sizes") {

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -11169,7 +11169,7 @@ TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionWithBlueFS) {
   ASSERT_EQ(label.meta["multi"], "yes");
 }
 
-TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionObjects) {
+TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionWithObjects) {
   static constexpr uint64_t _1G = uint64_t(1024)*1024*1024;
   static constexpr uint64_t _1M = uint64_t(1)*1024*1024;
   SetVal(g_conf(), "bluestore_block_db_create", "true");

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -12,6 +12,7 @@
  *
  */
 
+#include <fcntl.h>
 #include <glob.h>
 #include <stdio.h>
 #include <string.h>
@@ -25,6 +26,7 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include "global/global_context.h"
 #include "os/ObjectStore.h"
 #if defined(WITH_BLUESTORE)
 #include "os/bluestore/BlueStore.h"
@@ -194,6 +196,52 @@ class StoreTestDeferredSetup : public StoreTest {
 protected:
   void DeferredSetup() {
     StoreTest::SetUp();
+  }
+};
+
+
+class MultiLabelTest : public StoreTestDeferredSetup {
+  public:
+  std::string get_data_dir() {
+    return data_dir;
+  }
+  bool mounted = false;
+  void mount() {
+    ASSERT_FALSE(mounted);
+    store->mount();
+    mounted = true;
+  }
+  void umount() {
+    ASSERT_TRUE(mounted);
+    store->umount();
+    mounted = false;
+  }
+  bool corrupt_disk_at(uint64_t position) {
+    int fd = -1;
+    auto close_fd = make_scope_guard([&] {
+      if (fd != -1) ::close(fd); });
+    string block_file = get_data_dir() + "/block";
+    fd = ::open(block_file.c_str(), O_RDWR|O_CLOEXEC);
+    if (fd < 0) return false;
+    char data_fill[100] = {55};
+    int r = ::pwrite(fd, data_fill, 100, position);
+    if (r != 100) return false;
+    r = ::fsync(fd);
+    if (r != 0) return false;
+    return true;
+  }
+  protected:
+  void DeferredSetup() {
+    StoreTest::SetUp();
+    mounted = true;
+  }
+  void TearDown() override {
+    if (mounted) {
+      store->umount();
+    }
+    StoreTest::RemoveTestObjectStore();
+    store = nullptr;
+    StoreTest::TearDown();
   }
 };
 
@@ -7089,6 +7137,11 @@ INSTANTIATE_TEST_SUITE_P(
     "bluestore"));
 #endif
 
+INSTANTIATE_TEST_SUITE_P(
+  ObjectStore,
+  MultiLabelTest,
+  ::testing::Values(
+    "bluestore"));
 
 struct deferred_test_t {
   uint32_t bdev_block_size;
@@ -10824,6 +10877,237 @@ TEST_P(StoreTest, mergeRegionTest) {
     r = store->read(ch, hoid, 0, final_len, bl);
     ASSERT_EQ(final_len, static_cast<uint64_t>(r));
   }
+}
+
+TEST_P(MultiLabelTest, MultiSelectableOff) {
+  SetVal(g_conf(), "bluestore_bdev_label_multi", "false");
+  g_conf().apply_changes(nullptr);
+  DeferredSetup();
+  store->umount();
+  bluestore_bdev_label_t label;
+  int r = BlueStore::_read_bdev_label(
+    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(label.meta.end(), label.meta.find("multi"));
+  store->mount();
+}
+
+TEST_P(MultiLabelTest, MultiSelectableOn) {
+  SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
+  g_conf().apply_changes(nullptr);
+  DeferredSetup();
+  store->umount();
+  bluestore_bdev_label_t label;
+  int r = BlueStore::_read_bdev_label(
+    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  ASSERT_EQ(r, 0);
+  auto it = label.meta.find("multi");
+  ASSERT_NE(label.meta.end(), it);
+  ASSERT_EQ(it->second, "yes");
+  store->mount();
+}
+
+TEST_P(MultiLabelTest, DetectCorruptedFirst) {
+  SetVal(g_conf(), "bluestore_block_size",
+    stringify(101L * 1024 * 1024 * 1024).c_str());
+  SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
+  g_conf().apply_changes(nullptr);
+  DeferredSetup();
+  umount();
+  bool corrupt = corrupt_disk_at(0);
+  ASSERT_EQ(corrupt, true);
+  ASSERT_EQ(store->fsck(false), 1);
+  //store->mount();
+}
+
+TEST_P(MultiLabelTest, FixCorruptedFirst) {
+  SetVal(g_conf(), "bluestore_block_size",
+    stringify(101L * 1024 * 1024 * 1024).c_str());
+  SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
+  g_conf().apply_changes(nullptr);
+  DeferredSetup();
+  umount();
+  bool corrupt = corrupt_disk_at(0);
+  ASSERT_EQ(corrupt, true);
+  ASSERT_EQ(store->fsck(false), 1);
+  ASSERT_EQ(store->repair(false), 0);
+  mount();
+}
+
+TEST_P(MultiLabelTest, FixCorruptedTwo) {
+  static constexpr uint64_t _1G = uint64_t(1024)*1024*1024;
+  SetVal(g_conf(), "bluestore_block_size",
+    stringify(101 * _1G).c_str());
+  SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
+  g_conf().apply_changes(nullptr);
+  DeferredSetup();
+  umount();
+  bool corrupt = corrupt_disk_at(0);
+  ASSERT_EQ(corrupt, true);
+  corrupt = corrupt_disk_at(_1G);
+  ASSERT_EQ(corrupt, true);
+  ASSERT_EQ(store->fsck(false), 2);
+  ASSERT_EQ(store->repair(false), 0);
+  mount();
+}
+
+TEST_P(MultiLabelTest, FixCorruptedThree) {
+  static constexpr uint64_t _1G = uint64_t(1024)*1024*1024;
+  SetVal(g_conf(), "bluestore_block_size",
+    stringify(101 * _1G).c_str());
+  SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
+  g_conf().apply_changes(nullptr);
+  DeferredSetup();
+  umount();
+  bool corrupt = corrupt_disk_at(0);
+  ASSERT_EQ(corrupt, true);
+  corrupt = corrupt_disk_at(_1G);
+  ASSERT_EQ(corrupt, true);
+  corrupt = corrupt_disk_at(_1G * 10);
+  ASSERT_EQ(corrupt, true);
+  ASSERT_EQ(store->fsck(false), 3);
+  ASSERT_EQ(store->repair(false), 0);
+  mount();
+}
+
+TEST_P(MultiLabelTest, CantFixCorruptedAll) {
+  static constexpr uint64_t _1G = uint64_t(1024)*1024*1024;
+  SetVal(g_conf(), "bluestore_block_size",
+    stringify(101 * _1G).c_str());
+  SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
+  g_conf().apply_changes(nullptr);
+  DeferredSetup();
+  umount();
+  bool corrupt = corrupt_disk_at(0);
+  ASSERT_EQ(corrupt, true);
+  corrupt = corrupt_disk_at(_1G);
+  ASSERT_EQ(corrupt, true);
+  corrupt = corrupt_disk_at(_1G * 10);
+  ASSERT_EQ(corrupt, true);
+  corrupt = corrupt_disk_at(_1G * 100);
+  ASSERT_EQ(corrupt, true);
+  ASSERT_NE(store->fsck(false), 0);
+  ASSERT_NE(store->repair(false), 0);
+}
+
+TEST_P(MultiLabelTest, SelectNewestLabel) {
+  static constexpr uint64_t _1G = uint64_t(1024)*1024*1024;
+  SetVal(g_conf(), "bluestore_block_size",
+    stringify(101 * _1G).c_str());
+  SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
+  g_conf().apply_changes(nullptr);
+  DeferredSetup();
+  umount();
+  bluestore_bdev_label_t label;
+  int r = BlueStore::_read_bdev_label(
+    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  ASSERT_EQ(r, 0);
+  auto it = label.meta.find("epoch");
+  ASSERT_NE(it, label.meta.end());
+  it->second += "1"; //APPEND "1", not add
+  label.meta["canary"]="alive";
+  r = BlueStore::_write_bdev_label(
+    g_ceph_context, get_data_dir() + "/block", label, {_1G});
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(store->fsck(false), 3);
+  ASSERT_EQ(store->repair(false), 0);
+  r = BlueStore::_read_bdev_label(
+    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(label.meta["canary"], "alive");
+}
+
+TEST_P(MultiLabelTest, UpgradeToMultiLabel) {
+  static constexpr uint64_t _1G = uint64_t(1024)*1024*1024;
+  SetVal(g_conf(), "bluestore_block_size", stringify(101 * _1G).c_str());
+  SetVal(g_conf(), "bluestore_bdev_label_multi", "false");
+  SetVal(g_conf(), "bluestore_bdev_label_multi_upgrade", "true");
+  g_conf().apply_changes(nullptr);
+  DeferredSetup();
+  umount();
+  ASSERT_EQ(store->repair(false), 0);
+  ASSERT_EQ(store->fsck(false), 0);
+  bluestore_bdev_label_t label;
+  int r = BlueStore::_read_bdev_label(
+    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  ASSERT_EQ(r, 0);
+  auto it = label.meta.find("epoch");
+  ASSERT_NE(it, label.meta.end());
+  ASSERT_EQ(label.meta["multi"], "yes");
+}
+
+TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionWithBlueFS) {
+  static constexpr uint64_t _1G = uint64_t(1024)*1024*1024;
+  static constexpr uint64_t _1M = uint64_t(1)*1024*1024;
+  SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "0");
+  SetVal(g_conf(), "bluestore_block_size", stringify(101 * _1G).c_str());
+  SetVal(g_conf(), "bluestore_bdev_label_multi", "false");
+  SetVal(g_conf(), "bluestore_bdev_label_multi_upgrade", "true");
+  g_conf().apply_changes(nullptr);
+  DeferredSetup();
+  //fill BlueFS with data
+  BlueStore* bstore = dynamic_cast<BlueStore*> (store.get());
+  ceph_assert(bstore);
+  for (size_t i = 0; i < 128; i++) {
+    std::string name = to_string(i);
+    bstore->inject_bluefs_file("db", name, 16 * _1M);
+  }
+  umount();
+  ASSERT_EQ(store->repair(false), 1);
+  ASSERT_EQ(store->fsck(false), 1);
+  bluestore_bdev_label_t label;
+  int r = BlueStore::_read_bdev_label(
+    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  ASSERT_EQ(r, 0);
+  auto it = label.meta.find("epoch");
+  ASSERT_NE(it, label.meta.end());
+  ASSERT_EQ(label.meta["multi"], "yes");
+}
+
+TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionObjects) {
+  static constexpr uint64_t _1G = uint64_t(1024)*1024*1024;
+  static constexpr uint64_t _1M = uint64_t(1)*1024*1024;
+  SetVal(g_conf(), "bluestore_block_db_create", "true");
+  SetVal(g_conf(), "bluestore_block_db_size", stringify(10 * _1G).c_str());
+  SetVal(g_conf(), "bluestore_debug_inject_allocation_from_file_failure", "0");
+  SetVal(g_conf(), "bluestore_block_size", stringify(101 * _1G).c_str());
+  SetVal(g_conf(), "bluestore_bdev_label_multi", "false");
+  SetVal(g_conf(), "bluestore_bdev_label_multi_upgrade", "true");
+  g_conf().apply_changes(nullptr);
+  DeferredSetup();
+  //fill with object data
+  coll_t cid;
+  auto ch = store->create_new_collection(cid);
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    int r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    bufferlist bl;
+    bl.append(std::string(_1M, '0'));
+    for (int m = 0; m < 128 + 10; m++) {
+      for (int n = 0; n < 16; n++) {
+        ObjectStore::Transaction t;
+        std::string name = "OBJ-"+to_string(m)+"-"+to_string(n);
+        ghobject_t hoid(hobject_t(sobject_t(name, CEPH_NOSNAP)));
+        t.write(cid, hoid, 0, bl.length(), bl);
+        int r = queue_transaction(store, ch, std::move(t));
+        ASSERT_EQ(r, 0);
+      }
+    }
+  }
+  umount();
+  ASSERT_EQ(store->repair(false), 0);
+  ASSERT_EQ(store->fsck(false), 0);
+  bluestore_bdev_label_t label;
+  int r = BlueStore::_read_bdev_label(
+    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  ASSERT_EQ(r, 0);
+  auto it = label.meta.find("epoch");
+  ASSERT_NE(it, label.meta.end());
+  ASSERT_EQ(label.meta["multi"], "yes");
 }
 
 TEST_P(StoreTestSpecificAUSize, BluestoreEnforceHWSettingsHdd) {

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -206,10 +206,10 @@ class MultiLabelTest : public StoreTestDeferredSetup {
     return data_dir;
   }
   bool mounted = false;
-  void mount() {
-    ASSERT_FALSE(mounted);
-    store->mount();
-    mounted = true;
+  int mount() {
+    int r = store->mount();
+    if (r == 0) mounted = true;
+    return r;
   }
   void umount() {
     ASSERT_TRUE(mounted);
@@ -10933,7 +10933,6 @@ TEST_P(MultiLabelTest, DetectCorruptedFirst) {
   bool corrupt = corrupt_disk_at(0);
   ASSERT_EQ(corrupt, true);
   ASSERT_EQ(store->fsck(false), 1);
-  //store->mount();
 }
 
 TEST_P(MultiLabelTest, FixCorruptedFirst) {
@@ -11016,6 +11015,75 @@ TEST_P(MultiLabelTest, CantFixCorruptedAll) {
   ASSERT_EQ(corrupt, true);
   ASSERT_NE(store->fsck(false), 0);
   ASSERT_NE(store->repair(false), 0);
+}
+
+TEST_P(MultiLabelTest, SkipInvalidUUID) {
+  static constexpr uint64_t _1G = uint64_t(1024)*1024*1024;
+  SetVal(g_conf(), "bluestore_block_size",
+    stringify(101L * _1G).c_str());
+  SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
+  g_conf().apply_changes(nullptr);
+  DeferredSetup();
+  if (!bdev_supports_label()) {
+    GTEST_SKIP();
+  }
+  umount();
+  int r;
+  bluestore_bdev_label_t label;
+  r = BlueStore::debug_read_bdev_label(g_ceph_context,
+    get_data_dir()+"/block", &label, 0);
+  ASSERT_EQ(r, 0);
+  label.meta["epoch"] = "1";
+  uuid_d new_id;
+  new_id.generate_random();
+  label.osd_uuid = new_id;
+  r = BlueStore::debug_write_bdev_label(g_ceph_context,
+    get_data_dir()+"/block", label, 0);
+  ASSERT_EQ(r, 0);
+
+  ASSERT_EQ(store->fsck(false), 1);
+  ASSERT_EQ(store->repair(false), 0);
+  mount();
+}
+
+TEST_P(MultiLabelTest, FailAllInvalidUUID) {
+  static constexpr uint64_t _1G = uint64_t(1024)*1024*1024;
+  SetVal(g_conf(), "bluestore_block_size",
+    stringify(101 * _1G).c_str());
+  SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
+  SetVal(g_conf(), "bluestore_bdev_label_require_all", "false");
+  g_conf().apply_changes(nullptr);
+  DeferredSetup();
+  if (!bdev_supports_label()) {
+    GTEST_SKIP();
+  }
+  umount();
+  int r;
+  bluestore_bdev_label_t label;
+  r = BlueStore::debug_read_bdev_label(g_ceph_context,
+    get_data_dir()+"/block", &label, 0);
+  ASSERT_EQ(r, 0);
+  label.meta["epoch"] = "1";
+  uuid_d new_id;
+  new_id.generate_random();
+  label.osd_uuid = new_id;
+  r = BlueStore::debug_write_bdev_label(g_ceph_context,
+    get_data_dir()+"/block", label, 0);
+  ASSERT_EQ(r, 0);
+  r = BlueStore::debug_write_bdev_label(g_ceph_context,
+    get_data_dir()+"/block", label, _1G);
+  ASSERT_EQ(r, 0);
+  r = BlueStore::debug_write_bdev_label(g_ceph_context,
+    get_data_dir()+"/block", label, 10 * _1G);
+  ASSERT_EQ(r, 0);
+  r = BlueStore::debug_write_bdev_label(g_ceph_context,
+    get_data_dir()+"/block", label, 100 * _1G);
+  ASSERT_EQ(r, 0);
+
+  ASSERT_EQ(store->fsck(false), -2); // this is complete failure
+  ASSERT_EQ(store->repair(false), -2);
+  r = mount();
+  ASSERT_NE(r, 0);
 }
 
 TEST_P(MultiLabelTest, SelectNewestLabel) {

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -239,12 +239,24 @@ class MultiLabelTest : public StoreTestDeferredSetup {
   }
   bool read_bdev_label(bluestore_bdev_label_t* label, uint64_t position) {
     string bdev_path = get_data_dir() + "/block";
-    int r = BlueStore::read_bdev_label(g_ceph_context, bdev_path, label, position);
+    unique_ptr<BlockDevice> bdev(BlockDevice::create(
+      g_ceph_context, bdev_path, nullptr, nullptr, nullptr, nullptr));
+    int r = bdev->open(bdev_path);
+    if (r < 0)
+      return r;
+    r = BlueStore::debug_read_bdev_label(g_ceph_context, bdev.get(), bdev_path, label, position);
+    bdev->close();
     return r;
   }
   bool write_bdev_label(const bluestore_bdev_label_t& label, uint64_t position) {
     string bdev_path = get_data_dir() + "/block";
-    int r = BlueStore::write_bdev_label(g_ceph_context, bdev_path, label, position);
+    unique_ptr<BlockDevice> bdev(BlockDevice::create(
+      g_ceph_context, bdev_path, nullptr, nullptr, nullptr, nullptr));
+    int r = bdev->open(bdev_path);
+    if (r < 0)
+      return r;
+    r = BlueStore::debug_write_bdev_label(g_ceph_context, bdev.get(), bdev_path, label, position);
+    bdev->close();
     return r;
   }
   protected:

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -216,6 +216,13 @@ class MultiLabelTest : public StoreTestDeferredSetup {
     store->umount();
     mounted = false;
   }
+  bool bdev_supports_label() {
+    BlueStore* bstore = dynamic_cast<BlueStore*> (store.get());
+    if (!bstore) return false;
+    auto bdev = bstore->get_bdev();
+    if (!bdev) return false;
+    return bdev->supported_bdev_label();
+  }
   bool corrupt_disk_at(uint64_t position) {
     int fd = -1;
     auto close_fd = make_scope_guard([&] {
@@ -10883,20 +10890,26 @@ TEST_P(MultiLabelTest, MultiSelectableOff) {
   SetVal(g_conf(), "bluestore_bdev_label_multi", "false");
   g_conf().apply_changes(nullptr);
   DeferredSetup();
-  store->umount();
+  if (!bdev_supports_label()) {
+    GTEST_SKIP();
+  }
+  umount();
   bluestore_bdev_label_t label;
   int r = BlueStore::_read_bdev_label(
     g_ceph_context, get_data_dir() + "/block", &label, 0);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(label.meta.end(), label.meta.find("multi"));
-  store->mount();
+  mount();
 }
 
 TEST_P(MultiLabelTest, MultiSelectableOn) {
   SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
   g_conf().apply_changes(nullptr);
   DeferredSetup();
-  store->umount();
+  if (!bdev_supports_label()) {
+    GTEST_SKIP();
+  }
+  umount();
   bluestore_bdev_label_t label;
   int r = BlueStore::_read_bdev_label(
     g_ceph_context, get_data_dir() + "/block", &label, 0);
@@ -10904,7 +10917,7 @@ TEST_P(MultiLabelTest, MultiSelectableOn) {
   auto it = label.meta.find("multi");
   ASSERT_NE(label.meta.end(), it);
   ASSERT_EQ(it->second, "yes");
-  store->mount();
+  mount();
 }
 
 TEST_P(MultiLabelTest, DetectCorruptedFirst) {
@@ -10913,6 +10926,9 @@ TEST_P(MultiLabelTest, DetectCorruptedFirst) {
   SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
   g_conf().apply_changes(nullptr);
   DeferredSetup();
+  if (!bdev_supports_label()) {
+    GTEST_SKIP();
+  }
   umount();
   bool corrupt = corrupt_disk_at(0);
   ASSERT_EQ(corrupt, true);
@@ -10926,6 +10942,9 @@ TEST_P(MultiLabelTest, FixCorruptedFirst) {
   SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
   g_conf().apply_changes(nullptr);
   DeferredSetup();
+  if (!bdev_supports_label()) {
+    GTEST_SKIP();
+  }
   umount();
   bool corrupt = corrupt_disk_at(0);
   ASSERT_EQ(corrupt, true);
@@ -10941,6 +10960,9 @@ TEST_P(MultiLabelTest, FixCorruptedTwo) {
   SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
   g_conf().apply_changes(nullptr);
   DeferredSetup();
+  if (!bdev_supports_label()) {
+    GTEST_SKIP();
+  }
   umount();
   bool corrupt = corrupt_disk_at(0);
   ASSERT_EQ(corrupt, true);
@@ -10958,6 +10980,9 @@ TEST_P(MultiLabelTest, FixCorruptedThree) {
   SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
   g_conf().apply_changes(nullptr);
   DeferredSetup();
+  if (!bdev_supports_label()) {
+    GTEST_SKIP();
+  }
   umount();
   bool corrupt = corrupt_disk_at(0);
   ASSERT_EQ(corrupt, true);
@@ -10977,6 +11002,9 @@ TEST_P(MultiLabelTest, CantFixCorruptedAll) {
   SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
   g_conf().apply_changes(nullptr);
   DeferredSetup();
+  if (!bdev_supports_label()) {
+    GTEST_SKIP();
+  }
   umount();
   bool corrupt = corrupt_disk_at(0);
   ASSERT_EQ(corrupt, true);
@@ -10997,6 +11025,9 @@ TEST_P(MultiLabelTest, SelectNewestLabel) {
   SetVal(g_conf(), "bluestore_bdev_label_multi", "true");
   g_conf().apply_changes(nullptr);
   DeferredSetup();
+  if (!bdev_supports_label()) {
+    GTEST_SKIP();
+  }
   umount();
   bluestore_bdev_label_t label;
   int r = BlueStore::_read_bdev_label(
@@ -11024,6 +11055,9 @@ TEST_P(MultiLabelTest, UpgradeToMultiLabel) {
   SetVal(g_conf(), "bluestore_bdev_label_multi_upgrade", "true");
   g_conf().apply_changes(nullptr);
   DeferredSetup();
+  if (!bdev_supports_label()) {
+    GTEST_SKIP();
+  }
   umount();
   ASSERT_EQ(store->repair(false), 0);
   ASSERT_EQ(store->fsck(false), 0);
@@ -11045,6 +11079,9 @@ TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionWithBlueFS) {
   SetVal(g_conf(), "bluestore_bdev_label_multi_upgrade", "true");
   g_conf().apply_changes(nullptr);
   DeferredSetup();
+  if (!bdev_supports_label()) {
+    GTEST_SKIP();
+  }
   //fill BlueFS with data
   BlueStore* bstore = dynamic_cast<BlueStore*> (store.get());
   ceph_assert(bstore);
@@ -11075,6 +11112,9 @@ TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionObjects) {
   SetVal(g_conf(), "bluestore_bdev_label_multi_upgrade", "true");
   g_conf().apply_changes(nullptr);
   DeferredSetup();
+  if (!bdev_supports_label()) {
+    GTEST_SKIP();
+  }
   //fill with object data
   coll_t cid;
   auto ch = store->create_new_collection(cid);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -11215,6 +11215,10 @@ TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionWithObjects) {
     }
   }
   umount();
+  // Need to do 2 passes of repair:
+  // - the first one moves offending objects away
+  // - the second can then fix bdev labels
+  store->repair(false);
   ASSERT_EQ(store->repair(false), 0);
   ASSERT_EQ(store->fsck(false), 0);
   bluestore_bdev_label_t label;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -237,6 +237,16 @@ class MultiLabelTest : public StoreTestDeferredSetup {
     if (r != 0) return false;
     return true;
   }
+  bool read_bdev_label(bluestore_bdev_label_t* label, uint64_t position) {
+    string bdev_path = get_data_dir() + "/block";
+    int r = BlueStore::read_bdev_label(g_ceph_context, bdev_path, label, position);
+    return r;
+  }
+  bool write_bdev_label(const bluestore_bdev_label_t& label, uint64_t position) {
+    string bdev_path = get_data_dir() + "/block";
+    int r = BlueStore::write_bdev_label(g_ceph_context, bdev_path, label, position);
+    return r;
+  }
   protected:
   void DeferredSetup() {
     StoreTest::SetUp();
@@ -10895,8 +10905,7 @@ TEST_P(MultiLabelTest, MultiSelectableOff) {
   }
   umount();
   bluestore_bdev_label_t label;
-  int r = BlueStore::_read_bdev_label(
-    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  int r = read_bdev_label(&label, 0);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(label.meta.end(), label.meta.find("multi"));
   mount();
@@ -10911,8 +10920,7 @@ TEST_P(MultiLabelTest, MultiSelectableOn) {
   }
   umount();
   bluestore_bdev_label_t label;
-  int r = BlueStore::_read_bdev_label(
-    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  int r = read_bdev_label(&label, 0);
   ASSERT_EQ(r, 0);
   auto it = label.meta.find("multi");
   ASSERT_NE(label.meta.end(), it);
@@ -11030,15 +11038,13 @@ TEST_P(MultiLabelTest, SkipInvalidUUID) {
   umount();
   int r;
   bluestore_bdev_label_t label;
-  r = BlueStore::debug_read_bdev_label(g_ceph_context,
-    get_data_dir()+"/block", &label, 0);
+  r = read_bdev_label(&label, 0);
   ASSERT_EQ(r, 0);
   label.meta["epoch"] = "1";
   uuid_d new_id;
   new_id.generate_random();
   label.osd_uuid = new_id;
-  r = BlueStore::debug_write_bdev_label(g_ceph_context,
-    get_data_dir()+"/block", label, 0);
+  r = write_bdev_label(label, 0);
   ASSERT_EQ(r, 0);
 
   ASSERT_EQ(store->fsck(false), 1);
@@ -11060,24 +11066,19 @@ TEST_P(MultiLabelTest, FailAllInvalidUUID) {
   umount();
   int r;
   bluestore_bdev_label_t label;
-  r = BlueStore::debug_read_bdev_label(g_ceph_context,
-    get_data_dir()+"/block", &label, 0);
+  r = read_bdev_label(&label, 0);
   ASSERT_EQ(r, 0);
   label.meta["epoch"] = "1";
   uuid_d new_id;
   new_id.generate_random();
   label.osd_uuid = new_id;
-  r = BlueStore::debug_write_bdev_label(g_ceph_context,
-    get_data_dir()+"/block", label, 0);
+  r = write_bdev_label(label, 0);
   ASSERT_EQ(r, 0);
-  r = BlueStore::debug_write_bdev_label(g_ceph_context,
-    get_data_dir()+"/block", label, _1G);
+  r = write_bdev_label(label, _1G);
   ASSERT_EQ(r, 0);
-  r = BlueStore::debug_write_bdev_label(g_ceph_context,
-    get_data_dir()+"/block", label, 10 * _1G);
+  r = write_bdev_label(label, 10 * _1G);
   ASSERT_EQ(r, 0);
-  r = BlueStore::debug_write_bdev_label(g_ceph_context,
-    get_data_dir()+"/block", label, 100 * _1G);
+  r = write_bdev_label(label, 100 * _1G);
   ASSERT_EQ(r, 0);
 
   ASSERT_EQ(store->fsck(false), -2); // this is complete failure
@@ -11098,20 +11099,17 @@ TEST_P(MultiLabelTest, SelectNewestLabel) {
   }
   umount();
   bluestore_bdev_label_t label;
-  int r = BlueStore::_read_bdev_label(
-    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  int r = read_bdev_label(&label, 0);
   ASSERT_EQ(r, 0);
   auto it = label.meta.find("epoch");
   ASSERT_NE(it, label.meta.end());
   it->second += "1"; //APPEND "1", not add
   label.meta["canary"]="alive";
-  r = BlueStore::_write_bdev_label(
-    g_ceph_context, get_data_dir() + "/block", label, {_1G});
+  r = write_bdev_label(label, _1G);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(store->fsck(false), 3);
   ASSERT_EQ(store->repair(false), 0);
-  r = BlueStore::_read_bdev_label(
-    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  r = read_bdev_label(&label, 0);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(label.meta["canary"], "alive");
 }
@@ -11130,8 +11128,7 @@ TEST_P(MultiLabelTest, UpgradeToMultiLabel) {
   ASSERT_EQ(store->repair(false), 0);
   ASSERT_EQ(store->fsck(false), 0);
   bluestore_bdev_label_t label;
-  int r = BlueStore::_read_bdev_label(
-    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  int r = read_bdev_label(&label, 0);
   ASSERT_EQ(r, 0);
   auto it = label.meta.find("epoch");
   ASSERT_NE(it, label.meta.end());
@@ -11161,8 +11158,7 @@ TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionWithBlueFS) {
   ASSERT_EQ(store->repair(false), 1);
   ASSERT_EQ(store->fsck(false), 1);
   bluestore_bdev_label_t label;
-  int r = BlueStore::_read_bdev_label(
-    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  int r = read_bdev_label(&label, 0);
   ASSERT_EQ(r, 0);
   auto it = label.meta.find("epoch");
   ASSERT_NE(it, label.meta.end());
@@ -11210,8 +11206,7 @@ TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionWithObjects) {
   ASSERT_EQ(store->repair(false), 0);
   ASSERT_EQ(store->fsck(false), 0);
   bluestore_bdev_label_t label;
-  int r = BlueStore::_read_bdev_label(
-    g_ceph_context, get_data_dir() + "/block", &label, 0);
+  int r = read_bdev_label(&label, 0);
   ASSERT_EQ(r, 0);
   auto it = label.meta.find("epoch");
   ASSERT_NE(it, label.meta.end());

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -10920,7 +10920,6 @@ TEST_P(MultiLabelTest, MultiSelectableOff) {
   int r = read_bdev_label(&label, 0);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(label.meta.end(), label.meta.find("multi"));
-  mount();
 }
 
 TEST_P(MultiLabelTest, MultiSelectableOn) {
@@ -10937,7 +10936,6 @@ TEST_P(MultiLabelTest, MultiSelectableOn) {
   auto it = label.meta.find("multi");
   ASSERT_NE(label.meta.end(), it);
   ASSERT_EQ(it->second, "yes");
-  mount();
 }
 
 TEST_P(MultiLabelTest, DetectCorruptedFirst) {
@@ -10969,7 +10967,7 @@ TEST_P(MultiLabelTest, FixCorruptedFirst) {
   ASSERT_EQ(corrupt, true);
   ASSERT_EQ(store->fsck(false), 1);
   ASSERT_EQ(store->repair(false), 0);
-  mount();
+  ASSERT_EQ(store->fsck(false), 0);
 }
 
 TEST_P(MultiLabelTest, FixCorruptedTwo) {
@@ -10989,7 +10987,7 @@ TEST_P(MultiLabelTest, FixCorruptedTwo) {
   ASSERT_EQ(corrupt, true);
   ASSERT_EQ(store->fsck(false), 2);
   ASSERT_EQ(store->repair(false), 0);
-  mount();
+  ASSERT_EQ(store->fsck(false), 0);
 }
 
 TEST_P(MultiLabelTest, FixCorruptedThree) {
@@ -11011,7 +11009,7 @@ TEST_P(MultiLabelTest, FixCorruptedThree) {
   ASSERT_EQ(corrupt, true);
   ASSERT_EQ(store->fsck(false), 3);
   ASSERT_EQ(store->repair(false), 0);
-  mount();
+  ASSERT_EQ(store->fsck(false), 0);
 }
 
 TEST_P(MultiLabelTest, CantFixCorruptedAll) {
@@ -11035,6 +11033,7 @@ TEST_P(MultiLabelTest, CantFixCorruptedAll) {
   ASSERT_EQ(corrupt, true);
   ASSERT_NE(store->fsck(false), 0);
   ASSERT_NE(store->repair(false), 0);
+  ASSERT_NE(store->fsck(false), 0);
 }
 
 TEST_P(MultiLabelTest, SkipInvalidUUID) {
@@ -11061,6 +11060,7 @@ TEST_P(MultiLabelTest, SkipInvalidUUID) {
 
   ASSERT_EQ(store->fsck(false), 1);
   ASSERT_EQ(store->repair(false), 0);
+  ASSERT_EQ(store->fsck(false), 0);
   mount();
 }
 

--- a/src/test/objectstore/store_test_fixture.cc
+++ b/src/test/objectstore/store_test_fixture.cc
@@ -129,3 +129,7 @@ void StoreTestFixture::CloseAndReopen() {
   ASSERT_EQ(0, store->mount());
   g_conf().set_safe_to_start_threads();
 }
+
+void StoreTestFixture::RemoveTestObjectStore() {
+  rm_r(data_dir);
+}

--- a/src/test/objectstore/store_test_fixture.h
+++ b/src/test/objectstore/store_test_fixture.h
@@ -8,10 +8,12 @@ class ObjectStore;
 
 class StoreTestFixture : virtual public ::testing::Test {
   const std::string type;
-  const std::string data_dir;
 
   std::stack<std::pair<std::string, std::string>> saved_settings;
   ConfigProxy* conf = nullptr;
+
+protected:
+  const std::string data_dir;
 
 public:
   std::unique_ptr<ObjectStore> store;
@@ -41,6 +43,7 @@ public:
   }
   void PopSettings(size_t);
   void CloseAndReopen();
+  void RemoveTestObjectStore();
   const std::string get_type() const {
     return type;
   }

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -107,8 +107,8 @@ TEST(BlueFS, mkfs_mount) {
   ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, false, false }));
   ASSERT_EQ(0, fs.mount());
   ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
-  ASSERT_EQ(fs.get_total(BlueFS::BDEV_DB), size - DB_SUPER_RESERVED);
-  ASSERT_LT(fs.get_free(BlueFS::BDEV_DB), size - DB_SUPER_RESERVED);
+  ASSERT_EQ(fs.get_total(BlueFS::BDEV_DB), size - SUPER_RESERVED);
+  ASSERT_LT(fs.get_free(BlueFS::BDEV_DB), size - SUPER_RESERVED);
   fs.umount();
 }
 


### PR DESCRIPTION
Corruption of bdev label makes it very hard to recover OSD.
This PR copies bdev label to 4 potential replica places on device: 
0(original), 1GB, 10GB, 100GB, 1000GB.

If all replicas do not match system refuses to start.
Fsck (repair mode) is the way to fix it.

This is an alternative version for #53095. Borrows many concepts and some code from it.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
