### PR TITLE
src/test/common/test_hobject: remove constexpr

### DIFF
--- a/src/test/common/test_hobject.cc
+++ b/src/test/common/test_hobject.cc
@@ -98,7 +98,7 @@ struct test_hobject_fmt_t : public hobject_t {
     return snap == 0 && hash == 0 && !max && pool == INT64_MIN;
   }
 
-  constexpr auto operator<=>(const test_hobject_fmt_t& rhs) const noexcept
+  auto operator<=>(const test_hobject_fmt_t& rhs) const noexcept
   {
     auto cmp = is_max() <=> rhs.is_max();
     if (cmp != 0)
@@ -122,7 +122,7 @@ struct test_hobject_fmt_t : public hobject_t {
       return cmp;
     return snap <=> rhs.snap;
   }
-  constexpr bool operator==(const hobject_t& rhs) const noexcept
+  bool operator==(const hobject_t& rhs) const noexcept
   {
     return operator<=>(rhs) == 0;
   }
@@ -201,7 +201,7 @@ namespace fmt {
 template <>
 struct formatter<test_hobject_fmt_t> {
 
-  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
   template <typename FormatContext>
   auto format(const test_hobject_fmt_t& ho, FormatContext& ctx)


### PR DESCRIPTION
Remove `constexpr` from `src/test/common/test_hobject.cc`. It creates 2 issues when running `ninja tests` command.
Issues:
1. error: call to non-'constexpr' function 'bool test_hobject_fmt_t::is_max() const'
```
 /ceph-src/src/test/common/test_hobject.cc: In member function 'constexpr auto test_hobject_fmt_t::operator<=>(const test_hobject_fmt_t&) const':
/ceph-src/src/test/common/test_hobject.cc:103:22: error: call to non-'constexpr' function 'bool test_hobject_fmt_t::is_max() const'
103 |     auto cmp = is_max() <=> rhs.is_max();
|                ~~~~~~^~
/ceph-src/src/test/common/test_hobject.cc:94:8: note: 'bool test_hobject_fmt_t::is_max() const' declared here
94 |   bool is_max() const { return max; }
```
2.  error: temporary of non-literal type 'const test_hobject_fmt_t' in a constant expression
```
/ceph-src/src/test/common/test_hobject.cc:74:8: note: 'test_hobject_fmt_t' is not literal because:
74 | struct test_hobject_fmt_t : public hobject_t {
 |        ^~~~~~~~~~~~~~~~~~
/ceph-src/src/test/common/test_hobject.cc:74:8: note:   'test_hobject_fmt_t' does not have 'constexpr' destructor
/ceph-src/src/test/common/test_hobject.cc: In member function 'virtual void HObject_fmt_random_Test::TestBody()':
```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references [commit](https://github.com/ceph/ceph/commit/94f1cadda240292086eae7d1e484503005a6ceb1) where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
