### PR TITLE
crimson: Add support for pool compression

### DIFF
--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -75,6 +75,8 @@ public:
   seastar::future<CollectionRef> create_new_collection(const coll_t& cid) final;
   seastar::future<CollectionRef> open_collection(const coll_t& cid) final;
   seastar::future<std::vector<coll_core_t>> list_collections() final;
+  seastar::future<> set_collection_opts(CollectionRef c,
+                                        const pool_opts_t& opts) final;
 
   seastar::future<> do_transaction_no_callbacks(
     CollectionRef c,
@@ -90,6 +92,7 @@ public:
     const std::string& key) final;
   uuid_d get_fsid() const final;
   seastar::future<store_statfs_t> stat() const final;
+  seastar::future<store_statfs_t> pool_statfs(int64_t pool_id) const final;
   unsigned get_max_attr_name_length() const final;
   seastar::future<struct stat> stat(
     CollectionRef,

--- a/src/crimson/os/cyanstore/cyan_collection.h
+++ b/src/crimson/os/cyanstore/cyan_collection.h
@@ -36,6 +36,8 @@ struct Collection final : public FuturizedCollection {
   std::map<std::string,bufferptr> xattr;
   bool exists = true;
 
+  pool_opts_t pool_opts;
+
   Collection(const coll_t& c);
   ~Collection() final;
 

--- a/src/crimson/os/cyanstore/cyan_store.cc
+++ b/src/crimson/os/cyanstore/cyan_store.cc
@@ -71,6 +71,11 @@ seastar::future<store_statfs_t> CyanStore::stat() const
   });
 }
 
+seastar::future<store_statfs_t> CyanStore::pool_statfs(int64_t pool_id) const
+{
+  return stat();
+}
+
 
 CyanStore::mkfs_ertr::future<> CyanStore::mkfs(uuid_d new_osd_fsid)
 {
@@ -256,6 +261,16 @@ CyanStore::Shard::exists(
     return base_errorator::make_ready_future<bool>(false);
   }
   return base_errorator::make_ready_future<bool>(true);
+}
+
+seastar::future<>
+CyanStore::Shard::set_collection_opts(CollectionRef ch,
+                                      const pool_opts_t& opts)
+{
+  auto c = static_cast<Collection*>(ch.get());
+  logger().debug("{} {}", __func__, c->get_cid());
+  c->pool_opts = opts;
+  return seastar::now();
 }
 
 CyanStore::Shard::read_errorator::future<ceph::bufferlist>

--- a/src/crimson/os/cyanstore/cyan_store.h
+++ b/src/crimson/os/cyanstore/cyan_store.h
@@ -88,6 +88,10 @@ public:
 
     seastar::future<CollectionRef> open_collection(const coll_t& cid) final;
 
+    seastar::future<> set_collection_opts(
+      CollectionRef c,
+      const pool_opts_t& opts) final;
+
     seastar::future<> do_transaction_no_callbacks(
       CollectionRef ch,
       ceph::os::Transaction&& txn) final;
@@ -201,6 +205,8 @@ public:
   mkfs_ertr::future<> mkfs(uuid_d new_osd_fsid) final;
 
   seastar::future<store_statfs_t> stat() const final;
+
+  seastar::future<store_statfs_t> pool_statfs(int64_t pool_id) const final;
 
   uuid_d get_fsid() const final;
 

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -102,6 +102,9 @@ public:
 
     virtual seastar::future<CollectionRef> open_collection(const coll_t& cid) = 0;
 
+    virtual seastar::future<> set_collection_opts(CollectionRef c,
+                                        const pool_opts_t& opts) = 0;
+
   protected:
     virtual seastar::future<> do_transaction_no_callbacks(
       CollectionRef ch,
@@ -180,6 +183,8 @@ public:
   virtual mkfs_ertr::future<> mkfs(uuid_d new_osd_fsid) = 0;
 
   virtual seastar::future<store_statfs_t> stat() const = 0;
+
+  virtual seastar::future<store_statfs_t> pool_statfs(int64_t pool_id) const = 0;
 
   virtual uuid_d get_fsid() const  = 0;
 

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -566,6 +566,12 @@ seastar::future<store_statfs_t> SeaStore::stat() const
   });
 }
 
+seastar::future<store_statfs_t> SeaStore::pool_statfs(int64_t pool_id) const
+{
+   //TODO
+   return SeaStore::stat();
+}
+
 TransactionManager::read_extent_iertr::future<std::optional<unsigned>>
 SeaStore::Shard::get_coll_bits(CollectionRef ch, Transaction &t) const
 {
@@ -777,6 +783,14 @@ SeaStore::Shard::open_collection(const coll_t& cid)
       return seastar::make_ready_future<CollectionRef>();
     }
   });
+}
+
+seastar::future<>
+SeaStore::Shard::set_collection_opts(CollectionRef c,
+                                        const pool_opts_t& opts)
+{
+  //TODO
+  return seastar::now();
 }
 
 seastar::future<std::vector<coll_core_t>>

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -158,6 +158,8 @@ public:
 
     seastar::future<CollectionRef> create_new_collection(const coll_t& cid) final;
     seastar::future<CollectionRef> open_collection(const coll_t& cid) final;
+    seastar::future<> set_collection_opts(CollectionRef c,
+                                        const pool_opts_t& opts) final;
 
     seastar::future<> do_transaction_no_callbacks(
       CollectionRef ch,
@@ -491,6 +493,7 @@ public:
 
   mkfs_ertr::future<> mkfs(uuid_d new_osd_fsid) final;
   seastar::future<store_statfs_t> stat() const final;
+  seastar::future<store_statfs_t> pool_statfs(int64_t pool_id) const final;
 
   uuid_d get_fsid() const final {
     ceph_assert(seastar::this_shard_id() == primary_core);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -311,9 +311,8 @@ public:
 
   unsigned get_target_pg_log_entries() const final;
 
-  void on_pool_change() final {
-    // Not needed yet
-  }
+  void init_collection_pool_opts();
+  void on_pool_change();
   void on_role_change() final {
     // Not needed yet
   }


### PR DESCRIPTION
1. Send pool options to Bluestore which include compression options as well.
2. Add pool related stats to MPGStats so that they all compression details are available in 'ceph df detail' command.

Fixes: https://tracker.ceph.com/issues/59242





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
