### PR TITLE
mgr/dashboard: fix error while accessing roles tab when policy attached

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -850,9 +850,10 @@ edit_role_form = Form(path='/edit',
         "CreateDate": {'cellTemplate': 'date'},
         "MaxSessionDuration": {'cellTemplate': 'duration'},
         "RoleId": {'isHidden': True},
-        "AssumeRolePolicyDocument": {'isHidden': True}
+        "AssumeRolePolicyDocument": {'isHidden': True},
+        "PermissionPolicies": {'isHidden': True}
     },
-    detail_columns=['RoleId', 'AssumeRolePolicyDocument'],
+    detail_columns=['RoleId', 'AssumeRolePolicyDocument', 'PermissionPolicies'],
     meta=CRUDMeta()
 )
 class RgwUserRole(NamedTuple):
@@ -863,6 +864,7 @@ class RgwUserRole(NamedTuple):
     CreateDate: str
     MaxSessionDuration: int
     AssumeRolePolicyDocument: str
+    PermissionPolicies: List
 
 
 @APIRouter('/rgw/realm', Scope.RGW)

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/crud-table/crud-table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/crud-table/crud-table.component.html
@@ -36,7 +36,7 @@
           <tr *ngFor="let column of meta.detail_columns">
             <td i18n
                 class="bold">{{ column }}</td>
-            <td> {{ expandedRow[column] }} </td>
+            <td><pre>{{ expandedRow[column] }}</pre></td>
           </tr>
         </tbody>
       </table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/crud-table/crud-table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/crud-table/crud-table.component.ts
@@ -39,7 +39,7 @@ export class CRUDTableComponent implements OnInit {
   permissions: Permissions;
   permission: Permission;
   selection = new CdTableSelection();
-  expandedRow: any = null;
+  expandedRow: { [key: string]: any } = {};
   modalRef: NgbModalRef;
   tabs = {};
   resource: string;
@@ -145,7 +145,11 @@ export class CRUDTableComponent implements OnInit {
   }
 
   setExpandedRow(event: any) {
-    this.expandedRow = event;
+    for (let i = 0; i < this.meta.detail_columns.length; i++) {
+      let column = this.meta.detail_columns[i];
+      let columnDetail = event[column];
+      this.expandedRow[column] = this.formatColumnDetails(columnDetail);
+    }
   }
 
   edit() {
@@ -175,5 +179,31 @@ export class CRUDTableComponent implements OnInit {
       this.modalState['authExportData'] = data.trim();
       this.modalRef = this.modalService.show(ConfirmationModalComponent, modalVariables);
     });
+  }
+
+  /**
+   * Custom string replacer function for JSON.stringify
+   *
+   * This is specifically for objects inside an array.
+   * The custom replacer recursively stringifies deep nested objects
+   **/
+  stringReplacer(_key: string, value: any) {
+    try {
+      const parsedValue = JSON.parse(value);
+      return parsedValue;
+    } catch (e) {
+      return value;
+    }
+  }
+
+  /**
+   * returns a json string for arrays and string
+   * returns the same value for the rest
+   **/
+  formatColumnDetails(details: any) {
+    if (Array.isArray(details) || typeof details === 'string') {
+      return JSON.stringify(details, this.stringReplacer, 2);
+    }
+    return details;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/crud-table-metadata.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/crud-table-metadata.ts
@@ -15,4 +15,5 @@ export class CrudMetadata {
   forms: any;
   columnKey: string;
   resource: string;
+  detail_columns: string[];
 }


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/64270

### Issue:
Accessing Object->Users-Roles tab causing 500 internal servor error. This is due to the "PermissionPolicies" which are attached to role and backend was not handling this field for rgw roles.
![image](https://github.com/ceph/ceph/assets/25664409/7ea93fe3-2b10-4586-803d-293999429137)


### Fix:
Added "PermissionPolicies" as the valid field in backend and updated frontend to render the attached policy in formatted JSON
![Screenshot from 2024-02-06 14-46-12](https://github.com/ceph/ceph/assets/25664409/1330e218-9591-4f12-9d3b-86bf51e6b567)


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
