### PR TITLE
quincy: rgw/beast: Enable SSL session-id reuse speedup mechanism

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -481,7 +481,7 @@ unsigned short parse_port(const char *input, boost::system::error_code& ec)
   }
   return port;
 }
-	
+
 tcp::endpoint parse_endpoint(boost::asio::string_view input,
                              unsigned short default_port,
                              boost::system::error_code& ec)
@@ -1033,10 +1033,12 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
         handle_connection(context, env, stream, timeout, header_limit,
                           conn->buffer, true, pause_mutex, scheduler.get(),
                           ec, yield);
-        if (!ec) {
+
+        if (!ec || ec == http::error::end_of_stream) {
           // ssl shutdown (ignoring errors)
           stream.async_shutdown(yield[ec]);
         }
+
         conn->socket.shutdown(tcp::socket::shutdown_both, ec);
       }, make_stack_allocator());
   } else {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64767

---

backport of https://github.com/ceph/ceph/pull/55967
parent tracker: https://tracker.ceph.com/issues/64719

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh