### PR TITLE
quincy: mds: add debug logs during setxattr ceph.dir.subvolume

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -5151,6 +5151,11 @@ void CInode::dump(Formatter *f, int flags) const
     }
     f->close_section();
   }
+
+  auto realm = find_snaprealm();
+  inodeno_t subvol_ino = realm->get_subvolume_ino();
+  bool is_subvol = (subvol_ino && subvol_ino == ino());
+  f->dump_bool("is_subvolume", is_subvol);
 }
 
 /****** Scrub Stuff *****/


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64810

---

backport of https://github.com/ceph/ceph/pull/52631
parent tracker: https://tracker.ceph.com/issues/61958

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh