### PR TITLE
reef: cephadm: fix get_version for nvmeof

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -1220,7 +1220,7 @@ class CephNvmeof(object):
         out, err, ret = call(ctx,
                              [ctx.container_engine.path, 'inspect',
                               '--format', '{{index .Config.Labels "io.ceph.version"}}',
-                              ctx.image])
+                              container_id])
         version = None
         if ret == 0:
             version = out.strip()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64414

---

backport of https://github.com/ceph/ceph/pull/55355
parent tracker: https://tracker.ceph.com/issues/64229

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh