### PR TITLE
os/bluestore: fix the problem of l_bluefs_log_compactions double recording

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2763,7 +2763,6 @@ void BlueFS::_rewrite_log_and_layout_sync_LNF_LD(bool permit_dev_fallback,
 
   // we're mostly done
   dout(10) << __func__ << " log extents " << log_file->fnode.extents << dendl;
-  logger->inc(l_bluefs_log_compactions);
 
   // Part 4
   // Finalization. Release old space.


### PR DESCRIPTION
When sync log compaction, in `BlueFS::_compact_log_sync_LNF_LD`, `l_bluefs_log_compactions` is first counted in `_rewrite_log_and_layout_sync_LNF_LD`. After `_rewrite_log_and_layout_sync_LNF_LD`, `l_bluefs_log_compactions` is second counted.
Below, we used the command `ceph daemon osd.* perf dump bluefs` and observed the values of `log_compactions` and `compact_lock_lat`. In theory, these two values should be equal, but in reality, `log_compactions` is twice the value of `compact_lock_lat`.
<details>
<summary>ceph daemon osd.* perf dump bluefs</summary>
<pre><code>
{
    "bluefs": {
        "db_total_bytes": 10000831348736,
        "db_used_bytes": 589824,
        "wal_total_bytes": 1048571904,
        "wal_used_bytes": 22020096,
        "slow_total_bytes": 0,
        "slow_used_bytes": 0,
        "num_files": 12,
        "log_bytes": 1056768,
        "log_compactions": 118,
        "log_write_count": 25,
        "logged_bytes": 102400,
        "files_written_wal": 1,
        "files_written_sst": 3,
        "write_count_wal": 41,
        "write_count_sst": 2,
        "bytes_written_wal": 15360000,
        "bytes_written_sst": 8192,
        "bytes_written_slow": 0,
        "max_bytes_wal": 154140672,
        "max_bytes_db": 655360,
        "max_bytes_slow": 0,
        "alloc_unit_main": 0,
        "alloc_unit_db": 65536,
        "alloc_unit_wal": 1048576,
        "read_random_lat": {
            "avgcount": 18,
            "sum": 0.000010988,
            "avgtime": 0.000000610
        },
        "read_random_count": 18,
        "read_random_bytes": 3911,
        "read_random_disk_count": 0,
        "read_random_disk_bytes": 0,
        "read_random_disk_bytes_wal": 0,
        "read_random_disk_bytes_db": 0,
        "read_random_disk_bytes_slow": 0,
        "read_random_buffer_count": 18,
        "read_random_buffer_bytes": 3911,
        "read_lat": {
            "avgcount": 19,
            "sum": 0.001799583,
            "avgtime": 0.000094714
        },
        "read_count": 19,
        "read_bytes": 1120586,
        "read_disk_count": 13,
        "read_disk_bytes": 2199552,
        "read_disk_bytes_wal": 2105344,
        "read_disk_bytes_db": 98304,
        "read_disk_bytes_slow": 0,
        "read_prefetch_count": 3,
        "read_prefetch_bytes": 3795,
        "write_count": 130,
        "write_disk_count": 203,
        "write_bytes": 77643776,
        "compact_lat": {
            "avgcount": 59,
            "sum": 2.485496932,
            "avgtime": 0.042127066
        },
        "compact_lock_lat": {
            "avgcount": 59,
            "sum": 2.485349329,
            "avgtime": 0.042124564
        },
        "fsync_lat": {
            "avgcount": 23,
            "sum": 1.709156037,
            "avgtime": 0.074311132
        },
        "flush_lat": {
            "avgcount": 46,
            "sum": 0.062867415,
            "avgtime": 0.001366682
        },
        "unlink_lat": {
            "avgcount": 4,
            "sum": 0.000021111,
            "avgtime": 0.000005277
        },
        "truncate_lat": {
            "avgcount": 0,
            "sum": 0.000000000,
            "avgtime": 0.000000000
        },
        "alloc_slow_fallback": 0,
        "alloc_slow_size_fallback": 0,
        "read_zeros_candidate": 0,
        "read_zeros_errors": 0
    }
}
</code></pre>
</details>


Fixes: https://tracker.ceph.com/issues/64533
co-author: Jrchyang Yu <yuzhiqiang_yewu@cmss.chinamobile.com>
Signed-off-by: Wang Linke <wanglinke_yewu@cmss.chinamobile.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
