### PR TITLE
quincy: python-common: fix osdspec_affinity check

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/selector.py
+++ b/src/python-common/ceph/deployment/drive_selection/selector.py
@@ -132,7 +132,7 @@ class DriveSelection(object):
                 other_osdspec_affinity = ''
                 for lv in disk.lvs:
                     if 'osdspec_affinity' in lv.keys():
-                        if lv['osdspec_affinity'] != self.spec.service_id:
+                        if lv['osdspec_affinity'] != str(self.spec.service_id):
                             other_osdspec_affinity = lv['osdspec_affinity']
                             break
                 if other_osdspec_affinity:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63816

---

backport of https://github.com/ceph/ceph/pull/54786
parent tracker: https://tracker.ceph.com/issues/63729

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh