### PR TITLE
unittest-seastar-socket: tolerate connection_reset in test_unexpected_down

### DIFF
--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -449,7 +449,7 @@ future<> test_unexpected_down(bool is_fixed_cpu) {
     [](auto cs) {
       return Connection::dispatch_rw_bounded(cs, 128, true
         ).handle_exception_type([](const std::system_error& e) {
-        logger().debug("test_unexpected_down(): client get error {}", e);
+        logger().error("test_unexpected_down(): client get error {}", e);
         ceph_assert(e.code() == error::read_eof);
       });
     },

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -450,7 +450,8 @@ future<> test_unexpected_down(bool is_fixed_cpu) {
       return Connection::dispatch_rw_bounded(cs, 128, true
         ).handle_exception_type([](const std::system_error& e) {
         logger().error("test_unexpected_down(): client get error {}", e);
-        ceph_assert(e.code() == error::read_eof);
+        ceph_assert(e.code() == error::read_eof ||
+		    e.code() == std::errc::connection_reset);
       });
     },
     [](auto ss) { return Connection::dispatch_rw_unbounded(ss); }


### PR DESCRIPTION
Related: https://tracker.ceph.com/issues/64457

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
