### PR TITLE
mds: allow fetching ceph.dir.subvolume during getvxattr

### DIFF
--- a/qa/tasks/cephfs/test_subvolume.py
+++ b/qa/tasks/cephfs/test_subvolume.py
@@ -1,5 +1,6 @@
 import logging
 
+from io import StringIO
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from teuthology.exceptions import CommandFailedError
 
@@ -168,3 +169,33 @@ class TestSubvolume(CephFSTestCase):
 
         # clean up
         self.mount_a.run_shell(['rmdir', 'group/subvol2/dir/.snap/s2'])
+
+    def test_subvolume_vxattr(self):
+        """
+        To test presence and absence of ceph.dir.subvolume xattr on a subvolume
+        """
+        # create a subvolume
+        self.get_ceph_cmd_stdout('fs', 'subvolumegroup', 'create', self.fs.name, 'grp1')
+        self.get_ceph_cmd_stdout('fs', 'subvolume', 'create', self.fs.name, 'sv1', 'grp1')
+
+        # verify that ceph.dir.subvolume has value "1"
+        stdo = StringIO()
+        self.mount_a.run_shell(['getfattr', '-n', 'ceph.dir.subvolume',
+                                '--only-values', 'volumes/grp1/sv1'],
+                               stdout=stdo)
+        o = stdo.getvalue().strip()
+        self.assertTrue(o == "1")
+
+        # clear the ceph.dir.subvolume vxattr value
+        self.mount_a.run_shell(['sudo', 'setfattr', '-n', 'ceph.dir.subvolume',
+                                '-v', '0', 'volumes/grp1/sv1'])
+        stdo = StringIO()
+        # verify that ceph.dir.subvolume has value "0"
+        self.mount_a.run_shell(['getfattr', '-n', 'ceph.dir.subvolume',
+                                '--only-values', 'volumes/grp1/sv1'],
+                               stdout=stdo)
+        o = stdo.getvalue().strip()
+        self.assertTrue(o == "0")
+
+        self.get_ceph_cmd_stdout('fs', 'subvolume', 'rm', self.fs.name, 'sv1', 'grp1')
+        self.get_ceph_cmd_stdout('fs', 'subvolumegroup', 'rm', self.fs.name, 'grp1')

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -6943,6 +6943,14 @@ void Server::handle_client_getvxattr(const MDRequestRef& mdr)
       // since we only handle ceph vxattrs here
       r = -CEPHFS_ENODATA; // no such attribute
     }
+  } if (xattr_name == "ceph.dir.subvolume"sv) {
+    const auto srnode = cur->get_projected_srnode();
+    // unfortunately we can't delete the presence of this vxattr on any dir
+    if (srnode && srnode->is_subvolume()) {
+      *css << "1";
+    } else {
+      *css << "0";
+    }
   } else {
     // otherwise respond as invalid request
     // since we only handle ceph vxattrs here

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -462,7 +462,8 @@ private:
 	    xattr_name == "ceph.dir.layout.pool_namespace" ||
 	    xattr_name == "ceph.dir.pin" ||
 	    xattr_name == "ceph.dir.pin.random" ||
-	    xattr_name == "ceph.dir.pin.distributed");
+	    xattr_name == "ceph.dir.pin.distributed" ||
+	    xattr_name == "ceph.dir.subvolume");
   }
 
   static bool is_ceph_file_vxattr(std::string_view xattr_name) {


### PR DESCRIPTION
Add functionality to fetch value of the ceph.dir.subvolume vxattr on a dir.

Fixes: https://tracker.ceph.com/issues/64786
Signed-off-by: Milind Changire <mchangir@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
