### PR TITLE
rgw: ignore SIGXFSZ, which apparently can triggered by heavy ops-log …

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -134,6 +134,7 @@ int main(int argc, char *argv[])
   register_async_signal_handler(SIGTERM, rgw::signal::handle_sigterm);
   register_async_signal_handler(SIGINT, rgw::signal::handle_sigterm);
   register_async_signal_handler(SIGUSR1, rgw::signal::handle_sigterm);
+  register_async_signal_handler(SIGXFSZ, rgw::signal::sig_handler_noop);
   sighandler_alrm = signal(SIGALRM, godown_alarm);
 
   main.init_perfcounters();
@@ -184,6 +185,7 @@ int main(int argc, char *argv[])
     unregister_async_signal_handler(SIGTERM, rgw::signal::handle_sigterm);
     unregister_async_signal_handler(SIGINT, rgw::signal::handle_sigterm);
     unregister_async_signal_handler(SIGUSR1, rgw::signal::handle_sigterm);
+    unregister_async_signal_handler(SIGXFSZ, rgw::signal::sig_handler_noop);
     shutdown_async_signal_handler();
   };
 

--- a/src/rgw/rgw_signal.cc
+++ b/src/rgw/rgw_signal.cc
@@ -33,6 +33,10 @@ static int signal_fd[2] = {0, 0};
 namespace rgw {
 namespace signal {
 
+void sig_handler_noop(int signum) {
+  /* NOP */
+} /* sig_handler_noop */
+
 void sighup_handler(int signum) {
     if (rgw::AppMain::ops_log_file != nullptr) {
         rgw::AppMain::ops_log_file->reopen();

--- a/src/rgw/rgw_signal.h
+++ b/src/rgw/rgw_signal.h
@@ -19,6 +19,7 @@
 namespace rgw {
 namespace signal {
 
+void sig_handler_noop(int signum);
 void signal_shutdown();
 void wait_shutdown();
 int signal_fd_init();


### PR DESCRIPTION
…traffic

Fixes: https://tracker.ceph.com/issues/64244

That is, it causes radosgw to ignore SIGXFSZ, which in the apparent reproducer should not cause radosgw to terminate.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
