### PR TITLE
squid: qa/rgw: ignore POOL_APP_NOT_ENABLED in rgw/lua subsuite

### DIFF
--- a/qa/suites/rgw/lua/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/lua/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+.qa/rgw/ignore-pg-availability.yaml


### PR DESCRIPTION
> cluster [WRN] Health check failed: 1 pool(s) do not have an application enabled (POOL_APP_NOT_ENABLED)" in cluster log

(no associated tracker issue)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
