### PR TITLE
squid: rgw: Add missing empty checks to the split string in is_string_in_set().

### DIFF
--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -121,6 +121,8 @@ static bool is_string_in_set(set<string>& s, string h) {
       
       get_str_list((*it), "* \t", ssplit);
       if (off != 0) {
+        if (ssplit.empty())
+          continue;
         string sl = ssplit.front();
         flen = sl.length();
         dout(10) << "Finding " << sl << ", in " << h << ", at offset 0" << dendl;
@@ -129,6 +131,8 @@ static bool is_string_in_set(set<string>& s, string h) {
         ssplit.pop_front();
       }
       if (off != ((*it).length() - 1)) {
+        if (ssplit.empty())
+          continue;
         string sl = ssplit.front();
         dout(10) << "Finding " << sl << ", in " << h 
           << ", at offset not less than " << flen << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65004

---

backport of https://github.com/ceph/ceph/pull/56225
parent tracker: https://tracker.ceph.com/issues/64953

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh