### PR TITLE
quincy: qa: set mds config with `config set` for a particular test

### DIFF
--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -494,8 +494,8 @@ class TestDataScan(CephFSTestCase):
         split_size = 100 * file_count
 
         # Make sure and disable dirfrag auto merging and splitting
-        self.fs.mon_manager.run_cluster_cmd(args='config set mds mds_bal_merge_size 0')
-        self.fs.mon_manager.run_cluster_cmd(args=f'config set mds mds_bal_split_size {split_size}')
+        self.config_set('mds', 'mds_bal_merge_size', 0)
+        self.config_set('mds', 'mds_bal_split_size', split_size)
 
         # Create a directory of `file_count` files, each named after its
         # decimal number and containing the string of its decimal number

--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -491,10 +491,11 @@ class TestDataScan(CephFSTestCase):
 
         file_count = 100
         file_names = ["%s" % n for n in range(0, file_count)]
+        split_size = 100 * file_count
 
         # Make sure and disable dirfrag auto merging and splitting
-        self.fs.set_ceph_conf('mds', 'mds bal merge size', 0)
-        self.fs.set_ceph_conf('mds', 'mds bal split size', 100 * file_count)
+        self.fs.mon_manager.run_cluster_cmd(args='config set mds mds_bal_merge_size 0')
+        self.fs.mon_manager.run_cluster_cmd(args=f'config set mds mds_bal_split_size {split_size}')
 
         # Create a directory of `file_count` files, each named after its
         # decimal number and containing the string of its decimal number

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -674,7 +674,12 @@ void MDBalancer::queue_merge(CDir *dir)
       }
       bool all = true;
       for (auto& sib : sibs) {
-        if (!sib->is_auth() || !sib->should_merge()) {
+	auto is_auth = sib->is_auth();
+	auto should_merge = sib->should_merge();
+
+	dout(20) << ": sib=" << *sib << ", is_auth=" << is_auth << ", should_merge="
+		 << should_merge << dendl;
+        if (!is_auth || !should_merge) {
           all = false;
           break;
         }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64046

---

backport of https://github.com/ceph/ceph/pull/54590
parent tracker: https://tracker.ceph.com/issues/57087

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh