### PR TITLE
ec: rename object_size -> stripe_width in get_chunk_size()

### DIFF
--- a/src/erasure-code/ErasureCodeInterface.h
+++ b/src/erasure-code/ErasureCodeInterface.h
@@ -261,21 +261,21 @@ namespace ceph {
     /**
      * Return the size (in bytes) of a single chunk created by a call
      * to the **decode** method. The returned size multiplied by
-     * **get_chunk_count()** is greater or equal to **object_size**.
+     * **get_chunk_count()** is greater or equal to **stripe_width**.
      *
      * If the object size is properly aligned, the chunk size is
-     * **object_size / get_chunk_count()**. However, if
-     * **object_size** is not a multiple of **get_chunk_count** or if
+     * **stripe_width / get_chunk_count()**. However, if
+     * **stripe_width** is not a multiple of **get_chunk_count** or if
      * the implementation imposes additional alignment constraints,
      * the chunk size may be larger.
      *
      * The byte found at offset **B** of the original object is mapped
      * to chunk **B / get_chunk_size()** at offset **B % get_chunk_size()**.
      *
-     * @param [in] object_size the number of bytes of the object to **encode()**
+     * @param [in] stripe_width the number of bytes of the object to **encode()**
      * @return the size (in bytes) of a single chunk created by **encode()**
      */
-    virtual unsigned int get_chunk_size(unsigned int object_size) const = 0;
+    virtual unsigned int get_chunk_size(unsigned int stripe_width) const = 0;
 
     /**
      * Compute the smallest subset of **available** chunks that needs

--- a/src/erasure-code/clay/ErasureCodeClay.cc
+++ b/src/erasure-code/clay/ErasureCodeClay.cc
@@ -87,12 +87,12 @@ int ErasureCodeClay::init(ErasureCodeProfile &profile,
 
 }
 
-unsigned int ErasureCodeClay::get_chunk_size(unsigned int object_size) const
+unsigned int ErasureCodeClay::get_chunk_size(unsigned int stripe_width) const
 {
   unsigned int alignment_scalar_code = pft.erasure_code->get_chunk_size(1);
   unsigned int alignment = sub_chunk_no * k * alignment_scalar_code;
   
-  return round_up_to(object_size, alignment) / k;
+  return round_up_to(stripe_width, alignment) / k;
 }
 
 int ErasureCodeClay::minimum_to_decode(const set<int> &want_to_read,

--- a/src/erasure-code/clay/ErasureCodeClay.h
+++ b/src/erasure-code/clay/ErasureCodeClay.h
@@ -58,7 +58,7 @@ public:
     return sub_chunk_no;
   }
 
-  unsigned int get_chunk_size(unsigned int object_size) const override;
+  unsigned int get_chunk_size(unsigned int stripe_width) const override;
 
   int minimum_to_decode(const std::set<int> &want_to_read,
 			const std::set<int> &available,

--- a/src/erasure-code/isa/ErasureCodeIsa.cc
+++ b/src/erasure-code/isa/ErasureCodeIsa.cc
@@ -63,10 +63,10 @@ ErasureCodeIsa::init(ErasureCodeProfile &profile, ostream *ss)
 // -----------------------------------------------------------------------------
 
 unsigned int
-ErasureCodeIsa::get_chunk_size(unsigned int object_size) const
+ErasureCodeIsa::get_chunk_size(unsigned int stripe_width) const
 {
   unsigned alignment = get_alignment();
-  unsigned chunk_size = ( object_size + k - 1 ) / k;
+  unsigned chunk_size = (stripe_width + k - 1) / k;
   dout(20) << "get_chunk_size: chunk_size " << chunk_size
            << " must be modulo " << alignment << dendl;
   unsigned modulo = chunk_size % alignment;

--- a/src/erasure-code/isa/ErasureCodeIsa.h
+++ b/src/erasure-code/isa/ErasureCodeIsa.h
@@ -71,7 +71,7 @@ public:
     return k;
   }
 
-  unsigned int get_chunk_size(unsigned int object_size) const override;
+  unsigned int get_chunk_size(unsigned int stripe_width) const override;
 
   int encode_chunks(const std::set<int> &want_to_encode,
                     std::map<int, ceph::buffer::list> *encoded) override;

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.cc
@@ -77,12 +77,12 @@ int ErasureCodeJerasure::parse(ErasureCodeProfile &profile,
   return err;
 }
 
-unsigned int ErasureCodeJerasure::get_chunk_size(unsigned int object_size) const
+unsigned int ErasureCodeJerasure::get_chunk_size(unsigned int stripe_width) const
 {
   unsigned alignment = get_alignment();
   if (per_chunk_alignment) {
-    unsigned chunk_size = object_size / k;
-    if (object_size % k)
+    unsigned chunk_size = stripe_width / k;
+    if (stripe_width % k)
       chunk_size++;
     dout(20) << "get_chunk_size: chunk_size " << chunk_size
 	     << " must be modulo " << alignment << dendl; 
@@ -95,8 +95,8 @@ unsigned int ErasureCodeJerasure::get_chunk_size(unsigned int object_size) const
     }
     return chunk_size;
   } else {
-    unsigned tail = object_size % alignment;
-    unsigned padded_length = object_size + ( tail ?  ( alignment - tail ) : 0 );
+    unsigned tail = stripe_width % alignment;
+    unsigned padded_length = stripe_width + (tail ? (alignment - tail) : 0);
     ceph_assert(padded_length % k == 0);
     return padded_length / k;
   }

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.h
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.h
@@ -54,7 +54,7 @@ public:
     return k;
   }
 
-  unsigned int get_chunk_size(unsigned int object_size) const override;
+  unsigned int get_chunk_size(unsigned int stripe_width) const override;
 
   int encode_chunks(const std::set<int> &want_to_encode,
 		    std::map<int, ceph::buffer::list> *encoded) override;

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -555,9 +555,9 @@ set<int> ErasureCodeLrc::get_erasures(const set<int> &want,
   return result;
 }
 
-unsigned int ErasureCodeLrc::get_chunk_size(unsigned int object_size) const
+unsigned int ErasureCodeLrc::get_chunk_size(unsigned int stripe_width) const
 {
-  return layers.front().erasure_code->get_chunk_size(object_size);
+  return layers.front().erasure_code->get_chunk_size(stripe_width);
 }
 
 void p(const set<int> &s) { cerr << s; } // for gdb

--- a/src/erasure-code/lrc/ErasureCodeLrc.h
+++ b/src/erasure-code/lrc/ErasureCodeLrc.h
@@ -103,7 +103,7 @@ public:
     return data_chunk_count;
   }
 
-  unsigned int get_chunk_size(unsigned int object_size) const override;
+  unsigned int get_chunk_size(unsigned int stripe_width) const override;
 
   int encode_chunks(const std::set<int> &want_to_encode,
 		    std::map<int, ceph::buffer::list> *encoded) override;

--- a/src/erasure-code/shec/ErasureCodeShec.cc
+++ b/src/erasure-code/shec/ErasureCodeShec.cc
@@ -58,11 +58,11 @@ int ErasureCodeShec::init(ErasureCodeProfile &profile,
   return ErasureCode::init(profile, ss);
 }
 
-unsigned int ErasureCodeShec::get_chunk_size(unsigned int object_size) const
+unsigned int ErasureCodeShec::get_chunk_size(unsigned int stripe_width) const
 {
   unsigned alignment = get_alignment();
-  unsigned tail = object_size % alignment;
-  unsigned padded_length = object_size + ( tail ?  ( alignment - tail ) : 0 );
+  unsigned tail = stripe_width % alignment;
+  unsigned padded_length = stripe_width + (tail ? (alignment - tail) : 0);
 
   ceph_assert(padded_length % k == 0);
   return padded_length / k;

--- a/src/erasure-code/shec/ErasureCodeShec.h
+++ b/src/erasure-code/shec/ErasureCodeShec.h
@@ -69,7 +69,7 @@ public:
     return k;
   }
 
-  unsigned int get_chunk_size(unsigned int object_size) const override;
+  unsigned int get_chunk_size(unsigned int stripe_width) const override;
 
   int _minimum_to_decode(const std::set<int> &want_to_read,
 			 const std::set<int> &available_chunks,


### PR DESCRIPTION
`object_size` was misleading in my perception; it suggested to me that the chunking happens on objects, not their stripes.

`stripe_width` corresponds with the naming in the ctor of `ECBackend`.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
