### PR TITLE
squid: RGW: allow user disabling presigned urls in rgw configuration

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -892,6 +892,14 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_s3_auth_disable_signature_url
+  type: bool
+  level: advanced
+  desc: Should authentification with presigned URLs be disabled
+  long_desc: 'If enabled, any request that is presigned with either V2 or V4 signature will be denied'
+  default: false
+  services:
+  - rgw
 - name: rgw_barbican_url
   type: str
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -895,11 +895,12 @@ options:
 - name: rgw_s3_auth_disable_signature_url
   type: bool
   level: advanced
-  desc: Should authentification with presigned URLs be disabled
+  desc: Should authentication with presigned URLs be disabled
   long_desc: 'If enabled, any request that is presigned with either V2 or V4 signature will be denied'
   default: false
   services:
   - rgw
+  with_legacy: true
 - name: rgw_barbican_url
   type: str
   level: advanced

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -299,10 +299,15 @@ rgw::auth::Strategy::apply(const DoutPrefixProvider *dpp, const rgw::auth::Strat
        * nullptr inside. */
       ldpp_dout(dpp, 5) << "Failed the auth strategy, reason="
                        << result.get_reason() << dendl;
-      //Special handling for expired pre-signed URL
+      // Special handling for expired pre-signed URL
       if (result.get_reason() == ERR_PRESIGNED_URL_EXPIRED) {
         result = result_t::deny(-EPERM);
         set_req_state_err(s, -EPERM, "The pre-signed URL has expired");
+      }
+      // Special handling for disabled presigned URL
+      if (result.get_reason() == ERR_PRESIGNED_URL_DISABLED) {
+        result = result_t::deny(-EPERM);
+        set_req_state_err(s, -EPERM, "Presigned URLs are disabled by admin");
       }
       return result.get_reason();
     }

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -308,6 +308,7 @@ static inline const char* to_mime_type(const RGWFormat f)
 #define ERR_INVALID_BUCKET_STATE                         2221
 #define ERR_INVALID_OBJECT_STATE			 2222
 #define ERR_PRESIGNED_URL_EXPIRED			 2223
+#define ERR_PRESIGNED_URL_DISABLED     2224
 
 #define ERR_BUSY_RESHARDING      2300
 #define ERR_NO_SUCH_ENTITY       2301

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5551,19 +5551,20 @@ AWSGeneralAbstractor::get_auth_data(const req_state* const s) const
   AwsRoute route;
   std::tie(version, route) = discover_aws_flavour(s->info);
 
-  if (! s->cct->_conf->rgw_s3_auth_disable_signature_url) {
-    if (version == AwsVersion::V2) {
-      return get_auth_data_v2(s);
-    } else if (version == AwsVersion::V4) {
-      return get_auth_data_v4(s, route == AwsRoute::QUERY_STRING);
-    } else {
-      /* FIXME(rzarzynski): handle anon user. */
-      throw -EINVAL;
-    }
-  } else {
-    ldpp_dout(s, 0) << "Presigned URLs are disabled by admin" << dendl;
+  if (s->cct->_conf->rgw_s3_auth_disable_signature_url) {
+    ldpp_dout(s, 10) << "Presigned URLs are disabled by admin" << dendl;
     throw -ERR_PRESIGNED_URL_DISABLED;
   }
+  
+  if (version == AwsVersion::V2) {
+    return get_auth_data_v2(s);
+  } else if (version == AwsVersion::V4) {
+    return get_auth_data_v4(s, route == AwsRoute::QUERY_STRING);
+  } else {
+    /* FIXME(rzarzynski): handle anon user. */
+    throw -EINVAL;
+  }
+
 }
 
 boost::optional<std::string>

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5551,13 +5551,18 @@ AWSGeneralAbstractor::get_auth_data(const req_state* const s) const
   AwsRoute route;
   std::tie(version, route) = discover_aws_flavour(s->info);
 
-  if (version == AwsVersion::V2) {
-    return get_auth_data_v2(s);
-  } else if (version == AwsVersion::V4) {
-    return get_auth_data_v4(s, route == AwsRoute::QUERY_STRING);
+  if (! s->cct->_conf->rgw_s3_auth_disable_signature_url) {
+    if (version == AwsVersion::V2) {
+      return get_auth_data_v2(s);
+    } else if (version == AwsVersion::V4) {
+      return get_auth_data_v4(s, route == AwsRoute::QUERY_STRING);
+    } else {
+      /* FIXME(rzarzynski): handle anon user. */
+      throw -EINVAL;
+    }
   } else {
-    /* FIXME(rzarzynski): handle anon user. */
-    throw -EINVAL;
+    ldpp_dout(s, 0) << "Presigned URLs are disabled by admin" << dendl;
+    throw -ERR_PRESIGNED_URL_DISABLED;
   }
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65007

---

backport of https://github.com/ceph/ceph/pull/56044
parent tracker: https://tracker.ceph.com/issues/64797

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh