### PR TITLE
rgw/beast: Enable SSL session-id reuse speedup mechanism

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -1042,10 +1042,10 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
         handle_connection(context, env, stream, timeout, header_limit,
                           conn->buffer, true, pause_mutex, scheduler.get(),
                           uri_prefix, ec, yield);
-        if (!ec) {
-          // ssl shutdown (ignoring errors)
-          stream.async_shutdown(yield[ec]);
-        }
+
+        // ssl shutdown (ignoring errors)
+        stream.async_shutdown(yield[ec]);
+        
         conn->socket.shutdown(tcp::socket::shutdown_both, ec);
       }, make_stack_allocator());
   } else {


### PR DESCRIPTION
Enable the OpenSSL session-id reuse acceleration mechanism that is described in:

https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_session_id_context.html SSL_CTX_set_session_id_context, SSL_set_session_id_context - set context within which session can be reused (server side only)

For the SSL session-id reuse mechanism to operate the session has to be shut_down() so it can be re-used


Fixes: https://tracker.ceph.com/issues/64719


`- - - - -  8<  - - - - -`  below copying from tracker  `- - - - -  8<  - - - - -  `

The check methodology is with the 'openssl s_client' command below , note the `--reconnect` which is reconnecting 5 times:

`echo "" | openssl s_client -connect 0:8443 --reconnect -no_ticket -tls1_2 |& grep Session-ID`
(at this time the repro is with `TLS1.2` because of OpenSSL issue: `s_client -reconnect option is broken with TLSv1.3 #10714`)

When not working correctly the session-ids will be different
when working correctly the session-ids will be the same
(see example below)
performance measurements:
when the mechanism is not working performing a loop of 1000 openssl --connect --reconnect ... takes 38.870 seconds
when the mechanism is working performing a loop of 1000 openssl --connect --reconnect ... takes 16.038 seconds

```
// BEFORE FIX:
❯ time (for I in {1..1000}; do echo $I ; echo "" | openssl s_client -connect x.x.x.ceph.com:8443 --reconnect -no_ticket -tls1_2 |& grep 'Session-ID:' > openssl.txt ; done)
( for I in {1..1000}; do; echo $I; echo "" | openssl s_client -connect     | )  9.19s user 6.67s system 40% cpu 38.870 total
                                                                                                                ^^^^^^
❯ cat openssl.txt
    Session-ID: 0CAB532FC91584CAC1BBB0A91FF874C88CD4233C426BD7F5332E6A32643DB668
    Session-ID: E8349831EC98AC87215FAFCA12CC8573DEEDB4845522D417103AEB5109C5407D
    Session-ID: 6B5B566EDE2D84F8D43F023D451896FF9B50DF4EA1AE76EED9300AB2C8730B10
    Session-ID: ACDBD3EEDC4416C685BE962A6402869A6ECD25C00474EE457216C644E40719ED
    Session-ID: AB4C2EC629017FE0433C3B3702AB44E0030F5FDFEF0D48117958034BC71F3AF7
    Session-ID: 56BE99BC9E55A29A72A10B3BB88EEB3C40ED381140484382EB36186A5B56FB59

// AFTER FIX:
❯ time (for I in {1..1000}; do echo $I ; echo "" | openssl s_client -connect x.x.x.ceph.com:8443 --reconnect -no_ticket -tls1_2 |& grep 'Session-ID:' > openssl.txt ; done)
( for I in {1..1000}; do; echo $I; echo "" | openssl s_client -connect     | )  7.94s user 5.86s system 86% cpu 16.038 total
                                                                                                                ^^^^^^
❯ cat openssl.txt
    Session-ID: 6791FAC534C991F5787568CCEB4DC3BE5F160872B5681AC967CFCB8864ED2593                                                                                                         
    Session-ID: 6791FAC534C991F5787568CCEB4DC3BE5F160872B5681AC967CFCB8864ED2593                                                                                                         
    Session-ID: 6791FAC534C991F5787568CCEB4DC3BE5F160872B5681AC967CFCB8864ED2593                                                                                                         
    Session-ID: 6791FAC534C991F5787568CCEB4DC3BE5F160872B5681AC967CFCB8864ED2593                                                                                                         
    Session-ID: 6791FAC534C991F5787568CCEB4DC3BE5F160872B5681AC967CFCB8864ED2593
    Session-ID: 6791FAC534C991F5787568CCEB4DC3BE5F160872B5681AC967CFCB8864ED2593
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
