### PR TITLE
osd: restoring timely collection of PG stats

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -2918,18 +2918,16 @@ options:
 - name: osd_pg_stat_report_interval_max_seconds
   type: int
   level: advanced
-  desc: The maximum interval seconds for update pg's reported_epoch,
-        benefit for osdmap trim when osdmap not change frequently.
-  with_legacy: true
+  desc: How often (in seconds) should PGs stats be collected.
+  with_legacy: false
   default: 5
 - name: osd_pg_stat_report_interval_max_epochs
   type: int
   level: advanced
-  desc: The maximum interval by which pg's reported_epoch lags behind,
-        otherwise, pg's reported_epoch must be updated,
-        benefit for osdmap trim when osdmap changes frequently.
+  desc: The maximum number of epochs allowed to pass before PG stats
+        are collected.
   default: 500
-  with_legacy: true
+  with_legacy: false
 # Max number of snap intervals to report to mgr in pg_stat_t
 - name: osd_max_snap_prune_intervals_per_epoch
   type: uint

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -2920,8 +2920,8 @@ options:
   level: advanced
   desc: The maximum interval seconds for update pg's reported_epoch,
         benefit for osdmap trim when osdmap not change frequently.
-  default: 500
   with_legacy: true
+  default: 5
 - name: osd_pg_stat_report_interval_max_epochs
   type: int
   level: advanced

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3909,16 +3909,18 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
   // when there is no change in osdmap,
   // update info.stats.reported_epoch by the number of time seconds.
   utime_t cutoff_time = now;
-  cutoff_time -= cct->_conf->osd_pg_stat_report_interval_max_seconds;
-  bool is_time_expired = cutoff_time > info.stats.last_fresh ? true : false;
+  cutoff_time -=
+      cct->_conf.get_val<int64_t>("osd_pg_stat_report_interval_max_seconds");
+  const bool is_time_expired = cutoff_time > info.stats.last_fresh;
 
   // 500 epoch osdmaps are also the minimum number of osdmaps that mon must retain.
   // if info.stats.reported_epoch less than current osdmap epoch exceeds 500 osdmaps,
   // it can be considered that the one reported by pgid is too old and needs to be updated.
   // to facilitate mon trim osdmaps
   epoch_t cutoff_epoch = info.stats.reported_epoch;
-  cutoff_epoch += cct->_conf->osd_pg_stat_report_interval_max_epochs;
-  bool is_epoch_behind = cutoff_epoch < get_osdmap_epoch() ? true : false;
+  cutoff_epoch +=
+      cct->_conf.get_val<int64_t>("osd_pg_stat_report_interval_max_epochs");
+  const bool is_epoch_behind = cutoff_epoch < get_osdmap_epoch();
 
   if (pg_stats_publish && pre_publish == *pg_stats_publish &&
       (!is_epoch_behind && !is_time_expired)) {


### PR DESCRIPTION
Fixing the regression introduced by PR #54491.
Also - fixing review comments that were not addressed in the original PR.

Fixes tracker issue 53342 note 5 (a specific scenario leading to 'not all pgs scrubbed' failures)
