### PR TITLE
common/LogEntry.cc: fix clog_type_to_string default return type 

### DIFF
--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -183,7 +183,6 @@ string clog_type_to_string(clog_type t)
       return "crit";
     default:
       ceph_abort();
-      return 0;
   }
 }
 


### PR DESCRIPTION
Following #55886
```
FAILED: src/crimson/CMakeFiles/crimson-common.dir/__/common/LogEntry.cc.o
/opt/rh/gcc-toolset-13/root/usr/bin/g++ -DBOOST_ASIO_DISABLE_CONCEPTS -DBOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION -DBOOST_ASIO_HAS_IO_URING -DBOOST_ASIO_NO_TS_EXECUTORS -DBOOST_NO_CXX98_FUNCTION_BASE -DCEPH_INSTALL_DATADIR=\"/usr/local/share/ceph\" -DCEPH_INSTALL_FULL_PKGLIBDIR=\"/usr/local/lib64/ceph\" -DCMAKE_INSTALL_LIBDIR=\"lib64\" -DHAVE_CONFIG_H -DSEASTAR_API_LEVEL=6 -DSEASTAR_DEBUG -DSEASTAR_DEBUG_PROMISE -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_SCHEDULING_GROUPS_COUNT=16 -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_SSTRING -DSEASTAR_TYPE_ERASE_MORE -DWITH_SEASTAR=1 -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE -D__CEPH__ -D__STDC_FORMAT_MACROS -D__linux__ -I/home/matan/ceph/build/src/include -I/home/matan/ceph/src -I/home/matan/ceph/src/seastar/include -I/home/matan/ceph/build/src/seastar/gen/include -I/home/matan/ceph/build/src/seastar/gen/src -isystem /home/matan/ceph/build/boost/include -isystem /home/matan/ceph/build/include -isystem /home/matan/ceph/src/jaegertracing/opentelemetry-cpp/api/include -isystem /home/matan/ceph/src/jaegertracing/opentelemetry-cpp/exporters/jaeger/include -isystem /home/matan/ceph/src/jaegertracing/opentelemetry-cpp/ext/include -isystem /home/matan/ceph/src/jaegertracing/opentelemetry-cpp/sdk/include -isystem /home/matan/ceph/src/xxHash -isystem /home/matan/ceph/src/fmt/include -Og -g -std=c++23 -fPIC -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -DBOOST_PHOENIX_STL_TUPLE_H_ -Wall -fno-strict-aliasing -fsigned-char -Wtype-limits -Wignored-qualifiers -Wpointer-arith -Werror=format-security -Winit-self -Wno-unknown-pragmas -Wnon-virtual-dtor -Wno-ignored-qualifiers -ftemplate-depth-1024 -Wpessimizing-move -Wredundant-move -Wstrict-null-sentinel -Woverloaded-virtual -DCEPH_DEBUG_MUTEX -fstack-protector-strong -D_GLIBCXX_ASSERTIONS -fdiagnostics-color=auto -Wno-non-virtual-dtor -U_FORTIFY_SOURCE -Wno-maybe-uninitialized -Wno-error=unused-result -fstack-clash-protection -fsanitize=address -fsanitize=undefined -fno-sanitize=vptr -MD -MT src/crimson/CMakeFiles/crimson-common.dir/__/common/LogEntry.cc.o -MF src/crimson/CMakeFiles/crimson-common.dir/__/common/LogEntry.cc.o.d -o src/crimson/CMakeFiles/crimson-common.dir/__/common/LogEntry.cc.o -c /home/matan/ceph/src/common/LogEntry.cc
/home/matan/ceph/src/common/LogEntry.cc: In function ‘std::string clog_type_to_string(clog_type)’:
/home/matan/ceph/src/common/LogEntry.cc:186:14: error: use of deleted function ‘std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(std::nullptr_t) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::nullptr_t = std::nullptr_t]’
  186 |       return 0;
      |              ^
In file included from /opt/rh/gcc-toolset-13/root/usr/include/c++/13/string:54,
                 from /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/locale_classes.h:40,
                 from /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/ios_base.h:41,
                 from /opt/rh/gcc-toolset-13/root/usr/include/c++/13/streambuf:43,
                 from /opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/streambuf_iterator.h:35,
                 from /opt/rh/gcc-toolset-13/root/usr/include/c++/13/iterator:66,
                 from /home/matan/ceph/build/boost/include/boost/algorithm/string/predicate.hpp:14,
                 from /home/matan/ceph/src/common/LogEntry.cc:5:
/opt/rh/gcc-toolset-13/root/usr/include/c++/13/bits/basic_string.h:743:7: note: declared here
  743 |       basic_string(nullptr_t) = delete;
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
