### PR TITLE
common/Journald: fix alias and mis-align

### DIFF
--- a/src/common/Journald.cc
+++ b/src/common/Journald.cc
@@ -125,7 +125,7 @@ MESSAGE
 
     uint64_t msg_len = htole64(e.size());
     meta_buf.resize(meta_buf.size() + sizeof(msg_len));
-    *(reinterpret_cast<uint64_t*>(meta_buf.end()) - 1) = htole64(e.size());
+    memcpy(meta_buf.end() - sizeof(msg_len), &msg_len, sizeof(msg_len));
 
     meta_vec().iov_base = meta_buf.data();
     meta_vec().iov_len = meta_buf.size();

--- a/src/common/Journald.cc
+++ b/src/common/Journald.cc
@@ -87,6 +87,8 @@ class EntryEncoderBase {
     m_msg_vec[0].iov_len = static_segment.size();
   }
 
+  EntryEncoderBase(const EntryEncoderBase&) = delete; // we have self-referencing pointers
+
   constexpr struct iovec *iovec() { return this->m_msg_vec; }
   constexpr std::size_t iovec_len()
   {


### PR DESCRIPTION
We are using `-fno-strict-aliasing` compiler flags, so this should be fine currently, at least on x86-64, which supports unaligned memory access. But we'd better clean this up.

I just working on another project, and learned this may cause issue.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
