### PR TITLE
python: allow unit tests to use tox default envs

### DIFF
--- a/src/cephadm/CMakeLists.txt
+++ b/src/cephadm/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(WITH_TESTS)
   include(AddCephTest)
-  add_tox_test(cephadm TOX_ENVS py3 mypy flake8)
+  add_tox_test(cephadm TOX_ENVS __tox_defaults__)
 endif()
 
 set(bin_target_file ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cephadm)

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,6 +5,8 @@ envlist =
     check-black
     py3
 skipsdist = true
+# REMINDER: run `tox -e format-black` to apply black formatting
+# with the exact same specs as `check-black` expects.
 
 [flake8]
 max-line-length = 100

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -21,15 +21,6 @@ exclude =
     .eggs
 statistics = True
 
-[autopep8]
-addopts =
-    --max-line-length {[flake8]max-line-length} \
-    --ignore "{[flake8]ignore}" \
-    --exclude "{[flake8]exclude}" \
-    --in-place \
-    --recursive \
-    --ignore-local-config
-
 [testenv]
 skip_install=true
 deps =

--- a/src/script/run_tox.sh
+++ b/src/script/run_tox.sh
@@ -125,7 +125,11 @@ function main() {
     export CEPH_BUILD_DIR=$build_dir
     # use the wheelhouse prepared by install-deps.sh
     export PIP_FIND_LINKS="$tox_path/wheelhouse"
-    tox -c $tox_path/tox.ini -e "$tox_envs" "$@"
+    tox_cmd=(tox -c $tox_path/tox.ini)
+    if [ "$tox_envs" != "__tox_defaults__" ]; then
+        tox_cmd+=("-e" "$tox_envs")
+    fi
+    "${tox_cmd[@]}" "$@"
 }
 
 main "$@"


### PR DESCRIPTION
Add a "magic" --tox-envs value to force the run_tox.sh script to
defer to the tox.ini file's envlist rather than specifying a
custom env list. Pass `--tox-envs __tox_defaults__` to the script
to use whatever the tox.ini defaults are.

Adding a magic value like this avoids the need to make breaking changes
(or any changes) to the current cmake "code" used to invoke the
tox tests from make check. It's a little hacky but the funny looking
value should make it clear that it's special. In particular it avoids
adding new conditionals to the cmake files.

This is followed by a temporary "canary" commit to make sure these changes work as desired in the CI. 

Then there's a couple more clean ups to cephadm's tox.ini file I missed in a prior PR.



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
  - [x] Dunno, this is another one of those "between the cracks" kind of changes
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
  - [x] Tweaks how tests are run

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
