### PR TITLE
squid: qa/rgw: point rgw test repos at ceph-squid release branch

### DIFF
--- a/qa/rgw/s3tests-branch.yaml
+++ b/qa/rgw/s3tests-branch.yaml
@@ -1,4 +1,4 @@
 overrides:
   s3tests:
-    force-branch: ceph-master
+    force-branch: ceph-squid
     # git_remote: https://github.com/ceph/

--- a/qa/suites/rgw/cloud-transition/tasks/cloud_transition_s3tests.yaml
+++ b/qa/suites/rgw/cloud-transition/tasks/cloud_transition_s3tests.yaml
@@ -55,7 +55,7 @@ tasks:
       lifecycle_tests: True
       cloudtier_tests: True
     #client.2:
-      #force-branch: ceph-master
+      #force-branch: ceph-squid
       #rgw_server: client.2
       #storage classes: LUKEWARM, FROZEN
       #extra_attrs: ["cloud_transition"]

--- a/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
@@ -5,11 +5,11 @@ tasks:
 - tox: [client.0]
 - ragweed:
     client.0:
-      default-branch: ceph-master
+      default-branch: ceph-squid
       rgw_server: client.0
       stages: prepare
 - ragweed:
     client.0:
-      default-branch: ceph-master
+      default-branch: ceph-squid
       rgw_server: client.0
       stages: check

--- a/qa/suites/rgw/upgrade/1-install/quincy/overrides.yaml
+++ b/qa/suites/rgw/upgrade/1-install/quincy/overrides.yaml
@@ -1,3 +1,3 @@
 overrides:
   ragweed:
-    default-branch: ceph-master # ceph-quincy doesn't have tox, but tests are the same
+    default-branch: ceph-squid # ceph-quincy doesn't have tox, but tests are the same

--- a/qa/suites/rgw/verify/tasks/ragweed.yaml
+++ b/qa/suites/rgw/verify/tasks/ragweed.yaml
@@ -1,6 +1,6 @@
 tasks:
 - ragweed:
     client.0:
-      default-branch: ceph-master
+      default-branch: ceph-squid
       rgw_server: client.0
       stages: prepare,check

--- a/qa/suites/rgw/verify/tasks/s3tests-java.yaml
+++ b/qa/suites/rgw/verify/tasks/s3tests-java.yaml
@@ -1,6 +1,6 @@
 tasks:
 - s3tests-java:
     client.0:
-        force-branch: ceph-master
+        force-branch: ceph-squid
         force-repo: https://github.com/ceph/java_s3tests.git 
 

--- a/qa/suites/smoke/basic/tasks/test/rgw_ec_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rgw_ec_s3tests.yaml
@@ -10,7 +10,7 @@ tasks:
 - tox: [client.0]
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-squid
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/smoke/basic/tasks/test/rgw_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rgw_s3tests.yaml
@@ -7,7 +7,7 @@ tasks:
 - tox: [client.0]
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-squid
       unit_test_scan: True
       rgw_server: client.0
 overrides:

--- a/qa/suites/teuthology/rgw/tasks/s3tests-fastcgi.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests-fastcgi.yaml
@@ -11,7 +11,7 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      force-branch: ceph-master
+      force-branch: ceph-squid
 overrides:
   ceph:
     fs: xfs

--- a/qa/suites/teuthology/rgw/tasks/s3tests-fcgi.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests-fcgi.yaml
@@ -12,7 +12,7 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      force-branch: ceph-master
+      force-branch: ceph-squid
 overrides:
   ceph:
     fs: xfs

--- a/qa/suites/teuthology/rgw/tasks/s3tests.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests.yaml
@@ -11,7 +11,7 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      force-branch: ceph-master
+      force-branch: ceph-squid
 overrides:
   ceph:
     fs: xfs


### PR DESCRIPTION
the s3-tests, java_s3tests, and ragweed repos now have a ceph-squid release branch, freshly forked from ceph-master

update the squid qa suites to pin the these tests to the ceph-squid branch

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
