### PR TITLE
python: mypy version bump

### DIFF
--- a/src/mypy-constrains.txt
+++ b/src/mypy-constrains.txt
@@ -2,7 +2,7 @@
 # Unfortunately this means we have to manually update those 
 # packages regularly. 
 
-mypy==0.981
+mypy==1.1.1
 
 # global
 types-python-dateutil==0.1.3

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -57,6 +57,9 @@ class SpecialHostLabels(str, Enum):
     def to_json(self) -> str:
         return self.value
 
+    def __str__(self) -> str:
+        return self.value
+
 
 def name_to_config_section(name: str) -> ConfEntity:
     """

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -103,10 +103,10 @@ commands =
            -m progress \
            -m prometheus \
            -m rbd_support \
-	   -m rgw \
+           -m rgw \
            -m rook \
-           -m snap_schedule \
            -m selftest \
+           -m snap_schedule \
            -m stats \
            -m status \
            -m telegraf \

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py3,
-    mypy,
+    py3
+    mypy
     fix
     flake8
     jinjalint

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -65,12 +65,11 @@ commands =
     pytest {posargs:cephadm/tests/test_ssh.py}
 
 
-[testenv:mypy]
+[testenv:{,py37-,py38-,py39-,py310-}mypy]
 setenv =
     MYPYPATH = {toxinidir}/..
 passenv =
     MYPYPATH
-basepython = python3
 deps =
     -rrequirements.txt
     -c{toxinidir}/../../mypy-constrains.txt


### PR DESCRIPTION
<s>NOTE: This is a draft initially because, despited being "done", I only have tried it locally. I know the ci env is quite different from mine. Once I'm certain this doesn't interfere with normal make check (and other) jobs in the CI I'll move it out of draft.</s>

In PR #55255 I updated various files to be valid on newer versions of
mypy. Update the constrains file to specify mypy 1.1.1. This certainly
is not the newest version of mypy, but because ceph uses various older
versions of python I am being cautious and trying to only incrementally
update the mypy version. This version fixed an issue or two I hit while
working on a prototype manager module compared to the previous version
in the mypy-constrains.txt file.

In addition, I am cleaning some small mypy and related annoyances I bumped into while working on a new mgr module in the src/pybind/mgr tox.ini file.

Lastly, there's a commit in here that's a duplicate of one in #55068 . I did this because the python versions on my local machine default to versions that fail without the change. Depending on which PR is merged first I will end up dropping it from the other.



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
  - [x] Testing tool configuration updates
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
  - [x] I'm open to suggestions
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate. I'm confident on this one!
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
  - [x] Tweaks the testing environments

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
