### PR TITLE
reef: mgr/dashboard: change deprecated grafana URL in daemon logs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
@@ -85,7 +85,7 @@
                         [grafanaPath]="'explore?'"
                         [type]="'logs'"
                         uid="CrAHE0iZz"
-                        grafanaStyle="two">
+                        grafanaStyle="three">
             </cd-grafana>
           </div>
         </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.spec.ts
@@ -21,7 +21,7 @@ describe('GrafanaComponent', () => {
   const expected_url =
     'http:localhost:3000/d/foo/somePath&refresh=2s&var-datasource=Dashboard1&kiosk&from=now-1h&to=now';
   const expected_logs_url =
-    'http:localhost:3000/explore?orgId=1&left=["now-1h","now","Loki",{"refId":"A"}]&kiosk';
+    'http:localhost:3000/explore?orgId=1&left={"datasource": "Loki", "queries": [{"refId": "A"}], "range": {"from": "now-1h", "to": "now"}}&kiosk';
 
   configureTestBed({
     declarations: [GrafanaComponent, AlertPanelComponent, LoadingPanelComponent, DocComponent],

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
@@ -176,9 +176,9 @@ export class GrafanaComponent implements OnInit, OnChanges {
     if (this.type === 'metrics') {
       this.url = `${this.baseUrl}${this.uid}/${this.grafanaPath}&refresh=2s&var-datasource=${this.datasource}${this.mode}&${this.time}`;
     } else {
-      this.url = `${this.baseUrl.slice(0, -2)}${this.grafanaPath}orgId=1&left=["now-1h","now","${
+      this.url = `${this.baseUrl.slice(0, -2)}${this.grafanaPath}orgId=1&left={"datasource": "${
         this.datasource
-      }",{"refId":"A"}]${this.mode}`;
+      }", "queries": [{"refId": "A"}], "range": {"from": "now-1h", "to": "now"}}${this.mode}`;
     }
     this.grafanaSrc = this.sanitizer.bypassSecurityTrustResourceUrl(this.url);
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61657

---

backport of https://github.com/ceph/ceph/pull/51966
parent tracker: https://tracker.ceph.com/issues/61618

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh