### PR TITLE
quincy: cephadm: allow ports to be opened in firewall during adoption, reconfig, redeploy

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3219,23 +3219,26 @@ def extract_uid_gid(ctx, img='', file_path='/var/lib/ceph'):
     raise RuntimeError('uid/gid not found')
 
 
-def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
-                  config=None, keyring=None,
-                  osd_fsid=None,
-                  reconfig=False,
-                  ports=None):
-    # type: (CephadmContext, str, str, Union[int, str], Optional[CephContainer], int, int, Optional[str], Optional[str], Optional[str], Optional[bool], Optional[List[int]]) -> None
+def deploy_daemon(ctx: CephadmContext, fsid: str, daemon_type: str,
+                  daemon_id: Union[int, str], c: Optional['CephContainer'],
+                  uid: int, gid: int, config: Optional[str] = None,
+                  keyring: Optional[str] = None, osd_fsid: Optional[str] = None,
+                  reconfig: Optional[bool] = False, redeploy: Optional[bool] = False,
+                  ports: Optional[List[int]] = None) -> None:
 
     ports = ports or []
-    if any([port_in_use(ctx, port) for port in ports]):
-        if daemon_type == 'mgr':
-            # non-fatal for mgr when we are in mgr_standby_modules=false, but we can't
-            # tell whether that is the case here.
-            logger.warning(
-                f"ceph-mgr TCP port(s) {','.join(map(str, ports))} already in use"
-            )
-        else:
-            raise Error("TCP Port(s) '{}' required for {} already in use".format(','.join(map(str, ports)), daemon_type))
+    # only check port in use if not reconfig or redeploy since service
+    # we are redeploying/reconfiguring will already be using the port
+    if not reconfig and not redeploy:
+        if any([port_in_use(ctx, port) for port in ports]):
+            if daemon_type == 'mgr':
+                # non-fatal for mgr when we are in mgr_standby_modules=false, but we can't
+                # tell whether that is the case here.
+                logger.warning(
+                    f"ceph-mgr TCP port(s) {','.join(map(str, ports))} already in use"
+                )
+            else:
+                raise Error("TCP Port(s) '{}' required for {} already in use".format(','.join(map(str, ports)), daemon_type))
 
     data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
     if reconfig and not os.path.exists(data_dir):
@@ -5943,13 +5946,14 @@ def command_deploy(ctx):
     if daemon_type not in get_supported_daemons():
         raise Error('daemon type %s not recognized' % daemon_type)
 
+    reconfig = ctx.reconfig
     redeploy = False
     unit_name = get_unit_name(ctx.fsid, daemon_type, daemon_id)
     (_, state, _) = check_unit(ctx, unit_name)
     if state == 'running' or is_container_running(ctx, CephContainer.for_daemon(ctx, ctx.fsid, daemon_type, daemon_id, 'bash')):
         redeploy = True
 
-    if ctx.reconfig:
+    if reconfig:
         logger.info('%s daemon %s ...' % ('Reconfig', ctx.name))
     elif redeploy:
         logger.info('%s daemon %s ...' % ('Redeploy', ctx.name))
@@ -5962,11 +5966,8 @@ def command_deploy(ctx):
     # Get and check ports explicitly required to be opened
     daemon_ports = []  # type: List[int]
 
-    # only check port in use if not reconfig or redeploy since service
-    # we are redeploying/reconfiguring will already be using the port
-    if not ctx.reconfig and not redeploy:
-        if ctx.tcp_ports:
-            daemon_ports = list(map(int, ctx.tcp_ports.split()))
+    if ctx.tcp_ports:
+        daemon_ports = list(map(int, ctx.tcp_ports.split()))
 
     if daemon_type in Ceph.daemons:
         config, keyring = get_config_and_keyring(ctx)
@@ -5991,7 +5992,8 @@ def command_deploy(ctx):
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
                       osd_fsid=ctx.osd_fsid,
-                      reconfig=ctx.reconfig,
+                      reconfig=reconfig,
+                      redeploy=redeploy,
                       ports=daemon_ports)
 
     elif daemon_type in Monitoring.components:
@@ -6013,11 +6015,12 @@ def command_deploy(ctx):
         uid, gid = extract_uid_gid_monitoring(ctx, daemon_type)
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
-                      reconfig=ctx.reconfig,
+                      reconfig=reconfig,
+                      redeploy=redeploy,
                       ports=daemon_ports)
 
     elif daemon_type == NFSGanesha.daemon_type:
-        if not ctx.reconfig and not redeploy and not daemon_ports:
+        if not reconfig and not redeploy and not daemon_ports:
             daemon_ports = list(NFSGanesha.port_map.values())
 
         config, keyring = get_config_and_keyring(ctx)
@@ -6026,7 +6029,8 @@ def command_deploy(ctx):
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
-                      reconfig=ctx.reconfig,
+                      reconfig=reconfig,
+                      redeploy=redeploy,
                       ports=daemon_ports)
 
     elif daemon_type == CephIscsi.daemon_type:
@@ -6035,7 +6039,8 @@ def command_deploy(ctx):
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
-                      reconfig=ctx.reconfig,
+                      reconfig=reconfig,
+                      redeploy=redeploy,
                       ports=daemon_ports)
 
     elif daemon_type == HAproxy.daemon_type:
@@ -6043,7 +6048,8 @@ def command_deploy(ctx):
         uid, gid = haproxy.extract_uid_gid_haproxy()
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
-                      reconfig=ctx.reconfig,
+                      reconfig=reconfig,
+                      redeploy=redeploy,
                       ports=daemon_ports)
 
     elif daemon_type == Keepalived.daemon_type:
@@ -6051,33 +6057,39 @@ def command_deploy(ctx):
         uid, gid = keepalived.extract_uid_gid_keepalived()
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
-                      reconfig=ctx.reconfig,
+                      reconfig=reconfig,
+                      redeploy=redeploy,
                       ports=daemon_ports)
 
     elif daemon_type == CustomContainer.daemon_type:
         cc = CustomContainer.init(ctx, ctx.fsid, daemon_id)
-        if not ctx.reconfig and not redeploy:
+        if not reconfig and not redeploy:
             daemon_ports.extend(cc.ports)
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id,
                                      privileged=cc.privileged,
                                      ptrace=ctx.allow_ptrace)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c,
                       uid=cc.uid, gid=cc.gid, config=None,
-                      keyring=None, reconfig=ctx.reconfig,
-                      ports=daemon_ports)
+                      keyring=None, reconfig=reconfig,
+                      redeploy=redeploy, ports=daemon_ports)
 
     elif daemon_type == CephadmAgent.daemon_type:
         # get current user gid and uid
         uid = os.getuid()
         gid = os.getgid()
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, None,
-                      uid, gid, ports=daemon_ports)
+                      uid, gid,
+                      reconfig=reconfig,
+                      redeploy=redeploy,
+                      ports=daemon_ports)
 
     elif daemon_type == SNMPGateway.daemon_type:
         sc = SNMPGateway.init(ctx, ctx.fsid, daemon_id)
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c,
                       sc.uid, sc.gid,
+                      reconfig=reconfig,
+                      redeploy=redeploy,
                       ports=daemon_ports)
 
     else:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -165,6 +165,17 @@ class ContainerInfo:
                 and self.version == other.version)
 
 
+class DeploymentType(Enum):
+    # Fresh deployment of a daemon.
+    DEFAULT = 'Deploy'
+    # Redeploying a daemon. Works the same as fresh
+    # deployment minus port checking.
+    REDEPLOY = 'Redeploy'
+    # Reconfiguring a daemon. Rewrites config
+    # files and potentially restarts daemon.
+    RECONFIG = 'Reconfig'
+
+
 class BaseConfig:
 
     def __init__(self) -> None:
@@ -3223,13 +3234,13 @@ def deploy_daemon(ctx: CephadmContext, fsid: str, daemon_type: str,
                   daemon_id: Union[int, str], c: Optional['CephContainer'],
                   uid: int, gid: int, config: Optional[str] = None,
                   keyring: Optional[str] = None, osd_fsid: Optional[str] = None,
-                  reconfig: Optional[bool] = False, redeploy: Optional[bool] = False,
+                  deployment_type: DeploymentType = DeploymentType.DEFAULT,
                   ports: Optional[List[int]] = None) -> None:
 
     ports = ports or []
-    # only check port in use if not reconfig or redeploy since service
+    # only check port in use if fresh deployment since service
     # we are redeploying/reconfiguring will already be using the port
-    if not reconfig and not redeploy:
+    if deployment_type == DeploymentType.DEFAULT:
         if any([port_in_use(ctx, port) for port in ports]):
             if daemon_type == 'mgr':
                 # non-fatal for mgr when we are in mgr_standby_modules=false, but we can't
@@ -3241,7 +3252,7 @@ def deploy_daemon(ctx: CephadmContext, fsid: str, daemon_type: str,
                 raise Error("TCP Port(s) '{}' required for {} already in use".format(','.join(map(str, ports)), daemon_type))
 
     data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
-    if reconfig and not os.path.exists(data_dir):
+    if deployment_type == DeploymentType.RECONFIG and not os.path.exists(data_dir):
         raise Error('cannot reconfig, data path %s does not exist' % data_dir)
     if daemon_type == 'mon' and not os.path.exists(data_dir):
         assert config
@@ -3288,7 +3299,9 @@ def deploy_daemon(ctx: CephadmContext, fsid: str, daemon_type: str,
             uid, gid,
             config, keyring)
 
-    if not reconfig:
+    # only write out unit files and start daemon
+    # with systemd if this is not a reconfig
+    if deployment_type != DeploymentType.RECONFIG:
         if daemon_type == CephadmAgent.daemon_type:
             if ctx.config_json == '-':
                 config_js = get_parm('-')
@@ -3324,7 +3337,9 @@ def deploy_daemon(ctx: CephadmContext, fsid: str, daemon_type: str,
         fw.open_ports(ports + fw.external_ports.get(daemon_type, []))
         fw.apply_rules()
 
-    if reconfig and daemon_type not in Ceph.daemons:
+    # If this was a reconfig and the daemon is not a Ceph daemon, restart it
+    # so it can pick up potential changes to its configuration files
+    if deployment_type == DeploymentType.RECONFIG and daemon_type not in Ceph.daemons:
         # ceph daemons do not need a restart; others (presumably) do to pick
         # up the new config
         call_throws(ctx, ['systemctl', 'reset-failed',
@@ -5935,6 +5950,24 @@ def get_deployment_container(ctx: CephadmContext,
     return c
 
 
+def get_deployment_type(ctx: CephadmContext, daemon_type: str, daemon_id: str) -> DeploymentType:
+    deployment_type: DeploymentType = DeploymentType.DEFAULT
+    if ctx.reconfig:
+        deployment_type = DeploymentType.RECONFIG
+    unit_name = get_unit_name(ctx.fsid, daemon_type, daemon_id)
+    (_, state, _) = check_unit(ctx, unit_name)
+    if state == 'running' or is_container_running(ctx, CephContainer.for_daemon(ctx, ctx.fsid, daemon_type, daemon_id, 'bash')):
+        # if reconfig was set, that takes priority over redeploy. If
+        # this is considered a fresh deployment at this stage,
+        # mark it as a redeploy to avoid port checking
+        if deployment_type == DeploymentType.DEFAULT:
+            deployment_type = DeploymentType.REDEPLOY
+
+    logger.info(f'{deployment_type.value} daemon {ctx.name} ...')
+
+    return deployment_type
+
+
 @default_image
 def command_deploy(ctx):
     # type: (CephadmContext) -> None
@@ -5946,19 +5979,7 @@ def command_deploy(ctx):
     if daemon_type not in get_supported_daemons():
         raise Error('daemon type %s not recognized' % daemon_type)
 
-    reconfig = ctx.reconfig
-    redeploy = False
-    unit_name = get_unit_name(ctx.fsid, daemon_type, daemon_id)
-    (_, state, _) = check_unit(ctx, unit_name)
-    if state == 'running' or is_container_running(ctx, CephContainer.for_daemon(ctx, ctx.fsid, daemon_type, daemon_id, 'bash')):
-        redeploy = True
-
-    if reconfig:
-        logger.info('%s daemon %s ...' % ('Reconfig', ctx.name))
-    elif redeploy:
-        logger.info('%s daemon %s ...' % ('Redeploy', ctx.name))
-    else:
-        logger.info('%s daemon %s ...' % ('Deploy', ctx.name))
+    deployment_type: DeploymentType = get_deployment_type(ctx, daemon_type, daemon_id)
 
     # Migrate sysctl conf files from /usr/lib to /etc
     migrate_sysctl_dir(ctx, ctx.fsid)
@@ -5992,8 +6013,7 @@ def command_deploy(ctx):
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
                       osd_fsid=ctx.osd_fsid,
-                      reconfig=reconfig,
-                      redeploy=redeploy,
+                      deployment_type=deployment_type,
                       ports=daemon_ports)
 
     elif daemon_type in Monitoring.components:
@@ -6015,12 +6035,12 @@ def command_deploy(ctx):
         uid, gid = extract_uid_gid_monitoring(ctx, daemon_type)
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
-                      reconfig=reconfig,
-                      redeploy=redeploy,
+                      deployment_type=deployment_type,
                       ports=daemon_ports)
 
     elif daemon_type == NFSGanesha.daemon_type:
-        if not reconfig and not redeploy and not daemon_ports:
+        # only check ports if this is a fresh deployment
+        if deployment_type == DeploymentType.DEFAULT and not daemon_ports:
             daemon_ports = list(NFSGanesha.port_map.values())
 
         config, keyring = get_config_and_keyring(ctx)
@@ -6029,8 +6049,7 @@ def command_deploy(ctx):
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
-                      reconfig=reconfig,
-                      redeploy=redeploy,
+                      deployment_type=deployment_type,
                       ports=daemon_ports)
 
     elif daemon_type == CephIscsi.daemon_type:
@@ -6039,8 +6058,7 @@ def command_deploy(ctx):
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
-                      reconfig=reconfig,
-                      redeploy=redeploy,
+                      deployment_type=deployment_type,
                       ports=daemon_ports)
 
     elif daemon_type == HAproxy.daemon_type:
@@ -6048,8 +6066,7 @@ def command_deploy(ctx):
         uid, gid = haproxy.extract_uid_gid_haproxy()
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
-                      reconfig=reconfig,
-                      redeploy=redeploy,
+                      deployment_type=deployment_type,
                       ports=daemon_ports)
 
     elif daemon_type == Keepalived.daemon_type:
@@ -6057,21 +6074,21 @@ def command_deploy(ctx):
         uid, gid = keepalived.extract_uid_gid_keepalived()
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
-                      reconfig=reconfig,
-                      redeploy=redeploy,
+                      deployment_type=deployment_type,
                       ports=daemon_ports)
 
     elif daemon_type == CustomContainer.daemon_type:
         cc = CustomContainer.init(ctx, ctx.fsid, daemon_id)
-        if not reconfig and not redeploy:
+        # only check ports if this is a fresh deployment
+        if deployment_type == DeploymentType.DEFAULT:
             daemon_ports.extend(cc.ports)
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id,
                                      privileged=cc.privileged,
                                      ptrace=ctx.allow_ptrace)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c,
                       uid=cc.uid, gid=cc.gid, config=None,
-                      keyring=None, reconfig=reconfig,
-                      redeploy=redeploy, ports=daemon_ports)
+                      keyring=None, deployment_type=deployment_type,
+                      ports=daemon_ports)
 
     elif daemon_type == CephadmAgent.daemon_type:
         # get current user gid and uid
@@ -6079,8 +6096,7 @@ def command_deploy(ctx):
         gid = os.getgid()
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, None,
                       uid, gid,
-                      reconfig=reconfig,
-                      redeploy=redeploy,
+                      deployment_type=deployment_type,
                       ports=daemon_ports)
 
     elif daemon_type == SNMPGateway.daemon_type:
@@ -6088,8 +6104,7 @@ def command_deploy(ctx):
         c = get_deployment_container(ctx, ctx.fsid, daemon_type, daemon_id)
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c,
                       sc.uid, sc.gid,
-                      reconfig=reconfig,
-                      redeploy=redeploy,
+                      deployment_type=deployment_type,
                       ports=daemon_ports)
 
     else:
