### PR TITLE
mon: make unsupported ec profiles experimental

### DIFF
--- a/doc/rados/operations/erasure-code-jerasure.rst
+++ b/doc/rados/operations/erasure-code-jerasure.rst
@@ -29,6 +29,7 @@ To create a new *jerasure* erasure code profile:
      [crush-device-class={device-class}] \
      [directory={directory}] \
      [--force]
+     [--allow-experimental-ec-profile]
 
 Where:
 

--- a/qa/erasure-code/ec-rados-plugin=clay-k=4-m=2.yaml
+++ b/qa/erasure-code/ec-rados-plugin=clay-k=4-m=2.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        enable experimental unrecoverable data corrupting features: experimental_ec_profiles
 tasks:
 - rados:
     clients: [client.0]

--- a/qa/erasure-code/ec-rados-plugin=lrc-k=4-m=2-l=3.yaml
+++ b/qa/erasure-code/ec-rados-plugin=lrc-k=4-m=2-l=3.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        enable experimental unrecoverable data corrupting features: experimental_ec_profiles
 tasks:
 - rados:
     clients: [client.0]

--- a/qa/erasure-code/ec-rados-plugin=shec-k=4-m=3-c=2.yaml
+++ b/qa/erasure-code/ec-rados-plugin=shec-k=4-m=3-c=2.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        enable experimental unrecoverable data corrupting features: experimental_ec_profiles
 tasks:
 - rados:
     clients: [client.0]

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -2102,8 +2102,13 @@ class CephManager:
         Create an erasure code profile name that can be used as a parameter
         when creating an erasure coded pool.
         """
+        allow_experimental = self.ceph_manager.raw_cluster_cmd('config', 'get', 'mon.*',
+                           'enable_experimental_unrecoverable_data_corrupting_features')
         with self.lock:
-            args = cmd_erasure_code_profile(profile_name, profile)
+            if allow_experimental:
+                args = cmd_erasure_code_profile(profile_name, profile, True)
+            else:
+                args = cmd_erasure_code_profile(profile_name, profile)
             self.raw_cluster_cmd(*args)
 
     def create_pool_with_unique_name(self, pg_num=16,

--- a/qa/tasks/util/rados.py
+++ b/qa/tasks/util/rados.py
@@ -54,13 +54,14 @@ def create_cache_pool(remote, base_name, cache_name, pgnum, size, cluster_name="
         str(size), '--cluster', cluster_name
     ])
 
-def cmd_erasure_code_profile(profile_name, profile):
+def cmd_erasure_code_profile(profile_name, profile, allow_experimental=False):
     """
     Return the shell command to run to create the erasure code profile
     described by the profile parameter.
     
     :param profile_name: a string matching [A-Za-z0-9-_.]+
     :param profile: a map whose semantic depends on the erasure code plugin
+    :param allow_experimental: an optional setting to allow experimental ec profiles
     :returns: a shell command as an array suitable for Remote.run
 
     If profile is {}, it is replaced with 
@@ -81,7 +82,10 @@ def cmd_erasure_code_profile(profile_name, profile):
             'm': '1',
             'crush-failure-domain': 'osd'
         }
-    return [
+    cmd = [
         'osd', 'erasure-code-profile', 'set',
         profile_name
         ] + [ str(key) + '=' + str(value) for key, value in profile.items() ]
+    if allow_experimental:
+        cmd += [ '--allow-experimental-ec-profile']
+    return cmd

--- a/src/erasure-code/ErasureCode.h
+++ b/src/erasure-code/ErasureCode.h
@@ -115,6 +115,27 @@ namespace ceph {
     int decode_concat(const std::map<int, bufferlist> &chunks,
 			      bufferlist *decoded) override;
 
+   /**
+   * is_supported_profile
+   *
+   * We only test a limited subset of implemented plugin/technique combinations. Combinations for
+   * which this function returns false will be rejected unless the "experimental_ec_profiles" experimental
+   * feature is enabled.  See the "osd erasure-code-profile set" handler in
+   * OSDMonitor::prepare_command_impl. As new plugin/techique combinations are declared stable,
+   * this function should be updated.
+   */
+    static bool is_supported_profile(const std::map<std::string, std::string> &profile_map) {
+
+      auto plugin = profile_map.find("plugin");
+      auto technique = profile_map.find("technique");
+      if ((plugin == profile_map.end()) || (technique == profile_map.end())) {
+	return false;
+      }
+
+      return ((plugin->second == "jerasure") && (technique->second == "reed_sol_van")) ||
+	     ((plugin->second == "isa") && (technique->second == "reed_sol_van"));
+    }
+
   protected:
     int parse(const ErasureCodeProfile &profile,
 	      std::ostream *ss);

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -849,7 +849,8 @@ COMMAND("osd unpause", "unpause osd", "osd", "rw")
 COMMAND("osd erasure-code-profile set "
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] "
 	"name=profile,type=CephString,n=N,req=false "
-	"name=force,type=CephBool,req=false",
+	"name=force,type=CephBool,req=false "
+	"name=allow_experimental_ec_profile,type=CephBool,req=false",
 	"create erasure code profile <name> with [<key[=value]> ...] pairs. Add a --force at the end to override an existing profile (VERY DANGEROUS)",
 	"osd", "rw")
 COMMAND("osd erasure-code-profile get "

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -68,6 +68,7 @@
 #include "common/config.h"
 #include "common/errno.h"
 
+#include "erasure-code/ErasureCode.h"
 #include "erasure-code/ErasureCodePlugin.h"
 #include "compressor/Compressor.h"
 #include "common/Checksummer.h"
@@ -11312,6 +11313,26 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 	     << existing_profile_map
 	     << " is different from the proposed profile "
 	     << profile_map;
+	  goto reply_no_propose;
+	}
+      }
+
+      bool allow_experimental = false;
+      cmd_getval(cmdmap, "allow_experimental_ec_profile", allow_experimental);
+
+      bool supported_profile = ErasureCode::is_supported_profile(profile_map);
+      bool experimental_enabled =
+	g_ceph_context->check_experimental_feature_enabled("experimental_ec_profiles");
+      if (!supported_profile) {
+	if (!allow_experimental || !experimental_enabled) {
+	  ss << "This ec plugin or technique is considered experimental, and as such is not "
+	     << "recommended (see https://tracker.ceph.com/issues/63876 for a related "
+	     << "data corruption issue concerning the blaum_roth technique). Current supported "
+	     << "profiles include 'jerasure' and 'isa', and current supported techniques include "
+	     << "'reed_sol_van'. If you are sure you want to use this profile, add "
+	     << "'experimental_ec_profiles' to the experimental features config and add "
+	     << "--allow-experimental-ec-profile to the mon command.";
+	  err = -EPERM;
 	  goto reply_no_propose;
 	}
       }


### PR DESCRIPTION
As the blaum_roth technique is shown to cause data corruption in some scenarios (see https://tracker.ceph.com/issues/63876), it makes sense to make any unsupported ec plugin or technique an experimental feature until support is added.
    
With this patch, setting an ec profile with any plugin other than 'jerasure' or 'isa', or any technique other than 'reed_sol_van', for example with this command:
```
ceph osd erasure-code-profile set erasure_k4_m2 plugin=jerasure k=4 m=2 technique=blaum_roth crush-device-class=hdd
```
will issue a warning to users, pointing to https://tracker.ceph.com/issues/63876. The user must add "experimental_ec_profiles" to experimental features either by adding it to their ceph.conf file, or during runtime with this command:
```
ceph config set global enable_experimental_unrecoverable_data_corrupting_features experimental_ec_profiles
```
    
The user must also add the `--allow-experimental-ec-profile` flag to the mon command.

Fixes: https://tracker.ceph.com/issues/64419





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
