### PR TITLE
rgw/aio: avoid infinite recursion in aio_abstract()

### DIFF
--- a/src/rgw/rgw_aio.cc
+++ b/src/rgw/rgw_aio.cc
@@ -59,7 +59,7 @@ Aio::OpFunc aio_abstract(librados::IoCtx ctx, Op&& op, jspan_context* trace_ctx 
         (void)trace_ctx; // suppress unused trace_ctx warning. until we will support the read op trace
         r.result = ctx.aio_operate(r.obj.oid, s->c, &op, &r.data);
       } else {
-        r.result = ctx.aio_operate(r.obj.oid, s->c, &op, trace_ctx);
+        r.result = ctx.aio_operate(r.obj.oid, s->c, &op, 0, trace_ctx);
       }
       if (r.result < 0) {
         // cb() won't be called, so release everything here
@@ -124,7 +124,7 @@ Aio::OpFunc aio_abstract(librados::IoCtx ctx, Op&& op, optional_yield y, jspan_c
     return aio_abstract(std::move(ctx), std::forward<Op>(op),
                         y.get_io_context(), y.get_yield_context(), trace_ctx);
   }
-  return aio_abstract(std::move(ctx), std::forward<Op>(op), null_yield, trace_ctx);
+  return aio_abstract(std::move(ctx), std::forward<Op>(op), trace_ctx);
 }
 
 } // anonymous namespace


### PR DESCRIPTION
a recent regression from 320a2179a3c6c1981a0fd2494938515997c1bfad causes aio_abstract() to recurse when given an empty optional_yield. this is exposed by the librgw_file tests

Fixes: https://tracker.ceph.com/issues/64543

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
