### PR TITLE
ceph-volume: fix zap_partitions() in devices.lvm.zap

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -202,8 +202,11 @@ class Zap(object):
         """
         if device.is_encrypted:
             # find the holder
-            holders = [
-                '/dev/%s' % holder for holder in device.sys_api.get('holders', [])
+            pname = device.sys_api.get('parent')
+            devname = device.sys_api.get('devname')
+            parent_device = Device(f'/dev/{pname}')
+            holders: List[str] = [
+                f'/dev/{holder}' for holder in parent_device.sys_api['partitions'][devname]['holders']
             ]
             for mapper_uuid in os.listdir('/dev/mapper'):
                 mapper_path = os.path.join('/dev/mapper', mapper_uuid)

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -6,7 +6,7 @@ import time
 from ceph_volume import process
 from ceph_volume.api import lvm
 from ceph_volume.util.system import get_file_contents
-from typing import Dict, List
+from typing import Dict, List, Any
 
 
 logger = logging.getLogger(__name__)
@@ -825,6 +825,7 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         block_types.append('loop')
 
     for block in block_devs:
+        metadata: Dict[str, Any] = {}
         devname = os.path.basename(block[0])
         diskname = block[1]
         if block[2] not in block_types:
@@ -832,7 +833,6 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         sysdir = os.path.join(_sys_block_path, devname)
         if block[2] == 'part':
             sysdir = os.path.join(_sys_block_path, block[3], devname)
-        metadata = {}
 
         # If the device is ceph rbd it gets excluded
         if is_ceph_rbd(diskname):
@@ -897,7 +897,9 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         metadata['size'] = float(size) * 512
         metadata['human_readable_size'] = human_readable_size(metadata['size'])
         metadata['path'] = diskname
+        metadata['devname'] = devname
         metadata['type'] = block[2]
+        metadata['parent'] = block[3]
 
         # some facts from udevadm
         p = udevadm_property(sysdir)


### PR DESCRIPTION
The current logic is unable to find the holders for the partition being zapped.

This commit fixes this issue.

Fixes: https://tracker.ceph.com/issues/64248
