### PR TITLE
node-proxy: refactor entrypoint

### DIFF
--- a/src/ceph-node-proxy/ceph_node_proxy/basesystem.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/basesystem.py
@@ -1,14 +1,21 @@
 import socket
-from ceph_node_proxy.util import Config
+from threading import Lock
+from ceph_node_proxy.util import Config, get_logger, BaseThread
 from typing import Dict, Any
 from ceph_node_proxy.baseclient import BaseClient
 
 
-class BaseSystem:
+class BaseSystem(BaseThread):
     def __init__(self, **kw: Any) -> None:
+        super().__init__()
+        self.lock: Lock = Lock()
         self._system: Dict = {}
-        self.config: Config = kw['config']
+        self.config: Config = kw.get('config', {})
         self.client: BaseClient
+        self.log = get_logger(__name__)
+
+    def main(self) -> None:
+        raise NotImplementedError()
 
     def get_system(self) -> Dict[str, Any]:
         raise NotImplementedError()
@@ -76,19 +83,13 @@ class BaseSystem:
     def get_host(self) -> str:
         return socket.gethostname()
 
-    def start_update_loop(self) -> None:
-        raise NotImplementedError()
-
     def stop_update_loop(self) -> None:
-        raise NotImplementedError()
-
-    def start_client(self) -> None:
         raise NotImplementedError()
 
     def flush(self) -> None:
         raise NotImplementedError()
 
-    def shutdown(self, force: bool = False) -> int:
+    def shutdown_host(self, force: bool = False) -> int:
         raise NotImplementedError()
 
     def powercycle(self) -> int:

--- a/src/ceph-node-proxy/ceph_node_proxy/main.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/main.py
@@ -1,176 +1,84 @@
-from threading import Thread
 from ceph_node_proxy.redfishdellsystem import RedfishDellSystem
 from ceph_node_proxy.api import NodeProxyApi
 from ceph_node_proxy.reporter import Reporter
-from ceph_node_proxy.util import Config, Logger, http_req, write_tmp_file
+from ceph_node_proxy.util import Config, get_logger, http_req, write_tmp_file, CONFIG
 from typing import Dict, Any, Optional
 
 import argparse
-import traceback
-import logging
 import os
 import ssl
 import json
 import time
-
-logger = logging.getLogger(__name__)
-
-DEFAULT_CONFIG = {
-    'reporter': {
-        'check_interval': 5,
-        'push_data_max_retries': 30,
-        'endpoint': 'https://127.0.0.1:7150/node-proxy/data',
-    },
-    'system': {
-        'refresh_interval': 5
-    },
-    'server': {
-        'port': 8080,
-    },
-    'logging': {
-        'level': 20,
-    }
-}
+import signal
 
 
-class NodeProxyManager(Thread):
-    def __init__(self,
-                 mgr_host: str,
-                 cephx_name: str,
-                 cephx_secret: str,
-                 ca_path: str,
-                 api_ssl_crt: str,
-                 api_ssl_key: str,
-                 mgr_agent_port: int = 7150):
-        super().__init__()
-        self.mgr_host = mgr_host
-        self.cephx_name = cephx_name
-        self.cephx_secret = cephx_secret
-        self.ca_path = ca_path
-        self.api_ssl_crt = api_ssl_crt
-        self.api_ssl_key = api_ssl_key
-        self.mgr_agent_port = str(mgr_agent_port)
-        self.stop = False
+class NodeProxyManager:
+    def __init__(self, **kw: Any) -> None:
+        self.exc: Optional[Exception] = None
+        self.log = get_logger(__name__)
+        self.mgr_host: str = kw['mgr_host']
+        self.cephx_name: str = kw['cephx_name']
+        self.cephx_secret: str = kw['cephx_secret']
+        self.ca_path: str = kw['ca_path']
+        self.api_ssl_crt: str = kw['api_ssl_crt']
+        self.api_ssl_key: str = kw['api_ssl_key']
+        self.mgr_agent_port: str = str(kw['mgr_agent_port'])
+        self.stop: bool = False
         self.ssl_ctx = ssl.create_default_context()
         self.ssl_ctx.check_hostname = True
         self.ssl_ctx.verify_mode = ssl.CERT_REQUIRED
         self.ssl_ctx.load_verify_locations(self.ca_path)
+        self.reporter_scheme: str = kw.get('reporter_scheme', 'https')
+        self.reporter_endpoint: str = kw.get('reporter_endpoint', '/node-proxy/data')
+        self.cephx = {'cephx': {'name': self.cephx_name,
+                                'secret': self.cephx_secret}}
+        self.config = Config('/etc/ceph/node-proxy.yml', config=CONFIG)
 
     def run(self) -> None:
         self.init()
         self.loop()
 
     def init(self) -> None:
-        node_proxy_meta = {
-            'cephx': {
-                'name': self.cephx_name,
-                'secret': self.cephx_secret
-            }
-        }
+        self.init_system()
+        self.init_reporter()
+        self.init_api()
+
+    def fetch_oob_details(self) -> Dict[str, str]:
         headers, result, status = http_req(hostname=self.mgr_host,
                                            port=self.mgr_agent_port,
-                                           data=json.dumps(node_proxy_meta),
+                                           data=json.dumps(self.cephx),
                                            endpoint='/node-proxy/oob',
                                            ssl_ctx=self.ssl_ctx)
         if status != 200:
             msg = f'No out of band tool details could be loaded: {status}, {result}'
-            logger.debug(msg)
+            self.log.debug(msg)
             raise RuntimeError(msg)
 
         result_json = json.loads(result)
-        kwargs = {
+        oob_details: Dict[str, str] = {
             'host': result_json['result']['addr'],
             'username': result_json['result']['username'],
             'password': result_json['result']['password'],
-            'cephx': node_proxy_meta['cephx'],
-            'mgr_host': self.mgr_host,
-            'mgr_agent_port': self.mgr_agent_port,
-            'api_ssl_crt': self.api_ssl_crt,
-            'api_ssl_key': self.api_ssl_key
+            'port': result_json['result'].get('port', '443')
         }
-        if result_json['result'].get('port'):
-            kwargs['port'] = result_json['result']['port']
+        return oob_details
 
-        self.node_proxy: NodeProxy = NodeProxy(**kwargs)
-        self.node_proxy.start()
-
-    def loop(self) -> None:
-        while not self.stop:
-            try:
-                status = self.node_proxy.check_status()
-                label = 'Ok' if status else 'Critical'
-                logger.debug(f'node-proxy status: {label}')
-            except Exception as e:
-                logger.error(f'node-proxy not running: {e.__class__.__name__}: {e}')
-                time.sleep(120)
-                self.init()
-            else:
-                logger.debug('node-proxy alive, next check in 60sec.')
-                time.sleep(60)
-
-    def shutdown(self) -> None:
-        self.stop = True
-        # if `self.node_proxy.shutdown()` is called before self.start(), it will fail.
-        if self.__dict__.get('node_proxy'):
-            self.node_proxy.shutdown()
-
-
-class NodeProxy(Thread):
-    def __init__(self, **kw: Any) -> None:
-        super().__init__()
-        self.username: str = kw.get('username', '')
-        self.password: str = kw.get('password', '')
-        self.host: str = kw.get('host', '')
-        self.port: int = kw.get('port', 443)
-        self.cephx: Dict[str, Any] = kw.get('cephx', {})
-        self.reporter_scheme: str = kw.get('reporter_scheme', 'https')
-        self.mgr_host: str = kw.get('mgr_host', '')
-        self.mgr_agent_port: str = kw.get('mgr_agent_port', '')
-        self.reporter_endpoint: str = kw.get('reporter_endpoint', '/node-proxy/data')
-        self.api_ssl_crt: str = kw.get('api_ssl_crt', '')
-        self.api_ssl_key: str = kw.get('api_ssl_key', '')
-        self.exc: Optional[Exception] = None
-        self.log = Logger(__name__)
-
-    def run(self) -> None:
+    def init_system(self) -> None:
+        oob_details = self.fetch_oob_details()
+        self.username: str = oob_details['username']
+        self.password: str = oob_details['password']
         try:
-            self.main()
-        except Exception as e:
-            self.exc = e
-            return
-
-    def shutdown(self) -> None:
-        self.log.logger.info('Shutting down node-proxy...')
-        self.system.client.logout()
-        self.system.stop_update_loop()
-        self.reporter_agent.stop()
-
-    def check_status(self) -> bool:
-        if self.__dict__.get('system') and not self.system.run:
-            raise RuntimeError('node-proxy encountered an error.')
-        if self.exc:
-            traceback.print_tb(self.exc.__traceback__)
-            self.log.logger.error(f'{self.exc.__class__.__name__}: {self.exc}')
-            raise self.exc
-        return True
-
-    def main(self) -> None:
-        # TODO: add a check and fail if host/username/password/data aren't passed
-        self.config = Config('/etc/ceph/node-proxy.yml', default_config=DEFAULT_CONFIG)
-        self.log = Logger(__name__, level=self.config.__dict__['logging']['level'])
-
-        # create the redfish system and the obsever
-        self.log.logger.info('Server initialization...')
-        try:
-            self.system = RedfishDellSystem(host=self.host,
-                                            port=self.port,
-                                            username=self.username,
-                                            password=self.password,
+            self.system = RedfishDellSystem(host=oob_details['host'],
+                                            port=oob_details['port'],
+                                            username=oob_details['username'],
+                                            password=oob_details['password'],
                                             config=self.config)
+            self.system.start()
         except RuntimeError:
-            self.log.logger.error("Can't initialize the redfish system.")
+            self.log.error("Can't initialize the redfish system.")
             raise
 
+    def init_reporter(self) -> None:
         try:
             self.reporter_agent = Reporter(self.system,
                                            self.cephx,
@@ -178,22 +86,53 @@ class NodeProxy(Thread):
                                            reporter_hostname=self.mgr_host,
                                            reporter_port=self.mgr_agent_port,
                                            reporter_endpoint=self.reporter_endpoint)
-            self.reporter_agent.run()
+            self.reporter_agent.start()
         except RuntimeError:
-            self.log.logger.error("Can't initialize the reporter.")
+            self.log.error("Can't initialize the reporter.")
             raise
 
+    def init_api(self) -> None:
         try:
-            self.log.logger.info('Starting node-proxy API...')
-            self.api = NodeProxyApi(self,
-                                    username=self.username,
-                                    password=self.password,
-                                    ssl_crt=self.api_ssl_crt,
-                                    ssl_key=self.api_ssl_key)
+            self.log.info('Starting node-proxy API...')
+            self.api = NodeProxyApi(self)
             self.api.start()
         except Exception as e:
-            self.log.logger.error(f"Can't start node-proxy API: {e}")
+            self.log.error(f"Can't start node-proxy API: {e}")
             raise
+
+    def loop(self) -> None:
+        while not self.stop:
+            for thread in [self.system, self.reporter_agent]:
+                try:
+                    status = thread.check_status()
+                    label = 'Ok' if status else 'Critical'
+                    self.log.debug(f'{thread} status: {label}')
+                except Exception as e:
+                    self.log.error(f'{thread} not running: {e.__class__.__name__}: {e}')
+                    thread.shutdown()
+                    self.init_system()
+                    self.init_reporter()
+            self.log.debug('All threads are alive, next check in 20sec.')
+            time.sleep(20)
+
+    def shutdown(self) -> None:
+        self.stop = True
+        # if `self.system.shutdown()` is called before self.start(), it will fail.
+        if hasattr(self, 'api'):
+            self.api.shutdown()
+        if hasattr(self, 'reporter_agent'):
+            self.reporter_agent.shutdown()
+        if hasattr(self, 'system'):
+            self.system.shutdown()
+
+
+def handler(signum: Any, frame: Any, t_mgr: 'NodeProxyManager') -> None:
+    t_mgr.system.pending_shutdown = True
+    t_mgr.log.info('SIGTERM caught, shutting down threads...')
+    t_mgr.shutdown()
+    t_mgr.log.info('Logging out from RedFish API')
+    t_mgr.system.client.logout()
+    raise SystemExit(0)
 
 
 def main() -> None:
@@ -205,8 +144,15 @@ def main() -> None:
         help='path of config file in json format',
         required=True
     )
+    parser.add_argument(
+        '--debug',
+        help='increase logging verbosity (debug level)',
+        action='store_true',
+    )
 
     args = parser.parse_args()
+    if args.debug:
+        CONFIG['logging']['level'] = 10
 
     if not os.path.exists(args.config):
         raise Exception(f'No config file found at provided config path: {args.config}')
@@ -226,18 +172,19 @@ def main() -> None:
     listener_key = config['listener.key']
     name = config['name']
 
-    f = write_tmp_file(root_cert,
-                       prefix_name='cephadm-endpoint-root-cert')
+    ca_file = write_tmp_file(root_cert,
+                             prefix_name='cephadm-endpoint-root-cert')
 
     node_proxy_mgr = NodeProxyManager(mgr_host=target_ip,
                                       cephx_name=name,
                                       cephx_secret=keyring,
                                       mgr_agent_port=target_port,
-                                      ca_path=f.name,
+                                      ca_path=ca_file.name,
                                       api_ssl_crt=listener_cert,
                                       api_ssl_key=listener_key)
-    if not node_proxy_mgr.is_alive():
-        node_proxy_mgr.start()
+    signal.signal(signal.SIGTERM,
+                  lambda signum, frame: handler(signum, frame, node_proxy_mgr))
+    node_proxy_mgr.run()
 
 
 if __name__ == '__main__':

--- a/src/ceph-node-proxy/ceph_node_proxy/redfish_client.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/redfish_client.py
@@ -1,7 +1,7 @@
 import json
 from urllib.error import HTTPError, URLError
 from ceph_node_proxy.baseclient import BaseClient
-from ceph_node_proxy.util import Logger, http_req
+from ceph_node_proxy.util import get_logger, http_req
 from typing import Dict, Any, Tuple, Optional
 from http.client import HTTPMessage
 
@@ -15,8 +15,8 @@ class RedFishClient(BaseClient):
                  username: str = '',
                  password: str = ''):
         super().__init__(host, username, password)
-        self.log: Logger = Logger(__name__)
-        self.log.logger.info(f'Initializing redfish client {__name__}')
+        self.log = get_logger(__name__)
+        self.log.info(f'Initializing redfish client {__name__}')
         self.host: str = host
         self.port: str = port
         self.url: str = f'https://{self.host}:{self.port}'
@@ -25,8 +25,8 @@ class RedFishClient(BaseClient):
 
     def login(self) -> None:
         if not self.is_logged_in():
-            self.log.logger.info('Logging in to '
-                                 f"{self.url} as '{self.username}'")
+            self.log.info('Logging in to '
+                          f"{self.url} as '{self.username}'")
             oob_credentials = json.dumps({'UserName': self.username,
                                           'Password': self.password})
             headers = {'Content-Type': 'application/json'}
@@ -36,27 +36,27 @@ class RedFishClient(BaseClient):
                                                            headers=headers,
                                                            endpoint='/redfish/v1/SessionService/Sessions/')
                 if _status_code != 201:
-                    self.log.logger.error(f"Can't log in to {self.url} as '{self.username}': {_status_code}")
+                    self.log.error(f"Can't log in to {self.url} as '{self.username}': {_status_code}")
                     raise RuntimeError
             except URLError as e:
                 msg = f"Can't log in to {self.url} as '{self.username}': {e}"
-                self.log.logger.error(msg)
+                self.log.error(msg)
                 raise RuntimeError
             self.token = _headers['X-Auth-Token']
             self.location = _headers['Location']
 
     def is_logged_in(self) -> bool:
-        self.log.logger.debug(f'Checking token validity for {self.url}')
+        self.log.debug(f'Checking token validity for {self.url}')
         if not self.location or not self.token:
-            self.log.logger.debug(f'No token found for {self.url}.')
+            self.log.debug(f'No token found for {self.url}.')
             return False
         headers = {'X-Auth-Token': self.token}
         try:
             _headers, _data, _status_code = self.query(headers=headers,
                                                        endpoint=self.location)
         except URLError as e:
-            self.log.logger.error("Can't check token "
-                                  f'validity for {self.url}: {e}')
+            self.log.error("Can't check token "
+                           f'validity for {self.url}: {e}')
             raise
         return _status_code == 200
 
@@ -69,7 +69,7 @@ class RedFishClient(BaseClient):
                                                     endpoint=self.location)
                 result = json.loads(_data)
         except URLError:
-            self.log.logger.error(f"Can't log out from {self.url}")
+            self.log.error(f"Can't log out from {self.url}")
 
         self.location = ''
         self.token = ''
@@ -84,7 +84,7 @@ class RedFishClient(BaseClient):
             result_json = json.loads(result)
             return result_json
         except URLError as e:
-            self.log.logger.error(f"Can't get path {path}:\n{e}")
+            self.log.error(f"Can't get path {path}:\n{e}")
             raise RuntimeError
 
     def query(self,
@@ -111,5 +111,5 @@ class RedFishClient(BaseClient):
 
             return response_headers, response_str, response_status
         except (HTTPError, URLError) as e:
-            self.log.logger.debug(f'{e}')
+            self.log.debug(f'{e}')
             raise

--- a/src/ceph-node-proxy/ceph_node_proxy/redfishdellsystem.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/redfishdellsystem.py
@@ -1,12 +1,12 @@
 from ceph_node_proxy.baseredfishsystem import BaseRedfishSystem
-from ceph_node_proxy.util import Logger, normalize_dict, to_snake_case
+from ceph_node_proxy.util import get_logger, normalize_dict, to_snake_case
 from typing import Dict, Any, List
 
 
 class RedfishDellSystem(BaseRedfishSystem):
     def __init__(self, **kw: Any) -> None:
         super().__init__(**kw)
-        self.log = Logger(__name__)
+        self.log = get_logger(__name__)
         self.job_service_endpoint: str = '/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService'
         self.create_reboot_job_endpoint: str = f'{self.job_service_endpoint}/Actions/DellJobService.CreateRebootJob'
         self.setup_job_queue_endpoint: str = f'{self.job_service_endpoint}/Actions/DellJobService.SetupJobQueue'
@@ -23,7 +23,7 @@ class RedfishDellSystem(BaseRedfishSystem):
                 try:
                     result[member_id][to_snake_case(field)] = member_info[field]
                 except KeyError:
-                    self.log.logger.warning(f'Could not find field: {field} in member_info: {member_info}')
+                    self.log.warning(f'Could not find field: {field} in member_info: {member_info}')
 
         return normalize_dict(result)
 
@@ -41,7 +41,7 @@ class RedfishDellSystem(BaseRedfishSystem):
                     try:
                         result[_id][to_snake_case(field)] = member_elt[field]
                     except KeyError:
-                        self.log.logger.warning(f'Could not find field: {field} in data: {data[elt]}')
+                        self.log.warning(f'Could not find field: {field} in data: {data[elt]}')
         return normalize_dict(result)
 
     def get_sn(self) -> str:
@@ -73,7 +73,7 @@ class RedfishDellSystem(BaseRedfishSystem):
 
     def _update_network(self) -> None:
         fields = ['Description', 'Name', 'SpeedMbps', 'Status']
-        self.log.logger.debug('Updating network')
+        self.log.debug('Updating network')
         self._sys['network'] = self.build_common_data(data=self._system['Systems'],
                                                       fields=fields,
                                                       path='EthernetInterfaces')
@@ -86,7 +86,7 @@ class RedfishDellSystem(BaseRedfishSystem):
                   'Model',
                   'Status',
                   'Manufacturer']
-        self.log.logger.debug('Updating processors')
+        self.log.debug('Updating processors')
         self._sys['processors'] = self.build_common_data(data=self._system['Systems'],
                                                          fields=fields,
                                                          path='Processors')
@@ -100,7 +100,7 @@ class RedfishDellSystem(BaseRedfishSystem):
                   'PhysicalLocation']
         entities = self.get_members(data=self._system['Systems'],
                                     path='Storage')
-        self.log.logger.debug('Updating storage')
+        self.log.debug('Updating storage')
         result: Dict[str, Dict[str, Dict]] = dict()
         for entity in entities:
             for drive in entity['Drives']:
@@ -115,7 +115,7 @@ class RedfishDellSystem(BaseRedfishSystem):
         self._sys['storage'] = normalize_dict(result)
 
     def _update_sn(self) -> None:
-        self.log.logger.debug('Updating serial number')
+        self.log.debug('Updating serial number')
         self._sys['SKU'] = self._system['Systems']['SKU']
 
     def _update_memory(self) -> None:
@@ -123,7 +123,7 @@ class RedfishDellSystem(BaseRedfishSystem):
                   'MemoryDeviceType',
                   'CapacityMiB',
                   'Status']
-        self.log.logger.debug('Updating memory')
+        self.log.debug('Updating memory')
         self._sys['memory'] = self.build_common_data(data=self._system['Systems'],
                                                      fields=fields,
                                                      path='Memory')
@@ -137,7 +137,7 @@ class RedfishDellSystem(BaseRedfishSystem):
                 'Status'
             ]
         }
-        self.log.logger.debug('Updating powersupplies')
+        self.log.debug('Updating powersupplies')
         self._sys['power'] = self.build_chassis_data(fields, 'Power')
 
     def _update_fans(self) -> None:
@@ -148,7 +148,7 @@ class RedfishDellSystem(BaseRedfishSystem):
                 'Status'
             ],
         }
-        self.log.logger.debug('Updating fans')
+        self.log.debug('Updating fans')
         self._sys['fans'] = self.build_chassis_data(fields, 'Thermal')
 
     def _update_firmwares(self) -> None:
@@ -160,7 +160,7 @@ class RedfishDellSystem(BaseRedfishSystem):
             'Updateable',
             'Status',
         ]
-        self.log.logger.debug('Updating firmwares')
+        self.log.debug('Updating firmwares')
         self._sys['firmwares'] = self.build_common_data(data=self._system['UpdateService'],
                                                         fields=fields,
                                                         path='FirmwareInventory')

--- a/src/ceph-node-proxy/ceph_node_proxy/reporter.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/reporter.py
@@ -1,12 +1,11 @@
-from threading import Thread
 import time
 import json
-from ceph_node_proxy.util import Logger, http_req
+from ceph_node_proxy.util import get_logger, http_req, BaseThread
 from urllib.error import HTTPError, URLError
 from typing import Dict, Any
 
 
-class Reporter:
+class Reporter(BaseThread):
     def __init__(self,
                  system: Any,
                  cephx: Dict[str, Any],
@@ -14,61 +13,57 @@ class Reporter:
                  reporter_hostname: str = '',
                  reporter_port: str = '443',
                  reporter_endpoint: str = '/node-proxy/data') -> None:
