### PR TITLE
reef: debian/*.postinst: add adduser as a dependency and specify --home when adduser 

### DIFF
--- a/debian/ceph-common.postinst
+++ b/debian/ceph-common.postinst
@@ -52,16 +52,20 @@ case "$1" in
                  --system \
                  --no-create-home \
                  --disabled-password \
+                 --home $SERVER_HOME \
                  --uid $SERVER_UID \
                  --gid $SERVER_GID \
                  $SERVER_USER 2>/dev/null || true
          echo "..done"
        fi
        # 3. adjust passwd entry
+       # NOTE: we should use "adduser --comment" if we don't need to
+       # support adduser <3.136. "adduser --gecos" is deprecated,
+       # and will be removed, so we don't use it. the first distro
+       # using --comment is debian/trixie or ubuntu/mantic.
        echo -n "Setting system user $SERVER_USER properties.."
-       usermod -c "$SERVER_NAME" \
-               -d $SERVER_HOME   \
-               -g $SERVER_GROUP  \
+       usermod --comment "$SERVER_NAME" \
+               --gid $SERVER_GROUP      \
                $SERVER_USER
        # Unlock $SERVER_USER in case it is locked from an uninstall
        if [ -f /etc/shadow ]; then

--- a/debian/cephadm.postinst
+++ b/debian/cephadm.postinst
@@ -28,6 +28,7 @@ case "$1" in
          adduser --quiet \
                  --system \
                  --disabled-password \
+                 --home /home/cephadm \
                  --gecos 'cephadm user for mgr/cephadm' \
                  --shell /bin/bash cephadm 2>/dev/null || true
          echo "..done"

--- a/debian/cephadm.postinst
+++ b/debian/cephadm.postinst
@@ -25,7 +25,11 @@ case "$1" in
        # 1. create user if not existing
        if ! getent passwd | grep -q "^cephadm:"; then
          echo -n "Adding system user cephadm.."
-         adduser --quiet --system --disabled-password --gecos 'cephadm user for mgr/cephadm' --shell /bin/bash cephadm 2>/dev/null || true
+         adduser --quiet \
+                 --system \
+                 --disabled-password \
+                 --gecos 'cephadm user for mgr/cephadm' \
+                 --shell /bin/bash cephadm 2>/dev/null || true
          echo "..done"
        fi
 

--- a/debian/cephadm.postinst
+++ b/debian/cephadm.postinst
@@ -43,19 +43,19 @@ case "$1" in
 
        # set up (initially empty) .ssh/authorized_keys file
        if ! test -d /home/cephadm/.ssh; then
-	   mkdir /home/cephadm/.ssh
-	   chown --reference /home/cephadm /home/cephadm/.ssh
-	   chmod 0700 /home/cephadm/.ssh
+           mkdir /home/cephadm/.ssh
+           chown --reference /home/cephadm /home/cephadm/.ssh
+           chmod 0700 /home/cephadm/.ssh
        fi
        if ! test -e /home/cephadm/.ssh/authorized_keys; then
-	   touch /home/cephadm/.ssh/authorized_keys
-	   chown --reference /home/cephadm /home/cephadm/.ssh/authorized_keys
-	   chmod 0600 /home/cephadm/.ssh/authorized_keys
+           touch /home/cephadm/.ssh/authorized_keys
+           chown --reference /home/cephadm /home/cephadm/.ssh/authorized_keys
+           chmod 0600 /home/cephadm/.ssh/authorized_keys
        fi
 
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
-	:
+       :
     ;;
 
     *)

--- a/debian/cephadm.postinst
+++ b/debian/cephadm.postinst
@@ -29,8 +29,8 @@ case "$1" in
                  --system \
                  --disabled-password \
                  --home /home/cephadm \
-                 --gecos 'cephadm user for mgr/cephadm' \
                  --shell /bin/bash cephadm 2>/dev/null || true
+         usermod --comment "cephadm user for mgr/cephadm" cephadm
          echo "..done"
        fi
 

--- a/debian/control
+++ b/debian/control
@@ -184,7 +184,8 @@ Description: debugging symbols for ceph-base
 Package: cephadm
 Architecture: linux-any
 Recommends: podman (>= 2.0.2) | docker.io | docker-ce
-Depends: lvm2,
+Depends: adduser (>= 3.11),
+	 lvm2,
 	 python3,
 	 ${python3:Depends},
 Description: cephadm utility to bootstrap ceph daemons with systemd and containers
@@ -610,7 +611,8 @@ Description: debugging symbols for rbd-nbd
 
 Package: ceph-common
 Architecture: linux-any
-Depends: librbd1 (= ${binary:Version}),
+Depends: adduser (>= 3.11),
+         librbd1 (= ${binary:Version}),
          python3-cephfs (= ${binary:Version}),
          python3-ceph-argparse (= ${binary:Version}),
          python3-ceph-common (= ${binary:Version}),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64509

---

backport of https://github.com/ceph/ceph/pull/55218
parent tracker: https://tracker.ceph.com/issues/64069

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh