### PR TITLE
squid: rpm: disable system_qat for non-x86_64 arch

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -111,9 +111,14 @@
 # this is tracked in https://bugzilla.redhat.com/2152265
 %bcond_with system_arrow
 %endif
+# qat only supported for intel devices
+%ifarch x86_64
 %if 0%{?fedora} || 0%{?rhel} >= 9
 %bcond_without system_qat
-%else
+%else # not fedora/rhel
+%bcond_with system_qat
+%endif
+%else # not x86_64
 %bcond_with system_qat
 %endif
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel} >= 8 || 0%{?openEuler}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64754

---

backport of https://github.com/ceph/ceph/pull/56000
parent tracker: https://tracker.ceph.com/issues/64678

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh