### PR TITLE
crimson/os/pg_map: allow multiple shards to create new pg mappings at the same time

### DIFF
--- a/src/crimson/osd/pg_map.cc
+++ b/src/crimson/osd/pg_map.cc
@@ -19,75 +19,138 @@ seastar::future<core_id_t> PGShardMapping::get_or_create_pg_mapping(
   LOG_PREFIX(PGShardMapping::get_or_create_pg_mapping);
   auto find_iter = pg_to_core.find(pgid);
   if (find_iter != pg_to_core.end()) {
-    ceph_assert_always(find_iter->second != NULL_CORE);
-    if (core_expected != NULL_CORE) {
-      ceph_assert_always(find_iter->second == core_expected);
+    auto core_found = find_iter->second;
+    assert(core_found != NULL_CORE);
+    if (core_expected != NULL_CORE && core_expected != core_found) {
+      ERROR("the mapping is inconsistent for pg {}: core {}, expected {}",
+            pgid, core_found, core_expected);
+      ceph_abort("The pg mapping is inconsistent!");
     }
-    return seastar::make_ready_future<core_id_t>(find_iter->second);
+    return seastar::make_ready_future<core_id_t>(core_found);
   } else {
+    DEBUG("calling primary to add mapping for pg {} to the expected core {}",
+          pgid, core_expected);
     return container().invoke_on(
         0, [pgid, core_expected, FNAME](auto &primary_mapping) {
-      auto [insert_iter, inserted] =
-        primary_mapping.pg_to_core.emplace(pgid, core_expected);
-      ceph_assert_always(inserted);
-      ceph_assert_always(primary_mapping.core_to_num_pgs.size() > 0);
-      std::map<core_id_t, unsigned>::iterator core_iter;
-      if (core_expected == NULL_CORE) {
-        core_iter = std::min_element(
-          primary_mapping.core_to_num_pgs.begin(),
-          primary_mapping.core_to_num_pgs.end(),
-          [](const auto &left, const auto &right) {
-            return left.second < right.second;
+      auto core_to_update = core_expected;
+      auto find_iter = primary_mapping.pg_to_core.find(pgid);
+      if (find_iter != primary_mapping.pg_to_core.end()) {
+        // this pgid was already mapped within primary_mapping, assert that the
+        // mapping is consistent and avoid emplacing once again.
+        auto core_found = find_iter->second;
+        assert(core_found != NULL_CORE);
+        if (core_expected != NULL_CORE) {
+          if (core_expected != core_found) {
+            ERROR("the mapping is inconsistent for pg {} (primary): core {}, expected {}",
+                  pgid, core_found, core_expected);
+            ceph_abort("The pg mapping is inconsistent!");
           }
-        );
-        core_expected = core_iter->first;
-      } else {
-        core_iter = primary_mapping.core_to_num_pgs.find(core_expected);
-      }
-      assert(core_expected != NULL_CORE);
-      ceph_assert_always(primary_mapping.core_to_num_pgs.end() != core_iter);
-      insert_iter->second = core_expected;
-      core_iter->second++;
-      DEBUG("mapping pg {} to core {} (primary) with num_pgs {}",
-            pgid, core_expected, core_iter->second);
-      return primary_mapping.container().invoke_on_others(
-          [pgid, core_expected, FNAME](auto &other_mapping) {
+          // core_expected == core_found
+          DEBUG("mapping pg {} to core {} (primary): already mapped and expected",
+                pgid, core_to_update);
+        } else { // core_expected == NULL_CORE
+          core_to_update = core_found;
+          DEBUG("mapping pg {} to core {} (primary): already mapped",
+                pgid, core_to_update);
+        }
+        // proceed to broadcast core_to_update
+      } else { // find_iter == primary_mapping.pg_to_core.end()
+        // this pgid isn't mapped within primary_mapping,
+        // add the mapping and ajust core_to_num_pgs
+        ceph_assert_always(primary_mapping.core_to_num_pgs.size() > 0);
+        std::map<core_id_t, unsigned>::iterator count_iter;
+        if (core_expected == NULL_CORE) {
+          count_iter = std::min_element(
+            primary_mapping.core_to_num_pgs.begin(),
+            primary_mapping.core_to_num_pgs.end(),
+            [](const auto &left, const auto &right) {
+              return left.second < right.second;
+            }
+          );
+          core_to_update = count_iter->first;
+        } else { // core_expected != NULL_CORE
+          count_iter = primary_mapping.core_to_num_pgs.find(core_to_update);
+        }
+        ceph_assert_always(primary_mapping.core_to_num_pgs.end() != count_iter);
+        ++(count_iter->second);
         auto [insert_iter, inserted] =
-          other_mapping.pg_to_core.emplace(pgid, core_expected);
-        ceph_assert_always(inserted);
-        DEBUG("mapping pg {} to core {} (others)",
-              pgid, core_expected);
+          primary_mapping.pg_to_core.emplace(pgid, core_to_update);
+        assert(inserted);
+        DEBUG("mapping pg {} to core {} (primary): num_pgs {}",
+              pgid, core_to_update, count_iter->second);
+      }
+      assert(core_to_update != NULL_CORE);
+      return primary_mapping.container().invoke_on_others(
+          [pgid, core_to_update, FNAME](auto &other_mapping) {
+        auto find_iter = other_mapping.pg_to_core.find(pgid);
+        if (find_iter == other_mapping.pg_to_core.end()) {
+          DEBUG("mapping pg {} to core {} (others)",
+                pgid, core_to_update);
+          auto [insert_iter, inserted] =
+            other_mapping.pg_to_core.emplace(pgid, core_to_update);
+          assert(inserted);
+        } else {
+          auto core_found = find_iter->second;
+          if (core_found != core_to_update) {
+            ERROR("the mapping is inconsistent for pg {} (others): core {}, expected {}",
+                  pgid, core_found, core_to_update);
+            ceph_abort("The pg mapping is inconsistent!");
+          }
+          DEBUG("mapping pg {} to core {} (others): already mapped",
+                pgid, core_to_update);
+        }
       });
-    }).then([this, pgid, FNAME] {
+    }).then([this, pgid, core_expected, FNAME] {
       auto find_iter = pg_to_core.find(pgid);
-      ceph_assert_always(find_iter != pg_to_core.end());
-      DEBUG("returning pg {} mapping to core {}",
-            pgid, find_iter->second);
-      return seastar::make_ready_future<core_id_t>(find_iter->second);
+      if (find_iter == pg_to_core.end()) {
+        ERROR("the mapping is inconsistent for pg {}: core not found, expected {}",
+              pgid, core_expected);
+        ceph_abort("The pg mapping is inconsistent!");
+      }
+      auto core_found = find_iter->second;
+      if (core_expected != NULL_CORE && core_found != core_expected) {
+        ERROR("the mapping is inconsistent for pg {}: core {}, expected {}",
+              pgid, core_found, core_expected);
+        ceph_abort("The pg mapping is inconsistent!");
+      }
+      DEBUG("returning pg {} mapping to core {} after broadcasted",
+            pgid, core_found);
+      return seastar::make_ready_future<core_id_t>(core_found);
     });
   }
 }
 
 seastar::future<> PGShardMapping::remove_pg_mapping(spg_t pgid) {
   LOG_PREFIX(PGShardMapping::remove_pg_mapping);
-  DEBUG("{}", pgid);
+  auto find_iter = pg_to_core.find(pgid);
+  if (find_iter == pg_to_core.end()) {
+    ERROR("trying to remove non-exist mapping for pg {}", pgid);
+    ceph_abort("The pg mapping is inconsistent!");
+  }
+  DEBUG("calling primary to remove mapping for pg {}", pgid);
   return container().invoke_on(
       0, [pgid, FNAME](auto &primary_mapping) {
-    auto iter = primary_mapping.pg_to_core.find(pgid);
-    ceph_assert_always(iter != primary_mapping.pg_to_core.end());
-    ceph_assert_always(iter->second != NULL_CORE);
-    auto count_iter = primary_mapping.core_to_num_pgs.find(iter->second);
-    ceph_assert_always(count_iter != primary_mapping.core_to_num_pgs.end());
-    ceph_assert_always(count_iter->second > 0);
+    auto find_iter = primary_mapping.pg_to_core.find(pgid);
+    if (find_iter == primary_mapping.pg_to_core.end()) {
+      ERROR("trying to remove non-exist mapping for pg {} (primary)", pgid);
+      ceph_abort("The pg mapping is inconsistent!");
+    }
+    assert(find_iter->second != NULL_CORE);
+    auto count_iter = primary_mapping.core_to_num_pgs.find(find_iter->second);
+    assert(count_iter != primary_mapping.core_to_num_pgs.end());
+    assert(count_iter->second > 0);
     --(count_iter->second);
-    primary_mapping.pg_to_core.erase(iter);
+    primary_mapping.pg_to_core.erase(find_iter);
     DEBUG("pg {} mapping erased (primary)", pgid);
     return primary_mapping.container().invoke_on_others(
       [pgid, FNAME](auto &other_mapping) {
-      auto iter = other_mapping.pg_to_core.find(pgid);
-      ceph_assert_always(iter != other_mapping.pg_to_core.end());
-      ceph_assert_always(iter->second != NULL_CORE);
-      other_mapping.pg_to_core.erase(iter);
+      auto find_iter = other_mapping.pg_to_core.find(pgid);
+      if (find_iter == other_mapping.pg_to_core.end()) {
+        ERROR("trying to remove non-exist mapping for pg {} (others)", pgid);
+        ceph_abort("The pg mapping is inconsistent!");
+      }
+      assert(find_iter->second != NULL_CORE);
+      other_mapping.pg_to_core.erase(find_iter);
       DEBUG("pg {} mapping erased (others)", pgid);
     });
   });

--- a/src/crimson/osd/pg_map.h
+++ b/src/crimson/osd/pg_map.h
@@ -37,7 +37,7 @@ public:
   /// Returns mapping for pgid, creates new one if it doesn't already exist
   seastar::future<core_id_t> get_or_create_pg_mapping(
     spg_t pgid,
-    core_id_t core = NULL_CORE);
+    core_id_t core_expected = NULL_CORE);
 
   /// Remove pgid mapping
   seastar::future<> remove_pg_mapping(spg_t pgid);
@@ -60,7 +60,9 @@ public:
   }
 
 private:
+  // only in shard 0
   std::map<core_id_t, unsigned> core_to_num_pgs;
+  // per-shard, updated by shard 0
   std::map<spg_t, core_id_t> pg_to_core;
 };
 

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -183,7 +183,7 @@ seastar::future<> OSDSingletonState::osdmap_subscribe(
   version_t epoch, bool force_request)
 {
   LOG_PREFIX(OSDSingletonState::osdmap_subscribe);
-  INFO("epoch {}");
+  INFO("epoch {}", epoch);
   if (monc.sub_want_increment("osdmap", epoch, CEPH_SUBSCRIBE_ONETIME) ||
       force_request) {
     return monc.renew_subs();


### PR DESCRIPTION
Also:
* Better detections in case of inconsistent racings, such as:
  * The new mapping is creating towards different cores.
  * Mapping creation is racing with its eracing.
  * Multiple shards are eracing the same mapping at the same time.
* Add more logs to debug in case of unexpected issues.

Fixes: https://tracker.ceph.com/issues/64934
Fixes: https://tracker.ceph.com/issues/64009

Signed-off-by: Yingxin Cheng <yingxin.cheng@intel.com>
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
