### PR TITLE
quincy: mgr/dashboard: fix duplicate grafana panels when on mgr failover

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
@@ -15,9 +15,10 @@ scrape_configs:
   - job_name: 'ceph'
     honor_labels: true
     static_configs:
-    - targets:
 {% for mgr in mgr_scrape_list %}
-      - '{{ mgr }}'
+    - targets: ['{{ mgr }}']
+      labels:
+        instance: 'ceph_cluster'
 {% endfor %}
 
 {% if nodes %}

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -476,8 +476,9 @@ class TestMonitoring:
                   - job_name: 'ceph'
                     honor_labels: true
                     static_configs:
-                    - targets:
-                      - '[::1]:9283'
+                    - targets: ['[::1]:9283']
+                      labels:
+                        instance: 'ceph_cluster'
 
                   - job_name: 'node'
                     static_configs:


### PR DESCRIPTION
The PR isn't merely a backport because there have been significant changes in the Prometheus configuration in the main branch. Therefore, it's necessary to raise a separate fix for both the Quincy and main branches.

Fixes: https://tracker.ceph.com/issues/64970

We don't see duplicate panels anymore on mgr failover and also no multiple matches error in Object Ingress/Egress panel
[Screencast from 2024-03-18 22-57-47.webm](https://github.com/ceph/ceph/assets/23611106/41d7a09b-14a6-47d8-985c-ce7f0ac5da97)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
