### PR TITLE
crimson: set alien store op threads per core

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -12,11 +12,11 @@ options:
   level: advanced
   desc: The maximum number concurrent IO operations, 0 for unlimited
   default: 0
-- name: crimson_alien_op_num_threads
+- name: crimson_alien_num_threads_per_core
   type: uint
   level: advanced
-  desc: The number of threads for serving alienized ObjectStore
-  default: 6
+  desc: The number of threads for each core of serving alienized ObjectStore
+  default: 4
   flags:
   - startup
 - name: crimson_seastar_cpu_cores
@@ -25,7 +25,7 @@ options:
   desc: CPU cores on which seastar reactor threads will run in cpuset(7) format, smp::count is deduced from this option
   flags:
   - startup
-- name: crimson_alien_thread_cpu_cores
+- name: crimson_alien_cpu_cores
   type: str
   level: advanced
   desc: CPU cores on which alienstore threads will run in cpuset(7) format

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -102,7 +102,7 @@ seastar::future<> AlienStore::start()
     ceph_abort_msgf("unsupported objectstore type: %s", type.c_str());
   }
   auto cpu_cores = seastar::resource::parse_cpuset(
-    get_conf<std::string>("crimson_alien_thread_cpu_cores"));
+    get_conf<std::string>("crimson_alien_cpu_cores"));
   //  crimson_alien_thread_cpu_cores are assigned to alien threads.
   if (!cpu_cores.has_value()) {
     // no core isolation by default, seastar_cpu_cores will be
@@ -111,9 +111,9 @@ seastar::future<> AlienStore::start()
       get_conf<std::string>("crimson_seastar_cpu_cores"));
     ceph_assert(cpu_cores.has_value());
   }
-  const auto num_threads =
-    get_conf<uint64_t>("crimson_alien_op_num_threads");
-  tp = std::make_unique<crimson::os::ThreadPool>(num_threads, 128, cpu_cores);
+  const auto num_threads_per_core =
+    get_conf<uint64_t>("crimson_alien_num_threads_per_core");
+  tp = std::make_unique<crimson::os::ThreadPool>(num_threads_per_core * (*cpu_cores).size() , 128, cpu_cores);
   return tp->start();
 }
 


### PR DESCRIPTION
For alien store, per thread per alien core will not get the best performance especially for fio rand read.  when increase threads number for each alien core, performance also increased. see below: 

![image](https://github.com/ceph/ceph/assets/29928748/e8721900-657f-4a3b-bd07-83f600b28cd2)
![image](https://github.com/ceph/ceph/assets/29928748/bef40bd9-635a-43d6-bb35-5d768fc59b6a)


For fio rand read, each alien core has 4 threads,  when core <=8, crimson's performance will be better than classic ceph. still has problem for high cores.
For fio rand write, different thread policy for different cores, we can get similar or better performance than classic ceph.

The current problem is, for a certain cores, can't use same threads number for rand read and rand write for the best performance. 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
