### PR TITLE
rgw/putobj: RadosWriter uses part head object for multipart parts

### DIFF
--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -124,6 +124,11 @@ void RadosWriter::add_write_hint(librados::ObjectWriteOperation& op) {
   op.set_alloc_hint2(0, 0, alloc_hint_flags);
 }
 
+void RadosWriter::set_head_obj(const rgw_obj& head)
+{
+  head_obj = head;
+}
+
 int RadosWriter::set_stripe_obj(const rgw_raw_obj& raw_obj)
 {
   return rgw_get_rados_ref(dpp, store->get_rados_handle(), raw_obj,
@@ -457,6 +462,9 @@ int MultipartObjectProcessor::prepare_head()
   rgw_raw_obj stripe_obj = manifest_gen.get_cur_obj(store);
   RGWSI_Tier_RADOS::raw_obj_to_obj(head_obj.bucket, stripe_obj, &head_obj);
   head_obj.index_hash_source = target_obj.key.name;
+
+  // point part uploads at the part head instead of the final multipart head
+  writer.set_head_obj(head_obj);
 
   r = writer.set_stripe_obj(stripe_obj);
   if (r < 0) {

--- a/src/rgw/driver/rados/rgw_putobj_processor.h
+++ b/src/rgw/driver/rados/rgw_putobj_processor.h
@@ -68,7 +68,7 @@ class RadosWriter : public rgw::sal::DataProcessor {
   RGWRados *const store;
   const RGWBucketInfo& bucket_info;
   RGWObjectCtx& obj_ctx;
-  const rgw_obj head_obj;
+  rgw_obj head_obj;
   rgw_rados_ref stripe_obj; // current stripe object
   RawObjSet written; // set of written objects for deletion
   const DoutPrefixProvider *dpp;
@@ -86,6 +86,9 @@ class RadosWriter : public rgw::sal::DataProcessor {
 
   // add alloc hint to osd
   void add_write_hint(librados::ObjectWriteOperation& op);
+
+  // change the head object
+  void set_head_obj(const rgw_obj& head);
 
   // change the current stripe object
   int set_stripe_obj(const rgw_raw_obj& obj);


### PR DESCRIPTION
the cleanup logic in the RadosWrite destructor was using the wrong `head_obj` to avoid races between cleanup and part re-uploads. it pointed at the final location of the multipart upload, rather than the head object of the current part

Fixes: https://tracker.ceph.com/issues/63642

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
