### PR TITLE
qa: Add benign cluster warning from ec-inconsistent-hinfo test to ignorelist

### DIFF
--- a/qa/suites/rados/singleton/all/ec-inconsistent-hinfo.yaml
+++ b/qa/suites/rados/singleton/all/ec-inconsistent-hinfo.yaml
@@ -30,6 +30,7 @@ tasks:
       - slow request
       - unfound
       - \(POOL_APP_NOT_ENABLED\)
+      - enough copies available
     conf:
       osd:
         osd min pg log entries: 5


### PR DESCRIPTION
The changes introduced in PR: https://github.com/ceph/ceph/pull/53524 made the randomized values of osd_op_queue and osd_op_queue_cut_off consistent across all OSD shards.

Due to the above, ec-inconsistent-hinfo test could fail with the following cluster warning (benign) depending on the randomly selected scheduler type.

"cluster [WRN] Error(s) ignored for 2:ad551702:::test:head enough copies available"

NOTE:
The above warning doesn't show up currently on "main" branch due to https://github.com/ceph/ceph/pull/47830.
Once https://github.com/ceph/ceph/pull/55455 and/or https://github.com/ceph/ceph/pull/49730 is merged, the above warning might start showing up. Therefore, this is a preemptive PR.

In summary, the warning is generated due to the difference in the PG deletion rates between WPQ and mClock schedulers. Therefore, the warning shows up in cases where the mClock scheduler is the op queue scheduler chosen randomly for the test. The PG deletion rate with mClock scheduler is quicker compared to the WPQ scheduler since it doesn't use sleeps between each delete transaction and relies on the cost of the deletion which in turn is proportional to the average size of the objects in the PG.

For a more detailed analysis, see the associated tracker.

Fixes: https://tracker.ceph.com/issues/64573
Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
