### PR TITLE
reef: mgr/cephadm: refresh public_network for config checks before checking

### DIFF
--- a/src/pybind/mgr/cephadm/configchecks.py
+++ b/src/pybind/mgr/cephadm/configchecks.py
@@ -674,7 +674,7 @@ class CephadmConfigChecks:
             self.host_to_role[hostname] = list(self.mgr.cache.get_daemon_types(hostname))
 
     def run_checks(self) -> None:
-        checks_enabled = self.mgr.get_module_option('config_checks_enabled')
+        checks_enabled = self.mgr.config_checks_enabled
         if checks_enabled is not True:
             return
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -551,6 +551,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.registry_password: Optional[str] = None
             self.registry_insecure: bool = False
             self.use_repo_digest = True
+            self.config_checks_enabled = False
             self.default_registry = ''
             self.autotune_memory_target_ratio = 0.0
             self.autotune_interval = 0
@@ -1361,7 +1362,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     @orchestrator._cli_read_command('cephadm config-check status')
     def _config_check_status(self) -> HandleCommandResult:
         """Show whether the configuration checker feature is enabled/disabled"""
-        status = self.get_module_option('config_checks_enabled')
+        status = self.config_checks_enabled
         return HandleCommandResult(stdout="Enabled" if status else "Disabled")
 
     @orchestrator._cli_write_command('cephadm config-check enable')

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -67,7 +67,6 @@ class CephadmServe:
         of cephadm. This loop will then attempt to apply this new state.
         """
         self.log.debug("serve starting")
-        self.mgr.config_checker.load_network_config()
 
         while self.mgr.run:
             self.log.debug("serve loop start")
@@ -322,7 +321,9 @@ class CephadmServe:
         self.mgr.agent_helpers._update_agent_down_healthcheck(agents_down)
         self.mgr.http_server.config_update()
 
-        self.mgr.config_checker.run_checks()
+        if self.mgr.config_checks_enabled:
+            self.mgr.config_checker.load_network_config()
+            self.mgr.config_checker.run_checks()
 
         for k in [
                 'CEPHADM_HOST_CHECK_FAILED',

--- a/src/pybind/mgr/cephadm/tests/test_configchecks.py
+++ b/src/pybind/mgr/cephadm/tests/test_configchecks.py
@@ -238,6 +238,7 @@ class FakeMgr:
         self.default_version = 'quincy'
         self.version_overrides = {}
         self.daemon_to_host = {}
+        self.config_checks_enabled = True
 
         self.cache = HostCache(self)
         self.upgrade = CephadmUpgrade(self)
@@ -623,9 +624,7 @@ class TestConfigCheck:
         assert 'ceph_release' in checker.skipped_checks
 
     def test_skip_when_disabled(self, mgr):
-        mgr.module_option.update({
-            "config_checks_enabled": "false"
-        })
+        mgr.config_checks_enabled = False
         checker = CephadmConfigChecks(mgr)
         checker.cluster_network_list = []
         checker.public_network_list = ['10.9.64.0/24']


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64994

---

backport of https://github.com/ceph/ceph/pull/56178
parent tracker: https://tracker.ceph.com/issues/64902

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh