### PR TITLE
qa/rgw: enable valgrind for rgw/lifecycle suite

### DIFF
--- a/qa/suites/rgw/lifecycle/valgrind.yaml
+++ b/qa/suites/rgw/lifecycle/valgrind.yaml
@@ -1,0 +1,21 @@
+overrides:
+  install:
+    ceph:
+      #debuginfo: true
+  rgw:
+    client.0:
+      valgrind: [--tool=memcheck, --max-threads=1024] # http://tracker.ceph.com/issues/25214
+  ceph:
+    conf:
+      global:
+        osd heartbeat grace: 40
+      mon:
+        mon osd crush smoke test: false
+      osd:
+        osd fast shutdown: false
+#    valgrind:
+#      mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
+#      osd: [--tool=memcheck]
+#      mds: [--tool=memcheck]
+## https://tracker.ceph.com/issues/38621
+##      mgr: [--tool=memcheck]


### PR DESCRIPTION
to hopefully help with debugging for https://tracker.ceph.com/issues/64571

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
