### PR TITLE
quincy: batch backport of #50743,  #55342, #48557

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4931,7 +4931,7 @@ def infer_mon_network(ctx: CephadmContext, mon_eps: List[EndPoint]) -> Optional[
     mon_networks = []
     for net, ifaces in list_networks(ctx).items():
         # build local_ips list for the specified network
-        local_ips: List[str] = []
+        local_ips: List[Union[ipaddress.IPv4Address, ipaddress.IPv6Address]] = []
         for _, ls in ifaces.items():
             local_ips.extend([ipaddress.ip_address(ip) for ip in ls])
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -230,9 +230,8 @@ class ContainerEngine:
     def __init__(self) -> None:
         self.path = find_program(self.EXE)
 
-    @classmethod
     @property
-    def EXE(cls) -> str:
+    def EXE(self) -> str:
         raise NotImplementedError()
 
     def __str__(self) -> str:

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -69,8 +69,11 @@ def cephadm_fs(
          mock.patch('platform.processor', return_value='x86_64'), \
          mock.patch('cephadm.extract_uid_gid', return_value=(uid, gid)):
 
-        if not fake_filesystem.is_root():
-            fake_filesystem.set_uid(0)
+        try:
+            if not fake_filesystem.is_root():
+                fake_filesystem.set_uid(0)
+        except AttributeError:
+            pass
 
         fs.create_dir(cd.DATA_DIR)
         fs.create_dir(cd.LOG_DIR)

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -33,7 +33,8 @@ addopts =
 [testenv]
 skip_install=true
 deps =
-  pyfakefs == 5.0
+  pyfakefs == 4.5.6 ; python_version < "3.7"
+  pyfakefs >= 5, < 6 ; python_version >= "3.7"
   mock
   pytest
 commands=pytest {posargs}

--- a/src/mypy-constrains.txt
+++ b/src/mypy-constrains.txt
@@ -2,7 +2,7 @@
 # Unfortunately this means we have to manually update those 
 # packages regularly. 
 
-mypy==0.901
+mypy==0.981
 
 # global
 types-python-dateutil==0.1.3

--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -22,7 +22,7 @@ from prettytable import PrettyTable, HEADER
 from signal import signal, Signals, SIGWINCH
 from termios import TIOCGWINSZ
 from types import FrameType
-from typing import Any, Callable, Dict, List, Optional, Sequence, TextIO, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, TextIO, Tuple, Union
 
 from ceph_argparse import parse_json_funcsigs, validate_command
 
@@ -367,8 +367,8 @@ class DaemonWatcher(object):
             raise RuntimeError("no stats selected by filters")
 
     def _handle_sigwinch(self,
-                         signo: Signals,
-                         frame: FrameType) -> None:
+                         signo: Union[int, Signals],
+                         frame: Optional[FrameType]) -> None:
         self.termsize.update()
 
     def run(self,

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -98,7 +98,7 @@ class NFSService(CephService):
 
         # generate the ganesha config
         def get_ganesha_conf() -> str:
-            context = {
+            context: Dict[str, Any] = {
                 "user": rados_user,
                 "nodeid": nodeid,
                 "pool": POOL_NAME,

--- a/src/pybind/mgr/dashboard/controllers/_rest_controller.py
+++ b/src/pybind/mgr/dashboard/controllers/_rest_controller.py
@@ -70,6 +70,7 @@ class RESTController(BaseController, skip_registry=True):
         for k, v in cls._method_mapping.items():
             func = getattr(cls, k, None)
             while hasattr(func, "__wrapped__"):
+                assert func
                 func = func.__wrapped__
             if v['resource'] and func:
                 path_params = cls.get_path_param_names()

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -569,7 +569,7 @@ class AccessControlDB(object):
 
 
 def load_access_control_db():
-    mgr.ACCESS_CTRL_DB = AccessControlDB.load()
+    mgr.ACCESS_CTRL_DB = AccessControlDB.load()  # type: ignore
 
 
 # CLI dashboard access control scope commands

--- a/src/pybind/mgr/dashboard/services/exception.py
+++ b/src/pybind/mgr/dashboard/services/exception.py
@@ -34,7 +34,7 @@ def serialize_dashboard_exception(e, include_http_status=False, task=None):
     component = getattr(e, 'component', None)
     out['component'] = component if component else None
     if include_http_status:
-        out['status'] = getattr(e, 'status', 500)
+        out['status'] = getattr(e, 'status', 500)  # type: ignore
     if task:
         out['task'] = dict(name=task.name, metadata=task.metadata)  # type: ignore
     return out

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -480,7 +480,7 @@ class RgwClient(RestClient):
     def _is_system_user(self, admin_path, userid, request=None) -> bool:
         # pylint: disable=unused-argument
         response = request()
-        return strtobool(response['data']['system'])
+        return strtobool(response['data']['system'])  # type: ignore
 
     def is_system_user(self) -> bool:
         return self._is_system_user(self.admin_path, self.userid)

--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -90,7 +90,7 @@ class SsoDB(object):
 
 
 def load_sso_db():
-    mgr.SSO_DB = SsoDB.load()
+    mgr.SSO_DB = SsoDB.load()  # type: ignore
 
 
 SSO_COMMANDS = [

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -342,7 +342,7 @@ def _extract_target_func(
     wrapped = getattr(f, "__wrapped__", None)
     if not wrapped:
         return f, {}
-    extra_args = {}
+    extra_args: Dict[str, Any] = {}
     while wrapped is not None:
         extra_args.update(getattr(f, "extra_args", {}))
         f = wrapped

--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -2,3 +2,4 @@
 asyncssh==2.9
 kubernetes==11.0.0
 urllib3==1.26.15
+pytest==7.4.4

--- a/src/python-common/ceph/deployment/drive_selection/matchers.py
+++ b/src/python-common/ceph/deployment/drive_selection/matchers.py
@@ -313,10 +313,10 @@ class SizeMatcher(Matcher):
         and raises if none could be found.
         """
         low_high = re.match(r"\d+[A-Z]{1,2}:\d+[A-Z]{1,2}", self.value)
-        if low_high:
-            low, high = low_high.group().split(":")
-            self.low = self._get_k_v(low)
-            self.high = self._get_k_v(high)
+        if low_high is not None:
+            lowpart, highpart = low_high.group().split(":")
+            self.low = self._get_k_v(lowpart)
+            self.high = self._get_k_v(highpart)
 
         low = re.match(r"\d+[A-Z]{1,2}:$", self.value)
         if low:

--- a/src/python-common/tox.ini
+++ b/src/python-common/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3, lint
+envlist = py3, mypy, lint
 skip_missing_interpreters = true
 
 [testenv:py3]
@@ -9,6 +9,13 @@ deps=
 commands=
     pytest --doctest-modules ceph/deployment/service_spec.py ceph/utils.py
     pytest {posargs}
+    mypy --config-file=../mypy.ini -p ceph
+
+[testenv:mypy]
+deps=
+    -rrequirements.txt
+    -c{toxinidir}/../mypy-constrains.txt
+commands=
     mypy --config-file=../mypy.ini -p ceph
 
 [tool:pytest]


### PR DESCRIPTION
Backport of #50743 , #55342 and #48557


### About #50743 : update pinned mypy version
There is no tracker for #50743.
This is required to be backported to quincy because of https://github.com/ceph/ceph/pull/55516#issuecomment-1943676379
This is backported to reef in PR #50881

### About #55342: pin pytest to version 7.4.4
Tracker:  https://tracker.ceph.com/issues/64200
Backport tracker:  https://tracker.ceph.com/issues/64235
This is backported to reef in PR #55362

### About #48557: cephadm: fix running cephadm tox test suite on python 3.6 
Needed to be backported due to failing tests on this PR
See https://github.com/ceph/ceph/pull/55593#discussion_r1503382011

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Mypy is a testing tool
  - [X] pytest is a testing framework

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
