### PR TITLE
squid: debian/*.postinst: add adduser as a dependency and specify --home when adduser

### DIFF
--- a/debian/ceph-common.postinst
+++ b/debian/ceph-common.postinst
@@ -52,16 +52,20 @@ case "$1" in
                  --system \
                  --no-create-home \
                  --disabled-password \
+                 --home $SERVER_HOME \
                  --uid $SERVER_UID \
                  --gid $SERVER_GID \
                  $SERVER_USER 2>/dev/null || true
          echo "..done"
        fi
        # 3. adjust passwd entry
+       # NOTE: we should use "adduser --comment" if we don't need to
+       # support adduser <3.136. "adduser --gecos" is deprecated,
+       # and will be removed, so we don't use it. the first distro
+       # using --comment is debian/trixie or ubuntu/mantic.
        echo -n "Setting system user $SERVER_USER properties.."
-       usermod -c "$SERVER_NAME" \
-               -d $SERVER_HOME   \
-               -g $SERVER_GROUP  \
+       usermod --comment "$SERVER_NAME" \
+               --gid $SERVER_GROUP      \
                $SERVER_USER
        # Unlock $SERVER_USER in case it is locked from an uninstall
        if [ -f /etc/shadow ]; then

--- a/debian/cephadm.postinst
+++ b/debian/cephadm.postinst
@@ -28,6 +28,7 @@ case "$1" in
          adduser --quiet \
                  --system \
                  --disabled-password \
+                 --home /home/cephadm \
                  --gecos 'cephadm user for mgr/cephadm' \
                  --shell /bin/bash cephadm 2>/dev/null || true
          echo "..done"

--- a/debian/cephadm.postinst
+++ b/debian/cephadm.postinst
@@ -25,7 +25,11 @@ case "$1" in
        # 1. create user if not existing
        if ! getent passwd | grep -q "^cephadm:"; then
          echo -n "Adding system user cephadm.."
-         adduser --quiet --system --disabled-password --gecos 'cephadm user for mgr/cephadm' --shell /bin/bash cephadm 2>/dev/null || true
+         adduser --quiet \
+                 --system \
+                 --disabled-password \
+                 --gecos 'cephadm user for mgr/cephadm' \
+                 --shell /bin/bash cephadm 2>/dev/null || true
          echo "..done"
        fi
 

--- a/debian/cephadm.postinst
+++ b/debian/cephadm.postinst
@@ -43,19 +43,19 @@ case "$1" in
 
        # set up (initially empty) .ssh/authorized_keys file
        if ! test -d /home/cephadm/.ssh; then
-	   mkdir /home/cephadm/.ssh
-	   chown --reference /home/cephadm /home/cephadm/.ssh
-	   chmod 0700 /home/cephadm/.ssh
+           mkdir /home/cephadm/.ssh
+           chown --reference /home/cephadm /home/cephadm/.ssh
+           chmod 0700 /home/cephadm/.ssh
        fi
        if ! test -e /home/cephadm/.ssh/authorized_keys; then
-	   touch /home/cephadm/.ssh/authorized_keys
-	   chown --reference /home/cephadm /home/cephadm/.ssh/authorized_keys
-	   chmod 0600 /home/cephadm/.ssh/authorized_keys
+           touch /home/cephadm/.ssh/authorized_keys
+           chown --reference /home/cephadm /home/cephadm/.ssh/authorized_keys
+           chmod 0600 /home/cephadm/.ssh/authorized_keys
        fi
 
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
-	:
+       :
     ;;
 
     *)

--- a/debian/cephadm.postinst
+++ b/debian/cephadm.postinst
@@ -29,8 +29,8 @@ case "$1" in
                  --system \
                  --disabled-password \
                  --home /home/cephadm \
-                 --gecos 'cephadm user for mgr/cephadm' \
                  --shell /bin/bash cephadm 2>/dev/null || true
+         usermod --comment "cephadm user for mgr/cephadm" cephadm
          echo "..done"
        fi
 

--- a/debian/control
+++ b/debian/control
@@ -184,7 +184,8 @@ Description: debugging symbols for ceph-base
 Package: cephadm
 Architecture: linux-any
 Recommends: podman (>= 2.0.2) | docker.io | docker-ce
-Depends: lvm2,
+Depends: adduser (>= 3.11),
+	 lvm2,
 	 python3,
 	 ${python3:Depends},
 Description: cephadm utility to bootstrap ceph daemons with systemd and containers
@@ -610,7 +611,8 @@ Description: debugging symbols for rbd-nbd
 
 Package: ceph-common
 Architecture: linux-any
-Depends: librbd1 (= ${binary:Version}),
+Depends: adduser (>= 3.11),
+         librbd1 (= ${binary:Version}),
          python3-cephfs (= ${binary:Version}),
          python3-ceph-argparse (= ${binary:Version}),
          python3-ceph-common (= ${binary:Version}),


### PR DESCRIPTION
Squid backport for https://github.com/ceph/ceph/pull/55218

The original PR was merged around when we were setting up the squid branch and starting to do squid backports so I think this backport was missed, but we probably want it given a backport to reef has already been opened.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
