### PR TITLE
ceph-volume: allow encryption per device type

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -266,6 +266,8 @@ class Batch(object):
             '--dmcrypt',
             action=arg_validators.DmcryptAction,
             help='Enable device encryption via dm-crypt',
+            choices=['block', 'db', 'wal'],
+            nargs='*'
         )
         parser.add_argument(
             '--crush-device-class',

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -82,6 +82,8 @@ common_args = {
     '--dmcrypt': {
         'action': arg_validators.DmcryptAction,
         'help': 'Enable device encryption via dm-crypt',
+        'choices': ['block', 'db', 'wal'],
+        'nargs': '*',
     },
     '--no-systemd': {
         'dest': 'no_systemd',

--- a/src/ceph-volume/ceph_volume/devices/raw/common.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/common.py
@@ -57,6 +57,8 @@ def create_parser(prog, description):
         '--dmcrypt',
         action=arg_validators.DmcryptAction,
         help='Enable device encryption via dm-crypt',
+        choices=['block', 'db', 'wal'],
+        nargs='*',
     )
     parser.add_argument(
         '--osd-id',

--- a/src/ceph-volume/ceph_volume/objectstore/baseobjectstore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/baseobjectstore.py
@@ -36,6 +36,8 @@ class BaseObjectStore:
         self.block_device_path = ''
         if hasattr(self.args, 'dmcrypt'):
             if self.args.dmcrypt:
+                self.encrypted_device_types: List[str] = self.args.dmcrypt[0]
+                self.tags['ceph.encrypted'] = 1
                 self.encrypted = 1
                 self.cephx_lockbox_secret = prepare_utils.create_key()
                 self.secrets['cephx_lockbox_secret'] = \

--- a/src/ceph-volume/ceph_volume/objectstore/lvmbluestore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/lvmbluestore.py
@@ -177,19 +177,22 @@ class LvmBlueStore(BlueStore):
         # process can use the mapper paths
         key = self.secrets['dmcrypt_key']
 
-        self.block_device_path = \
-            self.luks_format_and_open(key,
-                                      self.block_device_path,
-                                      'block',
-                                      self.tags)
-        self.wal_device_path = self.luks_format_and_open(key,
-                                                         self.wal_device_path,
-                                                         'wal',
-                                                         self.tags)
-        self.db_device_path = self.luks_format_and_open(key,
-                                                        self.db_device_path,
-                                                        'db',
-                                                        self.tags)
+        if 'block' in self.encrypted_device_types:
+            self.block_device_path = \
+                self.luks_format_and_open(key,
+                                          self.block_device_path,
+                                          'block',
+                                          self.tags)
+        if 'wal' in self.encrypted_device_types:
+            self.wal_device_path = self.luks_format_and_open(key,
+                                                             self.wal_device_path,
+                                                             'wal',
+                                                             self.tags)
+        if 'db' in self.encrypted_device_types:
+            self.db_device_path = self.luks_format_and_open(key,
+                                                            self.db_device_path,
+                                                            'db',
+                                                            self.tags)
 
     def luks_format_and_open(self,
                              key: Optional[str],
@@ -314,6 +317,7 @@ class LvmBlueStore(BlueStore):
                 device_lv = lv
                 break
         if device_lv:
+            is_encrypted = device_lv.tags.get('ceph.encrypted', '0') == '1'
             if is_encrypted:
                 encryption_utils.luks_open(dmcrypt_secret,
                                            device_lv.__dict__['lv_path'],

--- a/src/ceph-volume/ceph_volume/objectstore/rawbluestore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/rawbluestore.py
@@ -37,7 +37,7 @@ class RawBlueStore(BlueStore):
                                     (self.db_device_path, 'db'),
                                     (self.wal_device_path, 'wal')]:
 
-            if device:
+            if device and device_type in self.encrypted_device_types:
                 kname = disk.lsblk(device)['KNAME']
                 mapping = 'ceph-{}-{}-{}-dmcrypt'.format(self.osd_fsid,
                                                          kname,

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import math
+import copy as _copy
 from ceph_volume import terminal, decorators, process
 from ceph_volume.util.device import Device
 from ceph_volume.util import disk
@@ -10,9 +11,15 @@ from ceph_volume.util.encryption import set_dmcrypt_no_workqueue
 def valid_osd_id(val):
     return str(int(val))
 
-class DmcryptAction(argparse._ExtendAction):
+class DmcryptAction(argparse._AppendAction):
     def __init__(self, *args, **kwargs):
         super(DmcryptAction, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    def _ensure_value(namespace, name, value):
+        if getattr(namespace, name, None) is None:
+            setattr(namespace, name, value)
+        return getattr(namespace, name)
 
     def __call__(self, parser, namespace, values, option_string=None):
         set_dmcrypt_no_workqueue()
@@ -20,7 +27,11 @@ class DmcryptAction(argparse._ExtendAction):
         if not values:
             values = ['block', 'db', 'wal']
 
-        super(DmcryptAction, self).__call__(parser, namespace, values, option_string)
+        # TODO: use argparse._ExtendAction when upgraded to python >= 3.8
+        items = _copy.copy(DmcryptAction._ensure_value(namespace, self.dest, []))
+        items.append(values)
+        setattr(namespace, self.dest, items)
+
 
 class ValidDevice(object):
 

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -10,13 +10,17 @@ from ceph_volume.util.encryption import set_dmcrypt_no_workqueue
 def valid_osd_id(val):
     return str(int(val))
 
-class DmcryptAction(argparse._StoreTrueAction):
+class DmcryptAction(argparse._ExtendAction):
     def __init__(self, *args, **kwargs):
         super(DmcryptAction, self).__init__(*args, **kwargs)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, parser, namespace, values, option_string=None):
         set_dmcrypt_no_workqueue()
-        super(DmcryptAction, self).__call__(*args, **kwargs)
+
+        if not values:
+            values = ['block', 'db', 'wal']
+
+        super(DmcryptAction, self).__call__(parser, namespace, values, option_string)
 
 class ValidDevice(object):
 


### PR DESCRIPTION
Extend `--dmcrypt` flag to support per device type encryption if specified.

Fixes: https://tracker.ceph.com/issues/64798