### PR TITLE
common/hobject: fix hobject_t::to_str()

### DIFF
--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -94,7 +94,7 @@ string hobject_t::to_str() const
     out = fmt::format(FMT_COMPILE("{:016X}.{:08X}.snapdir."), poolid, revhash);
   } else {
     out = fmt::format(
-	FMT_COMPILE("{:016X}.{:08X}.{:X}."), poolid, revhash,
+	FMT_COMPILE("{:016X}.{:08X}.{:x}."), poolid, revhash,
 	(unsigned long long)snap);
   }
 


### PR DESCRIPTION
Introduced recently in: e462f76aedbb89e8db57dc2324d4f5e9fe54cf9e
Causing the following failures:
```
[  FAILED  ] SnapMapperTest.CheckObjectKeyFormat
[  FAILED  ] SnapMapperTest.CheckRawKeyFormat
```
with the following error:
```
2024-03-09T17:31:57.117 INFO:teuthology.orchestra.run.smithi060.stdout:Expected equality of these values:
2024-03-09T17:31:57.117 INFO:teuthology.orchestra.run.smithi060.stdout:  object_key
2024-03-09T17:31:57.117 INFO:teuthology.orchestra.run.smithi060.stdout:    Which is: "OBJ_.1_7FFFFFFFFFFFFFEB.76543210.FFFFFFFFFFFFFFEC.test%uobject..namespace"
2024-03-09T17:31:57.117 INFO:teuthology.orchestra.run.smithi060.stdout:  test_object_key
2024-03-09T17:31:57.117 INFO:teuthology.orchestra.run.smithi060.stdout:    Which is: "OBJ_.1_7FFFFFFFFFFFFFEB.76543210.ffffffffffffffec.test%uobject..namespace"
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
