### PR TITLE
test/rgw: Add standalone Redis clients and unit tests

### DIFF
--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -58,6 +58,11 @@ target_link_libraries(ceph_test_rgw_d4n_filter PRIVATE
 install(TARGETS ceph_test_rgw_d4n_filter DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
+#unittest_redis_client
+add_executable(unittest_redis_client test_redis_client.cc redis_pull_client.cc redis_push_client.cc)
+add_ceph_unittest(unittest_redis_client)
+target_link_libraries(unittest_redis_client ${rgw_libs} ${UNITTEST_LIBS} ${EXTRALIBS})
+
 #unittest_rgw_bencode
 add_executable(unittest_rgw_bencode test_rgw_bencode.cc)
 add_ceph_unittest(unittest_rgw_bencode)

--- a/src/test/rgw/redis_pull_client.cc
+++ b/src/test/rgw/redis_pull_client.cc
@@ -1,0 +1,25 @@
+#include "redis_pull_client.h"
+
+PullClient::PullClient(const std::string& host, int port) {
+    client.connect(host, port, [](const std::string& host, std::size_t port, cpp_redis::client::connect_state status) {
+        if (status == cpp_redis::client::connect_state::dropped) {
+            std::cerr << "client disconnected from " << host << ":" << port << std::endl;
+        }
+    });
+}
+
+std::string PullClient::pull(const std::string& queueName) {
+    std::string data;
+    client.blpop({queueName}, 0, [&data](const cpp_redis::reply& reply) {
+        if (!reply.is_error() && reply.is_array()) {
+            const auto& fetchedData = reply.as_array();
+            data = fetchedData[1].as_string(); // Assuming data is at index 1
+        }
+    });
+    client.sync_commit();
+    return data;
+}
+
+void PullClient::disconnect() {
+    client.disconnect();
+}

--- a/src/test/rgw/redis_pull_client.h
+++ b/src/test/rgw/redis_pull_client.h
@@ -1,0 +1,16 @@
+#ifndef PULLCLIENT_H
+#define PULLCLIENT_H
+
+#include <cpp_redis/cpp_redis>
+#include <string>
+
+class PullClient {
+public:
+    PullClient(const std::string& host, int port);
+    std::string pull(const std::string& queueName);
+    void disconnect();
+private:
+    cpp_redis::client client;
+};
+
+#endif // PULLCLIENT_H

--- a/src/test/rgw/redis_push_client.cc
+++ b/src/test/rgw/redis_push_client.cc
@@ -1,0 +1,27 @@
+#include "redis_push_client.h"
+#include <stdexcept>
+
+PushClient::PushClient(const std::string& host, int port) {
+    client.connect(host, port, [](const std::string& host, std::size_t port, cpp_redis::client::connect_state status) {
+        if (status == cpp_redis::client::connect_state::dropped) {
+            std::cerr << "client disconnected from " << host << ":" << port << std::endl;
+        }
+    });
+}
+
+void PushClient::push(const std::string& queueName, const std::string& data) {
+    if (queueName.empty()) {
+        throw std::invalid_argument("Invalid queue name provided");
+    }
+
+    client.rpush(queueName, {data}, [](const cpp_redis::reply& reply) {
+        if (reply.is_error()) { 
+            std::cerr << "Error pushing data" << std::endl; 
+        }
+    });
+    client.sync_commit();
+}
+
+void PushClient::disconnect() {
+    client.disconnect();
+}

--- a/src/test/rgw/redis_push_client.h
+++ b/src/test/rgw/redis_push_client.h
@@ -1,0 +1,16 @@
+#ifndef PUSHCLIENT_H
+#define PUSHCLIENT_H
+
+#include <cpp_redis/cpp_redis>
+#include <string>
+
+class PushClient {
+public:
+    PushClient(const std::string& host, int port);
+    void push(const std::string& queueName, const std::string& data);
+    void disconnect();
+private:
+    cpp_redis::client client;
+};
+
+#endif // PUSHCLIENT_H

--- a/src/test/rgw/test_redis_client.cc
+++ b/src/test/rgw/test_redis_client.cc
@@ -1,0 +1,79 @@
+#include <gtest/gtest.h>
+#include "redis_push_client.h"
+#include "redis_pull_client.h"
+
+class RedisClientTest : public ::testing::Test {
+protected:
+    PushClient* pushClient;
+    PullClient* pullClient;
+    std::string host = "127.0.0.1";
+    int port = 6379;
+    std::string queueName = "test_queue";
+
+    void SetUp() override {
+        pushClient = new PushClient(host, port);
+        pullClient = new PullClient(host, port);
+    }
+
+    void TearDown() override {
+        if (pushClient) {
+            pushClient->disconnect(); // Ensure the push client disconnects
+            delete pushClient;
+            pushClient = nullptr;
+        }
+        if (pullClient) {
+            pullClient->disconnect(); // Ensure the pull client disconnects
+            delete pullClient;
+            pullClient = nullptr;
+        }
+    }
+};
+
+TEST_F(RedisClientTest, PushAndPull) {
+    std::string testData = "hello world";
+    pushClient->push(queueName, testData);
+    std::string result = pullClient->pull(queueName);
+    EXPECT_EQ(testData, result);
+}
+
+// Test for pushing and pulling empty data
+TEST_F(RedisClientTest, PushAndPullEmptyData) {
+    std::string emptyData = "";
+    pushClient->push(queueName, emptyData);
+    std::string result = pullClient->pull(queueName);
+    EXPECT_EQ(emptyData, result);
+}
+
+// Test for pushing and pulling large data
+TEST_F(RedisClientTest, PushAndPullLargeData) {
+    std::string largeData(1024 * 1024, 'a'); // 1MB of 'a'
+    pushClient->push(queueName, largeData);
+    std::string result = pullClient->pull(queueName);
+    EXPECT_EQ(largeData, result);
+}
+
+// Test pushing and pulling multiple items
+TEST_F(RedisClientTest, PushAndPullMultipleItems) {
+    std::vector<std::string> testData = {"first", "second", "third"};
+    for (const auto& data : testData) {
+        pushClient->push(queueName, data);
+    }
+
+    for (const auto& expectedData : testData) {
+        std::string result = pullClient->pull(queueName);
+        EXPECT_EQ(expectedData, result);
+    }
+}
+
+// Test for handling connection failure
+TEST_F(RedisClientTest, ConnectionFailure) {
+    // Assuming there's a way to simulate a connection failure or to disconnect the client
+    pushClient->disconnect();
+    EXPECT_THROW(pushClient->push(queueName, "data"), std::exception);
+}
+
+// Test for invalid queue name
+TEST_F(RedisClientTest, InvalidQueueName) {
+    std::string invalidQueueName = "";
+    EXPECT_THROW(pushClient->push(invalidQueueName, "data"), std::invalid_argument);
+}


### PR DESCRIPTION
[gsoc24-from-rados-to-redis]
Added standalone clients to push and pull data from Redis queues.
Integrated these clients into unit tests using Google Test framework.
Updated CMakeLists.txt to include test building.
Signed-off-by: Ming Zuo <zm1575098153@gmail.com>