### PR TITLE
reef: mgr/cephadm: update timestamp on repeat daemon/service events

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1698,6 +1698,8 @@ class EventStore():
 
         for e in self.events[event.kind_subject()]:
             if e.message == event.message:
+                # if subject and message match, just update the timestamp
+                e.created = event.created
                 return
 
         self.events[event.kind_subject()].append(event)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63434

---

backport of https://github.com/ceph/ceph/pull/54077
parent tracker: https://tracker.ceph.com/issues/63238

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh