### PR TITLE
pacific: rgw/putobj: RadosWriter uses part head object for multipart parts

### DIFF
--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -104,6 +104,9 @@ class RadosWriter : public DataProcessor {
 
   ~RadosWriter();
 
+  // change the head object
+  void set_head_obj(std::unique_ptr<rgw::sal::RGWObject> head);
+
   // change the current stripe object
   int set_stripe_obj(const rgw_raw_obj& obj);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64427

---

backport of https://github.com/ceph/ceph/pull/55582
parent tracker: https://tracker.ceph.com/issues/63642

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh