### PR TITLE
reef: rgw/beast: Enable SSL session-id reuse speedup mechanism

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -1036,10 +1036,10 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
         handle_connection(context, env, stream, timeout, header_limit,
                           conn->buffer, true, pause_mutex, scheduler.get(),
                           uri_prefix, ec, yield);
-        if (!ec) {
-          // ssl shutdown (ignoring errors)
-          stream.async_shutdown(yield[ec]);
-        }
+
+        // ssl shutdown (ignoring errors)
+        stream.async_shutdown(yield[ec]);
+        
         conn->socket.shutdown(tcp::socket::shutdown_both, ec);
       }, make_stack_allocator());
   } else {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64766

---

backport of https://github.com/ceph/ceph/pull/55967
parent tracker: https://tracker.ceph.com/issues/64719

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh