### PR TITLE
quincy: ceph-volume: Fix migration from WAL to data with no DB

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/migrate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/migrate.py
@@ -167,7 +167,11 @@ class VolumeTagTracker(object):
             aux_dev.lv_api.set_tags(tags)
 
     def remove_lvs(self, source_devices, target_type):
-        remaining_devices = [self.data_device, self.db_device, self.wal_device]
+        remaining_devices = [self.data_device]
+        if self.db_device:
+            remaining_devices.append(self.db_device)
+        if self.wal_device:
+            remaining_devices.append(self.wal_device)
 
         outdated_tags = []
         for device, type in source_devices:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64356

---

backport of https://github.com/ceph/ceph/pull/55398
parent tracker: https://tracker.ceph.com/issues/64260

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh