### PR TITLE
mgr/dashboard: Multi cluster improvements

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -54,50 +54,6 @@ class Auth(RESTController, ControllerAuthMixin):
                 pwd_expiration_date = user_data.get('pwdExpirationDate', None)
                 pwd_update_required = user_data.get('pwdUpdateRequired', False)
 
-            if isinstance(Settings.MULTICLUSTER_CONFIG, str):
-                try:
-                    item_to_dict = json.loads(Settings.MULTICLUSTER_CONFIG)
-                except json.JSONDecodeError:
-                    item_to_dict = {}
-                multicluster_config = item_to_dict.copy()
-            else:
-                multicluster_config = Settings.MULTICLUSTER_CONFIG.copy()
-            try:
-                if fsid in multicluster_config['config']:
-                    existing_entries = multicluster_config['config'][fsid]
-                    if not any(entry['user'] == username for entry in existing_entries):
-                        existing_entries.append({
-                            "name": fsid,
-                            "url": origin,
-                            "cluster_alias": "local-cluster",
-                            "user": username
-                        })
-                else:
-                    multicluster_config['config'][fsid] = [{
-                        "name": fsid,
-                        "url": origin,
-                        "cluster_alias": "local-cluster",
-                        "user": username
-                    }]
-
-            except KeyError:
-                multicluster_config = {
-                    'current_url': origin,
-                    'current_user': username,
-                    'hub_url': origin,
-                    'config': {
-                        fsid: [
-                            {
-                                "name": fsid,
-                                "url": origin,
-                                "cluster_alias": "local-cluster",
-                                "user": username
-                            }
-                        ]
-                    }
-                }
-            Settings.MULTICLUSTER_CONFIG = multicluster_config
-
             if user_perms is not None:
                 url_prefix = 'https' if mgr.get_localized_module_option('ssl') else 'http'
 
@@ -110,6 +66,49 @@ class Auth(RESTController, ControllerAuthMixin):
                 token = token.decode('utf-8') if isinstance(token, bytes) else token
 
                 self._set_token_cookie(url_prefix, token)
