### PR TITLE
mgr/dashboard: handle infinite values for pools

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import math
 import time
 from typing import Any, Dict, Iterable, List, Optional, Union, cast
 
@@ -101,7 +102,7 @@ class Pool(RESTController):
 
         crush_rules = {r['rule_id']: r["rule_name"] for r in mgr.get('osd_map_crush')['rules']}
 
-        res: Dict[Union[int, str], Union[str, List[Any]]] = {}
+        res: Dict[Union[int, str], Union[str, List[Any], Dict[str, Any]]] = {}
         for attr in attrs:
             if attr not in pool:
                 continue
@@ -111,6 +112,15 @@ class Pool(RESTController):
                 res[attr] = crush_rules[pool[attr]]
             elif attr == 'application_metadata':
                 res[attr] = list(pool[attr].keys())
+            # handle infinity values
+            elif attr == 'read_balance' and isinstance(pool[attr], dict):
+                read_balance: Dict[str, Any] = {}
+                for key, value in pool[attr].items():
+                    if isinstance(value, float) and math.isinf(value):
+                        read_balance[key] = "Infinity"
+                    else:
+                        read_balance[key] = value
+                res[attr] = read_balance
             else:
                 res[attr] = pool[attr]
 


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/64724

### Issue:
Json parsing is failing because of Infinity values present in pools meteadata. "read_balance": {"score_acting": Infinity, "score_stable": Infinity,}
Due to this entire pool list is not rendered.

### Fix:
Added a handler for checking "inf" values and replacing them with a string "Infinity" so that json parsing does not fail on frontend.

------------------
### Before 
![Screenshot from 2024-03-06 16-41-50](https://github.com/ceph/ceph/assets/25664409/2576d85e-b0d0-4f55-9029-e2a7389eb7a5)


### After
![Screenshot from 2024-03-07 01-26-30](https://github.com/ceph/ceph/assets/25664409/89986676-ae5a-459d-afea-5b919de17dc8)




## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
