### PR TITLE
mds: MDSCacheObject wait mask and SimpleLock wait shift

### DIFF
--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -156,14 +156,14 @@ mds_authority_t CDentry::authority() const
 }
 
 
-void CDentry::add_waiter(uint64_t tag, MDSContext *c)
+void CDentry::add_waiter(WaitTag tag, MDSContext *c, bool ordered)
 {
   // wait on the directory?
   if (tag & (WAIT_UNFREEZE|WAIT_SINGLEAUTH)) {
     dir->add_waiter(tag, c);
     return;
   }
-  MDSCacheObject::add_waiter(tag, c);
+  MDSCacheObject::add_waiter(tag, c, ordered);
 }
 
 

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -142,7 +142,7 @@ public:
   // -- wait --
   //static const int WAIT_LOCK_OFFSET = 8;
 
-  void add_waiter(uint64_t tag, MDSContext *c) override;
+  void add_waiter(WaitTag tag, MDSContext *c, bool ordered = false) override;
 
   bool is_lt(const MDSCacheObject *r) const override {
     return *this < *static_cast<const CDentry*>(r);

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -177,16 +177,17 @@ public:
 
   static const unsigned EXPORT_NONCE  = 1;
 
+  constexpr static WaitTag const WAIT_ID_CDIR   = WaitTag(1);
+
   // -- wait masks --
-  static const uint64_t WAIT_DENTRY       = (1<<0);  // wait for item to be in cache
-  static const uint64_t WAIT_COMPLETE     = (1<<1);  // wait for complete dir contents
-  static const uint64_t WAIT_FROZEN       = (1<<2);  // auth pins removed
-  static const uint64_t WAIT_CREATED	  = (1<<3);  // new dirfrag is logged
+  constexpr static WaitTag const WAIT_DENTRY       = WAIT_ID_CDIR.bit_mask(0);  // wait for item to be in cache
+  constexpr static WaitTag const WAIT_COMPLETE     = WAIT_ID_CDIR.bit_mask(1);  // wait for complete dir contents
+  constexpr static WaitTag const WAIT_FROZEN       = WAIT_ID_CDIR.bit_mask(2);  // auth pins removed
+  constexpr static WaitTag const WAIT_CREATED	   = WAIT_ID_CDIR.bit_mask(3);  // new dirfrag is logged
+  const static int WAIT_BITS = 4;
 
-  static const int WAIT_DNLOCK_OFFSET = 4;
-
-  static const uint64_t WAIT_ANY_MASK = (uint64_t)(-1);
-  static const uint64_t WAIT_ATSUBTREEROOT = (WAIT_SINGLEAUTH);
+  constexpr static WaitTag const  WAIT_ANY_MASK = WAIT_ID_CDIR | (uint64_t)((1 << WAIT_BITS) - 1);
+  constexpr static WaitTag const& WAIT_ATSUBTREEROOT = MDSCacheObject::WAIT_SINGLEAUTH;
 
   // -- dump flags --
   static const int DUMP_PATH             = (1 << 0);
@@ -509,9 +510,9 @@ public:
   void add_dentry_waiter(std::string_view dentry, snapid_t snap, MDSContext *c);
   void take_dentry_waiting(std::string_view dentry, snapid_t first, snapid_t last, MDSContext::vec& ls);
 
-  void add_waiter(uint64_t mask, MDSContext *c) override;
-  void take_waiting(uint64_t mask, MDSContext::vec& ls) override;  // may include dentry waiters
-  void finish_waiting(uint64_t mask, int result = 0);    // ditto
+  void add_waiter(WaitTag mask, MDSContext *c, bool ordered = false) override;
+  void take_waiting(WaitTag mask, MDSContext::vec& ls) override;  // may include dentry waiters
+  void finish_waiting(WaitTag mask, int result = 0);    // ditto
 
   // -- import/export --
   mds_rank_t get_export_pin(bool inherit=true) const;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2773,9 +2773,9 @@ void CInode::take_dir_waiting(frag_t fg, MDSContext::vec& ls)
   }
 }
 
-void CInode::add_waiter(uint64_t tag, MDSContext *c) 
+void CInode::add_waiter(WaitTag tag, MDSContext *c, bool ordered) 
 {
-  dout(10) << __func__ << " tag " << std::hex << tag << std::dec << " " << c
+  dout(10) << __func__ << tag << c
 	   << " !ambig " << !state_test(STATE_AMBIGUOUSAUTH)
 	   << " !frozen " << !is_frozen_inode()
 	   << " !freezing " << !is_freezing_inode()
@@ -2790,12 +2790,12 @@ void CInode::add_waiter(uint64_t tag, MDSContext *c)
     return;
   }
   dout(15) << "taking waiter here" << dendl;
-  MDSCacheObject::add_waiter(tag, c);
+  MDSCacheObject::add_waiter(tag, c, ordered);
 }
 
-void CInode::take_waiting(uint64_t mask, MDSContext::vec& ls)
+void CInode::take_waiting(WaitTag tag, MDSContext::vec& ls)
 {
-  if ((mask & WAIT_DIR) && !waiting_on_dir.empty()) {
+  if ((tag & WAIT_DIR) && !waiting_on_dir.empty()) {
     // take all dentry waiters
     while (!waiting_on_dir.empty()) {
       auto it = waiting_on_dir.begin();
@@ -2808,7 +2808,7 @@ void CInode::take_waiting(uint64_t mask, MDSContext::vec& ls)
   }
 
   // waiting
-  MDSCacheObject::take_waiting(mask, ls);
+  MDSCacheObject::take_waiting(tag, ls);
 }
 
 void CInode::maybe_finish_freeze_inode()

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -393,13 +393,16 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
    */
   static const int MASK_STATE_REPLICATED = STATE_RANDEPHEMERALPIN;
 
+  constexpr static WaitTag const  WAIT_ID_CINODE   = WaitTag(0);
+
   // -- waiters --
-  static const uint64_t WAIT_DIR         = (1<<0);
-  static const uint64_t WAIT_FROZEN      = (1<<1);
-  static const uint64_t WAIT_TRUNC       = (1<<2);
-  static const uint64_t WAIT_FLOCK       = (1<<3);
-  
-  static const uint64_t WAIT_ANY_MASK	= (uint64_t)(-1);
+  constexpr static WaitTag const  WAIT_DIR         = WAIT_ID_CINODE.bit_mask(0);
+  constexpr static WaitTag const  WAIT_FROZEN      = WAIT_ID_CINODE.bit_mask(1);
+  constexpr static WaitTag const  WAIT_TRUNC       = WAIT_ID_CINODE.bit_mask(2);
+  constexpr static WaitTag const  WAIT_FLOCK       = WAIT_ID_CINODE.bit_mask(3);
+  static const uint64_t WAIT_BITS        = 4;
+
+  constexpr static WaitTag const  WAIT_ANY_MASK = WAIT_ID_CINODE | (uint64_t)((1 << WAIT_BITS) - 1);
 
   // misc
   static const unsigned EXPORT_NONCE = 1; // nonce given to replicas created by export
@@ -767,8 +770,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   bool is_waiting_for_dir(frag_t fg) {
     return waiting_on_dir.count(fg);
   }
-  void add_waiter(uint64_t tag, MDSContext *c) override;
-  void take_waiting(uint64_t tag, MDSContext::vec& ls) override;
+  void add_waiter(WaitTag tag, MDSContext *c, bool ordered = false) override;
+  void take_waiting(WaitTag tag, MDSContext::vec& ls) override;
 
   // -- encode/decode helpers --
   void _encode_base(ceph::buffer::list& bl, uint64_t features);

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -1635,7 +1635,7 @@ bool Locker::rdlock_start(SimpleLock *lock, const MDRequestRef& mut, bool as_ano
   }
 
   // wait!
-  int wait_on;
+  WaitTag wait_on;
   if (lock->get_parent()->is_auth() && lock->is_stable())
     wait_on = SimpleLock::WAIT_RD;
   else

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -3071,8 +3071,8 @@ void MDCache::handle_mds_recovery(mds_rank_t who)
   dout(7) << "handle_mds_recovery mds." << who << dendl;
 
   // exclude all discover waiters. kick_discovers() will do the job
-  static const uint64_t i_mask = CInode::WAIT_ANY_MASK & ~CInode::WAIT_DIR;
-  static const uint64_t d_mask = CDir::WAIT_ANY_MASK & ~CDir::WAIT_DENTRY;
+  static const WaitTag i_mask = CInode::WAIT_ANY_MASK & ~CInode::WAIT_DIR;
+  static const WaitTag d_mask = CDir::WAIT_ANY_MASK & ~CDir::WAIT_DENTRY;
 
   MDSContext::vec waiters;
 
@@ -6634,7 +6634,7 @@ void MDCache::truncate_inode_finish(CInode *in, LogSegment *ls)
   mds->mdlog->submit_entry(le, new C_MDC_TruncateLogged(this, in, mut));
 
   // flush immediately if there are readers/writers waiting
-  if (in->is_waiter_for(CInode::WAIT_TRUNC) ||
+  if (in->has_waiter_for(CInode::WAIT_TRUNC) ||
       (in->get_caps_wanted() & (CEPH_CAP_FILE_RD|CEPH_CAP_FILE_WR)))
     mds->mdlog->flush();
 }

--- a/src/mds/MDSCacheObject.cc
+++ b/src/mds/MDSCacheObject.cc
@@ -23,12 +23,6 @@ std::string_view MDSCacheObject::generic_pin_name(int p) const {
   }
 }
 
-void MDSCacheObject::finish_waiting(uint64_t mask, int result) {
-  MDSContext::vec finished;
-  take_waiting(mask, finished);
-  finish_contexts(g_ceph_context, finished, result);
-}
-
 void MDSCacheObject::dump(ceph::Formatter *f) const
 {
   f->dump_bool("is_auth", is_auth());
@@ -84,54 +78,3 @@ void MDSCacheObject::dump_states(ceph::Formatter *f) const
   if (state_test(STATE_REJOINUNDEF))
     f->dump_string("state", "rejoinundef");
 }
-
-bool MDSCacheObject::is_waiter_for(uint64_t mask, uint64_t min) {
-  if (!min) {
-    min = mask;
-    while (min & (min-1))  // if more than one bit is set
-      min &= min-1;        //  clear LSB
-  }
-  for (auto p = waiting.lower_bound(min); p != waiting.end(); ++p) {
-    if (p->first & mask) return true;
-    if (p->first > mask) return false;
-  }
-  return false;
-}
-
-void MDSCacheObject::take_waiting(uint64_t mask, MDSContext::vec& ls) {
-  if (waiting.empty()) return;
-
-  // process ordered waiters in the same order that they were added.
-  std::map<uint64_t, MDSContext*> ordered_waiters;
-
-  for (auto it = waiting.begin(); it != waiting.end(); ) {
-    if (it->first & mask) {
-        if (it->second.first > 0) {
-          ordered_waiters.insert(it->second);
-        } else {
-          ls.push_back(it->second.second);
-        }
-//      pdout(10,g_conf()->debug_mds) << (mdsco_db_line_prefix(this))
-//                                 << "take_waiting mask " << hex << mask << dec << " took " << it->second
-//                                 << " tag " << hex << it->first << dec
-//                                 << " on " << *this
-//                                 << dendl;
-        waiting.erase(it++);
-    } else {
-//      pdout(10,g_conf()->debug_mds) << "take_waiting mask " << hex << mask << dec << " SKIPPING " << it->second
-//                                 << " tag " << hex << it->first << dec
-//                                 << " on " << *this 
-//                                 << dendl;
-        ++it;
-    }
-  }
-  for (auto it = ordered_waiters.begin(); it != ordered_waiters.end(); ++it) {
-    ls.push_back(it->second);
-  }
-  if (waiting.empty()) {
-    put(PIN_WAITER);
-    waiting.clear();
-  }
-}
-
-uint64_t MDSCacheObject::last_wait_seq = 0;

--- a/src/mds/MDSWaitable.h
+++ b/src/mds/MDSWaitable.h
@@ -1,0 +1,284 @@
+#pragma once
+
+#include <cstdint>
+#include <stdexcept>
+#include <algorithm>
+#include <iterator>
+#include <concepts>
+
+#include "include/Context.h"
+#include "include/ceph_assert.h"
+#include "include/mempool.h"
+#include "include/types.h"
+
+#include "mdstypes.h"
+
+struct WaitTag {
+  static constexpr const int MASK_BITS = 48;
+  static constexpr const int ID_BITS = 16;
+  static constexpr const uint16_t ANY_ID = 0xffff;
+
+  static_assert(MASK_BITS + ID_BITS == 64);
+
+  static constexpr const uint64_t FULL_MASK = (uint64_t(1) << MASK_BITS)-1;
+
+  union {
+    uint64_t raw;
+    struct {
+      uint64_t mask : MASK_BITS;
+      uint64_t id : ID_BITS;
+    };
+  };
+
+  constexpr WaitTag(uint16_t id = ANY_ID)
+      : WaitTag(id, 0)
+  {
+  }
+  constexpr WaitTag(uint16_t id, uint64_t mask)
+      : mask(mask)
+      , id(id)
+  {
+    if ((mask & FULL_MASK) != mask) {
+      throw std::logic_error("mask too large");
+    }
+  }
+
+  WaitTag(WaitTag const& other) : raw(other.raw) { }
+
+  constexpr static WaitTag const  from_raw(uint64_t raw) {
+    return WaitTag(raw >> MASK_BITS, raw & FULL_MASK);
+  }
+
+  constexpr static WaitTag const any(uint64_t mask = 0) {
+    return WaitTag(ANY_ID, mask);
+  }
+
+  constexpr WaitTag with_mask(uint64_t new_mask) const
+  {
+    return WaitTag(id, new_mask);
+  }
+
+  constexpr WaitTag or_mask(uint64_t or_mask) const
+  {
+    return WaitTag(id, mask | or_mask);
+  }
+
+  constexpr WaitTag and_mask(uint64_t and_mask) const
+  {
+    return WaitTag(id, mask & and_mask);
+  }
+
+  constexpr WaitTag bit_mask(int bit) const
+  {
+    return or_mask(uint64_t(1) << bit);
+  }
+
+  constexpr bool match(uint64_t raw) const
+  {
+    return match(from_raw(raw));
+  }
+
+  constexpr bool match(WaitTag const& other) const
+  {
+    return match_id(other) && (mask & other.mask);
+  }
+
+  constexpr bool match_id(WaitTag const& other) const
+  {
+    return (id == other.id || is_any_id() || other.is_any_id());
+  }
+
+  constexpr auto operator<=>(WaitTag const& other) const {
+    return raw <=> other.raw;
+  }
+
+  constexpr operator bool() const {
+    return mask != 0;
+  }
+
+  constexpr bool is_any_id() const {
+    return id == ANY_ID;
+  }
+};
+
+constexpr WaitTag operator~(WaitTag const& tag) {
+  return WaitTag(tag.id, ~tag.mask & WaitTag::FULL_MASK);
+}
+
+constexpr WaitTag operator|(WaitTag const& l, uint64_t mask) {
+  return l.or_mask(mask);
+}
+
+constexpr WaitTag operator|(WaitTag const& l, WaitTag const&r) {
+  if (!l.match_id(r)) {
+    throw std::logic_error("Can't combine tags with different IDs");
+  }
+  return WaitTag(std::min(l.id, r.id), l.mask | r.mask);
+}
+
+constexpr WaitTag operator&(WaitTag const& l, WaitTag const&r) {
+  if (!l.match_id(r)) {
+    throw std::logic_error("Can't combine tags with different IDs");
+  }
+  return WaitTag(std::min(l.id, r.id), l.mask & r.mask);
+}
+
+constexpr WaitTag operator&(WaitTag const& l, uint64_t mask) {
+  return l.and_mask(mask);
+}
+
+template <class CharT, class Traits>
+static std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const WaitTag& tag)
+{
+  os << "WaitTag(";
+  if (tag.is_any_id()) {
+    os << "*";
+  } else {
+    os << tag.id;
+  }
+  os << ":" << std::hex << tag.mask << std::dec << ")";
+  return os;
+}
+
+
+template<std::derived_from<Context> C>
+struct MDSWaitable {
+  virtual void add_waiter(WaitTag tag, C* c, bool ordered = false)
+  {
+    uint64_t seq = 0;
+    if (ordered) {
+      seq = ++last_wait_seq;
+    }
+    waiting.insert({ tag, { seq, c } });
+  }
+
+  bool has_waiter_for(WaitTag tag)
+  {
+    auto it = MatchingIterator(waiting, tag);
+    return it != waiting.end();
+  }
+
+  template <std::output_iterator<C*> S> 
+  void take_waiting(WaitTag tag, S &&sink)
+  {
+    if (waiting.empty())
+      return;
+
+    // process ordered waiters in the same order that they were added.
+    std::map<uint64_t, C*> ordered_waiters;
+
+    for (auto it = MatchingIterator(waiting, tag); it != waiting.end();) {
+      if (it->second.first > 0) {
+        ordered_waiters.insert(it->second);
+      } else {
+        *sink++ = it->second.second;
+      }
+      waiting.erase(it++);
+    }
+    for (auto it = ordered_waiters.begin(); it != ordered_waiters.end(); ++it) {
+      *sink++ = it->second;
+    }
+  }
+
+  bool waiting_empty() const {
+    return waiting.empty();
+  }
+
+  void waiting_clear() {
+    waiting.clear();
+  }
+
+  virtual ~MDSWaitable() { }
+
+  MDSWaitable() = default;
+  MDSWaitable(MDSWaitable<C> const& other) = default;
+  MDSWaitable(MDSWaitable<C> && other) = default;
+
+private:
+  using Waiters = mempool::mds_co::compact_multimap<WaitTag, std::pair<uint64_t, C*>>;
+  Waiters waiting;
+  uint64_t last_wait_seq = 0;
+
+  struct MatchingIterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = std::pair<const WaitTag, std::pair<uint64_t, C*>>;
+    using pointer = value_type*;
+    using reference = value_type&;
+
+    Waiters & parent;
+    WaitTag tag;
+    typename Waiters::iterator current;
+
+    /// @brief Reduces any value to its most significant bit
+    /// @param value 
+    /// @return a new value that has a single bit set at the position
+    ///         of the input's msb
+    static uint64_t reduce_to_msb(uint64_t value) {
+      while (value & (value - 1)) // if more than one bit is set
+        value &= value - 1; //  clear LSB
+      return value;
+    }
+
+    MatchingIterator(Waiters& parent, WaitTag tag)
+    : parent(parent)
+    , tag(tag)
+    {
+      auto min_mask = reduce_to_msb(tag.mask);
+
+      auto search_tag = WaitTag(tag.is_any_id() ? 0 : tag.id, min_mask);
+      current = parent.lower_bound(search_tag);
+      skip_to_matching();
+    }
+
+    MatchingIterator(MatchingIterator const& other) = default;
+
+    void skip_to_matching() {
+      while (true) {
+        if (current == parent.end()) {
+          return;
+        }
+        if (current->first.match(tag)) {
+          return;
+        }
+        if (!current->first.is_any_id() && current->first.id > tag.id) {
+          break;
+        }
+        ++current;
+      }
+      if (!tag.is_any_id()) {
+        current = parent.lower_bound(WaitTag::any());
+        skip_to_matching();
+      }
+    }
+
+    reference operator*() const { return *current; }
+    pointer operator->() { return current.operator->(); }
+
+    // Prefix increment
+    MatchingIterator& operator++()
+    {
+      ++current;
+      skip_to_matching();
+      return *this;
+    }
+
+    // Postfix increment
+    MatchingIterator operator++(int)
+    {
+      MatchingIterator tmp = *this;
+      ++(*this);
+      return tmp;
+    }
+
+    operator typename Waiters::iterator() { return current; }
+    operator typename Waiters::const_iterator() { return Waiters::const_iterator(current); }
+
+    friend bool operator==(const MatchingIterator& a, const MatchingIterator& b) { return a.current == b.current; };
+    friend bool operator==(const MatchingIterator& a, const typename Waiters::const_iterator& b) { return a.current == b; };
+    friend bool operator==(const MatchingIterator& a, const typename Waiters::iterator& b) { return a.current == b; };
+    friend bool operator!=(const MatchingIterator& a, const MatchingIterator& b) { return a.current != b.current; };
+    friend bool operator!=(const MatchingIterator& a, const typename Waiters::const_iterator& b) { return a.current != b; };
+    friend bool operator!=(const MatchingIterator& a, const typename Waiters::iterator& b) { return a.current != b; };
+  };
+};

--- a/src/mds/SimpleLock.cc
+++ b/src/mds/SimpleLock.cc
@@ -43,25 +43,6 @@ void SimpleLock::dump(ceph::Formatter *f) const {
   f->close_section();
 }
 
-int SimpleLock::get_wait_shift() const {
-  switch (get_type()) {
-    case CEPH_LOCK_DN:       return 8;
-    case CEPH_LOCK_DVERSION: return 8 + 1*SimpleLock::WAIT_BITS;
-    case CEPH_LOCK_IAUTH:    return 8 + 2*SimpleLock::WAIT_BITS;
-    case CEPH_LOCK_ILINK:    return 8 + 3*SimpleLock::WAIT_BITS;
-    case CEPH_LOCK_IDFT:     return 8 + 4*SimpleLock::WAIT_BITS;
-    case CEPH_LOCK_IFILE:    return 8 + 5*SimpleLock::WAIT_BITS;
-    case CEPH_LOCK_IVERSION: return 8 + 6*SimpleLock::WAIT_BITS;
-    case CEPH_LOCK_IXATTR:   return 8 + 7*SimpleLock::WAIT_BITS;
-    case CEPH_LOCK_ISNAP:    return 8 + 8*SimpleLock::WAIT_BITS;
-    case CEPH_LOCK_INEST:    return 8 + 9*SimpleLock::WAIT_BITS;
-    case CEPH_LOCK_IFLOCK:   return 8 +10*SimpleLock::WAIT_BITS;
-    case CEPH_LOCK_IPOLICY:  return 8 +11*SimpleLock::WAIT_BITS;
-    default:
-      ceph_abort();
-  }
-}
-
 int SimpleLock::get_cap_shift() const {
   switch (get_type()) {
     case CEPH_LOCK_IAUTH: return CEPH_CAP_SAUTH;

--- a/src/test/mds/CMakeLists.txt
+++ b/src/test/mds/CMakeLists.txt
@@ -14,3 +14,10 @@ add_executable(unittest_mds_sessionfilter
 add_ceph_unittest(unittest_mds_sessionfilter)
 target_link_libraries(unittest_mds_sessionfilter mds osdc ceph-common global ${BLKID_LIBRARIES})
 
+# unittest_mds_waitable
+add_executable(unittest_mds_waitable
+  TestMDSWaitable.cc
+  $<TARGET_OBJECTS:unit-main>
+)
+add_ceph_unittest(unittest_mds_waitable)
+target_link_libraries(unittest_mds_waitable ceph-common global)

--- a/src/test/mds/TestMDSWaitable.cc
+++ b/src/test/mds/TestMDSWaitable.cc
@@ -1,0 +1,127 @@
+
+#include "mds/MDSWaitable.h"
+#include "gtest/gtest.h"
+#include <random>
+#include <vector>
+#include <string>
+
+TEST(MDSWaitable, ConstexprWaitTags) {
+
+  // the next line fails due to mask being larger than supported
+  // constexpr auto a = WaitTag::any(WaitTag::FULL_MASK << 1);
+
+
+  // constexpr auto a = WaitTag(1, WaitTag::FULL_MASK);
+  // constexpr auto b = WaitTag(2, WaitTag::FULL_MASK);
+  // the below two lines fail because tag ids are different
+  //constexpr auto c = a | b;
+  //constexpr auto c = a & ~b;
+}
+
+TEST(MDSWaitable, WaitTags)
+{
+  std::random_device rd;
+  std::mt19937_64 gen(rd());
+
+  uint64_t raw1 = gen();
+
+  auto a = WaitTag::from_raw(raw1);
+
+  EXPECT_EQ((raw1 >> WaitTag::MASK_BITS), a.id);
+  EXPECT_EQ((raw1 & WaitTag::FULL_MASK), a.mask);
+  EXPECT_EQ(raw1, a.raw);
+
+  uint64_t mask2 = gen() & WaitTag::FULL_MASK;
+  uint64_t raw2 = (raw1 & ~WaitTag::FULL_MASK) | mask2;
+
+  auto b = a | mask2;
+  EXPECT_EQ(raw1 | raw2, b.raw);
+
+  auto c = a & mask2;
+  EXPECT_EQ(raw1 & raw2, c.raw);
+
+  auto d = b & c;
+  EXPECT_EQ(((raw1 | raw2) & raw1 & raw2) & WaitTag::FULL_MASK, d.mask);
+}
+
+struct TagContext : public Context {
+      TagContext(WaitTag const tag)
+          : tag(tag)
+      {
+      }
+      void finish(int r) override
+      {
+      }
+
+      void complete(int r) override {
+        Context::complete(r);
+      }
+      const WaitTag tag;
+};
+
+static void add_waiter(MDSWaitable<TagContext>& w, WaitTag tag) {
+  w.add_waiter(tag, new TagContext(tag));
+}
+
+TEST(MDSWaitable, AddTake)
+{
+  WaitTag any0 = WaitTag::any().bit_mask(0);
+  WaitTag any1 = WaitTag::any().bit_mask(1);
+  WaitTag any2 = WaitTag::any().bit_mask(2);
+  WaitTag one0 = WaitTag(1).bit_mask(0);
+  WaitTag one1 = WaitTag(1).bit_mask(1);
+  WaitTag two0 = WaitTag(2).bit_mask(0);
+  WaitTag two1 = WaitTag(2).bit_mask(1);
+  WaitTag tre1 = WaitTag(3).bit_mask(1);
+
+  MDSWaitable<TagContext> setup;
+
+  EXPECT_TRUE(setup.waiting_empty());
+
+  add_waiter(setup, any0);
+  add_waiter(setup, any1);
+  add_waiter(setup, one0);
+  add_waiter(setup, one1);
+  add_waiter(setup, two0);
+  add_waiter(setup, two1);
+  add_waiter(setup, one1 | any0);
+  add_waiter(setup, one1 | one0);
+  add_waiter(setup, two1 | any0);
+  add_waiter(setup, two1 | two0);
+
+  EXPECT_FALSE(setup.waiting_empty());
+
+  EXPECT_TRUE(setup.has_waiter_for(any0));
+  EXPECT_TRUE(setup.has_waiter_for(any1));
+  EXPECT_TRUE(setup.has_waiter_for(one0));
+  EXPECT_TRUE(setup.has_waiter_for(one1));
+  EXPECT_TRUE(setup.has_waiter_for(one1 | any0));
+  EXPECT_TRUE(setup.has_waiter_for(one1 | one0));
+  EXPECT_TRUE(setup.has_waiter_for(tre1)); // because of any1
+  EXPECT_FALSE(setup.has_waiter_for(any2));
+
+  {
+    auto w = setup;
+    std::vector<TagContext*> cc;
+    w.take_waiting(one0, std::back_inserter(cc));
+    EXPECT_EQ(4, cc.size());
+    EXPECT_FALSE(w.has_waiter_for(one0));
+  }
+
+  {
+    auto w = setup;
+    std::vector<TagContext*> cc;
+    w.take_waiting(two1, std::back_inserter(cc));
+    EXPECT_EQ(4, cc.size());
+    EXPECT_FALSE(w.has_waiter_for(two1));
+  }
+
+  {
+    auto w = setup;
+    std::vector<TagContext*> cc;
+    w.take_waiting(any0, std::back_inserter(cc));
+    EXPECT_EQ(7, cc.size());
+    EXPECT_FALSE(w.has_waiter_for(two0));
+    EXPECT_FALSE(w.has_waiter_for(one0));
+  }
+}


### PR DESCRIPTION
`MDSCacheObject` waiting interface accepts a wait mask to queue waiters. The mask is used to prioritize waiters, so lower absolute mask values will be invoked first.

`SimpleLock` used to create a different wait mask per lock type, thus prioritizing locks, but the approach proved to be unfair and #8965 changed the waiting to be FIFO per wanted wait bit. This change made the spreading of lock wait masks per lock type redundant.
Until now it wasn't an issue, but by adding a new lock type we found out that the 64-bit mask space was already exhausted given that each lock used up 4 bits from the mask

Further, there was a magic number `8` added to the lock mask shift offset, which was meant to accommodate for custom high-priority wait bits of the lock's parent object, but this wasn't properly communicated via interfaces and caused an overlap of the first lock's `WAIT_RD` bit with the fourth private wait bit of `CInode::WAIT_FLOCK`;


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