+                if isinstance(Settings.MULTICLUSTER_CONFIG, str):
+                    try:
+                        item_to_dict = json.loads(Settings.MULTICLUSTER_CONFIG)
+                    except json.JSONDecodeError:
+                        item_to_dict = {}
+                    multicluster_config = item_to_dict.copy()
+                else:
+                    multicluster_config = Settings.MULTICLUSTER_CONFIG.copy()
+                try:
+                    if fsid in multicluster_config['config']:
+                        existing_entries = multicluster_config['config'][fsid]
+                        if not any((entry['user'] == username or entry['cluster_alias'] == 'local-cluster') for entry in existing_entries):  # noqa E501 #pylint: disable=line-too-long
+                            existing_entries.append({
+                                "name": fsid,
+                                "url": origin,
+                                "cluster_alias": "local-cluster",
+                                "user": username
+                            })
+                    else:
+                        multicluster_config['config'][fsid] = [{
+                            "name": fsid,
+                            "url": origin,
+                            "cluster_alias": "local-cluster",
+                            "user": username
+                        }]
+
+                except KeyError:
+                    multicluster_config = {
+                        'current_url': origin,
+                        'current_user': username,
+                        'hub_url': origin,
+                        'config': {
+                            fsid: [
+                                {
+                                    "name": fsid,
+                                    "url": origin,
+                                    "cluster_alias": "local-cluster",
+                                    "user": username
+                                }
+                            ]
+                        }
+                    }
+                Settings.MULTICLUSTER_CONFIG = multicluster_config
                 return {
                     'token': token,
                     'username': username,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-form/multi-cluster-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-form/multi-cluster-form.component.html
@@ -20,7 +20,7 @@
         <cd-alert-panel type="info"
                         spacingClass="mb-3"
                         i18n
-                        *ngIf="connectionVerified !== undefined && !connectionVerified && connectionMessage === 'Connection refused'">
+                        *ngIf="connectionVerified !== undefined && !connectionVerified && connectionMessage === 'Connection refused' || remoteClusterForm.getValue('showToken')">
         <p>You need to set this cluster's url as the cross origin url in the remote cluster you are trying to connect.
           You can do it by running this CLI command in your remote cluster and proceed with authentication via token.</p>
           <cd-code-block [codes]="[crossOriginCmd]"></cd-code-block>
@@ -29,7 +29,14 @@
           <label class="cd-col-form-label required"
                  for="remoteClusterUrl"
                  i18n>Cluster API URL
-            <cd-helper>Enter the Dashboard API URL. You can retrieve it from the CLI with: <b>ceph mgr services</b></cd-helper>
+            <cd-helper>
+              <span>
+                <p>Enter the Dashboard API URL. You can retrieve it from the CLI with: <b>{{ clusterApiUrlCmd }} </b>
+                  <cd-copy-2-clipboard-button [source]="clusterApiUrlCmd"
+                                              [byId]="false"></cd-copy-2-clipboard-button>
+                </p>
+              </span>
+            </cd-helper>
           </label>
           <div class="cd-col-form-input">
             <input class="form-control"
@@ -106,6 +113,32 @@
                    formControlName="clusterFsid">
             <span class="invalid-feedback"
                   *ngIf="remoteClusterForm.showError('clusterFsid', frm, 'required')"
+                  i18n>This field is required.
+            </span>
+          </div>
+        </div>
+        <div class="form-group row"
+             *ngIf="remoteClusterForm.getValue('showToken') && action !== 'edit'">
+          <label class="cd-col-form-label required"
+                 for="prometheusApiUrl"
+                 i18n>Prometheus API URL
+            <cd-helper>
+              <span>
+                <p>Enter the Prometheus API URL. You can retrieve it from the CLI with: <b>{{ prometheusApiUrlCmd }} </b>
+                  <cd-copy-2-clipboard-button [source]="prometheusApiUrlCmd"
+                                              [byId]="false"></cd-copy-2-clipboard-button>
+                </p>
+              </span>
+            </cd-helper>
+          </label>
+          <div class="cd-col-form-input">
+            <input id="prometheusApiUrl"
+                   name="prometheusApiUrl"
+                   class="form-control"
+                   type="text"
+                   formControlName="prometheusApiUrl">
+            <span class="invalid-feedback"
+                  *ngIf="remoteClusterForm.showError('prometheusApiUrl', frm, 'required')"
                   i18n>This field is required.
             </span>
           </div>
@@ -211,7 +244,7 @@
             </div>
           </div>
         <div class="form-group row"
-             *ngIf="!showCrossOriginError && action !== 'edit' && !remoteClusterForm.getValue('showToken')">
+             *ngIf="!showCrossOriginError && action !== 'edit' && !remoteClusterForm.getValue('showToken') && !connectionVerified">
           <div class="cd-col-form-offset">
             <div class="custom-control">
               <button class="btn btn-primary"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster.component.html
@@ -42,6 +42,8 @@
         <i class="mx-auto d-block"
            [ngClass]="[icons.large3x, icons.spinner, icons.spin]">
         </i>
+        <p class="text-center mt-3"
+           i18n>Loading data, Please wait...</p>
       </div>
     </div>
   </div>
@@ -50,6 +52,16 @@
 <div class="container-fluid h-100 p-4"
      *ngIf="isMultiCluster; else emptyCluster">
   <ng-container *ngIf="!loading; else loadingTpl">
+    <cd-alert-panel type="info"
+                    spacingClass="mb-3"
+                    [showTitle]="false"
+                    size="slim"
+                    *ngIf="showDeletionMessage"
+                    (dismissed)="onDismissed()"
+                    [dismissible]="true"
+                    i18n>
+      <p>Please note that the data for the disconnected cluster will be visible for a duration of ~ 5 minutes. After this period, it will be automatically removed.</p>
+    </cd-alert-panel>
     <cd-card-group>
       <div class="col-lg-4">
         <div class="row">
@@ -112,7 +124,7 @@
                    i18n-title
                    class="col-sm-6 m-0 p-0 ps-2 pe-2"
                    aria-label="Total number of hosts"
-                   *ngIf="queriesResults['TOTAL_HOSTS'][0][1] !== '0'">
+                   *ngIf="queriesResults['TOTAL_HOSTS'] && queriesResults['TOTAL_HOSTS'][0]">
             <span class="text-center">
               <h3>{{ queriesResults['TOTAL_HOSTS'][0][1] }}</h3>
             </span>
@@ -142,10 +154,11 @@
                  aria-label="Cluster Utilization card"
                  *ngIf="clusters">
           <div class="ms-4 me-4 mt-0">
-            <cd-dashboard-time-selector (selectedTime)="getPrometheusData($event)">
+            <cd-dashboard-time-selector (selectedTime)="getPrometheusData($event, 'clusterUtilization')">
             </cd-dashboard-time-selector>
             <cd-dashboard-area-chart  chartTitle="Capacity"
                                       [labelsArray]="capacityLabels"
+                                      isMultiCluster="true"
                                       dataUnits="B"
                                       [dataArray]="capacityValues"
                                       [truncateLabel]="true"
@@ -155,6 +168,7 @@
                                      [labelsArray]="iopsLabels"
                                      dataUnits=""
                                      decimals="0"
+                                     isMultiCluster="true"
                                      [dataArray]="iopsValues"
                                      [truncateLabel]="true"
                                      *ngIf="iopsLabels && iopsValues">
@@ -163,6 +177,7 @@
                                      [labelsArray]="throughputLabels"
                                      dataUnits="B/s"
                                      decimals="2"
+                                     isMultiCluster="true"
                                      [dataArray]="throughputValues"
                                      [truncateLabel]="true"
                                      *ngIf="throughputLabels && throughputLabels">
@@ -190,11 +205,12 @@
                    aria-label="Pools Utilization card"
                    *ngIf="clusters">
             <div class="ms-4 me-4 mt-0">
-              <cd-dashboard-time-selector (selectedTime)="getPrometheusData($event)">
+              <cd-dashboard-time-selector (selectedTime)="getPrometheusData($event, 'poolUtilization')">
               </cd-dashboard-time-selector>
               <cd-dashboard-area-chart  chartTitle="Capacity"
                                         [labelsArray]="poolCapacityLabels"
                                         dataUnits="B"
+                                        isMultiCluster="true"
                                         [dataArray]="poolCapacityValues"
                                         *ngIf="poolCapacityLabels && poolCapacityValues"
                                         [truncateLabel]="true">
@@ -203,6 +219,7 @@
                                        [labelsArray]="poolIOPSLabels"
                                        dataUnits=""
                                        decimals="0"
+                                       isMultiCluster="true"
                                        [dataArray]="poolIOPSValues"
                                        *ngIf="poolIOPSLabels && poolIOPSValues"
                                        [truncateLabel]="true">
@@ -211,6 +228,7 @@
                                        [labelsArray]="poolThroughputLabels"
                                        dataUnits="B/s"
                                        decimals="2"
+                                       isMultiCluster="true"
                                        [dataArray]="poolThroughputValues"
                                        *ngIf="poolThroughputLabels && poolThroughputValues"
                                        [truncateLabel]="true">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard-area-chart/dashboard-area-chart.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard-area-chart/dashboard-area-chart.component.html
@@ -24,7 +24,7 @@
   </div>
 
   <div class="col-9 d-flex flex-column">
-    <div class="chart mt-3">
+    <div [ngClass]="{'chart mt-3': !isMultiCluster, 'mt-3': isMultiCluster}">
       <canvas baseChart
               [datasets]="chartData.dataset"
               [options]="options"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard-area-chart/dashboard-area-chart.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard-area-chart/dashboard-area-chart.component.spec.ts
@@ -63,22 +63,22 @@ describe('DashboardAreaChartComponent', () => {
 
   it('should set label', () => {
     component.ngOnChanges({ dataArray: new SimpleChange(null, component.dataArray, false) });
-    expect(component.chartData.dataset[0].label).toEqual('Read');
+    expect(component.chartData.dataset[0].label).toEqual('Total');
     expect(component.chartData.dataset[1].label).toEqual('Write');
-    expect(component.chartData.dataset[2].label).toEqual('Total');
+    expect(component.chartData.dataset[2].label).toEqual('Read');
   });
 
   it('should transform and update data', () => {
     component.ngOnChanges({ dataArray: new SimpleChange(null, component.dataArray, false) });
     expect(component.chartData.dataset[0].data).toEqual([
-      { x: 1000, y: 110 },
-      { x: 3000, y: 130 }
+      { x: 5000, y: 150 },
+      { x: 6000, y: 160 }
     ]);
   });
 
   it('should set currentData to last value', () => {
     component.ngOnChanges({ dataArray: new SimpleChange(null, component.dataArray, false) });
-    expect(component.currentChartData.dataset[0].currentData).toBe('130');
+    expect(component.currentChartData.dataset[0].currentData).toBe('160');
   });
 
   it('should keep data units consistency', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard-area-chart/dashboard-area-chart.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard-area-chart/dashboard-area-chart.component.ts
@@ -31,6 +31,8 @@ export class DashboardAreaChartComponent implements OnChanges {
   decimals?: number = 1;
   @Input()
   truncateLabel = false;
+  @Input()
+  isMultiCluster?: boolean = false;
 
   currentDataUnits: string;
   currentData: number;
@@ -214,8 +216,13 @@ export class DashboardAreaChartComponent implements OnChanges {
           [this.maxConvertedValue, this.maxConvertedValueUnits] = this.convertUnits(
             this.maxValue
           ).split(' ');
+          this.currentChartData.dataset[index]['currentDataValue'] = currentDataValue;
         }
       }
+      this.currentChartData.dataset.sort(
+        (a: { currentDataValue: string }, b: { currentDataValue: string }) =>
+          parseFloat(b['currentDataValue']) - parseFloat(a['currentDataValue'])
+      );
     }
 
     if (this.chart) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard-pie/dashboard-pie.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard-pie/dashboard-pie.component.ts
@@ -157,8 +157,10 @@ export class DashboardPieComponent implements OnChanges, OnInit {
   private prepareRawUsage(chart: Record<string, any>, data: Record<string, any>) {
     const nearFullRatioPercent = this.lowThreshold * 100;
     const fullRatioPercent = this.highThreshold * 100;
-    const percentAvailable = this.calcPercentage(data.max - data.current, data.max);
-    const percentUsed = this.calcPercentage(data.current, data.max);
+    const max = typeof data.max === 'string' ? parseFloat(data.max) : data.max;
+    const current = typeof data.current === 'string' ? parseFloat(data.current) : data.current;
+    const percentAvailable = this.calcPercentage(max - current, max);
+    const percentUsed = this.calcPercentage(current, max);
 
     if (fullRatioPercent >= 0 && percentUsed >= fullRatioPercent) {
       this.color = 'chart-color-red';

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
@@ -71,6 +71,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
       this.multiClusterService.subscribe((resp: object) => {
         const clustersConfig = resp['config'];
         if (clustersConfig) {
+          this.clustersMap.clear();
           Object.keys(clustersConfig).forEach((clusterKey: string) => {
             const clusterDetailsList = clustersConfig[clusterKey];
             clusterDetailsList.forEach((clusterDetails: MultiCluster) => {
@@ -212,9 +213,6 @@ export class NavigationComponent implements OnInit, OnDestroy {
       },
       () => {},
       () => {
-        this.multiClusterService.refresh();
-        this.summaryService.refresh();
-
         // force refresh grafana api url to get the correct url for the selected cluster
         this.settingsService.ifSettingConfigured(
           'api/grafana/url',
@@ -223,15 +221,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
           true
         );
         const currentRoute = this.router.url.split('?')[0];
-        if (currentRoute.includes('dashboard')) {
-          this.router.navigateByUrl('/pool', { skipLocationChange: true }).then(() => {
-            this.router.navigate([currentRoute]);
-          });
-        } else {
-          this.router.navigateByUrl('/', { skipLocationChange: true }).then(() => {
-            this.router.navigate([currentRoute]);
-          });
-        }
+        this.multiClusterService.refreshMultiCluster(currentRoute);
       }
     );
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html
@@ -10,6 +10,12 @@
           [formGroup]="deletionForm"
           novalidate>
       <div class="modal-body">
+        <cd-alert-panel *ngIf="infoMessage"
+                        type="info"
+                        spacingClass="mb-3"
+                        i18n>
+          <p>{{ infoMessage }}</p>
+        </cd-alert-panel>
         <ng-container *ngTemplateOutlet="bodyTemplate; context: bodyContext"></ng-container>
         <div class="question">
           <span *ngIf="itemNames; else noNames">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.ts
@@ -25,6 +25,7 @@ export class CriticalConfirmationModalComponent implements OnInit {
   itemDescription: 'entry';
   itemNames: string[];
   actionDescription = 'delete';
+  infoMessage: string;
 
   childFormGroup: CdFormGroup;
   childFormGroupTemplate: TemplateRef<any>;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/dashboard-promqls.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/dashboard-promqls.enum.ts
@@ -36,11 +36,17 @@ export enum MultiClusterPromqls {
   ALERTS = 'ALERTS{alertstate="firing"}',
   HOSTS = 'sum by (hostname, cluster) (group by (hostname, cluster) (ceph_osd_metadata)) or vector(0)',
   TOTAL_HOSTS = 'count by (cluster) (ceph_osd_metadata) or vector(0)',
-  CLUSTER_ALERTS = 'count by (cluster) (ALERTS{alertstate="firing"}) or vector(0)',
-  CLUSTER_CAPACITY_UTILIZATION = 'topk(2, ceph_cluster_total_used_bytes)',
-  CLUSTER_IOPS_UTILIZATION = 'topk(2, sum by (cluster) (rate(ceph_pool_wr[1m])) + sum by (cluster) (rate(ceph_pool_rd[1m])) )',
-  CLUSTER_THROUGHPUT_UTILIZATION = 'topk(2, sum by (cluster) (rate(ceph_pool_wr_bytes[1m])) + sum by (cluster) (rate(ceph_pool_rd_bytes[1m])) )',
-  POOL_CAPACITY_UTILIZATION = 'topk(2, ceph_pool_bytes_used/ceph_pool_max_avail * on(pool_id, cluster) group_left(instance, name) ceph_pool_metadata)',
-  POOL_IOPS_UTILIZATION = 'topk(2, (rate(ceph_pool_rd[1m]) + rate(ceph_pool_wr[1m])) * on(pool_id, cluster) group_left(instance, name) ceph_pool_metadata )',
-  POOL_THROUGHPUT_UTILIZATION = 'topk(2, (irate(ceph_pool_rd_bytes[1m]) + irate(ceph_pool_wr_bytes[1m])) * on(pool_id, cluster) group_left(instance, name) ceph_pool_metadata )'
+  CLUSTER_ALERTS = 'count by (cluster) (ALERTS{alertstate="firing"}) or vector(0)'
+}
+
+export enum MultiClusterPromqlsForClusterUtilization {
+  CLUSTER_CAPACITY_UTILIZATION = 'topk(5, ceph_cluster_total_used_bytes)',
+  CLUSTER_IOPS_UTILIZATION = 'topk(5, sum by (cluster) (rate(ceph_pool_wr[1m])) + sum by (cluster) (rate(ceph_pool_rd[1m])) )',
+  CLUSTER_THROUGHPUT_UTILIZATION = 'topk(5, sum by (cluster) (rate(ceph_pool_wr_bytes[1m])) + sum by (cluster) (rate(ceph_pool_rd_bytes[1m])) )'
+}
+
+export enum MultiClusterPromqlsForPoolUtilization {
+  POOL_CAPACITY_UTILIZATION = 'topk(5, ceph_pool_bytes_used/ceph_pool_max_avail * on(pool_id, cluster) group_left(instance, name) ceph_pool_metadata)',
+  POOL_IOPS_UTILIZATION = 'topk(5, (rate(ceph_pool_rd[1m]) + rate(ceph_pool_wr[1m])) * on(pool_id, cluster) group_left(instance, name) ceph_pool_metadata )',
+  POOL_THROUGHPUT_UTILIZATION = 'topk(5, (irate(ceph_pool_rd_bytes[1m]) + irate(ceph_pool_wr_bytes[1m])) * on(pool_id, cluster) group_left(instance, name) ceph_pool_metadata )'
 }


### PR DESCRIPTION
1. Since, after adding a new cluster we add its IP to the list of prometheus federation targets. The metrics of the added cluster take some time to be received at dashboard's end hence added a loading message for few seconds to show the correct data.
2. On disconnecting a cluster, show a message to the user that the disconnected cluster's data will be removed in around 5 minutes.
4. On disconnecting the only cluster connected, the context switcher was not getting removed, fixed that as well
5. Allow the user to enter the prometheus api url in the multi-cluster form in case of token authentication. This should fix adding cluster with a token.
6. Hide the Verify Connection button when the connection is verified.
7. Reconnect cluster was not working because of a typo..Fixed that as well.
8. The Cluster Capacity Card was not showing correct data ..fixed in this PR.
9. The graph timer selection was not working properly..fixed in this PR
10. Non-existent user login attempts are being added to the Multi-Cluster list - fixed in this PR
11. Charts were not updating live and top 5 values were not sorted - fixed in this PR.
12. Do not allow the user to do multi cluster management of remote cluster from the local cluster
13. Dashboard becomes unresponsive if the token of hub cluster expires..fixed in this PR.
14. Fix charts size in the Overview Page

Fixes: https://tracker.ceph.com/issues/64880



[Screencast from 2024-03-06 13-25-06.webm](https://github.com/ceph/ceph/assets/66050535/42cceb41-329a-4611-8a0a-80f8977118d7)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
