### PR TITLE
reef: osd: Report health error if OSD public address is not within subnet

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -522,6 +522,16 @@ Since this migration can take a considerable amount of time to complete, we
 recommend that you begin the process well in advance of any update to Reef or
 to later releases.
 
+OSD_UNREACHABLE
+_______________
+
+Registered v1/v2 public address of one or more OSD(s) is/are out of the
+defined `public_network` subnet, which will prevent these unreachable OSDs
+from communicating with ceph clients properly.
+
+Even though these unreachable OSDs are in up state, rados clients
+will hang till TCP timeout before erroring out due to this inconsistency.
+
 POOL_FULL
 _________
 

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -631,3 +631,22 @@ int get_iface_numa_node(
   return r;
 }
 
+bool is_addr_in_subnet(
+  CephContext *cct,
+  const std::string &networks,
+  const std::string &addr)
+{
+  const auto nets = get_str_list(networks);
+  ceph_assert(!nets.empty());
+  const auto &net = nets.front();
+  struct ifaddrs ifa;
+  unsigned ipv = CEPH_PICK_ADDRESS_IPV4;
+  struct sockaddr_in public_addr;
+
+  ifa.ifa_next = nullptr;
+  ifa.ifa_addr = (struct sockaddr*)&public_addr;
+  public_addr.sin_family = AF_INET;
+  inet_pton(AF_INET, addr.c_str(), &public_addr.sin_addr);
+
+  return matches_with_net(cct, ifa, net, ipv);
+}

--- a/src/common/pick_address.h
+++ b/src/common/pick_address.h
@@ -95,4 +95,9 @@ int get_iface_numa_node(
   const std::string& iface,
   int *node);
 
+bool is_addr_in_subnet(
+  CephContext *cct,
+  const std::string &networks,
+  const std::string &addr);
+
 #endif

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -761,6 +761,9 @@ public:
   void get_full_osd_counts(std::set<int> *full, std::set<int> *backfill,
 			   std::set<int> *nearfull) const;
 
+  void get_out_of_subnet_osd_counts(CephContext *cct,
+                                    std::string const &public_network,
+                                    std::set<int> *unreachable) const;
 
   /***** cluster state *****/
   /* osds */


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63842

---

backport of https://github.com/ceph/ceph/pull/46692
parent tracker: https://tracker.ceph.com/issues/56057

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh