### PR TITLE
reef: mgr/cephadm: discovery service (port 8765) fails on ipv6 only clusters

### DIFF
--- a/src/pybind/mgr/cephadm/ssl_cert_utils.py
+++ b/src/pybind/mgr/cephadm/ssl_cert_utils.py
@@ -46,7 +46,7 @@ class SSLCerts:
         root_builder = root_builder.public_key(root_public_key)
         root_builder = root_builder.add_extension(
             x509.SubjectAlternativeName(
-                [x509.IPAddress(ipaddress.IPv4Address(addr))]
+                [x509.IPAddress(ipaddress.ip_address(addr))]
             ),
             critical=False
         )
@@ -70,12 +70,9 @@ class SSLCerts:
     def generate_cert(self, host: str, addr: str) -> Tuple[str, str]:
         have_ip = True
         try:
-            ip = x509.IPAddress(ipaddress.IPv4Address(addr))
+            ip = x509.IPAddress(ipaddress.ip_address(addr))
         except Exception:
-            try:
-                ip = x509.IPAddress(ipaddress.IPv6Address(addr))
-            except Exception:
-                have_ip = False
+            have_ip = False
 
         private_key = rsa.generate_private_key(
             public_exponent=65537, key_size=4096, backend=default_backend())

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -12,6 +12,7 @@ import socket
 import time
 import logging
 import sys
+from ipaddress import ip_address
 from threading import Lock, Condition, Event
 from typing import no_type_check, NewType
 import urllib
@@ -413,7 +414,9 @@ def test_port_allocation(addr: str, port: int) -> None:
     If no exception is raised, the port can be assumed available
     """
     try:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        ip_version = ip_address(addr).version
+        addr_family = socket.AF_INET if ip_version == 4 else socket.AF_INET6
+        sock = socket.socket(addr_family, socket.SOCK_STREAM)
         sock.bind((addr, port))
         sock.close()
     except socket.error as e:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63448

---

backport of https://github.com/ceph/ceph/pull/54285
parent tracker: https://tracker.ceph.com/issues/63388

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh