### PR TITLE
reef: mds,cephfs_mirror: add labelled per-client and replication metrics

### DIFF
--- a/src/common/options/cephfs-mirror.yaml.in
+++ b/src/common/options/cephfs-mirror.yaml.in
@@ -92,3 +92,14 @@ options:
   services:
   - cephfs-mirror
   min: 0
+- name: cephfs_mirror_perf_stats_prio
+  type: int
+  level: advanced
+  desc: Priority level for mirror daemon replication perf counters
+  long_desc: The daemon will send perf counter data to the manager daemon if the priority
+    is not lower than mgr_stats_threshold.
+  default: 5
+  services:
+  - cephfs-mirror
+  min: 0
+  max: 11

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -253,6 +253,10 @@ class MDSRank {
       progress_thread.signal();
     }
 
+    uint64_t get_global_id() const {
+      return monc->get_global_id();
+    }
+
     // Daemon lifetime functions: these guys break the abstraction
     // and call up into the parent MDSDaemon instance.  It's kind
     // of unavoidable: if we want any depth into our calls 

--- a/src/mds/MetricAggregator.cc
+++ b/src/mds/MetricAggregator.cc
@@ -4,6 +4,9 @@
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/copy.hpp>
 
+#include "common/ceph_context.h"
+#include "common/perf_counters_key.h"
+
 #include "MDSRank.h"
 #include "MetricAggregator.h"
 #include "mgr/MgrClient.h"
@@ -13,8 +16,36 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "mds.metric.aggregator" << " " << __func__
 
+// Performance Counters
+ enum {
+  l_mds_client_metrics_start = 10000,
+  l_mds_client_metrics_num_clients,
+  l_mds_client_metrics_last
+ };
+
+enum {
+  l_mds_per_client_metrics_start = 20000,
+  l_mds_per_client_metrics_cap_hits,
+  l_mds_per_client_metrics_cap_misses,
+  l_mds_per_client_metrics_avg_read_latency,
+  l_mds_per_client_metrics_avg_write_latency,
+  l_mds_per_client_metrics_avg_metadata_latency,
+  l_mds_per_client_metrics_dentry_lease_hits,
+  l_mds_per_client_metrics_dentry_lease_misses,
+  l_mds_per_client_metrics_opened_files,
+  l_mds_per_client_metrics_opened_inodes,
+  l_mds_per_client_metrics_pinned_icaps,
+  l_mds_per_client_metrics_total_inodes,
+  l_mds_per_client_metrics_total_read_ops,
+  l_mds_per_client_metrics_total_read_size,
+  l_mds_per_client_metrics_total_write_ops,
+  l_mds_per_client_metrics_total_write_size,
+  l_mds_per_client_metrics_last
+ };
+
 MetricAggregator::MetricAggregator(CephContext *cct, MDSRank *mds, MgrClient *mgrc)
   : Dispatcher(cct),
