### PR TITLE
reef: mgr/dashboard: fix volume creation with multiple hosts

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -56,7 +56,7 @@ class CephFS(RESTController):
             service_spec_str = service_spec_str[:-1]
         if 'hosts' in service_spec['placement']:
             for host in service_spec['placement']['hosts']:
-                service_spec_str += f'{host},'
+                service_spec_str += f'{host} '
             service_spec_str = service_spec_str[:-1]
 
         error_code, _, err = mgr.remote('volumes', '_cmd_fs_volume_create', None,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64595

---

backport of https://github.com/ceph/ceph/pull/55752
parent tracker: https://tracker.ceph.com/issues/64559

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh