### PR TITLE
squid: rgw/multisite: add x-rgw-replicated-at header to replicated objects

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,5 +1,8 @@
 >=19.0.0
 
+* RGW: GetObject and HeadObject requests now return a x-rgw-replicated-at
+  header for replicated objects. This timestamp can be compared against the
+  Last-Modified header to determine how long the object took to replicate.
 * The cephfs-shell utility is now packaged for RHEL 9 / CentOS 9 as required
   python dependencies are now available in EPEL9.
 * RGW: S3 multipart uploads using Server-Side Encryption now replicate correctly in

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -21,6 +21,7 @@
 #include "common/Formatter.h"
 #include "common/Throttle.h"
 #include "common/BackTrace.h"
+#include "common/ceph_time.h"
 
 #include "rgw_sal.h"
 #include "rgw_zone.h"
@@ -4412,6 +4413,13 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     bufferlist bl;
     encode(trace, bl);
     cb.get_attrs()[RGW_ATTR_OBJ_REPLICATION_TRACE] = std::move(bl);
+  }
+  {
+    // add x-amz-replicated-at
+    bufferlist bl;
+    ceph::real_time timestamp = real_clock::now();
+    encode(timestamp, bl);
+    cb.get_attrs()[RGW_ATTR_OBJ_REPLICATION_TIMESTAMP] = std::move(bl);
   }
 
   if (source_zone.empty()) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8367,7 +8367,12 @@ next:
 
     formatter->open_object_section("attrs");
     for (iter = other_attrs.begin(); iter != other_attrs.end(); ++iter) {
-      dump_string(iter->first.c_str(), iter->second, formatter.get());
+      bufferlist& bl = iter->second;
+      if (iter->first == RGW_ATTR_OBJ_REPLICATION_TIMESTAMP) {
+        decode_dump<ceph::real_time>("user.rgw.replicated-at", bl, formatter.get());
+      } else {
+        dump_string(iter->first.c_str(), iter->second, formatter.get());
+      }
     }
     formatter->close_section();
     formatter->close_section();

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -145,6 +145,7 @@ using ceph::crypto::MD5;
 
 #define RGW_ATTR_OBJ_REPLICATION_STATUS RGW_ATTR_PREFIX "amz-replication-status"
 #define RGW_ATTR_OBJ_REPLICATION_TRACE RGW_ATTR_PREFIX "replication-trace"
+#define RGW_ATTR_OBJ_REPLICATION_TIMESTAMP RGW_ATTR_PREFIX "replicated-at"
 
 /* IAM Policy */
 #define RGW_ATTR_IAM_POLICY	RGW_ATTR_PREFIX "iam-policy"

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -464,6 +464,15 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs,
       }
     } catch (const buffer::error&) {} // omit x-rgw-replicated-from headers
   }
+  if (auto i = attrs.find(RGW_ATTR_OBJ_REPLICATION_TIMESTAMP);
+      i != attrs.end()) {
+    try {
+      ceph::real_time replicated_time;
+      decode(replicated_time, i->second);
+      dump_time(s, "x-rgw-replicated-at", replicated_time);
+    } catch (const buffer::error&) {}
+  }
+
   if (multipart_parts_count) {
     dump_header(s, "x-amz-mp-parts-count", *multipart_parts_count);
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64949

---

backport of https://github.com/ceph/ceph/pull/55503
parent tracker: https://tracker.ceph.com/issues/64365

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh