### PR TITLE
cephadm: enforce black formatting for cephadmlib

### DIFF
--- a/src/cephadm/cephadmlib/agent.py
+++ b/src/cephadm/cephadmlib/agent.py
@@ -6,13 +6,14 @@ import logging
 logger = logging.getLogger()
 
 
-def http_query(addr: str = '',
-               port: str = '',
-               data: Optional[bytes] = None,
-               endpoint: str = '',
-               ssl_ctx: Optional[Any] = None,
-               timeout: Optional[int] = 10) -> Tuple[int, str]:
-
+def http_query(
+    addr: str = '',
+    port: str = '',
+    data: Optional[bytes] = None,
+    endpoint: str = '',
+    ssl_ctx: Optional[Any] = None,
+    timeout: Optional[int] = 10,
+) -> Tuple[int, str]:
     url = f'https://{addr}:{port}{endpoint}'
     logger.debug(f'sending query to {url}')
     try:

--- a/src/cephadm/cephadmlib/container_daemon_form.py
+++ b/src/cephadm/cephadmlib/container_daemon_form.py
@@ -40,7 +40,9 @@ class ContainerDaemonForm(DaemonForm):
         """
         return []
 
-    def sidecar_containers(self, ctx: CephadmContext) -> List[SidecarContainer]:
+    def sidecar_containers(
+        self, ctx: CephadmContext
+    ) -> List[SidecarContainer]:
         """Returns a list of sidecar containers that should be executed along
         with the primary service container.
         """
@@ -167,7 +169,9 @@ def daemon_to_container(
         ctx.container_engine.update_mounts(ctx, container_mounts)
     if auto_podman_args and _is_podman:
         container_args.extend(
-            ctx.container_engine.service_args(ctx, daemon.identity.service_name)
+            ctx.container_engine.service_args(
+                ctx, daemon.identity.service_name
+            )
         )
 
     return CephContainer.for_daemon(

--- a/src/cephadm/cephadmlib/container_types.py
+++ b/src/cephadm/cephadmlib/container_types.py
@@ -147,13 +147,7 @@ class BasicContainer:
             [],
         )
 
-        return (
-            cmd_args
-            + self.container_args
-            + envs
-            + vols
-            + binds
-        )
+        return cmd_args + self.container_args + envs + vols + binds
 
     def build_run_cmd(self) -> List[str]:
         return (
@@ -190,7 +184,7 @@ class BasicContainer:
         cls,
         other: 'BasicContainer',
         *,
-        ident: Optional[DaemonIdentity] = None
+        ident: Optional[DaemonIdentity] = None,
     ) -> 'BasicContainer':
         return cls(
             other.ctx,
@@ -582,7 +576,6 @@ def extract_uid_gid(
     img: str = '',
     file_path: Union[str, List[str]] = '/var/lib/ceph',
 ) -> Tuple[int, int]:
-
     if not img:
         img = ctx.image
 

--- a/src/cephadm/cephadmlib/daemons/ceph.py
+++ b/src/cephadm/cephadmlib/daemons/ceph.py
@@ -327,7 +327,9 @@ class CephExporter(ContainerDaemonForm):
 
     def validate(self) -> None:
         if not os.path.isdir(self.sock_dir):
-            raise Error(f'Desired sock dir for ceph-exporter is not directory: {self.sock_dir}')
+            raise Error(
+                f'Desired sock dir for ceph-exporter is not directory: {self.sock_dir}'
+            )
 
     def container(self, ctx: CephadmContext) -> CephContainer:
         ctr = daemon_to_container(ctx, self)

--- a/src/cephadm/cephadmlib/daemons/node_proxy.py
+++ b/src/cephadm/cephadmlib/daemons/node_proxy.py
@@ -81,9 +81,17 @@ class NodeProxy(ContainerDaemonForm):
         data_dir = self.identity.data_dir(ctx.data_dir)
         # TODO: update this when we have the actual location
         # in the ceph container we are going to keep node-proxy
-        mounts.update({os.path.join(data_dir, 'node-proxy.json'): '/usr/share/ceph/node-proxy.json:z'})
+        mounts.update(
+            {
+                os.path.join(
+                    data_dir, 'node-proxy.json'
+                ): '/usr/share/ceph/node-proxy.json:z'
+            }
+        )
 
-    def customize_process_args(self, ctx: CephadmContext, args: List[str]) -> None:
+    def customize_process_args(
+        self, ctx: CephadmContext, args: List[str]
+    ) -> None:
         # TODO: this corresponds with the mount location of
         # the config in _get_container_mounts above. They
         # will both need to be updated when we have a proper

--- a/src/cephadm/cephadmlib/firewalld.py
+++ b/src/cephadm/cephadmlib/firewalld.py
@@ -14,7 +14,6 @@ logger = logging.getLogger()
 
 
 class Firewalld(object):
-
     # for specifying ports we should always open when opening
     # ports for a daemon of that type. Main use case is for ports
     # that we should open when deploying the daemon type but that
@@ -51,26 +50,44 @@ class Firewalld(object):
     def enable_service_for(self, svc: str) -> None:
         assert svc, 'service name not provided'
         if not self.available:
-            logger.debug('Not possible to enable service <%s>. firewalld.service is not available' % svc)
+            logger.debug(
+                'Not possible to enable service <%s>. firewalld.service is not available'
+                % svc
+            )
             return
 
         if not self.cmd:
             raise RuntimeError('command not defined')
 
-        out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--query-service', svc], verbosity=CallVerbosity.DEBUG)
+        out, err, ret = call(
+            self.ctx,
+            [self.cmd, '--permanent', '--query-service', svc],
+            verbosity=CallVerbosity.DEBUG,
+        )
         if ret:
-            logger.info('Enabling firewalld service %s in current zone...' % svc)
-            out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--add-service', svc])
+            logger.info(
+                'Enabling firewalld service %s in current zone...' % svc
+            )
+            out, err, ret = call(
+                self.ctx, [self.cmd, '--permanent', '--add-service', svc]
+            )
             if ret:
                 raise RuntimeError(
-                    'unable to add service %s to current zone: %s' % (svc, err))
+                    'unable to add service %s to current zone: %s'
+                    % (svc, err)
+                )
         else:
-            logger.debug('firewalld service %s is enabled in current zone' % svc)
+            logger.debug(
+                'firewalld service %s is enabled in current zone' % svc
+            )
 
     def open_ports(self, fw_ports):
         # type: (List[int]) -> None
         if not self.available:
-            logger.debug('Not possible to open ports <%s>. firewalld.service is not available' % fw_ports)
+            logger.debug(
+                'Not possible to open ports <%s>. firewalld.service is not available'
+                % fw_ports
+            )
             return
 
         if not self.cmd:
@@ -78,20 +95,36 @@ class Firewalld(object):
 
         for port in fw_ports:
             tcp_port = str(port) + '/tcp'
-            out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--query-port', tcp_port], verbosity=CallVerbosity.DEBUG)
+            out, err, ret = call(
+                self.ctx,
+                [self.cmd, '--permanent', '--query-port', tcp_port],
+                verbosity=CallVerbosity.DEBUG,
+            )
             if ret:
-                logger.info('Enabling firewalld port %s in current zone...' % tcp_port)
-                out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--add-port', tcp_port])
+                logger.info(
+                    'Enabling firewalld port %s in current zone...' % tcp_port
+                )
+                out, err, ret = call(
+                    self.ctx,
+                    [self.cmd, '--permanent', '--add-port', tcp_port],
+                )
                 if ret:
-                    raise RuntimeError('unable to add port %s to current zone: %s' %
-                                       (tcp_port, err))
+                    raise RuntimeError(
+                        'unable to add port %s to current zone: %s'
+                        % (tcp_port, err)
+                    )
             else:
-                logger.debug('firewalld port %s is enabled in current zone' % tcp_port)
+                logger.debug(
+                    'firewalld port %s is enabled in current zone' % tcp_port
+                )
 
     def close_ports(self, fw_ports):
         # type: (List[int]) -> None
         if not self.available:
-            logger.debug('Not possible to close ports <%s>. firewalld.service is not available' % fw_ports)
+            logger.debug(
+                'Not possible to close ports <%s>. firewalld.service is not available'
+                % fw_ports
+            )
             return
 
         if not self.cmd:
@@ -99,13 +132,22 @@ class Firewalld(object):
 
         for port in fw_ports:
             tcp_port = str(port) + '/tcp'
-            out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--query-port', tcp_port], verbosity=CallVerbosity.DEBUG)
+            out, err, ret = call(
+                self.ctx,
+                [self.cmd, '--permanent', '--query-port', tcp_port],
+                verbosity=CallVerbosity.DEBUG,
+            )
             if not ret:
                 logger.info('Disabling port %s in current zone...' % tcp_port)
-                out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--remove-port', tcp_port])
+                out, err, ret = call(
+                    self.ctx,
+                    [self.cmd, '--permanent', '--remove-port', tcp_port],
+                )
                 if ret:
-                    raise RuntimeError('unable to remove port %s from current zone: %s' %
-                                       (tcp_port, err))
+                    raise RuntimeError(
+                        'unable to remove port %s from current zone: %s'
+                        % (tcp_port, err)
+                    )
                 else:
                     logger.info(f'Port {tcp_port} disabled')
             else:

--- a/src/cephadm/cephadmlib/systemd_unit.py
+++ b/src/cephadm/cephadmlib/systemd_unit.py
@@ -78,7 +78,10 @@ def _write_init_containers_unit_file(
 
 
 def _write_sidecar_unit_file(
-    dest: IO, ctx: CephadmContext, primary: DaemonIdentity, sidecar: DaemonSubIdentity
+    dest: IO,
+    ctx: CephadmContext,
+    primary: DaemonIdentity,
+    sidecar: DaemonSubIdentity,
 ) -> None:
     has_docker_engine = isinstance(ctx.container_engine, Docker)
     has_podman_engine = isinstance(ctx.container_engine, Podman)
@@ -128,9 +131,7 @@ def _install_extended_systemd_services(
             difh = estack.enter_context(
                 write_new(pinfo.drop_in_file, perms=None)
             )
-            _write_drop_in(
-                difh, ctx, identity, enable_init_containers, sids
-            )
+            _write_drop_in(difh, ctx, identity, enable_init_containers, sids)
 
 
 def _get_unit_file(ctx: CephadmContext, fsid: str) -> str:

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     py3
     mypy
-    fix
     flake8
+    check-black
 skipsdist = true
 
 [flake8]
@@ -49,14 +49,6 @@ deps =
     -rzipapp-reqs.txt
     -c{toxinidir}/../mypy-constrains.txt
 commands = mypy --config-file ../mypy.ini {posargs:cephadm.py cephadmlib}
-
-[testenv:fix]
-basepython = python3
-deps =
-    autopep8
-commands =
-    python --version
-    autopep8 {[autopep8]addopts} {posargs: cephadm.py}
 
 [testenv:flake8]
 basepython = python3

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py3
-    mypy
     flake8
+    mypy
     check-black
+    py3
 skipsdist = true
 
 [flake8]


### PR DESCRIPTION
A few months ago when we were starting the cephadm refactoring effort in
earnest we agreed to use `black` to format the python files we moved
into `cephadmlib` (while leaving the formatting of cephadm.py as-is).
We created tox rules to check or apply black formatting but promptly
got lazy and stopped running the checks manually - they were not run
automatically.

Change the default environment list to call check-black to start
enforcing the use of black style formatting. At the same time, remove
the `fix` environment entirely. It is liable to leave uncommitted changes
in your working tree when run - unlike check-black. This moves cephadm
practices closer to ones I've seen widely used in other python
codebases.

Note that cephadm.py remains outside of this rule - it only requires
pep8 formatting (via flake8). cephadm.py should continue to be
disassembled and components moved into cephadmlib over time. flake8 also remains
in effect for cephadmlib, it's fast, finds obvious mistakes and does
some code-level linting (like unused vars) that black does not.



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), :pencil2: reformatting only
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
  - [x] :fountain_pen: reformatting only

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
