### PR TITLE
squid: mgr/dashboard: add snap schedule M, Y frequencies

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/repeat-frequency.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/repeat-frequency.enum.ts
@@ -1,17 +1,23 @@
 export enum RepeatFrequency {
   Hourly = 'h',
   Daily = 'd',
-  Weekly = 'w'
+  Weekly = 'w',
+  Monthly = 'M',
+  Yearly = 'Y'
 }
 
 export enum RepeaFrequencySingular {
   h = 'hour',
   d = 'day',
-  w = 'week'
+  w = 'week',
+  M = 'month',
+  Y = 'year'
 }
 
 export enum RepeaFrequencyPlural {
   h = 'hours',
   d = 'days',
-  w = 'weeks'
+  w = 'weeks',
+  M = 'months',
+  Y = 'years'
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64808

---

backport of https://github.com/ceph/ceph/pull/55812
parent tracker: https://tracker.ceph.com/issues/64614

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh