### PR TITLE
squid: mgr/cephadm: fix placement with label and host pattern

### DIFF
--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -413,6 +413,8 @@ class HostAssignment(object):
                                 hostname=x.hostname, ports=self.ports_start)
                 for x in self.hosts_by_label(self.spec.placement.label)
             ]
+            if self.spec.placement.host_pattern:
+                ls = [h for h in ls if h.hostname in self.spec.placement.filter_matching_hostspecs(self.hosts)]
         elif self.spec.placement.host_pattern:
             ls = [
                 DaemonPlacement(daemon_type=self.primary_daemon_type,

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -637,6 +637,17 @@ class NodeAssignmentTest(NamedTuple):
              'rgw:host2(*:81)', 'rgw:host3(*:81)'],
             ['rgw.c']
         ),
+        # label + host pattern
+        # Note all hosts will get the "foo" label, we are checking
+        # that it also filters on the host pattern when label is provided
+        NodeAssignmentTest(
+            'mgr',
+            PlacementSpec(label='foo', host_pattern='mgr*'),
+            'mgr1 mgr2 osd1'.split(),
+            [],
+            None, None,
+            ['mgr:mgr1', 'mgr:mgr2'], ['mgr:mgr1', 'mgr:mgr2'], []
+        ),
         # cephadm.py teuth case
         NodeAssignmentTest(
             'mgr',

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -306,8 +306,9 @@ class PlacementSpec(object):
             all_hosts = [hs.hostname for hs in hostspecs]
             return [h.hostname for h in self.hosts if h.hostname in all_hosts]
         if self.label:
-            return [hs.hostname for hs in hostspecs if self.label in hs.labels]
-        all_hosts = [hs.hostname for hs in hostspecs]
+            all_hosts = [hs.hostname for hs in hostspecs if self.label in hs.labels]
+        else:
+            all_hosts = [hs.hostname for hs in hostspecs]
         if self.host_pattern:
             return self.host_pattern.filter_hosts(all_hosts)
         return all_hosts


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64687

---

backport of https://github.com/ceph/ceph/pull/55587
parent tracker: https://tracker.ceph.com/issues/64428

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh