### PR TITLE
reef: mgr/cephadm: Allow idmap overrides in nfs-ganesha configuration

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -848,7 +848,7 @@ class NFSGanesha(object):
     entrypoint = '/usr/bin/ganesha.nfsd'
     daemon_args = ['-F', '-L', 'STDERR']
 
-    required_files = ['ganesha.conf']
+    required_files = ['ganesha.conf', 'idmap.conf']
 
     port_map = {
         'nfs': 2049,

--- a/src/cephadm/tests/test_nfs.py
+++ b/src/cephadm/tests/test_nfs.py
@@ -25,6 +25,7 @@ def nfs_json(**kwargs):
     if kwargs.get("files"):
         result["files"] = {
             "ganesha.conf": "",
+            "idmap.conf": "",
         }
     if kwargs.get("rgw_content"):
         result["rgw"] = dict(kwargs["rgw_content"])

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -16,6 +16,9 @@ NFSv4 {
         Delegations = false;
         RecoveryBackend = 'rados_cluster';
         Minor_Versions = 1, 2;
+{% if nfs_idmap_conf %}
+        IdmapConf = "{{ nfs_idmap_conf }}";
+{% endif %}
 }
 
 RADOS_KV {

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -2431,6 +2431,7 @@ class TestIngressService:
             '        Delegations = false;\n'
             "        RecoveryBackend = 'rados_cluster';\n"
             '        Minor_Versions = 1, 2;\n'
+            '        IdmapConf = "/etc/ganesha/idmap.conf";\n'
             '}\n'
             '\n'
             'RADOS_KV {\n'
@@ -2454,7 +2455,7 @@ class TestIngressService:
             "%url    rados://.nfs/foo/conf-nfs.foo"
         )
         nfs_expected_conf = {
-            'files': {'ganesha.conf': nfs_ganesha_txt},
+            'files': {'ganesha.conf': nfs_ganesha_txt, 'idmap.conf': ''},
             'config': '',
             'extra_args': ['-N', 'NIV_EVENT'],
             'keyring': (

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -952,6 +952,7 @@ class NFSServiceSpec(ServiceSpec):
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
                  enable_haproxy_protocol: bool = False,
+                 idmap_conf: Optional[Dict[str, Dict[str, str]]] = None,
                  custom_configs: Optional[List[CustomConfig]] = None,
                  ):
         assert service_type == 'nfs'
@@ -964,6 +965,7 @@ class NFSServiceSpec(ServiceSpec):
         self.port = port
         self.virtual_ip = virtual_ip
         self.enable_haproxy_protocol = enable_haproxy_protocol
+        self.idmap_conf = idmap_conf
 
     def get_port_start(self) -> List[int]:
         if self.port:

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -384,6 +384,12 @@ service_type: nfs
 service_id: mynfs
 service_name: nfs.mynfs
 spec:
+  idmap_conf:
+    general:
+      local-realms: domain.org
+    mapping:
+      nobody-group: nfsnobody
+      nobody-user: nfsnobody
   port: 1234
 ---
 service_type: iscsi


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64698

---

backport of https://github.com/ceph/ceph/pull/54383
parent tracker: https://tracker.ceph.com/issues/64577

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh