### PR TITLE
rgw: allow s3 bucket listing to return zero entries

### DIFF
--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -284,6 +284,7 @@ protected:
   // Return true if multiple rounds of OPs might be needed, this happens when
   // OP needs to be re-send until a certain code is returned.
   virtual bool need_multiple_rounds() { return false; }
+  virtual bool need_retries() { return true; }
   // Add a new object to the end of the container.
   virtual void add_object(int shard, const std::string& oid) {}
   virtual void reset_container(std::map<int, std::string>& objs) {}
@@ -428,10 +429,12 @@ class CLSRGWIssueBucketList : public CLSRGWConcurrentIO {
   uint32_t num_entries;
   bool list_versions;
   std::map<int, rgw_cls_list_ret>& result; // request_id -> return value
+  bool retry;
 
 protected:
   int issue_op(int shard_id, const std::string& oid) override;
   void reset_container(std::map<int, std::string>& objs) override;
+  bool need_retries() override { return retry; }
 
 public:
   CLSRGWIssueBucketList(librados::IoCtx& io_ctx,
@@ -443,11 +446,12 @@ public:
                         std::map<int, std::string>& oids, // shard_id -> shard_oid
 			// shard_id -> return value
                         std::map<int, rgw_cls_list_ret>& list_results,
-                        uint32_t max_aio) :
+                        uint32_t max_aio,
+                        bool _retry = true) :
   CLSRGWConcurrentIO(io_ctx, oids, max_aio),
     start_obj(_start_obj), filter_prefix(_filter_prefix), delimiter(_delimiter),
     num_entries(_num_entries), list_versions(_list_versions),
-    result(list_results)
+    result(list_results), retry(_retry)
   {}
 };
 
@@ -490,6 +494,7 @@ protected:
   // Trim until -ENODATA is returned.
   int valid_ret_code() override { return -ENODATA; }
   bool need_multiple_rounds() override { return true; }
+  bool need_retries() { return false; }
   void add_object(int shard, const std::string& oid) override { objs_container[shard] = oid; }
   void reset_container(std::map<int, std::string>& objs) override {
     objs_container.swap(objs);

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -704,7 +704,7 @@ int POSIXBucket::fill_cache(const DoutPrefixProvider* dpp, optional_yield y,
 
 // TODO  marker and other params
 int POSIXBucket::list(const DoutPrefixProvider* dpp, ListParams& params,
-		      int max, ListResults& results, optional_yield y)
+		      int max, ListResults& results, optional_yield y, bool requires_nonempty_result)
 {
   int count{0};
   bool in_prefix{false};

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -171,7 +171,7 @@ public:
 
   virtual std::unique_ptr<Object> get_object(const rgw_obj_key& key) override;
   virtual int list(const DoutPrefixProvider* dpp, ListParams&, int,
-		   ListResults&, optional_yield y) override;
+		   ListResults&, optional_yield y, bool requires_nonempty_result = true) override;
   virtual int merge_and_store_attrs(const DoutPrefixProvider* dpp,
 				    Attrs& new_attrs, optional_yield y) override;
   virtual int remove(const DoutPrefixProvider* dpp, bool delete_children,

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1012,13 +1012,15 @@ public:
 			       std::vector<rgw_bucket_dir_entry> *result,
 			       std::map<std::string, bool> *common_prefixes,
 			       bool *is_truncated,
-                               optional_yield y);
+                               optional_yield y,
+                               bool requires_nonempty_result = true);
       int list_objects_unordered(const DoutPrefixProvider *dpp,
                                  int64_t max,
 				 std::vector<rgw_bucket_dir_entry> *result,
 				 std::map<std::string, bool> *common_prefixes,
 				 bool *is_truncated,
-                                 optional_yield y);
+                                 optional_yield y,
+                                 bool requires_nonempty_result = true);
 
     public:
 
@@ -1047,13 +1049,14 @@ public:
 		       std::vector<rgw_bucket_dir_entry> *result,
 		       std::map<std::string, bool> *common_prefixes,
 		       bool *is_truncated,
-                       optional_yield y) {
+                       optional_yield y,
+                       bool requires_nonempty_result = true) {
 	if (params.allow_unordered) {
 	  return list_objects_unordered(dpp, max, result, common_prefixes,
-					is_truncated, y);
+					is_truncated, y, requires_nonempty_result);
 	} else {
 	  return list_objects_ordered(dpp, max, result, common_prefixes,
-				      is_truncated, y);
+				      is_truncated, y, requires_nonempty_result);
 	}
       }
       rgw_obj_key& get_next_marker() {
@@ -1476,7 +1479,8 @@ public:
 			      bool* cls_filtered,
 			      rgw_obj_index_key *last_entry,
                               optional_yield y,
-			      RGWBucketListNameFilter force_check_filter = {});
+			      RGWBucketListNameFilter force_check_filter = {},
+                              bool requires_nonempty_result = true);
   int cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
                                 RGWBucketInfo& bucket_info,
                                 const rgw::bucket_index_layout_generation& idx_layout,
@@ -1489,7 +1493,8 @@ public:
 				bool *is_truncated,
 				rgw_obj_index_key *last_entry,
                                 optional_yield y,
-				RGWBucketListNameFilter force_check_filter = {});
+				RGWBucketListNameFilter force_check_filter = {},
+                                const bool requires_nonempty_result = true);
   int cls_bucket_head(const DoutPrefixProvider *dpp,
 		      const RGWBucketInfo& bucket_info,
 		      const rgw::bucket_index_layout_generation& idx_layout,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -731,7 +731,8 @@ std::unique_ptr<Object> RadosBucket::get_object(const rgw_obj_key& k)
   return std::make_unique<RadosObject>(this->store, k, this);
 }
 
-int RadosBucket::list(const DoutPrefixProvider* dpp, ListParams& params, int max, ListResults& results, optional_yield y)
+int RadosBucket::list(const DoutPrefixProvider* dpp, ListParams& params, int max, ListResults& results, optional_yield y,
+                      bool requires_nonempty_result)
 {
   RGWRados::Bucket target(store->getRados(), get_info());
   if (params.shard_id >= 0) {
@@ -751,7 +752,7 @@ int RadosBucket::list(const DoutPrefixProvider* dpp, ListParams& params, int max
   list_op.params.list_versions = params.list_versions;
   list_op.params.allow_unordered = params.allow_unordered;
 
-  int ret = list_op.list_objects(dpp, max, &results.objs, &results.common_prefixes, &results.is_truncated, y);
+  int ret = list_op.list_objects(dpp, max, &results.objs, &results.common_prefixes, &results.is_truncated, y, requires_nonempty_result);
   if (ret >= 0) {
     results.next_marker = list_op.get_next_marker();
     params.marker = results.next_marker;

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -542,7 +542,7 @@ class RadosBucket : public StoreBucket {
 
     virtual ~RadosBucket();
     virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) override;
-    virtual int list(const DoutPrefixProvider* dpp, ListParams&, int, ListResults&, optional_yield y) override;
+    virtual int list(const DoutPrefixProvider* dpp, ListParams&, int, ListResults&, optional_yield y, bool requires_nonempty_result = true) override;
     virtual int remove(const DoutPrefixProvider* dpp, bool delete_children, optional_yield y) override;
     virtual int remove_bypass_gc(int concurrent_max, bool
 				 keep_index_consistent,

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -377,11 +377,10 @@ public:
   }
 
   int fetch(const DoutPrefixProvider *dpp) {
-    int ret = bucket->list(dpp, list_params, 1000, list_results, null_yield);
+    int ret = bucket->list(dpp, list_params, 1000, list_results, null_yield, false);
     if (ret < 0) {
       return ret;
     }
-
     obj_iter = list_results.objs.begin();
 
     return 0;
@@ -394,7 +393,7 @@ public:
   bool get_obj(const DoutPrefixProvider *dpp, rgw_bucket_dir_entry **obj,
 	       std::function<void(void)> fetch_barrier
 	       = []() { /* nada */}) {
-    if (obj_iter == list_results.objs.end()) {
+    while (obj_iter == list_results.objs.end()) {
       if (!list_results.is_truncated) {
         delay();
         return false;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3099,7 +3099,7 @@ void RGWListBucket::execute(optional_yield y)
 
   rgw::sal::Bucket::ListResults results;
 
-  op_ret = s->bucket->list(this, params, max, results, y);
+  op_ret = s->bucket->list(this, params, max, results, y, requires_nonempty_result);
   if (op_ret >= 0) {
     next_marker = results.next_marker;
     is_truncated = results.is_truncated;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -918,6 +918,7 @@ protected:
   std::vector<rgw_bucket_dir_entry> objs;
   std::map<std::string, bool> common_prefixes;
   std::optional<RGWStorageStats> stats; // initialized if need_container_stats()
+  bool requires_nonempty_result{true};
 
   int default_max{0};
   bool is_truncated{false};

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -78,6 +78,8 @@ using namespace std;
 using namespace rgw;
 using namespace ceph::crypto;
 
+const std::string LIST_OBJS_CONTINUATION_TOKEN_DELIMITER = "#";
+
 void list_all_buckets_start(req_state *s)
 {
   s->formatter->open_array_section_in_ns("ListAllMyBucketsResult", XMLNS_AWS_S3);
@@ -1723,19 +1725,25 @@ int RGWListBucket_ObjStore_S3::get_params(optional_yield y)
 
 int RGWListBucket_ObjStore_S3v2::get_params(optional_yield y)
 {
-int ret = get_common_params();
-if (ret < 0) {
-  return ret;
-}
-s->info.args.get_bool("fetch-owner", &fetchOwner, false);
-startAfter = s->info.args.get("start-after", &start_after_exist);
-continuation_token = s->info.args.get("continuation-token", &continuation_token_exist);
-if(!continuation_token_exist) {
-  marker = startAfter;
-} else {
-  marker = continuation_token;
-}
-return 0;
+  int ret = get_common_params();
+  if (ret < 0) {
+    return ret;
+  }
+  s->info.args.get_bool("fetch-owner", &fetchOwner, false);
+  startAfter = s->info.args.get("start-after", &start_after_exist);
+  continuation_token = s->info.args.get("continuation-token", &continuation_token_exist);
+  if(!continuation_token_exist || continuation_token.empty()) {
+    marker = startAfter;
+  } else {
+    size_t sep_idx = continuation_token.rfind(LIST_OBJS_CONTINUATION_TOKEN_DELIMITER);
+    if (sep_idx == std::string::npos) {
+      return -ERR_INVALID_REQUEST;
+    }
+    std::string name = continuation_token.substr(0, sep_idx);
+    std::string instance = continuation_token.substr(sep_idx + 1);
+    marker = {name, instance};
+  }
+  return 0;
 }
 
 void RGWListBucket_ObjStore_S3::send_common_versioned_response()
@@ -2073,7 +2081,9 @@ void RGWListBucket_ObjStore_S3v2::send_response()
     s->formatter->dump_string("ContinuationToken", continuation_token);
   }
   if (is_truncated && !next_marker.empty()) {
-    s->formatter->dump_string("NextContinuationToken", next_marker.name);
+    std::string next_continuation_token = next_marker.name +
+      LIST_OBJS_CONTINUATION_TOKEN_DELIMITER + next_marker.instance;
+    s->formatter->dump_string("NextContinuationToken", next_continuation_token);
   }
   s->formatter->dump_int("KeyCount", objs.size() + common_prefixes.size());
   if (start_after_exist) {

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -158,6 +158,7 @@ protected:
   public:
   RGWListBucket_ObjStore_S3() : objs_container(false) {
     default_max = 1000;
+    requires_nonempty_result = false;
   }
   ~RGWListBucket_ObjStore_S3() override {}
 

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -671,7 +671,7 @@ class Bucket {
     /** Get an @a Object belonging to this bucket */
     virtual std::unique_ptr<Object> get_object(const rgw_obj_key& key) = 0;
     /** List the contents of this bucket */
-    virtual int list(const DoutPrefixProvider* dpp, ListParams&, int, ListResults&, optional_yield y) = 0;
+    virtual int list(const DoutPrefixProvider* dpp, ListParams&, int, ListResults&, optional_yield y, bool requires_nonempty_result = true) = 0;
     /** Get the cached attributes associated with this bucket */
     virtual Attrs& get_attrs(void) = 0;
     /** Set the cached attributes on this bucket */

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -364,7 +364,7 @@ namespace rgw::sal {
     return std::make_unique<DBObject>(this->store, k, this);
   }
 
-  int DBBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max, ListResults& results, optional_yield y)
+  int DBBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max, ListResults& results, optional_yield y, bool requires_nonempty_result)
   {
     int ret = 0;
 

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -138,7 +138,7 @@ protected:
       ~DBBucket() { }
 
       virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) override;
-      virtual int list(const DoutPrefixProvider *dpp, ListParams&, int, ListResults&, optional_yield y) override;
+      virtual int list(const DoutPrefixProvider *dpp, ListParams&, int, ListResults&, optional_yield y, bool requires_nonempty_result = true) override;
       virtual int remove(const DoutPrefixProvider *dpp, bool delete_children, optional_yield y) override;
       virtual int remove_bypass_gc(int concurrent_max, bool
 				   keep_index_consistent,

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -561,9 +561,9 @@ std::unique_ptr<Object> FilterBucket::get_object(const rgw_obj_key& k)
 }
 
 int FilterBucket::list(const DoutPrefixProvider* dpp, ListParams& params, int max,
-		       ListResults& results, optional_yield y)
+		       ListResults& results, optional_yield y, bool requires_nonempty_result)
 {
-  return next->list(dpp, params, max, results, y);
+  return next->list(dpp, params, max, results, y, requires_nonempty_result);
 }
 
 int FilterBucket::remove(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -421,7 +421,7 @@ public:
 
   virtual std::unique_ptr<Object> get_object(const rgw_obj_key& key) override;
   virtual int list(const DoutPrefixProvider* dpp, ListParams&, int,
-		   ListResults&, optional_yield y) override;
+		   ListResults&, optional_yield y, bool requires_nonempty_result = true) override;
   virtual Attrs& get_attrs(void) override { return next->get_attrs(); }
   virtual int set_attrs(Attrs a) override { return next->set_attrs(a); }
   virtual int remove(const DoutPrefixProvider* dpp, bool delete_children,


### PR DESCRIPTION
When a bucket index shard had many contiguous delete markers, a single bucket listing request could cause huge read amplification on the backend because RGW needed to iteratively loop through all of the delete markers in order to find at least one listable entry to sort among other shards and return a response to the client. In extreme cases, long latencies due to excessive iteration led to client timeouts and client retries, which compounded impact on cluster performance.

The AWS S3 specification does not make any promises about the number of entries that will be returned
and claims that continuation tokens are obfuscated and not real keys. This permits us to workaround the aforementioned problem by returning zero keys when excessive iteration is required, advancing the continuation token to a marker associated with an un-listable entry, and letting the client drive continued iteration with subsequent requests.

Fixes: https://tracker.ceph.com/issues/64185

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