+        super().__init__()
         self.system = system
         self.data: Dict[str, Any] = {}
-        self.finish = False
+        self.stop: bool = False
         self.cephx = cephx
-        self.data['cephx'] = self.cephx
+        self.data['cephx'] = self.cephx['cephx']
         self.reporter_scheme: str = reporter_scheme
         self.reporter_hostname: str = reporter_hostname
         self.reporter_port: str = reporter_port
         self.reporter_endpoint: str = reporter_endpoint
-        self.log = Logger(__name__)
+        self.log = get_logger(__name__)
         self.reporter_url: str = (f'{reporter_scheme}://{reporter_hostname}:'
                                   f'{reporter_port}{reporter_endpoint}')
-        self.log.logger.info(f'Reporter url set to {self.reporter_url}')
+        self.log.info(f'Reporter url set to {self.reporter_url}')
 
-    def stop(self) -> None:
-        self.finish = True
-        self.thread.join()
-
-    def run(self) -> None:
-        self.thread = Thread(target=self.loop)
-        self.thread.start()
-
-    def loop(self) -> None:
-        while not self.finish:
+    def main(self) -> None:
+        while not self.stop:
             # Any logic to avoid sending the all the system
             # information every loop can go here. In a real
             # scenario probably we should just send the sub-parts
             # that have changed to minimize the traffic in
             # dense clusters
-            self.log.logger.debug('waiting for a lock in reporter loop.')
-            self.system.lock.acquire()
-            self.log.logger.debug('lock acquired in reporter loop.')
-            if self.system.data_ready:
-                self.log.logger.debug('data ready to be sent to the mgr.')
-                if not self.system.get_system() == self.system.previous_data:
-                    self.log.logger.info('data has changed since last iteration.')
-                    self.data['patch'] = self.system.get_system()
-                    try:
-                        # TODO: add a timeout parameter to the reporter in the config file
-                        self.log.logger.info(f'sending data to {self.reporter_url}')
-                        http_req(hostname=self.reporter_hostname,
-                                 port=self.reporter_port,
-                                 method='POST',
-                                 headers={'Content-Type': 'application/json'},
-                                 endpoint=self.reporter_endpoint,
-                                 scheme=self.reporter_scheme,
-                                 data=json.dumps(self.data))
-                    except (HTTPError, URLError) as e:
-                        self.log.logger.error(f"The reporter couldn't send data to the mgr: {e}")
-                        # Need to add a new parameter 'max_retries' to the reporter if it can't
-                        # send the data for more than x times, maybe the daemon should stop altogether
-                    else:
-                        self.system.previous_data = self.system.get_system()
-                else:
-                    self.log.logger.debug('no diff, not sending data to the mgr.')
-            self.system.lock.release()
-            self.log.logger.debug('lock released in reporter loop.')
-            time.sleep(5)
+            self.log.debug('waiting for a lock in reporter loop.')
+            with self.system.lock:
+                if not self.system.pending_shutdown:
+                    self.log.debug('lock acquired in reporter loop.')
+                    if self.system.data_ready:
+                        self.log.debug('data ready to be sent to the mgr.')
+                        if not self.system.get_system() == self.system.previous_data:
+                            self.log.info('data has changed since last iteration.')
+                            self.data['patch'] = self.system.get_system()
+                            try:
+                                # TODO: add a timeout parameter to the reporter in the config file
+                                self.log.info(f'sending data to {self.reporter_url}')
+                                http_req(hostname=self.reporter_hostname,
+                                         port=self.reporter_port,
+                                         method='POST',
+                                         headers={'Content-Type': 'application/json'},
+                                         endpoint=self.reporter_endpoint,
+                                         scheme=self.reporter_scheme,
+                                         data=json.dumps(self.data))
+                            except (HTTPError, URLError) as e:
+                                self.log.error(f"The reporter couldn't send data to the mgr: {e}")
+                                raise
+                                # Need to add a new parameter 'max_retries' to the reporter if it can't
+                                # send the data for more than x times, maybe the daemon should stop altogether
+                            else:
+                                self.system.previous_data = self.system.get_system()
+                        else:
+                            self.log.debug('no diff, not sending data to the mgr.')
+                    time.sleep(5)
+            self.log.debug('lock released in reporter loop.')
+        self.log.debug('exiting reporter loop.')
+        raise SystemExit(0)

--- a/src/cephadm/cephadmlib/daemons/node_proxy.py
+++ b/src/cephadm/cephadmlib/daemons/node_proxy.py
@@ -24,7 +24,7 @@ class NodeProxy(ContainerDaemonForm):
 
     daemon_type = 'node-proxy'
     # TODO: update this if we make node-proxy an executable
-    entrypoint = 'python3'
+    entrypoint = '/usr/sbin/ceph-node-proxy'
     required_files = ['node-proxy.json']
 
     @classmethod
@@ -88,7 +88,7 @@ class NodeProxy(ContainerDaemonForm):
         # the config in _get_container_mounts above. They
         # will both need to be updated when we have a proper
         # location in the container for node-proxy
-        args.extend(['/usr/share/ceph/ceph_node_proxy/main.py', '--config', '/usr/share/ceph/node-proxy.json'])
+        args.extend(['--config', '/usr/share/ceph/node-proxy.json'])
 
     def validate(self):
         # type: () -> None
@@ -130,7 +130,7 @@ class NodeProxy(ContainerDaemonForm):
     def container(self, ctx: CephadmContext) -> CephContainer:
         # So the container can modprobe iscsi_target_mod and have write perms
         # to configfs we need to make this a privileged container.
-        ctr = daemon_to_container(ctx, self, privileged=True, envs=['PYTHONPATH=$PYTHONPATH:/usr/share/ceph'])
+        ctr = daemon_to_container(ctx, self, privileged=True)
         return to_deployment_container(ctx, ctr)
 
     def config_and_keyring(

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -361,7 +361,7 @@ class NodeProxyEndpoint:
 
         try:
             headers, result, status = http_req(hostname=addr,
-                                               port='8080',
+                                               port='9456',
                                                headers=header,
                                                method=method,
                                                data=json.dumps(payload),

--- a/src/pybind/mgr/cephadm/services/node_proxy.py
+++ b/src/pybind/mgr/cephadm/services/node_proxy.py
@@ -105,7 +105,7 @@ class NodeProxy(CephService):
 
         try:
             headers, result, status = http_req(hostname=addr,
-                                               port='8080',
+                                               port='9456',
                                                headers=header,
                                                method=method,
                                                data=json.dumps(payload),
@@ -142,7 +142,7 @@ class NodeProxy(CephService):
 
         try:
             headers, result, status = http_req(hostname=addr,
-                                               port='8080',
+                                               port='9456',
                                                headers=header,
                                                data=json.dumps(payload),
                                                endpoint=endpoint,
@@ -165,7 +165,7 @@ class NodeProxy(CephService):
 
         try:
             headers, result, status = http_req(hostname=addr,
-                                               port='8080',
+                                               port='9456',
                                                headers=header,
                                                data="{}",
                                                endpoint=endpoint,


### PR DESCRIPTION
This commit introduces a major refactor of the main entrypoint.

- subclass threading.Thread:
  - Introduce a new class `BaseThread()` that is a `threading.Thread()` abstraction class in order to monitor the different threads.
  - `BaseSystem()` inherits from `BaseThread()`.
  - Handle `SIGTERM` signal in order to gracefully shutdown node-proxy (make threads exit gracefully, log out from RedFish API, etc.)

Additionally:
  - this drops the class `Logger()` from util.py which was not adding value. It is now replaced with a simple `get_logger()` function.
  - this changes the node-proxy API port from 8080 to 9456 (8080 being widely used for frontend apps...)
