### PR TITLE
cmake: enable building with Sanitizers

### DIFF
--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -19,6 +19,12 @@ function(add_ceph_test test_name test_path)
     PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}:${CMAKE_SOURCE_DIR}/src:$ENV{PATH}
     PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules/lib.3:${CMAKE_SOURCE_DIR}/src/pybind
     CEPH_BUILD_VIRTUALENV=${CEPH_BUILD_VIRTUALENV})
+  if(WITH_UBSAN)
+    set_property(TEST ${test_name}
+      APPEND
+      PROPERTY ENVIRONMENT
+      UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1)
+  endif()
   set_property(TEST ${test_name}
     PROPERTY TIMEOUT ${CEPH_TEST_TIMEOUT})
   # Crimson seastar unittest always run with --smp N to start N threads. By default, crimson seastar unittest

--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -25,6 +25,15 @@ function(add_ceph_test test_name test_path)
       PROPERTY ENVIRONMENT
       UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1)
   endif()
+  if(WITH_ASAN)
+    # AddressSanitizer: odr-violation: global 'ceph::buffer::list::always_empty_bptr' at
+    # /home/jenkins-build/build/workspace/ceph-pull-requests/src/common/buffer.cc:1267:34
+    # see https://tracker.ceph.com/issues/65098
+    set_property(TEST ${test_name}
+      APPEND
+      PROPERTY ENVIRONMENT
+      ASAN_OPTIONS=detect_odr_violation=0)
+  endif()
   set_property(TEST ${test_name}
     PROPERTY TIMEOUT ${CEPH_TEST_TIMEOUT})
   # Crimson seastar unittest always run with --smp N to start N threads. By default, crimson seastar unittest

--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -32,7 +32,8 @@ function(add_ceph_test test_name test_path)
     set_property(TEST ${test_name}
       APPEND
       PROPERTY ENVIRONMENT
-      ASAN_OPTIONS=detect_odr_violation=0)
+      ASAN_OPTIONS=detect_odr_violation=0
+      LSAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/qa/lsan.supp)
   endif()
   set_property(TEST ${test_name}
     PROPERTY TIMEOUT ${CEPH_TEST_TIMEOUT})

--- a/cmake/modules/Distutils.cmake
+++ b/cmake/modules/Distutils.cmake
@@ -73,6 +73,8 @@ function(distutils_add_cython_module target name src)
   set(PY_CC ${compiler_launcher} ${CMAKE_C_COMPILER} ${c_compiler_arg1})
   set(PY_CXX ${compiler_launcher} ${CMAKE_CXX_COMPILER} ${cxx_compiler_arg1})
   set(PY_LDSHARED ${link_launcher} ${CMAKE_C_COMPILER} ${c_compiler_arg1} "-shared")
+  string(REPLACE " " ";" PY_LDFLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+  list(APPEND PY_LDFLAGS -L${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
   execute_process(COMMAND "${Python3_EXECUTABLE}" -c
     "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"
@@ -98,7 +100,7 @@ function(distutils_add_cython_module target name src)
     CXX="${PY_CXX}"
     LDSHARED="${PY_LDSHARED}"
     OPT=\"-DNDEBUG -g -fwrapv -O2 -w\"
-    LDFLAGS=-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    LDFLAGS="${PY_LDFLAGS}"
     CYTHON_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
     CEPH_LIBDIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
     ${Python3_EXECUTABLE} ${setup_py}
@@ -130,7 +132,7 @@ function(distutils_install_cython_module name)
                         -D'void0=dead_function\(void\)' \
                         -D'__Pyx_check_single_interpreter\(ARG\)=ARG\#\#0' \
                         ${CFLAG_DISABLE_VTA}\")
-    set(ENV{LDFLAGS} \"-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}\")
+    set(ENV{LDFLAGS} \"${PY_LDFLAGS}\")
     set(ENV{CYTHON_BUILD_DIR} \"${CMAKE_CURRENT_BINARY_DIR}\")
     set(ENV{CEPH_LIBDIR} \"${CMAKE_LIBRARY_OUTPUT_DIRECTORY}\")
 

--- a/cmake/modules/FindSanitizers.cmake
+++ b/cmake/modules/FindSanitizers.cmake
@@ -14,8 +14,8 @@ foreach(component ${Sanitizers_FIND_COMPONENTS})
   elseif(component STREQUAL "leak")
     set(Sanitizers_leak_COMPILE_OPTIONS "-fsanitize=leak")
   elseif(component STREQUAL "thread")
-    if ("address" IN_LIST ${Sanitizers_FIND_COMPONENTS} OR
-        "leak" IN_LIST ${Sanitizers_FIND_COMPONENTS})
+    if ("address" IN_LIST "${Sanitizers_FIND_COMPONENTS}" OR
+        "leak" IN_LIST "${Sanitizers_FIND_COMPONENTS}")
       message(SEND_ERROR "Cannot combine -fsanitize-leak w/ -fsanitize-thread")
     elseif(NOT CMAKE_POSITION_INDEPENDENT_CODE)
       message(SEND_ERROR "TSan requires all code to be position independent")

--- a/qa/lsan.supp
+++ b/qa/lsan.supp
@@ -3,6 +3,9 @@
 # LSAN_OPTIONS="suppressions=../qa/lsan.supp"
 # export ASAN_OPTIONS="detect_odr_violation=0"
 
+# gperftools allocates a singleton of MallocExtension and never frees it
+leak:^MallocExtension::Initialize
+
 # from perfglue/heap_profiler.cc
 # gperftools allocates a singleton and never frees it
 leak:^InitModule

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,7 +143,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12) # require >= clang-12
     message(FATAL_ERROR "C++20 support requires a minimum Clang version of 12.")
   endif()
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_EXPORTS_C_FLAG}")
+  string(APPEND CMAKE_EXE_LINKER_FLAGS " ${CMAKE_EXE_EXPORTS_C_FLAG}")
   string(APPEND CMAKE_LINKER_FLAGS " -rdynamic -export-dynamic ${CMAKE_EXE_EXPORTS_C_FLAG}")
   string(PREPEND CMAKE_CXX_FLAGS_DEBUG "-g ")
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-inconsistent-missing-override>)

--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -117,10 +117,15 @@ def check_sanity():
             extra_preargs=['-iquote{path}'.format(path=os.path.join(CEPH_SRC_DIR, 'include'))]
         )
 
+        if ldflags := os.environ.get('LDFLAGS'):
+            extra_postargs = ldflags.split()
+        else:
+            extra_postargs = None
         compiler.link_executable(
             objects=link_objects,
             output_progname=os.path.join(tmp_dir, 'cephfs_dummy'),
             libraries=['cephfs'],
+            extra_postargs=extra_postargs,
             output_dir=tmp_dir,
         )
 

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -112,10 +112,15 @@ def check_sanity():
             sources=[tmp_file],
             output_dir=tmp_dir
         )
+        if ldflags := os.environ.get('LDFLAGS'):
+            extra_postargs = ldflags.split()
+        else:
+            extra_postargs = None
         compiler.link_executable(
             objects=link_objects,
             output_progname=os.path.join(tmp_dir, 'rados_dummy'),
             libraries=['rados'],
+            extra_postargs=extra_postargs,
             output_dir=tmp_dir,
         )
 

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -116,10 +116,15 @@ def check_sanity():
             output_dir=tmp_dir
         )
 
+        if ldflags := os.environ.get('LDFLAGS'):
+            extra_postargs = ldflags.split()
+        else:
+            extra_postargs = None
         compiler.link_executable(
             objects=link_objects,
             output_progname=os.path.join(tmp_dir, 'rbd_dummy'),
             libraries=['rbd', 'rados'],
+            extra_postargs=extra_postargs,
             output_dir=tmp_dir,
         )
 

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -116,10 +116,15 @@ def check_sanity():
             output_dir=tmp_dir,
         )
 
+        if ldflags := os.environ.get('LDFLAGS'):
+            extra_postargs = ldflags.split()
+        else:
+            extra_postargs = None
         compiler.link_executable(
             objects=link_objects,
             output_progname=os.path.join(tmp_dir, 'rgw_dummy'),
             libraries=['rgw', 'rados'],
+            extra_postargs=extra_postargs,
             output_dir=tmp_dir,
         )
 


### PR DESCRIPTION
when performing tests, we should enable sanitizers for detecting potential issues. so, in this change, we address various issues in CMake when enabling  ASsan, TSan and UBSan.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
