### PR TITLE
  rgw/auth: Remove Keystone v2.0 API support

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -775,16 +775,6 @@ options:
   services:
   - rgw
   with_legacy: true
-- name: rgw_keystone_api_version
-  type: int
-  level: advanced
-  desc: Version of Keystone API to use (2 or 3).
-  fmt_desc: The version (2 or 3) of OpenStack Identity API that should be
-    used for communication with the Keystone server.
-  default: 2
-  services:
-  - rgw
-  with_legacy: true
 - name: rgw_keystone_accepted_roles
   type: str
   level: advanced

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -58,18 +58,13 @@ TokenEngine::get_from_keystone(const DoutPrefixProvider* dpp,
     throw -EINVAL;
   }
 
-  const auto keystone_version = config.get_api_version();
-  if (keystone_version == rgw::keystone::ApiVersion::VER_2) {
-    url.append("v2.0/tokens/" + token);
-  } else if (keystone_version == rgw::keystone::ApiVersion::VER_3) {
-    url.append("v3/auth/tokens");
+  url.append("v3/auth/tokens");
 
-    if (allow_expired) {
-      url.append("?allow_expired=1");
-    }
-
-    validate.append_header("X-Subject-Token", token);
+  if (allow_expired) {
+    url.append("?allow_expired=1");
   }
+
+  validate.append_header("X-Subject-Token", token);
 
   std::string admin_token;
   if (rgw::keystone::Service::get_admin_token(dpp, token_cache, config,
@@ -110,7 +105,7 @@ TokenEngine::get_from_keystone(const DoutPrefixProvider* dpp,
                  << ", body=" << token_body_bl.c_str() << dendl;
 
   TokenEngine::token_envelope_t token_body;
-  ret = token_body.parse(dpp, token, token_body_bl, config.get_api_version());
+  ret = token_body.parse(dpp, token, token_body_bl);
   if (ret < 0) {
     throw ret;
   }
@@ -395,12 +390,7 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
     throw -EINVAL;
   }
 
-  const auto api_version = config.get_api_version();
-  if (api_version == rgw::keystone::ApiVersion::VER_3) {
-    keystone_url.append("v3/s3tokens");
-  } else {
-    keystone_url.append("v2.0/s3tokens");
-  }
+  keystone_url.append("v3/s3tokens");
 
   /* get authentication token for Keystone. */
   std::string admin_token;
@@ -462,7 +452,7 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
 
   /* now parse response */
   rgw::keystone::TokenEnvelope token_envelope;
-  ret = token_envelope.parse(dpp, std::string(), token_body_bl, api_version);
+  ret = token_envelope.parse(dpp, std::string(), token_body_bl);
   if (ret < 0) {
     ldpp_dout(dpp, 2) << "s3 keystone: token parsing failed, ret=0" << ret
                   << dendl;
@@ -487,12 +477,7 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
     return make_pair(boost::none, -EINVAL);
   }
 
-  const auto api_version = config.get_api_version();
-  if (api_version == rgw::keystone::ApiVersion::VER_3) {
-    keystone_url.append("v3/");
-  } else {
-    keystone_url.append("v2.0/");
-  }
+  keystone_url.append("v3/");
   keystone_url.append("users/");
   keystone_url.append(user_id);
   keystone_url.append("/credentials/OS-EC2/");

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -29,12 +29,6 @@ static inline std::string rgw_get_token_id(const std::string& token)
 namespace rgw {
 namespace keystone {
 
-enum class ApiVersion {
-  VER_2,
-  VER_3
-};
-
-
 class Config {
 protected:
   Config() = default;
@@ -42,7 +36,6 @@ protected:
 
 public:
   virtual std::string get_endpoint_url() const noexcept = 0;
-  virtual ApiVersion get_api_version() const noexcept = 0;
 
   virtual std::string get_admin_token() const noexcept = 0;
   virtual std::string_view get_admin_user() const noexcept = 0;
@@ -66,7 +59,6 @@ public:
   }
 
   std::string get_endpoint_url() const noexcept override;
-  ApiVersion get_api_version() const noexcept override;
 
   std::string get_admin_token() const noexcept override;
 
@@ -155,7 +147,6 @@ public:
     Token() : expires(0) { }
     std::string id;
     time_t expires;
-    Project tenant_v2;
     void decode_json(JSONObj *obj);
   };
 
@@ -180,7 +171,6 @@ public:
     std::string id;
     std::string name;
     Domain domain;
-    std::list<Role> roles_v2;
     void decode_json(JSONObj *obj);
   };
 
@@ -189,8 +179,7 @@ public:
   User user;
   std::list<Role> roles;
 
-  void decode_v3(JSONObj* obj);
-  void decode_v2(JSONObj* obj);
+  void decode(JSONObj* obj);
 
 public:
   /* We really need the default ctor because of the internals of TokenCache. */
@@ -211,8 +200,7 @@ public:
   }
   int parse(const DoutPrefixProvider *dpp,
             const std::string& token_str,
-            ceph::buffer::list& bl /* in */,
-            ApiVersion version);
+            ceph::buffer::list& bl /* in */);
   void update_roles(const std::vector<std::string> & admin,
                     const std::vector<std::string> & reader);
 };
@@ -293,47 +281,28 @@ private:
 };
 
 
-class AdminTokenRequest {
+class TokenRequestBase {
 public:
-  virtual ~AdminTokenRequest() = default;
+  virtual ~TokenRequestBase() = default;
   virtual void dump(Formatter* f) const = 0;
 };
 
-class AdminTokenRequestVer2 : public AdminTokenRequest {
+class AdminTokenRequest : public TokenRequestBase {
   const Config& conf;
 
 public:
-  explicit AdminTokenRequestVer2(const Config& conf)
-    : conf(conf) {
-  }
+  explicit AdminTokenRequest(const Config& conf)
+     : conf(conf) {
+   }
   void dump(Formatter *f) const override;
 };
 
-class AdminTokenRequestVer3 : public AdminTokenRequest {
-  const Config& conf;
 
-public:
-  explicit AdminTokenRequestVer3(const Config& conf)
-    : conf(conf) {
-  }
-  void dump(Formatter *f) const override;
-};
-
-class BarbicanTokenRequestVer2 : public AdminTokenRequest {
+class BarbicanTokenRequest : public TokenRequestBase {
   CephContext *cct;
 
 public:
-  explicit BarbicanTokenRequestVer2(CephContext * const _cct)
-    : cct(_cct) {
-  }
-  void dump(Formatter *f) const override;
-};
-
-class BarbicanTokenRequestVer3 : public AdminTokenRequest {
-  CephContext *cct;
-
-public:
-  explicit BarbicanTokenRequestVer3(CephContext * const _cct)
+  explicit BarbicanTokenRequest(CephContext * const _cct)
     : cct(_cct) {
   }
   void dump(Formatter *f) const override;


### PR DESCRIPTION
The v2.0 API was removed from Keystone [1] in
the Queens release back in 2018 so we can
safely remove it for the next release.

This helps cleanup a lot of code and removes
the need for the rgw_keystone_api_version
configuration option.

[1] https://docs.openstack.org/keystone/latest/contributor/http-api.html





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
