### PR TITLE
os/bluestore: eliminate build warnings

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2865,7 +2865,7 @@ uint32_t BlueStore::Blob::merge_blob(CephContext* cct, Blob* blob_to_dissolve)
     auto buf = src->bc.buffer_map.extract(src->bc.buffer_map.cbegin());
     buf.mapped().space = &dst->bc;
     if (dst->bc.buffer_map.count(buf.key()) == 0) {
-      dst->bc.buffer_map.insert({buf.key(), std::move(buf.mapped())});
+      dst->bc.buffer_map.emplace(buf.key(), std::move(buf.mapped()));
     }
   }
   // move BufferSpace writing

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1049,7 +1049,7 @@ public:
 
     void bound_encode_spanning_blobs(size_t& p);
     void encode_spanning_blobs(ceph::buffer::list::contiguous_appender& p);
-    BlobRef get_spanning_blob(int id) {
+    BlobRef& get_spanning_blob(int id) {
       auto p = spanning_blob_map.find(id);
       ceph_assert(p != spanning_blob_map.end());
       return p->second;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1455,19 +1455,19 @@ private:
       _trim_to(0);
     }
 
-    virtual void shift_bins() {
+    void shift_bins() {
       std::lock_guard l(lock);
       age_bins.push_front(std::make_shared<int64_t>(0));
     }
-    virtual uint32_t get_bin_count() {
+    uint32_t get_bin_count() {
       std::lock_guard l(lock);
       return age_bins.capacity();
     }
-    virtual void set_bin_count(uint32_t count) {
+    void set_bin_count(uint32_t count) {
       std::lock_guard l(lock);
       age_bins.set_capacity(count);
     }
-    virtual uint64_t sum_bins(uint32_t start, uint32_t end) {
+    uint64_t sum_bins(uint32_t start, uint32_t end) {
       std::lock_guard l(lock);
       auto size = age_bins.size();
       if (size < start) {


### PR DESCRIPTION
I don't completely understand the reasons behind these warnings but provided patch eliminates them.
Warnings to be fixed:
- Call to virtual method 'CacheShard::shift_bins' during construction bypasses virtual dispatch
- In function ‘constexpr std::_Require<std::__not_<std::__is_tuple_like<_Tp> >, std::is_move_constructible<_Tp>, std::is_move_assignable<_Tp> > std::swap(_Tp&, _Tp&) [with _Tp = unsigned int]’,
    inlined from ‘BlueStore::Buffer::Buffer(BlueStore::Buffer&&)’ at /home/if/quincy.2/src/os/bluestore/BlueStore.h:322:16,
    inlined from ‘constexpr std::pair<_T1, _T2>::pair(_U1&&, _U2&&) [with _U1 = unsigned int&; _U2 = BlueStore::Buffer; _T1 = const unsigned int; _T2 = BlueStore::Buffer]’ at /usr/include/c++/12/bits/stl_pair.h:281:35,
    inlined from ‘uint32_t BlueStore::Blob::merge_blob(ceph::common::CephContext*, BlueStore::Blob*)’ at /home/if/quincy.2/src/os/bluestore/BlueStore.cc:2868:32:
/usr/include/c++/12/bits/move.h:204:11: warning: ‘*(__vector(2) unsigned int*)((char*)&<unnamed> + offsetof(std::value_type, std::pair<const unsigned int, BlueStore::Buffer>::second.BlueStore::Buffer::offset))’ may be used uninitialized [-Wmaybe-uninitialized]
  204 |       _Tp __tmp = _GLIBCXX_MOVE(__a);
      |           ^~~~~
/home/if/quincy.2/src/os/bluestore/BlueStore.cc: In member function ‘uint32_t BlueStore::Blob::merge_blob(ceph::common::CephContext*, BlueStore::Blob*)’:
/home/if/quincy.2/src/os/bluestore/BlueStore.cc:2868:32: note: ‘<anonymous>’ declared here
 2868 |       dst->bc.buffer_map.insert({buf.key(), std::move(buf.mapped())});
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

- In file included from /usr/include/c++/12/bits/shared_ptr_atomic.h:33,
                 from /usr/include/c++/12/memory:77,
                 from /home/if/quincy.2/build/boost/include/boost/function/function_base.hpp:33,
                 from /home/if/quincy.2/build/boost/include/boost/function/detail/prologue.hpp:18,
                 from /home/if/quincy.2/build/boost/include/boost/function.hpp:30,
                 from /home/if/quincy.2/build/boost/include/boost/algorithm/string/detail/find_iterator.hpp:18,
                 from /home/if/quincy.2/build/boost/include/boost/algorithm/string/find_iterator.hpp:24,
                 from /home/if/quincy.2/build/boost/include/boost/algorithm/string/iter_find.hpp:27,
                 from /home/if/quincy.2/build/boost/include/boost/algorithm/string/split.hpp:16,
                 from /home/if/quincy.2/build/boost/include/boost/algorithm/string.hpp:23,
                 from /home/if/quincy.2/src/os/bluestore/BlueStore.cc:24:
In member function ‘std::__atomic_base<_IntTp>::__int_type std::__atomic_base<_IntTp>::operator++() [with _ITp = long unsigned int]’,
    inlined from ‘void BlueStore::BufferCacheShard::add_extent()’ at /home/if/quincy.2/src/os/bluestore/BlueStore.h:1538:7,
    inlined from ‘void BlueStore::Extent::assign_blob(const BlueStore::BlobRef&)’ at /home/if/quincy.2/src/os/bluestore/BlueStore.h:863:49,
    inlined from ‘virtual void BlueStore::ExtentMap::ExtentDecoderFull::consume_blobid(BlueStore::Extent*, bool, uint64_t)’ at /home/if/quincy.2/src/os/bluestore/BlueStore.cc:4087:20:
/usr/include/c++/12/bits/atomic_base.h:385:34: warning: ‘long unsigned int __atomic_add_fetch_8(volatile void*, long unsigned int, int)’ writing 8 bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
  385 |       { return __atomic_add_fetch(&_M_i, 1, int(memory_order_seq_cst)); }
      |                ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
