### PR TITLE
squid: crimson: update seastar submodule to fix prometheus build error

### DIFF
--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -69,7 +69,6 @@ namespace seastar::internal {
   {};
 }
 
-SEASTAR_CONCEPT(
 namespace crimson::interruptible {
   template<typename InterruptCond, typename FutureType>
   class interruptible_future_detail;
@@ -79,7 +78,6 @@ namespace seastar::impl {
   struct is_tuple_of_futures<std::tuple<crimson::interruptible::interruptible_future_detail<InterruptCond, FutureType>, Rest...>>
     : is_tuple_of_futures<std::tuple<Rest...>> {};
 }
-)
 
 namespace crimson::interruptible {
 


### PR DESCRIPTION
Backport #55878 to squid to address a build failure:
```
[1509/2740] Building CXX object src/seastar/CMakeFiles/seastar.dir/src/core/prometheus.cc.o
FAILED: src/seastar/CMakeFiles/seastar.dir/src/core/prometheus.cc.o 
/usr/bin/ccache /usr/bin/clang++-14 -DBOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION -DBOOST_ASIO_HAS_IO_URING -DBOOST_ASIO_NO_TS_EXECUTORS -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DHAVE_CONFIG_H -DSEASTAR_API_LEVEL=6 -DSEASTAR_BROKEN_SOURCE_LOCATION -DSEASTAR_DEBUG -DSEASTAR_DEBUG_PROMISE -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT -DSEASTAR_HAS_MEMBARRIER -DSEASTAR_HAVE_NUMA -DSEASTAR_HAVE_SYSTEMTAP_SDT -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_PTHREAD_ATTR_SETAFFINITY_NP -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_SSTRING -DSEASTAR_STRERROR_R_CHAR_P -DSEASTAR_THREAD_STACK_GUARDS -DSEASTAR_TYPE_ERASE_MORE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE -D__CEPH__ -D__STDC_FORMAT_MACROS -D__linux__ -I/home/jenkins-build/build/workspace/ceph-pull-requests/build/src/include -I/home/jenkins-build/build/workspace/ceph-pull-requests/src -I/home/jenkins-build/build/workspace/ceph-pull-requests/src/seastar/include -I/home/jenkins-build/build/workspace/ceph-pull-requests/build/src/seastar/gen/include -I/home/jenkins-build/build/workspace/ceph-pull-requests/build/src/seastar/gen/src -I/home/jenkins-build/build/workspace/ceph-pull-requests/src/seastar/src -isystem /opt/ceph/include -isystem /home/jenkins-build/build/workspace/ceph-pull-requests/build/include -isystem /home/jenkins-build/build/workspace/ceph-pull-requests/src/xxHash -isystem /home/jenkins-build/build/workspace/ceph-pull-requests/src/fmt/include -g -Werror -fPIC -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -DBOOST_PHOENIX_STL_TUPLE_H_ -Wall -fno-strict-aliasing -fsigned-char -Wtype-limits -Wignored-qualifiers -Wpointer-arith -Werror=format-security -Winit-self -Wno-unknown-pragmas -Wnon-virtual-dtor -Wno-ignored-qualifiers -ftemplate-depth-1024 -Wpessimizing-move -Wredundant-move -Wno-inconsistent-missing-override -Wno-mismatched-tags -Wno-unused-private-field -Wno-address-of-packed-member -Wno-unused-function -Wno-unused-local-typedef -Wno-varargs -Wno-gnu-designator -Wno-missing-braces -Wno-parentheses -Wno-deprecated-register -DCEPH_DEBUG_MUTEX -D_GLIBCXX_ASSERTIONS -fdiagnostics-color=auto -U_FORTIFY_SOURCE -Wno-error=unused-result "-Wno-error=#warnings" -fstack-clash-protection -UNDEBUG -Werror -Wimplicit-fallthrough -Wdeprecated -Wno-error=deprecated -fvisibility=hidden -gz -DSEASTAR_NO_EXCEPTION_HACK -Wno-error -Wno-sign-compare -Wno-attributes -Wno-pessimizing-move -Wno-non-virtual-dtor -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -std=gnu++20 -MD -MT src/seastar/CMakeFiles/seastar.dir/src/core/prometheus.cc.o -MF src/seastar/CMakeFiles/seastar.dir/src/core/prometheus.cc.o.d -o src/seastar/CMakeFiles/seastar.dir/src/core/prometheus.cc.o -c /home/jenkins-build/build/workspace/ceph-pull-requests/src/seastar/src/core/prometheus.cc
In file included from /home/jenkins-build/build/workspace/ceph-pull-requests/src/seastar/src/core/prometheus.cc:25:
/home/jenkins-build/build/workspace/ceph-pull-requests/build/src/seastar/gen/src/proto/metrics2.pb.h:2838:16: error: call to member function 'Set' is ambiguous
  _impl_.name_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
  ~~~~~~~~~~~~~^~~
/home/jenkins-build/build/workspace/ceph-pull-requests/src/seastar/src/core/prometheus.cc:81:16: note: in instantiation of function template specialization 'io::prometheus::client::LabelPair::set_name<const seastar::basic_sstring<char, unsigned int, 15, true>>' requested here
        label->set_name(ctx.label->key());
               ^
/usr/include/google/protobuf/arenastring.h:295:8: note: candidate function
  void Set(absl::string_view value, Arena* arena);
       ^
/usr/include/google/protobuf/arenastring.h:296:8: note: candidate function
  void Set(std::string&& value, Arena* arena);
       ^
```