### PR TITLE
squid: cephadm: Add nvmeof to autotuner calculation

### DIFF
--- a/src/pybind/mgr/cephadm/autotune.py
+++ b/src/pybind/mgr/cephadm/autotune.py
@@ -15,6 +15,7 @@ class MemoryAutotuner(object):
         'crash': 128 * 1048576,
         'keepalived': 128 * 1048576,
         'haproxy': 128 * 1048576,
+        'nvmeof': 4096 * 1048576,
     }
     default_size = 1024 * 1048576
 

--- a/src/pybind/mgr/cephadm/tests/test_autotune.py
+++ b/src/pybind/mgr/cephadm/tests/test_autotune.py
@@ -46,6 +46,17 @@ from orchestrator import DaemonDescription
             ],
             {},
             62 * 1024 * 1024 * 1024,
+        ),
+        (
+            128 * 1024 * 1024 * 1024,
+            [
+                DaemonDescription('mgr', 'a', 'host1'),
+                DaemonDescription('osd', '1', 'host1'),
+                DaemonDescription('osd', '2', 'host1'),
+                DaemonDescription('nvmeof', 'a', 'host1'),
+            ],
+            {},
+            60 * 1024 * 1024 * 1024,
         )
     ])
 def test_autotune(total, daemons, config, result):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64621

---

backport of https://github.com/ceph/ceph/pull/55273
parent tracker: https://tracker.ceph.com/issues/64020

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh