### PR TITLE
rgw: enhance radoslist to allow object & object version to be specified

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7088,11 +7088,19 @@ int main(int argc, const char **argv)
     }
 
     if (bucket_name.empty()) {
+      if (!object.empty() || !object_version.empty()) {
+	std::cerr << "ERROR: may not specify --object or --object-version unless --bucket is also specified." << std::endl;
+	return EINVAL;
+      }
       // yes_i_really_mean_it means continue with listing even if
       // there are indexless buckets
       ret = lister.run(dpp(), yes_i_really_mean_it);
     } else {
-      ret = lister.run(dpp(), bucket_name);
+      if (object.empty() && !object_version.empty()) {
+	std::cerr << "ERROR: may not specify --object-version unless --object is also specified." << std::endl;
+	return EINVAL;
+      }
+      ret = lister.run(dpp(), bucket_name, object, object_version);
     }
 
     if (ret < 0) {

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -290,7 +290,9 @@ public:
   int build_linked_oids_index();
 
   int run(const DoutPrefixProvider *dpp,
-	  const std::string& bucket_id,
+	  const std::string& bucket_name,
+	  const std::string& object_name = std::string(),
+	  const std::string& object_version = std::string(),
 	  const bool silent_indexless = false);
   int run(const DoutPrefixProvider *dpp,
 	  const bool yes_i_really_mean_it = false);


### PR DESCRIPTION
Previously `radosgw-admin bucket radoslist ...` could be run with or without a --bucket specified. Either way, if only the information for a single object is desired, there will be a lot of unwanted extra information. So the command is enhanced to optionally allow --object and --object_version to be specified. Each does the obvious thing. For example, on a versioned bucket if --object is specified but --object_version is not, it will produce a list of rados objects for *all* versions.

Tracker: https://tracker.ceph.com/issues/64322



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