+    m_cct(cct),
     mds(mds),
     mgrc(mgrc),
     mds_pinger(mds) {
@@ -31,6 +62,15 @@ void MetricAggregator::ping_all_active_ranks() {
 
 int MetricAggregator::init() {
   dout(10) << dendl;
+
+  std::string labels = ceph::perf_counters::key_create("mds_client_metrics",
+						       {{"fs_name", mds->mdsmap->get_fs_name()},
+							{"id", stringify(mds->get_global_id())}});
+  PerfCountersBuilder plb(m_cct, labels, l_mds_client_metrics_start, l_mds_client_metrics_last);
+  plb.add_u64(l_mds_client_metrics_num_clients,
+	      "num_clients", "Numer of client sessions", "mcli", PerfCountersBuilder::PRIO_CRITICAL);
+  m_perf_counters = plb.create_perf_counters();
+  m_cct->get_perfcounters_collection()->add(m_perf_counters);
 
   pinger = std::thread([this]() {
       std::unique_lock locker(lock);
@@ -61,6 +101,24 @@ void MetricAggregator::shutdown() {
     std::scoped_lock locker(lock);
     ceph_assert(!stopping);
     stopping = true;
+
+    // dealloc per-client perf counter
+    for (auto [crpair, pc] : client_perf_counters) {
+      PerfCounters *perf_counters = nullptr;
+      std::swap(perf_counters, pc);
+      if (perf_counters != nullptr) {
+	m_cct->get_perfcounters_collection()->remove(perf_counters);
+	delete perf_counters;
+      }
+    }
+    client_perf_counters.clear();
+
+    PerfCounters *perf_counters = nullptr;
+    std::swap(perf_counters, m_perf_counters);
+    if (perf_counters != nullptr) {
+      m_cct->get_perfcounters_collection()->remove(perf_counters);
+      delete perf_counters;
+    }
   }
 
   if (pinger.joinable()) {
@@ -97,10 +155,110 @@ void MetricAggregator::refresh_metrics_for_rank(const entity_inst_t &client,
            << metrics << dendl;
 
   auto &p = clients_by_rank.at(rank);
+  auto crpair = std::make_pair(client, rank);
   bool ins = p.insert(client).second;
   if (ins) {
     dout(20) << ": rank=" << rank << " has " << p.size() << " connected"
              << " client(s)" << dendl;
+    if (m_perf_counters) {
+      m_perf_counters->inc(l_mds_client_metrics_num_clients);
+    }
+
+    std::string labels = ceph::perf_counters::key_create("mds_client_metrics-" + std::string(mds->mdsmap->get_fs_name()),
+							 {{"client", stringify(client.name)},
+							  {"rank", stringify(rank)}});
+    PerfCountersBuilder plb(m_cct, labels, l_mds_per_client_metrics_start, l_mds_per_client_metrics_last);
+    plb.add_u64(l_mds_per_client_metrics_cap_hits,
+		"cap_hits", "Capability hits", "hcap", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_u64(l_mds_per_client_metrics_cap_misses,
+		"cap_miss", "Capability misses", "mcap", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_time(l_mds_per_client_metrics_avg_read_latency,
+		 "avg_read_latency", "Average Read Latency", "arlt", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_time(l_mds_per_client_metrics_avg_write_latency,
+		 "avg_write_latency", "Average Write Latency", "awlt", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_time(l_mds_per_client_metrics_avg_metadata_latency,
+		 "avg_metadata_latency", "Average Metadata Latency", "amlt", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_u64(l_mds_per_client_metrics_dentry_lease_hits,
+		"dentry_lease_hits", "Dentry Lease Hits", "hden", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_u64(l_mds_per_client_metrics_dentry_lease_misses,
+		"dentry_lease_miss", "Dentry Lease Misses", "mden", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_u64(l_mds_per_client_metrics_opened_files,
+		"opened_files", "Open Files", "ofil", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_u64(l_mds_per_client_metrics_opened_inodes,
+		"opened_inodes", "Open Inodes", "oino", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_u64(l_mds_per_client_metrics_pinned_icaps,
+		"pinned_icaps", "Pinned Inode Caps", "pino", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_u64(l_mds_per_client_metrics_total_inodes,
+		"total_inodes", "Total Inodes", "tino", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_u64(l_mds_per_client_metrics_total_read_ops,
+		"total_read_ops", "Total Read Operations", "rops", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_u64(l_mds_per_client_metrics_total_read_size,
+		"total_read_size", "Total Read Size", "rsiz", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_u64(l_mds_per_client_metrics_total_write_ops,
+		"total_write_ops", "Total Write Operations", "wops", PerfCountersBuilder::PRIO_CRITICAL);
+    plb.add_u64(l_mds_per_client_metrics_total_write_size,
+		"total_write_size", "Total Write Size", "wsiz", PerfCountersBuilder::PRIO_CRITICAL);
+    client_perf_counters[crpair] = plb.create_perf_counters();
+    m_cct->get_perfcounters_collection()->add(client_perf_counters[crpair]);
+  }
+
+  // update perf counters
+  PerfCounters *perf_counter_ptr = nullptr;
+  if (client_perf_counters.contains(crpair)) {
+    perf_counter_ptr = client_perf_counters[crpair];
+  }
+
+  if (perf_counter_ptr) {
+    // client capability hit ratio
+    perf_counter_ptr->set(l_mds_per_client_metrics_cap_hits, metrics.cap_hit_metric.hits);
+    perf_counter_ptr->set(l_mds_per_client_metrics_cap_misses, metrics.cap_hit_metric.misses);
+
+    // some averages
+    if (metrics.read_latency_metric.updated) {
+      utime_t ravg(metrics.read_latency_metric.mean.tv.tv_sec * 100,
+		   metrics.read_latency_metric.mean.tv.tv_nsec / 1000000);
+      perf_counter_ptr->tset(l_mds_per_client_metrics_avg_read_latency, ravg);
+    }
+    if (metrics.write_latency_metric.updated) {
+      utime_t wavg(metrics.write_latency_metric.mean.tv.tv_sec * 100,
+		   metrics.write_latency_metric.mean.tv.tv_nsec / 1000000);
+      perf_counter_ptr->set(l_mds_per_client_metrics_avg_write_latency, wavg);
+    }
+    if (metrics.metadata_latency_metric.updated) {
+      utime_t mavg(metrics.metadata_latency_metric.mean.tv.tv_sec * 100,
+		   metrics.metadata_latency_metric.mean.tv.tv_nsec / 1000000);
+      perf_counter_ptr->set(l_mds_per_client_metrics_avg_metadata_latency, mavg);
+    }
+
+    // dentry leases
+    if (metrics.dentry_lease_metric.updated) {
+      perf_counter_ptr->set(l_mds_per_client_metrics_dentry_lease_hits, metrics.dentry_lease_metric.hits);
+      perf_counter_ptr->set(l_mds_per_client_metrics_dentry_lease_misses, metrics.dentry_lease_metric.misses);
+    }
+
+    // file+inode opens, pinned inode caps
+    if (metrics.opened_files_metric.updated) {
+      perf_counter_ptr->set(l_mds_per_client_metrics_opened_files, metrics.opened_files_metric.opened_files);
+      perf_counter_ptr->set(l_mds_per_client_metrics_total_inodes, metrics.opened_files_metric.total_inodes);
+    }
+    if (metrics.opened_inodes_metric.updated) {
+      perf_counter_ptr->set(l_mds_per_client_metrics_opened_inodes, metrics.opened_inodes_metric.total_inodes);
+      perf_counter_ptr->set(l_mds_per_client_metrics_total_inodes, metrics.opened_inodes_metric.total_inodes);
+    }
+    if (metrics.pinned_icaps_metric.updated) {
+      perf_counter_ptr->set(l_mds_per_client_metrics_pinned_icaps, metrics.pinned_icaps_metric.pinned_icaps);
+      perf_counter_ptr->set(l_mds_per_client_metrics_total_inodes, metrics.pinned_icaps_metric.total_inodes);
+    }
+
+    // read+write io metrics
+    if (metrics.read_io_sizes_metric.updated) {
+      perf_counter_ptr->set(l_mds_per_client_metrics_total_read_ops, metrics.read_io_sizes_metric.total_ops);
+      perf_counter_ptr->set(l_mds_per_client_metrics_total_read_size, metrics.read_io_sizes_metric.total_size);
+    }
+    if (metrics.write_io_sizes_metric.updated) {
+      perf_counter_ptr->set(l_mds_per_client_metrics_total_write_ops, metrics.write_io_sizes_metric.total_ops);
+      perf_counter_ptr->set(l_mds_per_client_metrics_total_write_size, metrics.write_io_sizes_metric.total_size);
+    }
   }
 
   auto update_counter_func = [&metrics](const MDSPerformanceCounterDescriptor &d,
@@ -260,6 +418,13 @@ void MetricAggregator::remove_metrics_for_rank(const entity_inst_t &client,
     ceph_assert(rm);
     dout(20) << ": rank=" << rank << " has " << p.size() << " connected"
              << " client(s)" << dendl;
+    auto crpair = std::make_pair(client, rank);
+    m_cct->get_perfcounters_collection()->remove(client_perf_counters[crpair]);
+    delete client_perf_counters[crpair];
+    client_perf_counters.erase(crpair);
+  }
+  if (m_perf_counters) {
+    m_perf_counters->dec(l_mds_client_metrics_num_clients);
   }
 
   auto sub_key_func = [client, rank](const MDSPerfMetricSubKeyDescriptor &d,
@@ -315,6 +480,10 @@ void MetricAggregator::handle_mds_metrics(const cref_t<MMDSMetrics> &m) {
            << rank << " with sequence number " << seq << dendl;
 
   std::scoped_lock locker(lock);
+  if (stopping) {
+    dout(10) << ": stopping" << dendl;
+    return;
+  }
   if (!mds_pinger.pong_received(rank, seq)) {
     return;
   }

--- a/src/mds/MetricAggregator.h
+++ b/src/mds/MetricAggregator.h
@@ -11,6 +11,7 @@
 #include "msg/msg_types.h"
 #include "msg/Dispatcher.h"
 #include "common/ceph_mutex.h"
+#include "common/perf_counters.h"
 #include "include/common_fwd.h"
 #include "messages/MMDSMetrics.h"
 
@@ -55,6 +56,7 @@ private:
   // drop this lock when calling ->send_message_mds() else mds might
   // deadlock
   ceph::mutex lock = ceph::make_mutex("MetricAggregator::lock");
+  CephContext *m_cct;
   MDSRank *mds;
   MgrClient *mgrc;
 
@@ -71,6 +73,9 @@ private:
   std::map<mds_rank_t, entity_addrvec_t> active_rank_addrs;
 
   bool stopping = false;
+
+  PerfCounters *m_perf_counters;
+  std::map<std::pair<entity_inst_t, mds_rank_t>, PerfCounters*> client_perf_counters;
 
   void handle_mds_metrics(const cref_t<MMDSMetrics> &m);
 

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -2059,7 +2059,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
     @profile_method()
     def get_unlabeled_perf_counters(self, prio_limit: int = PRIO_USEFUL,
                               services: Sequence[str] = ("mds", "mon", "osd",
-                                                         "rbd-mirror", "rgw",
+                                                         "rbd-mirror", "cephfs-mirror", "rgw",
                                                          "tcmu-runner")) -> Dict[str, dict]:
         """
         Return the perf counters currently known to this ceph-mgr

--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -8,6 +8,8 @@
 #include "common/debug.h"
 #include "common/errno.h"
 #include "common/WorkQueue.h"
+#include "common/perf_counters.h"
+#include "common/perf_counters_key.h"
 #include "include/stringify.h"
 #include "msg/Messenger.h"
 #include "FSMirror.h"
@@ -24,6 +26,14 @@
 #define dout_prefix *_dout << "cephfs::mirror::FSMirror " << __func__
 
 using namespace std;
+
+// Performance Counters
+enum {
+  l_cephfs_mirror_fs_mirror_first = 5000,
+  l_cephfs_mirror_fs_mirror_peers,
+  l_cephfs_mirror_fs_mirror_dir_count,
+  l_cephfs_mirror_fs_mirror_last,
+};
 
 namespace cephfs {
 namespace mirror {
@@ -107,6 +117,18 @@ FSMirror::FSMirror(CephContext *cct, const Filesystem &filesystem, uint64_t pool
     m_asok_hook(new MirrorAdminSocketHook(cct, filesystem, this)) {
   m_service_daemon->add_or_update_fs_attribute(m_filesystem.fscid, SERVICE_DAEMON_DIR_COUNT_KEY,
                                                (uint64_t)0);
+
+  std::string labels = ceph::perf_counters::key_create("cephfs_mirror_mirrored_filesystems",
+						       {{"filesystem", m_filesystem.fs_name}});
+  PerfCountersBuilder plb(m_cct, labels, l_cephfs_mirror_fs_mirror_first,
+			  l_cephfs_mirror_fs_mirror_last);
+  auto prio = m_cct->_conf.get_val<int64_t>("cephfs_mirror_perf_stats_prio");
+  plb.add_u64(l_cephfs_mirror_fs_mirror_peers,
+	      "mirroring_peers", "Mirroring Peers", "mpee", prio);
+  plb.add_u64(l_cephfs_mirror_fs_mirror_dir_count,
+	      "directory_count", "Directory Count", "dirc", prio);
+  m_perf_counters = plb.create_perf_counters();
+  m_cct->get_perfcounters_collection()->add(m_perf_counters);
 }
 
 FSMirror::~FSMirror() {
@@ -120,6 +142,12 @@ FSMirror::~FSMirror() {
   // outside the lock so that in-progress commands can acquire
   // lock and finish executing.
   delete m_asok_hook;
+  PerfCounters *perf_counters = nullptr;
+  std::swap(perf_counters, m_perf_counters);
+  if (perf_counters != nullptr) {
+    m_cct->get_perfcounters_collection()->remove(perf_counters);
+    delete perf_counters;
+  }
 }
 
 int FSMirror::init_replayer(PeerReplayer *peer_replayer) {
@@ -355,6 +383,9 @@ void FSMirror::handle_acquire_directory(string_view dir_path) {
       peer_replayer->add_directory(dir_path);
     }
   }
+  if (m_perf_counters) {
+    m_perf_counters->set(l_cephfs_mirror_fs_mirror_dir_count, m_directories.size());
+  }
 }
 
 void FSMirror::handle_release_directory(string_view dir_path) {
@@ -371,6 +402,9 @@ void FSMirror::handle_release_directory(string_view dir_path) {
         dout(10) << ": peer=" << peer << dendl;
         peer_replayer->remove_directory(dir_path);
       }
+    }
+    if (m_perf_counters) {
+      m_perf_counters->set(l_cephfs_mirror_fs_mirror_dir_count, m_directories.size());
     }
   }
 }
@@ -395,6 +429,9 @@ void FSMirror::add_peer(const Peer &peer) {
   }
   m_peer_replayers.emplace(peer, std::move(replayer));
   ceph_assert(m_peer_replayers.size() == 1); // support only a single peer
+  if (m_perf_counters) {
+    m_perf_counters->inc(l_cephfs_mirror_fs_mirror_peers);
+  }
 }
 
 void FSMirror::remove_peer(const Peer &peer) {
@@ -414,6 +451,9 @@ void FSMirror::remove_peer(const Peer &peer) {
   if (replayer) {
     dout(5) << ": shutting down replayers for peer=" << peer << dendl;
     shutdown_replayer(replayer.get());
+  }
+  if (m_perf_counters) {
+    m_perf_counters->dec(l_cephfs_mirror_fs_mirror_peers);
   }
 }
 

--- a/src/tools/cephfs_mirror/FSMirror.h
+++ b/src/tools/cephfs_mirror/FSMirror.h
@@ -154,6 +154,8 @@ private:
 
   MountRef m_mount;
 
+  PerfCounters *m_perf_counters;
+
   int init_replayer(PeerReplayer *peer_replayer);
   void shutdown_replayer(PeerReplayer *peer_replayer);
   void cleanup();

--- a/src/tools/cephfs_mirror/Mirror.cc
+++ b/src/tools/cephfs_mirror/Mirror.cc
@@ -9,6 +9,8 @@
 #include "common/errno.h"
 #include "common/Timer.h"
 #include "common/WorkQueue.h"
+#include "common/perf_counters.h"
+#include "common/perf_counters_key.h"
 #include "include/types.h"
 #include "mon/MonClient.h"
 #include "msg/Messenger.h"
@@ -19,6 +21,14 @@
 #define dout_subsys ceph_subsys_cephfs_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "cephfs::mirror::Mirror " << __func__
+
+// Performance Counters
+enum {
+  l_cephfs_mirror_first = 4000,
+  l_cephfs_mirror_file_systems_mirrorred,
+  l_cephfs_mirror_file_systems_mirror_enable_failures,
+  l_cephfs_mirror_last,
+};
 
 namespace cephfs {
 namespace mirror {
@@ -277,6 +287,17 @@ int Mirror::init(std::string &reason) {
     return r;
   }
 
+  std::string labels = ceph::perf_counters::key_create("cephfs_mirror");
+  PerfCountersBuilder plb(m_cct, labels, l_cephfs_mirror_first, l_cephfs_mirror_last);
+
+  auto prio = m_cct->_conf.get_val<int64_t>("cephfs_mirror_perf_stats_prio");
+  plb.add_u64(l_cephfs_mirror_file_systems_mirrorred,
+	      "mirrored_filesystems", "Filesystems mirrored", "mir", prio);
+  plb.add_u64_counter(l_cephfs_mirror_file_systems_mirror_enable_failures,
+		      "mirror_enable_failures", "Mirroring enable failures", "mirf", prio);
+  m_perf_counters = plb.create_perf_counters();
+  m_cct->get_perfcounters_collection()->add(m_perf_counters);
+
   return 0;
 }
 
@@ -285,6 +306,13 @@ void Mirror::shutdown() {
   m_stopping = true;
   m_cluster_watcher->shutdown();
   m_cond.notify_all();
+
+  PerfCounters *perf_counters = nullptr;
+  std::swap(perf_counters, m_perf_counters);
+  if (perf_counters != nullptr) {
+    m_cct->get_perfcounters_collection()->remove(perf_counters);
+    delete perf_counters;
+  }
 }
 
 void Mirror::reopen_logs() {
@@ -328,6 +356,9 @@ void Mirror::handle_enable_mirroring(const Filesystem &filesystem,
     m_service_daemon->add_or_update_fs_attribute(filesystem.fscid,
                                                  SERVICE_DAEMON_MIRROR_ENABLE_FAILED_KEY,
                                                  true);
+    if (m_perf_counters) {
+      m_perf_counters->inc(l_cephfs_mirror_file_systems_mirror_enable_failures);
+    }
     return;
   }
 
@@ -336,6 +367,9 @@ void Mirror::handle_enable_mirroring(const Filesystem &filesystem,
   }
 
   dout(10) << ": Initialized FSMirror for filesystem=" << filesystem << dendl;
+  if (m_perf_counters) {
+    m_perf_counters->inc(l_cephfs_mirror_file_systems_mirrorred);
+  }
 }
 
 void Mirror::handle_enable_mirroring(const Filesystem &filesystem, int r) {
@@ -353,10 +387,16 @@ void Mirror::handle_enable_mirroring(const Filesystem &filesystem, int r) {
     m_service_daemon->add_or_update_fs_attribute(filesystem.fscid,
                                                  SERVICE_DAEMON_MIRROR_ENABLE_FAILED_KEY,
                                                  true);
+    if (m_perf_counters) {
+      m_perf_counters->inc(l_cephfs_mirror_file_systems_mirror_enable_failures);
+    }
     return;
   }
 
   dout(10) << ": Initialized FSMirror for filesystem=" << filesystem << dendl;
+  if (m_perf_counters) {
+    m_perf_counters->inc(l_cephfs_mirror_file_systems_mirrorred);
+  }
 }
 
 void Mirror::enable_mirroring(const Filesystem &filesystem, uint64_t local_pool_id,
@@ -411,6 +451,10 @@ void Mirror::handle_disable_mirroring(const Filesystem &filesystem, int r) {
       dout(10) << ": no pending actions for filesystem=" << filesystem << dendl;
       m_mirror_actions.erase(filesystem);
     }
+  }
+
+  if (m_perf_counters) {
+    m_perf_counters->dec(l_cephfs_mirror_file_systems_mirrorred);
   }
 }
 

--- a/src/tools/cephfs_mirror/Mirror.cc
+++ b/src/tools/cephfs_mirror/Mirror.cc
@@ -510,7 +510,7 @@ void Mirror::update_fs_mirrors() {
       if (!mirror_action.action_in_progress && !_is_restarting(filesystem)) {
 	if (failed_restart || blocklisted_restart) {
 	  dout(5) << ": filesystem=" << filesystem << " failed mirroring (failed: "
-		  << failed_restart << ", blocklisted: " << blocklisted_restart << dendl;
+		  << failed_restart << ", blocklisted: " << blocklisted_restart << ")" << dendl;
 	  _set_restarting(filesystem);
 	  auto peers = mirror_action.fs_mirror->get_peers();
 	  auto ctx =  new C_RestartMirroring(this, filesystem, mirror_action.pool_id, peers);

--- a/src/tools/cephfs_mirror/Mirror.h
+++ b/src/tools/cephfs_mirror/Mirror.h
@@ -104,6 +104,8 @@ private:
   RadosRef m_local;
   std::unique_ptr<ServiceDaemon> m_service_daemon;
 
+  PerfCounters *m_perf_counters;
+
   int init_mon_client();
 
   // called via listener

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -269,6 +269,8 @@ private:
 
   ServiceDaemonStats m_service_daemon_stats;
 
+  PerfCounters *m_perf_counters;
+
   void run(SnapshotReplayerThread *replayer);
 
   boost::optional<std::string> pick_directory();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64485

---

backport of https://github.com/ceph/ceph/pull/55471
parent tracker: https://tracker.ceph.com/issues/63945

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh