### PR TITLE
cmake: skip boost dependency on ALIAS executable targets

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -303,5 +303,8 @@ endfunction()
 
 function(add_executable target)
   _add_executable(${target} ${ARGN})
-  maybe_add_boost_dep(${target})
+  # can't add dependencies to aliases
+  if (NOT ";${ARGN};" MATCHES ";(ALIAS);")
+    maybe_add_boost_dep(${target})
+  endif()
 endfunction()


### PR DESCRIPTION
Can't add dependencies to aliases