### PR TITLE
quincy: mgr/dashboard: fix the jsonschema issue in install-deps 

### DIFF
--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -8,4 +8,4 @@ rstcheck==3.3.1
 autopep8==1.5.7
 pyfakefs==4.5.0
 isort==5.5.3
-jsonschema==4.16.0
+jsonschema~=4.0

--- a/src/pybind/mgr/dashboard/requirements-test.txt
+++ b/src/pybind/mgr/dashboard/requirements-test.txt
@@ -1,4 +1,4 @@
 pytest-cov
 pytest-instafail
 pyfakefs==4.5.0
-jsonschema==4.16.0
+jsonschema~=4.0


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61715

---

backport of https://github.com/ceph/ceph/pull/52095
parent tracker: https://tracker.ceph.com/issues/61690

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh