### PR TITLE
rgw/iam: refactor OpenIDConnectProvider rest and sal APIs

### DIFF
--- a/src/rgw/driver/d4n/rgw_sal_d4n.h
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.h
@@ -17,7 +17,6 @@
 
 #include "rgw_sal_filter.h"
 #include "rgw_sal.h"
-#include "rgw_oidc_provider.h"
 #include "rgw_role.h"
 #include "common/dout.h" 
 

--- a/src/rgw/driver/daos/rgw_sal_daos.cc
+++ b/src/rgw/driver/daos/rgw_sal_daos.cc
@@ -2100,14 +2100,32 @@ int DaosStore::get_roles(const DoutPrefixProvider* dpp, optional_yield y,
   return DAOS_NOT_IMPLEMENTED_LOG(dpp);
 }
 
-std::unique_ptr<RGWOIDCProvider> DaosStore::get_oidc_provider() {
-  RGWOIDCProvider* p = nullptr;
-  return std::unique_ptr<RGWOIDCProvider>(p);
+int DaosStore::store_oidc_provider(const DoutPrefixProvider* dpp,
+                                   optional_yield y,
+                                   const RGWOIDCProviderInfo& info,
+                                   bool exclusive) {
+  return DAOS_NOT_IMPLEMENTED_LOG(dpp);
 }
 
-int DaosStore::get_oidc_providers(
-    const DoutPrefixProvider* dpp, const std::string& tenant,
-    vector<std::unique_ptr<RGWOIDCProvider>>& providers) {
+int DaosStore::load_oidc_provider(const DoutPrefixProvider* dpp,
+                                  optional_yield y,
+                                  std::string_view tenant,
+                                  std::string_view url,
+                                  RGWOIDCProviderInfo& info) {
+  return DAOS_NOT_IMPLEMENTED_LOG(dpp);
+}
+
+int DaosStore::delete_oidc_provider(const DoutPrefixProvider* dpp,
+                                    optional_yield y,
+                                    std::string_view tenant,
+                                    std::string_view url) {
+  return DAOS_NOT_IMPLEMENTED_LOG(dpp);
+}
+
+int DaosStore::get_oidc_providers(const DoutPrefixProvider* dpp,
+                                  optional_yield y,
+                                  std::string_view tenant,
+                                  std::vector<RGWOIDCProviderInfo>& providers) {
   return DAOS_NOT_IMPLEMENTED_LOG(dpp);
 }
 

--- a/src/rgw/driver/daos/rgw_sal_daos.h
+++ b/src/rgw/driver/daos/rgw_sal_daos.h
@@ -28,7 +28,6 @@
 
 #include "rgw_multi.h"
 #include "rgw_notify.h"
-#include "rgw_oidc_provider.h"
 #include "rgw_putobj_processor.h"
 #include "rgw_rados.h"
 #include "rgw_role.h"
@@ -994,10 +993,23 @@ class DaosStore : public StoreDriver {
                         const std::string& path_prefix,
                         const std::string& tenant,
                         std::vector<std::unique_ptr<RGWRole>>& roles) override;
-  virtual std::unique_ptr<RGWOIDCProvider> get_oidc_provider() override;
-  virtual int get_oidc_providers(
-      const DoutPrefixProvider* dpp, const std::string& tenant,
-      std::vector<std::unique_ptr<RGWOIDCProvider>>& providers) override;
+  int store_oidc_provider(const DoutPrefixProvider* dpp,
+                          optional_yield y,
+                          const RGWOIDCProviderInfo& info,
+                          bool exclusive) override;
+  int load_oidc_provider(const DoutPrefixProvider* dpp,
+                         optional_yield y,
+                         std::string_view tenant,
+                         std::string_view url,
+                         RGWOIDCProviderInfo& info) override;
+  int delete_oidc_provider(const DoutPrefixProvider* dpp,
+                           optional_yield y,
+                           std::string_view tenant,
+                           std::string_view url) override;
+  int get_oidc_providers(const DoutPrefixProvider* dpp,
+                         optional_yield y,
+                         std::string_view tenant,
+                         std::vector<RGWOIDCProviderInfo>& providers) override;
   virtual std::unique_ptr<Writer> get_append_writer(
       const DoutPrefixProvider* dpp, optional_yield y,
       rgw::sal::Object* obj, const rgw_user& owner,

--- a/src/rgw/driver/motr/rgw_sal_motr.cc
+++ b/src/rgw/driver/motr/rgw_sal_motr.cc
@@ -3057,17 +3057,37 @@ int MotrStore::get_roles(const DoutPrefixProvider *dpp,
   return 0;
 }
 
-std::unique_ptr<RGWOIDCProvider> MotrStore::get_oidc_provider()
+int DaosStore::store_oidc_provider(const DoutPrefixProvider* dpp,
+                                   optional_yield y,
+                                   const RGWOIDCProviderInfo& info,
+                                   bool exclusive)
 {
-  RGWOIDCProvider* p = nullptr;
-  return std::unique_ptr<RGWOIDCProvider>(p);
+  return -ENOTSUP;
 }
 
-int MotrStore::get_oidc_providers(const DoutPrefixProvider *dpp,
-    const std::string& tenant,
-    vector<std::unique_ptr<RGWOIDCProvider>>& providers)
+int DaosStore::load_oidc_provider(const DoutPrefixProvider* dpp,
+                                  optional_yield y,
+                                  std::string_view tenant,
+                                  std::string_view url,
+                                  RGWOIDCProviderInfo& info)
 {
-  return 0;
+  return -ENOTSUP;
+}
+
+int DaosStore::delete_oidc_provider(const DoutPrefixProvider* dpp,
+                                    optional_yield y,
+                                    std::string_view tenant,
+                                    std::string_view url)
+{
+  return -ENOTSUP;
+}
+
+int DaosStore::get_oidc_providers(const DoutPrefixProvider* dpp,
+                                  optional_yield y,
+                                  std::string_view tenant,
+                                  std::vector<RGWOIDCProviderInfo>& providers)
+{
+  return -ENOTSUP;
 }
 
 std::unique_ptr<MultipartUpload> MotrBucket::get_multipart_upload(const std::string& oid,

--- a/src/rgw/rgw_oidc_provider.cc
+++ b/src/rgw/rgw_oidc_provider.cc
@@ -1,182 +1,41 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
-#include <errno.h>
-#include <ctime>
-#include <regex>
-
-#include "common/errno.h"
-#include "common/Formatter.h"
-#include "common/ceph_json.h"
-#include "common/ceph_time.h"
-#include "rgw_rados.h"
-#include "rgw_zone.h"
-
-#include "include/types.h"
-#include "rgw_string.h"
-
-#include "rgw_common.h"
-#include "rgw_tools.h"
 #include "rgw_oidc_provider.h"
-
-#include "services/svc_zone.h"
-#include "services/svc_sys_obj.h"
 
 #define dout_subsys ceph_subsys_rgw
 
-using namespace std;
-
-namespace rgw { namespace sal {
-
-const string RGWOIDCProvider::oidc_url_oid_prefix = "oidc_url.";
-const string RGWOIDCProvider::oidc_arn_prefix = "arn:aws:iam::";
-
-int RGWOIDCProvider::get_tenant_url_from_arn(string& tenant, string& url)
+void RGWOIDCProviderInfo::dump(Formatter *f) const
 {
-  auto provider_arn = rgw::ARN::parse(arn);
-  if (!provider_arn) {
-    return -EINVAL;
-  }
-  url = provider_arn->resource;
-  tenant = provider_arn->account;
-  auto pos = url.find("oidc-provider/");
-  if (pos != std::string::npos) {
-    url.erase(pos, 14);
-  }
-  return 0;
+  encode_json("id", id, f);
+  encode_json("provider_url", provider_url, f);
+  encode_json("arn", arn, f);
+  encode_json("creation_date", creation_date, f);
+  encode_json("tenant", tenant, f);
+  encode_json("client_ids", client_ids, f);
+  encode_json("thumbprints", thumbprints, f);
 }
 
-int RGWOIDCProvider::create(const DoutPrefixProvider *dpp, bool exclusive, optional_yield y)
+void RGWOIDCProviderInfo::decode_json(JSONObj *obj)
 {
-  int ret;
-
-  if (! validate_input(dpp)) {
-    return -EINVAL;
-  }
-
-  string idp_url = url_remove_prefix(provider_url);
-
-  /* check to see the name is not used */
-  ret = read_url(dpp, idp_url, tenant, y);
-  if (exclusive && ret == 0) {
-    ldpp_dout(dpp, 0) << "ERROR: url " << provider_url << " already in use"
-                    << id << dendl;
-    return -EEXIST;
-  } else if ( ret < 0 && ret != -ENOENT) {
-    ldpp_dout(dpp, 0) << "failed reading provider url  " << provider_url << ": "
-                  << cpp_strerror(-ret) << dendl;
-    return ret;
-  }
-
-  //arn
-  arn = oidc_arn_prefix + tenant + ":oidc-provider/" + idp_url;
-
-  // Creation time
-  real_clock::time_point t = real_clock::now();
-
-  struct timeval tv;
-  real_clock::to_timeval(t, tv);
-
-  char buf[30];
-  struct tm result;
-  gmtime_r(&tv.tv_sec, &result);
-  strftime(buf,30,"%Y-%m-%dT%H:%M:%S", &result);
-  sprintf(buf + strlen(buf),".%dZ",(int)tv.tv_usec/1000);
-  creation_date.assign(buf, strlen(buf));
-
-  ret = store_url(dpp, idp_url, exclusive, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR:  storing role info in OIDC pool: "
-                  << provider_url << ": " << cpp_strerror(-ret) << dendl;
-    return ret;
-  }
-
-  return 0;
+  JSONDecoder::decode_json("id", id, obj);
+  JSONDecoder::decode_json("provider_url", provider_url, obj);
+  JSONDecoder::decode_json("arn", arn, obj);
+  JSONDecoder::decode_json("creation_date", creation_date, obj);
+  JSONDecoder::decode_json("tenant", tenant, obj);
+  JSONDecoder::decode_json("client_ids", client_ids, obj);
+  JSONDecoder::decode_json("thumbprints", thumbprints, obj);
 }
 
-int RGWOIDCProvider::get(const DoutPrefixProvider *dpp, optional_yield y)
+void RGWOIDCProviderInfo::generate_test_instances(std::list<RGWOIDCProviderInfo*>& l)
 {
-  string url, tenant;
-  auto ret = get_tenant_url_from_arn(tenant, url);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: failed to parse arn" << dendl;
-    return -EINVAL;
-  }
-
-  if (this->tenant != tenant) {
-    ldpp_dout(dpp, 0) << "ERROR: tenant in arn doesn't match that of user " << this->tenant << ", "
-                  << tenant << ": " << dendl;
-    return -EINVAL;
-  }
-
-  ret = read_url(dpp, url, tenant, y);
-  if (ret < 0) {
-    return ret;
-  }
-
-  return 0;
+  auto p = new RGWOIDCProviderInfo;
+  p->id = "id";
+  p->provider_url = "server.example.com";
+  p->arn = "arn:aws:iam::acct:oidc-provider/server.example.com";
+  p->creation_date = "someday";
+  p->client_ids = {"a", "b"};
+  p->thumbprints = {"c", "d"};
+  l.push_back(p);
+  l.push_back(new RGWOIDCProviderInfo);
 }
-
-void RGWOIDCProvider::dump(Formatter *f) const
-{
-  encode_json("OpenIDConnectProviderArn", arn, f);
-}
-
-void RGWOIDCProvider::dump_all(Formatter *f) const
-{
-  f->open_object_section("ClientIDList");
-  for (auto it : client_ids) {
-    encode_json("member", it, f);
-  }
-  f->close_section();
-  encode_json("CreateDate", creation_date, f);
-  f->open_object_section("ThumbprintList");
-  for (auto it : thumbprints) {
-    encode_json("member", it, f);
-  }
-  f->close_section();
-  encode_json("Url", provider_url, f);
-}
-
-void RGWOIDCProvider::decode_json(JSONObj *obj)
-{
-  JSONDecoder::decode_json("OpenIDConnectProviderArn", arn, obj);
-}
-
-bool RGWOIDCProvider::validate_input(const DoutPrefixProvider *dpp)
-{
-  if (provider_url.length() > MAX_OIDC_URL_LEN) {
-    ldpp_dout(dpp, 0) << "ERROR: Invalid length of url " << dendl;
-    return false;
-  }
-  if (client_ids.size() > MAX_OIDC_NUM_CLIENT_IDS) {
-    ldpp_dout(dpp, 0) << "ERROR: Invalid number of client ids " << dendl;
-    return false;
-  }
-
-  for (auto& it : client_ids) {
-    if (it.length() > MAX_OIDC_CLIENT_ID_LEN) {
-      return false;
-    }
-  }
-
-  if (thumbprints.size() > MAX_OIDC_NUM_THUMBPRINTS) {
-    ldpp_dout(dpp, 0) << "ERROR: Invalid number of thumbprints " << thumbprints.size() << dendl;
-    return false;
-  }
-
-  for (auto& it : thumbprints) {
-    if (it.length() > MAX_OIDC_THUMBPRINT_LEN) {
-      return false;
-    }
-  }
-  
-  return true;
-}
-
-const string& RGWOIDCProvider::get_url_oid_prefix()
-{
-  return oidc_url_oid_prefix;
-}
-
-} } // namespace rgw::sal

--- a/src/rgw/rgw_oidc_provider.h
+++ b/src/rgw/rgw_oidc_provider.h
@@ -3,27 +3,14 @@
 
 #pragma once
 
+#include <list>
 #include <string>
+#include <vector>
 
-#include "common/ceph_context.h"
 #include "common/ceph_json.h"
 
-#include "rgw/rgw_sal.h"
-
-namespace rgw { namespace sal {
-
-class RGWOIDCProvider
+struct RGWOIDCProviderInfo
 {
-public:
-  static const std::string oidc_url_oid_prefix;
-  static const std::string oidc_arn_prefix;
-  static constexpr int MAX_OIDC_NUM_CLIENT_IDS = 100;
-  static constexpr int MAX_OIDC_CLIENT_ID_LEN = 255;
-  static constexpr int MAX_OIDC_NUM_THUMBPRINTS = 5;
-  static constexpr int MAX_OIDC_THUMBPRINT_LEN = 40;
-  static constexpr int MAX_OIDC_URL_LEN = 255;
-
-protected:
   std::string id;
   std::string provider_url;
   std::string arn;
@@ -31,51 +18,6 @@ protected:
   std::string tenant;
   std::vector<std::string> client_ids;
   std::vector<std::string> thumbprints;
-
-  int get_tenant_url_from_arn(std::string& tenant, std::string& url);
-  virtual int store_url(const DoutPrefixProvider *dpp, const std::string& url, bool exclusive, optional_yield y) = 0;
-  virtual int read_url(const DoutPrefixProvider *dpp, const std::string& url, const std::string& tenant, optional_yield y) = 0;
-  bool validate_input(const DoutPrefixProvider *dpp);
-
-public:
-  void set_arn(std::string _arn) {
-    arn = _arn;
-  }
-  void set_url(std::string _provider_url) {
-    provider_url = _provider_url;
-  }
-  void set_tenant(std::string _tenant) {
-    tenant = _tenant;
-  }
-  void set_client_ids(std::vector<std::string>& _client_ids) {
-    client_ids = std::move(_client_ids);
-  }
-  void set_thumbprints(std::vector<std::string>& _thumbprints) {
-    thumbprints = std::move(_thumbprints);
-  }
-
-  RGWOIDCProvider(std::string provider_url,
-                    std::string tenant,
-                    std::vector<std::string> client_ids,
-                    std::vector<std::string> thumbprints)
-  : provider_url(std::move(provider_url)),
-    tenant(std::move(tenant)),
-    client_ids(std::move(client_ids)),
-    thumbprints(std::move(thumbprints)) {
-  }
-
-  RGWOIDCProvider( std::string arn,
-                    std::string tenant)
-  : arn(std::move(arn)),
-    tenant(std::move(tenant)) {
-  }
-
-  RGWOIDCProvider(std::string tenant)
-  : tenant(std::move(tenant)) {}
-
-  RGWOIDCProvider() {}
-
-  virtual ~RGWOIDCProvider() = default;
 
   void encode(bufferlist& bl) const {
     ENCODE_START(3, 1, bl);
@@ -90,7 +32,7 @@ public:
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     decode(id, bl);
     decode(provider_url, bl);
     decode(arn, bl);
@@ -101,21 +43,8 @@ public:
     DECODE_FINISH(bl);
   }
 
-  const std::string& get_provider_url() const { return provider_url; }
-  const std::string& get_arn() const { return arn; }
-  const std::string& get_create_date() const { return creation_date; }
-  const std::vector<std::string>& get_client_ids() const { return client_ids;}
-  const std::vector<std::string>& get_thumbprints() const { return thumbprints; }
-
-  int create(const DoutPrefixProvider *dpp, bool exclusive, optional_yield y);
-  virtual int delete_obj(const DoutPrefixProvider *dpp, optional_yield y) = 0;
-  int get(const DoutPrefixProvider *dpp, optional_yield y);
   void dump(Formatter *f) const;
-  void dump_all(Formatter *f) const;
   void decode_json(JSONObj *obj);
-
-  static const std::string& get_url_oid_prefix();
+  static void generate_test_instances(std::list<RGWOIDCProviderInfo*>& l);
 };
-WRITE_CLASS_ENCODER(RGWOIDCProvider)
-
-} } // namespace rgw::sal
+WRITE_CLASS_ENCODER(RGWOIDCProviderInfo)

--- a/src/rgw/rgw_rest_oidc_provider.h
+++ b/src/rgw/rgw_rest_oidc_provider.h
@@ -22,9 +22,7 @@ public:
 };
 
 class RGWCreateOIDCProvider : public RGWRestOIDCProvider {
-  std::vector<std::string> client_ids;
-  std::vector<std::string> thumbprints;
-  std::string provider_url; //'iss' field in JWT
+  RGWOIDCProviderInfo info;
  public:
   RGWCreateOIDCProvider();
 
@@ -35,7 +33,7 @@ class RGWCreateOIDCProvider : public RGWRestOIDCProvider {
 };
 
 class RGWDeleteOIDCProvider : public RGWRestOIDCProvider {
-  std::string provider_arn;
+  std::string url;
  public:
   RGWDeleteOIDCProvider();
 
@@ -46,7 +44,7 @@ class RGWDeleteOIDCProvider : public RGWRestOIDCProvider {
 };
 
 class RGWGetOIDCProvider : public RGWRestOIDCProvider {
-  std::string provider_arn;
+  std::string url;
  public:
   RGWGetOIDCProvider();
 

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -40,7 +40,9 @@ class WebTokenEngine : public rgw::auth::Engine {
 
   bool is_cert_valid(const std::vector<std::string>& thumbprints, const std::string& cert) const;
 
-  std::unique_ptr<rgw::sal::RGWOIDCProvider> get_provider(const DoutPrefixProvider *dpp, const std::string& role_arn, const std::string& iss, optional_yield y) const;
+  int load_provider(const DoutPrefixProvider *dpp, optional_yield y,
+                    const std::string& role_arn, const std::string& iss,
+                    RGWOIDCProviderInfo& info) const;
 
   std::string get_role_tenant(const std::string& role_arn) const;
 

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -44,6 +44,7 @@ class RGWCompressionInfo;
 struct rgw_pubsub_topics;
 struct rgw_pubsub_bucket_topics;
 class RGWZonePlacementInfo;
+struct RGWOIDCProviderInfo;
 
 
 using RGWBucketListNameFilter = std::function<bool (const std::string&)>;
@@ -182,7 +183,6 @@ namespace rgw { namespace sal {
 
 struct MPSerializer;
 class GCChain;
-class RGWOIDCProvider;
 class RGWRole;
 
 enum AttrsMod {
@@ -390,12 +390,24 @@ class Driver {
 			  const std::string& path_prefix,
 			  const std::string& tenant,
 			  std::vector<std::unique_ptr<RGWRole>>& roles) = 0;
-    /** Get an empty Open ID Connector provider */
-    virtual std::unique_ptr<RGWOIDCProvider> get_oidc_provider() = 0;
+    virtual int store_oidc_provider(const DoutPrefixProvider* dpp,
+                                    optional_yield y,
+                                    const RGWOIDCProviderInfo& info,
+                                    bool exclusive) = 0;
+    virtual int load_oidc_provider(const DoutPrefixProvider* dpp,
+                                   optional_yield y,
+                                   std::string_view tenant,
+                                   std::string_view url,
+                                   RGWOIDCProviderInfo& info) = 0;
+    virtual int delete_oidc_provider(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view tenant,
+                                     std::string_view url) = 0;
     /** Get all Open ID Connector providers, optionally filtered by tenant  */
-    virtual int get_oidc_providers(const DoutPrefixProvider *dpp,
-				   const std::string& tenant,
-				   std::vector<std::unique_ptr<RGWOIDCProvider>>& providers, optional_yield y) = 0;
+    virtual int get_oidc_providers(const DoutPrefixProvider* dpp,
+                                   optional_yield y,
+                                   std::string_view tenant,
+                                   std::vector<RGWOIDCProviderInfo>& providers) = 0;
     /** Get a Writer that appends to an object */
     virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1436,15 +1436,34 @@ namespace rgw::sal {
     return 0;
   }
 
-  std::unique_ptr<RGWOIDCProvider> DBStore::get_oidc_provider()
+  int DBStore::store_oidc_provider(const DoutPrefixProvider *dpp,
+                                   optional_yield y,
+                                   const RGWOIDCProviderInfo& info,
+                                   bool exclusive)
   {
-    RGWOIDCProvider* p = nullptr;
-    return std::unique_ptr<RGWOIDCProvider>(p);
+    return -ENOTSUP;
+  }
+
+  int DBStore::load_oidc_provider(const DoutPrefixProvider *dpp,
+                                  optional_yield y,
+                                  std::string_view account,
+                                  std::string_view url,
+                                  RGWOIDCProviderInfo& info)
+  {
+    return -ENOTSUP;
+  }
+
+  int DBStore::delete_oidc_provider(const DoutPrefixProvider *dpp,
+                                    optional_yield y,
+                                    std::string_view account,
+                                    std::string_view url)
+  {
+    return -ENOTSUP;
   }
 
   int DBStore::get_oidc_providers(const DoutPrefixProvider *dpp,
-      const std::string& tenant,
-      vector<std::unique_ptr<RGWOIDCProvider>>& providers, optional_yield y)
+      optional_yield y, std::string_view tenant,
+      vector<RGWOIDCProviderInfo>& providers)
   {
     return 0;
   }

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -417,16 +417,37 @@ int FilterDriver::get_roles(const DoutPrefixProvider *dpp,
   return next->get_roles(dpp, y, path_prefix, tenant, roles);
 }
 
-std::unique_ptr<RGWOIDCProvider> FilterDriver::get_oidc_provider()
+int FilterDriver::store_oidc_provider(const DoutPrefixProvider* dpp,
+                                      optional_yield y,
+                                      const RGWOIDCProviderInfo& info,
+                                      bool exclusive)
 {
-  return next->get_oidc_provider();
+  return next->store_oidc_provider(dpp, y, info, exclusive);
 }
 
-int FilterDriver::get_oidc_providers(const DoutPrefixProvider *dpp,
-				    const std::string& tenant,
-				    std::vector<std::unique_ptr<RGWOIDCProvider>>& providers, optional_yield y)
+int FilterDriver::load_oidc_provider(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view tenant,
+                                     std::string_view url,
+                                     RGWOIDCProviderInfo& info)
 {
-  return next->get_oidc_providers(dpp, tenant, providers, y);
+  return next->load_oidc_provider(dpp, y, tenant, url, info);
+}
+
+int FilterDriver::delete_oidc_provider(const DoutPrefixProvider* dpp,
+                                       optional_yield y,
+                                       std::string_view tenant,
+                                       std::string_view url)
+{
+  return next->delete_oidc_provider(dpp, y, tenant, url);
+}
+
+int FilterDriver::get_oidc_providers(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     std::string_view tenant,
+                                     std::vector<RGWOIDCProviderInfo>& providers)
+{
+  return next->get_oidc_providers(dpp, y, tenant, providers);
 }
 
 std::unique_ptr<Writer> FilterDriver::get_append_writer(const DoutPrefixProvider *dpp,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include "rgw_sal.h"
-#include "rgw_oidc_provider.h"
 #include "rgw_role.h"
 
 namespace rgw { namespace sal {
@@ -261,11 +260,23 @@ public:
 			const std::string& path_prefix,
 			const std::string& tenant,
 			std::vector<std::unique_ptr<RGWRole>>& roles) override;
-  virtual std::unique_ptr<RGWOIDCProvider> get_oidc_provider() override;
-  virtual int get_oidc_providers(const DoutPrefixProvider *dpp,
-				 const std::string& tenant,
-				 std::vector<std::unique_ptr<RGWOIDCProvider>>&
-				 providers, optional_yield y) override;
+  int store_oidc_provider(const DoutPrefixProvider* dpp,
+                          optional_yield y,
+                          const RGWOIDCProviderInfo& info,
+                          bool exclusive) override;
+  int load_oidc_provider(const DoutPrefixProvider* dpp,
+                         optional_yield y,
+                         std::string_view tenant,
+                         std::string_view url,
+                         RGWOIDCProviderInfo& info) override;
+  int delete_oidc_provider(const DoutPrefixProvider* dpp,
+                           optional_yield y,
+                           std::string_view tenant,
+                           std::string_view url) override;
+  int get_oidc_providers(const DoutPrefixProvider* dpp,
+                         optional_yield y,
+                         std::string_view tenant,
+                         std::vector<RGWOIDCProviderInfo>& providers) override;
   virtual std::unique_ptr<Writer> get_append_writer(const DoutPrefixProvider *dpp,
 				  optional_yield y,
 				  rgw::sal::Object* obj,

--- a/src/tools/ceph-dencoder/rgw_types.h
+++ b/src/tools/ceph-dencoder/rgw_types.h
@@ -236,4 +236,7 @@ TYPE(RGWUID)
 #include "rgw_user_types.h"
 TYPE(rgw_user)
 
+#include "rgw_oidc_provider.h"
+TYPE(RGWOIDCProviderInfo)
+
 #endif


### PR DESCRIPTION
these commits were part of https://github.com/ceph/ceph/pull/54333 where i go on to add account support to the rest apis

but there's a separate need to support multisite replication of oidc-provider metadata for https://tracker.ceph.com/issues/64431, so i split them because i think the sal changes will make it easier to implement the oidc RGWMetadataHandler

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
