### PR TITLE
squid: rgw/kafka: set message timeout to 5 seconds

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3983,7 +3983,7 @@ options:
     are sent to it for more than the time defined.
     Note that the connection will not be considered idle, even if it is down,
     as long as there are attempts to send messages to it.
-  default: 30
+  default: 300
   services:
   - rgw
   with_legacy: true
@@ -3996,6 +3996,16 @@ options:
     The same values times 3 will be used to sleep if there were no messages
     sent or received across all kafka connections
   default: 10
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_kafka_message_timeout
+  type: uint 
+  level: advanced
+  desc: This is the maximum time in milliseconds to deliver a message (including retries)
+  long_desc: Delivery error occurs when the message timeout is exceeded.
+    Value must be greater than zero, if set to zero, a value of 1 millisecond will be used.
+  default: 5000
   services:
   - rgw
   with_legacy: true


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64887

---

backport of https://github.com/ceph/ceph/pull/55952
parent tracker: https://tracker.ceph.com/issues/64710

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh