### PR TITLE
squid: mds: disable `defer_client_eviction_on_laggy_osds' by default

### DIFF
--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1582,7 +1582,7 @@ options:
   long_desc: Laggy OSD(s) can make clients laggy or unresponsive, this can
     lead to their eviction, this option once enabled can help defer client
     eviction.
-  default: true
+  default: false
   services:
   - mds
   flags:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64924

---

backport of https://github.com/ceph/ceph/pull/55922
parent tracker: https://tracker.ceph.com/issues/64685

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh