### PR TITLE
rgw: switch back to boost::asio for spawn() and yield_context

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,9 +50,6 @@
 [submodule "src/c-ares"]
 	path = src/c-ares
 	url = https://github.com/ceph/c-ares.git
-[submodule "src/spawn"]
-	path = src/spawn
-	url = https://github.com/ceph/spawn.git
 [submodule "src/pybind/mgr/rook/rook-client-python"]
 	path = src/pybind/mgr/rook/rook-client-python
 	url = https://github.com/ceph/rook-client-python.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -891,10 +891,6 @@ if(WITH_RBD)
   add_subdirectory(rbd_replay)
 endif(WITH_RBD)
 
-set(SPAWN_BUILD_TESTS OFF CACHE INTERNAL "disable building of spawn unit tests")
-set(SPAWN_INSTALL OFF CACHE INTERNAL "disable installation of spawn headers")
-add_subdirectory(spawn)
-
 # RadosGW
 if(WITH_KVS)
   add_subdirectory(key_value_store)

--- a/src/cls/CMakeLists.txt
+++ b/src/cls/CMakeLists.txt
@@ -76,8 +76,7 @@ if (WITH_RADOSGW)
   target_link_libraries(cls_otp OATH::OATH)
   target_include_directories(cls_otp
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
-	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
-	  PUBLIC "${CMAKE_SOURCE_DIR}/src/spawn/include")
+	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw")
   set_target_properties(cls_otp PROPERTIES
     VERSION "1.0.0"
     SOVERSION "1"
@@ -204,8 +203,7 @@ if (WITH_RADOSGW)
   target_link_libraries(cls_rgw ${FMT_LIB} json_spirit)
   target_include_directories(cls_rgw
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
-	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
-	  PUBLIC "${CMAKE_SOURCE_DIR}/src/spawn/include")
+	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw")
   set_target_properties(cls_rgw PROPERTIES
     VERSION "1.0.0"
     SOVERSION "1"
@@ -220,8 +218,7 @@ if (WITH_RADOSGW)
   add_library(cls_rgw_client STATIC ${cls_rgw_client_srcs})
   target_include_directories(cls_rgw_client
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
-	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
-	  PUBLIC "${CMAKE_SOURCE_DIR}/src/spawn/include")
+	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw")
 
 endif (WITH_RADOSGW)
 
@@ -313,8 +310,7 @@ if (WITH_RADOSGW)
   add_library(cls_rgw_gc SHARED ${cls_rgw_gc_srcs})
   target_include_directories(cls_rgw_gc
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
-	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
-	  PUBLIC "${CMAKE_SOURCE_DIR}/src/spawn/include")
+	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw")
   set_target_properties(cls_rgw_gc PROPERTIES
     VERSION "1.0.0"
     SOVERSION "1"
@@ -328,8 +324,7 @@ if (WITH_RADOSGW)
   add_library(cls_rgw_gc_client STATIC ${cls_rgw_gc_client_srcs})
   target_include_directories(cls_rgw_gc_client
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
-	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
-	  PUBLIC "${CMAKE_SOURCE_DIR}/src/spawn/include")
+	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw")
 endif (WITH_RADOSGW)
 
 

--- a/src/common/async/context_pool.h
+++ b/src/common/async/context_pool.h
@@ -106,6 +106,7 @@ public:
   operator boost::asio::io_context&() {
     return ioctx;
   }
+  using executor_type = boost::asio::io_context::executor_type;
   boost::asio::io_context::executor_type get_executor() {
     return ioctx.get_executor();
   }

--- a/src/common/async/yield_context.h
+++ b/src/common/async/yield_context.h
@@ -17,23 +17,18 @@
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/asio/io_context.hpp>
+#include <boost/asio/spawn.hpp>
 
 #include "acconfig.h"
 
-#include <spawn/spawn.hpp>
-
-/// optional-like wrapper for a spawn::yield_context and its associated
-/// boost::asio::io_context. operations that take an optional_yield argument
-/// will, when passed a non-empty yield context, suspend this coroutine instead
-/// of the blocking the thread of execution
+/// optional-like wrapper for a boost::asio::yield_context. operations that take
+/// an optional_yield argument will, when passed a non-empty yield context,
+/// suspend this coroutine instead of the blocking the thread of execution
 class optional_yield {
-  boost::asio::io_context *c = nullptr;
-  spawn::yield_context *y = nullptr;
+  boost::asio::yield_context *y = nullptr;
  public:
   /// construct with a valid io and yield_context
-  explicit optional_yield(boost::asio::io_context& c,
-                          spawn::yield_context& y) noexcept
-    : c(&c), y(&y) {}
+  optional_yield(boost::asio::yield_context& y) noexcept : y(&y) {}
 
   /// type tag to construct an empty object
   struct empty_t {};
@@ -42,11 +37,8 @@ class optional_yield {
   /// implicit conversion to bool, returns true if non-empty
   operator bool() const noexcept { return y; }
 
-  /// return a reference to the associated io_context. only valid if non-empty
-  boost::asio::io_context& get_io_context() const noexcept { return *c; }
-
   /// return a reference to the yield_context. only valid if non-empty
-  spawn::yield_context& get_yield_context() const noexcept { return *y; }
+  boost::asio::yield_context& get_yield_context() const noexcept { return *y; }
 };
 
 // type tag object to construct an empty optional_yield

--- a/src/crypto/isa-l/CMakeLists.txt
+++ b/src/crypto/isa-l/CMakeLists.txt
@@ -30,7 +30,7 @@ endif(HAVE_NASM_X64)
 add_library(ceph_crypto_isal SHARED ${isal_crypto_plugin_srcs})
 target_include_directories(ceph_crypto_isal PRIVATE ${isal_dir}/include)
 
-target_link_libraries(ceph_crypto_isal PRIVATE spawn)
+target_link_libraries(ceph_crypto_isal PRIVATE Boost::context)
 
 set_target_properties(ceph_crypto_isal PROPERTIES
   VERSION 1.0.0

--- a/src/crypto/openssl/CMakeLists.txt
+++ b/src/crypto/openssl/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(ceph_crypto_openssl SHARED ${openssl_crypto_plugin_srcs})
 target_link_libraries(ceph_crypto_openssl
     PRIVATE OpenSSL::Crypto
     $<$<PLATFORM_ID:Windows>:ceph-common>
-    spawn)
+    Boost::context)
 target_include_directories(ceph_crypto_openssl PRIVATE ${OPENSSL_INCLUDE_DIR})
 add_dependencies(crypto_plugins ceph_crypto_openssl)
 set_target_properties(ceph_crypto_openssl PROPERTIES INSTALL_RPATH "")

--- a/src/crypto/qat/CMakeLists.txt
+++ b/src/crypto/qat/CMakeLists.txt
@@ -14,7 +14,7 @@ add_dependencies(crypto_plugins ceph_crypto_qat)
 target_link_libraries(ceph_crypto_qat PRIVATE
                       QAT::qat
                       QAT::usdm
-                      spawn)
+                      Boost::context)
 
 add_dependencies(crypto_plugins ceph_crypto_qat)
 set_target_properties(ceph_crypto_qat PROPERTIES VERSION 1.0.0 SOVERSION 1)

--- a/src/crypto/qat/qcccrypto.cc
+++ b/src/crypto/qat/qcccrypto.cc
@@ -331,7 +331,7 @@ bool QccCrypto::perform_op_batch(unsigned char* out, const unsigned char* in, si
   int avail_inst = NON_INSTANCE;
 
   if (y) {
-    spawn::yield_context yield = y.get_yield_context();
+    boost::asio::yield_context yield = y.get_yield_context();
     avail_inst = async_get_instance(yield);
   } else {
     auto result = async_get_instance(boost::asio::use_future);
@@ -546,7 +546,7 @@ bool QccCrypto::symPerformOp(int avail_inst,
     do {
       poll_retry_num = RETRY_MAX_NUM;
       if (y) {
-        spawn::yield_context yield = y.get_yield_context();
+        boost::asio::yield_context yield = y.get_yield_context();
         status = helper.async_perform_op(std::span<CpaCySymDpOpData*>(pOpDataVec), yield);
       } else {
         auto result = helper.async_perform_op(std::span<CpaCySymDpOpData*>(pOpDataVec), boost::asio::use_future);

--- a/src/crypto/qat/qcccrypto.cc
+++ b/src/crypto/qat/qcccrypto.cc
@@ -12,6 +12,8 @@
 #include <future>
 #include <chrono>
 
+#include <boost/asio/append.hpp>
+#include <boost/asio/async_result.hpp>
 #include "boost/container/static_vector.hpp"
 
 // -----------------------------------------------------------------------------
@@ -49,36 +51,31 @@ static std::condition_variable poll_inst_cv;
 
 template <typename CompletionToken>
 auto QccCrypto::async_get_instance(CompletionToken&& token) {
-  using boost::asio::async_completion;
   using Signature = void(int);
-  async_completion<CompletionToken, Signature> init(token);
-
-  auto ex = boost::asio::get_associated_executor(init.completion_handler);
-
-  boost::asio::post(my_pool, [this, ex, handler = std::move(init.completion_handler)]()mutable{
-    auto handler1 = std::move(handler);
-    if (!open_instances.empty()) {
-      int avail_inst = open_instances.front();
-      open_instances.pop_front();
-      boost::asio::post(ex, std::bind(handler1, avail_inst));
-    } else if (!instance_completions.full()) {
-      // keep a few objects to wait QAT instance to make sure qat full utilization as much as possible,
-      // that is, QAT don't need to wait for new objects to ensure
-      // that QAT will not be in a free state as much as possible
-      instance_completions.push_back([ex, handler2 = std::move(handler1)](int inst)mutable{
-        boost::asio::post(ex, std::bind(handler2, inst));
-      });
-    } else {
-      boost::asio::post(ex, std::bind(handler1, NON_INSTANCE));
-    }
-  });
-  return init.result.get();
+  return boost::asio::async_initiate<CompletionToken, Signature>(
+      [this] (auto handler) {
+        boost::asio::post(my_pool, [this, handler = std::move(handler)]()mutable{
+          if (!open_instances.empty()) {
+            int avail_inst = open_instances.front();
+            open_instances.pop_front();
+            boost::asio::post(boost::asio::append(std::move(handler), avail_inst));
+          } else if (!instance_completions.full()) {
+            // keep a few objects to wait QAT instance to make sure qat full utilization as much as possible,
+            // that is, QAT don't need to wait for new objects to ensure
+            // that QAT will not be in a free state as much as possible
+            instance_completions.push_back(std::move(handler));
+          } else {
+            boost::asio::post(boost::asio::append(std::move(handler), NON_INSTANCE));
+          }
+        });
+      }, token);
 }
 
 void QccCrypto::QccFreeInstance(int entry) {
   boost::asio::post(my_pool, [this, entry]()mutable{
     if (!instance_completions.empty()) {
-      instance_completions.front()(entry);
+      boost::asio::dispatch(boost::asio::append(
+          std::move(instance_completions.front()), entry));
       instance_completions.pop_front();
     } else {
       open_instances.push_back(entry);
@@ -477,24 +474,29 @@ CpaStatus QccCrypto::initSession(CpaInstanceHandle cyInstHandle,
 }
 
 template <typename CompletionToken>
-auto QatCrypto::async_perform_op(int avail_inst, std::span<CpaCySymDpOpData*> pOpDataVec, CompletionToken&& token) {
-  CpaStatus status = CPA_STATUS_SUCCESS;
-  using boost::asio::async_completion;
+auto QatCrypto::async_perform_op(std::span<CpaCySymDpOpData*> pOpDataVec, CompletionToken&& token) {
   using Signature = void(CpaStatus);
-  async_completion<CompletionToken, Signature> init(token);
-  auto ex = boost::asio::get_associated_executor(init.completion_handler);
-  completion_handler = [ex, handler = init.completion_handler](CpaStatus stat) {
-    boost::asio::post(ex, std::bind(handler, stat));
-  };
+  return boost::asio::async_initiate<CompletionToken, Signature>(
+      [this] (auto handler, std::span<CpaCySymDpOpData*> pOpDataVec) {
+        completion_handler = std::move(handler);
 
-  count = pOpDataVec.size();
-  poll_inst_cv.notify_one();
-  status = cpaCySymDpEnqueueOpBatch(pOpDataVec.size(), pOpDataVec.data(), CPA_TRUE);
+        count = pOpDataVec.size();
+        poll_inst_cv.notify_one();
+        CpaStatus status = cpaCySymDpEnqueueOpBatch(pOpDataVec.size(), pOpDataVec.data(), CPA_TRUE);
 
-  if (status != CPA_STATUS_SUCCESS) {
-    completion_handler(status);
+        if (status != CPA_STATUS_SUCCESS) {
+          boost::asio::post(bind_executor(ex,
+              boost::asio::append(std::move(completion_handler), status)));
+        }
+      }, token, pOpDataVec);
+}
+
+void QatCrypto::complete() {
+  if (--count == 0) {
+    boost::asio::post(bind_executor(ex,
+        boost::asio::append(std::move(completion_handler), CPA_STATUS_SUCCESS)));
   }
-  return init.result.get();
+  return;
 }
 
 bool QccCrypto::symPerformOp(int avail_inst,
@@ -510,7 +512,7 @@ bool QccCrypto::symPerformOp(int avail_inst,
   Cpa32U iv_index = 0;
   size_t perform_retry_num = 0;
   for (Cpa32U off = 0; off < size; off += one_batch_size) {
-    QatCrypto helper;
+    QatCrypto helper{my_pool.get_executor()};
     boost::container::static_vector<CpaCySymDpOpData*, MAX_NUM_SYM_REQ_BATCH> pOpDataVec;
     for (Cpa32U offset = off, i = 0; offset < size && i < MAX_NUM_SYM_REQ_BATCH; offset += chunk_size, i++) {
       CpaCySymDpOpData *pOpData = qcc_op_mem[avail_inst].sym_op_data[i];
@@ -545,9 +547,9 @@ bool QccCrypto::symPerformOp(int avail_inst,
       poll_retry_num = RETRY_MAX_NUM;
       if (y) {
         spawn::yield_context yield = y.get_yield_context();
-        status = helper.async_perform_op(avail_inst, std::span<CpaCySymDpOpData*>(pOpDataVec), yield);
+        status = helper.async_perform_op(std::span<CpaCySymDpOpData*>(pOpDataVec), yield);
       } else {
-        auto result = helper.async_perform_op(avail_inst, std::span<CpaCySymDpOpData*>(pOpDataVec), boost::asio::use_future);
+        auto result = helper.async_perform_op(std::span<CpaCySymDpOpData*>(pOpDataVec), boost::asio::use_future);
         status = result.get();
       }
       if (status == CPA_STATUS_RETRY) {

--- a/src/librados/librados_asio.h
+++ b/src/librados/librados_asio.h
@@ -110,18 +110,20 @@ auto async_read(ExecutionContext& ctx, IoCtx& io, const std::string& oid,
 {
   using Op = detail::AsyncOp<bufferlist>;
   using Signature = typename Op::Signature;
-  boost::asio::async_completion<CompletionToken, Signature> init(token);
-  auto p = Op::create(ctx.get_executor(), init.completion_handler);
-  auto& op = p->user_data;
+  return boost::asio::async_initiate<CompletionToken, Signature>(
+      [] (auto handler, auto ex, IoCtx& io, const std::string& oid,
+          size_t len, uint64_t off) {
+        auto p = Op::create(ex, std::move(handler));
+        auto& op = p->user_data;
 
-  int ret = io.aio_read(oid, op.aio_completion.get(), &op.result, len, off);
-  if (ret < 0) {
-    auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
-    ceph::async::post(std::move(p), ec, bufferlist{});
-  } else {
-    p.release(); // release ownership until completion
-  }
-  return init.result.get();
+        int ret = io.aio_read(oid, op.aio_completion.get(), &op.result, len, off);
+        if (ret < 0) {
+          auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
+          ceph::async::post(std::move(p), ec, bufferlist{});
+        } else {
+          p.release(); // release ownership until completion
+        }
+      }, token, ctx.get_executor(), io, oid, len, off);
 }
 
 /// Calls IoCtx::aio_write() and arranges for the AioCompletion to call a
@@ -133,18 +135,20 @@ auto async_write(ExecutionContext& ctx, IoCtx& io, const std::string& oid,
 {
   using Op = detail::AsyncOp<void>;
   using Signature = typename Op::Signature;
-  boost::asio::async_completion<CompletionToken, Signature> init(token);
-  auto p = Op::create(ctx.get_executor(), init.completion_handler);
-  auto& op = p->user_data;
+  return boost::asio::async_initiate<CompletionToken, Signature>(
+      [] (auto handler, auto ex, IoCtx& io, const std::string& oid,
+          bufferlist &bl, size_t len, uint64_t off) {
+        auto p = Op::create(ex, std::move(handler));
+        auto& op = p->user_data;
 
-  int ret = io.aio_write(oid, op.aio_completion.get(), bl, len, off);
-  if (ret < 0) {
-    auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
-    ceph::async::post(std::move(p), ec);
-  } else {
-    p.release(); // release ownership until completion
-  }
-  return init.result.get();
+        int ret = io.aio_write(oid, op.aio_completion.get(), bl, len, off);
+        if (ret < 0) {
+          auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
+          ceph::async::post(std::move(p), ec);
+        } else {
+          p.release(); // release ownership until completion
+        }
+      }, token, ctx.get_executor(), io, oid, bl, len, off);
 }
 
 /// Calls IoCtx::aio_operate() and arranges for the AioCompletion to call a
@@ -152,23 +156,25 @@ auto async_write(ExecutionContext& ctx, IoCtx& io, const std::string& oid,
 template <typename ExecutionContext, typename CompletionToken>
 auto async_operate(ExecutionContext& ctx, IoCtx& io, const std::string& oid,
                    ObjectReadOperation *read_op, int flags,
-                   CompletionToken&& token, const jspan_context* trace_ctx = nullptr)
+                   const jspan_context* trace_ctx, CompletionToken&& token)
 {
   using Op = detail::AsyncOp<bufferlist>;
   using Signature = typename Op::Signature;
-  boost::asio::async_completion<CompletionToken, Signature> init(token);
-  auto p = Op::create(ctx.get_executor(), init.completion_handler);
-  auto& op = p->user_data;
+  return boost::asio::async_initiate<CompletionToken, Signature>(
+      [] (auto handler, auto ex, IoCtx& io, const std::string& oid,
+          ObjectReadOperation *read_op, int flags) {
+        auto p = Op::create(ex, std::move(handler));
+        auto& op = p->user_data;
 
-  int ret = io.aio_operate(oid, op.aio_completion.get(), read_op,
-                           flags, &op.result);
-  if (ret < 0) {
-    auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
-    ceph::async::post(std::move(p), ec, bufferlist{});
-  } else {
-    p.release(); // release ownership until completion
-  }
-  return init.result.get();
+        int ret = io.aio_operate(oid, op.aio_completion.get(), read_op,
+                                 flags, &op.result);
+        if (ret < 0) {
+          auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
+          ceph::async::post(std::move(p), ec, bufferlist{});
+        } else {
+          p.release(); // release ownership until completion
+        }
+      }, token, ctx.get_executor(), io, oid, read_op, flags);
 }
 
 /// Calls IoCtx::aio_operate() and arranges for the AioCompletion to call a
@@ -176,22 +182,25 @@ auto async_operate(ExecutionContext& ctx, IoCtx& io, const std::string& oid,
 template <typename ExecutionContext, typename CompletionToken>
 auto async_operate(ExecutionContext& ctx, IoCtx& io, const std::string& oid,
                    ObjectWriteOperation *write_op, int flags,
-                   CompletionToken &&token, const jspan_context* trace_ctx = nullptr)
+                   const jspan_context* trace_ctx, CompletionToken &&token)
 {
   using Op = detail::AsyncOp<void>;
   using Signature = typename Op::Signature;
-  boost::asio::async_completion<CompletionToken, Signature> init(token);
-  auto p = Op::create(ctx.get_executor(), init.completion_handler);
-  auto& op = p->user_data;
+  return boost::asio::async_initiate<CompletionToken, Signature>(
+      [] (auto handler, auto ex, IoCtx& io, const std::string& oid,
+          ObjectWriteOperation *write_op, int flags,
+          const jspan_context* trace_ctx) {
+        auto p = Op::create(ex, std::move(handler));
+        auto& op = p->user_data;
 
-  int ret = io.aio_operate(oid, op.aio_completion.get(), write_op, flags, trace_ctx);
-  if (ret < 0) {
-    auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
-    ceph::async::post(std::move(p), ec);
-  } else {
-    p.release(); // release ownership until completion
-  }
-  return init.result.get();
+        int ret = io.aio_operate(oid, op.aio_completion.get(), write_op, flags, trace_ctx);
+        if (ret < 0) {
+          auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
+          ceph::async::post(std::move(p), ec);
+        } else {
+          p.release(); // release ownership until completion
+        }
+      }, token, ctx.get_executor(), io, oid, write_op, flags, trace_ctx);
 }
 
 /// Calls IoCtx::aio_notify() and arranges for the AioCompletion to call a
@@ -202,19 +211,21 @@ auto async_notify(ExecutionContext& ctx, IoCtx& io, const std::string& oid,
 {
   using Op = detail::AsyncOp<bufferlist>;
   using Signature = typename Op::Signature;
-  boost::asio::async_completion<CompletionToken, Signature> init(token);
-  auto p = Op::create(ctx.get_executor(), init.completion_handler);
-  auto& op = p->user_data;
+  return boost::asio::async_initiate<CompletionToken, Signature>(
+      [] (auto handler, auto ex, IoCtx& io, const std::string& oid,
+          bufferlist& bl, uint64_t timeout_ms) {
+        auto p = Op::create(ex, std::move(handler));
+        auto& op = p->user_data;
 
-  int ret = io.aio_notify(oid, op.aio_completion.get(),
-                          bl, timeout_ms, &op.result);
-  if (ret < 0) {
-    auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
-    ceph::async::post(std::move(p), ec, bufferlist{});
-  } else {
-    p.release(); // release ownership until completion
-  }
-  return init.result.get();
+        int ret = io.aio_notify(oid, op.aio_completion.get(),
+                                bl, timeout_ms, &op.result);
+        if (ret < 0) {
+          auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
+          ceph::async::post(std::move(p), ec, bufferlist{});
+        } else {
+          p.release(); // release ownership until completion
+        }
+      }, token, ctx.get_executor(), io, oid, bl, timeout_ms);
 }
 
 } // namespace librados

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -301,7 +301,7 @@ target_link_libraries(rgw_common
   PUBLIC
     ${LUA_LIBRARIES}
     RapidJSON::RapidJSON
-    spawn
+    Boost::context
     ${FMT_LIB}
     OpenSSL::SSL)
 target_include_directories(rgw_common
@@ -433,7 +433,7 @@ target_link_libraries(rgw_a
     OATH::OATH
   PUBLIC
     rgw_common
-    spawn)
+    Boost::context)
 
 if(WITH_CURL_OPENSSL)
   # used by rgw_http_client_curl.cc
@@ -449,7 +449,7 @@ set(rgw_schedulers_srcs
 
 add_library(rgw_schedulers STATIC ${rgw_schedulers_srcs})
 target_link_libraries(rgw_schedulers
-  PUBLIC dmclock::dmclock spawn)
+  PUBLIC dmclock::dmclock Boost::context)
 
 set(radosgw_srcs
   rgw_main.cc)

--- a/src/rgw/driver/d4n/d4n_directory.cc
+++ b/src/rgw/driver/d4n/d4n_directory.cc
@@ -17,7 +17,7 @@ struct initiate_exec {
   {
     auto h = boost::asio::consign(std::move(handler), conn);
     return boost::asio::dispatch(get_executor(),
-        [c = conn, &req, &resp, h = std::move(h)] {
+        [c = conn, &req, &resp, h = std::move(h)] () mutable {
             return c->async_exec(req, resp, std::move(h));
     });
   }

--- a/src/rgw/driver/d4n/d4n_policy.cc
+++ b/src/rgw/driver/d4n/d4n_policy.cc
@@ -17,9 +17,10 @@ struct initiate_exec {
   void operator()(Handler handler, const boost::redis::request& req, Response& resp)
   {
     auto h = asio::consign(std::move(handler), conn);
-    return asio::dispatch(get_executor(), [c=conn, &req, &resp, h=std::move(h)] {
-      c->async_exec(req, resp, std::move(h));
-    });
+    return asio::dispatch(get_executor(),
+        [c=conn, &req, &resp, h=std::move(h)] () mutable {
+          c->async_exec(req, resp, std::move(h));
+        });
   }
 };
 

--- a/src/rgw/driver/dbstore/CMakeLists.txt
+++ b/src/rgw/driver/dbstore/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(dbstore_lib
     PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
     PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/store/rados"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-set(link_targets spawn)
+set(link_targets Boost::context)
 if(WITH_JAEGER)
   list(APPEND link_targets jaeger_base)
 endif()

--- a/src/rgw/driver/rados/cls_fifo_legacy.h
+++ b/src/rgw/driver/rados/cls_fifo_legacy.h
@@ -89,7 +89,7 @@ using part_info = fifo::part_header;
 ///
 /// This library uses optional_yield. Please see
 /// /src/common/async/yield_context.h. In summary, optional_yield
-/// contains either a spawn::yield_context (in which case the current
+/// contains either a boost::asio::yield_context (in which case the current
 /// coroutine is suspended until completion) or null_yield (in which
 /// case the current thread is blocked until completion.)
 ///

--- a/src/rgw/driver/rados/rgw_pubsub_push.cc
+++ b/src/rgw/driver/rados/rgw_pubsub_push.cc
@@ -19,7 +19,7 @@
 #ifdef WITH_RADOSGW_KAFKA_ENDPOINT
 #include "rgw_kafka.h"
 #endif
-#include <boost/asio/yield.hpp>
+//#include <boost/asio/yield.hpp>
 #include <boost/algorithm/string.hpp>
 #include <functional>
 #include "rgw_perf_counters.h"
@@ -153,7 +153,7 @@ public:
       boost::system::error_code ec;
       auto yield = y.get_yield_context();
       auto&& token = yield[ec];
-      boost::asio::async_initiate<spawn::yield_context, Signature>(
+      boost::asio::async_initiate<boost::asio::yield_context, Signature>(
           [this] (auto handler, auto ex) {
             completion = Completion::create(ex, std::move(handler));
           }, token, yield.get_executor());

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -1153,10 +1153,9 @@ int RGWReshardWait::wait(optional_yield y)
   }
 
   if (y) {
-    auto& context = y.get_io_context();
     auto& yield = y.get_yield_context();
 
-    Waiter waiter(context);
+    Waiter waiter(yield.get_executor());
     waiters.push_back(waiter);
     lock.unlock();
 

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -252,11 +252,11 @@ class RGWReshardWait {
   ceph::condition_variable cond;
 
   struct Waiter : boost::intrusive::list_base_hook<> {
-    using Executor = boost::asio::io_context::executor_type;
+    using Executor = boost::asio::any_io_executor;
     using Timer = boost::asio::basic_waitable_timer<Clock,
           boost::asio::wait_traits<Clock>, Executor>;
     Timer timer;
-    explicit Waiter(boost::asio::io_context& ioc) : timer(ioc) {}
+    explicit Waiter(boost::asio::any_io_executor ex) : timer(ex) {}
   };
   boost::intrusive::list<Waiter> waiters;
 

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -203,11 +203,10 @@ int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, con
   // given a yield_context, call async_operate() to yield the coroutine instead
   // of blocking
   if (y) {
-    auto& context = y.get_io_context();
     auto& yield = y.get_yield_context();
     boost::system::error_code ec;
     auto bl = librados::async_operate(
-      context, ioctx, oid, op, flags, trace_info, yield[ec]);
+      yield, ioctx, oid, op, flags, trace_info, yield[ec]);
     if (pbl) {
       *pbl = std::move(bl);
     }
@@ -228,10 +227,9 @@ int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, con
 		      int flags, const jspan_context* trace_info)
 {
   if (y) {
-    auto& context = y.get_io_context();
     auto& yield = y.get_yield_context();
     boost::system::error_code ec;
-    librados::async_operate(context, ioctx, oid, op, flags, trace_info, yield[ec]);
+    librados::async_operate(yield, ioctx, oid, op, flags, trace_info, yield[ec]);
     return -ec.value();
   }
   if (is_asio_thread) {
@@ -248,10 +246,9 @@ int rgw_rados_notify(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, cons
                      optional_yield y)
 {
   if (y) {
-    auto& context = y.get_io_context();
     auto& yield = y.get_yield_context();
     boost::system::error_code ec;
-    auto reply = librados::async_notify(context, ioctx, oid,
+    auto reply = librados::async_notify(yield, ioctx, oid,
                                         bl, timeout_ms, yield[ec]);
     if (pbl) {
       *pbl = std::move(reply);

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -207,7 +207,7 @@ int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, con
     auto& yield = y.get_yield_context();
     boost::system::error_code ec;
     auto bl = librados::async_operate(
-      context, ioctx, oid, op, flags, yield[ec]);
+      context, ioctx, oid, op, flags, trace_info, yield[ec]);
     if (pbl) {
       *pbl = std::move(bl);
     }
@@ -231,7 +231,7 @@ int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, con
     auto& context = y.get_io_context();
     auto& yield = y.get_yield_context();
     boost::system::error_code ec;
-    librados::async_operate(context, ioctx, oid, op, flags, yield[ec], trace_info);
+    librados::async_operate(context, ioctx, oid, op, flags, trace_info, yield[ec]);
     return -ec.value();
   }
   if (is_asio_thread) {

--- a/src/rgw/driver/rados/topic_migration.cc
+++ b/src/rgw/driver/rados/topic_migration.cc
@@ -263,10 +263,8 @@ int migrate_topics(const DoutPrefixProvider* dpp, optional_yield y,
 int migrate(const DoutPrefixProvider* dpp,
             rgw::sal::RadosStore* driver,
             boost::asio::io_context& context,
-            spawn::yield_context yield)
+            boost::asio::yield_context y)
 {
-  auto y = optional_yield{context, yield};
-
   ldpp_dout(dpp, 1) << "starting v1 topic migration.." << dendl;
 
   librados::Rados* rados = driver->getRados()->get_rados_handle();

--- a/src/rgw/driver/rados/topic_migration.h
+++ b/src/rgw/driver/rados/topic_migration.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <boost/asio/io_context.hpp>
-#include <spawn/spawn.hpp>
+#include <boost/asio/spawn.hpp>
 
 class DoutPrefixProvider;
 namespace rgw::sal { class RadosStore; }
@@ -29,6 +29,6 @@ namespace rgwrados::topic_migration {
 int migrate(const DoutPrefixProvider* dpp,
             rgw::sal::RadosStore* driver,
             boost::asio::io_context& context,
-            spawn::yield_context yield);
+            boost::asio::yield_context yield);
 
 } // rgwrados::topic_migration

--- a/src/rgw/rgw_aio.cc
+++ b/src/rgw/rgw_aio.cc
@@ -90,16 +90,14 @@ struct Handler {
 
 template <typename Op>
 Aio::OpFunc aio_abstract(librados::IoCtx ctx, Op&& op,
-                         boost::asio::io_context& context,
-                         spawn::yield_context yield, jspan_context* trace_ctx = nullptr) {
-  return [ctx = std::move(ctx), op = std::move(op), &context, yield, trace_ctx] (Aio* aio, AioResult& r) mutable {
+                         boost::asio::yield_context yield,
+                         jspan_context* trace_ctx) {
+  return [ctx = std::move(ctx), op = std::move(op), yield, trace_ctx] (Aio* aio, AioResult& r) mutable {
       // arrange for the completion Handler to run on the yield_context's strand
       // executor so it can safely call back into Aio without locking
-      using namespace boost::asio;
-      async_completion<spawn::yield_context, void()> init(yield);
-      auto ex = get_associated_executor(init.completion_handler);
+      auto ex = yield.get_executor();
 
-      librados::async_operate(context, ctx, r.obj.oid, &op, 0, trace_ctx,
+      librados::async_operate(yield, ctx, r.obj.oid, &op, 0, trace_ctx,
                               bind_executor(ex, Handler{aio, ctx, r}));
     };
 }
@@ -111,7 +109,7 @@ Aio::OpFunc d3n_cache_aio_abstract(const DoutPrefixProvider *dpp, optional_yield
     ceph_assert(y);
     auto c = std::make_unique<D3nL1CacheRequest>();
     lsubdout(g_ceph_context, rgw_datacache, 20) << "D3nDataCache: d3n_cache_aio_abstract(): libaio Read From Cache, oid=" << r.obj.oid << dendl;
-    c->file_aio_read_abstract(dpp, y.get_io_context(), y.get_yield_context(), cache_location, read_ofs, read_len, aio, r);
+    c->file_aio_read_abstract(dpp, y.get_yield_context(), cache_location, read_ofs, read_len, aio, r);
   };
 }
 
@@ -123,7 +121,7 @@ Aio::OpFunc aio_abstract(librados::IoCtx ctx, Op&& op, optional_yield y, jspan_c
   static_assert(!std::is_const_v<Op>);
   if (y) {
     return aio_abstract(std::move(ctx), std::forward<Op>(op),
-                        y.get_io_context(), y.get_yield_context(), trace_ctx);
+                        y.get_yield_context(), trace_ctx);
   }
   return aio_abstract(std::move(ctx), std::forward<Op>(op), trace_ctx);
 }

--- a/src/rgw/rgw_aio.cc
+++ b/src/rgw/rgw_aio.cc
@@ -99,8 +99,8 @@ Aio::OpFunc aio_abstract(librados::IoCtx ctx, Op&& op,
       async_completion<spawn::yield_context, void()> init(yield);
       auto ex = get_associated_executor(init.completion_handler);
 
-      librados::async_operate(context, ctx, r.obj.oid, &op, 0,
-                              bind_executor(ex, Handler{aio, ctx, r}), trace_ctx);
+      librados::async_operate(context, ctx, r.obj.oid, &op, 0, trace_ctx,
+                              bind_executor(ex, Handler{aio, ctx, r}));
     };
 }
 

--- a/src/rgw/rgw_aio_throttle.cc
+++ b/src/rgw/rgw_aio_throttle.cc
@@ -111,12 +111,12 @@ AioResultList BlockingAioThrottle::drain()
 template <typename CompletionToken>
 auto YieldingAioThrottle::async_wait(CompletionToken&& token)
 {
-  using boost::asio::async_completion;
   using Signature = void(boost::system::error_code);
-  async_completion<CompletionToken, Signature> init(token);
-  completion = Completion::create(context.get_executor(),
-                                  std::move(init.completion_handler));
-  return init.result.get();
+  return boost::asio::async_initiate<CompletionToken, Signature>(
+      [this] (auto handler) {
+        completion = Completion::create(yield.get_executor(),
+                                        std::move(handler));
+      }, token);
 }
 
 AioResultList YieldingAioThrottle::get(rgw_raw_obj obj,

--- a/src/rgw/rgw_aio_throttle.h
+++ b/src/rgw/rgw_aio_throttle.h
@@ -80,8 +80,7 @@ class BlockingAioThrottle final : public Aio, private Throttle {
 // a throttle that yields the coroutine instead of blocking. all public
 // functions must be called within the coroutine strand
 class YieldingAioThrottle final : public Aio, private Throttle {
-  boost::asio::io_context& context;
-  spawn::yield_context yield;
+  boost::asio::yield_context yield;
   struct Handler;
 
   // completion callback associated with the waiter
@@ -94,9 +93,8 @@ class YieldingAioThrottle final : public Aio, private Throttle {
   struct Pending : AioResultEntry { uint64_t cost = 0; };
 
  public:
-  YieldingAioThrottle(uint64_t window, boost::asio::io_context& context,
-                      spawn::yield_context yield)
-    : Throttle(window), context(context), yield(yield)
+  YieldingAioThrottle(uint64_t window, boost::asio::yield_context yield)
+    : Throttle(window), yield(yield)
   {}
 
   virtual ~YieldingAioThrottle() override {};
@@ -119,7 +117,6 @@ inline auto make_throttle(uint64_t window_size, optional_yield y)
   std::unique_ptr<Aio> aio;
   if (y) {
     aio = std::make_unique<YieldingAioThrottle>(window_size,
-                                                y.get_io_context(),
                                                 y.get_yield_context());
   } else {
     aio = std::make_unique<BlockingAioThrottle>(window_size);

--- a/src/rgw/rgw_d3n_cacherequest.h
+++ b/src/rgw/rgw_d3n_cacherequest.h
@@ -95,29 +95,33 @@ struct D3nL1CacheRequest {
     }
   };
 
-  template <typename ExecutionContext, typename CompletionToken>
-  auto async_read(const DoutPrefixProvider *dpp, ExecutionContext& ctx, const std::string& location,
+  template <typename Executor, typename CompletionToken>
+  auto async_read(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& location,
                   off_t read_ofs, off_t read_len, CompletionToken&& token) {
     using Op = AsyncFileReadOp;
     using Signature = typename Op::Signature;
-    boost::asio::async_completion<CompletionToken, Signature> init(token);
-    auto p = Op::create(ctx.get_executor(), init.completion_handler);
-    auto& op = p->user_data;
+    return boost::asio::async_initiate<CompletionToken, Signature>(
+        [] (auto handler, const DoutPrefixProvider *dpp,
+            const Executor& ex, const std::string& location,
+            off_t read_ofs, off_t read_len) {
+          auto p = Op::create(ex, std::move(handler));
+          auto& op = p->user_data;
 
-    ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): location=" << location << dendl;
-    int ret = op.init_async_read(dpp, location, read_ofs, read_len, p.get());
-    if(0 == ret) {
-      ret = ::aio_read(op.aio_cb.get());
-    }
-    ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): ::aio_read(), ret=" << ret << dendl;
-    if(ret < 0) {
-      auto ec = boost::system::error_code{-ret, boost::system::system_category()};
-      ceph::async::post(std::move(p), ec, bufferlist{});
-    } else {
-      // coverity[leaked_storage:SUPPRESS]
-      (void)p.release();
-    }
-    return init.result.get();
+          ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): location=" << location << dendl;
+          int ret = op.init_async_read(dpp, location, read_ofs, read_len, p.get());
+          if(0 == ret) {
+            ret = ::aio_read(op.aio_cb.get());
+          }
+          ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): ::aio_read(), ret=" << ret << dendl;
+          if(ret < 0) {
+            auto ec = boost::system::error_code{-ret, boost::system::system_category()};
+            ceph::async::post(std::move(p), ec, bufferlist{});
+          } else {
+            // coverity[leaked_storage:SUPPRESS]
+            (void)p.release();
+          }
+
+        }, token, dpp, ex, location, read_ofs, read_len);
   }
 
   struct d3n_libaio_handler {
@@ -131,7 +135,7 @@ struct D3nL1CacheRequest {
     }
   };
 
-  void file_aio_read_abstract(const DoutPrefixProvider *dpp, boost::asio::io_context& context, spawn::yield_context yield,
+  void file_aio_read_abstract(const DoutPrefixProvider *dpp, spawn::yield_context yield,
                               std::string& cache_location, off_t read_ofs, off_t read_len,
                               rgw::Aio* aio, rgw::AioResult& r) {
     using namespace boost::asio;
@@ -139,7 +143,7 @@ struct D3nL1CacheRequest {
     auto ex = get_associated_executor(init.completion_handler);
 
     ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): oid=" << r.obj.oid << dendl;
-    async_read(dpp, context, cache_location+"/"+url_encode(r.obj.oid, true), read_ofs, read_len, bind_executor(ex, d3n_libaio_handler{aio, r}));
+    async_read(dpp, ex, cache_location+"/"+url_encode(r.obj.oid, true), read_ofs, read_len, bind_executor(ex, d3n_libaio_handler{aio, r}));
   }
 
 };

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -61,15 +61,13 @@ struct rgw_http_req_data : public RefCountedObject {
     memset(error_buf, 0, sizeof(error_buf));
   }
 
-  template <typename ExecutionContext, typename CompletionToken>
-  auto async_wait(ExecutionContext& ctx, CompletionToken&& token) {
-    boost::asio::async_completion<CompletionToken, Signature> init(token);
-    auto& handler = init.completion_handler;
-    {
-      std::unique_lock l{lock};
-      completion = Completion::create(ctx.get_executor(), std::move(handler));
-    }
-    return init.result.get();
+  template <typename Executor, typename CompletionToken>
+  auto async_wait(const Executor& ex, CompletionToken&& token) {
+    return boost::asio::async_initiate<CompletionToken, Signature>(
+        [this] (auto handler, auto ex) {
+          std::unique_lock l{lock};
+          completion = Completion::create(ex, std::move(handler));
+        }, token, ex);
   }
 
   int wait(optional_yield y) {
@@ -77,10 +75,9 @@ struct rgw_http_req_data : public RefCountedObject {
       return ret;
     }
     if (y) {
-      auto& context = y.get_io_context();
       auto& yield = y.get_yield_context();
       boost::system::error_code ec;
-      async_wait(context, yield[ec]);
+      async_wait(yield.get_executor(), yield[ec]);
       return -ec.value();
     }
     // work on asio threads should be asynchronous, so warn when they block

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6789,7 +6789,8 @@ void RGWDeleteMultiObj::execute(optional_yield y)
   char* buf;
   std::optional<boost::asio::deadline_timer> formatter_flush_cond;
   if (y) {
-    formatter_flush_cond = std::make_optional<boost::asio::deadline_timer>(y.get_io_context());  
+    auto ex = y.get_yield_context().get_executor();
+    formatter_flush_cond = std::make_optional<boost::asio::deadline_timer>(ex);
   }
 
   buf = data.c_str();
@@ -6857,9 +6858,11 @@ void RGWDeleteMultiObj::execute(optional_yield y)
         return aio_count < max_aio;
       });
       aio_count++;
-      spawn::spawn(y.get_yield_context(), [this, &y, &aio_count, obj_key, &formatter_flush_cond] (spawn::yield_context yield) {
-        handle_individual_object(obj_key, optional_yield { y.get_io_context(), yield }, &*formatter_flush_cond); 
+      boost::asio::spawn(y.get_yield_context(), [this, &aio_count, obj_key, &formatter_flush_cond] (boost::asio::yield_context yield) {
+        handle_individual_object(obj_key, yield, &*formatter_flush_cond);
         aio_count--;
+      }, [] (std::exception_ptr eptr) {
+        if (eptr) std::rethrow_exception(eptr);
       }); 
     } else {
       handle_individual_object(obj_key, y, nullptr);

--- a/src/rgw/rgw_redis_driver.cc
+++ b/src/rgw/rgw_redis_driver.cc
@@ -35,9 +35,9 @@ struct initiate_exec {
   {
     auto h = boost::asio::consign(std::move(handler), conn);
     return boost::asio::dispatch(get_executor(),
-        [c=conn, &req, &resp, h=std::move(h)] {
+        [c=conn, &req, &resp, h=std::move(h)] () mutable {
           return c->async_exec(req, resp, std::move(h));
-          });
+        });
   } 
 };
 
@@ -555,9 +555,8 @@ Aio::OpFunc RedisDriver::redis_read_op(optional_yield y, std::shared_ptr<connect
 {
   return [y, conn, &key] (Aio* aio, AioResult& r) mutable {
     using namespace boost::asio;
-    spawn::yield_context yield = y.get_yield_context();
-    async_completion<spawn::yield_context, void()> init(yield);
-    auto ex = get_associated_executor(init.completion_handler);
+    yield_context yield = y.get_yield_context();
+    auto ex = yield.get_executor();
 
     // TODO: Make unique pointer once support is added
     auto s = std::make_shared<RedisDriver::redis_response>();
@@ -574,9 +573,8 @@ Aio::OpFunc RedisDriver::redis_write_op(optional_yield y, std::shared_ptr<connec
 {
   return [y, conn, &bl, &attrs, &key] (Aio* aio, AioResult& r) mutable {
     using namespace boost::asio;
-    spawn::yield_context yield = y.get_yield_context();
-    async_completion<spawn::yield_context, void()> init(yield);
-    auto ex = get_associated_executor(init.completion_handler);
+    yield_context yield = y.get_yield_context();
+    auto ex = yield.get_executor();
 
     auto redisAttrs = build_attrs(attrs);
 

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -98,9 +98,8 @@ int SSDDriver::put(const DoutPrefixProvider* dpp, const std::string& key, const 
     boost::system::error_code ec;
     if (y) {
         using namespace boost::asio;
-        spawn::yield_context yield = y.get_yield_context();
-        async_completion<spawn::yield_context, void()> init(yield);
-        auto ex = get_associated_executor(init.completion_handler);
+        yield_context yield = y.get_yield_context();
+        auto ex = yield.get_executor();
         this->put_async(dpp, ex, key, bl, len, attrs, yield[ec]);
     } else {
       auto ex = boost::asio::system_executor{};
@@ -285,9 +284,8 @@ rgw::Aio::OpFunc SSDDriver::ssd_cache_read_op(const DoutPrefixProvider *dpp, opt
     ldpp_dout(dpp, 20) << "SSDCache: cache_read_op(): Read From Cache, oid=" << r.obj.oid << dendl;
 
     using namespace boost::asio;
-    spawn::yield_context yield = y.get_yield_context();
-    async_completion<spawn::yield_context, void()> init(yield);
-    auto ex = get_associated_executor(init.completion_handler);
+    yield_context yield = y.get_yield_context();
+    auto ex = yield.get_executor();
 
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key=" << key << dendl;
     this->get_async(dpp, ex, key, read_ofs, read_len, bind_executor(ex, SSDDriver::libaio_read_handler{aio, r}));
@@ -301,9 +299,8 @@ rgw::Aio::OpFunc SSDDriver::ssd_cache_write_op(const DoutPrefixProvider *dpp, op
     ldpp_dout(dpp, 20) << "SSDCache: cache_write_op(): Write to Cache, oid=" << r.obj.oid << dendl;
 
     using namespace boost::asio;
-    spawn::yield_context yield = y.get_yield_context();
-    async_completion<spawn::yield_context, void()> init(yield);
-    auto ex = get_associated_executor(init.completion_handler);
+    yield_context yield = y.get_yield_context();
+    auto ex = yield.get_executor();
 
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key=" << key << dendl;
     this->put_async(dpp, ex, key, bl, len, attrs, bind_executor(ex, SSDDriver::libaio_write_handler{aio, r}));

--- a/src/rgw/rgw_ssd_driver.cc
+++ b/src/rgw/rgw_ssd_driver.cc
@@ -99,9 +99,12 @@ int SSDDriver::put(const DoutPrefixProvider* dpp, const std::string& key, const 
     if (y) {
         using namespace boost::asio;
         spawn::yield_context yield = y.get_yield_context();
-        this->put_async(dpp, y.get_io_context(), key, bl, len, attrs, yield[ec]);
+        async_completion<spawn::yield_context, void()> init(yield);
+        auto ex = get_associated_executor(init.completion_handler);
+        this->put_async(dpp, ex, key, bl, len, attrs, yield[ec]);
     } else {
-        this->put_async(dpp, y.get_io_context(), key, bl, len, attrs, ceph::async::use_blocked[ec]);
+      auto ex = boost::asio::system_executor{};
+      this->put_async(dpp, ex, key, bl, len, attrs, ceph::async::use_blocked[ec]);
     }
     if (ec) {
         return ec.value();
@@ -199,18 +202,21 @@ auto SSDDriver::AsyncWriteRequest::create(const Executor1& ex1, CompletionHandle
     return p;
 }
 
-template <typename ExecutionContext, typename CompletionToken>
-auto SSDDriver::get_async(const DoutPrefixProvider *dpp, ExecutionContext& ctx, const std::string& key,
+template <typename Executor, typename CompletionToken>
+auto SSDDriver::get_async(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
                 off_t read_ofs, off_t read_len, CompletionToken&& token)
 {
+  using Op = AsyncReadOp;
+  using Signature = typename Op::Signature;
+  return boost::asio::async_initiate<CompletionToken, Signature>(
+      [this] (auto handler, const DoutPrefixProvider *dpp,
+              const Executor& ex, const std::string& key,
+              off_t read_ofs, off_t read_len) {
+    auto p = Op::create(ex, handler);
+    auto& op = p->user_data;
+
     std::string location = partition_info.location + key;
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): location=" << location << dendl;
-
-    using Op = AsyncReadOp;
-    using Signature = typename Op::Signature;
-    boost::asio::async_completion<CompletionToken, Signature> init(token);
-    auto p = Op::create(ctx.get_executor(), init.completion_handler);
-    auto& op = p->user_data;
 
     int ret = op.prepare_libaio_read_op(dpp, location, read_ofs, read_len, p.get());
     if(0 == ret) {
@@ -223,22 +229,24 @@ auto SSDDriver::get_async(const DoutPrefixProvider *dpp, ExecutionContext& ctx, 
     } else {
         (void)p.release();
     }
-    ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): Before init.result.get()" << ret << dendl;
-    return init.result.get();
+  }, token, dpp, ex, key, read_ofs, read_len);
 }
 
-template <typename ExecutionContext, typename CompletionToken>
-void SSDDriver::put_async(const DoutPrefixProvider *dpp, ExecutionContext& ctx, const std::string& key,
+template <typename Executor, typename CompletionToken>
+void SSDDriver::put_async(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
                 const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, CompletionToken&& token)
 {
+  using Op = AsyncWriteRequest;
+  using Signature = typename Op::Signature;
+  return boost::asio::async_initiate<CompletionToken, Signature>(
+      [this] (auto handler, const DoutPrefixProvider *dpp,
+              const Executor& ex, const std::string& key, const bufferlist& bl,
+              uint64_t len, const rgw::sal::Attrs& attrs) {
+    auto p = Op::create(ex, handler);
+    auto& op = p->user_data;
+
     std::string location = partition_info.location + key;
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): location=" << location << dendl;
-
-    using Op = AsyncWriteRequest;
-    using Signature = typename Op::Signature;
-    boost::asio::async_completion<CompletionToken, Signature> init(token);
-    auto p = Op::create(ctx.get_executor(), init.completion_handler);
-    auto& op = p->user_data;
 
     int r = 0;
     bufferlist src = bl;
@@ -267,7 +275,7 @@ void SSDDriver::put_async(const DoutPrefixProvider *dpp, ExecutionContext& ctx, 
     } else {
         (void)p.release();
     }
-    init.result.get();
+  }, token, dpp, ex, key, bl, len, attrs);
 }
 
 rgw::Aio::OpFunc SSDDriver::ssd_cache_read_op(const DoutPrefixProvider *dpp, optional_yield y, rgw::cache::CacheDriver* cache_driver,
@@ -282,7 +290,7 @@ rgw::Aio::OpFunc SSDDriver::ssd_cache_read_op(const DoutPrefixProvider *dpp, opt
     auto ex = get_associated_executor(init.completion_handler);
 
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key=" << key << dendl;
-    this->get_async(dpp, y.get_io_context(), key, read_ofs, read_len, bind_executor(ex, SSDDriver::libaio_read_handler{aio, r}));
+    this->get_async(dpp, ex, key, read_ofs, read_len, bind_executor(ex, SSDDriver::libaio_read_handler{aio, r}));
   };
 }
 
@@ -298,7 +306,7 @@ rgw::Aio::OpFunc SSDDriver::ssd_cache_write_op(const DoutPrefixProvider *dpp, op
     auto ex = get_associated_executor(init.completion_handler);
 
     ldpp_dout(dpp, 20) << "SSDCache: " << __func__ << "(): key=" << key << dendl;
-    this->put_async(dpp, y.get_io_context(), key, bl, len, attrs, bind_executor(ex, SSDDriver::libaio_write_handler{aio, r}));
+    this->put_async(dpp, ex, key, bl, len, attrs, bind_executor(ex, SSDDriver::libaio_write_handler{aio, r}));
   };
 }
 

--- a/src/rgw/rgw_ssd_driver.h
+++ b/src/rgw/rgw_ssd_driver.h
@@ -70,12 +70,12 @@ private:
     }
   };
 
-  template <typename ExecutionContext, typename CompletionToken>
-    auto get_async(const DoutPrefixProvider *dpp, ExecutionContext& ctx, const std::string& key,
+  template <typename Executor, typename CompletionToken>
+    auto get_async(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
 		    off_t read_ofs, off_t read_len, CompletionToken&& token);
   
-  template <typename ExecutionContext, typename CompletionToken>
-  void put_async(const DoutPrefixProvider *dpp, ExecutionContext& ctx, const std::string& key,
+  template <typename Executor, typename CompletionToken>
+  void put_async(const DoutPrefixProvider *dpp, const Executor& ex, const std::string& key,
                   const bufferlist& bl, uint64_t len, const rgw::sal::Attrs& attrs, CompletionToken&& token);
   
   rgw::Aio::OpFunc ssd_cache_read_op(const DoutPrefixProvider *dpp, optional_yield y, rgw::cache::CacheDriver* cache_driver,

--- a/src/rgw/rgw_sync_checkpoint.cc
+++ b/src/rgw/rgw_sync_checkpoint.cc
@@ -226,8 +226,8 @@ int rgw_bucket_sync_checkpoint(const DoutPrefixProvider* dpp,
     entry.pipe = pipe;
 
     // fetch remote markers
-    spawn::spawn(ioctx, [&] (spawn::yield_context yield) {
-      auto y = optional_yield{ioctx, yield};
+    boost::asio::spawn(ioctx, [&] (boost::asio::yield_context yield) {
+      auto y = optional_yield{yield};
       rgw_bucket_index_marker_info info;
       int r = source_bilog_info(dpp, store->svc()->zone, entry.pipe,
                                 info, entry.remote_markers, y);
@@ -237,10 +237,12 @@ int rgw_bucket_sync_checkpoint(const DoutPrefixProvider* dpp,
         throw std::system_error(-r, std::system_category());
       }
       entry.latest_gen = info.latest_gen;
+    }, [] (std::exception_ptr eptr) {
+      if (eptr) std::rethrow_exception(eptr);
     });
     // fetch source bucket info
-    spawn::spawn(ioctx, [&] (spawn::yield_context yield) {
-      auto y = optional_yield{ioctx, yield};
+    boost::asio::spawn(ioctx, [&] (boost::asio::yield_context yield) {
+      auto y = optional_yield{yield};
       int r = store->getRados()->get_bucket_instance_info(
           *entry.pipe.source.bucket, entry.source_bucket_info,
           nullptr, nullptr, y, dpp);
@@ -249,6 +251,8 @@ int rgw_bucket_sync_checkpoint(const DoutPrefixProvider* dpp,
             << cpp_strerror(r) << dendl;
         throw std::system_error(-r, std::system_category());
       }
+    }, [] (std::exception_ptr eptr) {
+      if (eptr) std::rethrow_exception(eptr);
     });
   }
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -340,7 +340,7 @@ target_link_libraries(ceph_test_librgw_file_nfsns
   ${LUA_LIBRARIES}
   ${ALLOC_LIBS}
   )
-  target_link_libraries(ceph_test_librgw_file_nfsns spawn)
+  target_link_libraries(ceph_test_librgw_file_nfsns Boost::context)
 install(TARGETS ceph_test_librgw_file_nfsns DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_librgw_file_aw (nfs write transaction [atomic write] tests)
@@ -374,7 +374,7 @@ target_link_libraries(ceph_test_librgw_file_marker
   ${LUA_LIBRARIES}
   ${ALLOC_LIBS}
   )
-  target_link_libraries(ceph_test_librgw_file_marker spawn)
+  target_link_libraries(ceph_test_librgw_file_marker Boost::context)
 install(TARGETS ceph_test_librgw_file_marker DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_librgw_file_xattr (attribute ops)
@@ -393,7 +393,7 @@ target_link_libraries(ceph_test_librgw_file_xattr
   ${LUA_LIBRARIES}
   ${ALLOC_LIBS}
   )
-target_link_libraries(ceph_test_librgw_file_xattr spawn)
+target_link_libraries(ceph_test_librgw_file_xattr Boost::context)
 
 # ceph_test_librgw_file_rename (mv/rename tests)
 add_executable(ceph_test_librgw_file_rename

--- a/src/test/librados/CMakeLists.txt
+++ b/src/test/librados/CMakeLists.txt
@@ -60,7 +60,7 @@ target_link_libraries(ceph_test_rados_api_aio_pp
 
 add_executable(ceph_test_rados_api_asio asio.cc)
 target_link_libraries(ceph_test_rados_api_asio global
-  librados ${UNITTEST_LIBS} spawn)
+  librados ${UNITTEST_LIBS} Boost::context)
 
 add_executable(ceph_test_rados_api_list
   list.cc
@@ -133,7 +133,7 @@ target_include_directories(ceph_test_rados_api_tier_pp
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw")
 target_link_libraries(ceph_test_rados_api_tier_pp
   librados global ${UNITTEST_LIBS} Boost::system radostest-cxx cls_cas_internal
-  cls_cas_client spawn)
+  cls_cas_client Boost::context)
 
 add_executable(ceph_test_rados_api_snapshots
   snapshots.cc)

--- a/src/test/librados/asio.cc
+++ b/src/test/librados/asio.cc
@@ -208,7 +208,7 @@ TEST_F(AsioRados, AsyncReadOperationCallback)
       EXPECT_FALSE(ec);
       EXPECT_EQ("hello", bl.to_str());
     };
-    librados::async_operate(service, io, "exist", &op, 0, success_cb);
+    librados::async_operate(service, io, "exist", &op, 0, nullptr, success_cb);
   }
   {
     librados::ObjectReadOperation op;
@@ -216,7 +216,7 @@ TEST_F(AsioRados, AsyncReadOperationCallback)
     auto failure_cb = [&] (boost::system::error_code ec, bufferlist bl) {
       EXPECT_EQ(boost::system::errc::no_such_file_or_directory, ec);
     };
-    librados::async_operate(service, io, "noexist", &op, 0, failure_cb);
+    librados::async_operate(service, io, "noexist", &op, 0, nullptr, failure_cb);
   }
   service.run();
 }
@@ -228,14 +228,14 @@ TEST_F(AsioRados, AsyncReadOperationFuture)
   {
     librados::ObjectReadOperation op;
     op.read(0, 0, nullptr, nullptr);
-    f1 = librados::async_operate(service, io, "exist", &op, 0,
+    f1 = librados::async_operate(service, io, "exist", &op, 0, nullptr,
                                  boost::asio::use_future);
   }
   std::future<bufferlist> f2;
   {
     librados::ObjectReadOperation op;
     op.read(0, 0, nullptr, nullptr);
-    f2 = librados::async_operate(service, io, "noexist", &op, 0,
+    f2 = librados::async_operate(service, io, "noexist", &op, 0, nullptr,
                                  boost::asio::use_future);
   }
   service.run();
@@ -255,7 +255,7 @@ TEST_F(AsioRados, AsyncReadOperationYield)
     librados::ObjectReadOperation op;
     op.read(0, 0, nullptr, nullptr);
     boost::system::error_code ec;
-    auto bl = librados::async_operate(service, io, "exist", &op, 0,
+    auto bl = librados::async_operate(service, io, "exist", &op, 0, nullptr,
                                       yield[ec]);
     EXPECT_FALSE(ec);
     EXPECT_EQ("hello", bl.to_str());
@@ -266,7 +266,7 @@ TEST_F(AsioRados, AsyncReadOperationYield)
     librados::ObjectReadOperation op;
     op.read(0, 0, nullptr, nullptr);
     boost::system::error_code ec;
-    auto bl = librados::async_operate(service, io, "noexist", &op, 0,
+    auto bl = librados::async_operate(service, io, "noexist", &op, 0, nullptr,
                                       yield[ec]);
     EXPECT_EQ(boost::system::errc::no_such_file_or_directory, ec);
   };
@@ -288,7 +288,7 @@ TEST_F(AsioRados, AsyncWriteOperationCallback)
     auto success_cb = [&] (boost::system::error_code ec) {
       EXPECT_FALSE(ec);
     };
-    librados::async_operate(service, io, "exist", &op, 0, success_cb);
+    librados::async_operate(service, io, "exist", &op, 0, nullptr, success_cb);
   }
   {
     librados::ObjectWriteOperation op;
@@ -296,7 +296,7 @@ TEST_F(AsioRados, AsyncWriteOperationCallback)
     auto failure_cb = [&] (boost::system::error_code ec) {
       EXPECT_EQ(boost::system::errc::read_only_file_system, ec);
     };
-    librados::async_operate(service, snapio, "exist", &op, 0, failure_cb);
+    librados::async_operate(service, snapio, "exist", &op, 0, nullptr, failure_cb);
   }
   service.run();
 }
@@ -312,14 +312,14 @@ TEST_F(AsioRados, AsyncWriteOperationFuture)
   {
     librados::ObjectWriteOperation op;
     op.write_full(bl);
-    f1 = librados::async_operate(service, io, "exist", &op, 0,
+    f1 = librados::async_operate(service, io, "exist", &op, 0, nullptr,
                                  boost::asio::use_future);
   }
   std::future<void> f2;
   {
     librados::ObjectWriteOperation op;
     op.write_full(bl);
-    f2 = librados::async_operate(service, snapio, "exist", &op, 0,
+    f2 = librados::async_operate(service, snapio, "exist", &op, 0, nullptr,
                                  boost::asio::use_future);
   }
   service.run();
@@ -339,7 +339,7 @@ TEST_F(AsioRados, AsyncWriteOperationYield)
     librados::ObjectWriteOperation op;
     op.write_full(bl);
     boost::system::error_code ec;
-    librados::async_operate(service, io, "exist", &op, 0, yield[ec]);
+    librados::async_operate(service, io, "exist", &op, 0, nullptr, yield[ec]);
     EXPECT_FALSE(ec);
   };
   spawn::spawn(service, success_cr);
@@ -348,7 +348,7 @@ TEST_F(AsioRados, AsyncWriteOperationYield)
     librados::ObjectWriteOperation op;
     op.write_full(bl);
     boost::system::error_code ec;
-    librados::async_operate(service, snapio, "exist", &op, 0, yield[ec]);
+    librados::async_operate(service, snapio, "exist", &op, 0, nullptr, yield[ec]);
     EXPECT_EQ(boost::system::errc::read_only_file_system, ec);
   };
   spawn::spawn(service, failure_cr);

--- a/src/test/librados/asio.cc
+++ b/src/test/librados/asio.cc
@@ -21,8 +21,8 @@
 
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
-#include <spawn/spawn.hpp>
 #include <boost/asio/io_context.hpp>
+#include <boost/asio/spawn.hpp>
 #include <boost/asio/use_future.hpp>
 
 #define dout_subsys ceph_subsys_rados
@@ -73,6 +73,10 @@ librados::Rados AsioRados::rados;
 librados::IoCtx AsioRados::io;
 librados::IoCtx AsioRados::snapio;
 
+void rethrow(std::exception_ptr eptr) {
+  if (eptr) std::rethrow_exception(eptr);
+}
+
 TEST_F(AsioRados, AsyncReadCallback)
 {
   boost::asio::io_context service;
@@ -113,20 +117,20 @@ TEST_F(AsioRados, AsyncReadYield)
 {
   boost::asio::io_context service;
 
-  auto success_cr = [&] (spawn::yield_context yield) {
+  auto success_cr = [&] (boost::asio::yield_context yield) {
     boost::system::error_code ec;
     auto bl = librados::async_read(service, io, "exist", 256, 0, yield[ec]);
     EXPECT_FALSE(ec);
     EXPECT_EQ("hello", bl.to_str());
   };
-  spawn::spawn(service, success_cr);
+  boost::asio::spawn(service, success_cr, rethrow);
 
-  auto failure_cr = [&] (spawn::yield_context yield) {
+  auto failure_cr = [&] (boost::asio::yield_context yield) {
     boost::system::error_code ec;
     auto bl = librados::async_read(service, io, "noexist", 256, 0, yield[ec]);
     EXPECT_EQ(boost::system::errc::no_such_file_or_directory, ec);
   };
-  spawn::spawn(service, failure_cr);
+  boost::asio::spawn(service, failure_cr, rethrow);
 
   service.run();
 }
@@ -178,22 +182,22 @@ TEST_F(AsioRados, AsyncWriteYield)
   bufferlist bl;
   bl.append("hello");
 
-  auto success_cr = [&] (spawn::yield_context yield) {
+  auto success_cr = [&] (boost::asio::yield_context yield) {
     boost::system::error_code ec;
     librados::async_write(service, io, "exist", bl, bl.length(), 0,
                           yield[ec]);
     EXPECT_FALSE(ec);
     EXPECT_EQ("hello", bl.to_str());
   };
-  spawn::spawn(service, success_cr);
+  boost::asio::spawn(service, success_cr, rethrow);
 
-  auto failure_cr = [&] (spawn::yield_context yield) {
+  auto failure_cr = [&] (boost::asio::yield_context yield) {
     boost::system::error_code ec;
     librados::async_write(service, snapio, "exist", bl, bl.length(), 0,
                           yield[ec]);
     EXPECT_EQ(boost::system::errc::read_only_file_system, ec);
   };
-  spawn::spawn(service, failure_cr);
+  boost::asio::spawn(service, failure_cr, rethrow);
 
   service.run();
 }
@@ -251,7 +255,7 @@ TEST_F(AsioRados, AsyncReadOperationYield)
 {
   boost::asio::io_context service;
 
-  auto success_cr = [&] (spawn::yield_context yield) {
+  auto success_cr = [&] (boost::asio::yield_context yield) {
     librados::ObjectReadOperation op;
     op.read(0, 0, nullptr, nullptr);
     boost::system::error_code ec;
@@ -260,9 +264,9 @@ TEST_F(AsioRados, AsyncReadOperationYield)
     EXPECT_FALSE(ec);
     EXPECT_EQ("hello", bl.to_str());
   };
-  spawn::spawn(service, success_cr);
+  boost::asio::spawn(service, success_cr, rethrow);
 
-  auto failure_cr = [&] (spawn::yield_context yield) {
+  auto failure_cr = [&] (boost::asio::yield_context yield) {
     librados::ObjectReadOperation op;
     op.read(0, 0, nullptr, nullptr);
     boost::system::error_code ec;
@@ -270,7 +274,7 @@ TEST_F(AsioRados, AsyncReadOperationYield)
                                       yield[ec]);
     EXPECT_EQ(boost::system::errc::no_such_file_or_directory, ec);
   };
-  spawn::spawn(service, failure_cr);
+  boost::asio::spawn(service, failure_cr, rethrow);
 
   service.run();
 }
@@ -335,23 +339,23 @@ TEST_F(AsioRados, AsyncWriteOperationYield)
   bufferlist bl;
   bl.append("hello");
 
-  auto success_cr = [&] (spawn::yield_context yield) {
+  auto success_cr = [&] (boost::asio::yield_context yield) {
     librados::ObjectWriteOperation op;
     op.write_full(bl);
     boost::system::error_code ec;
     librados::async_operate(service, io, "exist", &op, 0, nullptr, yield[ec]);
     EXPECT_FALSE(ec);
   };
-  spawn::spawn(service, success_cr);
+  boost::asio::spawn(service, success_cr, rethrow);
 
-  auto failure_cr = [&] (spawn::yield_context yield) {
+  auto failure_cr = [&] (boost::asio::yield_context yield) {
     librados::ObjectWriteOperation op;
     op.write_full(bl);
     boost::system::error_code ec;
     librados::async_operate(service, snapio, "exist", &op, 0, nullptr, yield[ec]);
     EXPECT_EQ(boost::system::errc::read_only_file_system, ec);
   };
-  spawn::spawn(service, failure_cr);
+  boost::asio::spawn(service, failure_cr, rethrow);
 
   service.run();
 }

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -34,7 +34,6 @@ target_link_libraries(ceph_test_rgw_d4n_directory PRIVATE
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
-  target_link_libraries(ceph_test_rgw_d4n_directory PRIVATE spawn)
 install(TARGETS ceph_test_rgw_d4n_directory DESTINATION ${CMAKE_INSTALL_BINDIR})
   
 add_executable(ceph_test_rgw_d4n_policy
@@ -50,7 +49,6 @@ target_link_libraries(ceph_test_rgw_d4n_policy PRIVATE
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
-  target_link_libraries(ceph_test_rgw_d4n_policy PRIVATE spawn)
 install(TARGETS ceph_test_rgw_d4n_policy DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(ceph_test_rgw_redis_driver
@@ -66,7 +64,6 @@ target_link_libraries(ceph_test_rgw_redis_driver PRIVATE
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
-  target_link_libraries(ceph_test_rgw_redis_driver PRIVATE spawn)
 install(TARGETS ceph_test_rgw_redis_driver DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(ceph_test_rgw_ssd_driver
@@ -82,7 +79,6 @@ target_link_libraries(ceph_test_rgw_ssd_driver PRIVATE
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
-  target_link_libraries(ceph_test_rgw_ssd_driver PRIVATE spawn)
 install(TARGETS ceph_test_rgw_ssd_driver DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 

--- a/src/test/rgw/test_d4n_directory.cc
+++ b/src/test/rgw/test_d4n_directory.cc
@@ -138,10 +138,14 @@ class BlockDirectoryFixture: public ::testing::Test {
 				     "objName", "bucketName", "creationTime", "dirty", "objHosts"};
 };
 
+void rethrow(std::exception_ptr eptr) {
+  if (eptr) std::rethrow_exception(eptr);
+}
+
 TEST_F(ObjectDirectoryFixture, SetYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, dir->set(obj, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, dir->set(obj, yield));
 
     boost::system::error_code ec;
     request req;
@@ -156,15 +160,15 @@ TEST_F(ObjectDirectoryFixture, SetYield)
     ASSERT_EQ((bool)ec, false);
     EXPECT_EQ(std::get<0>(resp).value(), vals);
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(ObjectDirectoryFixture, GetYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, dir->set(obj, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, dir->set(obj, yield));
 
     {
       boost::system::error_code ec;
@@ -178,7 +182,7 @@ TEST_F(ObjectDirectoryFixture, GetYield)
       EXPECT_EQ(std::get<0>(resp).value(), 0);
     }
 
-    ASSERT_EQ(0, dir->get(obj, optional_yield{io, yield}));
+    ASSERT_EQ(0, dir->get(obj, yield));
     EXPECT_EQ(obj->objName, "newoid");
 
     {
@@ -191,16 +195,16 @@ TEST_F(ObjectDirectoryFixture, GetYield)
     }
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(ObjectDirectoryFixture, CopyYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, dir->set(obj, optional_yield{io, yield}));
-    ASSERT_EQ(0, dir->copy(obj, "copyTestName", "copyBucketName", optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, dir->set(obj, yield));
+    ASSERT_EQ(0, dir->copy(obj, "copyTestName", "copyBucketName", yield));
 
     boost::system::error_code ec;
     request req;
@@ -222,15 +226,15 @@ TEST_F(ObjectDirectoryFixture, CopyYield)
     EXPECT_EQ(std::get<1>(resp).value(), copyVals);
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(ObjectDirectoryFixture, DelYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, dir->set(obj, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, dir->set(obj, yield));
 
     {
       boost::system::error_code ec;
@@ -244,7 +248,7 @@ TEST_F(ObjectDirectoryFixture, DelYield)
       EXPECT_EQ(std::get<0>(resp).value(), 1);
     }
 
-    ASSERT_EQ(0, dir->del(obj, optional_yield{io, yield}));
+    ASSERT_EQ(0, dir->del(obj, yield));
 
     {
       boost::system::error_code ec;
@@ -260,17 +264,17 @@ TEST_F(ObjectDirectoryFixture, DelYield)
     }
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(ObjectDirectoryFixture, UpdateFieldYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, dir->set(obj, optional_yield{io, yield}));
-    ASSERT_EQ(0, dir->update_field(obj, "objName", "newTestName", optional_yield{io, yield}));
-    ASSERT_EQ(0, dir->update_field(obj, "objHosts", "127.0.0.1:5000", optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, dir->set(obj, yield));
+    ASSERT_EQ(0, dir->update_field(obj, "objName", "newTestName", yield));
+    ASSERT_EQ(0, dir->update_field(obj, "objHosts", "127.0.0.1:5000", yield));
 
     boost::system::error_code ec;
     request req;
@@ -286,7 +290,7 @@ TEST_F(ObjectDirectoryFixture, UpdateFieldYield)
     EXPECT_EQ(std::get<0>(resp).value()[1], "127.0.0.1:6379_127.0.0.1:5000");
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
@@ -294,8 +298,8 @@ TEST_F(ObjectDirectoryFixture, UpdateFieldYield)
 
 TEST_F(BlockDirectoryFixture, SetYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, dir->set(block, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, dir->set(block, yield));
 
     boost::system::error_code ec;
     request req;
@@ -310,15 +314,15 @@ TEST_F(BlockDirectoryFixture, SetYield)
     ASSERT_EQ((bool)ec, false);
     EXPECT_EQ(std::get<0>(resp).value(), vals);
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(BlockDirectoryFixture, GetYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, dir->set(block, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, dir->set(block, yield));
 
     {
       boost::system::error_code ec;
@@ -332,7 +336,7 @@ TEST_F(BlockDirectoryFixture, GetYield)
       EXPECT_EQ(std::get<0>(resp).value(), 0);
     }
 
-    ASSERT_EQ(0, dir->get(block, optional_yield{io, yield}));
+    ASSERT_EQ(0, dir->get(block, yield));
     EXPECT_EQ(block->cacheObj.objName, "newoid");
 
     {
@@ -345,16 +349,16 @@ TEST_F(BlockDirectoryFixture, GetYield)
     }
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(BlockDirectoryFixture, CopyYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, dir->set(block, optional_yield{io, yield}));
-    ASSERT_EQ(0, dir->copy(block, "copyTestName", "copyBucketName", optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, dir->set(block, yield));
+    ASSERT_EQ(0, dir->copy(block, "copyTestName", "copyBucketName", yield));
 
     boost::system::error_code ec;
     request req;
@@ -376,15 +380,15 @@ TEST_F(BlockDirectoryFixture, CopyYield)
     EXPECT_EQ(std::get<1>(resp).value(), copyVals);
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(BlockDirectoryFixture, DelYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, dir->set(block, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, dir->set(block, yield));
 
     {
       boost::system::error_code ec;
@@ -398,7 +402,7 @@ TEST_F(BlockDirectoryFixture, DelYield)
       EXPECT_EQ(std::get<0>(resp).value(), 1);
     }
 
-    ASSERT_EQ(0, dir->del(block, optional_yield{io, yield}));
+    ASSERT_EQ(0, dir->del(block, yield));
 
     {
       boost::system::error_code ec;
@@ -414,17 +418,17 @@ TEST_F(BlockDirectoryFixture, DelYield)
     }
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(BlockDirectoryFixture, UpdateFieldYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, dir->set(block, optional_yield{io, yield}));
-    ASSERT_EQ(0, dir->update_field(block, "objName", "newTestName", optional_yield{io, yield}));
-    ASSERT_EQ(0, dir->update_field(block, "blockHosts", "127.0.0.1:5000", optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, dir->set(block, yield));
+    ASSERT_EQ(0, dir->update_field(block, "objName", "newTestName", yield));
+    ASSERT_EQ(0, dir->update_field(block, "blockHosts", "127.0.0.1:5000", yield));
 
     boost::system::error_code ec;
     request req;
@@ -440,17 +444,17 @@ TEST_F(BlockDirectoryFixture, UpdateFieldYield)
     EXPECT_EQ(std::get<0>(resp).value()[1], "127.0.0.1:6379_127.0.0.1:5000");
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(BlockDirectoryFixture, RemoveHostYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
     block->hostsList.push_back("127.0.0.1:6000");
-    ASSERT_EQ(0, dir->set(block, optional_yield{io, yield}));
-    ASSERT_EQ(0, dir->remove_host(block, "127.0.0.1:6379", optional_yield{io, yield}));
+    ASSERT_EQ(0, dir->set(block, yield));
+    ASSERT_EQ(0, dir->remove_host(block, "127.0.0.1:6379", yield));
 
     {
       boost::system::error_code ec;
@@ -466,7 +470,7 @@ TEST_F(BlockDirectoryFixture, RemoveHostYield)
       EXPECT_EQ(std::get<1>(resp).value(), "127.0.0.1:6000");
     }
 
-    ASSERT_EQ(0, dir->remove_host(block, "127.0.0.1:6000", optional_yield{io, yield}));
+    ASSERT_EQ(0, dir->remove_host(block, "127.0.0.1:6000", yield));
 
     {
       boost::system::error_code ec;
@@ -482,7 +486,7 @@ TEST_F(BlockDirectoryFixture, RemoveHostYield)
     }
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }

--- a/src/test/rgw/test_d4n_policy.cc
+++ b/src/test/rgw/test_d4n_policy.cc
@@ -156,14 +156,18 @@ class LFUDAPolicyFixture : public ::testing::Test {
     rgw::sal::Attrs attrs;
 };
 
+void rethrow(std::exception_ptr eptr) {
+  if (eptr) std::rethrow_exception(eptr);
+}
+
 TEST_F(LFUDAPolicyFixture, LocalGetBlockYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
     std::string key = block->cacheObj.bucketName + "_" + block->cacheObj.objName + "_" + std::to_string(block->blockID) + "_" + std::to_string(block->size);
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, key, bl, bl.length(), attrs, optional_yield{io, yield}));
-    policyDriver->get_cache_policy()->update(env->dpp, key, 0, bl.length(), "", optional_yield{io, yield});
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, key, bl, bl.length(), attrs, yield));
+    policyDriver->get_cache_policy()->update(env->dpp, key, 0, bl.length(), "", yield);
 
-    ASSERT_EQ(lfuda(env->dpp, block, cacheDriver, optional_yield{io, yield}), 0);
+    ASSERT_EQ(lfuda(env->dpp, block, cacheDriver, yield), 0);
 
     cacheDriver->shutdown();
 
@@ -179,14 +183,14 @@ TEST_F(LFUDAPolicyFixture, LocalGetBlockYield)
     ASSERT_EQ((bool)ec, false);
     EXPECT_EQ(std::get<0>(resp).value(), "2");
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(LFUDAPolicyFixture, RemoteGetBlockYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
     /* Set victim block for eviction */
     rgw::d4n::CacheBlock victim = rgw::d4n::CacheBlock{
       .cacheObj = {
@@ -210,10 +214,10 @@ TEST_F(LFUDAPolicyFixture, RemoteGetBlockYield)
     attrVal.append("testBucket");
     attrs.insert({"bucket_name", attrVal});
 
-    ASSERT_EQ(0, dir->set(&victim, optional_yield{io, yield}));
+    ASSERT_EQ(0, dir->set(&victim, yield));
     std::string victimKey = victim.cacheObj.bucketName + "_" + victim.cacheObj.objName + "_" + std::to_string(victim.blockID) + "_" + std::to_string(victim.size);
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, victimKey, bl, bl.length(), attrs, optional_yield{io, yield}));
-    policyDriver->get_cache_policy()->update(env->dpp, victimKey, 0, bl.length(), "", optional_yield{io, yield});
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, victimKey, bl, bl.length(), attrs, yield));
+    policyDriver->get_cache_policy()->update(env->dpp, victimKey, 0, bl.length(), "", yield);
 
     /* Remote block */
     block->size = cacheDriver->get_free_space(env->dpp) + 1; /* To trigger eviction */
@@ -222,9 +226,9 @@ TEST_F(LFUDAPolicyFixture, RemoteGetBlockYield)
     block->hostsList.push_back("127.0.0.1:6000");
     block->cacheObj.hostsList.push_back("127.0.0.1:6000");
 
-    ASSERT_EQ(0, dir->set(block, optional_yield{io, yield}));
+    ASSERT_EQ(0, dir->set(block, yield));
 
-    ASSERT_GE(lfuda(env->dpp, block, cacheDriver, optional_yield{io, yield}), 0);
+    ASSERT_GE(lfuda(env->dpp, block, cacheDriver, yield), 0);
 
     cacheDriver->shutdown();
 
@@ -246,15 +250,15 @@ TEST_F(LFUDAPolicyFixture, RemoteGetBlockYield)
     EXPECT_EQ(std::get<1>(resp).value(), 0);
     EXPECT_EQ(std::get<2>(resp).value(), "1");
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(LFUDAPolicyFixture, BackendGetBlockYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_GE(lfuda(env->dpp, block, cacheDriver, optional_yield{io, yield}), 0);
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_GE(lfuda(env->dpp, block, cacheDriver, yield), 0);
 
     cacheDriver->shutdown();
 
@@ -267,16 +271,16 @@ TEST_F(LFUDAPolicyFixture, BackendGetBlockYield)
     conn->async_exec(req, resp, yield[ec]);
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(LFUDAPolicyFixture, RedisSyncTest)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
     env->cct->_conf->rgw_lfuda_sync_frequency = 1;
-    dynamic_cast<rgw::d4n::LFUDAPolicy*>(policyDriver->get_cache_policy())->save_y(optional_yield{io, yield});
+    dynamic_cast<rgw::d4n::LFUDAPolicy*>(policyDriver->get_cache_policy())->save_y(yield);
     policyDriver->get_cache_policy()->init(env->cct, env->dpp, io);
   
     cacheDriver->shutdown();
@@ -308,7 +312,7 @@ TEST_F(LFUDAPolicyFixture, RedisSyncTest)
     
     delete policyDriver; 
     policyDriver = nullptr;
-  });
+  }, rethrow);
 
   io.run();
 }

--- a/src/test/rgw/test_redis_driver.cc
+++ b/src/test/rgw/test_redis_driver.cc
@@ -122,10 +122,14 @@ class RedisDriverFixture: public ::testing::Test {
     rgw::sal::Attrs attrs;
 };
 
+void rethrow(std::exception_ptr eptr) {
+  if (eptr) std::rethrow_exception(eptr);
+}
+
 TEST_F(RedisDriverFixture, PutYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, yield));
     cacheDriver->shutdown();
 
     boost::system::error_code ec;
@@ -140,15 +144,15 @@ TEST_F(RedisDriverFixture, PutYield)
     ASSERT_EQ((bool)ec, false);
     EXPECT_EQ(std::get<0>(resp).value(), "attrVal");
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(RedisDriverFixture, GetYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, yield));
 
     {
       boost::system::error_code ec;
@@ -165,7 +169,7 @@ TEST_F(RedisDriverFixture, GetYield)
     bufferlist ret;
     rgw::sal::Attrs retAttrs;
 
-    ASSERT_EQ(0, cacheDriver->get(env->dpp, "testName", 0, bl.length(), ret, retAttrs, optional_yield{io, yield}));
+    ASSERT_EQ(0, cacheDriver->get(env->dpp, "testName", 0, bl.length(), ret, retAttrs, yield));
     EXPECT_EQ(ret.to_str(), "new data");
     EXPECT_EQ(retAttrs.begin()->second.to_str(), "newVal");
     cacheDriver->shutdown();
@@ -182,16 +186,16 @@ TEST_F(RedisDriverFixture, GetYield)
     }
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(RedisDriverFixture, PutAsyncYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    std::unique_ptr<rgw::Aio> aio = rgw::make_throttle(env->cct->_conf->rgw_get_obj_window_size, optional_yield{io, yield});
-    auto completed = cacheDriver->put_async(env->dpp, optional_yield{io, yield}, aio.get(), "testName", bl, bl.length(), attrs, 0, 0);
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    std::unique_ptr<rgw::Aio> aio = rgw::make_throttle(env->cct->_conf->rgw_get_obj_window_size, yield);
+    auto completed = cacheDriver->put_async(env->dpp, yield, aio.get(), "testName", bl, bl.length(), attrs, 0, 0);
     drain(env->dpp, aio.get());
 
     cacheDriver->shutdown();
@@ -208,18 +212,18 @@ TEST_F(RedisDriverFixture, PutAsyncYield)
     EXPECT_EQ(std::get<0>(resp).value()[0], "attrVal");
     EXPECT_EQ(std::get<0>(resp).value()[1], "test data");
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(RedisDriverFixture, GetAsyncYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, yield));
 
-    std::unique_ptr<rgw::Aio> aio = rgw::make_throttle(env->cct->_conf->rgw_get_obj_window_size, optional_yield{io, yield});
-    auto completed = cacheDriver->get_async(env->dpp, optional_yield{io, yield}, aio.get(), "testName", 0, bl.length(), 0, 0);
+    std::unique_ptr<rgw::Aio> aio = rgw::make_throttle(env->cct->_conf->rgw_get_obj_window_size, yield);
+    auto completed = cacheDriver->get_async(env->dpp, yield, aio.get(), "testName", 0, bl.length(), 0, 0);
     drain(env->dpp, aio.get());
 
     cacheDriver->shutdown();
@@ -236,15 +240,15 @@ TEST_F(RedisDriverFixture, GetAsyncYield)
     EXPECT_EQ(std::get<0>(resp).value()[0], "attrVal");
     EXPECT_EQ(std::get<0>(resp).value()[1], "test data");
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(RedisDriverFixture, DelYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, yield));
 
     {
       boost::system::error_code ec;
@@ -258,7 +262,7 @@ TEST_F(RedisDriverFixture, DelYield)
       EXPECT_EQ(std::get<0>(resp).value(), 1);
     }
 
-    ASSERT_EQ(0, cacheDriver->del(env->dpp, "testName", optional_yield{io, yield}));
+    ASSERT_EQ(0, cacheDriver->del(env->dpp, "testName", yield));
     cacheDriver->shutdown();
 
     {
@@ -275,15 +279,15 @@ TEST_F(RedisDriverFixture, DelYield)
     }
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(RedisDriverFixture, AppendDataYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, yield));
 
     {
       boost::system::error_code ec;
@@ -300,7 +304,7 @@ TEST_F(RedisDriverFixture, AppendDataYield)
     bufferlist val;
     val.append(" has been written");
 
-    ASSERT_EQ(0, cacheDriver->append_data(env->dpp, "testName", val, optional_yield{io, yield}));
+    ASSERT_EQ(0, cacheDriver->append_data(env->dpp, "testName", val, yield));
     cacheDriver->shutdown();
 
     {
@@ -317,15 +321,15 @@ TEST_F(RedisDriverFixture, AppendDataYield)
     }
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(RedisDriverFixture, DeleteDataYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, yield));
 
     {
       boost::system::error_code ec;
@@ -339,7 +343,7 @@ TEST_F(RedisDriverFixture, DeleteDataYield)
       EXPECT_EQ(std::get<0>(resp).value(), 1);
     }
 
-    ASSERT_EQ(0, cacheDriver->delete_data(env->dpp, "testName", optional_yield{io, yield}));
+    ASSERT_EQ(0, cacheDriver->delete_data(env->dpp, "testName", yield));
     cacheDriver->shutdown();
 
     {
@@ -356,15 +360,15 @@ TEST_F(RedisDriverFixture, DeleteDataYield)
     }
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(RedisDriverFixture, SetAttrsYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, yield));
 
     rgw::sal::Attrs newAttrs;
     bufferlist newVal;
@@ -375,7 +379,7 @@ TEST_F(RedisDriverFixture, SetAttrsYield)
     newVal.append("nextVal");
     newAttrs.insert({"nextAttr", newVal});
 
-    ASSERT_EQ(0, cacheDriver->set_attrs(env->dpp, "testName", newAttrs, optional_yield{io, yield}));
+    ASSERT_EQ(0, cacheDriver->set_attrs(env->dpp, "testName", newAttrs, yield));
     cacheDriver->shutdown();
 
     boost::system::error_code ec;
@@ -392,20 +396,20 @@ TEST_F(RedisDriverFixture, SetAttrsYield)
     EXPECT_EQ(std::get<0>(resp).value()[0], "newVal");
     EXPECT_EQ(std::get<0>(resp).value()[1], "nextVal");
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(RedisDriverFixture, GetAttrsYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
     rgw::sal::Attrs nextAttrs = attrs;
     bufferlist nextVal;
     nextVal.append("nextVal");
     nextAttrs.insert({"nextAttr", nextVal});
 
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), nextAttrs, optional_yield{io, yield}));
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), nextAttrs, yield));
 
     {
       boost::system::error_code ec;
@@ -421,7 +425,7 @@ TEST_F(RedisDriverFixture, GetAttrsYield)
 
     rgw::sal::Attrs retAttrs;
 
-    ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "testName", retAttrs, optional_yield{io, yield}));
+    ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "testName", retAttrs, yield));
    
     auto it = retAttrs.begin();
     EXPECT_EQ(it->second.to_str(), "newVal1");
@@ -441,22 +445,22 @@ TEST_F(RedisDriverFixture, GetAttrsYield)
     }
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(RedisDriverFixture, UpdateAttrsYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, yield));
 
     rgw::sal::Attrs newAttrs;
     bufferlist newVal;
     newVal.append("newVal");
     newAttrs.insert({"attr", newVal});
 
-    ASSERT_EQ(0, cacheDriver->update_attrs(env->dpp, "testName", newAttrs, optional_yield{io, yield}));
+    ASSERT_EQ(0, cacheDriver->update_attrs(env->dpp, "testName", newAttrs, yield));
     cacheDriver->shutdown();
 
     boost::system::error_code ec;
@@ -471,15 +475,15 @@ TEST_F(RedisDriverFixture, UpdateAttrsYield)
     EXPECT_EQ(std::get<0>(resp).value(), "newVal");
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(RedisDriverFixture, DeleteAttrsYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, yield));
 
     {
       boost::system::error_code ec;
@@ -497,7 +501,7 @@ TEST_F(RedisDriverFixture, DeleteAttrsYield)
     bufferlist delVal;
     delAttrs.insert({"attr", delVal});
 
-    ASSERT_GE(cacheDriver->delete_attrs(env->dpp, "testName", delAttrs, optional_yield{io, yield}), 0);
+    ASSERT_GE(cacheDriver->delete_attrs(env->dpp, "testName", delAttrs, yield), 0);
     cacheDriver->shutdown();
 
     {
@@ -514,16 +518,16 @@ TEST_F(RedisDriverFixture, DeleteAttrsYield)
     }
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(RedisDriverFixture, SetAttrYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, optional_yield{io, yield}));
-    ASSERT_GE(cacheDriver->set_attr(env->dpp, "testName", "newAttr", "newVal", optional_yield{io, yield}), 0);
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, yield));
+    ASSERT_GE(cacheDriver->set_attr(env->dpp, "testName", "newAttr", "newVal", yield), 0);
     cacheDriver->shutdown();
 
     boost::system::error_code ec;
@@ -538,15 +542,15 @@ TEST_F(RedisDriverFixture, SetAttrYield)
     ASSERT_EQ((bool)ec, false);
     EXPECT_EQ(std::get<0>(resp).value(), "newVal");
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }
 
 TEST_F(RedisDriverFixture, GetAttrYield)
 {
-  spawn::spawn(io, [this] (spawn::yield_context yield) {
-    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, optional_yield{io, yield}));
+  boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+    ASSERT_EQ(0, cacheDriver->put(env->dpp, "testName", bl, bl.length(), attrs, yield));
 
     {
       boost::system::error_code ec;
@@ -560,7 +564,7 @@ TEST_F(RedisDriverFixture, GetAttrYield)
       EXPECT_EQ(std::get<0>(resp).value(), 0);
     }
     std::string attr_val;
-    ASSERT_EQ(0, cacheDriver->get_attr(env->dpp, "testName", "attr", attr_val, optional_yield{io, yield}));
+    ASSERT_EQ(0, cacheDriver->get_attr(env->dpp, "testName", "attr", attr_val, yield));
     ASSERT_EQ("newVal", attr_val);
     cacheDriver->shutdown();
 
@@ -576,7 +580,7 @@ TEST_F(RedisDriverFixture, GetAttrYield)
     }
 
     conn->cancel();
-  });
+  }, rethrow);
 
   io.run();
 }

--- a/src/test/rgw/test_ssd_driver.cc
+++ b/src/test/rgw/test_ssd_driver.cc
@@ -112,159 +112,163 @@ class SSDDriverFixture: public ::testing::Test {
     rgw::sal::Attrs del_attrs;
 };
 
+void rethrow(std::exception_ptr eptr) {
+  if (eptr) std::rethrow_exception(eptr);
+}
+
 TEST_F(SSDDriverFixture, PutAndGet)
 {
-    spawn::spawn(io, [this] (spawn::yield_context yield) {
+    boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
         rgw::sal::Attrs attrs = {};
-        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testPutGet", bl, bl.length(), attrs, optional_yield{io, yield}));
+        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testPutGet", bl, bl.length(), attrs, yield));
         bufferlist ret;
         rgw::sal::Attrs get_attrs;
-        ASSERT_EQ(0, cacheDriver->get(env->dpp, "testPutGet", 0, bl.length(), ret, get_attrs, optional_yield{io, yield}));
+        ASSERT_EQ(0, cacheDriver->get(env->dpp, "testPutGet", 0, bl.length(), ret, get_attrs, yield));
         EXPECT_EQ(ret, bl);
         EXPECT_EQ(get_attrs.size(), 0);
-    });
+    }, rethrow);
 
     io.run();
 }
 
 TEST_F(SSDDriverFixture, AppendData)
 {
-    spawn::spawn(io, [this] (spawn::yield_context yield) {
+    boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
         rgw::sal::Attrs attrs = {};
-        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testAppend", bl, bl.length(), attrs, optional_yield{io, yield}));
+        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testAppend", bl, bl.length(), attrs, yield));
     
         bufferlist bl_append;
         bl_append.append(" xyz");
-        ASSERT_EQ(0, cacheDriver->append_data(env->dpp, "testAppend", bl_append, optional_yield{io, yield}));
+        ASSERT_EQ(0, cacheDriver->append_data(env->dpp, "testAppend", bl_append, yield));
     
         bufferlist ret;
         bl.append(bl_append);
         rgw::sal::Attrs get_attrs;
-        ASSERT_EQ(0, cacheDriver->get(env->dpp, "testAppend", 0, bl.length(), ret, get_attrs, optional_yield{io, yield}));
+        ASSERT_EQ(0, cacheDriver->get(env->dpp, "testAppend", 0, bl.length(), ret, get_attrs, yield));
         EXPECT_EQ(ret, bl);
         EXPECT_EQ(get_attrs.size(), 0);
-    });
+    }, rethrow);
 
     io.run();
 }
 
 TEST_F(SSDDriverFixture, SetGetAttrs)
 {
-    spawn::spawn(io, [this] (spawn::yield_context yield) {
-        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testSetGetAttrs", bl, bl.length(), attrs, optional_yield{io, yield}));
+    boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testSetGetAttrs", bl, bl.length(), attrs, yield));
         bufferlist ret;
         rgw::sal::Attrs ret_attrs;
-        ASSERT_EQ(0, cacheDriver->get(env->dpp, "testSetGetAttrs", 0, bl.length(), ret, ret_attrs, optional_yield{io, yield}));
+        ASSERT_EQ(0, cacheDriver->get(env->dpp, "testSetGetAttrs", 0, bl.length(), ret, ret_attrs, yield));
         EXPECT_EQ(ret, bl);
         EXPECT_EQ(ret_attrs.size(), 1);
         for (auto& it : ret_attrs) {
           EXPECT_EQ(it.first, "user.rgw.attrName");
           EXPECT_EQ(it.second, attrVal);
         }
-    });
+    }, rethrow);
 
     io.run();
 }
 
 TEST_F(SSDDriverFixture, UpdateAttrs)
 {
-    spawn::spawn(io, [this] (spawn::yield_context yield) {
-        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testUpdateAttrs", bl, bl.length(), attrs, optional_yield{io, yield}));
-        ASSERT_EQ(0, cacheDriver->update_attrs(env->dpp, "testUpdateAttrs", update_attrs, optional_yield{io, yield}));
+    boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testUpdateAttrs", bl, bl.length(), attrs, yield));
+        ASSERT_EQ(0, cacheDriver->update_attrs(env->dpp, "testUpdateAttrs", update_attrs, yield));
         rgw::sal::Attrs get_attrs;
-        ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "testUpdateAttrs", get_attrs, optional_yield{io, yield}));
+        ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "testUpdateAttrs", get_attrs, yield));
         EXPECT_EQ(get_attrs.size(), 2);
         EXPECT_EQ(get_attrs["user.rgw.attrName"], updateAttrVal1);
         EXPECT_EQ(get_attrs["user.rgw.testAttr"], updateAttrVal2);
-    });
+    }, rethrow);
 
     io.run();
 }
 
 TEST_F(SSDDriverFixture, SetGetAttr)
 {
-    spawn::spawn(io, [this] (spawn::yield_context yield) {
+    boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
       rgw::sal::Attrs attrs = {};
-      ASSERT_EQ(0, cacheDriver->put(env->dpp, "testSetGetAttr", bl, bl.length(), attrs, optional_yield{io, yield}));
+      ASSERT_EQ(0, cacheDriver->put(env->dpp, "testSetGetAttr", bl, bl.length(), attrs, yield));
       std::string attr_name = "user.ssd.testattr";
       std::string attr_val = "testattrVal";
-      ASSERT_EQ(0, cacheDriver->set_attr(env->dpp, "testSetGetAttr", attr_name, attr_val, optional_yield{io, yield}));
+      ASSERT_EQ(0, cacheDriver->set_attr(env->dpp, "testSetGetAttr", attr_name, attr_val, yield));
       std::string attr_val_ret;
-      ASSERT_EQ(0, cacheDriver->get_attr(env->dpp, "testSetGetAttr", attr_name, attr_val_ret, optional_yield{io, yield}));
+      ASSERT_EQ(0, cacheDriver->get_attr(env->dpp, "testSetGetAttr", attr_name, attr_val_ret, yield));
       ASSERT_EQ(attr_val, attr_val_ret);
-    });
+    }, rethrow);
 
     io.run();
 }
 
 TEST_F(SSDDriverFixture, DeleteAttr)
 {
-    spawn::spawn(io, [this] (spawn::yield_context yield) {
+    boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
       rgw::sal::Attrs attrs = {};
-      ASSERT_EQ(0, cacheDriver->put(env->dpp, "testDeleteAttr", bl, bl.length(), attrs, optional_yield{io, yield}));
+      ASSERT_EQ(0, cacheDriver->put(env->dpp, "testDeleteAttr", bl, bl.length(), attrs, yield));
       std::string attr_name = "user.ssd.testattr";
       std::string attr_val = "testattrVal";
-      ASSERT_EQ(0, cacheDriver->set_attr(env->dpp, "testDeleteAttr", attr_name, attr_val, optional_yield{io, yield}));
+      ASSERT_EQ(0, cacheDriver->set_attr(env->dpp, "testDeleteAttr", attr_name, attr_val, yield));
       std::string attr_val_ret;
-      ASSERT_EQ(0, cacheDriver->get_attr(env->dpp, "testDeleteAttr", attr_name, attr_val_ret, optional_yield{io, yield}));
+      ASSERT_EQ(0, cacheDriver->get_attr(env->dpp, "testDeleteAttr", attr_name, attr_val_ret, yield));
       ASSERT_EQ(attr_val, attr_val_ret);
 
       attr_val_ret.clear();
       ASSERT_EQ(0, cacheDriver->delete_attr(env->dpp, "testDeleteAttr", attr_name));
-      ASSERT_EQ(ENODATA, cacheDriver->get_attr(env->dpp, "testDeleteAttr", attr_name, attr_val_ret, optional_yield{io, yield}));
+      ASSERT_EQ(ENODATA, cacheDriver->get_attr(env->dpp, "testDeleteAttr", attr_name, attr_val_ret, yield));
       ASSERT_EQ("", attr_val_ret);
-    });
+    }, rethrow);
 
     io.run();
 }
 
 TEST_F(SSDDriverFixture, DeleteAttrs)
 {
-    spawn::spawn(io, [this] (spawn::yield_context yield) {
-      ASSERT_EQ(0, cacheDriver->put(env->dpp, "testDeleteAttr", bl, bl.length(), attrs, optional_yield{io, yield}));
+    boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
+      ASSERT_EQ(0, cacheDriver->put(env->dpp, "testDeleteAttr", bl, bl.length(), attrs, yield));
       rgw::sal::Attrs ret_attrs;
-      ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "testDeleteAttr", ret_attrs, optional_yield{io, yield}));
+      ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "testDeleteAttr", ret_attrs, yield));
       EXPECT_EQ(ret_attrs.size(), 1);
       for (auto& it : ret_attrs) {
         EXPECT_EQ(it.first, "user.rgw.attrName");
         EXPECT_EQ(it.second, attrVal);
       }
 
-      ASSERT_EQ(0, cacheDriver->delete_attrs(env->dpp, "testDeleteAttr", del_attrs, optional_yield{io, yield}));
+      ASSERT_EQ(0, cacheDriver->delete_attrs(env->dpp, "testDeleteAttr", del_attrs, yield));
       ret_attrs.clear();
-      ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "testDeleteAttr", del_attrs, optional_yield{io, yield}));
+      ASSERT_EQ(0, cacheDriver->get_attrs(env->dpp, "testDeleteAttr", del_attrs, yield));
       EXPECT_EQ(ret_attrs.size(), 0);
-    });
+    }, rethrow);
 
     io.run();
 }
 
 TEST_F(SSDDriverFixture, DeleteData)
 {
-    spawn::spawn(io, [this] (spawn::yield_context yield) {
+    boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
         rgw::sal::Attrs attrs = {};
-        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testDeleteData", bl, bl.length(), attrs, optional_yield{io, yield}));
+        ASSERT_EQ(0, cacheDriver->put(env->dpp, "testDeleteData", bl, bl.length(), attrs, yield));
         bufferlist ret;
         rgw::sal::Attrs get_attrs;
-        ASSERT_EQ(0, cacheDriver->get(env->dpp, "testDeleteData", 0, bl.length(), ret, get_attrs, optional_yield{io, yield}));
+        ASSERT_EQ(0, cacheDriver->get(env->dpp, "testDeleteData", 0, bl.length(), ret, get_attrs, yield));
         EXPECT_EQ(ret, bl);
         EXPECT_EQ(get_attrs.size(), 0);
-        ASSERT_EQ(0, cacheDriver->delete_data(env->dpp, "testDeleteData", optional_yield{io, yield}));
-        ASSERT_EQ(-ENOENT, cacheDriver->get(env->dpp, "testDeleteData", 0, bl.length(), ret, get_attrs, optional_yield{io, yield}));
-    });
+        ASSERT_EQ(0, cacheDriver->delete_data(env->dpp, "testDeleteData", yield));
+        ASSERT_EQ(-ENOENT, cacheDriver->get(env->dpp, "testDeleteData", 0, bl.length(), ret, get_attrs, yield));
+    }, rethrow);
 
     io.run();
 }
 
 TEST_F(SSDDriverFixture, PutAsync)
 {
-    spawn::spawn(io, [this] (spawn::yield_context yield) {
+    boost::asio::spawn(io, [this] (boost::asio::yield_context yield) {
         rgw::sal::Attrs attrs = {};
         const uint64_t window_size = env->cct->_conf->rgw_put_obj_min_window_size;
-        std::unique_ptr<rgw::Aio> aio = rgw::make_throttle(window_size, optional_yield{io, yield});
-        auto results = cacheDriver->put_async(env->dpp, optional_yield{io, yield}, aio.get(), "testPutAsync", bl, bl.length(), attrs, bl.length(), 0);
+        std::unique_ptr<rgw::Aio> aio = rgw::make_throttle(window_size, yield);
+        auto results = cacheDriver->put_async(env->dpp, yield, aio.get(), "testPutAsync", bl, bl.length(), attrs, bl.length(), 0);
         drain(env->dpp, aio.get());
-    });
+    }, rethrow);
 
     io.run();
 }


### PR DESCRIPTION
a fork of `boost::asio::spawn()` was introduced in 2020 with `spawn::spawn()` from https://github.com/ceph/ceph/pull/31580. this fork enabled rgw to customize how the coroutine stacks are allocated in order to avoid stack overflows in frontend request coroutines. this customization was based on a StackAllocator concept from the boost::context library

in boost 1.80, that same [StackAllocator overload](https://www.boost.org/doc/libs/1_80_0/doc/html/boost_asio/reference/spawn/overload4.html) was added to `boost::asio::spawn()`, along with other improvements like per-op cancellation. now that boost has everything we need, switch back and drop the spawn submodule

this required switching a lot of async functions from `async_completion<>` to `async_initiate<>`. similar changes were necessary to enable the c++20 coroutine token `boost::asio::use_awaitable`

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
