### PR TITLE
osd: update latest overlap to [0,obs.oi.size] before rollback_to #64735

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8501,16 +8501,26 @@ void PrimaryLogPG::_do_rollback_to(OpContext *ctx, ObjectContextRef rollback_to,
   t->clone(soid, rollback_to_sobject);
   t->add_obc(rollback_to);
 
+  if (obs.oi.size > 0) {
+    // change most recent clone_overlap to [0, obs.oi.size] before rollback to snap
+    if (ctx->new_snapset.clones.size() > 0) {
+      interval_set<uint64_t> rollback_overlaps;
+      rollback_overlaps.insert(0, obs.oi.size);
+      interval_set<uint64_t> &newest_overlap =
+        ctx->new_snapset.clone_overlap.rbegin()->second;
+      newest_overlap.swap(rollback_overlaps);
+    }
+
   map<snapid_t, interval_set<uint64_t> >::iterator iter =
     snapset.clone_overlap.lower_bound(snapid);
   ceph_assert(iter != snapset.clone_overlap.end());
   interval_set<uint64_t> overlaps = iter->second;
   for ( ;
 	iter != snapset.clone_overlap.end();
-	++iter)
-    overlaps.intersection_of(iter->second);
+	++iter) {
+        overlaps.intersection_of(iter->second);
+      }
 
-  if (obs.oi.size > 0) {
     interval_set<uint64_t> modified;
     modified.insert(0, obs.oi.size);
     overlaps.intersection_of(modified);


### PR DESCRIPTION
osd: snapshot update overlap to [0,obs.oi.size] before rollback_to snap

when rollback_to snap, we currently use the latest clone's current overlap to intersection_of older snapshot's clone overlap (which is not that correct). 
we should update the latest clone's current overlap to [0, obs.oi.size] before intersection_of other clone's overlap.
rbd du/rbd  diff/rbd export-diff will be affected.

Fixes: https://tracker.ceph.com/issues/64735
      Signed-off-by: 18142813996@163.com



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
