### PR TITLE
debian: recursively adjust permissions of /var/lib/ceph/crash

### DIFF
--- a/debian/ceph-base.postinst
+++ b/debian/ceph-base.postinst
@@ -35,11 +35,13 @@ case "$1" in
 
         # adjust file and directory permissions
 	for DIR in /var/lib/ceph/* ; do
-	    if ! dpkg-statoverride --list $DIR >/dev/null
+	    if ! dpkg-statoverride --list "${DIR}" >/dev/null
 	    then
-		chown $SERVER_USER:$SERVER_GROUP $DIR
+		chown "${SERVER_USER}:${SERVER_GROUP}" "${DIR}"
 	    fi
 	done
+
+	chown "${SERVER_USER}:${SERVER_GROUP}" -R /var/lib/ceph/crash/*;
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
 	:


### PR DESCRIPTION
A rather recent PR made `ceph-crash` run as `ceph` user instead of root[^0]. However, because `/var/lib/ceph/crash/posted` belongs to root, `ceph-crash` cannot actually post any crash logs now.

This commit fixes this by recursively updating the permissions of `/var/lib/ceph/crash`, which ensures that all files and directories used by `ceph-crash.service` are actually owned by the user configured for Ceph.

The previously existing loop has also been replaced by an invocation of `find | xargs`.

Fixes: https://tracker.ceph.com/issues/64548

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

## Further Notes

I'm not 100% sure if this is the best way to fix this issue, so please let me know if you prefer a different solution. This patch is originally from our mailing list[^1] - we've decided that it's what works best for us, due to `find | xargs` being a bit more fine-grained than, let's say, something like `for FILE in /var/lib/ceph/**/*; do ...; done`.

Also, should this get merged (in whatever form), I'll also gladly provide backports for Reef and Quincy.


[^0]: https://github.com/ceph/ceph/pull/48713
[^1]: https://lists.proxmox.com/pipermail/pve-devel/2024-February/061803.html