### PR TITLE
reef: mgr/dashboard: debugging make check failure

### DIFF
--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -6,7 +6,7 @@ requests
 Routes
 -e ../../../python-common
 prettytable
-pytest
+pytest==8.0.2
 pyyaml
 natsort
 setuptools


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64836

---

backport of https://github.com/ceph/ceph/pull/55920
parent tracker: https://tracker.ceph.com/issues/64684

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh