### PR TITLE
logrotate: fix racecondition between rotate and compress 

### DIFF
--- a/src/logrotate.conf
+++ b/src/logrotate.conf
@@ -2,6 +2,7 @@
     rotate 7
     daily
     compress
+    delaycompress
     sharedscripts
     postrotate
         killall -q -1 ceph-mon ceph-mgr ceph-mds ceph-osd ceph-fuse radosgw rbd-mirror cephfs-mirror || pkill -1 -x "ceph-mon|ceph-mgr|ceph-mds|ceph-osd|ceph-fuse|radosgw|rbd-mirror|cephfs-mirror" || true


### PR DESCRIPTION
sometimes ceph needs a bit longer to reopen it logfiles. This can cause the following logrotate error/warning

error: Compressing program wrote following message to stderr when compressing log /var/log/ceph/ceph-osd.1456.log-20240131:
gzip: stdin: file size changed while zipping

this is fixed with a delaycompress, so the logfile will compressed one day after rotating. This should be enough time for ceph to reopen its logfiles

Fixes: https://tracker.ceph.com/issues/58920
Signed-off-by: Manuel Lausch <manuel.lausch@1und1.de>
