### PR TITLE
osd/scrub: fixing minor clang-tidy warnings

### DIFF
--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -266,10 +266,10 @@ OsdScrub::LoadTracker::LoadTracker(
 ///\todo replace with Knuth's algo (to reduce the numerical error)
 std::optional<double> OsdScrub::LoadTracker::update_load_average()
 {
-  int hb_interval = conf->osd_heartbeat_interval;
+  auto hb_interval = conf->osd_heartbeat_interval;
   int n_samples = std::chrono::duration_cast<seconds>(24h).count();
   if (hb_interval > 1) {
-    n_samples = std::max(n_samples / hb_interval, 1);
+    n_samples = std::max(n_samples / hb_interval, 1L);
   }
 
   double loadavg;

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1504,7 +1504,7 @@ void PgScrubber::apply_snap_mapper_fixes(
 
 void PgScrubber::maps_compare_n_cleanup()
 {
-  m_pg->add_objects_scrubbed_count(m_be->get_primary_scrubmap().objects.size());
+  m_pg->add_objects_scrubbed_count(std::ssize(m_be->get_primary_scrubmap().objects));
 
   auto required_fixes =
     m_be->scrub_compare_maps(m_end.is_max(), get_snap_mapper_accessor());

--- a/src/osd/scrubber/scrub_reservations.cc
+++ b/src/osd/scrubber/scrub_reservations.cc
@@ -103,7 +103,7 @@ void ReplicaReservations::log_success_and_duration()
   m_perf_set.tinc(scrbcnt_resrv_successful_elapsed, logged_duration);
   m_perf_set.inc(scrbcnt_resrv_success);
   m_osds->logger->hinc(
-      l_osd_scrub_reservation_dur_hist, m_sorted_secondaries.size(),
+      l_osd_scrub_reservation_dur_hist, std::ssize(m_sorted_secondaries),
       logged_duration.count());
   m_process_started_at.reset();
 }

--- a/src/osd/scrubber/scrub_reservations.cc
+++ b/src/osd/scrubber/scrub_reservations.cc
@@ -98,6 +98,7 @@ void ReplicaReservations::discard_remote_reservations()
 
 void ReplicaReservations::log_success_and_duration()
 {
+  ceph_assert(m_process_started_at.has_value());
   auto logged_duration = ScrubClock::now() - m_process_started_at.value();
   m_perf_set.tinc(scrbcnt_resrv_successful_elapsed, logged_duration);
   m_perf_set.inc(scrbcnt_resrv_success);


### PR DESCRIPTION
regarding ints conversions and std::optional access.