### PR TITLE
[WIP] src/mon/ElectionLogic: Improve victory logic for connectivity strategy 

### DIFF
--- a/qa/suites/netsplit/ceph.yaml
+++ b/qa/suites/netsplit/ceph.yaml
@@ -10,6 +10,7 @@ overrides:
         mon osdmap full prune min: 15
         mon osdmap full prune interval: 2
         mon osdmap full prune txsize: 2
+        debug mon: 30
 # thrashing monitors may make mgr have trouble w/ its keepalive
     log-whitelist:
       - overall HEALTH_

--- a/qa/suites/netsplit/tests/mon_pool_ops.yaml
+++ b/qa/suites/netsplit/tests/mon_pool_ops.yaml
@@ -7,15 +7,7 @@ tasks:
 - workunit:
     clients:
       client.0:
-        - mon/pool_ops.sh
-- netsplit.disconnect: [mon.a, mon.c]
-- workunit:
-    clients:
-      client.0:
-        - mon/pool_ops.sh
-- netsplit.reconnect: [mon.a, mon.c]
-- netsplit.disconnect: [mon.b, mon.c]
-- workunit:
-    clients:
-      client.0:
-        - mon/pool_ops.sh
+        - mon/setup_stretch_cluster.sh
+- cephfs_test_runner:
+    modules:
+      - tasks.test_netsplit

--- a/qa/tasks/test_netsplit.py
+++ b/qa/tasks/test_netsplit.py
@@ -1,0 +1,136 @@
+from tasks.ceph_test_case import CephTestCase
+import logging
+from tasks.netsplit import disconnect, reconnect, get_ip_and_ports
+import itertools
+import time
+log = logging.getLogger(__name__)
+
+
+class TestNetSplit(CephTestCase):
+    MON_LIST = ["mon.a", "mon.b", "mon.c"]
+    CLUSTER = "ceph"
+    WRITE_PERIOD = 10
+    RECOVERY_PERIOD = WRITE_PERIOD * 6
+    SUCCESS_HOLD_TIME = 10
+
+    def setUp(self):
+        """
+        Set up the cluster for the test.
+        """
+        super(TestNetSplit, self).setUp()
+
+    def tearDown(self):
+        """
+        Clean up the cluter after the test.
+        """
+        super(TestNetSplit, self).tearDown()
+
+    def _disconnect_mons(self, config):
+        """
+        Disconnect the mons in the <config> list.
+        """
+        disconnect(self.ctx, config)
+
+    def _reconnect_mons(self, config):
+        """
+        Reconnect the mons in the <config> list.
+        """
+        reconnect(self.ctx, config)
+
+    def _reply_to_mon_command(self):
+        """
+        Check if the cluster is accessible.
+        """
+        try:
+            self.mgr_cluster.mon_manager.raw_cluster_cmd('status')
+            return True
+        except Exception:
+            return False
+
+    def _check_if_disconnect(self, config):
+        """
+        Check if the mons in the <config> list are disconnected.
+        """
+        assert config[0].startswith('mon.')
+        assert config[1].startswith('mon.')
+        log.info("Checking if the {} and {} are disconnected".format(
+            config[0], config[1]))
+        (ip1, _) = get_ip_and_ports(self.ctx, config[0])
+        (ip2, _) = get_ip_and_ports(self.ctx, config[1])
+        (host1,) = self.ctx.cluster.only(config[0]).remotes.keys()
+        (host2,) = self.ctx.cluster.only(config[1]).remotes.keys()
+        assert host1 is not None
+        assert host2 is not None
+        # if the mons are disconnected, the ping should fail (exitstatus = 1)
+        try:
+            if (host1.run(args=["ping", "-c", "1", ip2]).exitstatus == 0 or
+                    host2.run(args=["ping", "-c", "1", ip1]).exitstatus == 0):
+                return False
+        except Exception:
+            return True
+
+    def _check_if_connect(self, config):
+        """
+        Check if the mons in the <config> list are connected.
+        """
+        assert config[0].startswith('mon.')
+        assert config[1].startswith('mon.')
+        log.info("Checking if {} and {} are connected".format(
+                config[0], config[1]))
+        (ip1, _) = get_ip_and_ports(self.ctx, config[0])
+        (ip2, _) = get_ip_and_ports(self.ctx, config[1])
+        (host1,) = self.ctx.cluster.only(config[0]).remotes.keys()
+        (host2,) = self.ctx.cluster.only(config[1]).remotes.keys()
+        assert host1 is not None
+        assert host2 is not None
+        # if the mons are connected, the ping should succeed (exitstatus = 0)
+        try:
+            if (host1.run(args=["ping", "-c", "1", ip2]).exitstatus == 0 and
+                    host2.run(args=["ping", "-c", "1", ip1]).exitstatus == 0):
+                return True
+        except Exception:
+            return False
+
+    def test_mon_netsplit(self):
+        """
+        Test the mon netsplit.
+        """
+        log.info("Running test_mon_netsplit")
+        # check if all the mons are connected
+        self.wait_until_true(
+            lambda: all(
+                [
+                    self._check_if_connect([mon1, mon2])
+                    for mon1, mon2 in itertools.combinations(self.MON_LIST, 2)
+                ]
+            ),
+            timeout=self.RECOVERY_PERIOD,
+        )
+        # Scenario 1: disconnect Site 1 and Site 2
+        # Arbiter node is still connected to both sites
+        config = ["mon.a", "mon.b"]
+        # disconnect the mons
+        self._disconnect_mons(config)
+        # wait for the mons to be disconnected
+        time.sleep(self.RECOVERY_PERIOD)
+        # check if the mons are disconnected
+        self.wait_until_true(
+            lambda: self._check_if_disconnect(config),
+            timeout=self.RECOVERY_PERIOD,
+        )
+        # check the cluster is accessible
+        self.wait_until_true_and_hold(
+            lambda: self._reply_to_mon_command(),
+            timeout=self.RECOVERY_PERIOD * 5,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+        # reconnect the mons
+        self._reconnect_mons(config)
+        # wait for the mons to be reconnected
+        time.sleep(self.RECOVERY_PERIOD)
+        # check if the mons are reconnected
+        self.wait_until_true(
+            lambda: self._check_if_connect(config),
+            timeout=self.RECOVERY_PERIOD,
+        )
+        log.info("test_mon_netsplit passed!")

--- a/qa/workunits/mon/setup_stretch_cluster.sh
+++ b/qa/workunits/mon/setup_stretch_cluster.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -ex
+
+NUM_OSDS_UP=$(ceph osd df | grep "up" | wc -l)
+
+if [ $NUM_OSDS_UP -lt 8 ]; then
+    echo "test requires at least 8 OSDs up and running"
+    exit 1
+fi
+
+ceph mon set election_strategy connectivity
+ceph mon add disallowed_leader c
+
+for zone in iris pze
+    do
+      ceph osd crush add-bucket $zone zone
+      ceph osd crush move $zone root=default
+    done
+
+ceph osd crush add-bucket node-2 host
+ceph osd crush add-bucket node-3 host
+
+ceph osd crush move node-2 zone=iris
+ceph osd crush move node-3 zone=pze
+
+ceph osd crush move osd.0 host=node-2
+ceph osd crush move osd.1 host=node-2
+ceph osd crush move osd.2 host=node-2
+ceph osd crush move osd.3 host=node-2
+ceph osd crush move osd.4 host=node-3
+ceph osd crush move osd.5 host=node-3
+ceph osd crush move osd.6 host=node-3
+ceph osd crush move osd.7 host=node-3
+
+
+ceph mon set_location a zone=iris host=node-2
+ceph mon set_location b zone=pze host=node-3
+
+hostname=$(hostname -s)
+ceph osd crush remove $hostname ||  { echo 'command failed' ; exit 1; }
+ceph osd getcrushmap > crushmap ||  { echo 'command failed' ; exit 1; }
+crushtool --decompile crushmap > crushmap.txt ||  { echo 'command failed' ; exit 1; }
+sed 's/^# end crush map$//' crushmap.txt > crushmap_modified.txt || { echo 'command failed' ; exit 1; }
+cat >> crushmap_modified.txt << EOF
+rule stretch_rule {
+        id 1
+        type replicated
+        step take iris
+        step chooseleaf firstn 2 type host
+        step emit
+        step take pze
+        step chooseleaf firstn 2 type host
+        step emit
+}
+# end crush map
+EOF
+
+crushtool --compile crushmap_modified.txt -o crushmap.bin || { echo 'command failed' ; exit 1; }
+ceph osd setcrushmap -i crushmap.bin  || { echo 'command failed' ; exit 1; }
+stretched_poolname=stretch_pool
+ceph osd pool create $stretched_poolname 32 32 stretch_rule || { echo 'command failed' ; exit 1; }
+ceph osd pool set $stretched_poolname size 4 || { echo 'command failed' ; exit 1; }
+ceph osd pool application enable $stretched_poolname rados || { echo 'command failed' ; exit 1; }
+ceph mon set_location c zone=arbiter host=node-1 || { echo 'command failed' ; exit 1; }
+ceph mon enable_stretch_mode c stretch_rule zone || { echo 'command failed' ; exit 1; } # Enter strech mode

--- a/qa/workunits/mon/stretch_workload.sh
+++ b/qa/workunits/mon/stretch_workload.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -ex
+
+rados bench -p stretched_rbdpool 10 write -b 4096 --no-cleanup

--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -92,6 +92,13 @@ public:
    */
   virtual unsigned paxos_size() const = 0;
   /**
+  * Obtain quorum from monitor
+  *
+  * @returns quorum.
+  */
+  virtual const std::set<int>& get_quorum() const = 0;
+  virtual const std::set<int>& get_dead_pinging() const = 0;
+  /**
    * Retrieve a set of ranks which are not allowed to become the leader.
    * Like paxos_size(), This set can change between elections, but not
    * during them.

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -121,6 +121,11 @@ int Elector::get_my_rank() const
   return mon->rank;
 }
 
+const std::set<int>& Elector::get_quorum() const
+{
+return mon->get_quorum();
+}
+
 void Elector::reset_election()
 {
   mon->bootstrap();

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -241,6 +241,13 @@ class Elector : public ElectionOwner, RankProvider {
   bool ever_participated() const;
   /* Retrieve monmap->size() */
   unsigned paxos_size() const;
+  /**
+  * Obtain quorum from monitor
+  *
+  * @returns quorum.
+  */
+  const std::set<int>& get_quorum() const;
+  const std::set<int>& get_dead_pinging() const {return dead_pinging;}
   /* Right now we don't disallow anybody */
   std::set<int> disallowed_leaders;
   const std::set<int>& get_disallowed_leaders() const { return disallowed_leaders; }


### PR DESCRIPTION
Problem:

When there are 3 MONs in 3 different hosts [mon.a, mon.b, mon.c (tiebreaker)]
and there is a netsplit scenario between mon.a and mon.b
while mon.a is still able to connect to mon.c and mon.b still
able to connect to mon.c, lets say mon.a has the best connection score
it still has to wait until the end of an election period before
sending out a victory message because the current logic states
that monitor needs to wait for all acks == quorum.size before delcaring victory
or if acks >= quorum.size/2 when election ends. Sometimes, the later
case turns out to create a never ending election because in this example,
mon.b would also reach an end of election period and starts a new election,
bumping the epoch to higher than mon.c, then propose to mon.c which then
the incoming victory message from mon.a gets dropped because mon.c
bumps its epoch due to mon.b's proposal.

Solution:

Change the declare victory logic in Connectivity Strategy to be
If we recieved >= quorum.size/2 and the remaining monitors matches
the dead_pinging set we tracked (meaning we declared
them dead), then we can go ahead and delcare ourself victory.

Also, changed the logic of how we handle victory message
where if the mon recieves 2 consecutive victory messages
we drop the later one because we assume who ever sends it
first probably is the true winner.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
