### PR TITLE
os/seastore: fix FTBFS due to passing const d_node to _omap_set_kvs()

### DIFF
--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1591,10 +1591,10 @@ SeaStore::Shard::_clone_omaps(
   OnodeRef &d_onode,
   const omap_type_t otype)
 {
-  return trans_intr::repeat([&ctx, onode, d_onode, this, otype] {
+  return trans_intr::repeat([&ctx, onode, d_onode, this, otype]() mutable {
     return seastar::do_with(
       std::optional<std::string>(std::nullopt),
-      [&ctx, onode, d_onode, this, otype](auto &start) {
+      [&ctx, onode, d_onode, this, otype](auto &start) mutable {
       auto& layout = onode->get_layout();
       return omap_list(
 	*onode,


### PR DESCRIPTION
```
[ 96%] Building CXX object src/crimson/os/seastore/CMakeFiles/crimson-seastore.dir/seastore.cc.o
/home/jenkins-build/build/workspace/ceph-dev-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/19.0.0-1777-ga04996aa/rpm/el8/BUILD/ceph-19.0.0-1777-ga04996aa/src/crimson/os/seastore/seastore.cc: In lambda function:
/home/jenkins-build/build/workspace/ceph-dev-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/19.0.0-1777-ga04996aa/rpm/el8/BUILD/ceph-19.0.0-1777-ga04996aa/src/crimson/os/seastore/seastore.cc:1618:11: error: cannot convert ‘const OnodeRef’ {aka ‘const boost::intrusive_ptr<crimson::os::seastore::Onode>’} to ‘crimson::os::seastore::OnodeRef&’ {aka ‘boost::intrusive_ptr<crimson::os::seastore::Onode>&’}
 1618 |           d_onode,
      |           ^~~~~~~
      |           |
      |           const OnodeRef {aka const boost::intrusive_ptr<crimson::os::seastore::Onode>}
In file included from /home/jenkins-build/build/workspace/ceph-dev-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/19.0.0-1777-ga04996aa/rpm/el8/BUILD/ceph-19.0.0-1777-ga04996aa/src/crimson/os/seastore/seastore.cc:4:
/home/jenkins-build/build/workspace/ceph-dev-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/19.0.0-1777-ga04996aa/rpm/el8/BUILD/ceph-19.0.0-1777-ga04996aa/src/crimson/os/seastore/seastore.h:429:17: note:   initializing argument 1 of ‘crimson::os::seastore::SeaStore::Shard::omap_set_kvs_ret crimson::os::seastore::SeaStore::Shard::_omap_set_kvs(crimson::os::seastore::OnodeRef&, const crimson::os::seastore::omap_root_le_t&, crimson::os::seastore::Transaction&, std::map<std::__cxx11::basic_string<char>, ceph::buffer::v15_2_0::list>&&)’
  429 |       OnodeRef &onode,
      |       ~~~~~~~~~~^~~~~
make[2]: *** [src/crimson/os/seastore/CMakeFiles/crimson-seastore.dir/build.make:622: src/crimson/os/seastore/CMakeFiles/crimson-seastore.dir/seastore.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
