### PR TITLE
common: fix string creation from '0' in LogEntry

### DIFF
--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -183,7 +183,6 @@ string clog_type_to_string(clog_type t)
       return "crit";
     default:
       ceph_abort();
-      return 0;
   }
 }
 


### PR DESCRIPTION
C++23 disallows conversion from 'int' to 'string'. 

That includes returning '0' from a function that returns a string.
