### PR TITLE
rgw/iam: zero-pad milliseconds for role and oidc-provider CreateDate

### DIFF
--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -3634,7 +3634,7 @@ int RadosRole::create(const DoutPrefixProvider *dpp, bool exclusive, const std::
   struct tm result;
   gmtime_r(&tv.tv_sec, &result);
   strftime(buf,30,"%Y-%m-%dT%H:%M:%S", &result);
-  sprintf(buf + strlen(buf),".%dZ",(int)tv.tv_usec/1000);
+  sprintf(buf + strlen(buf),".%03dZ",(int)tv.tv_usec/1000);
   info.creation_date.assign(buf, strlen(buf));
 
   auto& pool = store->svc()->zone->get_zone_params().roles_pool;

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -3624,18 +3624,20 @@ int RadosRole::create(const DoutPrefixProvider *dpp, bool exclusive, const std::
   //arn
   info.arn = role_arn_prefix + info.tenant + ":role" + info.path + info.name;
 
-  // Creation time
-  real_clock::time_point t = real_clock::now();
+  if (info.creation_date.empty()) {
+    // Creation time
+    real_clock::time_point t = real_clock::now();
 
-  struct timeval tv;
-  real_clock::to_timeval(t, tv);
+    struct timeval tv;
+    real_clock::to_timeval(t, tv);
 
-  char buf[30];
-  struct tm result;
-  gmtime_r(&tv.tv_sec, &result);
-  strftime(buf,30,"%Y-%m-%dT%H:%M:%S", &result);
-  sprintf(buf + strlen(buf),".%03dZ",(int)tv.tv_usec/1000);
-  info.creation_date.assign(buf, strlen(buf));
+    char buf[30];
+    struct tm result;
+    gmtime_r(&tv.tv_sec, &result);
+    strftime(buf,30,"%Y-%m-%dT%H:%M:%S", &result);
+    sprintf(buf + strlen(buf),".%03dZ",(int)tv.tv_usec/1000);
+    info.creation_date.assign(buf, strlen(buf));
+  }
 
   auto& pool = store->svc()->zone->get_zone_params().roles_pool;
   ret = store_info(dpp, exclusive, y);

--- a/src/rgw/rgw_oidc_provider.cc
+++ b/src/rgw/rgw_oidc_provider.cc
@@ -81,7 +81,7 @@ int RGWOIDCProvider::create(const DoutPrefixProvider *dpp, bool exclusive, optio
   struct tm result;
   gmtime_r(&tv.tv_sec, &result);
   strftime(buf,30,"%Y-%m-%dT%H:%M:%S", &result);
-  sprintf(buf + strlen(buf),".%dZ",(int)tv.tv_usec/1000);
+  sprintf(buf + strlen(buf),".%03dZ",(int)tv.tv_usec/1000);
   creation_date.assign(buf, strlen(buf));
 
   ret = store_url(dpp, idp_url, exclusive, y);

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -327,6 +327,7 @@ void RGWCreateRole::execute(optional_yield y)
     try {
       if (role_obj) {
         RGWXMLDecoder::decode_xml("RoleId", role_id, role_obj, true);
+        RGWXMLDecoder::decode_xml("CreateDate", role->get_info().creation_date, role_obj);
       }
     } catch (RGWXMLDecoder::err& err) {
       ldpp_dout(this, 5) << "ERROR: unexpected xml: RoleId" << dendl;

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -802,7 +802,7 @@ void RGWDeleteRolePolicy::execute(optional_yield y)
     op_ret = _role->update(this, y);
   }
 
-  s->formatter->open_object_section("DeleteRolePoliciesResponse");
+  s->formatter->open_object_section("DeleteRolePolicyResponse");
   s->formatter->open_object_section("ResponseMetadata");
   s->formatter->dump_string("RequestId", s->trans_id);
   s->formatter->close_section();

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -408,7 +408,6 @@ void RGWDeleteRole::execute(optional_yield y)
     } else {
       op_ret = -ERR_NO_ROLE_FOUND;
     }
-    return;
   }
   if (!op_ret) {
     s->formatter->open_object_section("DeleteRoleResponse");


### PR DESCRIPTION
make sure that tv_usec=41000 gets rendered as `.041Z` instead of `.41Z`

Fixes: https://tracker.ceph.com/issues/64381

Fixes: https://tracker.ceph.com/issues/64475

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
