### PR TITLE
pacific: qa/upgrade: use ragweed branch for starting ceph release

### DIFF
--- a/qa/suites/upgrade/nautilus-x/parallel/2-workload/rgw_ragweed_prepare.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/2-workload/rgw_ragweed_prepare.yaml
@@ -6,7 +6,7 @@ workload:
   - sequential:
     - ragweed:
         client.1:
-          default-branch: ceph-pacific
+          default-branch: ceph-nautilus
           rgw_server: client.1
           stages: prepare
     - print: "**** done rgw ragweed prepare 2-workload"

--- a/qa/suites/upgrade/nautilus-x/parallel/5-final-workload/rgw_ragweed_check.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/5-final-workload/rgw_ragweed_check.yaml
@@ -5,7 +5,7 @@ rgw-final-workload:
   full_sequential:
   - ragweed:
       client.1:
-        default-branch: ceph-pacific
+        default-branch: ceph-nautilus
         rgw_server: client.1
         stages: check
   - print: "**** done ragweed check 4-final-workload"

--- a/qa/suites/upgrade/octopus-x/parallel-no-cephadm/5-final-workload/rgw_ragweed_check.yaml
+++ b/qa/suites/upgrade/octopus-x/parallel-no-cephadm/5-final-workload/rgw_ragweed_check.yaml
@@ -5,7 +5,7 @@ rgw-final-workload:
   full_sequential:
   - ragweed:
       client.1:
-        default-branch: ceph-pacific
+        default-branch: ceph-octopus
         rgw_server: client.1
         stages: check
   - print: "**** done ragweed check 4-final-workload"


### PR DESCRIPTION
don't run new test cases against older ceph versions

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
