### PR TITLE
qa/cephfs: update get_ceph_cmd_stdout()

### DIFF
--- a/qa/tasks/ceph_test_case.py
+++ b/qa/tasks/ceph_test_case.py
@@ -52,7 +52,7 @@ class RunCephCmd:
                 args = args[0]
             kwargs['args'] = args
         kwargs['stdout'] = kwargs.pop('stdout', StringIO())
-        return self.run_ceph_cmd(**kwargs).stdout.getvalue()
+        return self.run_ceph_cmd(**kwargs).stdout.getvalue().strip()
 
     def assert_retval(self, proc_retval, exp_retval):
         msg = (f'expected return value: {exp_retval}\n'

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -159,6 +159,7 @@ class MonCapTester:
         fs is any fs object so that ceph commands can be exceuted.
         """
         keyring = fs.get_ceph_cmd_stdout(args=f'auth get client.{client_id}')
+        keyring += '\n'
         moncap = get_mon_cap_from_keyring(keyring)
         keyring_path = fs.admin_remote.mktemp(data=keyring)
 

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -437,4 +437,6 @@ class CephFSTestCase(CephTestCase):
             cmd += ['mds', mdscap]
 
         self.run_ceph_cmd(*cmd)
-        return self.get_ceph_cmd_stdout(f'auth get {self.client_name}')
+        keyring = self.get_ceph_cmd_stdout(f'auth get {self.client_name}')
+        keyring += '\n'
+        return keyring

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -1792,8 +1792,10 @@ class FilesystemBase(MDSClusterBase):
             caps = tuple(x)
 
         client_name = 'client.' + client_id
-        return self.get_ceph_cmd_stdout('fs', 'authorize', self.name,
-                                        client_name, *caps)
+        keyring = self.get_ceph_cmd_stdout('fs', 'authorize', self.name,
+                                           client_name, *caps)
+        keyring += '\n'
+        return keyring
 
     def grow(self, new_max_mds, status=None):
         oldmax = self.get_var('max_mds', status=status)

--- a/qa/tasks/cephfs/test_sessionmap.py
+++ b/qa/tasks/cephfs/test_sessionmap.py
@@ -163,7 +163,7 @@ class TestSessionMap(CephFSTestCase):
             "mds", mds_caps,
             "osd", osd_caps,
             "mon", mon_caps
-        )
+        ) + '\n'
         mount.client_id = id_name
         mount.client_remote.write_file(mount.get_keyring_path(), out, sudo=True)
         self.set_conf("client.{name}".format(name=id_name), "keyring", mount.get_keyring_path())


### PR DESCRIPTION
Before returning stdout (which is of type "str"), run str method strip()
on it so that whitspace like space character and newline characters are
deleted. Such whitespace characters are an hinderance when this str is
to be used eventually.







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>