### PR TITLE
rgw/rest: remove unused dump_errno() overloads

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -322,17 +322,6 @@ void rgw_flush_formatter(req_state *s, Formatter *formatter)
   }
 }
 
-void dump_errno(int http_ret, string& out) {
-  stringstream ss;
-
-  ss <<  http_ret << " " << http_status_names[http_ret];
-  out = ss.str();
-}
-
-void dump_errno(const struct rgw_err &err, string& out) {
-  dump_errno(err.http_ret, out);
-}
-
 void dump_errno(req_state *s)
 {
   dump_status(s, s->err.http_ret, http_status_names[s->err.http_ret]);

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -692,8 +692,6 @@ public:
 static constexpr int64_t NO_CONTENT_LENGTH = -1;
 static constexpr int64_t CHUNKED_TRANSFER_ENCODING = -2;
 
-extern void dump_errno(int http_ret, std::string& out);
-extern void dump_errno(const struct rgw_err &err, std::string& out);
 extern void dump_errno(req_state *s);
 extern void dump_errno(req_state *s, int http_ret);
 extern void end_header(req_state *s,


### PR DESCRIPTION


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
