### PR TITLE
rgw/notification: Fix the notification FilterRule to emit unique key name in json & Log successful delivery of notification event.

### DIFF
--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -23,20 +23,24 @@ void set_event_id(std::string& id, const std::string& hash, const utime_t& ts) {
 }
 
 void rgw_s3_key_filter::dump(Formatter *f) const {
+  if (!has_content()) {
+    return;
+  }
+  f->open_array_section("FilterRules");
   if (!prefix_rule.empty()) {
-    f->open_object_section("FilterRule");
+    f->open_object_section("");
     ::encode_json("Name", "prefix", f);
     ::encode_json("Value", prefix_rule, f);
     f->close_section();
   }
   if (!suffix_rule.empty()) {
-    f->open_object_section("FilterRule");
+    f->open_object_section("");
     ::encode_json("Name", "suffix", f);
     ::encode_json("Value", suffix_rule, f);
     f->close_section();
   }
   if (!regex_rule.empty()) {
-    f->open_object_section("FilterRule");
+    f->open_object_section("");
     ::encode_json("Name", "regex", f);
     ::encode_json("Value", regex_rule, f);
     f->close_section();
@@ -97,8 +101,12 @@ bool rgw_s3_key_filter::has_content() const {
 }
 
 void rgw_s3_key_value_filter::dump(Formatter *f) const {
+  if (!has_content()) {
+    return;
+  }
+  f->open_array_section("FilterRules");
   for (const auto& key_value : kv) {
-    f->open_object_section("FilterRule");
+    f->open_object_section("");
     ::encode_json("Name", key_value.first, f);
     ::encode_json("Value", key_value.second, f);
     f->close_section();


### PR DESCRIPTION
Fixes tracker https://tracker.ceph.com/issues/64653


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
