### PR TITLE
pacific: rgw/auth: ignoring signatures for HTTP OPTIONS calls

### DIFF
--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -151,7 +151,8 @@ class EC2Engine : public rgw::auth::s3::AWSEngine {
                    const std::string_view& access_key_id,
                    const std::string& string_to_sign,
                    const std::string_view& signature,
-		   const signature_factory_t& signature_factory) const;
+		   const signature_factory_t& signature_factory,
+                   bool ignore_signature) const;
   result_t authenticate(const DoutPrefixProvider* dpp,
                         const std::string_view& access_key_id,
                         const std::string_view& signature,

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5774,6 +5774,13 @@ rgw::auth::s3::LocalEngine::authenticate(
   }
   const RGWAccessKey& k = iter->second;
 
+  /* Ignore signature for HTTP OPTIONS */
+  if (s->op_type == RGW_OP_OPTIONS_CORS) {
+    auto apl = apl_factory->create_apl_local(cct, s, user_info,
+                                             k.subuser, boost::none, access_key_id);
+    return result_t::grant(std::move(apl), completer_factory(k.key));
+  }
+
   const VersionAbstractor::server_signature_t server_signature = \
     signature_factory(cct, k.key, string_to_sign);
   auto compare = signature.compare(server_signature);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64404

---

backport of https://github.com/ceph/ceph/pull/55458
parent tracker: https://tracker.ceph.com/issues/64308

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh