### PR TITLE
async/rdma:  When creating qp fails, ceph service not crash and try again. 

### DIFF
--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -1260,9 +1260,9 @@ Infiniband::CompletionQueue* Infiniband::create_comp_queue(
 
 Infiniband::QueuePair::~QueuePair()
 {
-  ldout(cct, 20) << __func__ << " destroy Queue Pair, qp number: " << qp->qp_num << " left SQ WR " << recv_queue.size() << dendl;
+  ldout(cct, 20) << __func__ << " destroy Queue Pair: " << this  << " left SQ WR " << recv_queue.size() << dendl;
   if (qp) {
-    ldout(cct, 20) << __func__ << " destroy qp=" << qp << dendl;
+    ldout(cct, 20) << __func__ << " destroy qp=" << qp << " qp number=" << qp->qp_num  << dendl;
     ceph_assert(!ibv_destroy_qp(qp));
   }
 

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -1109,7 +1109,13 @@ void Infiniband::init()
   memory_manager->create_tx_pool(cct->_conf->ms_async_rdma_buffer_size, tx_queue_len);
 
   if (support_srq) {
-    srq = create_shared_receive_queue(rx_queue_len, MAX_SHARED_RX_SGE_COUNT);
+    while (!srq) {
+      srq = create_shared_receive_queue(rx_queue_len, MAX_SHARED_RX_SGE_COUNT);
+      if (!srq) {
+        lderr(cct) << __func__ << " failed to create srq. " << cpp_strerror(errno) << dendl;
+        sleep(5);
+      }
+    }
     post_chunks_to_rq(rx_queue_len, NULL); //add to srq
   }
 }

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -74,7 +74,10 @@ RDMAConnectedSocketImpl::~RDMAConnectedSocketImpl()
 {
   ldout(cct, 20) << __func__ << " destruct." << dendl;
   cleanup();
-  worker->remove_pending_conn(this);
+  //create qp failed, pending_conn not exist, so skip.
+  if(qp) {
+    worker->remove_pending_conn(this);
+  }
   dispatcher->schedule_qp_destroy(local_qpn);
 
   for (unsigned i=0; i < wc.size(); ++i) {

--- a/src/msg/async/rdma/RDMAServerSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAServerSocketImpl.cc
@@ -115,8 +115,7 @@ int RDMAServerSocketImpl::accept(ConnectedSocket *sock, const SocketOptions &opt
   server = new RDMAConnectedSocketImpl(cct, ib, dispatcher, dynamic_cast<RDMAWorker*>(w));
   if (!server->get_qp()) {
     lderr(cct) << __func__ << " server->qp is null" << dendl;
-    // cann't use delete server here, destructor will fail.
-    server->cleanup();
+    delete server;
     ::close(sd);
     return -1;
   }

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -721,6 +721,13 @@ int RDMAWorker::connect(const entity_addr_t &addr, const SocketOptions &opts, Co
   } else {
     p = new RDMAConnectedSocketImpl(cct, ib, dispatcher, this);
   }
+
+  if (!p->get_qp()) {
+    lderr(cct) << __func__ << " p->qp is null: " << cpp_strerror(errno) << dendl;
+    delete p;
+    return -1;
+  }
+
   int r = p->try_connect(addr, opts);
 
   if (r < 0) {


### PR DESCRIPTION
handle failed qp gracefully.

Signed-off-by: WeiGuo Ren [weiguo.ren@xtaotech.com](mailto:weiguo.ren@xtaotech.com)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
