### PR TITLE
reef: rgw/putobj: RadosWriter uses part head object for multipart parts

### DIFF
--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -124,6 +124,11 @@ void RadosWriter::add_write_hint(librados::ObjectWriteOperation& op) {
   op.set_alloc_hint2(0, 0, alloc_hint_flags);
 }
 
+void RadosWriter::set_head_obj(const rgw_obj& head)
+{
+  head_obj = head;
+}
+
 int RadosWriter::set_stripe_obj(const rgw_raw_obj& raw_obj)
 {
   stripe_obj = store->svc.rados->obj(raw_obj);
@@ -450,6 +455,9 @@ int MultipartObjectProcessor::prepare_head()
   rgw_raw_obj stripe_obj = manifest_gen.get_cur_obj(store);
   RGWSI_Tier_RADOS::raw_obj_to_obj(head_obj.bucket, stripe_obj, &head_obj);
   head_obj.index_hash_source = target_obj.key.name;
+
+  // point part uploads at the part head instead of the final multipart head
+  writer.set_head_obj(head_obj);
 
   r = writer.set_stripe_obj(stripe_obj);
   if (r < 0) {

--- a/src/rgw/driver/rados/rgw_putobj_processor.h
+++ b/src/rgw/driver/rados/rgw_putobj_processor.h
@@ -69,7 +69,7 @@ class RadosWriter : public rgw::sal::DataProcessor {
   RGWRados *const store;
   const RGWBucketInfo& bucket_info;
   RGWObjectCtx& obj_ctx;
-  const rgw_obj head_obj;
+  rgw_obj head_obj;
   RGWSI_RADOS::Obj stripe_obj; // current stripe object
   RawObjSet written; // set of written objects for deletion
   const DoutPrefixProvider *dpp;
@@ -87,6 +87,9 @@ class RadosWriter : public rgw::sal::DataProcessor {
 
   // add alloc hint to osd
   void add_write_hint(librados::ObjectWriteOperation& op);
+
+  // change the head object
+  void set_head_obj(const rgw_obj& head);
 
   // change the current stripe object
   int set_stripe_obj(const rgw_raw_obj& obj);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64426

---

backport of https://github.com/ceph/ceph/pull/55582
parent tracker: https://tracker.ceph.com/issues/63642

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh