### PR TITLE
Fixes the error prompted by the check bugprone-branch-clone in clang-…

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5430,20 +5430,21 @@ void OSD::resume_creating_pg()
     }
   }
   version_t start = get_osdmap_epoch() + 1;
-  if (have_pending_creates) {
-    // don't miss any new osdmap deleting PGs
+  if (have_pending_creates || do_sub_pg_creates) {
     if (monc->sub_want("osdmap", start, 0)) {
-      dout(4) << __func__ << ": resolicit osdmap from mon since "
-	      << start << dendl;
-      do_renew_subs = true;
-    }
-  } else if (do_sub_pg_creates) {
-    // no need to subscribe the osdmap continuously anymore
-    // once the pgtemp and/or mon_subscribe(pg_creates) is sent
-    if (monc->sub_want_increment("osdmap", start, CEPH_SUBSCRIBE_ONETIME)) {
-      dout(4) << __func__ << ": re-subscribe osdmap(onetime) since "
-	      << start << dendl;
-      do_renew_subs = true;
+        dout(4) << __func__ << ": resolicit osdmap from mon since "
+                << start << dendl;
+        do_renew_subs = true;
+    } else {
+        // No need to subscribe the osdmap continuously anymore
+        // once the pgtemp and/or mon_subscribe(pg_creates) is sent
+        if (do_sub_pg_creates) {
+            if (monc->sub_want_increment("osdmap", start, CEPH_SUBSCRIBE_ONETIME)) {
+                dout(4) << __func__ << ": re-subscribe osdmap(onetime) since "
+                        << start << dendl;
+                do_renew_subs = true;
+            }
+        }
     }
   }
 


### PR DESCRIPTION
When executing the command: `clang-tidy -checks='bugprone-branch-clone' OSD.cc` 

clang-tidy gave the warning: `warning: repeated branch in conditional chain [bugprone-branch-clone]`

This PR aims to fix it.   

Signed-off-by: Suyash Dongre suyashd999@gmail.com

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
