### PR TITLE
common/LogEntry: Add log level to str helper for fmt::formatter<LogEntry>

### DIFF
--- a/src/common/LogEntry.h
+++ b/src/common/LogEntry.h
@@ -125,6 +125,23 @@ struct LogEntry {
   void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<LogEntry*>& o);
   static clog_type str_to_level(std::string const &str);
+  static std::string_view level_to_str(clog_type t) {
+    switch (t) {
+    case CLOG_DEBUG:
+      return "DBG";
+    case CLOG_INFO:
+      return "INF";
+    case CLOG_SEC:
+      return "SEC";
+    case CLOG_WARN:
+      return "WRN";
+    case CLOG_ERROR:
+      return "ERR";
+    case CLOG_UNKNOWN:
+      return "UNKNOWN";
+    }
+    return "???";
+  }
 };
 WRITE_CLASS_ENCODER_FEATURES(LogEntry)
 
@@ -204,8 +221,9 @@ template <> struct fmt::formatter<EntityName> : fmt::formatter<std::string_view>
 template <> struct fmt::formatter<LogEntry> : fmt::formatter<std::string_view> {
   template <typename FormatContext>
   auto format(const LogEntry& e, FormatContext& ctx) {
-    return fmt::format_to(ctx.out(), "{} {} ({}) {} : {} {} {}",
-			  e.stamp, e.name, e.rank, e.seq, e.channel, e.prio, e.msg);
+    return fmt::format_to(ctx.out(), "{} {} ({}) {} : {} [{}] {}",
+                          e.stamp, e.name, e.rank, e.seq, e.channel,
+                          LogEntry::level_to_str(e.prio), e.msg);
   }
 };
 


### PR DESCRIPTION
The Ceph cluster logs were missing the string equivalent [INF|WRN|ERR|DBG] representation of the 'prio' field. This was broken since the introduction of commit 2901943618f071060f72d69cf632a4097e439df4 of PR: https://github.com/ceph/ceph/pull/47830. This probably caused false positives in teuthology testing and particularly for those tests that check for cluster badness by parsing the cluster logs.

The fix involves adding a static helper function to the LogEntry struct. This function returns the string appropriate representation of the log level similar to the operator<<() for LogEntry.

Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>
Fixes: https://tracker.ceph.com/issues/64314





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
