### PR TITLE
qa/rgw: hadoop-s3a uses supported-random-distro$

### DIFF
--- a/qa/suites/rgw/hadoop-s3a/supported-random-distro$
+++ b/qa/suites/rgw/hadoop-s3a/supported-random-distro$
@@ -1,0 +1,1 @@
+.qa/distros/supported-random-distro$


### PR DESCRIPTION
without this, teuthology-suite tries to schedule against centos8 which is not supported for squid

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