@@ -7043,7 +7058,8 @@ def command_adopt_prometheus(ctx, daemon_id, fsid):
 
     make_var_run(ctx, fsid, uid, gid)
     c = get_container(ctx, fsid, daemon_type, daemon_id)
-    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid, redeploy=True, ports=ports)
+    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
+                  deployment_type=DeploymentType.REDEPLOY, ports=ports)
     update_firewalld(ctx, daemon_type)
 
 
@@ -7100,7 +7116,8 @@ def command_adopt_grafana(ctx, daemon_id, fsid):
 
     make_var_run(ctx, fsid, uid, gid)
     c = get_container(ctx, fsid, daemon_type, daemon_id)
-    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid, redeploy=True, ports=ports)
+    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
+                  deployment_type=DeploymentType.REDEPLOY, ports=ports)
     update_firewalld(ctx, daemon_type)
 
 
@@ -7133,7 +7150,8 @@ def command_adopt_alertmanager(ctx, daemon_id, fsid):
 
     make_var_run(ctx, fsid, uid, gid)
     c = get_container(ctx, fsid, daemon_type, daemon_id)
-    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid, redeploy=True, ports=ports)
+    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
+                  deployment_type=DeploymentType.REDEPLOY, ports=ports)
     update_firewalld(ctx, daemon_type)
 
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -7019,6 +7019,9 @@ def command_adopt_prometheus(ctx, daemon_id, fsid):
     # type: (CephadmContext, str, str) -> None
     daemon_type = 'prometheus'
     (uid, gid) = extract_uid_gid_monitoring(ctx, daemon_type)
+    # should try to set the ports we know cephadm defaults
+    # to for these services in the firewall.
+    ports = Monitoring.port_map['prometheus']
 
     _stop_and_disable(ctx, 'prometheus')
 
@@ -7040,7 +7043,7 @@ def command_adopt_prometheus(ctx, daemon_id, fsid):
 
     make_var_run(ctx, fsid, uid, gid)
     c = get_container(ctx, fsid, daemon_type, daemon_id)
-    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid)
+    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid, redeploy=True, ports=ports)
     update_firewalld(ctx, daemon_type)
 
 
@@ -7049,6 +7052,9 @@ def command_adopt_grafana(ctx, daemon_id, fsid):
 
     daemon_type = 'grafana'
     (uid, gid) = extract_uid_gid_monitoring(ctx, daemon_type)
+    # should try to set the ports we know cephadm defaults
+    # to for these services in the firewall.
+    ports = Monitoring.port_map['grafana']
 
     _stop_and_disable(ctx, 'grafana-server')
 
@@ -7094,7 +7100,7 @@ def command_adopt_grafana(ctx, daemon_id, fsid):
 
     make_var_run(ctx, fsid, uid, gid)
     c = get_container(ctx, fsid, daemon_type, daemon_id)
-    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid)
+    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid, redeploy=True, ports=ports)
     update_firewalld(ctx, daemon_type)
 
 
@@ -7103,6 +7109,9 @@ def command_adopt_alertmanager(ctx, daemon_id, fsid):
 
     daemon_type = 'alertmanager'
     (uid, gid) = extract_uid_gid_monitoring(ctx, daemon_type)
+    # should try to set the ports we know cephadm defaults
+    # to for these services in the firewall.
+    ports = Monitoring.port_map['alertmanager']
 
     _stop_and_disable(ctx, 'prometheus-alertmanager')
 
@@ -7124,7 +7133,7 @@ def command_adopt_alertmanager(ctx, daemon_id, fsid):
 
     make_var_run(ctx, fsid, uid, gid)
     c = get_container(ctx, fsid, daemon_type, daemon_id)
-    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid)
+    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid, redeploy=True, ports=ports)
     update_firewalld(ctx, daemon_type)
 
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -314,6 +314,7 @@ class TestCephAdm(object):
         ctx.allow_ptrace = True
         ctx.config_json = '-'
         ctx.osd_fsid = '0'
+        ctx.tcp_ports = '3300 6789'
         _get_parm.return_value = {
             'crush_location': 'database=a'
         }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61676

---

backport of https://github.com/ceph/ceph/pull/51070
parent tracker: https://tracker.ceph.com/issues/59443

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh