### PR TITLE
cephadm.py: add timemaster to timesync services list

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -4418,6 +4418,7 @@ def check_time_sync(ctx, enabler=None):
         'ntp.service',  # 18.04 (at least)
         'ntpsec.service',  # 20.04 (at least) / buster
         'openntpd.service',  # ubuntu / debian
+        'timemaster.service',  # linuxptp on ubuntu/debian
     ]
     if not check_units(ctx, units, enabler):
         logger.warning('No time sync service is running; checked for %s' % units)


### PR DESCRIPTION
On debian/ubuntu, if you need PTP, it's possible to use the linuxptp package for time-synchonization. In that case the systemd service is called timemaster and is a wrapper for chrony/ntpd/phc2sys/ptp4l.
This commits add timemaster.service to the list of allowed timesync services.