### PR TITLE
osd/PrimaryLogPG: erase gather op during op cancel

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10379,6 +10379,12 @@ int PrimaryLogPG::start_cls_gather(OpContext *ctx, std::map<std::string, bufferl
 
   ObjectContextRef obc = get_object_context(soid, false);
   C_GatherBuilder gather(cct);
+  if (cls_gather_ops.count(soid)) {
+    auto gather_op_iter = cls_gather_ops.find(soid);
+    vector<ceph_tid_t> tids;
+    cancel_cls_gather(gather_op_iter, false, &tids);
+    osd->objecter->op_cancel(tids, -ECANCELED);
+  }
 
   auto [iter, inserted] = cls_gather_ops.emplace(soid, CLSGatherOp(ctx, obc, op));
   ceph_assert(inserted);

--- a/src/test/librados/cls_remote_reads.cc
+++ b/src/test/librados/cls_remote_reads.cc
@@ -18,25 +18,26 @@ TEST(ClsTestRemoteReads, TestGather) {
   cluster.ioctx_create(pool_name.c_str(), ioctx);
 
   bufferlist in, out;
+  int src_objs = 300;
   int object_size = 4096;
   char buf[object_size];
   memset(buf, 1, sizeof(buf));
 
-  // create source objects from which data are gathered
-  in.append(buf, sizeof(buf));
-  ASSERT_EQ(0, ioctx.write_full("src_object.1", in));
-  in.append(buf, sizeof(buf));
-  ASSERT_EQ(0, ioctx.write_full("src_object.2", in));
-  in.append(buf, sizeof(buf));
-  ASSERT_EQ(0, ioctx.write_full("src_object.3", in));
+  // create src_objs source objects from which data are gathered
+  for (int i = 0; i < src_objs; i++) {
+    std::string oid = "src_object." + std::to_string(i);
+    in.append(buf, sizeof(buf));
+    ASSERT_EQ(0, ioctx.write_full(oid, in));
+  }
 
+  
   // construct JSON request passed to "test_gather" method, and in turn, to "test_read" method
   JSONFormatter *formatter = new JSONFormatter(true);
   formatter->open_object_section("foo");
   std::set<std::string> src_objects;
-  src_objects.insert("src_object.1");
-  src_objects.insert("src_object.2");
-  src_objects.insert("src_object.3");
+  for (int i = 0; i < src_objs; i++) {
+    src_objects.insert("src_object." + std::to_string(i));
+  }
   encode_json("src_objects", src_objects, formatter);
   encode_json("cls", "test_remote_reads", formatter);
   encode_json("method", "test_read", formatter);
@@ -49,7 +50,7 @@ TEST(ClsTestRemoteReads, TestGather) {
   ASSERT_EQ(0, ioctx.exec("tgt_object", "test_remote_reads", "test_gather", in, out));
 
   // read target object and check its size
-  ASSERT_EQ(3*object_size, ioctx.read("tgt_object", out, 0, 0));
+  ASSERT_EQ(src_objs*object_size, ioctx.read("tgt_object", out, 0, 0));
 
   ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));
 }


### PR DESCRIPTION
The erase exist, but it try to delete iter and not the name of the soid

Fixes: https://tracker.ceph.com/issues/64258
Signed-off-by: Nitzan Mordechai <nmordech@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
