### PR TITLE
quincy: qa: `fs volume rename` requires `fs fail` and `refuse_client_session` set

### DIFF
--- a/qa/suites/fs/cephadm/renamevolume/1-rename.yaml
+++ b/qa/suites/fs/cephadm/renamevolume/1-rename.yaml
@@ -1,7 +1,11 @@
 tasks:
 - cephadm.shell:
     host.a:
+      - ceph fs fail foo
+      - ceph fs set foo refuse_client_session true
       - ceph fs volume rename foo bar --yes-i-really-mean-it
+      - ceph fs set bar joinable true
+      - ceph fs set bar refuse_client_session false
 - fs.ready:
     timeout: 300
 - cephadm.shell:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64217

---

backport of https://github.com/ceph/ceph/pull/55309
parent tracker: https://tracker.ceph.com/issues/64174

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh