### PR TITLE
quincy: librbd: return ENOENT from Snapshot::get_timestamp for nonexistent snap_id

### DIFF
--- a/src/librbd/api/Snapshot.cc
+++ b/src/librbd/api/Snapshot.cc
@@ -378,7 +378,9 @@ int Snapshot<I>::remove(I *ictx, const char *snap_name, uint32_t flags,
 template <typename I>
 int Snapshot<I>::get_timestamp(I *ictx, uint64_t snap_id, struct timespec *timestamp) {
   auto snap_it = ictx->snap_info.find(snap_id);
-  ceph_assert(snap_it != ictx->snap_info.end());
+  if (snap_it == ictx->snap_info.end()) {
+    return -ENOENT;
+  }
   utime_t time = snap_it->second.timestamp;
   time.to_timespec(timestamp);
   return 0;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -1894,6 +1894,8 @@ TEST_F(TestLibRBD, TestGetSnapShotTimeStamp)
   ASSERT_EQ(0, create_image(ioctx, name.c_str(), size, &order));
   ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
 
+  ASSERT_EQ(-ENOENT, rbd_snap_get_timestamp(image, 0, NULL));
+
   ASSERT_EQ(0, rbd_snap_create(image, "snap1"));
   num_snaps = rbd_snap_list(image, snaps, &max_size);
   ASSERT_EQ(1, num_snaps);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64274

---

backport of https://github.com/ceph/ceph/pull/55397
parent tracker: https://tracker.ceph.com/issues/47287