### PR TITLE
quincy: qa/tasks/cephadm: enable mon_cluster_log_to_file

### DIFF
--- a/qa/tasks/cephadm.conf
+++ b/qa/tasks/cephadm.conf
@@ -3,6 +3,7 @@
 log_to_file = true
 log_to_stderr = false
 log to journald = false
+mon cluster log to file = true
 mon cluster log file level = debug
 
 mon clock drift allowed = 1.000


### PR DESCRIPTION
https://tracker.ceph.com/issues/64468