### PR TITLE
reef: qa: fix error reporting string in assert_cluster_log

### DIFF
--- a/qa/tasks/ceph_test_case.py
+++ b/qa/tasks/ceph_test_case.py
@@ -141,7 +141,7 @@ class CephTestCase(unittest.TestCase):
 
                 if present and not self.match():
                     log.error(f"Log output: \n{self.watcher_process.stdout.getvalue()}\n")
-                    raise AssertionError(f"Expected log message found: '{expected_pattern}'")
+                    raise AssertionError(f"Expected log message not found: '{expected_pattern}'")
                 elif fail or (not present and self.match()):
                     log.error(f"Log output: \n{self.watcher_process.stdout.getvalue()}\n")
                     raise AssertionError(f"Unexpected log message found: '{expected_pattern}'")


### PR DESCRIPTION
Backport tracker: https://tracker.ceph.com/issues/64066
Parent tracker https://tracker.ceph.com/issues/63217
Backport of https://github.com/ceph/ceph/pull/54041
Signed-off-by: Dhairya Parmar <dparmar@redhat.com>


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
