### PR TITLE
quincy: test/rgw: increase timeouts in unittest_rgw_dmclock_scheduler

### DIFF
--- a/src/test/rgw/test_rgw_dmclock_scheduler.cc
+++ b/src/test/rgw/test_rgw_dmclock_scheduler.cc
@@ -105,7 +105,7 @@ TEST(Queue, RateLimit)
   EXPECT_EQ(1u, counters(client_id::admin)->get(queue_counters::l_qlen));
   EXPECT_EQ(1u, counters(client_id::auth)->get(queue_counters::l_qlen));
 
-  context.run_for(std::chrono::milliseconds(1));
+  context.run_for(std::chrono::milliseconds(50));
   EXPECT_TRUE(context.stopped());
 
   ASSERT_TRUE(ec1);
@@ -163,7 +163,7 @@ TEST(Queue, AsyncRequest)
   EXPECT_EQ(1u, counters(client_id::admin)->get(queue_counters::l_qlen));
   EXPECT_EQ(1u, counters(client_id::auth)->get(queue_counters::l_qlen));
 
-  context.run_for(std::chrono::milliseconds(1));
+  context.run_for(std::chrono::milliseconds(50));
   EXPECT_TRUE(context.stopped());
 
   ASSERT_TRUE(ec1);
@@ -217,7 +217,7 @@ TEST(Queue, Cancel)
   EXPECT_FALSE(ec1);
   EXPECT_FALSE(ec2);
 
-  context.run_for(std::chrono::milliseconds(1));
+  context.run_for(std::chrono::milliseconds(50));
   EXPECT_TRUE(context.stopped());
 
   ASSERT_TRUE(ec1);
@@ -265,7 +265,7 @@ TEST(Queue, CancelClient)
   EXPECT_FALSE(ec1);
   EXPECT_FALSE(ec2);
 
-  context.run_for(std::chrono::milliseconds(1));
+  context.run_for(std::chrono::milliseconds(50));
   EXPECT_TRUE(context.stopped());
 
   ASSERT_TRUE(ec1);
@@ -315,7 +315,7 @@ TEST(Queue, CancelOnDestructor)
   EXPECT_FALSE(ec1);
   EXPECT_FALSE(ec2);
 
-  context.run_for(std::chrono::milliseconds(1));
+  context.run_for(std::chrono::milliseconds(50));
   EXPECT_TRUE(context.stopped());
 
   ASSERT_TRUE(ec1);
@@ -369,20 +369,20 @@ TEST(Queue, CrossExecutorRequest)
   EXPECT_EQ(1u, counters(client_id::admin)->get(queue_counters::l_qlen));
   EXPECT_EQ(1u, counters(client_id::auth)->get(queue_counters::l_qlen));
 
-  callback_context.run_for(std::chrono::milliseconds(1));
+  callback_context.poll();
   // maintains work on callback executor while in queue
   EXPECT_FALSE(callback_context.stopped());
 
   EXPECT_FALSE(ec1);
   EXPECT_FALSE(ec2);
 
-  queue_context.run_for(std::chrono::milliseconds(1));
+  queue_context.run_for(std::chrono::milliseconds(50));
   EXPECT_TRUE(queue_context.stopped());
 
   EXPECT_FALSE(ec1); // no callbacks until callback executor runs
   EXPECT_FALSE(ec2);
 
-  callback_context.run_for(std::chrono::milliseconds(1));
+  callback_context.run_for(std::chrono::milliseconds(50));
   EXPECT_TRUE(callback_context.stopped());
 
   ASSERT_TRUE(ec1);
@@ -421,7 +421,7 @@ TEST(Queue, SpawnAsyncRequest)
     EXPECT_EQ(PhaseType::priority, p2);
   });
 
-  context.run_for(std::chrono::milliseconds(1));
+  context.run_for(std::chrono::milliseconds(50));
   EXPECT_TRUE(context.stopped());
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64599

---

backport of https://github.com/ceph/ceph/pull/55760
parent tracker: https://tracker.ceph.com/issues/64568

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh