### PR TITLE
pacific: qa/upgrade: disable a failing ceph_test_cls_cmpomap test case

### DIFF
--- a/qa/workunits/cls/test_cls_cmpomap.sh
+++ b/qa/workunits/cls/test_cls_cmpomap.sh
@@ -1,5 +1,6 @@
 #!/bin/sh -e
 
-ceph_test_cls_cmpomap
+# this test case changed in 16.2.6 so had been failing in pacific-p2p upgrades since
+ceph_test_cls_cmpomap --gtest_filter=-CmpOmap.cmp_vals_u64_invalid_default
 
 exit 0


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/52590

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
