### PR TITLE
systemd: do not pass --cluster option

### DIFF
--- a/systemd/ceph-fuse@.service.in
+++ b/systemd/ceph-fuse@.service.in
@@ -6,9 +6,8 @@ Conflicts=umount.target
 PartOf=ceph-fuse.target
 
 [Service]
-Environment=CLUSTER=ceph
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
-ExecStart=/usr/bin/ceph-fuse -f --cluster ${CLUSTER} %I
+ExecStart=/usr/bin/ceph-fuse -f %I
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true

--- a/systemd/ceph-immutable-object-cache@.service.in
+++ b/systemd/ceph-immutable-object-cache@.service.in
@@ -5,10 +5,9 @@ Wants=network-online.target local-fs.target
 PartOf=ceph-immutable-object-cache.target
 
 [Service]
-Environment=CLUSTER=ceph
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/ceph-immutable-object-cache -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStart=/usr/bin/ceph-immutable-object-cache -f --id %i --setuser ceph --setgroup ceph
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true

--- a/systemd/ceph-mds@.service.in
+++ b/systemd/ceph-mds@.service.in
@@ -6,10 +6,9 @@ Before=remote-fs-pre.target ceph-mds.target
 Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.target ceph-mds.target
 
 [Service]
-Environment=CLUSTER=ceph
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStart=/usr/bin/ceph-mds -f --id %i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LockPersonality=true

--- a/systemd/ceph-mgr@.service.in
+++ b/systemd/ceph-mgr@.service.in
@@ -6,10 +6,9 @@ Before=remote-fs-pre.target ceph-mgr.target
 Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.target ceph-mgr.target
 
 [Service]
-Environment=CLUSTER=ceph
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/ceph-mgr -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStart=/usr/bin/ceph-mgr -f --id %i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LockPersonality=true

--- a/systemd/ceph-mon@.service.in
+++ b/systemd/ceph-mon@.service.in
@@ -10,10 +10,9 @@ Before=remote-fs-pre.target ceph-mon.target
 Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.target ceph-mon.target
 
 [Service]
-Environment=CLUSTER=ceph
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStart=/usr/bin/ceph-mon -f --id %i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LockPersonality=true

--- a/systemd/ceph-osd@.service.in
+++ b/systemd/ceph-osd@.service.in
@@ -6,11 +6,10 @@ Before=remote-fs-pre.target ceph-osd.target
 Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.target ceph-osd.target
 
 [Service]
-Environment=CLUSTER=ceph
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
-ExecStartPre=@CMAKE_INSTALL_FULL_LIBEXECDIR@/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
+ExecStart=/usr/bin/ceph-osd -f --id %i --setuser ceph --setgroup ceph
+ExecStartPre=@CMAKE_INSTALL_FULL_LIBEXECDIR@/ceph/ceph-osd-prestart.sh --id %i
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LockPersonality=true

--- a/systemd/ceph-radosgw@.service.in
+++ b/systemd/ceph-radosgw@.service.in
@@ -6,9 +6,8 @@ Before=remote-fs-pre.target ceph-radosgw.target
 Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.target ceph-radosgw.target
 
 [Service]
-Environment=CLUSTER=ceph
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
-ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} --name client.%i --setuser ceph --setgroup ceph
+ExecStart=/usr/bin/radosgw -f --name client.%i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LockPersonality=true

--- a/systemd/ceph-rbd-mirror@.service.in
+++ b/systemd/ceph-rbd-mirror@.service.in
@@ -5,10 +5,9 @@ Wants=network-online.target local-fs.target
 PartOf=ceph-rbd-mirror.target
 
 [Service]
-Environment=CLUSTER=ceph
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/rbd-mirror -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
+ExecStart=/usr/bin/rbd-mirror -f --id %i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LockPersonality=true

--- a/systemd/cephfs-mirror@.service.in
+++ b/systemd/cephfs-mirror@.service.in
@@ -5,9 +5,8 @@ Wants=network-online.target local-fs.target
 PartOf=cephfs-mirror.target
 
 [Service]
-Environment=CLUSTER=ceph
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
-ExecStart=/usr/bin/cephfs-mirror --id %i --cluster ${CLUSTER} -f --setuser ceph --setgroup ceph
+ExecStart=/usr/bin/cephfs-mirror --id %i -f --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LockPersonality=true


### PR DESCRIPTION
we do not encourage user to run multiple cluster using different cluster name since 8fe460e7562b28e007179eeb533ef68a3e99b4c8, and the recommended way is to use cephadm. see also
https://docs.ceph.com/en/latest/rados/configuration/common/#naming-clusters-deprecated, so let's stop passing `--cluster` in systemd service units. there are more places where we are still feeding this optoin to command line tools or services. we should do the cleanup piecemeal to reduce the potential risk.

FWIW, if not specified, the cluster name is "ceph" by default.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
