### PR TITLE
msg: do not abort if driver->del_event() returns -ENOENT

### DIFF
--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -16,6 +16,7 @@
 
 #include "include/compat.h"
 #include "common/errno.h"
+#include <cerrno>
 #include "Event.h"
 
 #ifdef HAVE_DPDK
@@ -285,7 +286,10 @@ void EventCenter::delete_file_event(int fd, int mask)
     return ;
 
   int r = driver->del_event(fd, event->mask, mask);
-  if (r < 0) {
+  if (r < 0 && r != -ENOENT) {
+    // if the socket fd is closed by the underlying nic driver, the
+    // corresponding epoll item would be removed from the interest list, that'd
+    // lead to ENOENT when removing the fd from the list.
     // see create_file_event
     ceph_abort_msg("BUG!");
   }


### PR DESCRIPTION
when shutting down a connection, we call into
`EpollDriver::del_event(..., EVENT_READABLE | EVENT_WRITABLE)`, and its caller, `EventCenter::delete_file_event()` considers a negative return value from this function a signal of bug and aborts in that case. but in linux, if a nic is hot unplugged, all the socket file descriptors associated with it are closed, and we would have following chain:

__fput() -> eventpoll_release() -> eventpoll_release_file() -> __ep_remove()

in __ep_remove(), the epitem representing the fd is removed from the list. so if we perform the cleanup when shutting down the TCP connection, and try to unregister the fd from the interest list, -ENOENT is returned.

librbd is using EpollDriver as well, and it sits at the client side. the machine on which librbd is running could unplug its NIC without shutting down librbd first. so, if librbd happen to be reading/writing to the socket associated with the NIC being unplugged, there are chances that librbd could crash due to the `ceph_abort_msg()` call in `EventCenter::delete_file_event()`. but this is not a fatal error, as we are unregistering the fd anyway.

in this change, in order to avoid the crash, we don't consider it a bug if `driver->del_event()` returns -ENOENT anymore.

Fixes: https://tracker.ceph.com/issues/64788

Reported-by: Zhang Jiao <zhangjiao@cmss.chinamobile.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
