### PR TITLE
ceph-volume: fix a bug in create_lv

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -976,6 +976,9 @@ def create_lv(name_prefix,
             vg = vgs[0]
         else:
             # create on if not
+            # create pv
+            create_pv(device)
+            # create vg
             vg = create_vg(device, name_prefix='ceph')
     assert(vg)
 


### PR DESCRIPTION
when create osd, we should run pvcreate before vgcreate
    
fix: https://tracker.ceph.com/issues/64560
Signed-off-by: tancz <544463199@qq.com>
