### PR TITLE
squid: RGW - Swift retarget needs bucket set on object

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2597,6 +2597,7 @@ RGWOp* RGWSwiftWebsiteHandler::get_ws_index_op()
   } else {
     s->object->set_name(s->bucket->get_info().website_conf.get_index_doc());
   }
+  s->object->set_bucket(s->bucket.get());
 
   auto getop = new RGWGetObj_ObjStore_SWIFT;
   getop->set_get_data(boost::algorithm::equals("GET", s->info.method));


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64834

---

backport of https://github.com/ceph/ceph/pull/56003
parent tracker: https://tracker.ceph.com/issues/63684

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh