### PR TITLE
rgw/auth: ignoring signatures for HTTP OPTIONS calls

### DIFF
--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -164,6 +164,7 @@ class EC2Engine : public rgw::auth::s3::AWSEngine {
                    const std::string& string_to_sign,
                    const std::string_view& signature,
 		   const signature_factory_t& signature_factory,
+                   bool ignore_signature,
                    optional_yield y) const;
   result_t authenticate(const DoutPrefixProvider* dpp,
                         const std::string_view& access_key_id,

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -6213,6 +6213,13 @@ rgw::auth::s3::LocalEngine::authenticate(
   }
   const RGWAccessKey& k = iter->second;
 
+  /* Ignore signature for HTTP OPTIONS */
+  if (s->op_type == RGW_OP_OPTIONS_CORS) {
+    auto apl = apl_factory->create_apl_local(cct, s, user->get_info(),
+                                             k.subuser, std::nullopt, access_key_id);
+    return result_t::grant(std::move(apl), completer_factory(k.key));
+  }
+
   const VersionAbstractor::server_signature_t server_signature = \
     signature_factory(cct, k.key, string_to_sign);
   auto compare = signature.compare(server_signature);


### PR DESCRIPTION
Before [1] we always sent all HTTP OPTIONS requests to the S3AnonymousEngine and ignored any provided AWSv4 credentials sent in the request.

That PR changed so that if we got credentials in the request we instead sent it through the authentication code in order to solve HTTP OPTIONS requests on tenanted users to start working (because we need to resolve the tenant, also called bucket tenant in the code, and we can't only rely on the bucket name since it will not be found).

We solved this by modifying the canonical HTTP method used when calculating the AWSv4 signature by instead using the access-control-request-method header which worked good.

This change did not take into account that when you generated a presigned URL for a put_object request you can also pass in extra parameters like a canned ACL [2] to the Params variable in for example boto3's generated_presigned_url().

Doing that will cause the client to add the x-amz-acl header to x-amz-signedheaders and also use that in their signature calculation.

When doing a HTTP OPTIONS calls for CORS on that presigned URL the browser will never send a x-amz-acl header with the correct data since that is something that the actual PUT request should include later, so that HTTP OPTIONS call should pass even though the signature can never be calculated correctly server-side like verified against AWS S3 in tracker [3].

This patch as a result skips the signature calculation when doing EC2 auth using the LocalEngine but we still need to pass the request there in order to lookup the user to support buckets in a tenant.

For the Keystone EC2 auth we're pretty out of luck in the sense that Keystone's API itself requires us to send the AWSv4 signature in the request with the access_key in order to obtain a token, and we cannot leave the signature out, we also cannot spoof the signature from rgw -> keystone since we don't have access to the secret_key if it's not in our cache.

For that approach we simply pass on to get_access_token() that if it's an HTTP OPTIONS and we find the access_key in the cache we pull that and ignore verifying signature and pass it on for validation. This means that the cache must be warm if using Keystone auth and adding extra params to a presigned URL.

This partly makes some of the commits in [1] redundant for EC2 LocalEngine auth but we still need it for tenanted bucket support.

[1] https://github.com/ceph/ceph/pull/52673
[2] https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
[3] https://tracker.ceph.com/issues/64308

Fixes: https://tracker.ceph.com/issues/64308





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
