### PR TITLE
squid: qa: ignore container checkpoint/restore related selinux denials for centos9

### DIFF
--- a/qa/distros/all/centos_7.6.yaml
+++ b/qa/distros/all/centos_7.6.yaml
@@ -2,6 +2,6 @@ os_type: centos
 os_version: "7.6"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/all/centos_8.0.yaml
+++ b/qa/distros/all/centos_8.0.yaml
@@ -2,6 +2,6 @@ os_type: centos
 os_version: "8.0"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/all/centos_8.1.yaml
+++ b/qa/distros/all/centos_8.1.yaml
@@ -2,6 +2,6 @@ os_type: centos
 os_version: "8.1"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/all/centos_8.2.yaml
+++ b/qa/distros/all/centos_8.2.yaml
@@ -2,6 +2,6 @@ os_type: centos
 os_version: "8.2"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/all/centos_8.3.yaml
+++ b/qa/distros/all/centos_8.3.yaml
@@ -2,6 +2,6 @@ os_type: centos
 os_version: "8.3"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/all/centos_8.stream.yaml
+++ b/qa/distros/all/centos_8.stream.yaml
@@ -2,6 +2,6 @@ os_type: centos
 os_version: "8.stream"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/all/centos_9.stream.yaml
+++ b/qa/distros/all/centos_9.stream.yaml
@@ -1,2 +1,6 @@
 os_type: centos
 os_version: "9.stream"
+overrides:
+  selinux:
+    allowlist:
+      - scontext=system_u:system_r:getty_t:s0

--- a/qa/distros/all/rhel_7.6.yaml
+++ b/qa/distros/all/rhel_7.6.yaml
@@ -2,6 +2,6 @@ os_type: rhel
 os_version: "7.6"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/all/rhel_7.7.yaml
+++ b/qa/distros/all/rhel_7.7.yaml
@@ -2,6 +2,6 @@ os_type: rhel
 os_version: "7.7"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/all/rhel_8.0.yaml
+++ b/qa/distros/all/rhel_8.0.yaml
@@ -2,6 +2,6 @@ os_type: rhel
 os_version: "8.0"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/all/rhel_8.1.yaml
+++ b/qa/distros/all/rhel_8.1.yaml
@@ -2,6 +2,6 @@ os_type: rhel
 os_version: "8.1"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/all/rhel_8.3.yaml
+++ b/qa/distros/all/rhel_8.3.yaml
@@ -2,6 +2,6 @@ os_type: rhel
 os_version: "8.3"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/all/rhel_8.4.yaml
+++ b/qa/distros/all/rhel_8.4.yaml
@@ -2,6 +2,6 @@ os_type: rhel
 os_version: "8.4"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/all/rhel_8.5.yaml
+++ b/qa/distros/all/rhel_8.5.yaml
@@ -2,6 +2,6 @@ os_type: rhel
 os_version: "8.5"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/all/rhel_8.6.yaml
+++ b/qa/distros/all/rhel_8.6.yaml
@@ -2,6 +2,6 @@ os_type: rhel
 os_version: "8.6"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 ktype: distro

--- a/qa/distros/container-hosts/centos_8.stream_container_tools.yaml
+++ b/qa/distros/container-hosts/centos_8.stream_container_tools.yaml
@@ -2,7 +2,7 @@ os_type: centos
 os_version: "8.stream"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 
 tasks:

--- a/qa/distros/container-hosts/centos_8.stream_container_tools_crun.yaml
+++ b/qa/distros/container-hosts/centos_8.stream_container_tools_crun.yaml
@@ -2,7 +2,7 @@ os_type: centos
 os_version: "8.stream"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 
 tasks:

--- a/qa/distros/container-hosts/centos_9.stream.yaml
+++ b/qa/distros/container-hosts/centos_9.stream.yaml
@@ -2,6 +2,6 @@ os_type: centos
 os_version: "9.stream"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 

--- a/qa/distros/container-hosts/centos_9.stream_runc.yaml
+++ b/qa/distros/container-hosts/centos_9.stream_runc.yaml
@@ -2,7 +2,7 @@ os_type: centos
 os_version: "9.stream"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 
 tasks:

--- a/qa/distros/podman/centos_8.stream_container_tools.yaml
+++ b/qa/distros/podman/centos_8.stream_container_tools.yaml
@@ -2,7 +2,7 @@ os_type: centos
 os_version: "8.stream"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 
 tasks:

--- a/qa/distros/podman/centos_9.stream.yaml
+++ b/qa/distros/podman/centos_9.stream.yaml
@@ -4,4 +4,4 @@ overrides:
   selinux:
     allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
-
+      - scontext=system_u:system_r:getty_t:s0

--- a/qa/distros/podman/centos_9.stream.yaml
+++ b/qa/distros/podman/centos_9.stream.yaml
@@ -2,6 +2,6 @@ os_type: centos
 os_version: "9.stream"
 overrides:
   selinux:
-    whitelist:
+    allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64755

---

backport of https://github.com/ceph/ceph/pull/55908
parent tracker: https://tracker.ceph.com/issues/64616

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh