### PR TITLE
crimson/osd/osd_operations/client_request: make loading-obc concurrent

### DIFF
--- a/src/crimson/common/operation.h
+++ b/src/crimson/common/operation.h
@@ -502,15 +502,43 @@ class PipelineHandle {
   }
 
   template <typename OpT, typename T>
-  seastar::future<>
-  do_enter(T &stage, typename T::BlockingEvent::template Trigger<OpT>&& t) {
-    auto fut = t.maybe_record_blocking(stage.enter(t), stage);
-    return std::move(fut).then(
-      [this, t=std::move(t)](auto &&barrier_ref) mutable {
+  std::optional<seastar::future<>>
+  do_enter_maybe_sync(T &stage, typename T::BlockingEvent::template Trigger<OpT>&& t) {
+    if constexpr (!T::is_enter_sync) {
+      auto fut = t.maybe_record_blocking(stage.enter(t), stage);
+      return std::move(fut).then(
+        [this, t=std::move(t)](auto &&barrier_ref) {
+        exit();
+        barrier = std::move(barrier_ref);
+        return seastar::now();
+      });
+    } else {
+      auto barrier_ref = stage.enter(t);
       exit();
       barrier = std::move(barrier_ref);
-      return seastar::now();
-    });
+      return std::nullopt;
+    }
+  }
+
+  template <typename OpT, typename T>
+  std::optional<seastar::future<>>
+  enter_maybe_sync(T &stage, typename T::BlockingEvent::template Trigger<OpT>&& t) {
+    assert(stage.core == seastar::this_shard_id());
+    auto wait_fut = wait_barrier();
+    if (wait_fut.has_value()) {
+      return wait_fut.value(
+      ).then([this, &stage, t=std::move(t)]() mutable {
+        auto ret = do_enter_maybe_sync<OpT, T>(stage, std::move(t));
+        if constexpr (!T::is_enter_sync) {
+          return std::move(ret.value());
+        } else {
+          assert(ret == std::nullopt);
+          return seastar::now();
+        }
+      });
+    } else {
+      return do_enter_maybe_sync<OpT, T>(stage, std::move(t));
+    }
   }
 
 public:
@@ -530,16 +558,27 @@ public:
   template <typename OpT, typename T>
   seastar::future<>
   enter(T &stage, typename T::BlockingEvent::template Trigger<OpT>&& t) {
-    assert(stage.core == seastar::this_shard_id());
-    auto wait_fut = wait_barrier();
-    if (wait_fut.has_value()) {
-      return wait_fut.value(
-      ).then([this, &stage, t=std::move(t)]() mutable {
-        return do_enter<OpT, T>(stage, std::move(t));
-      });
+    auto ret = enter_maybe_sync<OpT, T>(stage, std::move(t));
+    if (ret.has_value()) {
+      return std::move(ret.value());
     } else {
-      return do_enter<OpT, T>(stage, std::move(t));
+      return seastar::now();
     }
+  }
+
+  /**
+   * Synchronously leaves the previous stage and enters the next stage.
+   * Required for the use case which needs ordering upon entering an
+   * ordered concurrent phase.
+   */
+  template <typename OpT, typename T>
+  void
+  enter_sync(T &stage, typename T::BlockingEvent::template Trigger<OpT>&& t) {
+    static_assert(T::is_enter_sync);
+    auto ret = enter_maybe_sync<OpT, T>(stage, std::move(t));
+    // Expect that barrier->wait() (leaving the previous stage)
+    // also returns nullopt, see enter_maybe_sync() above
+    ceph_assert(!ret.has_value());
   }
 
   /**
@@ -607,6 +646,8 @@ class OrderedExclusivePhaseT : public PipelineStageIT<T> {
   }
 
 public:
+  static constexpr bool is_enter_sync = false;
+
   template <class TriggerT>
   seastar::future<PipelineExitBarrierI::Ref> enter(TriggerT& t) {
     waiting++;
@@ -709,10 +750,11 @@ private:
   };
 
 public:
+  static constexpr bool is_enter_sync = true;
+
   template <class TriggerT>
-  seastar::future<PipelineExitBarrierI::Ref> enter(TriggerT& t) {
-    return seastar::make_ready_future<PipelineExitBarrierI::Ref>(
-      new ExitBarrier<TriggerT>{*this, mutex.lock(), t});
+  PipelineExitBarrierI::Ref enter(TriggerT& t) {
+    return std::make_unique<ExitBarrier<TriggerT>>(*this, mutex.lock(), t);
   }
 
 private:
@@ -742,10 +784,11 @@ class UnorderedStageT : public PipelineStageIT<T> {
   };
 
 public:
-  template <class... IgnoreArgs>
-  seastar::future<PipelineExitBarrierI::Ref> enter(IgnoreArgs&&...) {
-    return seastar::make_ready_future<PipelineExitBarrierI::Ref>(
-      new ExitBarrier);
+  static constexpr bool is_enter_sync = true;
+
+  template <class TriggerT>
+  PipelineExitBarrierI::Ref enter(TriggerT&) {
+    return std::make_unique<ExitBarrier>();
   }
 };
 

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -153,11 +153,15 @@ protected:
     get_event<EventT>().trigger(*that(), std::forward<Args>(args)...);
   }
 
+  template <class BlockingEventT>
+  typename BlockingEventT::template Trigger<T>
+  get_trigger() {
+    return {get_event<BlockingEventT>(), *that()};
+  }
+
   template <class BlockingEventT, class InterruptorT=void, class F>
   auto with_blocking_event(F&& f) {
-    auto ret = std::forward<F>(f)(typename BlockingEventT::template Trigger<T>{
-      get_event<BlockingEventT>(), *that()
-    });
+    auto ret = std::forward<F>(f)(get_trigger<BlockingEventT>());
     if constexpr (std::is_same_v<InterruptorT, void>) {
       return ret;
     } else {
@@ -194,6 +198,12 @@ protected:
         // for ConnectionPipeline).
         return that()->get_handle().template enter<T>(stage, std::move(trigger));
     });
+  }
+
+  template <class StageT>
+  void enter_stage_sync(StageT& stage) {
+    that()->get_handle().template enter_sync<T>(
+        stage, this->template get_trigger<typename StageT::BlockingEvent>());
   }
 
   template <class OpT>

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -38,6 +38,8 @@ struct LttngBackend
       BlockingEvent::ExitBarrierEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissingSnaps::BlockingEvent::Backend,
     ClientRequest::PGPipeline::GetOBC::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::LockOBC::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::LockOBC::BlockingEvent::ExitBarrierEvent::Backend,
     ClientRequest::PGPipeline::Process::BlockingEvent::Backend,
     ClientRequest::PGPipeline::WaitRepop::BlockingEvent::Backend,
     ClientRequest::PGPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent::Backend,
@@ -125,6 +127,15 @@ struct LttngBackend
   void handle(ClientRequest::PGPipeline::GetOBC::BlockingEvent& ev,
               const Operation& op,
               const ClientRequest::PGPipeline::GetOBC& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::LockOBC::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::LockOBC& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::LockOBC::BlockingEvent::ExitBarrierEvent& ev,
+              const Operation& op) override {
   }
 
   void handle(ClientRequest::PGPipeline::Process::BlockingEvent& ev,
@@ -169,6 +180,8 @@ struct HistoricBackend
       BlockingEvent::ExitBarrierEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissingSnaps::BlockingEvent::Backend,
     ClientRequest::PGPipeline::GetOBC::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::LockOBC::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::LockOBC::BlockingEvent::ExitBarrierEvent::Backend,
     ClientRequest::PGPipeline::Process::BlockingEvent::Backend,
     ClientRequest::PGPipeline::WaitRepop::BlockingEvent::Backend,
     ClientRequest::PGPipeline::WaitRepop::BlockingEvent::ExitBarrierEvent::Backend,
@@ -256,6 +269,15 @@ struct HistoricBackend
   void handle(ClientRequest::PGPipeline::GetOBC::BlockingEvent& ev,
               const Operation& op,
               const ClientRequest::PGPipeline::GetOBC& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::LockOBC::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::LockOBC& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::LockOBC::BlockingEvent::ExitBarrierEvent& ev,
+              const Operation& op) override {
   }
 
   void handle(ClientRequest::PGPipeline::Process::BlockingEvent& ev,

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -33,6 +33,10 @@ struct LttngBackend
     PGActivationBlocker::BlockingEvent::Backend,
     scrub::PGScrubber::BlockingEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::RecoverMissingLockOBC::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::RecoverMissingLockOBC::
+      BlockingEvent::ExitBarrierEvent::Backend,
+    ClientRequest::PGPipeline::RecoverMissingSnaps::BlockingEvent::Backend,
     ClientRequest::PGPipeline::GetOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::Process::BlockingEvent::Backend,
     ClientRequest::PGPipeline::WaitRepop::BlockingEvent::Backend,
@@ -101,6 +105,21 @@ struct LttngBackend
   void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent& ev,
               const Operation& op,
               const ClientRequest::PGPipeline::RecoverMissing& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::RecoverMissingLockOBC::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::RecoverMissingLockOBC& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::RecoverMissingLockOBC::
+                BlockingEvent::ExitBarrierEvent& ev,
+              const Operation& op) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::RecoverMissingSnaps::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::RecoverMissingSnaps& blocker) override {
   }
 
   void handle(ClientRequest::PGPipeline::GetOBC::BlockingEvent& ev,
@@ -145,6 +164,10 @@ struct HistoricBackend
     PGActivationBlocker::BlockingEvent::Backend,
     scrub::PGScrubber::BlockingEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::RecoverMissingLockOBC::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::RecoverMissingLockOBC::
+      BlockingEvent::ExitBarrierEvent::Backend,
+    ClientRequest::PGPipeline::RecoverMissingSnaps::BlockingEvent::Backend,
     ClientRequest::PGPipeline::GetOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::Process::BlockingEvent::Backend,
     ClientRequest::PGPipeline::WaitRepop::BlockingEvent::Backend,
@@ -213,6 +236,21 @@ struct HistoricBackend
   void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent& ev,
               const Operation& op,
               const ClientRequest::PGPipeline::RecoverMissing& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::RecoverMissingLockOBC::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::RecoverMissingLockOBC& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::RecoverMissingLockOBC::
+                BlockingEvent::ExitBarrierEvent& ev,
+              const Operation& op) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::RecoverMissingSnaps::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::RecoverMissingSnaps& blocker) override {
   }
 
   void handle(ClientRequest::PGPipeline::GetOBC::BlockingEvent& ev,

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -343,6 +343,9 @@ ClientRequest::process_op(
 
   DEBUGDPP("{}.{}: past scrub blocker, getting obc",
 	   *pg, *this, this_instance_id);
+  // call with_locked_obc() in order, but wait concurrently for loading.
+  ihref.enter_stage_sync(
+      client_pp(*pg).lock_obc, *this);
   auto process = pg->with_locked_obc(
     m->get_hobj(), op_info,
     [FNAME, this, pg, this_instance_id, &ihref] (

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -115,6 +115,7 @@ public:
       PGPipeline::RecoverMissingSnaps::BlockingEvent,
       scrub::PGScrubber::BlockingEvent,
       PGPipeline::GetOBC::BlockingEvent,
+      PGPipeline::LockOBC::BlockingEvent,
       PGPipeline::Process::BlockingEvent,
       PGPipeline::WaitRepop::BlockingEvent,
       PGPipeline::SendReply::BlockingEvent,

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -113,12 +113,15 @@ public:
       CompletionEvent
       > pg_tracking_events;
 
+    template <class BlockingEventT>
+    typename BlockingEventT::template Trigger<ClientRequest>
+    get_trigger(ClientRequest &op) {
+      return {std::get<BlockingEventT>(pg_tracking_events), op};
+    }
+
     template <typename BlockingEventT, typename InterruptorT=void, typename F>
     auto with_blocking_event(F &&f, ClientRequest &op) {
-      auto ret = std::forward<F>(f)(
-	typename BlockingEventT::template Trigger<ClientRequest>{
-	  std::get<BlockingEventT>(pg_tracking_events), op
-	});
+      auto ret = std::forward<F>(f)(get_trigger<BlockingEventT>(op));
       if constexpr (std::is_same_v<InterruptorT, void>) {
 	return ret;
       } else {
@@ -136,6 +139,12 @@ public:
 	    return handle.template enter<ClientRequest>(
 	      stage, std::move(trigger));
 	  }, op);
+    }
+
+    template <typename StageT>
+    void enter_stage_sync(StageT &stage, ClientRequest &op) {
+      handle.template enter_sync<ClientRequest>(
+          stage, get_trigger<typename StageT::BlockingEvent>(op));
     }
 
     template <

--- a/src/crimson/osd/osd_operations/client_request_common.cc
+++ b/src/crimson/osd/osd_operations/client_request_common.cc
@@ -31,6 +31,9 @@ CommonClientRequest::recover_missings(
   return do_recover_missing(
     pg, soid.get_head(), reqid
   ).then_interruptible([snaps=std::move(snaps), pg, soid, reqid]() mutable {
+    if (snaps.empty()) {
+      return ObjectContextLoader::load_obc_iertr::now();
+    }
     return pg->obc_loader.with_obc<RWState::RWREAD>(
       soid.get_head(),
       [snaps=std::move(snaps), pg, soid, reqid](auto head, auto) mutable {

--- a/src/crimson/osd/osd_operations/client_request_common.cc
+++ b/src/crimson/osd/osd_operations/client_request_common.cc
@@ -11,60 +11,7 @@ namespace {
   }
 }
 
-SET_SUBSYS(osd);
-
 namespace crimson::osd {
-
-InterruptibleOperation::template interruptible_future<>
-CommonClientRequest::recover_missings(
-  Ref<PG> pg,
-  const hobject_t& soid,
-  std::set<snapid_t> &&snaps,
-  const osd_reqid_t& reqid)
-{
-  LOG_PREFIX(CommonClientRequest::recover_missings);
-  if (!pg->is_primary()) {
-    DEBUGDPP(
-      "Skipping recover_missings on non primary pg for soid {}", *pg, soid);
-    return seastar::now();
-  }
-  return do_recover_missing(
-    pg, soid.get_head(), reqid
-  ).then_interruptible([snaps=std::move(snaps), pg, soid, reqid]() mutable {
-    if (snaps.empty()) {
-      return InterruptibleOperation::interruptor::now();
-    }
-    return seastar::do_with(
-      std::move(snaps),
-      [pg, soid, reqid](auto& snaps) {
-      return pg->obc_loader.with_obc<RWState::RWREAD>(
-        soid.get_head(),
-        [&snaps, pg, soid, reqid](auto head, auto) {
-        return InterruptibleOperation::interruptor::do_for_each(
-          snaps,
-          [pg, soid, head, reqid](auto &snap)
-          -> InterruptibleOperation::template interruptible_future<> {
-          auto coid = head->obs.oi.soid;
-          coid.snap = snap;
-          auto oid = resolve_oid(head->get_head_ss(), coid);
-          /* Rollback targets may legitimately not exist if, for instance,
-           * the object is an rbd block which happened to be sparse and
-           * therefore non-existent at the time of the specified snapshot.
-           * In such a case, rollback will simply delete the object.  Here,
-           * we skip the oid as there is no corresponding clone to recover.
-           * See https://tracker.ceph.com/issues/63821 */
-          if (oid) {
-            return do_recover_missing(pg, *oid, reqid);
-          } else {
-            return seastar::now();
-          }
-        });
-      }).handle_error_interruptible(
-        crimson::ct_error::assert_all("unexpected error")
-      );
-    });
-  });
-}
 
 typename InterruptibleOperation::template interruptible_future<>
 CommonClientRequest::do_recover_missing(

--- a/src/crimson/osd/osd_operations/client_request_common.h
+++ b/src/crimson/osd/osd_operations/client_request_common.h
@@ -13,14 +13,14 @@ struct CommonClientRequest {
 
   static InterruptibleOperation::template interruptible_future<>
   recover_missings(
-    Ref<PG> &pg,
+    Ref<PG> pg,
     const hobject_t& soid,
     std::set<snapid_t> &&snaps,
     const osd_reqid_t& reqid);
 
   static InterruptibleOperation::template interruptible_future<>
   do_recover_missing(
-    Ref<PG>& pg,
+    Ref<PG> pg,
     const hobject_t& soid,
     const osd_reqid_t& reqid);
 

--- a/src/crimson/osd/osd_operations/client_request_common.h
+++ b/src/crimson/osd/osd_operations/client_request_common.h
@@ -12,13 +12,6 @@ namespace crimson::osd {
 struct CommonClientRequest {
 
   static InterruptibleOperation::template interruptible_future<>
-  recover_missings(
-    Ref<PG> pg,
-    const hobject_t& soid,
-    std::set<snapid_t> &&snaps,
-    const osd_reqid_t& reqid);
-
-  static InterruptibleOperation::template interruptible_future<>
   do_recover_missing(
     Ref<PG> pg,
     const hobject_t& soid,

--- a/src/crimson/osd/osd_operations/common/pg_pipeline.h
+++ b/src/crimson/osd/osd_operations/common/pg_pipeline.h
@@ -23,6 +23,9 @@ protected:
   struct GetOBC : OrderedExclusivePhaseT<GetOBC> {
     static constexpr auto type_name = "CommonPGPipeline::get_obc";
   } get_obc;
+  struct LockOBC : OrderedConcurrentPhaseT<LockOBC> {
+    static constexpr auto type_name = "CommonPGPipeline::lock_obc";
+  } lock_obc;
   struct Process : OrderedExclusivePhaseT<Process> {
     static constexpr auto type_name = "CommonPGPipeline::process";
   } process;

--- a/src/crimson/osd/osd_operations/common/pg_pipeline.h
+++ b/src/crimson/osd/osd_operations/common/pg_pipeline.h
@@ -19,7 +19,7 @@ protected:
   } wait_for_active;
   struct RecoverMissing : OrderedExclusivePhaseT<RecoverMissing> {
     static constexpr auto type_name = "CommonPGPipeline::recover_missing";
-  } recover_missing, recover_missing2;
+  } recover_missing;
   struct GetOBC : OrderedExclusivePhaseT<GetOBC> {
     static constexpr auto type_name = "CommonPGPipeline::get_obc";
   } get_obc;

--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -84,6 +84,8 @@ seastar::future<> InternalClientRequest::start()
             [[maybe_unused]] const int ret = op_info.set_from_op(
               std::as_const(osd_ops), pg->get_pgid().pgid, *pg->get_osdmap());
             assert(ret == 0);
+            // call with_locked_obc() in order, but wait concurrently for loading.
+            enter_stage_sync(client_pp().lock_obc);
             return pg->with_locked_obc(get_target_oid(), op_info,
               [&osd_ops, this](auto, auto obc) {
               return enter_stage<interruptor>(client_pp().process

--- a/src/crimson/osd/osd_operations/internal_client_request.h
+++ b/src/crimson/osd/osd_operations/internal_client_request.h
@@ -56,6 +56,7 @@ public:
     PGActivationBlocker::BlockingEvent,
     CommonPGPipeline::RecoverMissing::BlockingEvent,
     CommonPGPipeline::GetOBC::BlockingEvent,
+    CommonPGPipeline::LockOBC::BlockingEvent,
     CommonPGPipeline::Process::BlockingEvent,
     CompletionEvent
   > tracking_events;


### PR DESCRIPTION
Major changes:
1. Introduce `std::optional<future<>> enter_stage_maybe_sync()` so that the ordering can be preserved upon entering an ordered concurrent phase.
2. Wrap `with_obc()` in ordered concurrent phases and use `enter_stage_maybe_sync()`, so that loading missing obcs from object store can become concurrent.

Unfortunately, I'm not able to see improved performance in the local tests. So I dig into the waiting-for-load-obc issue which was initially observed:

Firstly, the issue isn't related to the read path. The hit ratio of obc-lru cache is good after increasing size to 512 (https://github.com/ceph/ceph/pull/55188), so normally read won't load missing obcs frequently.

Secondly, the issue only appears with alienstore -- reading from seastore is so fast that loading missing obcs won't accumulate.

I'm able to reproduce the issue using rados bench random 4K write to stress a 32-core crimson-osd/alienstore, it seems rados bench will always write to new objects in this case, so that obc always needs to be loaded from the store.

In this scenario and in the worst case, I saw in one shard, (e.g.) 2093 client-requests were waiting outside the exclusive `recover_missing` phase, while 11 requests were pending inside `recover_missing`, and the rest 55 requests were pending inside the concurrent `wait_repop` phase. Normally however, the issue isn't that serious, (e.g.) only 4/4/49 requests were in the according phases.

Further analysis shows the requests inside `recover_missing` were mostly pending to load missing obcs from the alienstore. 

After this PR, in the worst case and in one shard, (e.g.) 8 requests were pending in the newly introduced concurrent `lock_obc` phase, and the rest 3108 requests were pending in the concurrent `wait_repop` phase. Normally, (e.g.) 15/48 requests were in the according phases. This means all requests were pending in the alienstore.

In short, after this PR, most of the IO requests are effectively pending in the store in the random 4K write rados-bench stressed scenario, and performance-not-improved is probably due to that the alienstore/bluestore was already saturated during my tests.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
