### PR TITLE
cmake/modules/BuildRocksDB.cmake: inherit CMAKE_C_COMPILER from parent

### DIFF
--- a/cmake/modules/BuildRocksDB.cmake
+++ b/cmake/modules/BuildRocksDB.cmake
@@ -24,6 +24,7 @@ function(build_rocksdb)
   endif()
 
   list(APPEND rocksdb_CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
+  list(APPEND rocksdb_CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER})
 
   list(APPEND rocksdb_CMAKE_ARGS -DWITH_SNAPPY=${SNAPPY_FOUND})
   if(SNAPPY_FOUND)


### PR DESCRIPTION
if we set the CFLAGS globally, and the CFLAGS contains options only acceptable by a certain C compiler, RocksDB could fail to configure. for instance, if we set CXXFLAGS so it contains `--config /usr/lib/rpm/redhat/redhat-hardened-clang.cfg` and use clang++ as the CMAKE_CXX_COMPILER, while keep CMAKE_C_COMPILER unchanged. RocksDB would fail to configure like:

```-- Check for working C compiler: /usr/bin/cc - broken
CMake Error at /usr/share/cmake/Modules/CMakeTestCCompiler.cmake:67 (message):
  The C compiler

    "/usr/bin/cc"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: /home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos9/DIST/centos9/MACHINE_SIZE/gigantic/release/19.0.0-1717-g0f726187/rpm/el9/BUILD/ceph-19.0.0-1717-g0f726187/redhat-linux-build/src/rocksdb/CMakeFiles/CMakeScratch/TryCompile-RU5UFV

    Run Build Command(s):/usr/bin/cmake -E env VERBOSE=1 /usr/bin/gmake -f Makefile cmTC_65e36/fast && gmake[3]: Entering directory '/home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos9/DIST/centos9/MACHINE_SIZE/gigantic/release/19.0.0-1717-g0f726187/rpm/el9/BUILD/ceph-19.0.0-1717-g0f726187/redhat-linux-build/src/rocksdb/CMakeFiles/CMakeScratch/TryCompile-RU5UFV'
    /usr/bin/gmake  -f CMakeFiles/cmTC_65e36.dir/build.make CMakeFiles/cmTC_65e36.dir/build
    gmake[4]: Entering directory '/home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos9/DIST/centos9/MACHINE_SIZE/gigantic/release/19.0.0-1717-g0f726187/rpm/el9/BUILD/ceph-19.0.0-1717-g0f726187/redhat-linux-build/src/rocksdb/CMakeFiles/CMakeScratch/TryCompile-RU5UFV'
    Building C object CMakeFiles/cmTC_65e36.dir/testCCompiler.c.o
    /usr/bin/cc   -O2 -flto=thin -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security  -Wp,-D_GLIBCXX_ASSERTIONS --config /usr/lib/rpm/redhat/redhat-hardened-clang.cfg -fstack-protector-strong -m64 -march=x86-64-v2 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection  -fPIE -o CMakeFiles/cmTC_65e36.dir/testCCompiler.c.o -c /home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos9/DIST/centos9/MACHINE_SIZE/gigantic/release/19.0.0-1717-g0f726187/rpm/el9/BUILD/ceph-19.0.0-1717-g0f726187/redhat-linux-build/src/rocksdb/CMakeFiles/CMakeScratch/TryCompile-RU5UFV/testCCompiler.c
    cc: error: unrecognized command-line option ‘--config’; did you mean ‘-mpconfig’?
    gmake[4]: *** [CMakeFiles/cmTC_65e36.dir/build.make:78: CMakeFiles/cmTC_65e36.dir/testCCompiler.c.o] Error 1
```

where RocksDB tries to check C compiler -- /usr/bin/cc along with the said CFLAGS, and fails to compile the test C program, because GCC does not support this option.

so, in this change, let's pass the CMAKE_C_COMPILER as well.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
