### PR TITLE
doc: deprecate blkin tracing

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -10,6 +10,9 @@
   For multi-site deployments that make any use of Server-Side Encryption, we
   recommended running this command against every bucket in every zone after all
   zones have upgraded.
+* Tracing: The blkin tracing feature (see https://docs.ceph.com/en/reef/dev/blkin/)
+  is now deprecated in favor of Opentracing (https://docs.ceph.com/en/reef/dev/developer_guide/jaegertracing/)
+  and will be removed in a later release.
 * CEPHFS: MDS evicts clients which are not advancing their request tids which causes
   a large buildup of session metadata resulting in the MDS going read-only due to
   the RADOS operation exceeding the size threshold. `mds_session_metadata_threshold`

--- a/doc/dev/blkin.rst
+++ b/doc/dev/blkin.rst
@@ -72,6 +72,9 @@ Destroy tracing session::
  Tracing Ceph With Blkin
 =========================
 
+.. deprecated:: This feature was deprecated in the Squid release and will
+   be removed in a later release.
+
 Ceph can use Blkin, a library created by Marios Kogias and others,
 which enables tracking a specific request from the time it enters
 the system at higher levels till it is finally served by RADOS.


### PR DESCRIPTION
following discussions in https://github.com/ceph/ceph/pull/52114, document the blkin tracing feature as deprecated

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
