### PR TITLE
squid: unittest-seastar-socket: tolerate connection_reset in test_unexpected_down

### DIFF
--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -449,7 +449,7 @@ future<> test_unexpected_down(bool is_fixed_cpu) {
     [](auto cs) {
       return Connection::dispatch_rw_bounded(cs, 128, true
         ).handle_exception_type([](const std::system_error& e) {
-        logger().debug("test_unexpected_down(): client get error {}", e);
+        logger().error("test_unexpected_down(): client get error {}", e);
         ceph_assert(e.code() == error::read_eof);
       });
     },

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -450,7 +450,8 @@ future<> test_unexpected_down(bool is_fixed_cpu) {
       return Connection::dispatch_rw_bounded(cs, 128, true
         ).handle_exception_type([](const std::system_error& e) {
         logger().error("test_unexpected_down(): client get error {}", e);
-        ceph_assert(e.code() == error::read_eof);
+        ceph_assert(e.code() == error::read_eof ||
+		    e.code() == std::errc::connection_reset);
       });
     },
     [](auto ss) { return Connection::dispatch_rw_unbounded(ss); }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64663

---

backport of https://github.com/ceph/ceph/pull/55608
parent tracker: https://tracker.ceph.com/issues/64457

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh