### PR TITLE
doc/rbd: "rbd flatten" doesn't take encryption options in quincy

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -333,7 +333,7 @@ Commands
   Enable the specified feature on the specified image. Multiple features can
   be specified.
 
-:command:`flatten` [--encryption-format *encryption-format* --encryption-passphrase-file *passphrase-file*]... *image-spec*
+:command:`flatten` *image-spec*
   If the image is a clone, copy all shared blocks from the parent snapshot and
   make the child independent of the parent, severing the link between
   parent snap and child.  The parent snapshot can be unprotected and


### PR DESCRIPTION
A quincy-only change to clean up incorrect conflict resolution in https://github.com/ceph/ceph/pull/56257 when backporting https://github.com/ceph/ceph/pull/56248.