### PR TITLE
squid: rgw: rgw-restore-bucket-index -- sort uses specified temp dir

### DIFF
--- a/src/rgw/rgw-restore-bucket-index
+++ b/src/rgw/rgw-restore-bucket-index
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# version 2024-03-04
+# version 2024-03-11
 
 # rgw-restore-bucket-index is an EXPERIMENTAL tool to use in case
 # bucket index entries for objects in the bucket are somehow lost. It
@@ -65,7 +65,7 @@ EOF
 # cleans all temporary files
 clean() {
   if [ "$clean_temps" == 1 ] ;then
-    rm -f $bkt_entry $temp_file_list
+    rm -f $bkt_entry $temp_file_list \
        $zone_info $olh_info_enc $olh_info_json
   fi
 }
@@ -272,7 +272,7 @@ handle_versioned() {
 		test_temp_space
 		rados -p $pool stat2 $obj --object-locator "$loc"
 	    done | # output of stat2, which includes mtime
-	    sort -k 3 | # stat2 but sorted by mtime earlier to later
+	    sort -T $temp_dir -k 3 | # stat2 but sorted by mtime earlier to later
 	    grep -v -e "$filter_out_last_instance" | # remove the final instance in case it's not last
 
 	    # sed 1) removes pool and marker, 2) removes indicator of


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64909

---

backport of https://github.com/ceph/ceph/pull/56133
parent tracker: https://tracker.ceph.com/issues/64875

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh