### PR TITLE
reef: qa: Add benign cluster warning from ec-inconsistent-hinfo test to ignorelist

### DIFF
--- a/qa/suites/rados/singleton/all/ec-inconsistent-hinfo.yaml
+++ b/qa/suites/rados/singleton/all/ec-inconsistent-hinfo.yaml
@@ -30,6 +30,7 @@ tasks:
       - slow request
       - unfound
       - \(POOL_APP_NOT_ENABLED\)
+      - enough copies available
     conf:
       osd:
         osd min pg log entries: 5


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64881

---

backport of https://github.com/ceph/ceph/pull/55764
parent tracker: https://tracker.ceph.com/issues/64573

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh