### PR TITLE
squid: mgr/node-proxy: handle 'None' statuses returned by RedFish

### DIFF
--- a/src/ceph-node-proxy/ceph_node_proxy/util.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/util.py
@@ -126,6 +126,8 @@ def normalize_dict(test_dict: Dict) -> Dict:
         if isinstance(test_dict[key], dict):
             res[key.lower()] = normalize_dict(test_dict[key])
         else:
+            if test_dict[key] is None:
+                test_dict[key] = 'unknown'
             res[key.lower()] = test_dict[key]
     return res
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64749

---

backport of https://github.com/ceph/ceph/pull/55955
parent tracker: https://tracker.ceph.com/issues/64712

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh