### PR TITLE
reef: mon: fix health store size growing infinitely

### DIFF
--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -400,7 +400,7 @@ void HealthMonitor::tick()
 
 bool HealthMonitor::check_mutes()
 {
-  bool changed = true;
+  bool changed = false;
   auto now = ceph_clock_now();
   health_check_map_t all;
   gather_all_health_checks(&all);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64397

---

backport of https://github.com/ceph/ceph/pull/55347
parent tracker: https://tracker.ceph.com/issues/64236

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh