### PR TITLE
[wip] Enhance Scrub Store to Separately Index Shallow and Deep Errors

### DIFF
--- a/src/common/map_cacher.hpp
+++ b/src/common/map_cacher.hpp
@@ -16,6 +16,7 @@
 #define MAPCACHER_H
 
 #include "include/Context.h"
+#include "include/expected.hpp"
 #include "common/sharedptr_registry.hpp"
 
 namespace MapCacher {
@@ -125,6 +126,49 @@ public:
     ceph_abort(); // not reachable
     return -EINVAL;
   } ///< @return error value, 0 on success, -ENOENT if no more entries
+
+  /// Fetch first key/value std::pair after specified key
+  struct PosAndData {
+    K last_key;
+    V data;
+  };
+  using MaybePosAndData = tl::expected<PosAndData, int>;
+
+  MaybePosAndData get_1st_after_key(
+      K key  ///< [in] key after which to get next
+  )
+  {
+    while (true) {
+      std::pair<K, boost::optional<V>> cached;
+      bool got_cached = in_progress.get_next(key, &cached);
+
+      ///\todo a driver->get_next() that returns an expected<K, V> would be nice
+      bool got_store{false};
+      std::pair<K, V> store;
+      int r = driver->get_next(key, &store);
+      if (r < 0 && r != -ENOENT) {
+        return tl::unexpected(r);
+      } else if (r == 0) {
+	got_store = true;
+      }
+
+      if (!got_cached && !got_store) {
+        return tl::unexpected(-ENOENT);
+      } else if (got_cached && (!got_store || store.first >= cached.first)) {
+	if (cached.second) {
+	  return PosAndData{cached.first, *cached.second};
+	} else {
+	  key = cached.first;
+	  continue;  // value was cached as removed, recurse
+	}
+      } else {
+	return PosAndData{store.first, store.second};
+      }
+    }
+    ceph_abort();  // not reachable
+    return tl::unexpected(-EINVAL);
+  }
+
 
   /// Adds operation setting keys to Transaction
   void set_keys(

--- a/src/common/perf_counters_cache.cc
+++ b/src/common/perf_counters_cache.cc
@@ -4,16 +4,16 @@
 namespace ceph::perf_counters {
 
 void PerfCountersCache::check_key(const std::string &key) {
-  [[maybe_unused]] std::string_view key_name = ceph::perf_counters::key_name(key);
+  [[maybe_unused]]std::string_view key_name = ceph::perf_counters::key_name(key);
   // don't accept an empty key name
   assert(key_name != "");
 
   // if there are no labels, key name is not valid
-  auto key_labels = ceph::perf_counters::key_labels(key);
+  [[maybe_unused]]auto key_labels = ceph::perf_counters::key_labels(key);
   assert(key_labels.begin() != key_labels.end());
 
   // don't accept keys where any labels in the key have an empty key name
-  for ([[maybe_unused]] auto key_label : key_labels) {
+  for ([[maybe_unused]]auto key_label : key_labels) {
     assert(key_label.first != "");
   }
 }

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -28,6 +28,7 @@
 #endif
 #include "include/buffer.h"
 #include "include/encoding.h"
+#include "include/expected.hpp"
 #include "include/object.h"
 #include "os/ObjectStore.h"
 #include "osd/OSDMap.h"

--- a/src/osd/scrubber/ScrubStore.cc
+++ b/src/osd/scrubber/ScrubStore.cc
@@ -1,10 +1,12 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "ScrubStore.h"
-#include "osd/osd_types.h"
 #include "common/scrub_types.h"
 #include "include/rados/rados_types.hpp"
+#include "osd/osd_types.h"
+#include "osd/osd_types_fmt.h"
+
+#include "ScrubStore.h"
 
 using std::ostringstream;
 using std::string;
@@ -13,48 +15,45 @@ using std::vector;
 using ceph::bufferlist;
 
 namespace {
-ghobject_t make_scrub_object(const spg_t& pgid)
+/**
+ * create two special temp objects in the PG. Those are used to
+ * hold the last/ongoing scrub errors detected. The errors are
+ * coded as OMAP entries attached to the objects.
+ * One of the objects stores detected shallow errors, and the other -
+ * deep errors.
+ */
+auto make_scrub_objects(const spg_t& pgid)
 {
-  ostringstream ss;
-  ss << "scrub_" << pgid;
-  return pgid.make_temp_ghobject(ss.str());
+  return std::pair{
+      pgid.make_temp_ghobject(fmt::format("scrub_{}", pgid)),
+      pgid.make_temp_ghobject(fmt::format("deep_scrub_{}", pgid))};
 }
 
 string first_object_key(int64_t pool)
 {
-  auto hoid = hobject_t(object_t(),
-			"",
-			0,
-			0x00000000,
-			pool,
-			"");
-  hoid.build_hash_cache();
-  return "SCRUB_OBJ_" + hoid.to_str();
+  auto shallow_hoid = hobject_t(object_t(), "", 0, 0x00000000, pool, "");
+  shallow_hoid.build_hash_cache();
+  return "SCRUB_OBJ_" + shallow_hoid.to_str();
 }
 
 // the object_key should be unique across pools
 string to_object_key(int64_t pool, const librados::object_id_t& oid)
 {
-  auto hoid = hobject_t(object_t(oid.name),
-			oid.locator, // key
-			oid.snap,
-			0,		// hash
-			pool,
-			oid.nspace);
-  hoid.build_hash_cache();
-  return "SCRUB_OBJ_" + hoid.to_str();
+  auto shallow_hoid = hobject_t(
+      object_t(oid.name),
+      oid.locator,  // key
+      oid.snap,
+      0,  // hash
+      pool, oid.nspace);
+  shallow_hoid.build_hash_cache();
+  return "SCRUB_OBJ_" + shallow_hoid.to_str();
 }
 
 string last_object_key(int64_t pool)
 {
-  auto hoid = hobject_t(object_t(),
-			"",
-			0,
-			0xffffffff,
-			pool,
-			"");
-  hoid.build_hash_cache();
-  return "SCRUB_OBJ_" + hoid.to_str();
+  auto shallow_hoid = hobject_t(object_t(), "", 0, 0xffffffff, pool, "");
+  shallow_hoid.build_hash_cache();
+  return "SCRUB_OBJ_" + shallow_hoid.to_str();
 }
 
 string first_snap_key(int64_t pool)
@@ -62,66 +61,91 @@ string first_snap_key(int64_t pool)
   // scrub object is per spg_t object, so we can misuse the hash (pg.seed) for
   // the representing the minimal and maximum keys. and this relies on how
   // hobject_t::to_str() works: hex(pool).hex(revhash).
-  auto hoid = hobject_t(object_t(),
-			"",
-			0,
-			0x00000000,
-			pool,
-			"");
-  hoid.build_hash_cache();
-  return "SCRUB_SS_" + hoid.to_str();
+  auto shallow_hoid = hobject_t(object_t(), "", 0, 0x00000000, pool, "");
+  shallow_hoid.build_hash_cache();
+  return "SCRUB_SS_" + shallow_hoid.to_str();
 }
 
 string to_snap_key(int64_t pool, const librados::object_id_t& oid)
 {
-  auto hoid = hobject_t(object_t(oid.name),
-			oid.locator, // key
-			oid.snap,
-			0x77777777, // hash
-			pool,
-			oid.nspace);
-  hoid.build_hash_cache();
-  return "SCRUB_SS_" + hoid.to_str();
+  auto shallow_hoid = hobject_t(
+      object_t(oid.name),
+      oid.locator,  // key
+      oid.snap,
+      0x77777777,  // hash
+      pool, oid.nspace);
+  shallow_hoid.build_hash_cache();
+  return "SCRUB_SS_" + shallow_hoid.to_str();
 }
 
 string last_snap_key(int64_t pool)
 {
-  auto hoid = hobject_t(object_t(),
-			"",
-			0,
-			0xffffffff,
-			pool,
-			"");
-  hoid.build_hash_cache();
-  return "SCRUB_SS_" + hoid.to_str();
+  auto shallow_hoid = hobject_t(object_t(), "", 0, 0xffffffff, pool, "");
+  shallow_hoid.build_hash_cache();
+  return "SCRUB_SS_" + shallow_hoid.to_str();
 }
+
+uint64_t decode_errors(
+    hobject_t o,
+    const ceph::buffer::list& bl)
+{
+  inconsistent_obj_wrapper iow{o};
+  auto sbi = bl.cbegin();
+  // should add an iterator for r-value
+  iow.decode(sbi);
+  return iow.errors;
 }
+
+void reencode_errors(hobject_t o, uint64_t errors, ceph::buffer::list& bl)
+{
+  inconsistent_obj_wrapper iow{o};
+  auto sbi = bl.cbegin();
+  // should add an iterator for r-value
+  iow.decode(sbi);
+  iow.errors = errors;
+  iow.encode(bl);
+}
+
+}  // namespace
 
 namespace Scrub {
 
-Store*
-Store::create(ObjectStore* store,
-	      ObjectStore::Transaction* t,
-	      const spg_t& pgid,
-	      const coll_t& coll)
+Store* Store::create(
+    ObjectStore* store,
+    ObjectStore::Transaction* t,
+    const spg_t& pgid,
+    const coll_t& coll,
+    LoggerSinkSet& logger)
 {
   ceph_assert(store);
   ceph_assert(t);
-  ghobject_t oid = make_scrub_object(pgid);
-  t->touch(coll, oid);
-  return new Store{coll, oid, store};
+  auto [shallow_oid, deep_oid] = make_scrub_objects(pgid);
+  t->touch(coll, shallow_oid);
+  t->touch(coll, deep_oid);
+
+  return new Store{coll, shallow_oid, deep_oid, store, logger};
 }
 
-Store::Store(const coll_t& coll, const ghobject_t& oid, ObjectStore* store)
-  : coll(coll),
-    hoid(oid),
-    driver(store, coll, hoid),
-    backend(&driver)
+Store::Store(
+    const coll_t& coll,
+    const ghobject_t& sh_oid,
+    const ghobject_t& dp_oid,
+    ObjectStore* store,
+    LoggerSinkSet& logger)
+    : coll(coll)
+    , shallow_hoid(sh_oid)
+    , shallow_driver(store, coll, sh_oid)
+    , shallow_backend(&shallow_driver)
+    , deep_hoid(dp_oid)
+    , deep_driver(store, coll, dp_oid)
+    , deep_backend(&deep_driver)
+    , clog(logger)
 {}
 
 Store::~Store()
 {
-  ceph_assert(results.empty());
+  ceph_assert(shallow_results.empty());
+  ceph_assert(deep_results.empty());
 }
 
 void Store::add_error(int64_t pool, const inconsistent_obj_wrapper& e)
@@ -133,7 +157,10 @@ void Store::add_object_error(int64_t pool, const inconsistent_obj_wrapper& e)
 {
   bufferlist bl;
   e.encode(bl);
-  results[to_object_key(pool, e.object)] = bl;
+  if (e.has_deep_errors()) {
+    deep_results[to_object_key(pool, e.object)] = bl;
+  }
+  shallow_results[to_object_key(pool, e.object)] = bl;
 }
 
 void Store::add_error(int64_t pool, const inconsistent_snapset_wrapper& e)
@@ -145,64 +172,170 @@ void Store::add_snap_error(int64_t pool, const inconsistent_snapset_wrapper& e)
 {
   bufferlist bl;
   e.encode(bl);
-  results[to_snap_key(pool, e.object)] = bl;
+  shallow_results[to_snap_key(pool, e.object)] = bl;
 }
 
 bool Store::empty() const
 {
-  return results.empty();
+  return shallow_results.empty() && deep_results.empty();
 }
 
 void Store::flush(ObjectStore::Transaction* t)
 {
   if (t) {
-    OSDriver::OSTransaction txn = driver.get_transaction(t);
-    backend.set_keys(results, &txn);
+    OSDriver::OSTransaction txn = shallow_driver.get_transaction(t);
+    shallow_backend.set_keys(shallow_results, &txn);
+
+    OSDriver::OSTransaction deep_txn = deep_driver.get_transaction(t);
+    deep_backend.set_keys(deep_results, &deep_txn);
   }
-  results.clear();
+
+  shallow_results.clear();
+  deep_results.clear();
 }
 
-void Store::cleanup(ObjectStore::Transaction* t)
+void Store::cleanup(ObjectStore::Transaction* t, scrub_level_t level)
 {
-  t->remove(coll, hoid);
+  // always clear the known shallow errors DB (as both shallow and deep scrubs
+  // would recreate it)
+  t->remove(coll, shallow_hoid);
+
+  // only a deep scrub recreates the deep errors DB
+  if (level == scrub_level_t::deep) {
+    t->remove(coll, deep_hoid);
+  }
 }
 
-std::vector<bufferlist>
-Store::get_snap_errors(int64_t pool,
-		       const librados::object_id_t& start,
-		       uint64_t max_return) const
+std::vector<bufferlist> Store::get_snap_errors(
+    int64_t pool,
+    const librados::object_id_t& start,
+    uint64_t max_return) const
 {
-  const string begin = (start.name.empty() ?
-			first_snap_key(pool) : to_snap_key(pool, start));
+  const string begin =
+      (start.name.empty() ? first_snap_key(pool) : to_snap_key(pool, start));
   const string end = last_snap_key(pool);
   return get_errors(begin, end, max_return);
 }
 
-std::vector<bufferlist>
-Store::get_object_errors(int64_t pool,
-			 const librados::object_id_t& start,
-			 uint64_t max_return) const
+std::vector<bufferlist> Store::get_object_errors(
+    int64_t pool,
+    const librados::object_id_t& start,
+    uint64_t max_return) const
 {
-  const string begin = (start.name.empty() ?
-			first_object_key(pool) : to_object_key(pool, start));
+  const string begin =
+      (start.name.empty() ? first_object_key(pool)
+			  : to_object_key(pool, start));
   const string end = last_object_key(pool);
   return get_errors(begin, end, max_return);
 }
 
-std::vector<bufferlist>
-Store::get_errors(const string& begin,
-		  const string& end,
-		  uint64_t max_return) const
+inline void decode(
+    librados::inconsistent_obj_t& obj,
+    ceph::buffer::list::const_iterator& bp)
 {
-  vector<bufferlist> errors;
-  auto next = std::make_pair(begin, bufferlist{});
-  while (max_return && !backend.get_next(next.first, &next)) {
-    if (next.first >= end)
-      break;
-    errors.push_back(next.second);
+  reinterpret_cast<inconsistent_obj_wrapper&>(obj).decode(bp);
+}
+
+
+void Store::collect_specific_store(
+    MapCacher::MapCacher<std::string, ceph::buffer::list>& backend,
+    Store::ExpCacherPosData& latest,
+    std::vector<bufferlist>& errors,
+    const std::string& end_key,
+    uint64_t& max_return) const
+{
+  while (max_return && latest.has_value() &&
+	 latest.value().last_key < end_key) {
+    errors.push_back(latest->data);
     max_return--;
   }
+}
+
+// a better way to implement this: use two generators, one for each store.
+// and sort-merge the results. Almost like a merge-sort, but with equal
+// keys combined.
+
+std::vector<bufferlist> Store::get_errors(
+    const string& from_key,
+    const string& end_key,
+    uint64_t max_return) const
+{
+  vector<bufferlist> errors;
+
+  // until enough errors are collected, merge the input from the
+  // two sorted DBs
+
+  ExpCacherPosData latest_sh = shallow_backend.get_1st_after_key(from_key);
+  ExpCacherPosData latest_dp = deep_backend.get_1st_after_key(from_key);
+
+  while (max_return) {
+    clog.debug() << fmt::format(
+	"{}: n:{} latest_sh: {}, latest_dp: {}", __func__, max_return,
+	(latest_sh ? latest_sh->last_key : "(none)"),
+	(latest_dp ? latest_dp->last_key : "(none)"));
+
+    // returned keys that are greater than end_key are not interesting
+    if (latest_sh.has_value() && latest_sh->last_key >= end_key) {
+      latest_sh = tl::unexpected(-EINVAL);
+    }
+    if (latest_dp.has_value() && latest_dp->last_key >= end_key) {
+      latest_dp = tl::unexpected(-EINVAL);
+    }
+
+    if (!latest_sh && !latest_dp) {
+      // both stores are exhausted
+      break;
+    }
+    if (!latest_sh.has_value()) {
+      // continue with the deep store
+      clog.debug() << fmt::format("{}: collecting from deep store", __func__);
+      collect_specific_store(
+	  deep_backend, latest_dp, errors, end_key, max_return);
+      break;
+    }
+    if (!latest_dp.has_value()) {
+      // continue with the shallow store
+      clog.debug() << fmt::format(
+	  "{}: collecting from shallow store", __func__);
+      collect_specific_store(
+	  shallow_backend, latest_sh, errors, end_key, max_return);
+      break;
+    }
+
+    // we have results from both stores. Select the one with a lower key.
+    // If the keys are equal, combine the errors.
+    if (latest_sh->last_key == latest_dp->last_key) {
+
+      uint64_t known_errs = decode_errors(shallow_hoid.hobj, latest_sh->data);
+      uint64_t known_dp_errs = decode_errors(deep_hoid.hobj, latest_dp->data);
+      known_errs |= (known_dp_errs & librados::obj_err_t::DEEP_ERRORS);
+      clog.debug() << fmt::format(
+	  "{}: == n:{} dp_errs: {}, known_errs: {}", __func__, max_return,
+	  known_dp_errs, known_errs);
+
+      reencode_errors(shallow_hoid.hobj, known_errs, latest_sh->data);
+      errors.push_back(latest_sh->data);
+      max_return--;
+      latest_sh = shallow_backend.get_1st_after_key(latest_sh->last_key);
+      latest_dp = deep_backend.get_1st_after_key(latest_dp->last_key);
+
+    } else if (latest_sh->last_key < latest_dp->last_key) {
+      clog.debug() << fmt::format(
+	  "{}: shallow store element ({})", __func__, latest_sh->last_key);
+      errors.push_back(latest_sh->data);
+      latest_sh = shallow_backend.get_1st_after_key(latest_sh->last_key);
+    } else {
+      clog.debug() << fmt::format(
+	  "{}: deep store element ({})", __func__, latest_dp->last_key);
+      errors.push_back(latest_dp->data);
+      latest_dp = deep_backend.get_1st_after_key(latest_dp->last_key);
+    }
+    max_return--;
+  }
+  clog.debug() << fmt::format(
+      "{}: == n:{} #errors: {}", __func__, max_return, errors.size());
+
   return errors;
 }
 
-} // namespace Scrub
+}  // namespace Scrub

--- a/src/osd/scrubber/ScrubStore.h
+++ b/src/osd/scrubber/ScrubStore.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_SCRUB_RESULT_H
 #define CEPH_SCRUB_RESULT_H
 
+#include "common/LogClient.h"
 #include "common/map_cacher.hpp"
 #include "osd/SnapMapper.h"  // for OSDriver
 
@@ -16,47 +17,99 @@ struct inconsistent_snapset_wrapper;
 
 namespace Scrub {
 
+/**
+ * Storing errors detected during scrubbing.
+ *
+ * From both functional and internal perspectives, the store is a pair of key-value
+ * databases: one maps objects to shallow errors detected during their scrubbing,
+ * and other stores deep errors.
+ * Note that the first store is updated in both shallow and in deep scrubs. The
+ * second - only while deep scrubbing.
+ *
+ * The DBs can be consulted by the operator, when trying to list 'errors known
+ * at this point in time'. Whenever a scrub starts - the relevant entries in the
+ * DBs are removed. Specifically - the shallow errors DB is recreated each scrub,
+ * while the deep errors DB is recreated only when a deep scrub starts.
+ *
+ * When queried - the data from both DBs is merged for each named object, and
+ * returned to the operator.
+ *
+ * Implementation:
+ * Each of the two DBs is implemented as OMAP entries of a single, uniquely named,
+ * object. Both DBs are cached using the general KV Cache mechanism.
+ */
+
 class Store {
  public:
   ~Store();
-  static Store* create(ObjectStore* store,
-		       ObjectStore::Transaction* t,
-		       const spg_t& pgid,
-		       const coll_t& coll);
+  static Store* create(
+      ObjectStore* store,
+      ObjectStore::Transaction* t,
+      const spg_t& pgid,
+      const coll_t& coll,
+      LoggerSinkSet& logger);
+
   void add_object_error(int64_t pool, const inconsistent_obj_wrapper& e);
   void add_snap_error(int64_t pool, const inconsistent_snapset_wrapper& e);
 
   // and a variant-friendly interface:
   void add_error(int64_t pool, const inconsistent_obj_wrapper& e);
   void add_error(int64_t pool, const inconsistent_snapset_wrapper& e);
-
   bool empty() const;
   void flush(ObjectStore::Transaction*);
-  void cleanup(ObjectStore::Transaction*);
+  void cleanup(ObjectStore::Transaction*, scrub_level_t level);
 
   std::vector<ceph::buffer::list> get_snap_errors(
-    int64_t pool,
-    const librados::object_id_t& start,
-    uint64_t max_return) const;
+      int64_t pool,
+      const librados::object_id_t& start,
+      uint64_t max_return) const;
 
   std::vector<ceph::buffer::list> get_object_errors(
-    int64_t pool,
-    const librados::object_id_t& start,
-    uint64_t max_return) const;
+      int64_t pool,
+      const librados::object_id_t& start,
+      uint64_t max_return) const;
 
  private:
-  Store(const coll_t& coll, const ghobject_t& oid, ObjectStore* store);
-  std::vector<ceph::buffer::list> get_errors(const std::string& start,
-					     const std::string& end,
-					     uint64_t max_return) const;
- private:
+  // the collection (i.e. - the PG store) in which the errors are stored
   const coll_t coll;
-  const ghobject_t hoid;
-  // a temp object holding mappings from seq-id to inconsistencies found in
-  // scrubbing
-  OSDriver driver;
-  mutable MapCacher::MapCacher<std::string, ceph::buffer::list> backend;
-  std::map<std::string, ceph::buffer::list> results;
+
+  LoggerSinkSet& clog;
+
+  // the machinery for storing the shallow errors: a fake object in the PG store,
+  // caching mechanism, and the actual backend
+  const ghobject_t shallow_hoid;
+  OSDriver shallow_driver;  //< a temp object mapping seq-id to inconsistencies
+  mutable MapCacher::MapCacher<std::string, ceph::buffer::list> shallow_backend;
+
+  // same for all deep errors
+  const ghobject_t deep_hoid;
+  OSDriver deep_driver;
+  mutable MapCacher::MapCacher<std::string, ceph::buffer::list> deep_backend;
+
+  std::map<std::string, ceph::buffer::list> shallow_results;
+  std::map<std::string, ceph::buffer::list> deep_results;
+  using CacherPosData =
+      MapCacher::MapCacher<std::string, ceph::buffer::list>::PosAndData;
+  using ExpCacherPosData = tl::expected<CacherPosData, int>;
+
+  Store(
+      const coll_t& coll,
+      const ghobject_t& oid,
+      const ghobject_t& deep_oid,
+      ObjectStore* store,
+      LoggerSinkSet& logger);
+
+  std::vector<ceph::buffer::list> get_errors(
+      const std::string& start,
+      const std::string& end,
+      uint64_t max_return) const;
+
+  void collect_specific_store(
+      MapCacher::MapCacher<std::string, ceph::buffer::list>& backend,
+      ExpCacherPosData& latest,
+      std::vector<bufferlist>& errors,
+      const std::string& end_key,
+      uint64_t& max_return) const;
 };
 }  // namespace Scrub
 

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2717,15 +2717,6 @@ std::optional<requested_scrub_t> PgScrubber::validate_periodic_mode(
 
 {
   ceph_assert(!planned.must_deep_scrub && !planned.must_repair);
-
-  if (!pg_cond.allow_deep && pg_cond.has_deep_errors) {
-    get_clog()->error() << fmt::format(
-	"osd.{} pg {} Regular scrub skipped due to deep-scrub errors and "
-	"nodeep-scrub set",
-	get_whoami(), m_pg_id);
-    return std::nullopt;  // no scrubbing
-  }
-
   requested_scrub_t upd_flags{planned};
 
   upd_flags.time_for_deep = time_for_deep;

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1188,7 +1188,9 @@ void PgScrubber::cleanup_store(ObjectStore::Transaction* t)
     {}
     void finish(int) override {}
   };
-  m_store->cleanup(t);
+  // clearing both - just to get it to compile RRR
+  m_store->cleanup(t, scrub_level_t::shallow);
+  m_store->cleanup(t, scrub_level_t::deep);
   t->register_on_complete(new OnComplete(std::move(m_store)));
   ceph_assert(!m_store);
 }
@@ -1215,7 +1217,7 @@ void PgScrubber::on_init()
     ObjectStore::Transaction t;
     cleanup_store(&t);
     m_store.reset(
-      Scrub::Store::create(m_pg->osd->store, &t, m_pg->info.pgid, m_pg->coll));
+      Scrub::Store::create(m_pg->osd->store, &t, m_pg->info.pgid, m_pg->coll, get_logger()));
     m_pg->osd->store->queue_transaction(m_pg->ch, std::move(t), nullptr);
   }
 


### PR DESCRIPTION

Problem:
The current scrub store combines "shallow" and "deep" errors for each object, preventing shallow scrubs when "deep errors" exist, as initiating a scrub resets the store and erases existing deep error records without resolving them. This limitation not only restricts certain scrub operations but also complicates scrub scheduling, as the type of scrub to be run cannot be predetermined. The proposed solution is to split the scrub store into two distinct sections for deep and shallow scrubs, necessitating modifications to both the code and the tools operators use to access the scrub store, including compatibility with legacy stores.

Proposed Solution:

To address the issue of combined error records, we propose the introduction of two separate storage mechanisms within the ScrubStore for deep and shallow scrub errors. This solution involves:

Distinct Storage Objects: Implementing separate "artificial" objects within each PG's ScrubStore, one for logging deep scrub errors and another for shallow scrub errors.

Error Type Segregation: Modifying the scrubbing process to categorize errors as either deep or shallow at the point of detection and storing them in the corresponding storage object.

Preservation of Error History: Ensuring that initiating a shallow scrub does not overwrite or remove existing records of deep errors, thereby preserving the integrity of historical error data.
