### PR TITLE
reef: cephadm: rm podman-auth.json if removing last cluster

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -8218,6 +8218,13 @@ def _rm_cluster(ctx: CephadmContext, keep_logs: bool, zap_osds: bool) -> None:
             for fname in glob(f'{ctx.log_dir}/cephadm.log*'):
                 os.remove(fname)
 
+        try:
+            Path('/etc/ceph/podman-auth.json').unlink()
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            logger.debug(f'Could not remove podman-auth.json: {e}')
+
     # rm sysctl settings
     sysctl_dirs: List[Path] = [Path(ctx.sysctl_dir), Path('/usr/lib/sysctl.d')]
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64634

---

backport of https://github.com/ceph/ceph/pull/55588
parent tracker: https://tracker.ceph.com/issues/64433

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh