### PR TITLE
rgw/notifications: forward sns requests similar to iam

### DIFF
--- a/src/rgw/rgw_rest_iam.cc
+++ b/src/rgw/rgw_rest_iam.cc
@@ -9,6 +9,8 @@
 #include "rgw_rest_role.h"
 #include "rgw_rest_user_policy.h"
 #include "rgw_rest_oidc_provider.h"
+#include "rgw_rest_conn.h"
+#include "driver/rados/rgw_zone.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
@@ -88,3 +90,55 @@ RGWRESTMgr_IAM::get_handler(rgw::sal::Driver* driver,
   bufferlist bl;
   return new RGWHandler_REST_IAM(auth_registry, bl);
 }
+
+int forward_iam_request_to_master(const DoutPrefixProvider* dpp,
+                                  const rgw::SiteConfig& site,
+                                  const RGWUserInfo& user,
+                                  bufferlist& indata,
+                                  RGWXMLDecoder::XMLParser& parser,
+                                  req_info& req, optional_yield y)
+{
+  const auto& period = site.get_period();
+  if (!period) {
+    return 0; // not multisite
+  }
+  if (site.is_meta_master()) {
+    return 0; // don't need to forward metadata requests
+  }
+  const auto& pmap = period->period_map;
+  auto zg = pmap.zonegroups.find(pmap.master_zonegroup);
+  if (zg == pmap.zonegroups.end()) {
+    return -EINVAL;
+  }
+  auto z = zg->second.zones.find(zg->second.master_zone);
+  if (z == zg->second.zones.end()) {
+    return -EINVAL;
+  }
+
+  RGWAccessKey creds;
+  if (auto i = user.access_keys.begin(); i != user.access_keys.end()) {
+    creds.id = i->first;
+    creds.key = i->second.key;
+  }
+
+  // use the master zone's endpoints
+  auto conn = RGWRESTConn{dpp->get_cct(), z->second.id, z->second.endpoints,
+                          std::move(creds), zg->second.id, zg->second.api_name};
+  bufferlist outdata;
+  constexpr size_t max_response_size = 128 * 1024; // we expect a very small response
+  int ret = conn.forward_iam_request(dpp, req, nullptr, max_response_size,
+                                     &indata, &outdata, y);
+  if (ret < 0) {
+    return ret;
+  }
+
+  std::string r = rgw_bl_str(outdata);
+  boost::replace_all(r, "&quot;", "\"");
+
+  if (!parser.parse(r.c_str(), r.length(), 1)) {
+    ldpp_dout(dpp, 0) << "ERROR: failed to parse response from master zonegroup" << dendl;
+    return -EIO;
+  }
+  return 0;
+}
+

--- a/src/rgw/rgw_rest_iam.h
+++ b/src/rgw/rgw_rest_iam.h
@@ -6,7 +6,21 @@
 #include "rgw_auth.h"
 #include "rgw_auth_filters.h"
 #include "rgw_rest.h"
+#include "rgw_xml.h"
 
+inline constexpr const char* RGW_REST_IAM_XMLNS =
+    "https://iam.amazonaws.com/doc/2010-05-08/";
+
+class DoutPrefixProvider;
+namespace rgw { class SiteConfig; }
+struct RGWUserInfo;
+
+int forward_iam_request_to_master(const DoutPrefixProvider* dpp,
+                                  const rgw::SiteConfig& site,
+                                  const RGWUserInfo& user,
+                                  bufferlist& indata,
+                                  RGWXMLDecoder::XMLParser& parser,
+                                  req_info& req, optional_yield y);
 class RGWHandler_REST_IAM : public RGWHandler_REST {
   const rgw::auth::StrategyRegistry& auth_registry;
   bufferlist bl_post_body;

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -18,6 +18,7 @@
 #include "common/dout.h"
 #include "rgw_url.h"
 #include "rgw_process_env.h"
+#include "rgw_rest_iam.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
@@ -257,10 +258,11 @@ class RGWPSCreateTopicOp : public RGWOp {
 
 void RGWPSCreateTopicOp::execute(optional_yield y) {
   // master request will replicate the topic creation.
-  bufferlist indata;
   if (!driver->is_meta_master()) {
-    op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->user->get_id(), &indata, nullptr, s->info, y);
+    bufferlist indata;
+    RGWXMLDecoder::XMLParser parser;
+    op_ret = forward_iam_request_to_master(
+        this, *s->penv.site, s->user->get_info(), indata, parser, s->info, y);
     if (op_ret < 0) {
       ldpp_dout(this, 1)
           << "CreateTopic forward_request_to_master returned ret = " << op_ret
@@ -689,8 +691,9 @@ class RGWPSSetTopicAttributesOp : public RGWOp {
 void RGWPSSetTopicAttributesOp::execute(optional_yield y) {
   if (!driver->is_meta_master()) {
     bufferlist indata;
-    op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->user->get_id(), &indata, nullptr, s->info, y);
+    RGWXMLDecoder::XMLParser parser;
+    op_ret = forward_iam_request_to_master(
+        this, *s->penv.site, s->user->get_info(), indata, parser, s->info, y);
     if (op_ret < 0) {
       ldpp_dout(this, 1)
           << "SetTopicAttributes forward_request_to_master returned ret = "
@@ -788,8 +791,9 @@ void RGWPSDeleteTopicOp::execute(optional_yield y) {
   }
   if (!driver->is_meta_master()) {
     bufferlist indata;
-    op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->user->get_id(), &indata, nullptr, s->info, y);
+    RGWXMLDecoder::XMLParser parser;
+    op_ret = forward_iam_request_to_master(
+        this, *s->penv.site, s->user->get_info(), indata, parser, s->info, y);
     if (op_ret < 0) {
       ldpp_dout(this, 1)
           << "DeleteTopic forward_request_to_master returned ret = " << op_ret
@@ -1004,8 +1008,10 @@ void RGWPSCreateNotifOp::execute(optional_yield y) {
     return;
   }
   if (!driver->is_meta_master()) {
-    op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->user->get_id(), &data, nullptr, s->info, y);
+    bufferlist indata;
+    RGWXMLDecoder::XMLParser parser;
+    op_ret = forward_iam_request_to_master(
+        this, *s->penv.site, s->user->get_info(), indata, parser, s->info, y);
     if (op_ret < 0) {
       ldpp_dout(this, 1) << "CreateBucketNotification "
                             "forward_request_to_master returned ret = "
@@ -1136,8 +1142,10 @@ void RGWPSCreateNotifOp::execute_v2(optional_yield y) {
     return;
   }
   if (!driver->is_meta_master()) {
-    op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->user->get_id(), &data, nullptr, s->info, y);
+    bufferlist indata;
+    RGWXMLDecoder::XMLParser parser;
+    op_ret = forward_iam_request_to_master(
+        this, *s->penv.site, s->user->get_info(), indata, parser, s->info, y);
     if (op_ret < 0) {
       ldpp_dout(this, 1) << "CreateBucketNotification "
                             "forward_request_to_master returned ret = "
@@ -1302,8 +1310,9 @@ void RGWPSDeleteNotifOp::execute(optional_yield y) {
   }
   if (!driver->is_meta_master()) {
     bufferlist indata;
-    op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->user->get_id(), &indata, nullptr, s->info, y);
+    RGWXMLDecoder::XMLParser parser;
+    op_ret = forward_iam_request_to_master(
+        this, *s->penv.site, s->user->get_info(), indata, parser, s->info, y);
     if (op_ret < 0) {
       ldpp_dout(this, 1) << "DeleteBucketNotification "
                             "forward_request_to_master returned error ret= "
@@ -1365,8 +1374,9 @@ void RGWPSDeleteNotifOp::execute_v2(optional_yield y) {
   }
   if (!driver->is_meta_master()) {
     bufferlist indata;
-    op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->user->get_id(), &indata, nullptr, s->info, y);
+    RGWXMLDecoder::XMLParser parser;
+    op_ret = forward_iam_request_to_master(
+        this, *s->penv.site, s->user->get_info(), indata, parser, s->info, y);
     if (op_ret < 0) {
       ldpp_dout(this, 1) << "DeleteBucketNotification "
                             "forward_request_to_master returned error ret= "


### PR DESCRIPTION
get 403 when tryingto forward request from 2ndary zone:
```
2024-02-12T20:39:30.643+0000 7ffee754b700 20 QUERY_STRING=Action=CreateTopic&Name=fishtopic&Version=2010-03-31&push-endpoint=kafka%3A%2F%2Flocalhost                                                                                         
2024-02-12T20:39:30.643+0000 7ffee754b700 20 REQUEST_URI=/?Action=CreateTopic&Name=fishtopic&Version=2010-03-31&push-endpoint=kafka%3A%2F%2Flocalhost                                                                                        
2024-02-12T20:39:30.643+0000 7ffee754b700 10 req 9951298151402851201 0.000000000s name: Action val: CreateTopic
2024-02-12T20:39:30.643+0000 7ffee754b700 10 req 9951298151402851201 0.000000000s name: Name val: fishtopic
2024-02-12T20:39:30.643+0000 7ffee754b700 20 req 9951298151402851201 0.000000000s get_handler handler=27RGWHandler_REST_PSTopic_AWS                                                                                                          
2024-02-12T20:39:30.643+0000 7ffee754b700 10 req 9951298151402851201 0.000000000s handler=27RGWHandler_REST_PSTopic_AWS                                                                                                                      
2024-02-12T20:39:30.643+0000 7ffee754b700 10 req 9951298151402851201 0.000000000s sns:pubsub_topic_create scheduling with throttler client=3 cost=1                                                                                          
2024-02-12T20:39:30.643+0000 7ffee754b700 10 req 9951298151402851201 0.000000000s sns:pubsub_topic_create op=18RGWPSCreateTopicOp                                                                                                            
2024-02-12T20:39:30.643+0000 7ffee754b700  2 req 9951298151402851201 0.000000000s sns:pubsub_topic_create verifying requester                                                                                                                
2024-02-12T20:39:30.643+0000 7ffee754b700 20 req 9951298151402851201 0.000000000s sns:pubsub_topic_create rgw::auth::StrategyRegistry::s3_main_strategy_t: trying rgw::auth::s3::AWSAuthStrategy                                             
2024-02-12T20:39:30.643+0000 7ffee754b700 20 req 9951298151402851201 0.000000000s sns:pubsub_topic_create rgw::auth::s3::AWSAuthStrategy: trying rgw::auth::s3::S3AnonymousEngine                                                            
2024-02-12T20:39:30.643+0000 7ffee754b700 20 req 9951298151402851201 0.000000000s sns:pubsub_topic_create rgw::auth::s3::S3AnonymousEngine denied with reason=-1                                                                             
2024-02-12T20:39:30.643+0000 7ffee754b700 20 req 9951298151402851201 0.000000000s sns:pubsub_topic_create rgw::auth::s3::AWSAuthStrategy: trying rgw::auth::s3::LocalEngine                                                                  
Action=CreateTopic&Name=fishtopic&Version=2010-03-31&push-endpoint=kafka%3A%2F%2Flocalhost
2024-02-12T20:39:30.643+0000 7ffee754b700 15 req 9951298151402851201 0.000000000s sns:pubsub_topic_create string_to_sign=AWS4-HMAC-SHA256                                                                                                    
2024-02-12T20:39:30.643+0000 7ffee754b700 15 req 9951298151402851201 0.000000000s sns:pubsub_topic_create server signature=180489e6fe76de5a313210a3ab48f08648bf893c53d7e0e07d47b96d040b8fff                                                  
2024-02-12T20:39:30.643+0000 7ffee754b700 15 req 9951298151402851201 0.000000000s sns:pubsub_topic_create client signature=36a99206219b003c0782c8133ab4d23a9cd93f8137a3ee90701ba2e5d92b8b70                                                  
2024-02-12T20:39:30.643+0000 7ffee754b700 15 req 9951298151402851201 0.000000000s sns:pubsub_topic_create compare=2
2024-02-12T20:39:30.643+0000 7ffee754b700 20 req 9951298151402851201 0.000000000s sns:pubsub_topic_create rgw::auth::s3::LocalEngine rejected with reason=-2027                                                                              
2024-02-12T20:39:30.643+0000 7ffee754b700 20 req 9951298151402851201 0.000000000s sns:pubsub_topic_create rgw::auth::s3::AWSAuthStrategy rejected with reason=-2027                                                                          
2024-02-12T20:39:30.643+0000 7ffee754b700  5 req 9951298151402851201 0.000000000s sns:pubsub_topic_create Failed the auth strategy, reason=-2027                                                                                             
2024-02-12T20:39:30.643+0000 7ffee754b700  2 req 9951298151402851201 0.000000000s sns:pubsub_topic_create op status=0
2024-02-12T20:39:30.643+0000 7ffee754b700  2 req 9951298151402851201 0.000000000s sns:pubsub_topic_create http status=403                                                                                                                    
2024-02-12T20:39:30.643+0000 7ffee754b700  1 beast: 0x7ffeb601e650: ::1 - - [12/Feb/2024:20:39:30.643 +0000] "POST /?Action=CreateTopic&Name=fishtopic&Version=2010-03-31&push-endpoint=kafka%3A%2F%2Flocalhost HTTP/1.1" 403 205 - - - latency=0.000000000s
```



## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
