### PR TITLE
cmake: find_package(cap) before linking against it

### DIFF
--- a/cmake/modules/Findcap.cmake
+++ b/cmake/modules/Findcap.cmake
@@ -1,0 +1,35 @@
+# Try to find libcap
+#
+find_package(PkgConfig QUIET REQUIRED)
+
+pkg_check_modules(PC_cap QUIET cap)
+
+find_library(cap_LIBRARY
+  NAMES cap
+  HINTS
+    ${PC_cap_LIBDIR}
+    ${PC_cap_LIBRARY_DIRS})
+
+find_path(cap_INCLUDE_DIR
+  NAMES sys/capability.h
+  HINTS
+    ${PC_cap_INCLUDEDIR}
+    ${PC_cap_INCLUDE_DIRS})
+
+mark_as_advanced(
+  cap_LIBRARY
+  cap_INCLUDE_DIR)
+
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (cap
+  REQUIRED_VARS
+    cap_LIBRARY
+    cap_INCLUDE_DIR)
+
+if(cap_FOUND AND NOT TARGET cap::cap)
+  add_library(cap::cap UNKNOWN IMPORTED)
+  set_target_properties(cap::cap
+    PROPERTIES
+      IMPORTED_LOCATION ${cap_LIBRARY}
+      INTERFACE_INCLUDE_DIRECTORIES ${cap_INCLUDE_DIR})
+endif()

--- a/src/extblkdev/CMakeLists.txt
+++ b/src/extblkdev/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(vdo)
 add_library(extblkdev STATIC ExtBlkDevPlugin.cc)
 
 if(NOT WIN32)
+find_package(cap)
 target_link_libraries(extblkdev cap)
 endif()
 


### PR DESCRIPTION
before this change, we link against libcap without finding it. this works fine as long as libcap-devel or libcap-dev is installed in the system. but if it is not, the source would fail to build due to missing `sys/capability.h`. this is not a great developer experience.

in this change, a `Findcap.cmake` is added to find the capability library. which would fail the build at the configure phase.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
