### PR TITLE
osd: clean compiler warnings

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -11531,7 +11531,7 @@ void PrimaryLogPG::submit_log_entries(
   }
 
   pgbackend->call_write_ordered(
-    [this, entries, repop, on_complete]() {
+    [this, entries, repop, on_complete]() mutable {
       ObjectStore::Transaction t;
       eversion_t old_last_update = info.last_update;
       recovery_state.merge_new_log_entries(
@@ -12109,7 +12109,6 @@ int PrimaryLogPG::find_object_context(const hobject_t& oid,
   dout(20) << __func__ << " " << soid
 	   << " snapset " << obc->ssc->snapset
 	   << dendl;
-  snapid_t first, last;
   auto p = obc->ssc->snapset.clone_snaps.find(soid.snap);
   ceph_assert(p != obc->ssc->snapset.clone_snaps.end());
   if (p->second.empty()) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10503,7 +10503,7 @@ int PrimaryLogPG::start_dedup(OpRequestRef op, ObjectContextRef obc)
     obc_g ? &(obc_g->obs.oi.manifest) : nullptr,
     refs);
 
-  for (auto p : chunks) {
+  for (const auto& p : chunks) {
     hobject_t target = mop->new_manifest.chunk_map[p.first].oid;
     if (refs.find(target) == refs.end()) {
       continue;

--- a/src/test/crush/crush.cc
+++ b/src/test/crush/crush.cc
@@ -337,11 +337,6 @@ TEST_P(IndepTest, out_progressive) {
       if (i > 0) cout << "marked out " << i - 1 << " ";
       cout << x << " -> " << out << std::endl;
 
-      int num_none = 0;
-      for (unsigned k=0; k<out.size(); ++k) {
-	if (out[k] == CRUSH_ITEM_NONE)
-	  num_none++;
-      }
       ASSERT_EQ(0, get_num_dups(out));
 
       // make sure nothing moved


### PR DESCRIPTION
... for unused variables, for code that has no effect, and for trying to std::move out of a const lvalue.

