### PR TITLE
mgr/dashboard: Handle errors for /api/osd/settings

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -168,11 +168,18 @@ class Osd(RESTController):
     @RESTController.Collection('GET', version=APIVersion.EXPERIMENTAL)
     @ReadPermission
     def settings(self):
-        result = CephService.send_command('mon', 'osd dump')
-        return {
-            'nearfull_ratio': result['nearfull_ratio'],
-            'full_ratio': result['full_ratio']
+        data = {
+            'nearfull_ratio': -1,
+            'full_ratio': -1
         }
+        try:
+            result = CephService.send_command('mon', 'osd dump')
+            data['nearfull_ratio'] = result['nearfull_ratio']
+            data['full_ratio'] = result['full_ratio']
+        except TypeError:
+            logger.error(
+                'Error setting nearfull_ratio and full_ratio:', exc_info=True)
+        return data
 
     def _get_operational_status(self, osd_id: int, removing_osd_ids: Optional[List[int]]):
         if removing_osd_ids is None:

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard-pie/dashboard-pie.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard-pie/dashboard-pie.component.ts
@@ -59,7 +59,7 @@ export class DashboardPieComponent implements OnChanges, OnInit {
   constructor(private cssHelper: CssHelper, private dimlessBinary: DimlessBinaryPipe) {
     this.chartConfig = {
       chartType: 'doughnut',
-      labels: ['', '', ''],
+      labels: [],
       dataset: [
         {
           label: null,
@@ -97,19 +97,20 @@ export class DashboardPieComponent implements OnChanges, OnInit {
                   fillStyle: chart.data.datasets[1].backgroundColor[0],
                   strokeStyle: chart.data.datasets[1].backgroundColor[0]
                 };
-                labels[1] = {
-                  text: $localize`Warning: ${chart.data.datasets[0].data[0]}%`,
-                  fillStyle: chart.data.datasets[0].backgroundColor[1],
-                  strokeStyle: chart.data.datasets[0].backgroundColor[1]
-                };
-                labels[2] = {
-                  text: $localize`Danger: ${
-                    chart.data.datasets[0].data[0] + chart.data.datasets[0].data[1]
-                  }%`,
-                  fillStyle: chart.data.datasets[0].backgroundColor[2],
-                  strokeStyle: chart.data.datasets[0].backgroundColor[2]
-                };
-
+                if (chart.data.datasets[0].data?.length) {
+                  labels[1] = {
+                    text: $localize`Warning: ${chart.data.datasets[0].data[0]}%`,
+                    fillStyle: chart.data.datasets[0].backgroundColor[1],
+                    strokeStyle: chart.data.datasets[0].backgroundColor[1]
+                  };
+                  labels[2] = {
+                    text: $localize`Danger: ${
+                      chart.data.datasets[0].data[0] + chart.data.datasets[0].data[1]
+                    }%`,
+                    fillStyle: chart.data.datasets[0].backgroundColor[2],
+                    strokeStyle: chart.data.datasets[0].backgroundColor[2]
+                  };
+                }
                 return labels;
               }
             }
@@ -158,19 +159,24 @@ export class DashboardPieComponent implements OnChanges, OnInit {
     const fullRatioPercent = this.highThreshold * 100;
     const percentAvailable = this.calcPercentage(data.max - data.current, data.max);
     const percentUsed = this.calcPercentage(data.current, data.max);
-    if (percentUsed >= fullRatioPercent) {
+
+    if (fullRatioPercent >= 0 && percentUsed >= fullRatioPercent) {
       this.color = 'chart-color-red';
-    } else if (percentUsed >= nearFullRatioPercent) {
+    } else if (nearFullRatioPercent >= 0 && percentUsed >= nearFullRatioPercent) {
       this.color = 'chart-color-yellow';
     } else {
       this.color = 'chart-color-blue';
     }
 
-    chart.dataset[0].data = [
-      Math.round(nearFullRatioPercent),
-      Math.round(Math.abs(nearFullRatioPercent - fullRatioPercent)),
-      Math.round(100 - fullRatioPercent)
-    ];
+    if (fullRatioPercent >= 0 && nearFullRatioPercent >= 0) {
+      chart.dataset[0].data = [
+        Math.round(nearFullRatioPercent),
+        Math.round(Math.abs(nearFullRatioPercent - fullRatioPercent)),
+        Math.round(100 - fullRatioPercent)
+      ];
+    } else {
+      chart.dataset[1].backgroundColor[1] = this.cssHelper.propertyValue('chart-color-light-gray');
+    }
 
     chart.dataset[1].data = [
       percentUsed,
@@ -178,7 +184,6 @@ export class DashboardPieComponent implements OnChanges, OnInit {
       this.dimlessBinary.transform(data.current)
     ];
     chart.dataset[1].backgroundColor[0] = this.cssHelper.propertyValue(this.color);
-
     chart.dataset[0].label = [`${percentUsed}%\nof ${this.dimlessBinary.transform(data.max)}`];
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
@@ -164,9 +164,12 @@ export class HealthComponent implements OnInit, OnDestroy {
       data.df.stats.total_bytes
     );
 
-    if (percentUsed / 100 >= this.osdSettings.nearfull_ratio) {
+    const nearfullRatio = this.osdSettings.nearfull_ratio;
+    const fullRatio = this.osdSettings.nearfull_ratio;
+
+    if (nearfullRatio >= 0 && percentUsed / 100 >= nearfullRatio) {
       this.color = 'chart-color-red';
-    } else if (percentUsed / 100 >= this.osdSettings.full_ratio) {
+    } else if (fullRatio >= 0 && percentUsed / 100 >= fullRatio) {
       this.color = 'chart-color-yellow';
     } else {
       this.color = 'chart-color-blue';

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.html
@@ -29,7 +29,7 @@
      data-placement="left"
      [ngbTooltip]="usageTooltipTpl">
   <div class="progress-bar bg-info"
-       [ngClass]="{'bg-warning': usedPercentage/100 >= warningThreshold, 'bg-danger': usedPercentage/100 >= errorThreshold}"
+       [ngClass]="{'bg-warning': (warningThreshold >= 0) && (usedPercentage/100 >= warningThreshold), 'bg-danger': (errorThreshold >= 0) && (usedPercentage/100 >= errorThreshold)}"
        role="progressbar"
        [attr.aria-label]="{ title }"
        i18n-aria-label="The title of this usage bar is { title }"


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/62089

## Issue:
/api/osd/settings returns "TypeError: string indices must be integers" sometimes.
The result is coming from `osd dump` command which instead of returning an object returns an error message which then displays error on dashboard.

This breaks frontend with repeated error notifs and hides capacity card and shows the bar % on osd page in red.

## Fix:
Added a try-catch block to handle error and updated frontend dashboard to catch those and show appropriately the data.

## Now:
In case of any error with the nearfull/full ratios the capacity card looks like as follows
![Screenshot from 2024-02-21 14-29-02](https://github.com/ceph/ceph/assets/25664409/7702f8b9-3602-45d7-87e3-04b33b869537)
![Screenshot from 2024-02-21 14-28-01](https://github.com/ceph/ceph/assets/25664409/43db4959-9ce3-451a-b760-c17ce3d5b5b8)


In case of any  error the osd list page looks like:
![Screenshot from 2024-02-21 14-28-23](https://github.com/ceph/ceph/assets/25664409/0f566ea6-9ea0-4200-b760-852ab6bf6cd5)



## Before:
![image](https://github.com/ceph/ceph/assets/25664409/262dd096-f9ff-42a0-a712-1df63e4e0409)



## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
