### PR TITLE
quincy: qa/cephfs: add more ignorelist entries

### DIFF
--- a/qa/cephfs/overrides/ignorelist_health.yaml
+++ b/qa/cephfs/overrides/ignorelist_health.yaml
@@ -12,3 +12,4 @@ overrides:
       - MDS_UP_LESS_THAN_MAX
       - POOL_APP_NOT_ENABLED
       - overall HEALTH_
+      - Replacing daemon

--- a/qa/cephfs/overrides/ignorelist_health.yaml
+++ b/qa/cephfs/overrides/ignorelist_health.yaml
@@ -8,6 +8,7 @@ overrides:
       - MDS_DAMAGE
       - MDS_DEGRADED
       - MDS_FAILED
+      - MDS_INSUFFICIENT_STANDBY
       - MDS_UP_LESS_THAN_MAX
       - POOL_APP_NOT_ENABLED
       - overall HEALTH_

--- a/qa/cephfs/overrides/ignorelist_health.yaml
+++ b/qa/cephfs/overrides/ignorelist_health.yaml
@@ -13,3 +13,4 @@ overrides:
       - POOL_APP_NOT_ENABLED
       - overall HEALTH_
       - Replacing daemon
+      - deprecated feature inline_data

--- a/qa/cephfs/overrides/ignorelist_health.yaml
+++ b/qa/cephfs/overrides/ignorelist_health.yaml
@@ -1,14 +1,13 @@
 overrides:
   ceph:
     log-ignorelist:
+      - FS_DEGRADED
+      - FS_INLINE_DATA_DEPRECATED
+      - FS_WITH_FAILED_MDS
+      - MDS_ALL_DOWN
+      - MDS_DAMAGE
+      - MDS_DEGRADED
+      - MDS_FAILED
+      - MDS_UP_LESS_THAN_MAX
+      - POOL_APP_NOT_ENABLED
       - overall HEALTH_
-      - \(FS_DEGRADED\)
-      - \(MDS_FAILED\)
-      - \(MDS_DEGRADED\)
-      - \(FS_WITH_FAILED_MDS\)
-      - \(MDS_DAMAGE\)
-      - \(MDS_ALL_DOWN\)
-      - filesystem is online with fewer MDS than max_mds
-      - \(MDS_UP_LESS_THAN_MAX\)
-      - \(FS_INLINE_DATA_DEPRECATED\)
-      - \(POOL_APP_NOT_ENABLED\)

--- a/qa/cephfs/overrides/ignorelist_wrongly_marked_down.yaml
+++ b/qa/cephfs/overrides/ignorelist_wrongly_marked_down.yaml
@@ -7,3 +7,4 @@ overrides:
       - but it is still running
 # MDS daemon 'b' is not responding, replacing it as rank 0 with standby 'a'
       - is not responding
+      - MON_DOWN

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/overrides/ignorelist_upgrade.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/overrides/ignorelist_upgrade.yaml
@@ -1,0 +1,4 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - OSD_DOWN


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64776

---

backport of https://github.com/ceph/ceph/pull/55909
parent tracker: https://tracker.ceph.com/issues/64746

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh