### PR TITLE
crimson: update seastar submodule to fix prometheus build error

### DIFF
--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -69,7 +69,6 @@ namespace seastar::internal {
   {};
 }
 
-SEASTAR_CONCEPT(
 namespace crimson::interruptible {
   template<typename InterruptCond, typename FutureType>
   class interruptible_future_detail;
@@ -79,7 +78,6 @@ namespace seastar::impl {
   struct is_tuple_of_futures<std::tuple<crimson::interruptible::interruptible_future_detail<InterruptCond, FutureType>, Rest...>>
     : is_tuple_of_futures<std::tuple<Rest...>> {};
 }
-)
 
 namespace crimson::interruptible {
 


### PR DESCRIPTION
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
