### PR TITLE
mgr: add a new smb cluster & share module

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -739,6 +739,11 @@ Requires:       python%{python3_pkgversion}-CherryPy
 Requires:       python%{python3_pkgversion}-PyYAML
 Requires:       python%{python3_pkgversion}-Werkzeug
 %endif
+# RHEL8 has python 3.6 and that lacks dataclasses in the stdlib, so pull in the
+# backport dataclasses module instead.
+%if 0%{?rhel} <= 8
+Requires:       python%{python3_pkgversion}-dataclasses
+%endif
 %if 0%{?weak_deps}
 Recommends:	ceph-mgr-rook = %{_epoch_prefix}%{version}-%{release}
 %endif
@@ -1981,6 +1986,7 @@ fi
 %{_datadir}/ceph/mgr/restful
 %{_datadir}/ceph/mgr/rgw
 %{_datadir}/ceph/mgr/selftest
+%{_datadir}/ceph/mgr/smb
 %{_datadir}/ceph/mgr/snap_schedule
 %{_datadir}/ceph/mgr/stats
 %{_datadir}/ceph/mgr/status

--- a/doc/mgr/index.rst
+++ b/doc/mgr/index.rst
@@ -48,5 +48,6 @@ sensible.
     RGW module <rgw>
     MDS Autoscaler module <mds_autoscaler>
     NFS module <nfs>
+    SMB module <smb>
     Progress Module <progress>
     CLI API Commands module <cli_api>

--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -1,0 +1,740 @@
+.. _mgr-smb:
+
+=============================
+File System Shares Over SMB
+=============================
+
+CephFS access can be provided to clients using the `SMB protocol`_ via the
+`Samba suite`_ and `samba-container`_ images - managed by Ceph.
+
+The ``smb`` manager module provides an interface for deploying and controlling
+clusters of Samba services as well as managing SMB shares. In the ``smb``
+manager module a cluster is a logical management unit that may map to one or
+more managed Samba service - by itself a cluster may or may not be using any
+high-availability mechanisms.
+
+If the module is not already enabled on your cluster you can enable by running
+``ceph mgr module enable smb``.
+
+There are two ways of interacting with the ``smb`` module. The :ref:`imperative
+method <mgr-smb-imperative>` uses commands like ``ceph smb cluster create ...``
+and ``ceph smb share rm ...`` and should be very familiar to those who have
+used Ceph's ``nfs`` manager module on the command line. The :ref:`declarative
+method <mgr-smb-declarative>` uses the command ``ceph smb apply`` to process
+"resource descriptions" specified in YAML or JSON. This method should be
+familiar to those who have used Ceph orchestration with cephadm, just using SMB
+specific resource types.
+
+.. note::
+   Ceph managed Samba only supports SMB2 and SMB3 versions of the protocol.
+   The SMB1 version of the protocol, sometimes known as CIFS, is not supported.
+   Some systems, such as the Linux kernel, provide tooling for both SMB1 and SMB2+
+   under the CIFS moniker. Check the documentation of the software packages used
+   to ensure they support SMB2+ regardless of how the tool is named.
+
+.. note::
+   At this time, the ``smb`` module requires cephadm orchestration. It
+   does not function without orchestration.
+
+.. _SMB protocol: https://en.wikipedia.org/wiki/Server_Message_Block
+
+.. _Samba suite: https://samba.org
+
+.. _samba-container: https://github.com/samba-in-kubernetes/samba-container
+
+.. _mgr-smb-imperative:
+
+Management Commands - Imperative Style
+======================================
+
+Cluster Commands
+----------------
+
+Create Cluster
+++++++++++++++
+
+.. code:: bash
+
+    $ ceph smb cluster create <cluster_id> {user|active-directory} [--domain-realm=<domain_realm>] [--domain-join-user-pass=<domain_join_user_pass>] [--custom-dns=<custom_dns>] [--placement=<placement>]
+
+Create a new logical cluster, identified by the cluster id value. The cluster
+create command must specify the authentication mode the cluster will use. This
+may either be one of:
+
+- Custom users and groups, also known as a standalone server, with the ``user``
+  keyword
+- An Active Directory (AD) domain member server, with the ``active-directory``
+  keyword
+
+Options:
+
+cluster_id
+    A short string uniquely identifying the cluster
+auth_mode
+    One of ``user`` or ``active-directory``
+domain_realm
+    The domain/realm value identifying the AD domain. Required when choosing
+    ``active-directory``
+domain_join_user_pass
+    A string in the form ``<username>%<password>`` that will be used to join
+    Samba servers to the AD domain.
+custom_dns
+    Optional. Can be specified multiple times. One or more IP Addresses that
+    will be applied to the Samba containers to override the default DNS
+    resolver(s). This option is intended to be used when the host Ceph node is
+    not configured to resolve DNS entries within AD domain(s).
+placement
+    A Ceph orchestration :ref:`placement specifier <orchestrator-cli-placement-spec>`
+
+Remove Cluster
+++++++++++++++
+
+.. code:: bash
+
+    $ ceph smb cluster rm <cluster_id>
+
+Remove a logical SMB cluster from the Ceph cluster.
+
+List Clusters
+++++++++++++++
+
+.. code:: bash
+
+    $ ceph smb cluster ls [--format=<format>]
+
+Print a listing of cluster ids. The output defaults to JSON, select YAML
+encoding with the ``--format=yaml`` option.
+
+
+Share Commands
+--------------
+
+Create Share
+++++++++++++
+
+.. code:: bash
+
+    $ ceph smb share create <cluster_id> <share_id> <cephfs_volume> <path> [--share-name=<share_name>] [--subvolume=<subvolume>] [--readonly]
+
+Create a new SMB share, hosted by the named cluster, that maps to the given
+CephFS volume and path.
+
+Options:
+
+cluster_id
+    A short string uniquely identifying the cluster
+share_id
+    A short string uniquely identifying the share
+cephfs_volume
+    The name of the cephfs volume to be shared
+path
+    A path relative to the root of the volume and/or subvolume
+share_name
+    Optional. The public name of the share, visible to clients. If not provided
+    the ``share_id`` will be used automatically
+subvolume
+    Optional. A subvolume name in the form ``[<subvolumegroup>/]<subvolume>``.
+    The option causes the path to be relative to the CephFS subvolume
+    specified.
+readonly
+    Creates a read-only share
+
+Remove Share
+++++++++++++
+
+.. code:: bash
+
+    $ ceph smb share rm <cluster_id> <share_id>
+
+Remove an SMB Share from the cluster.
+
+
+List Shares
++++++++++++
+
+.. code:: bash
+
+    $ ceph smb share ls <cluster_id> [--format=<format>]
+
+Print a listing of share ids. The output defaults to JSON, select YAML
+encoding with the ``--format=yaml`` option.
+
+.. _mgr-smb-declarative:
+
+Management Commands - Declarative Style
+=======================================
+
+In addition to the basic imperative management commands the ``smb`` manager
+module supports configuration using declarative resource specifications.
+Resource specifications can be written in either JSON or YAML. These resource
+specifications can be applied to the cluster using the ``ceph smb apply``
+command, for example:
+
+.. code:: bash
+
+    $ ceph smb apply -i /path/to/resources.yaml
+
+Resources that have already been applied to the Ceph cluster configuration can
+be viewed using the ``ceph smb show`` command. For example:
+
+.. code:: bash
+
+    $ ceph smb show [<resource_name>...]
+
+The ``show`` command can show all resources of a given type or specific
+resources by id. ``resource_name`` arguments can take the following forms:
+
+- ``ceph.smb.cluster``: show all cluster resources
+- ``ceph.smb.cluster.<cluster_id>``: show specific cluster with given cluster id
+- ``ceph.smb.share``: show all share resources
+- ``ceph.smb.share.<cluster_id>``: show all share resources part of the given
+  cluster
+- ``ceph.smb.share.<cluster_id>.<share_id>``: show specific share resource with
+  the given cluster and share ids
+- ``ceph.smb.usersgroups``: show all Users & Groups resources
+- ``ceph.smb.usersgroups.<users_goups_id>``: show a specific Users & Groups
+  resource
+- ``ceph.smb.join.auth``: show all join auth resources
+- ``ceph.smb.join.auth.<auth_id>``: show a specific join auth resource
+
+For example:
+
+.. code:: bash
+
+    $ ceph smb show ceph.smb.cluster.bob ceph.smb.share.bob
+
+Will show one cluster resource (if it exists) for the cluster "bob" as well as
+all share resources associated with the cluster "bob".
+
+.. note::
+    The `show` subcommand prints out resources in the same form that the
+    ``apply`` command accepts, making it possible to "round-trip" values
+    between show and apply.
+
+
+Composing Resource Specifications
+---------------------------------
+
+A resource specification is made up of one or more Ceph SMB resource
+descriptions written in either JSON or YAML formats. More than one resource
+can be specified if the resources are contained within a JSON/YAML *list*,
+or a JSON/YAML object containing the key ``resources`` with a corresponding
+*list* value containing the resources. Additionally, a YAML specification
+may consist of a series of YAML documents each containing a resource.
+
+An example YAML based simple list looks like the following:
+
+.. code-block:: yaml
+
+    - resource_type: ceph.smb.cluster
+      cluster_id: rhumba
+      # ... other fields skipped for brevity ...
+    - resource_type: ceph.smb.cluster
+      cluster_id: salsa
+      # ... other fields skipped for brevity ...
+    - resource_type: ceph.smb.share
+      cluster_id: salsa
+      share_id: foo
+      # ... other fields skipped for brevity ...
+
+
+An example JSON based simple list looks like the following:
+
+.. code-block:: json
+
+    [
+      {"resource_type": "ceph.smb.cluster",
+       "cluster_id": "rhumba",
+       "...": "... other fields skipped for brevity ..."
+      },
+      {"resource_type": "ceph.smb.cluster",
+       "cluster_id": "salsa",
+       "...": "... other fields skipped for brevity ..."
+      },
+      {"resource_type": "ceph.smb.share",
+       "cluster_id": "salsa",
+       "share_id": "foo",
+       "...": "... other fields skipped for brevity ..."
+      }
+    ]
+
+An example YAML based resource list looks like the following:
+
+.. code-block:: yaml
+
+    resources:
+      - resource_type: ceph.smb.cluster
+        cluster_id: rhumba
+        # ... other fields skipped for brevity ...
+      - resource_type: ceph.smb.cluster
+        cluster_id: salsa
+        # ... other fields skipped for brevity ...
+      - resource_type: ceph.smb.share
+        cluster_id: salsa
+        share_id: foo
+        # ... other fields skipped for brevity ...
+
+
+An example JSON based resoure list looks like the following:
+
+.. code-block:: json
+
+    {
+      "resources": [
+        {"resource_type": "ceph.smb.cluster",
+         "cluster_id": "rhumba",
+         "...": "... other fields skipped for brevity ..."
+        },
+        {"resource_type": "ceph.smb.cluster",
+         "cluster_id": "salsa",
+         "...": "... other fields skipped for brevity ..."
+        },
+        {"resource_type": "ceph.smb.share",
+         "cluster_id": "salsa",
+         "share_id": "foo",
+         "...": "... other fields skipped for brevity ..."
+        }
+      ]
+    }
+
+An example YAML resource list consisting of multiple documents looks like
+the following:
+
+.. code-block:: yaml
+
+    ---
+    resource_type: ceph.smb.cluster
+    cluster_id: rhumba
+    # ... other fields skipped for brevity ...
+    ---
+    resource_type: ceph.smb.cluster
+    cluster_id: salsa
+    # ... other fields skipped for brevity ...
+    ---
+    resource_type: ceph.smb.share
+    cluster_id: salsa
+    share_id: foo
+    # ... other fields skipped for brevity ...
+
+
+Each individual resource description must belong to one of the types described
+below.
+
+.. note::
+   For brevity, all following examples will use YAML only. Assume that the
+   equivalent JSON forms are valid.
+
+Cluster Resource
+----------------
+
+A cluster resource supports the following fields:
+
+resource_type
+    A literal string ``ceph.smb.cluster``
+cluster_id
+    A short string identifying the cluster
+auth_mode
+    One of ``user`` or ``active-directory``
+intent
+    One of ``present`` or ``removed``. If not provided, ``present`` is
+    assumed. If ``removed`` all following fields are optional
+domain_settings
+    Object. Ignored/optional for ``user`` auth. Required for ``active-directory``
+    Fields:
+
+    realm
+        Required string. AD domain/realm name.
+    join_sources
+        Required list. Each element is an object with :ref:`join source fields
+        <join-source-fields>`
+user_group_settings
+    List. Ignored/optional for ``active-directory``. Each element is an object
+    with :ref:`user group source fields <user-group-source-fields>`
+custom_dns
+    Optional. List of IP Addresses. IP addresses will be used as DNS
+    resolver(s) in Samba containers allowing the containers to use domain DNS
+    even if the Ceph host does not
+placement
+    Optional. A Ceph Orchestration :ref:`placement specifier
+    <orchestrator-cli-placement-spec>`.  Defaults to one host if not provided
+
+
+.. _join-source-fields:
+
+A join source object supports the following fields:
+
+source_type
+    One of ``password`` or ``resource``
+auth
+    Object. Required for ``source_type: password``. Fields:
+
+    username:
+        Required string. User with ability to join a system to AD.
+    password:
+        Required string. The AD user's password
+ref
+    String. Required for ``source_type: resource``. Must refer to the ID of a
+    ``ceph.smb.join.auth`` resource
+
+.. _user-group-source-fields:
+
+A user group source object supports the following fields:
+
+source_type
+    One of ``inline`` or ``resource``
+values
+    Object. Required for ``source_type: inline``. Fields:
+
+    users
+        List of objects. Fields:
+
+        username
+            A user name
+        password
+            A password
+    groups
+        List of objects. Fields:
+
+        name
+            The name of the group
+ref
+    String. Required for ``source_type: resource``. Must refer to the ID of a
+    ``ceph.smb.join.auth`` resource
+
+The following is an example of a cluster configured for AD membership:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.cluster
+    cluster_id: tango
+    auth_mode: active-directory
+    domain_settings:
+      realm: DOMAIN1.SINK.TEST
+      join_sources:
+        # this join source refers to a join auth resource with id "join1-admin"
+        - source_type: resource
+          ref: join1-admin
+    custom_dns:
+      - "192.168.76.204"
+    placement:
+      count: 1
+
+The following is an example of a cluster configured for standalone operation:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.cluster
+    cluster_id: rhumba
+    auth_mode: user
+    user_group_settings:
+      - source_type: inline
+        values:
+          users:
+            - name: chuckx
+              password: 3xample101
+            - name: steves
+              password: F00Bar123
+          groups: []
+    placement:
+      hosts:
+        - node6.mycluster.sink.test
+
+An example cluster resource with intent to remove:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.cluster
+    cluster_id: rhumba
+    intent: removed
+
+
+
+Share Resource
+--------------
+
+A share resource supports the following fields:
+
+resource_type
+    A literal string ``ceph.smb.share``
+cluster_id
+    A short string identifying the cluster
+share_id
+    A short string identifying the share. Must be Unique within a cluster
+intent
+    One of ``present`` or ``removed``. If not provided, ``present`` is assumed.
+    If ``removed`` all following fields are optional
+name
+    Optional string. A longer name capable of supporting spaces and other
+    characters that will be presented to SMB clients
+readonly
+    Optional boolean, defaulting to false. If true no clients are permitted to
+    write to the share
+browseable
+    Optional boolean, defaulting to true. If true the share will be included in
+    share listings visible to clients
+cephfs
+    Required object. Fields:
+
+    volume
+        Required string. Name of the cephfs volume to use
+    path
+        Required string. Path within the volume or subvolume to share
+    subvolumegroup
+        Optional string. Name of a subvolumegroup to share
+    subvolume
+        Optional string. Name of a subvolume to share. If ``subvolumegroup`` is
+        not set and this value contains a exactly one ``/`` character, the
+        subvolume field will automatically be split into
+        ``<subvolumegroup>/<subvolume>`` parts for convenience
+    provider
+        Optional. One of ``samba-vfs`` or ``kcephfs`` (``kcephfs`` is not yet
+        supported) . Selects how CephFS storage should be provided to the share
+
+The following is an example of a share:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.share
+    cluster_id: tango
+    share_id: sp1
+    name: "Staff Pics"
+    cephfs:
+      volume: cephfs
+      path: /pics
+      subvolumegroup: smbshares
+      subvolume: staff
+
+
+Another example, this time of a share with an intent to be removed:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.share
+    cluster_id: tango
+    share_id: sp2
+    intent: removed
+
+
+Join-Auth Resource
+------------------
+
+A join auth resource supports the following fields:
+
+resource_type
+    A literal string ``ceph.smb.join.auth``
+auth_id
+    A short string identifying the join auth resource
+intent
+    One of ``present`` or ``removed``. If not provided, ``present`` is assumed.
+    If ``removed`` all following fields are optional
+auth
+    Required object. Fields:
+
+    username
+        Required string. User with ability to join a system to AD
+    password
+        Required string. The AD user's password
+
+Example:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.join.auth
+    auth_id: join1-admin
+    auth:
+      username: Administrator
+      password: Passw0rd
+
+
+Users-and-Groups Resource
+-------------------------
+
+A users & groups resource supports the following fields:
+
+resource_type
+    A literal string ``ceph.smb.usersgroups``
+users_groups_id
+    A short string identifying the users and groups resource
+intent
+    One of ``present`` or ``removed``. If not provided, ``present`` is assumed.
+    If ``removed`` all following fields are optional.
+values
+    Required object. Fields:
+
+    users
+        List of objects. Fields:
+
+        username
+            A user name
+        password
+            A password
+    groups
+        List of objects. Fields:
+
+        name
+            The name of the group
+
+
+Example:
+
+.. code-block:: yaml
+
+    resource_type: ceph.smb.usersgroups
+    users_groups_id: ug1
+    values:
+      users:
+        - name: chuckx
+          password: 3xample101
+        - name: steves
+          password: F00Bar123
+        groups: []
+
+
+A Declarative Configuration Example
+-----------------------------------
+
+Using the resource descriptions above we can put together an example
+that creates a cluster and shares from scratch based on a resource
+configuration file. First, create the YAML with the contents:
+
+.. code-block:: yaml
+
+    resources:
+      # Define an AD member server cluster
+      - resource_type: ceph.smb.cluster
+        cluster_id: tango
+        auth_mode: active-directory
+        domain_settings:
+          realm: DOMAIN1.SINK.TEST
+          join_sources:
+            - source_type: resource
+              ref: join1-admin
+        custom_dns:
+          - "192.168.76.204"
+        # deploy 1 set of samba containers on a host labeled "ilovesmb"
+        placement:
+          count: 1
+          label: ilovesmb
+      # Define a join auth that our cluster will use to join AD
+      # Warning: Typically you do not want to use the Administrator user
+      # to perform joins on a production AD
+      - resource_type: ceph.smb.join.auth
+        auth_id: join1-admin
+        auth:
+          username: Administrator
+          password: Passw0rd
+      # A share that uses the root of a subvolume
+      # The share name is the same as its id
+      - resource_type: ceph.smb.share
+        cluster_id: tango
+        share_id: cache
+        cephfs:
+          volume: cephfs
+          subvolumegroup: smb1
+          subvolume: cache
+          path: /
+      # A share that uses the a sub-dir of a subvolume
+      # The share name is not the same as its id
+      - resource_type: ceph.smb.share
+        cluster_id: tango
+        share_id: sp1
+        name: "Staff Pics"
+        cephfs:
+          volume: cephfs
+          path: /pics
+          subvolumegroup: smb1
+          subvolume: staff
+
+
+Save this text to a YAML file named ``resources.yaml`` and make it available
+on a cluster admin host. Then run:
+
+.. code:: bash
+
+    $ ceph smb apply -i resources.yaml
+
+The command will print a summary of the changes made and begin to automatically
+deploy the needed resources. See `Accessing Shares`_ for more information
+about how to test this example deployment.
+
+Later, if these resources are no longer needed they can be cleaned up in one
+action with a new file ``removed.yaml`` containing:
+
+.. code-block:: yaml
+
+    resources:
+      - resource_type: ceph.smb.cluster
+        cluster_id: tango
+        intent: removed
+      - resource_type: ceph.smb.join.auth
+        auth_id: join1-admin
+        intent: removed
+      - resource_type: ceph.smb.share
+        cluster_id: tango
+        share_id: cache
+        intent: removed
+      - resource_type: ceph.smb.share
+        cluster_id: tango
+        share_id: sp1
+        intent: removed
+
+By issuing the command:
+
+.. code:: bash
+
+    $ ceph smb apply -i removed.yaml
+
+
+SMB Cluster Management
+======================
+
+The ``smb`` module will automatically deploy logical clusters on hosts using
+cephadm orchestration. This orchestration is automatically triggered when a
+cluster has been configured for at least one share. The ``placement`` field of
+the cluster resource is passed onto the orchestration layer and is used to
+determine on what nodes of the Ceph cluster Samba containers will be run.
+
+At this time Samba services can only listen on port 445. Due to this
+restriction only one Samba server, as part of one cluster, may run on a single
+Ceph node at a time. Ensure that the placement specs on each cluster do not
+overlap.
+
+The ``smb`` clusters are fully isolated from each other. This means that, as
+long as you have sufficient resources in your Ceph cluster, you can run multiple
+independent clusters that may or may not join the same AD domains/forests.
+However you should not share a directory with multiple different clusters
+that may have different authentication modes and/or identity mapping schemes.
+
+.. note::
+   Future versions of the ``smb`` module may programatically attempt to prevent
+   such conditions.
+
+
+Accessing Shares
+================
+
+Once a cluster and it's component Samba containers have been deployed and the
+shares have been configured clients may connect to the servers. Microsoft
+Windows systems have SMB support built in and using Windows Explorer a share
+can be specified like so: ``\\<hostname>\<sharename>``. For example:
+``\\ceph0.mycluster.sink.test\Staff Pics``. The Windows node should
+automatically attempt to log into the share. If the cluster and Windows client
+are both configured for the same AD Domain then a password-less single sign-on
+login will automatically be performed. If the cluster is configured for
+``user`` auth, a username and password prompt should appear. Enter one user
+name and password combination that was specified in the cluster and/or
+``ceph.smb.usersgroups`` resource.
+
+MacOS X systems and many Linux based systems also support connecting to SMB
+shares. Consult the documentation for those Operating Systems and Distributions
+for how to connect to SMB shares.
+
+A Ceph cluster operator wanting to quickly test a share is functioning may want
+to install ``smbclient`` or use the Samba Client Container image available from
+the `samba-container`_ project with the image
+``quay.io/samba.org/samba-client:latest``. On a client or within the container
+run ``smbclient -U <username> //<hostname>/<sharename>`` and enter the password
+at the prompt. Refer to the `smbclient documentation`_ for more details.
+
+.. _smbclient documentation:
+   https://www.samba.org/samba/docs/current/man-html/smbclient.1.html

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_basic.yaml
@@ -1,0 +1,60 @@
+roles:
+# Test is for basic smb deployment & functionality. one node cluster is OK
+- - host.a
+  - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+  - client.0
+# Reserve a host for acting as a domain controller
+- - host.b
+  - cephadm.exclude
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
+tasks:
+- cephadm.configure_samba_client_container:
+    role: host.b
+- cephadm:
+
+- cephadm.shell:
+    host.a:
+      - ceph fs volume create cephfs
+- cephadm.wait_for_service:
+    service: mds.cephfs
+
+- cephadm.shell:
+    host.a:
+      # add subvolgroup & subvolumes for test
+      - cmd: ceph fs subvolumegroup create cephfs smb
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      # set up smb cluster and shares
+      - cmd: ceph mgr module enable smb
+      # TODO: replace sleep with poll of mgr state?
+      - cmd: sleep 30
+      - cmd: >
+          ceph smb cluster create modusr1 user
+          --define-user-pass=user1%t3stP4ss1
+          --define-user-pass=user2%t3stP4ss2
+      - cmd: ceph smb share create modusr1 share1 cephfs / --subvolume=smb/sv1
+      - cmd: ceph smb share create modusr1 share2 cephfs / --subvolume=smb/sv2
+# Wait for the smb service to start
+- cephadm.wait_for_service:
+    service: smb.modusr1
+# Check if shares exist
+- cephadm.exec:
+    host.b:
+      - sleep 30
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user1%t3stP4ss1 //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user2%t3stP4ss2 //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
+
+- cephadm.shell:
+    host.a:
+      - cmd: ceph smb share rm modusr1 share2
+      - cmd: ceph smb share rm modusr1 share1
+      - cmd: ceph smb cluster rm modusr1
+# Wait for the smb service to be removed
+- cephadm.wait_for_service_not_present:
+    service: smb.modusr1

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_domain.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_domain.yaml
@@ -1,0 +1,61 @@
+roles:
+# Test is for basic smb deployment & functionality. one node cluster is OK
+- - host.a
+  - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+  - client.0
+# Reserve a host for acting as a domain controller
+- - host.b
+  - cephadm.exclude
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
+tasks:
+- cephadm.deploy_samba_ad_dc:
+    role: host.b
+- cephadm:
+
+- cephadm.shell:
+    host.a:
+      - ceph fs volume create cephfs
+- cephadm.wait_for_service:
+    service: mds.cephfs
+
+- cephadm.shell:
+    host.a:
+      # add subvolgroup & subvolumes for test
+      - cmd: ceph fs subvolumegroup create cephfs smb
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      # set up smb cluster and shares
+      - cmd: ceph mgr module enable smb
+      # TODO: replace sleep with poll of mgr state?
+      - cmd: sleep 30
+      - cmd: >
+          ceph smb cluster create modtest1 active-directory
+          --domain-realm=domain1.sink.test
+          --domain-join-user-pass=Administrator%Passw0rd
+          --custom-dns={{ctx.samba_ad_dc_ip}}
+      - cmd: ceph smb share create modtest1 share1 cephfs / --subvolume=smb/sv1
+      - cmd: ceph smb share create modtest1 share2 cephfs / --subvolume=smb/sv2
+# Wait for the smb service to start
+- cephadm.wait_for_service:
+    service: smb.modtest1
+# Check if shares exist
+- cephadm.exec:
+    host.b:
+      - sleep 30
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
+
+- cephadm.shell:
+    host.a:
+      - cmd: ceph smb share rm modtest1 share2
+      - cmd: ceph smb share rm modtest1 share1
+      - cmd: ceph smb cluster rm modtest1
+# Wait for the smb service to be removed
+- cephadm.wait_for_service_not_present:
+    service: smb.modtest1

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_basic.yaml
@@ -1,0 +1,103 @@
+roles:
+# Test is for basic smb deployment & functionality. one node cluster is OK
+- - host.a
+  - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+  - client.0
+# Reserve a host for acting as a domain controller
+- - host.b
+  - cephadm.exclude
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
+tasks:
+- cephadm.configure_samba_client_container:
+    role: host.b
+- cephadm:
+
+- cephadm.shell:
+    host.a:
+      - ceph fs volume create cephfs
+- cephadm.wait_for_service:
+    service: mds.cephfs
+
+- cephadm.shell:
+    host.a:
+      # add subvolgroup & subvolumes for test
+      - cmd: ceph fs subvolumegroup create cephfs smb
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      # set up smb cluster and shares
+      - cmd: ceph mgr module enable smb
+      # TODO: replace sleep with poll of mgr state?
+      - cmd: sleep 30
+      - cmd: ceph smb apply -i -
+        stdin: |
+          # --- Begin Embedded YAML
+          - resource_type: ceph.smb.cluster
+            cluster_id: modusr1
+            auth_mode: user
+            user_group_settings:
+              - {source_type: resource, ref: ug1}
+            placement:
+              count: 1
+          - resource_type: ceph.smb.usersgroups
+            users_groups_id: ug1
+            values:
+              users:
+                - {name: user1, password: t3stP4ss1}
+                - {name: user2, password: t3stP4ss2}
+              groups: []
+          - resource_type: ceph.smb.share
+            cluster_id: modusr1
+            share_id: share1
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv1
+              path: /
+          - resource_type: ceph.smb.share
+            cluster_id: modusr1
+            share_id: share2
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv2
+              path: /
+          # --- End Embedded YAML
+# Wait for the smb service to start
+- cephadm.wait_for_service:
+    service: smb.modusr1
+# Check if shares exist
+- cephadm.exec:
+    host.b:
+      - sleep 30
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user1%t3stP4ss1 //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U user2%t3stP4ss2 //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
+
+- cephadm.shell:
+    host.a:
+      - cmd: ceph smb apply -i -
+        stdin: |
+          # --- Begin Embedded YAML
+          - resource_type: ceph.smb.cluster
+            cluster_id: modusr1
+            intent: removed
+          - resource_type: ceph.smb.usersgroups
+            users_groups_id: ug1
+            intent: removed
+          - resource_type: ceph.smb.share
+            cluster_id: modusr1
+            share_id: share1
+            intent: removed
+          - resource_type: ceph.smb.share
+            cluster_id: modusr1
+            share_id: share2
+            intent: removed
+          # --- End Embedded YAML
+# Wait for the smb service to be removed
+- cephadm.wait_for_service_not_present:
+    service: smb.modusr1

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_dom.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_dom.yaml
@@ -1,0 +1,106 @@
+roles:
+# Test is for basic smb deployment & functionality. one node cluster is OK
+- - host.a
+  - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+  - client.0
+# Reserve a host for acting as a domain controller
+- - host.b
+  - cephadm.exclude
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
+tasks:
+- cephadm.deploy_samba_ad_dc:
+    role: host.b
+- cephadm:
+
+- cephadm.shell:
+    host.a:
+      - ceph fs volume create cephfs
+- cephadm.wait_for_service:
+    service: mds.cephfs
+
+- cephadm.shell:
+    host.a:
+      # add subvolgroup & subvolumes for test
+      - cmd: ceph fs subvolumegroup create cephfs smb
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      # set up smb cluster and shares
+      - cmd: ceph mgr module enable smb
+      # TODO: replace sleep with poll of mgr state?
+      - cmd: sleep 30
+      - cmd: ceph smb apply -i -
+        stdin: |
+          # --- Begin Embedded YAML
+          - resource_type: ceph.smb.cluster
+            cluster_id: modtest1
+            auth_mode: active-directory
+            domain_settings:
+              realm: DOMAIN1.SINK.TEST
+              join_sources:
+                - source_type: resource
+                  ref: join1-admin
+            custom_dns:
+              - "{{ctx.samba_ad_dc_ip}}"
+            placement:
+              count: 1
+          - resource_type: ceph.smb.join.auth
+            auth_id: join1-admin
+            auth:
+              username: Administrator
+              password: Passw0rd
+          - resource_type: ceph.smb.share
+            cluster_id: modtest1
+            share_id: share1
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv1
+              path: /
+          - resource_type: ceph.smb.share
+            cluster_id: modtest1
+            share_id: share2
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv2
+              path: /
+          # --- End Embedded YAML
+# Wait for the smb service to start
+- cephadm.wait_for_service:
+    service: smb.modtest1
+# Check if shares exist
+- cephadm.exec:
+    host.b:
+      - sleep 30
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
+
+- cephadm.shell:
+    host.a:
+      - cmd: ceph smb apply -i -
+        stdin: |
+          # --- Begin Embedded YAML
+          - resource_type: ceph.smb.cluster
+            cluster_id: modtest1
+            intent: removed
+          - resource_type: ceph.smb.join.auth
+            auth_id: join1-admin
+            intent: removed
+          - resource_type: ceph.smb.share
+            cluster_id: modtest1
+            share_id: share1
+            intent: removed
+          - resource_type: ceph.smb.share
+            cluster_id: modtest1
+            share_id: share2
+            intent: removed
+          # --- End Embedded YAML
+# Wait for the smb service to be removed
+- cephadm.wait_for_service_not_present:
+    service: smb.modtest1

--- a/src/pybind/mgr/CMakeLists.txt
+++ b/src/pybind/mgr/CMakeLists.txt
@@ -46,6 +46,7 @@ set(mgr_modules
   rgw
   # rook (optional)
   selftest
+  smb
   snap_schedule
   stats
   status

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -46,6 +46,8 @@ class SMBService(CephService):
         config_blobs['config_uri'] = smb_spec.config_uri
         if smb_spec.join_sources:
             config_blobs['join_sources'] = smb_spec.join_sources
+        if smb_spec.user_sources:
+            config_blobs['user_sources'] = smb_spec.user_sources
         if smb_spec.custom_dns:
             config_blobs['custom_dns'] = smb_spec.custom_dns
         ceph_users = smb_spec.include_ceph_users or []
@@ -86,6 +88,7 @@ class SMBService(CephService):
     def _pools_in_spec(self, smb_spec: SMBSpec) -> Iterator[str]:
         uris = [smb_spec.config_uri]
         uris.extend(smb_spec.join_sources or [])
+        uris.extend(smb_spec.user_sources or [])
         for uri in uris:
             pool = self._rados_uri_to_pool(uri)
             if pool:

--- a/src/pybind/mgr/smb/__init__.py
+++ b/src/pybind/mgr/smb/__init__.py
@@ -1,0 +1,9 @@
+# enable unit test automagical mocks
+import os
+
+if 'UNITTEST' in os.environ:
+    import tests  # noqa: F401
+
+from .module import Module
+
+__all__ = ['Module']

--- a/src/pybind/mgr/smb/cli.py
+++ b/src/pybind/mgr/smb/cli.py
@@ -1,0 +1,58 @@
+from typing import Any, Callable, Tuple
+
+import errno
+
+import object_format
+from mgr_module import CLICommand
+
+from .proto import Self
+
+
+class _cmdlet:
+    def __init__(self, func: Callable, cmd: Callable) -> None:
+        self._func = func
+        self.command = cmd
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._func(*args, **kwargs)
+
+
+class SMBCommand:
+    """A combined decorator and descriptor. Sets up the common parts of the
+    CLICommand and object formatter.
+    As a descriptor, it returns objects that can be called and wrap the
+    "normal" function but also have a `.command` attribute so the CLI wrapped
+    version can also be used under the same namespace.
+
+    Example:
+    >>> class Example:
+    ...     @SMBCommand('share foo', perm='r')
+    ...     def foo(self):
+    ...         return {'test': 1}
+    ...
+    >>> ex = Example()
+    >>> assert ex.foo() == {'test': 1}
+    >>> assert ex.foo.command(format='yaml') == (0, "test: 1\\n", "")
+    """
+
+    def __init__(self, name: str, perm: str) -> None:
+        self._name = name
+        self._perm = perm
+
+    def __call__(self, func: Callable) -> Self:
+        self._func = func
+        cc = CLICommand(f'smb {self._name}', perm=self._perm)
+        rsp = object_format.Responder()
+        self._command = cc(rsp(func))
+        return self
+
+    def __get__(self, obj: Any, objtype: Any = None) -> _cmdlet:
+        return _cmdlet(
+            self._func.__get__(obj, objtype),
+            self._command.__get__(obj, objtype),
+        )
+
+
+class InvalidInputValue(object_format.ErrorResponseBase):
+    def format_response(self) -> Tuple[int, str, str]:
+        return -errno.EINVAL, "", str(self)

--- a/src/pybind/mgr/smb/config_store.py
+++ b/src/pybind/mgr/smb/config_store.py
@@ -1,0 +1,99 @@
+from typing import Collection, Dict, Iterator
+
+from .proto import ConfigEntry, EntryKey, Simplified
+
+
+class MemConfigEntry:
+    """A simple in-memory config store entry. Meant only for testing.
+    Objects are not serialized like most other stores.
+    """
+
+    def __init__(self, store: 'MemConfigStore', ns: str, name: str) -> None:
+        self._store = store
+        self._ns = ns
+        self._name = name
+
+    def set(self, obj: Simplified) -> None:
+        self._store._data[(self._ns, self._name)] = obj
+
+    def get(self) -> Simplified:
+        return self._store._data[(self._ns, self._name)]
+
+    def remove(self) -> bool:
+        return self._store.remove(self.full_key)
+
+    def exists(self) -> bool:
+        return (self._ns, self._name) in self._store._data
+
+    @property
+    def uri(self) -> str:
+        return f'mem:{self._ns}/{self._name}'
+
+    @property
+    def full_key(self) -> EntryKey:
+        return (self._ns, self._name)
+
+
+class MemConfigStore:
+    """A simple in-memory config store. Meant only for testing."""
+
+    def __init__(self) -> None:
+        self._data: Dict[EntryKey, Simplified] = {}
+
+    def __getitem__(self, key: EntryKey) -> MemConfigEntry:
+        return MemConfigEntry(self, key[0], key[1])
+
+    def remove(self, key: EntryKey) -> bool:
+        return self._data.pop(key, None) is not None
+
+    def namespaces(self) -> Collection[str]:
+        return {k[0] for k in self._data.keys()}
+
+    def contents(self, ns: str) -> Collection[str]:
+        return [k[1] for k in self._data.keys() if k[0] == ns]
+
+    def __iter__(self) -> Iterator[EntryKey]:
+        return iter(self._data.keys())
+
+    # for testing only
+    def overwrite(self, data: Simplified) -> None:
+        self._data = {}
+        for key, value in data.items():
+            if isinstance(key, str):
+                keyns, keyname = key.split('.', 1)
+            else:
+                keyns, keyname = key
+            self._data[(keyns, keyname)] = value
+
+    # for testing only
+    @property
+    def data(self) -> Dict[EntryKey, Simplified]:
+        return self._data
+
+
+class EntryCache:
+    """An in-memory cache compatible with the ConfigStore interface. It should
+    be used to cache *existing* ConfigEntry objects produced by/for other
+    stores.
+    """
+
+    def __init__(self) -> None:
+        self._entries: Dict[EntryKey, ConfigEntry] = {}
+
+    def __getitem__(self, key: EntryKey) -> ConfigEntry:
+        return self._entries[key]
+
+    def __setitem__(self, key: EntryKey, value: ConfigEntry) -> None:
+        self._entries[key] = value
+
+    def remove(self, key: EntryKey) -> bool:
+        return self._entries.pop(key, None) is not None
+
+    def namespaces(self) -> Collection[str]:
+        return {k[0] for k in self}
+
+    def contents(self, ns: str) -> Collection[str]:
+        return [kname for kns, kname in self if ns == ns]
+
+    def __iter__(self) -> Iterator[EntryKey]:
+        return iter(self._entries.keys())

--- a/src/pybind/mgr/smb/enums.py
+++ b/src/pybind/mgr/smb/enums.py
@@ -1,0 +1,59 @@
+"""Assorted enum values used throughout the smb mgr module."""
+
+import sys
+
+if sys.version_info >= (3, 11):  # pragma: no cover
+    from enum import StrEnum as _StrEnum
+else:  # pragma: no cover
+    import enum
+
+    # work like StrEnum for older python versions for our purposes
+    class _StrEnum(str, enum.Enum):
+        def __str__(self) -> str:
+            return self.value
+
+
+class CephFSStorageProvider(_StrEnum):
+    KERNEL_MOUNT = 'kcephfs'
+    SAMBA_VFS = 'samba-vfs'
+
+
+class SubSystem(_StrEnum):
+    CEPHFS = 'cephfs'
+
+
+class Intent(_StrEnum):
+    PRESENT = 'present'
+    REMOVED = 'removed'
+
+
+class State(_StrEnum):
+    CREATED = 'created'
+    NOT_PRESENT = 'not present'
+    PRESENT = 'present'
+    REMOVED = 'removed'
+    UPDATED = 'updated'
+
+
+class AuthMode(_StrEnum):
+    USER = 'user'
+    ACTIVE_DIRECTORY = 'active-directory'
+
+
+class JoinSourceType(_StrEnum):
+    PASSWORD = 'password'
+    HTTP_URI = 'http_uri'
+    RESOURCE = 'resource'
+
+
+class UserGroupSourceType(_StrEnum):
+    INLINE = 'inline'
+    HTTP_URI = 'http_uri'
+    RESOURCE = 'resource'
+
+
+class ConfigNS(_StrEnum):
+    CLUSTERS = 'clusters'
+    SHARES = 'shares'
+    USERS_AND_GROUPS = 'users_and_groups'
+    JOIN_AUTHS = 'join_auths'

--- a/src/pybind/mgr/smb/external.py
+++ b/src/pybind/mgr/smb/external.py
@@ -1,0 +1,133 @@
+"""Support for working with the external data stores and the items within.
+
+The external data stores exist specifially to share configuration with
+systems outside the mgr module. The naming is simpilfied and the
+cluster id acts as a namespace so that external entities can be
+granted access to only one cluster at a time.
+"""
+from typing import Collection, Tuple
+
+from .proto import ConfigStore, EntryKey
+
+# Convert identifiers into config entry keys
+
+
+def config_key(cluster_id: str, override: bool = False) -> EntryKey:
+    """Return key identifying a (cluster) config in an external store."""
+    return (cluster_id, 'config.smb.override' if override else 'config.smb')
+
+
+def cluster_placeholder_key(cluster_id: str) -> EntryKey:
+    """Return key identifying a cluster info in an external store."""
+    return (cluster_id, 'cluster-info')
+
+
+def join_source_key(cluster_id: str, name: str) -> EntryKey:
+    """Return key identifying a join source object in an external store."""
+    # don't feed "keys" back into this function, it's only for
+    # generating the key from an internal name
+    assert not name.startswith('join.')
+    assert not name.endswith('.json')
+    return (cluster_id, f'join.{name}.json')
+
+
+def users_and_groups_key(cluster_id: str, name: str) -> EntryKey:
+    """Return key identifying a users-and-groups object in an external
+    store.
+    """
+    # don't feed "keys" back into this function, it's only for
+    # generating the key from an internal name
+    assert not name.startswith('users-groups.')
+    assert not name.endswith('.json')
+    return (cluster_id, f'users-groups.{name}.json')
+
+
+def spec_backup_key(cluster_id: str) -> EntryKey:
+    """Return key identifying a smb service spec backup object in an external
+    store.
+    """
+    return (cluster_id, 'spec.smb')
+
+
+# Enumerate keys in a store
+
+
+def stored_join_source_keys(
+    store: ConfigStore, cluster_id: str
+) -> Collection[str]:
+    """Return a collection of names for join source objects in an external
+    store.
+    """
+    return [k for k in store.contents(cluster_id) if k.startswith('join.')]
+
+
+def stored_cluster_placeholder_keys(
+    store: ConfigStore, cluster_id: str
+) -> Collection[str]:
+    """Return a collection of names for join source objects in an external
+    store.
+    """
+    return [k for k in store.contents(cluster_id) if k == 'cluster-info']
+
+
+def stored_usergroup_source_keys(
+    store: ConfigStore, cluster_id: str
+) -> Collection[str]:
+    """Return a collection of names for users & groups source objects in an external
+    store.
+    """
+    return [
+        k for k in store.contents(cluster_id) if k.startswith('users-groups.')
+    ]
+
+
+def stored_config_keys(
+    store: ConfigStore, cluster_id: str
+) -> Collection[str]:
+    """Return a collection of names for config objects in an external store."""
+    return [
+        k for k in store.contents(cluster_id) if k.startswith('config.smb')
+    ]
+
+
+def stored_cluster_ids(
+    store: ConfigStore, *alt: ConfigStore
+) -> Collection[str]:
+    """Return a collection of cluster ids present in one or more external
+    config stores.
+    """
+    ns = set(store.namespaces())
+    for alt_store in alt:
+        ns.update(store.namespaces())
+    return ns
+
+
+# Remove objcts in an external config store
+
+
+def rm_cluster(store: ConfigStore, cluster_id: str) -> None:
+    """Remove all objects belonging to a given cluster id in a config store."""
+    knames = set(store.contents(cluster_id))
+    for kname in knames:
+        store.remove((cluster_id, kname))
+    # if the config store needs to remove the (now empty) namespace explicitly
+    # it must provide a remove_namespace method.
+    rm_namespace = getattr(store, 'remove_namespace', None)
+    if rm_namespace:
+        rm_namespace(cluster_id)
+    # TODO: this can probably be removed once the code has matured
+    assert cluster_id not in store.namespaces()
+
+
+def rm_other_in_ns(
+    store: ConfigStore,
+    namespace: str,
+    expected_keys: Collection[Tuple[str, str]],
+) -> None:
+    """Remove all objects within a given namespace that do not appear in the
+    given collection of expected_keys.
+    """
+    nskeys = set(key for key in store if key[0] == namespace)
+    remove_keys = nskeys - set(expected_keys)
+    for key in remove_keys:
+        store.remove(key)

--- a/src/pybind/mgr/smb/fs.py
+++ b/src/pybind/mgr/smb/fs.py
@@ -1,0 +1,108 @@
+from typing import List, Optional
+
+import logging
+import posixpath
+import stat
+
+import cephfs
+from mgr_util import CephfsClient, Module_T, open_filesystem
+
+from .proto import MonCommandIssuer
+
+log = logging.getLogger(__name__)
+
+
+class AuthorizationGrantError(ValueError):
+    pass
+
+
+class FileSystemAuthorizer:
+    """Using the rados apis provided by the ceph mgr, authorize cephx users for
+    file system access.
+    """
+
+    def __init__(self, mc: MonCommandIssuer) -> None:
+        self._mc = mc
+
+    def authorize_entity(
+        self, volume: str, entity: str, caps: Optional[List[str]] = None
+    ) -> None:
+        # TODO: the prototype is starting with wide open caps. we may want
+        # to have more restricted defaults in the future
+        assert entity.startswith('client.')
+        if not caps:
+            caps = ['/', 'rw']
+        cmd = {
+            'prefix': 'fs authorize',
+            'filesystem': volume,
+            'entity': entity,
+            'caps': caps,
+        }
+        log.info('Requesting fs authorzation: %r', cmd)
+        ret, _, status = self._mc.mon_command(cmd)
+        if ret != 0:
+            raise AuthorizationGrantError(status)
+        log.info('Authorization request success: %r', status)
+
+
+class CephFSSubvolumeResolutionError(KeyError):
+    pass
+
+
+class CephFSPathResolver:
+    """Using the rados and cephfs apis, the CephFSPathResolver can be used to
+    map to real paths in the cephfs volume and determine if those paths exist.
+    """
+
+    def __init__(self, mgr: Module_T) -> None:
+        self._mgr = mgr
+        self._cephfs_client = CephfsClient(mgr)
+
+    def resolve(
+        self, volume: str, subvolumegroup: str, subvolume: str, path: str
+    ) -> str:
+        """Given a volume, subvolumegroup, subvolume, and path, return the real
+        path within the file system. subvolumegroup and subvolume may be empty
+        strings when no subvolume is being used.
+        """
+        path = path.lstrip('/')
+        if not (subvolumegroup or subvolume):
+            return f'/{path}'
+        cmd = {
+            'prefix': 'fs subvolume getpath',
+            'vol_name': volume,
+            'sub_name': subvolume,
+        }
+        if subvolumegroup:
+            cmd['group_name'] = subvolumegroup
+        log.debug('Mapping subvolume to path: %r', cmd)
+        ret, data, status = self._mgr.mon_command(cmd)
+        if ret != 0:
+            raise CephFSSubvolumeResolutionError(status)
+        log.debug('Mapped subvolume to path: %r', data)
+        return posixpath.join(data.strip(), path)
+
+    def resolve_exists(
+        self, volume: str, subvolumegroup: str, subvolume: str, path: str
+    ) -> str:
+        """Executes the `resolve` method and verifies that it maps to a real
+        sharable directory. May raise FileNotFoundError or NotADirectoryError
+        when the path is not valid.
+        """
+        volpath = self.resolve(volume, subvolumegroup, subvolume, path)
+        with open_filesystem(self._cephfs_client, volume) as fs:
+            log.debug('checking if %r is a dir in %r', volpath, volume)
+            try:
+                stx = fs.statx(
+                    volpath.encode('utf-8'),
+                    cephfs.CEPH_STATX_MODE,
+                    cephfs.AT_SYMLINK_NOFOLLOW,
+                )
+            except (cephfs.ObjectNotFound, OSError) as err:
+                log.info('%r failed to stat: %s', volpath, err)
+                raise FileNotFoundError(volpath)
+            if not stat.S_ISDIR(stx.get('mode')):
+                log.info('%r is not a directory', volpath)
+                raise NotADirectoryError(volpath)
+        log.debug('Verified that %r exists in %r', volpath, volume)
+        return volpath

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -1,0 +1,987 @@
+from typing import (
+    Any,
+    Collection,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
+
+import logging
+import time
+
+from ceph.deployment.service_spec import SMBSpec
+
+from . import config_store, external, resources
+from .enums import (
+    AuthMode,
+    CephFSStorageProvider,
+    Intent,
+    JoinSourceType,
+    State,
+    UserGroupSourceType,
+)
+from .internal import (
+    ClusterEntry,
+    JoinAuthEntry,
+    ResourceEntry,
+    ShareEntry,
+    UsersAndGroupsEntry,
+)
+from .proto import (
+    AccessAuthorizer,
+    ConfigEntry,
+    ConfigStore,
+    OrchSubmitter,
+    PathResolver,
+    Simplified,
+    checked,
+)
+from .resources import SMBResource
+from .results import ErrorResult, Result, ResultGroup
+
+ClusterRef = Union[resources.Cluster, resources.RemovedCluster]
+ShareRef = Union[resources.Share, resources.RemovedShare]
+
+_DOMAIN = 'domain'
+log = logging.getLogger(__name__)
+
+
+class InvalidResourceMatch(ValueError):
+    pass
+
+
+class ClusterChangeGroup:
+    """A bag of holding for items being modified and thus needing synchronizing
+    with the external stores & components.
+    """
+
+    def __init__(
+        self,
+        cluster: ClusterRef,
+        shares: List[resources.Share],
+        join_auths: List[resources.JoinAuth],
+        users_and_groups: List[resources.UsersAndGroups],
+    ):
+        self.cluster = cluster
+        self.shares = shares
+        self.join_auths = join_auths
+        self.users_and_groups = users_and_groups
+        # a cache for modified entries
+        self.cache = config_store.EntryCache()
+
+    def cache_updated_entry(self, entry: ConfigEntry) -> None:
+        self.cache[entry.full_key] = entry
+
+
+class _FakePathResolver:
+    """A stub PathResolver for unit testing."""
+
+    def resolve(
+        self, volume: str, subvolumegroup: str, subvolume: str, path: str
+    ) -> str:
+        path = path.lstrip('/')
+        if subvolumegroup or subvolume:
+            import uuid
+
+            # mimic the uuid found in a real ceph subvolume path
+            # by deriving a uuid from the existing values we have
+            vid = str(
+                uuid.uuid3(
+                    uuid.NAMESPACE_URL,
+                    f'cephfs+{volume}:{subvolumegroup}:{subvolume}',
+                )
+            )
+            subvolumegroup = subvolumegroup or '_nogroup'
+            return f'/volumes/{subvolumegroup}/{subvolume}/{vid}/{path}'
+        return f'/{path}'
+
+    resolve_exists = resolve
+
+
+class _FakeAuthorizer:
+    """A stub AccessAuthorizer for unit testing."""
+
+    def authorize_entity(
+        self, volume: str, entity: str, caps: str = ''
+    ) -> None:
+        pass
+
+
+class _Matcher:
+    def __init__(self) -> None:
+        self._contents: Set[Any] = set()
+        self._inputs: Set[str] = set()
+
+    def __str__(self) -> str:
+        if not self._contents:
+            return 'match-all'
+        return 'match-resources:' + ','.join(self._inputs)
+
+    def __contains__(self, value: Any) -> bool:
+        if not self._contents:
+            return True
+        if not isinstance(value, tuple):
+            return value in self._contents
+        assert len(value) > 1
+        return (
+            # match a specific resource id
+            value in self._contents
+            # match all ids of a given resource type
+            or (value[0], None) in self._contents
+            # match a all partial ids (shares only)
+            or (
+                len(value) == 3
+                and (value[0], value[1], None) in self._contents
+            )
+        )
+
+    def parse(self, txt: str) -> None:
+        rtypes: Dict[str, Any] = {
+            cast(Any, r).resource_type: r
+            for r in (
+                resources.Cluster,
+                resources.Share,
+                resources.JoinAuth,
+                resources.UsersAndGroups,
+            )
+        }
+        if txt in rtypes:
+            resource_cls = rtypes[txt]
+            self._contents.add(resource_cls)
+            self._contents.add((resource_cls, None))
+            self._inputs.add(txt)
+            return
+        try:
+            prefix, id_a = txt.rsplit('.', 1)
+            resource_cls = rtypes[prefix]
+            self._contents.add(resource_cls)
+            self._contents.add((resource_cls, id_a))
+            self._contents.add((resource_cls, id_a, None))
+            self._inputs.add(txt)
+            return
+        except (ValueError, KeyError):
+            pass
+        try:
+            prefix, id_a, id_b = txt.rsplit('.', 2)
+            resource_cls = rtypes[prefix]
+            self._contents.add(resource_cls)
+            self._contents.add((resource_cls, id_a, id_b))
+            self._inputs.add(txt)
+            return
+        except (ValueError, KeyError):
+            pass
+        raise InvalidResourceMatch(
+            f'{txt!r} does not match a valid resource type'
+        )
+
+
+class ClusterConfigHandler:
+    """The central class for ingesting and handling smb configuration change
+    requests.
+
+    The ClusterConfigHandler works in roughly three phases:
+    1. Validation - for the resources being updated makes sure they're valid
+                    internally and also performs basic consistency checks.
+    2. Update     - updates the internal configuration store to persist the
+                    new resource objects
+    3. Sync'ing   - convert internal resources to externally usable data and
+                    update external components as needed.
+                    (see also "reconciliation")
+
+    It makes use of three data stores.
+    * internal_store: items that belong to the smb module. Generally, our
+      own saved resource types.
+    * public_store: A public store that is meant for sharing configuration data
+      with other processes. It is intended for non-sensitive general
+      configuration data
+    * priv_store: A priv(ate/ileged) store that is also meant for sharing data
+      with other processes. But unlike public store this data might be
+      sensitive.
+
+    Note that these stores are permitted to overlap. A public_store and
+    priv_store could use the exact same store object if the caller configures
+    the ClusterConfigHandler that way. This is very much expected when
+    executed in unit/other tests. Do NOT assume the keys in stores are mutually
+    exclusive!
+
+    This class also exposes some extra functionality for reading/iterating
+    the internal store so that the mgr module can be largely encapsulated
+    away from the store(s).
+    """
+
+    def __init__(
+        self,
+        *,
+        internal_store: ConfigStore,
+        public_store: ConfigStore,
+        priv_store: ConfigStore,
+        path_resolver: Optional[PathResolver] = None,
+        authorizer: Optional[AccessAuthorizer] = None,
+        orch: Optional[OrchSubmitter] = None,
+    ) -> None:
+        self.internal_store = internal_store
+        self.public_store = public_store
+        self.priv_store = priv_store
+        if path_resolver is None:
+            path_resolver = _FakePathResolver()
+        self._path_resolver: PathResolver = path_resolver
+        if authorizer is None:
+            authorizer = _FakeAuthorizer()
+        self._authorizer: AccessAuthorizer = authorizer
+        self._orch = orch  # if None, disables updating the spec via orch
+        log.info(
+            'Initialized new ClusterConfigHandler with'
+            f' internal store {self.internal_store!r},'
+            f' public store {self.public_store!r},'
+            f' priv store {self.priv_store!r},'
+            f' path resolver {self._path_resolver!r},'
+            f' authorizer {self._authorizer!r},'
+            f' orch {self._orch!r}'
+        )
+
+    def apply(self, inputs: Iterable[SMBResource]) -> ResultGroup:
+        log.debug('applying changes to internal data store')
+        results = ResultGroup()
+        for resource in self._order_inputs(inputs):
+            try:
+                result = self._update_resource(resource)
+            except ErrorResult as err:
+                result = err
+            except Exception as err:
+                log.exception("error updating resource")
+                result = ErrorResult(resource, msg=str(err))
+            results.append(result)
+        if results.success:
+            log.debug(
+                'successfully updated %s resources. syncing changes to public stores',
+                len(list(results)),
+            )
+            self._sync_modified(results)
+        return results
+
+    def cluster_ids(self) -> List[str]:
+        return list(ClusterEntry.ids(self.internal_store))
+
+    def share_ids(self) -> List[Tuple[str, str]]:
+        return list(ShareEntry.ids(self.internal_store))
+
+    def share_ids_by_cluster(self) -> Dict[str, List[str]]:
+        out: Dict[str, List[str]] = {}
+        for cluster_id, share_id in ShareEntry.ids(self.internal_store):
+            out.setdefault(cluster_id, []).append(share_id)
+        return out
+
+    def join_auth_ids(self) -> List[str]:
+        return list(JoinAuthEntry.ids(self.internal_store))
+
+    def user_and_group_ids(self) -> List[str]:
+        return list(UsersAndGroupsEntry.ids(self.internal_store))
+
+    def all_resources(self) -> List[SMBResource]:
+        return self._search_resources(_Matcher())
+
+    def matching_resources(self, names: List[str]) -> List[SMBResource]:
+        matcher = _Matcher()
+        for name in names:
+            matcher.parse(name)
+        return self._search_resources(matcher)
+
+    def _search_resources(self, matcher: _Matcher) -> List[SMBResource]:
+        log.debug("performing search with matcher: %s", matcher)
+        out: List[SMBResource] = []
+        if resources.Cluster in matcher or resources.Share in matcher:
+            log.debug("searching for clusters and/or shares")
+            cluster_shares = self.share_ids_by_cluster()
+            for cluster_id in self.cluster_ids():
+                if (resources.Cluster, cluster_id) in matcher:
+                    out.append(self._cluster_entry(cluster_id).get_cluster())
+                for share_id in cluster_shares[cluster_id]:
+                    if (resources.Share, cluster_id, share_id) in matcher:
+                        out.append(
+                            self._share_entry(
+                                cluster_id, share_id
+                            ).get_share()
+                        )
+        if resources.JoinAuth in matcher:
+            log.debug("searching for join auths")
+            for auth_id in self.join_auth_ids():
+                if (resources.JoinAuth, auth_id) in matcher:
+                    out.append(self._join_auth_entry(auth_id).get_join_auth())
+        if resources.UsersAndGroups in matcher:
+            log.debug("searching for users and groups")
+            for ug_id in self.user_and_group_ids():
+                if (resources.UsersAndGroups, ug_id) in matcher:
+                    out.append(
+                        self._users_and_groups_entry(
+                            ug_id
+                        ).get_users_and_groups()
+                    )
+        log.debug("search found %d resources", len(out))
+        return out
+
+    def _order_inputs(
+        self, inputs: Iterable[SMBResource]
+    ) -> List[SMBResource]:
+        """Sort resource objects by type so that the user can largely input
+        objects freely but that references map out cleanly.
+        """
+
+        def _keyfunc(r: SMBResource) -> int:
+            if isinstance(r, resources.RemovedShare):
+                return -2
+            if isinstance(r, resources.RemovedCluster):
+                return -1
+            if isinstance(r, resources.Share):
+                return 2
+            if isinstance(r, resources.Cluster):
+                return 1
+            return 0
+
+        return sorted(inputs, key=_keyfunc)
+
+    def _update_resource(self, resource: SMBResource) -> Result:
+        """Update the internal store with a new resource object."""
+        entry: ResourceEntry
+        log.debug('updating resource: %r', resource)
+        if isinstance(
+            resource, (resources.Cluster, resources.RemovedCluster)
+        ):
+            self._check_cluster(resource)
+            entry = self._cluster_entry(resource.cluster_id)
+        elif isinstance(resource, (resources.Share, resources.RemovedShare)):
+            self._check_share(resource)
+            entry = self._share_entry(resource.cluster_id, resource.share_id)
+        elif isinstance(resource, resources.JoinAuth):
+            self._check_join_auths(resource)
+            entry = self._join_auth_entry(resource.auth_id)
+        elif isinstance(resource, resources.UsersAndGroups):
+            self._check_users_and_groups(resource)
+            entry = self._users_and_groups_entry(resource.users_groups_id)
+        else:
+            raise TypeError('not a valid smb resource')
+        state = self._save(entry, resource)
+        result = Result(resource, success=True, status={'state': state})
+        log.debug('saved resource: %r; state: %s', resource, state)
+        return result
+
+    def _save(self, entry: ResourceEntry, resource: SMBResource) -> State:
+        # Returns the Intent indicating the previous state.
+        if resource.intent == Intent.REMOVED:
+            removed = entry.remove()
+            return State.REMOVED if removed else State.NOT_PRESENT
+        return entry.create_or_update(resource)
+
+    def _sync_clusters(
+        self, modified_cluster_ids: Optional[Collection[str]] = None
+    ) -> None:
+        """Trigger synchronization for all the clusters listed in
+        `modified_cluster_ids` or all clusters if None.
+        """
+        share_ids = self.share_ids()
+        present_cluster_ids = set()
+        removed_cluster_ids = set()
+        change_groups = []
+        cluster_ids = modified_cluster_ids or ClusterEntry.ids(
+            self.internal_store
+        )
+        log.debug(
+            'syncing %s clusters: %s',
+            'all' if not modified_cluster_ids else 'selected',
+            ' '.join(cluster_ids),
+        )
+        for cluster_id in cluster_ids:
+            entry = self._cluster_entry(cluster_id)
+            try:
+                cluster = entry.get_cluster()
+            except KeyError:
+                removed_cluster_ids.add(cluster_id)
+                continue
+            present_cluster_ids.add(cluster_id)
+            change_group = ClusterChangeGroup(
+                cluster,
+                [
+                    self._share_entry(cid, shid).get_share()
+                    for cid, shid in share_ids
+                    if cid == cluster_id
+                ],
+                [
+                    self._join_auth_entry(_id).get_join_auth()
+                    for _id in _auth_refs(cluster)
+                ],
+                [
+                    self._users_and_groups_entry(_id).get_users_and_groups()
+                    for _id in _ug_refs(cluster)
+                ],
+            )
+            change_groups.append(change_group)
+        for change_group in change_groups:
+            self._save_cluster_settings(change_group)
+
+        # if there are clusters in the public store, that don't exist
+        # in the internal store, we need to clean them up.
+        if not modified_cluster_ids:
+            ext_ids = set(
+                external.stored_cluster_ids(
+                    self.public_store, self.priv_store
+                )
+            )
+            removed_cluster_ids = ext_ids - set(cluster_ids)
+        for cluster_id in removed_cluster_ids:
+            self._remove_cluster(cluster_id)
+
+    def _sync_modified(self, updated: ResultGroup) -> None:
+        cluster_ids = self._find_modifications(updated)
+        self._sync_clusters(cluster_ids)
+
+    def _find_modifications(self, updated: ResultGroup) -> Collection[str]:
+        """Given a ResultGroup tracking what was recently updated in the
+        internal store, return all cluster_ids that may need external syncing.
+        """
+        # this initial version is going to take a simplistic approach and try
+        # to broadly collect anything that could be a change.
+        # Later, this function can be refined to trigger fewer changes by looking
+        # at the objects in more detail any only producing a change group for
+        # something that really has been modified.
+        chg_cluster_ids: Set[str] = set()
+        chg_join_ids: Set[str] = set()
+        chg_ug_ids: Set[str] = set()
+        for result in updated:
+            state = (result.status or {}).get('state', None)
+            if state in (State.PRESENT, State.NOT_PRESENT):
+                # these are the no-change states. we can ignore them
+                continue
+            if isinstance(
+                result.src, (resources.Cluster, resources.RemovedCluster)
+            ):
+                chg_cluster_ids.add(result.src.cluster_id)
+            elif isinstance(
+                result.src, (resources.Share, resources.RemovedShare)
+            ):
+                # shares always belong to one cluster
+                chg_cluster_ids.add(result.src.cluster_id)
+            elif isinstance(result.src, resources.JoinAuth):
+                chg_join_ids.add(result.src.auth_id)
+            elif isinstance(result.src, resources.UsersAndGroups):
+                chg_ug_ids.add(result.src.users_groups_id)
+
+        # TODO: here's a lazy bit. if any join auths or users/groups changed we
+        # will regen all clusters because these can be shared by >1 cluster.
+        # In future, make this only pick clusters using the named resources.
+        if chg_join_ids or chg_ug_ids:
+            chg_cluster_ids.update(ClusterEntry.ids(self.internal_store))
+        return chg_cluster_ids
+
+    def _save_cluster_settings(
+        self, change_group: ClusterChangeGroup
+    ) -> None:
+        """Save the external facing objects. Tickle the external components."""
+        log.debug(
+            'saving external store for cluster: %s',
+            change_group.cluster.cluster_id,
+        )
+        # vols: hold the cephfs volumes our shares touch. some operations are
+        # disabled/skipped unless we touch volumes.
+        vols = {share.checked_cephfs.volume for share in change_group.shares}
+        data_entity = _cephx_data_entity(change_group.cluster.cluster_id)
+        # save the various object types
+        previous_info = _swap_pending_cluster_info(
+            self.public_store,
+            change_group,
+            orch_needed=bool(vols and self._orch),
+        )
+        _save_pending_join_auths(self.priv_store, change_group)
+        _save_pending_users_and_groups(self.priv_store, change_group)
+        _save_pending_config(
+            self.public_store,
+            change_group,
+            self._path_resolver,
+            data_entity,
+        )
+        # remove any stray objects
+        external.rm_other_in_ns(
+            self.priv_store,
+            change_group.cluster.cluster_id,
+            set(change_group.cache),
+        )
+        external.rm_other_in_ns(
+            self.public_store,
+            change_group.cluster.cluster_id,
+            set(change_group.cache),
+        )
+
+        # ensure a entity exists with access to the volumes
+        for volume in vols:
+            self._authorizer.authorize_entity(volume, data_entity)
+        if not vols:
+            # there were no volumes, and thus nothing to authorize. set data_entity
+            # to an empty string to avoid adding it to the svc spec later.
+            data_entity = ''
+
+        # build a service spec for smb cluster
+        cluster = change_group.cluster
+        assert isinstance(cluster, resources.Cluster)
+        config_entries = [
+            change_group.cache[external.config_key(cluster.cluster_id)],
+            self.public_store[
+                external.config_key(cluster.cluster_id, override=True)
+            ],
+        ]
+        join_source_entries = [
+            change_group.cache[(cluster.cluster_id, key)]
+            for key in external.stored_join_source_keys(
+                change_group.cache, cluster.cluster_id
+            )
+        ]
+        user_source_entries = [
+            change_group.cache[(cluster.cluster_id, key)]
+            for key in external.stored_usergroup_source_keys(
+                change_group.cache, cluster.cluster_id
+            )
+        ]
+        smb_spec = _generate_smb_service_spec(
+            cluster,
+            config_entries=config_entries,
+            join_source_entries=join_source_entries,
+            user_source_entries=user_source_entries,
+            data_entity=data_entity,
+        )
+        _save_pending_spec_backup(self.public_store, change_group, smb_spec)
+        # if orch was ever needed in the past we must "re-orch", but if we have
+        # no volumes and never orch'ed before wait until we have something to
+        # share before orchestrating the smb cluster. This is done because we
+        # need volumes in order to have cephx keys that we pass to the services
+        # via orch.  This differs from NFS because ganesha embeds the cephx
+        # keys directly in each export definition block while samba needs the
+        # ceph keyring to load keys.
+        previous_orch = previous_info.get('orch_needed', False)
+        if self._orch and (vols or previous_orch):
+            self._orch.submit_smb_spec(smb_spec)
+
+    def _remove_cluster(self, cluster_id: str) -> None:
+        log.info('Removing cluster: %s', cluster_id)
+        spec_key = external.spec_backup_key(cluster_id)
+        if self.public_store[spec_key].exists() and self._orch:
+            service_name = f'smb.{cluster_id}'
+            log.debug('Removing smb orch service: %r', service_name)
+            self._orch.remove_smb_service(service_name)
+        external.rm_cluster(self.priv_store, cluster_id)
+        external.rm_cluster(self.public_store, cluster_id)
+
+    def _check_cluster(self, cluster: ClusterRef) -> None:
+        """Check that the cluster resource can be updated."""
+        if cluster.intent == Intent.REMOVED:
+            share_ids = ShareEntry.ids(self.internal_store)
+            clusters_used = {cid for cid, _ in share_ids}
+            if cluster.cluster_id in clusters_used:
+                raise ErrorResult(
+                    cluster,
+                    msg="cluster in use by shares",
+                    status={
+                        'clusters': [
+                            shid
+                            for cid, shid in share_ids
+                            if cid == cluster.cluster_id
+                        ]
+                    },
+                )
+            return
+        assert isinstance(cluster, resources.Cluster)
+        cluster.validate()
+
+    def _check_share(self, share: ShareRef) -> None:
+        """Check that the share resource can be updated."""
+        if share.intent == Intent.REMOVED:
+            return
+        assert isinstance(share, resources.Share)
+        share.validate()
+        if share.cluster_id not in ClusterEntry.ids(self.internal_store):
+            raise ErrorResult(
+                share,
+                msg="no matching cluster id",
+                status={"cluster_id": share.cluster_id},
+            )
+        assert share.cephfs is not None
+        try:
+            self._path_resolver.resolve_exists(
+                share.cephfs.volume,
+                share.cephfs.subvolumegroup,
+                share.cephfs.subvolume,
+                share.cephfs.path,
+            )
+        except (FileNotFoundError, NotADirectoryError):
+            raise ErrorResult(
+                share, msg="path is not a valid directory in volume"
+            )
+
+    def _check_join_auths(self, join_auth: resources.JoinAuth) -> None:
+        """Check that the JoinAuth resource can be updated."""
+        if join_auth.intent == Intent.PRESENT:
+            return  # adding is always ok
+        refs_in_use: Dict[str, List[str]] = {}
+        for cluster_id in ClusterEntry.ids(self.internal_store):
+            cluster = self._cluster_entry(cluster_id).get_cluster()
+            for ref in _auth_refs(cluster):
+                refs_in_use.setdefault(ref, []).append(cluster_id)
+        log.debug('refs_in_use: %r', refs_in_use)
+        if join_auth.auth_id in refs_in_use:
+            raise ErrorResult(
+                join_auth,
+                msg='join auth resource in use by clusters',
+                status={
+                    'clusters': refs_in_use[join_auth.auth_id],
+                },
+            )
+
+    def _check_users_and_groups(
+        self, users_and_groups: resources.UsersAndGroups
+    ) -> None:
+        """Check that the UsersAndGroups resource can be updated."""
+        if users_and_groups.intent == Intent.PRESENT:
+            return  # adding is always ok
+        refs_in_use: Dict[str, List[str]] = {}
+        for cluster_id in ClusterEntry.ids(self.internal_store):
+            cluster = self._cluster_entry(cluster_id).get_cluster()
+            for ref in _ug_refs(cluster):
+                refs_in_use.setdefault(ref, []).append(cluster_id)
+        log.debug('refs_in_use: %r', refs_in_use)
+        if users_and_groups.users_groups_id in refs_in_use:
+            raise ErrorResult(
+                users_and_groups,
+                msg='users and groups resource in use by clusters',
+                status={
+                    'clusters': refs_in_use[users_and_groups.users_groups_id],
+                },
+            )
+
+    def _cluster_entry(self, cluster_id: str) -> ClusterEntry:
+        return ClusterEntry.from_store(self.internal_store, cluster_id)
+
+    def _share_entry(self, cluster_id: str, share_id: str) -> ShareEntry:
+        return ShareEntry.from_store(
+            self.internal_store, cluster_id, share_id
+        )
+
+    def _join_auth_entry(self, auth_id: str) -> JoinAuthEntry:
+        return JoinAuthEntry.from_store(self.internal_store, auth_id)
+
+    def _users_and_groups_entry(self, ug_id: str) -> UsersAndGroupsEntry:
+        return UsersAndGroupsEntry.from_store(self.internal_store, ug_id)
+
+    def generate_config(self, cluster_id: str) -> Dict[str, Any]:
+        """Demo function that generates a config on demand."""
+        cluster = self._cluster_entry(cluster_id).get_cluster()
+        shares = [
+            self._share_entry(cluster_id, shid).get_share()
+            for shid in self.share_ids_by_cluster()[cluster_id]
+        ]
+        return _generate_config(
+            cluster,
+            shares,
+            self._path_resolver,
+            _cephx_data_entity(cluster_id),
+        )
+
+    def generate_smb_service_spec(self, cluster_id: str) -> SMBSpec:
+        """Demo function that generates a smb service spec on demand."""
+        cluster = self._cluster_entry(cluster_id).get_cluster()
+        # if the user manually puts custom configurations (aka "override"
+        # configs) in the store, use that in favor of the generated config.
+        # this is mainly intended for development/test
+        config_entries = [
+            self.public_store[external.config_key(cluster_id)],
+            self.public_store[external.config_key(cluster_id, override=True)],
+        ]
+        join_source_entries = [
+            self.priv_store[(cluster_id, key)]
+            for key in external.stored_join_source_keys(
+                self.priv_store, cluster_id
+            )
+        ]
+        user_source_entries = [
+            self.priv_store[(cluster_id, key)]
+            for key in external.stored_usergroup_source_keys(
+                self.priv_store, cluster_id
+            )
+        ]
+        return _generate_smb_service_spec(
+            cluster,
+            config_entries=config_entries,
+            join_source_entries=join_source_entries,
+            user_source_entries=user_source_entries,
+        )
+
+
+def _auth_refs(cluster: resources.Cluster) -> Collection[str]:
+    if cluster.auth_mode != AuthMode.ACTIVE_DIRECTORY:
+        return set()
+    return {
+        j.ref
+        for j in checked(cluster.domain_settings).join_sources
+        if j.source_type == JoinSourceType.RESOURCE and j.ref
+    }
+
+
+def _ug_refs(cluster: resources.Cluster) -> Collection[str]:
+    if (
+        cluster.auth_mode != AuthMode.USER
+        or cluster.user_group_settings is None
+    ):
+        return set()
+    return {
+        ug.ref
+        for ug in cluster.user_group_settings
+        if ug.source_type == UserGroupSourceType.RESOURCE and ug.ref
+    }
+
+
+def _ynbool(value: bool) -> str:
+    """Convert a bool to an smb.conf compatible string."""
+    return 'Yes' if value else 'No'
+
+
+def _generate_share(
+    share: resources.Share, resolver: PathResolver, cephx_entity: str
+) -> Dict[str, Dict[str, str]]:
+    assert share.cephfs is not None
+    assert share.cephfs.provider == CephFSStorageProvider.SAMBA_VFS
+    assert cephx_entity, "cephx entity name missing"
+    # very annoyingly, samba's ceph module absolutely must NOT have the
+    # "client." bit in front. JJM has been tripped up by this multiple times -
+    # seemingly every time this module is touched.
+    _prefix = 'client.'
+    plen = len(_prefix)
+    if cephx_entity.startswith(_prefix):
+        cephx_entity = cephx_entity[plen:]
+    path = resolver.resolve(
+        share.cephfs.volume,
+        share.cephfs.subvolumegroup,
+        share.cephfs.subvolume,
+        share.cephfs.path,
+    )
+    return {
+        # smb.conf options
+        'options': {
+            'path': path,
+            "vfs objects": "ceph",
+            'ceph:config_file': '/etc/ceph/ceph.conf',
+            'ceph:filesystem': share.cephfs.volume,
+            'ceph:user_id': cephx_entity,
+            'read only': _ynbool(share.readonly),
+            'browseable': _ynbool(share.browseable),
+            'kernel share modes': 'no',
+            'x:ceph:id': f'{share.cluster_id}.{share.share_id}',
+        }
+    }
+
+
+def _generate_config(
+    cluster: resources.Cluster,
+    shares: Iterable[resources.Share],
+    resolver: PathResolver,
+    cephx_entity: str = "",
+) -> Dict[str, Any]:
+    cluster_global_opts = {}
+    if cluster.auth_mode == AuthMode.ACTIVE_DIRECTORY:
+        assert cluster.domain_settings is not None
+        cluster_global_opts['security'] = 'ads'
+        cluster_global_opts['realm'] = cluster.domain_settings.realm
+        # TODO: support alt. workgroup values
+        wg = cluster.domain_settings.realm.upper().split('.')[0]
+        cluster_global_opts['workgroup'] = wg
+        cluster_global_opts['idmap config * : backend'] = 'autorid'
+        cluster_global_opts['idmap config * : range'] = '2000-9999999'
+
+    share_configs = {
+        share.name: _generate_share(share, resolver, cephx_entity)
+        for share in shares
+    }
+
+    return {
+        'samba-container-config': 'v0',
+        'configs': {
+            cluster.cluster_id: {
+                'instance_name': cluster.cluster_id,
+                'instance_features': [],
+                'globals': ['default', cluster.cluster_id],
+                'shares': list(share_configs.keys()),
+            },
+        },
+        'globals': {
+            'default': {
+                'options': {
+                    'server min protocol': 'SMB2',
+                    'load printers': 'No',
+                    'printing': 'bsd',
+                    'printcap name': '/dev/null',
+                    'disable spoolss': 'Yes',
+                }
+            },
+            cluster.cluster_id: {
+                'options': cluster_global_opts,
+            },
+        },
+        'shares': share_configs,
+    }
+
+
+def _generate_smb_service_spec(
+    cluster: resources.Cluster,
+    *,
+    config_entries: List[ConfigEntry],
+    join_source_entries: List[ConfigEntry],
+    user_source_entries: List[ConfigEntry],
+    data_entity: str = '',
+) -> SMBSpec:
+    features = []
+    if cluster.auth_mode == AuthMode.ACTIVE_DIRECTORY:
+        features.append(_DOMAIN)
+    # only one config uri can be used, the input list should be
+    # ordered from lowest to highest priority and the highest priority
+    # item that exists in the store will be used.
+    config_uri = ''
+    for entry in config_entries:
+        if entry.exists():
+            config_uri = entry.uri
+    if not config_uri:
+        raise ValueError('no samba container configuration available')
+    # collect the the uris for the join sources
+    join_sources: List[str] = []
+    for entry in join_source_entries:
+        # if entry.exists():
+        join_sources.append(entry.uri)
+    # collect the uris for the user sources
+    user_sources: List[str] = []
+    for entry in user_source_entries:
+        user_sources.append(entry.uri)
+    user_entities: Optional[List[str]] = None
+    if data_entity:
+        user_entities = [data_entity]
+    return SMBSpec(
+        service_id=cluster.cluster_id,
+        placement=cluster.placement,
+        cluster_id=cluster.cluster_id,
+        features=features,
+        config_uri=config_uri,
+        join_sources=join_sources,
+        user_sources=user_sources,
+        custom_dns=cluster.custom_dns,
+        include_ceph_users=user_entities,
+    )
+
+
+def _swap_pending_cluster_info(
+    store: ConfigStore,
+    change_group: ClusterChangeGroup,
+    orch_needed: bool,
+) -> Simplified:
+    # TODO: its not just a  placeholder any more. rename the key func!
+    pentry = store[
+        external.cluster_placeholder_key(change_group.cluster.cluster_id)
+    ]
+    try:
+        existing = pentry.get()
+    except KeyError:
+        existing = {}
+    pentry.set(
+        {
+            'cluster_id': change_group.cluster.cluster_id,
+            'timestamp': int(time.time()),
+            'orch_needed': orch_needed,
+        }
+    )
+    change_group.cache_updated_entry(pentry)
+    return existing
+
+
+def _save_pending_join_auths(
+    store: ConfigStore,
+    change_group: ClusterChangeGroup,
+) -> None:
+    cluster = change_group.cluster
+    assert isinstance(cluster, resources.Cluster)
+    # save each join auth source in the priv store
+    if cluster.auth_mode != AuthMode.ACTIVE_DIRECTORY:
+        return
+    arefs = {j.auth_id: j for j in change_group.join_auths}
+    for idx, src in enumerate(checked(cluster.domain_settings).join_sources):
+        if src.source_type == JoinSourceType.RESOURCE:
+            javalues = checked(arefs[src.ref].auth)
+        elif src.source_type == JoinSourceType.PASSWORD:
+            javalues = checked(src.auth)
+        else:
+            raise ValueError(
+                f'unsupported join source type: {src.source_type}'
+            )
+        jentry = store[external.join_source_key(cluster.cluster_id, str(idx))]
+        jentry.set(javalues.to_simplified())
+        change_group.cache_updated_entry(jentry)
+
+
+def _save_pending_users_and_groups(
+    store: ConfigStore,
+    change_group: ClusterChangeGroup,
+) -> None:
+    cluster = change_group.cluster
+    assert isinstance(cluster, resources.Cluster)
+    # save each users-and-groups settings in the priv store
+    if cluster.auth_mode != AuthMode.USER:
+        return
+    augs = {ug.users_groups_id: ug for ug in change_group.users_and_groups}
+    for idx, ugsv in enumerate(checked(cluster.user_group_settings)):
+        if ugsv.source_type == UserGroupSourceType.RESOURCE:
+            ugvalues = augs[ugsv.ref].values
+            assert ugvalues
+        elif ugsv.source_type == UserGroupSourceType.INLINE:
+            ugvalues = ugsv.values
+            assert ugvalues
+        else:
+            raise ValueError(
+                f'unsupported users/groups source type: {ugsv.source_type}'
+            )
+        ugentry = store[
+            external.users_and_groups_key(cluster.cluster_id, str(idx))
+        ]
+        ugsimple = ugvalues.to_simplified()
+        ug_config: Simplified = {'samba-container-config': 'v0'}
+        if 'users' in ugsimple:
+            ug_config['users'] = {'all_entries': ugsimple['users']}
+        if 'groups' in ugsimple:
+            ug_config['groups'] = {'all_entries': ugsimple['groups']}
+        ugentry.set(ug_config)
+        change_group.cache_updated_entry(ugentry)
+
+
+def _save_pending_config(
+    store: ConfigStore,
+    change_group: ClusterChangeGroup,
+    resolver: PathResolver,
+    cephx_entity: str = "",
+) -> None:
+    assert isinstance(change_group.cluster, resources.Cluster)
+    # generate the cluster configuration and save it in the public store
+    cconfig = _generate_config(
+        change_group.cluster, change_group.shares, resolver, cephx_entity
+    )
+    centry = store[external.config_key(change_group.cluster.cluster_id)]
+    centry.set(cconfig)
+    change_group.cache_updated_entry(centry)
+
+
+def _save_pending_spec_backup(
+    store: ConfigStore, change_group: ClusterChangeGroup, smb_spec: SMBSpec
+) -> None:
+    ssentry = store[external.spec_backup_key(change_group.cluster.cluster_id)]
+    ssentry.set(smb_spec.to_json())
+    change_group.cache_updated_entry(ssentry)
+
+
+def _cephx_data_entity(cluster_id: str) -> str:
+    """Generate a name for the (default?) cephx key that a cluster (smbd) will
+    use for data access.
+    """
+    return f'client.smb.fs.cluster.{cluster_id}'

--- a/src/pybind/mgr/smb/internal.py
+++ b/src/pybind/mgr/smb/internal.py
@@ -1,0 +1,166 @@
+"""Support for working with the internal data store and the strucutured
+resources that the internal store holds.
+"""
+from typing import Collection, Tuple, Type, TypeVar
+
+from . import resources
+from .enums import AuthMode, ConfigNS, State
+from .proto import ConfigEntry, ConfigStore, Self, Simplifiable, one
+from .resources import SMBResource
+from .results import ErrorResult
+
+T = TypeVar('T')
+
+
+class ResourceEntry:
+    """Base class for resource entry getter/setter objects."""
+
+    namespace: ConfigNS
+
+    def __init__(self, key: str, config_entry: ConfigEntry) -> None:
+        self.key = key
+        self.config_entry = config_entry
+
+    @property
+    def uri(self) -> str:
+        return self.config_entry.uri
+
+    def get(self) -> SMBResource:
+        return one(resources.load(self.config_entry.get()))
+
+    def get_resource_type(self, cls: Type[T]) -> T:
+        obj = self.get()
+        assert isinstance(obj, cls)
+        return obj
+
+    def set(self, resource: Simplifiable) -> None:
+        self.config_entry.set(resource.to_simplified())
+
+    def create_or_update(self, resource: Simplifiable) -> State:
+        try:
+            previous = self.config_entry.get()
+        except KeyError:
+            previous = None
+        current = resource.to_simplified()
+        if current == previous:
+            return State.PRESENT
+        self.config_entry.set(current)
+        return State.CREATED if previous is None else State.UPDATED
+
+    def remove(self) -> bool:
+        return self.config_entry.remove()
+
+
+class ClusterEntry(ResourceEntry):
+    """Cluster resource getter/setter for the smb internal data store(s)."""
+
+    namespace = ConfigNS.CLUSTERS
+
+    @classmethod
+    def from_store(cls, store: ConfigStore, cluster_id: str) -> Self:
+        return cls(cluster_id, store[str(cls.namespace), cluster_id])
+
+    @classmethod
+    def ids(cls, store: ConfigStore) -> Collection[str]:
+        return store.contents(str(cls.namespace))
+
+    def get_cluster(self) -> resources.Cluster:
+        return self.get_resource_type(resources.Cluster)
+
+    def create_or_update(self, resource: Simplifiable) -> State:
+        assert isinstance(resource, resources.Cluster)
+        try:
+            previous = self.config_entry.get()
+        except KeyError:
+            previous = None
+        current = resource.to_simplified()
+        if current == previous:
+            return State.PRESENT
+        elif previous is None:
+            self.config_entry.set(current)
+            return State.CREATED
+        # cluster is special in that is has some fields that we do not
+        # permit changing.
+        prev = getattr(
+            resources.Cluster, '_resource_config'
+        ).object_from_simplified(previous)
+        if resource.auth_mode != prev.auth_mode:
+            raise ErrorResult(
+                resource,
+                'auth_mode value may not be changed',
+                status={'existing_auth_mode': prev.auth_mode},
+            )
+        if resource.auth_mode == AuthMode.ACTIVE_DIRECTORY:
+            assert resource.domain_settings
+            assert prev.domain_settings
+            if resource.domain_settings.realm != prev.domain_settings.realm:
+                raise ErrorResult(
+                    resource,
+                    'domain/realm value may not be changed',
+                    status={
+                        'existing_domain_realm': prev.domain_settings.realm
+                    },
+                )
+        self.config_entry.set(current)
+        return State.UPDATED
+
+
+class ShareEntry(ResourceEntry):
+    """Share resource getter/setter for the smb internal data store(s)."""
+
+    namespace = ConfigNS.SHARES
+
+    @classmethod
+    def from_store(
+        cls, store: ConfigStore, cluster_id: str, share_id: str
+    ) -> Self:
+        key = f'{cluster_id}.{share_id}'
+        return cls(key, store[str(cls.namespace), key])
+
+    @classmethod
+    def ids(cls, store: ConfigStore) -> Collection[Tuple[str, str]]:
+        return [_split(k) for k in store.contents(str(cls.namespace))]
+
+    def get_share(self) -> resources.Share:
+        return self.get_resource_type(resources.Share)
+
+
+class JoinAuthEntry(ResourceEntry):
+    """JoinAuth resource getter/setter for the smb internal data store(s)."""
+
+    namespace = ConfigNS.JOIN_AUTHS
+
+    @classmethod
+    def from_store(cls, store: ConfigStore, auth_id: str) -> Self:
+        return cls(auth_id, store[str(cls.namespace), auth_id])
+
+    @classmethod
+    def ids(cls, store: ConfigStore) -> Collection[str]:
+        return store.contents(str(cls.namespace))
+
+    def get_join_auth(self) -> resources.JoinAuth:
+        return self.get_resource_type(resources.JoinAuth)
+
+
+class UsersAndGroupsEntry(ResourceEntry):
+    """UsersAndGroupsEntry resource getter/setter for the smb internal data
+    store(s).
+    """
+
+    namespace = ConfigNS.USERS_AND_GROUPS
+
+    @classmethod
+    def from_store(cls, store: ConfigStore, auth_id: str) -> Self:
+        return cls(auth_id, store[str(cls.namespace), auth_id])
+
+    @classmethod
+    def ids(cls, store: ConfigStore) -> Collection[str]:
+        return store.contents(str(cls.namespace))
+
+    def get_users_and_groups(self) -> resources.UsersAndGroups:
+        return self.get_resource_type(resources.UsersAndGroups)
+
+
+def _split(share_key: str) -> Tuple[str, str]:
+    cluster_id, share_id = share_key.split('.', 1)
+    return cluster_id, share_id

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -1,19 +1,278 @@
+from typing import Any, Dict, List, Optional, cast
+
 import logging
 
-from typing import Any, List
-
+import orchestrator
+from ceph.deployment.service_spec import PlacementSpec, SMBSpec
 from mgr_module import MgrModule, Option
 
-import orchestrator
-
-
+from . import cli, fs, handler, mon_store, rados_store, resources
+from .enums import AuthMode, JoinSourceType, UserGroupSourceType
+from .proto import AccessAuthorizer, Simplified
 
 log = logging.getLogger(__name__)
 
 
 class Module(orchestrator.OrchestratorClientMixin, MgrModule):
-    MODULE_OPTIONS: List[Option] = []
+    MODULE_OPTIONS: List[Option] = [
+        Option(
+            'update_orchestration',
+            type='bool',
+            default=True,
+            desc='automatically update orchestration when smb resources are changed',
+        ),
+    ]
+
+    update_orchestration: bool = True
 
     def __init__(self, *args: str, **kwargs: Any) -> None:
+        internal_store = kwargs.pop('internal_store', None)
+        priv_store = kwargs.pop('priv_store', None)
+        public_store = kwargs.pop('public_store', None)
+        path_resolver = kwargs.pop('path_resolver', None)
+        authorizer = kwargs.pop('authorizer', None)
+        update_orchestration = kwargs.pop(
+            'update_orchestration', self.update_orchestration
+        )
         super().__init__(*args, **kwargs)
-        log.info('hello smb')
+        self._internal_store = internal_store or mon_store.ModuleConfigStore(
+            self
+        )
+        self._priv_store = priv_store or mon_store.MonKeyConfigStore(self)
+        # self._public_store = public_store or mon_store.MonKeyConfigStore(self)
+        self._public_store = (
+            public_store or rados_store.RADOSConfigStore.init(self)
+        )
+        path_resolver = path_resolver or fs.CephFSPathResolver(self)
+        # Why the honk is the cast needed but path_resolver doesn't need it??
+        # Sometimes mypy drives me batty.
+        authorizer = cast(
+            AccessAuthorizer, authorizer or fs.FileSystemAuthorizer(self)
+        )
+        self._handler = handler.ClusterConfigHandler(
+            internal_store=self._internal_store,
+            priv_store=self._priv_store,
+            public_store=self._public_store,
+            path_resolver=path_resolver,
+            authorizer=authorizer,
+            orch=(self if update_orchestration else None),
+        )
+
+    @cli.SMBCommand('apply', perm='rw')
+    def apply_resources(self, inbuf: str) -> handler.ResultGroup:
+        """Create, update, or remove smb configuration resources based on YAML
+        or JSON specs
+        """
+        return self._handler.apply(resources.load_text(inbuf))
+
+    @cli.SMBCommand('cluster ls', perm='r')
+    def cluster_ls(self) -> List[str]:
+        """List smb clusters by ID"""
+        return [cid for cid in self._handler.cluster_ids()]
+
+    @cli.SMBCommand('cluster create', perm='rw')
+    def cluster_create(
+        self,
+        cluster_id: str,
+        auth_mode: AuthMode,
+        domain_realm: str = '',
+        domain_join_ref: Optional[List[str]] = None,
+        domain_join_user_pass: Optional[List[str]] = None,
+        user_group_ref: Optional[List[str]] = None,
+        define_user_pass: Optional[List[str]] = None,
+        custom_dns: Optional[List[str]] = None,
+        placement: Optional[str] = None,
+    ) -> handler.Result:
+        """Create an smb cluster"""
+        domain_settings = None
+        user_group_settings = None
+
+        if domain_realm or domain_join_ref or domain_join_user_pass:
+            join_sources: List[resources.JoinSource] = []
+            # create join auth resource references
+            for djref in domain_join_ref or []:
+                join_sources.append(
+                    resources.JoinSource(
+                        source_type=JoinSourceType.RESOURCE,
+                        ref=djref,
+                    )
+                )
+            # as a "short cut" allow passing username%password combos on the
+            # command line for testing / automation where the auth tokens are
+            # single use or don't really matter security wise
+            for djunpw in domain_join_user_pass or []:
+                try:
+                    username, password = djunpw.split('%', 1)
+                except ValueError:
+                    raise ValueError(
+                        'a domain join username & password value'
+                        ' must contain a "%" separator'
+                    )
+                join_sources.append(
+                    resources.JoinSource(
+                        source_type=JoinSourceType.PASSWORD,
+                        auth=resources.JoinAuthValues(
+                            username=username,
+                            password=password,
+                        ),
+                    )
+                )
+            domain_settings = resources.DomainSettings(
+                realm=domain_realm,
+                join_sources=join_sources,
+            )
+
+        # we don't permit creating groups on the command line. A bit too
+        # complex for very little payoff.  We do support a very simple
+        # <username>%<password> split for just creating users
+        # However, it's much preferred to use the declarative resources for
+        # managing these.
+        user_group_settings = []
+        if user_group_ref:
+            user_group_settings += [
+                resources.UserGroupSource(
+                    source_type=UserGroupSourceType.RESOURCE, ref=r
+                )
+                for r in user_group_ref
+            ]
+        if define_user_pass:
+            users = []
+            for unpw in define_user_pass or []:
+                username, password = unpw.split('%', 1)
+                users.append({'name': username, 'password': password})
+            user_group_settings += [
+                resources.UserGroupSource(
+                    source_type=UserGroupSourceType.INLINE,
+                    values=resources.UserGroupSettings(
+                        users=users,
+                        groups=[],
+                    ),
+                )
+            ]
+
+        pspec = resources.WrappedPlacementSpec.wrap(
+            PlacementSpec.from_string(placement)
+        )
+        cluster = resources.Cluster(
+            cluster_id=cluster_id,
+            auth_mode=auth_mode,
+            domain_settings=domain_settings,
+            user_group_settings=user_group_settings,
+            custom_dns=custom_dns,
+            placement=pspec,
+        )
+        return self._handler.apply([cluster]).one()
+
+    @cli.SMBCommand('cluster rm', perm='rw')
+    def cluster_rm(self, cluster_id: str) -> handler.Result:
+        """Remove an smb cluster"""
+        cluster = resources.RemovedCluster(cluster_id=cluster_id)
+        return self._handler.apply([cluster]).one()
+
+    @cli.SMBCommand('share ls', perm='r')
+    def share_ls(self, cluster_id: str) -> List[str]:
+        """List smb shares in a cluster by ID"""
+        return [
+            shid
+            for cid, shid in self._handler.share_ids()
+            if cid == cluster_id
+        ]
+
+    @cli.SMBCommand('share create', perm='rw')
+    def share_create(
+        self,
+        cluster_id: str,
+        share_id: str,
+        cephfs_volume: str,
+        path: str,
+        # plain old 'name' conflicts with builtin options to the `ceph` command.
+        # use `share_name` to avoid having to `ceph -- smb share create ...`.
+        share_name: str = '',
+        subvolume: str = '',
+        readonly: bool = False,
+    ) -> handler.Result:
+        """Create an smb share"""
+        share = resources.Share(
+            cluster_id=cluster_id,
+            share_id=share_id,
+            name=share_name,
+            readonly=readonly,
+            cephfs=resources.CephFSStorage(
+                volume=cephfs_volume,
+                path=path,
+                subvolume=subvolume,
+            ),
+        )
+        return self._handler.apply([share]).one()
+
+    @cli.SMBCommand('share rm', perm='rw')
+    def share_rm(self, cluster_id: str, share_id: str) -> handler.Result:
+        """Remove an smb share"""
+        share = resources.RemovedShare(
+            cluster_id=cluster_id, share_id=share_id
+        )
+        return self._handler.apply([share]).one()
+
+    @cli.SMBCommand('show', perm='r')
+    def show(self, resource_names: Optional[List[str]] = None) -> Simplified:
+        """Show resources fetched from the local config store based on resource
+        type or resource type and id(s).
+        """
+        if not resource_names:
+            resources = self._handler.all_resources()
+        else:
+            try:
+                resources = self._handler.matching_resources(resource_names)
+            except handler.InvalidResourceMatch as err:
+                raise cli.InvalidInputValue(str(err)) from err
+        if len(resources) == 1:
+            return resources[0].to_simplified()
+        return {'resources': [r.to_simplified() for r in resources]}
+
+    @cli.SMBCommand('dump cluster-config', perm='r')
+    def dump_config(self, cluster_id: str) -> Dict[str, Any]:
+        """DEBUG: Generate an example configuration"""
+        # TODO: Remove this command prior to release
+        return self._handler.generate_config(cluster_id)
+
+    @cli.SMBCommand('dump service-spec', perm='r')
+    def dump_service_spec(self, cluster_id: str) -> Dict[str, Any]:
+        """DEBUG: Generate an example smb service spec"""
+        # TODO: Remove this command prior to release
+        return dict(
+            self._handler.generate_smb_service_spec(cluster_id).to_json()
+        )
+
+    @cli.SMBCommand('dump everything', perm='r')
+    def dump_everything(self) -> Dict[str, Any]:
+        """DEBUG: Show me everything"""
+        # TODO: Remove this command prior to release
+        everything: Dict[str, Any] = {}
+        everything['PUBLIC'] = {}
+        log.warning('dumping PUBLIC')
+        for key in self._public_store:
+            e = self._public_store[key]
+            log.warning('dumping e: %s %r', e.uri, e.full_key)
+            everything['PUBLIC'][e.uri] = e.get()
+        log.warning('dumping PRIV')
+        everything['PRIV'] = {}
+        for key in self._priv_store:
+            e = self._priv_store[key]
+            log.warning('dumping e: %s %r', e.uri, e.full_key)
+            everything['PRIV'][e.uri] = e.get()
+        log.warning('dumping INTERNAL')
+        everything['INTERNAL'] = {}
+        for key in self._internal_store:
+            e = self._internal_store[key]
+            log.warning('dumping e: %s %r', e.uri, e.full_key)
+            everything['INTERNAL'][e.uri] = e.get()
+        return everything
+
+    def submit_smb_spec(self, spec: SMBSpec) -> None:
+        """Submit a new or updated smb spec object to ceph orchestration."""
+        completion = self.apply_smb(spec)
+        orchestrator.raise_if_exception(completion)
+
+    def remove_smb_service(self, service_name: str) -> None:
+        completion = self.remove_service(service_name)
+        orchestrator.raise_if_exception(completion)

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -1,0 +1,19 @@
+import logging
+
+from typing import Any, List
+
+from mgr_module import MgrModule, Option
+
+import orchestrator
+
+
+
+log = logging.getLogger(__name__)
+
+
+class Module(orchestrator.OrchestratorClientMixin, MgrModule):
+    MODULE_OPTIONS: List[Option] = []
+
+    def __init__(self, *args: str, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        log.info('hello smb')

--- a/src/pybind/mgr/smb/mon_store.py
+++ b/src/pybind/mgr/smb/mon_store.py
@@ -1,0 +1,276 @@
+from typing import Collection, Dict, Iterator, Optional, cast
+
+import json
+
+from .proto import EntryKey, MonCommandIssuer, Protocol, Simplified
+
+
+class MgrStoreProtocol(Protocol):
+    """A simple protocol describing the minimal per-mgr-module (mon) store interface
+    provided by the fairly giganto MgrModule class.
+    """
+
+    def get_store(self, key: str) -> Optional[str]:
+        ...
+
+    def set_store(self, key: str, val: Optional[str]) -> None:
+        ...
+
+    def get_store_prefix(self, key_prefix: str) -> Dict[str, str]:
+        ...
+
+
+def _ksplit(key: str, prefix: str = '') -> EntryKey:
+    if prefix and key.startswith(prefix):
+        plen = len(prefix)
+        key = key[plen:]
+    ek = tuple(key.split('/', 1))
+    assert len(ek) == 2
+    # the cast is needed for older mypy versions, where asserting
+    # the length doesn't narrow the type
+    return cast(EntryKey, ek)
+
+
+def _kjoin(key: EntryKey) -> str:
+    assert len(key) == 2
+    return '/'.join(key)
+
+
+class ModuleStoreEntry:
+    """A store entry for the manager module config store."""
+
+    def __init__(
+        self, module_store: 'ModuleConfigStore', key: EntryKey
+    ) -> None:
+        self._store = module_store
+        self._key = key
+        self._store_key = self._store.PREFIX + _kjoin(key)
+
+    def set(self, obj: Simplified) -> None:
+        """Set the store entry value to that of the serialized value of obj."""
+        value = json.dumps(obj)
+        self._store._mstore.set_store(self._store_key, value)
+
+    def get(self) -> Simplified:
+        """Get the deserialized store entry value."""
+        value = self._store._mstore.get_store(self._store_key)
+        if value is None:
+            raise KeyError(self._key)
+        return json.loads(value)
+
+    def remove(self) -> bool:
+        """Remove the current entry from the store."""
+        return self._store.remove(self.full_key)
+
+    def exists(self) -> bool:
+        """Returns true if the entry currently exists within the store."""
+        return self._key in set(self._store)
+
+    @property
+    def uri(self) -> str:
+        """Returns an identifier for the entry within the store."""
+        ns, name = self._key
+        return f'ceph-smb-resource:{ns}/{name}'
+
+    @property
+    def full_key(self) -> EntryKey:
+        """Return a namespaced key for the entry."""
+        return self._key
+
+
+class ModuleConfigStore:
+    """A store that serves as a layer on top of a mgr module's key/value store.
+    Most appropriate for the smb module internal store.
+
+    N.B. This store is ulimately backed by the same data store as the
+    MonKeyConfigStore or commands like `ceph config-key ...` commands. The mgr
+    C++ code that implements the three functions we use for this class
+    automatically prefix the keys we provide with the module in use. These
+    functions also cache. The built-in prefixing make this store less
+    appropriate for use outside of the mgr module. There's little point in
+    caching at this layer - at least not caching the serialized strings -
+    because the mgr c++ layer is already doing that.
+    """
+
+    PREFIX = 'ceph.smb.resources/'
+
+    def __init__(self, mstore: MgrStoreProtocol):
+        self._mstore = mstore
+
+    def __getitem__(self, key: EntryKey) -> ModuleStoreEntry:
+        """Return an entry object given a namespaced entry key. This entry does
+        not have to exist in the store.
+        """
+        return ModuleStoreEntry(self, key)
+
+    def remove(self, key: EntryKey) -> bool:
+        """Remove an entry from the store. Returns true if an entry was
+        present.
+        """
+        # The Ceph Mgr api uses none as special token to delete the item.
+        # Otherwise it only accepts strings to set.
+        if key not in self:
+            return False
+        self._mstore.set_store(self.PREFIX + _kjoin(key), None)
+        return True
+
+    def namespaces(self) -> Collection[str]:
+        """Return all namespaces currently in the store."""
+        return {k[0] for k in self}
+
+    def contents(self, ns: str) -> Collection[str]:
+        """Return all subkeys currently in the namespace."""
+        return [k[1] for k in self if k[0] == ns]
+
+    def __iter__(self) -> Iterator[EntryKey]:
+        """Iterate over all namespaced keys currently in the store."""
+        for k in self._mstore.get_store_prefix(self.PREFIX).keys():
+            yield _ksplit(k, prefix=self.PREFIX)
+
+
+class MonKeyStoreEntry:
+    """A config store entry for items in the global ceph mon config-key store."""
+
+    def __init__(
+        self, mon_key_store: 'MonKeyConfigStore', key: EntryKey
+    ) -> None:
+        self._store = mon_key_store
+        self._key = key
+        self._store_key = self._store.PREFIX + _kjoin(key)
+
+    def set(self, obj: Simplified) -> None:
+        """Set the store entry value to that of the serialized value of obj."""
+        self._store._set_val(self._key, json.dumps(obj))
+
+    def get(self) -> Simplified:
+        """Get the deserialized store entry value."""
+        return json.loads(self._store._get_val(self._key))
+
+    def remove(self) -> bool:
+        """Remove the current entry from the store."""
+        return self._store.remove(self.full_key)
+
+    def exists(self) -> bool:
+        """Returns true if the entry currently exists within the store."""
+        return self._key in self._store
+
+    @property
+    def uri(self) -> str:
+        """Returns an identifier for the entry within the store."""
+        # The rados:mon-config-key pseudo scheme is made up for the
+        # purposes of communicating a key using the URI syntax with
+        # other components, particularly the sambacc library.
+        return f'rados:mon-config-key:{self._store_key}'
+
+    @property
+    def full_key(self) -> EntryKey:
+        """Return a namespaced key for the entry."""
+        return self._key
+
+
+class MonKeyConfigStore:
+    """A config store that wraps the global ceph mon config-key store. Unlike
+    the module config store, it is not directly linked to the mgr module in
+    use.
+
+    N.B. The features that this store provide overlap with the MgrConfigStore
+    but this store allows us to use the generic interface that does not
+    automatically prefix keys making this store more appropriate for things we
+    want stored in the mon but shareable across many components (not limited to
+    just this mgr module).
+    Currently, this store doesn't do any caching. Items are serialized and
+    saved/fetched via the mon_command api directly.
+    """
+
+    PREFIX = 'smb/config/'
+
+    def __init__(self, mc: MonCommandIssuer):
+        self._mc = mc
+
+    def __getitem__(self, key: EntryKey) -> MonKeyStoreEntry:
+        """Return an entry object given a namespaced entry key. This entry does
+        not have to exist in the store.
+        """
+        return MonKeyStoreEntry(self, key)
+
+    def remove(self, key: EntryKey) -> bool:
+        """Remove an entry from the store. Returns true if an entry was
+        present.
+        """
+        if key not in self:
+            return False
+        self._rm(key)
+        return True
+
+    def namespaces(self) -> Collection[str]:
+        """Return all namespaces currently in the store."""
+        return {k[0] for k in self}
+
+    def contents(self, ns: str) -> Collection[str]:
+        """Return all subkeys currently in the namespace."""
+        return [k[1] for k in self if k[0] == ns]
+
+    def __iter__(self) -> Iterator[EntryKey]:
+        """Iterate over all namespaced keys currently in the store."""
+        ret, json_data, err = self._mc.mon_command(
+            {
+                'prefix': 'config-key dump',
+                'key': self.PREFIX,
+            }
+        )
+        if ret != 0:
+            raise KeyError(
+                f'config-key dump {self.PREFIX!r} failed [{ret}]: {err}'
+            )
+        for k in json.loads(json_data):
+            yield _ksplit(k, prefix=self.PREFIX)
+
+    def __contains__(self, key: EntryKey) -> bool:
+        """Return true if the namespaced key currently exists within the store."""
+        key = self.PREFIX + _kjoin(key)
+        ret, _, err = self._mc.mon_command(
+            {
+                'prefix': 'config-key exists',
+                'key': key,
+            }
+        )
+        return ret == 0
+
+    def _get_val(self, key: EntryKey) -> str:
+        """Fetch value from mon."""
+        key = self.PREFIX + _kjoin(key)
+        ret, json_data, err = self._mc.mon_command(
+            {
+                'prefix': 'config-key get',
+                'key': key,
+            }
+        )
+        if ret != 0:
+            raise KeyError(f'config-key get {key!r} failed [{ret}]: {err}')
+        return json_data
+
+    def _set_val(self, key: EntryKey, val: str) -> None:
+        """Set value in mon."""
+        key = self.PREFIX + _kjoin(key)
+        ret, _, err = self._mc.mon_command(
+            {
+                'prefix': 'config-key set',
+                'key': key,
+                'val': val,
+            }
+        )
+        if ret != 0:
+            raise KeyError(f'config-key set failed [{ret}]: {err}')
+
+    def _rm(self, key: EntryKey) -> str:
+        """Remove value from mon."""
+        key = self.PREFIX + _kjoin(key)
+        ret, json_data, err = self._mc.mon_command(
+            {
+                'prefix': 'config-key rm',
+                'key': key,
+            }
+        )
+        if ret != 0:
+            raise KeyError(f'config-key rm {key!r} failed [{ret}]: {err}')
+        return json_data

--- a/src/pybind/mgr/smb/proto.py
+++ b/src/pybind/mgr/smb/proto.py
@@ -1,0 +1,177 @@
+"""Assorted protocols/interfaces and types used in the smb mgr module."""
+
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+)
+
+import sys
+
+from ceph.deployment.service_spec import SMBSpec
+
+# this uses a version check as opposed to a try/except because this
+# form makes mypy happy and try/except doesn't.
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+elif TYPE_CHECKING:  # pragma: no cover
+    # typing_extensions will not be available for the real mgr server
+    from typing_extensions import Protocol
+else:  # pragma: no cover
+    # fallback type that is acceptable to older python on prod. builds
+    class Protocol:  # type: ignore
+        pass
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+elif TYPE_CHECKING:  # pragma: no cover
+    # typing_extensions will not be available for the real mgr server
+    from typing_extensions import Self
+else:  # pragma: no cover
+    # fallback type that should be ignored at runtime
+    Self = Any  # type: ignore
+
+
+Simplified = Dict[str, Any]
+SimplifiedList = List[Simplified]
+
+
+class Simplifiable(Protocol):
+    def to_simplified(self) -> Simplified:
+        ...  # pragma: no cover
+
+
+EntryKey = Tuple[str, str]
+
+
+class ConfigEntry(Protocol):
+    """A protocol for describing a configuration object that can be kept within
+    a configuration store. Has the ability to identify itself either by a
+    relative key or by a global URI value.
+    """
+
+    def get(self) -> Simplified:
+        ...  # pragma: no cover
+
+    def set(self, obj: Simplified) -> None:
+        ...  # pragma: no cover
+
+    def remove(self) -> bool:
+        ...  # pragma: no cover
+
+    def exists(self) -> bool:
+        ...  # pragma: no cover
+
+    @property
+    def uri(self) -> str:
+        ...  # pragma: no cover
+
+    @property
+    def full_key(self) -> EntryKey:
+        ...  # pragma: no cover
+
+
+class ConfigStore(Protocol):
+    """A protocol for describing a configuration data store capable of
+    retaining and tracking configuration entry objects.
+    """
+
+    def __getitem__(self, key: EntryKey) -> ConfigEntry:
+        ...  # pragma: no cover
+
+    def namespaces(self) -> Collection[str]:
+        ...  # pragma: no cover
+
+    def contents(self, ns: str) -> Collection[str]:
+        ...  # pragma: no cover
+
+    def __iter__(self) -> Iterator[EntryKey]:
+        ...  # pragma: no cover
+
+    def remove(self, ns: EntryKey) -> bool:
+        ...  # pragma: no cover
+
+
+class PathResolver(Protocol):
+    """A protocol describing a type that can map volumes, subvolumes, and
+    paths to real paths within a cephfs system.
+    """
+
+    def resolve(
+        self, volume: str, subvolumegroup: str, subvolume: str, path: str
+    ) -> str:
+        """Return the path within the volume for the given subvolume and path.
+        No other checking is performed.
+        """
+        ...  # pragma: no cover
+
+    def resolve_exists(
+        self, volume: str, subvolumegroup: str, subvolume: str, path: str
+    ) -> str:
+        """Return the path within the volume for the given subvolume and path.
+        Raises an exception if the path does not exist or is not a directory.
+        """
+        ...  # pragma: no cover
+
+
+class OrchSubmitter(Protocol):
+    """A protocol describing a type that can submit a SMBSpec to ceph's
+    orchestration system.
+    """
+
+    def submit_smb_spec(self, smb_spec: SMBSpec) -> None:
+        ...  # pragma: no cover
+
+    def remove_smb_service(self, service_name: str) -> None:
+        ...  # pragma: no cover
+
+
+class MonCommandIssuer(Protocol):
+    """A protocol describing the minimal interface that can issue mon commands."""
+
+    def mon_command(
+        self, cmd_dict: dict, inbuf: Optional[str] = None
+    ) -> Tuple[int, str, str]:
+        ...  # pragma: no cover
+
+
+class AccessAuthorizer(Protocol):
+    """A protocol for a type that can requrest cephx caps needed for file
+    system access.
+    """
+
+    def authorize_entity(
+        self, volume: str, entity: str, caps: str = ''
+    ) -> None:
+        ...  # pragma: no cover
+
+
+T = TypeVar('T')
+
+
+# TODO: move to a utils.py
+def one(lst: List[T]) -> T:
+    if len(lst) != 1:
+        raise ValueError("list does not contain exactly one element")
+    return lst[0]
+
+
+class IsNoneError(ValueError):
+    pass
+
+
+def checked(v: Optional[T]) -> T:
+    """Ensures the provided value is not a None or raises a IsNoneError.
+    Intended use is similar to an `assert v is not None` but more usable in
+    one-liners and list/dict/etc comprehensions.
+    """
+    if v is None:
+        raise IsNoneError('value is None')
+    return v

--- a/src/pybind/mgr/smb/rados_store.py
+++ b/src/pybind/mgr/smb/rados_store.py
@@ -1,0 +1,203 @@
+from typing import TYPE_CHECKING, Callable, Collection, Iterator, Optional
+
+import functools
+import json
+import logging
+
+import rados
+
+from .proto import EntryKey, Self, Simplified
+
+if TYPE_CHECKING:  # pragma: no cover
+    from mgr_module import MgrModule
+
+_CHUNK_SIZE = 1024 * 1024
+SMB_POOL = '.smb'
+
+log = logging.getLogger(__name__)
+
+
+class RADOSConfigEntry:
+    """A store entry object for the RADOS pool based store."""
+
+    def __init__(
+        self, rados: rados.Rados, pool: str, ns: str, key: str
+    ) -> None:
+        self._rados = rados
+        self._pool = pool
+        self._ns = ns
+        self._key = key
+
+    @property
+    def uri(self) -> str:
+        """Returns an identifier for the entry within the store."""
+        # The rados://<pool>/<ns>/<key> convention can be found elsewhere
+        # in ceph. borrowed here for communicating resource keys to
+        # other components.
+        return f'rados://{self._pool}/{self._ns}/{self._key}'
+
+    @property
+    def full_key(self) -> EntryKey:
+        """Return a namespaced key for the entry."""
+        return (self._ns, self._key)
+
+    def read(self) -> str:
+        """Read a RAODS object."""
+        log.debug('rados read of %s', self.full_key)
+        with self._rados.open_ioctx(self._pool) as ioctx:
+            ioctx.set_namespace(self._ns)
+            try:
+                val = ioctx.read(self._key, _CHUNK_SIZE).decode()
+            except rados.ObjectNotFound:
+                val = ''
+        log.debug('rados read result of %s = %r', self.full_key, val)
+        return val
+
+    def write(self, content: str) -> None:
+        """Write a RADOS object."""
+        log.debug('rados write to %s', self.full_key)
+        data = content.encode('utf-8')
+        assert len(data) < _CHUNK_SIZE
+        with self._rados.open_ioctx(self._pool) as ioctx:
+            ioctx.set_namespace(self._ns)
+            ioctx.write_full(self._key, data)
+
+    def get(self) -> Simplified:
+        """Get the deserialized store entry value."""
+        if not self.exists():
+            raise KeyError(self.full_key)
+        return json.loads(self.read())
+
+    def set(self, obj: Simplified) -> None:
+        """Set the store entry value to that of the serialized value of obj."""
+        self.write(json.dumps(obj))
+
+    def remove(self) -> bool:
+        """Remove the current entry from the store."""
+        log.debug('rados remove of %s', self.full_key)
+        with self._rados.open_ioctx(self._pool) as ioctx:
+            ioctx.set_namespace(self._ns)
+            try:
+                ioctx.remove_object(self._key)
+                removed = True
+            except rados.ObjectNotFound:
+                removed = False
+        log.debug('rados remove result of %s = %r', self.full_key, removed)
+        return removed
+
+    def exists(self) -> bool:
+        """Returns true if the entry currently exists within the store."""
+        log.debug('rados exists of %s', self.full_key)
+        try:
+            with self._rados.open_ioctx(self._pool) as ioctx:
+                ioctx.set_namespace(self._ns)
+                ioctx.stat(self._key)
+            found = True
+        except rados.ObjectNotFound:
+            found = False
+        log.debug('rados exists result of %s = %r', self.full_key, found)
+        return found
+
+
+class RADOSConfigStore:
+    """A config store that saves entries in a RADOS pool.
+
+    N.B. The RADOS config store exposes a subset of the RADOS functionality
+    to implement a simple key-value store. As the namespaced keys map directly
+    to RADOS namespaces and object names this store is suitable for sharing
+    configuration items with external components.
+    """
+
+    def __init__(
+        self,
+        rados: rados.Rados,
+        pool: str = SMB_POOL,
+        init_cb: Optional[Callable] = None,
+    ) -> None:
+        self._rados = rados
+        self._pool = pool
+        # An optional initialization callback. If set, the callback will be
+        # called once before any get, set, or other data-access call.  This is
+        # to support lazily setting up the pool when we start acessing the
+        # store contents.
+        self._init_cb = init_cb
+
+    def _lazy_init(self) -> None:
+        if self._init_cb:
+            self._init_cb
+            self._init_cb = None
+
+    def __getitem__(self, key: EntryKey) -> RADOSConfigEntry:
+        """Return an entry object given a namespaced entry key. This entry does
+        not have to exist in the store.
+        """
+        self._lazy_init()
+        ns, okey = key
+        return RADOSConfigEntry(self._rados, self._pool, ns, okey)
+
+    def remove(self, ns: EntryKey) -> bool:
+        """Remove an entry from the store. Returns true if an entry was
+        present.
+        """
+        self._lazy_init()
+        return self[ns].remove()
+
+    def namespaces(self) -> Collection[str]:
+        """Return all namespaces currently in the store."""
+        self._lazy_init()
+        return {item[0] for item in self}
+
+    def contents(self, ns: str) -> Collection[str]:
+        """Return all subkeys currently in the namespace."""
+        self._lazy_init()
+        return [item[1] for item in self if ns == item[0]]
+
+    def __iter__(self) -> Iterator[EntryKey]:
+        """Iterate over all namespaced keys currently in the store."""
+        self._lazy_init()
+        out = []
+        with self._rados.open_ioctx(self._pool) as ioctx:
+            ioctx.set_namespace(rados.LIBRADOS_ALL_NSPACES)
+            for obj in ioctx.list_objects():
+                out.append((obj.nspace, obj.key))
+        return iter(out)
+
+    @classmethod
+    def init(cls, mgr: 'MgrModule', pool: str = SMB_POOL) -> Self:
+        """Return a new RADOSConfigStore using the specified pool. The pool
+        will be immediately created if it doesn't already exist.
+        """
+        _init_pool(mgr, pool)
+        return cls(mgr.rados, pool=pool)
+
+    @classmethod
+    def lazy_init(cls, mgr: 'MgrModule', pool: str = SMB_POOL) -> Self:
+        """Return a new RADOSConfigStore using the specified pool. The pool
+        will be created when other RADOSConfigStore methods are called if it
+        doesn't already exist.
+        """
+        cb = functools.partial(_init_pool, mgr, pool)
+        return cls(mgr.rados, pool=pool, init_cb=cb)
+
+
+def _init_pool(mgr: 'MgrModule', pool: str) -> None:
+    """Use mgr apis to initialize a new pool if it doesn't exist."""
+    pools = mgr.get_osdmap().dump().get('pools', [])
+    pool_names = {p['pool_name'] for p in pools}
+    if pool in pool_names:
+        return
+    log.debug('rados pool %r not found, creating it', pool)
+    mgr.check_mon_command(
+        {
+            'prefix': 'osd pool create',
+            'pool': pool,
+            'yes_i_really_mean_it': True,
+        }
+    )
+    mgr.check_mon_command(
+        {
+            'prefix': 'osd pool application enable',
+            'pool': pool,
+            'app': 'smb',
+        }
+    )

--- a/src/pybind/mgr/smb/resourcelib.py
+++ b/src/pybind/mgr/smb/resourcelib.py
@@ -1,0 +1,641 @@
+"""resourcelib - a semi-automated library for structured objects
+
+This library aims to be both compatible with the mgr's object_format library
+and be a base for a cleaner looking & easier working way to accomplish things
+like the `ceph nfs export apply` command and the `ceph orch apply` command
+but for smb. This only defines the tools to do semi-automated structuring/unstructuring
+- serialization into JSON/YAML can be handled at higher levels but without
+needing to get fancy in those libraries.
+
+Quick Example:
+>>> from . import resourcelib
+>>> @resourcelib.component()
+... class Rect:
+...     x_pos: int
+...     y_pos: int
+...     width: int
+...     height: int
+>>> @resourcelib.resource('art')
+... class Art:
+...    name: str
+...    rectangles: List[Rect]
+>>> rdata = {
+...     'resource_type': 'art',
+...     'name': 'My Paintings',
+...     'rectangles': [
+...         {'x_pos': 5, 'y_pos': 0, 'width': 12, 'height': 9},
+...         {'x_pos': 20, 'y_pos': 35, 'width': 10, 'height': 40},
+...     ],
+... }
+>>> a = resourcelib.load(rdata)
+>>> isinstance(a[0], Art)
+True
+
+That is, a dictionary containing a `resource_type` field and other data
+fields can be easily converted into a more structured python object
+based on dataclasses and a few decorators. This object can also be
+converted back into a less-structured dict using the automatically
+created `to_simplified` method.
+
+One can also work directly with the Resource objects that are created
+for each class. First, the special method `_customize_resource` with
+the `customize` decorator can be used to alter the Resource immediately
+after it is created. Alternatively, the property `_resource_config` is
+added to every resourcelib component or resource.
+
+Example:
+>>> @resourcelib.resource('widget')
+... class Widget:
+...    name: str
+...    description: str = ''
+...    labels: Optional[List[str]] = None
+...    @resourcelib.customize
+...    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+...        # set description field quiet property to true. this will hide
+...        # empty strings from the unstructured dict
+...        rc.description.quiet = True
+...        return rc
+>>> def do_something():
+...     "Do something silly with the widget class resource."
+...     w = Widget('default', 'A generic widget')
+...     return Widget._resource_config.object_to_simplified(w)
+>>> do_something()
+{'resource_type': 'widget', 'name': 'default', 'description': 'A generic widget'}
+
+Technically, in the _customize_resource method, you can manipulate the Resource
+object deeply or even return a truly customized Resource subclass object
+if you want to!
+
+Multiple classes can share a single `resource_type` name if, and only if,
+all resources are configured to have a condition. A condition is a function
+that takes the raw dict and returns true/false indicating that the resource
+and the dataclass it handles are appropriate for the data in question.
+One can set the condition function using the `Resource.on_condition` method.
+This can be invoked via the `_customize_resource` method.
+
+The library doesn't check if the conditions are comprehensive. If you have
+two classes mapped to resource_type "x" and neither condition returns true
+the library will simply raise an exception.
+"""
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Hashable,
+    List,
+    Optional,
+    Tuple,
+)
+
+import dataclasses
+import logging
+import sys
+from itertools import chain
+
+from .proto import Self, Simplified
+
+log = logging.getLogger(__name__)
+
+_RESOURCE_TYPE = 'resource_type'
+_RESOURCES = 'resources'
+_DEBUG = False
+
+
+if _DEBUG:
+
+    def _xt(f: Callable) -> Callable:
+        def _func(*args: Any, **kwargs: Any) -> Any:
+            log.debug(f'\nCALL({f}): {args!r}, {kwargs!r}')
+            try:
+                result = f(*args, **kwargs)
+                log.debug(f'\n RET({f}): result={result!r}')
+                return result
+            except Exception as err:
+                log.debug(f'\n EXC({f}): {err!r}')
+                raise
+
+        return _func
+
+else:
+
+    def _xt(f: Callable) -> Callable:
+        return f
+
+
+if sys.version_info >= (3, 11):
+    from typing import dataclass_transform
+elif TYPE_CHECKING:
+    from typing_extensions import dataclass_transform
+else:
+    # no-op decorator, placeholder for dataclass_transform
+    def dataclass_transform(*args: Any, **kwargs: Any) -> Callable:
+        def _phony(f: Callable) -> Callable:
+            return f
+
+        return _phony
+
+
+# ---- Error Types ----
+
+
+class ResourceTypeError(ValueError):
+    """Generic error working with smb resource types."""
+
+    pass
+
+
+class MissingResourceTypeError(KeyError, ResourceTypeError):
+    """Exception raised when converting from unstructured data and a required
+    `resource_type` field is missing.
+    """
+
+    def __init__(self, data: Simplified) -> None:
+        self.data = data
+
+    def __str__(self) -> str:
+        return 'source data is missing a resource_type field'
+
+
+class InvalidResourceTypeError(ResourceTypeError):
+    """Exception raised when an object can not be converted from unstructured
+    data.
+    """
+
+    def __init__(self, *, expected: Any = None, actual: Any = None) -> None:
+        self.expected = expected
+        self.actual = actual
+
+    def __str__(self) -> str:
+        msg = f'invalid resource type value: {self.actual!r}'
+        if self.expected:
+            msg += f'; expected: {self.expected!r}'
+        return msg
+
+
+class MissingRequiredFieldError(KeyError, ResourceTypeError):
+    """Exception raised when an object can not be converted from unstructured
+    data due to a missing required field.
+    """
+
+    def __init__(self, key: str) -> None:
+        self.key = key
+
+    def __str__(self) -> str:
+        return f'data object missing required field: {self.key}'
+
+
+# ---- Internal Resource Types ----
+
+# Sentinel object for unset/missing value conditions.
+_unset = object()
+
+
+def _unwrap_type(atype: Any) -> Tuple[Tuple, bool]:
+    """Given an Optional[T] type return (T, True). Given a non-optional type
+    return the  (T, false).
+    """
+    args = _get_args(atype)
+    uargs: Tuple[Any, ...] = tuple(a for a in args if a is not type(None))
+    return uargs, bool(args and len(args) != len(uargs))
+
+
+def _get_args(atype: Any) -> Tuple:
+    """Given a type object return the types args.
+    Example: List[T] -> (T,), Union[A, B] -> (A, B).
+    """
+    return getattr(atype, '__args__', tuple())
+
+
+def _get_origin(atype: Any) -> Any:
+    """Given a type such as List[T] return the outer type (List)."""
+    return getattr(atype, '__origin__', None)
+
+
+@dataclasses.dataclass
+class Field:
+    """Metadata about a field (member) of a resource type class."""
+
+    name: str
+    field_type: Any
+    default: Any = _unset
+    quiet: bool = False  # customization value
+    keep_none: bool = False  # customization value
+
+    def optional(self) -> bool:
+        """Return true if the type of the field is Optional."""
+        _, optional = _unwrap_type(self.field_type)
+        return optional
+
+    def inner_type(self) -> Any:
+        """For a field with an optional type (Optional[T]) return the
+        nested type (T). Otherwise return the current field type.
+        """
+        args, optional = _unwrap_type(self.field_type)
+        if optional:
+            assert len(args) == 1
+            return args[0]
+        return self.field_type
+
+    @_xt
+    def takes(self, dest_type: Any) -> bool:
+        """Returns true if the field's type is composed of a matching container
+        type. It supports field types of the form `List[T]`, `Optional[List[T]]`,
+        `Dict[T, V]`, `Optional[Dict[T, V]]`.
+
+        For example a field with type `List[str]` returns true for
+        `f.takes(list)`. Similarly, `Optional[List[str]]` returns true for
+        `f.takes(list)`. A field `Dict[int, int]` returns true for `f.takes(dict)`,
+        and so on.
+
+        Ideally newer-style types like `list[T] | None` supported by later
+        python versions should also work but this has not been tested.
+        """
+        otype = _get_origin(self.inner_type())
+        if otype is None:
+            return False
+
+        if dest_type is list:
+            dest_type = (list, List)
+        elif dest_type is dict:
+            dest_type = (dict, Dict)
+        elif not isinstance(dest_type, tuple):
+            dest_type = (dest_type,)
+        return otype in dest_type
+
+    def list_element_type(self) -> Any:
+        """Assuming the field type is a list (List[T]) return the type
+        of the list's elements (T).
+        """
+        args, optional = _unwrap_type(self.inner_type())
+        assert not optional
+        assert len(args) == 1
+        return args[0]
+
+    def dict_element_types(self) -> Tuple[Any, Any]:
+        """Assuming the field type is a dict (List[KT, VT]) return the types
+        of the dict's keys & values (KT, VT).
+        """
+        args, optional = _unwrap_type(self.inner_type())
+        assert not optional
+        assert len(args) == 2
+        return args[0], args[1]
+
+    @classmethod
+    def create(cls, fld: dataclasses.Field) -> Self:
+        """Contructor converting from a dataclasses.Field."""
+        default = _unset
+        if fld.default is not dataclasses.MISSING:
+            default = fld.default
+        return cls(
+            name=fld.name,
+            field_type=fld.type,
+            default=default,
+        )
+
+
+class Resource:
+    """Type converter that maintains metadata about a structured python object
+    and can be used to convert to / from the structured object and unstructured
+    (JSON/YAML-safe dict) data.
+    """
+
+    def __init__(self, cls: Any) -> None:
+        self.resource_cls = cls
+        self.fields: Dict[str, Field] = {}
+        self._on_condition: Optional[Callable[..., bool]] = None
+
+        for fld in dataclasses.fields(self.resource_cls):
+            self.fields[fld.name] = Field.create(fld)
+
+    @property
+    def conditional(self) -> bool:
+        """Return true if the resource is selectable based on a condition."""
+        return self._on_condition is not None
+
+    def on_condition(self, cond: Callable[..., bool]) -> None:
+        """Set a condition function."""
+        self._on_condition = cond
+
+    def type_name(self) -> str:
+        """Return the name of the type managed by this resource."""
+        return self.resource_cls.__name__
+
+    def __getattr__(self, name: str) -> Field:
+        """Return a field metadata object for the type managed by this resource."""
+        return self.fields[name]
+
+    @_xt
+    def object_from_simplified(self, data: Simplified) -> Any:
+        """Given a dict-based unstructured data object return the structured
+        object-based equivalent.
+        """
+        kw = {}
+        for fld in self.fields.values():
+            value = self._object_field_from_simplified(fld, data)
+            if value is not _unset:
+                kw[fld.name] = value
+        obj = self.resource_cls(**kw)
+        validate = getattr(obj, 'validate', None)
+        if validate:
+            validate()
+        return obj
+
+    @_xt
+    def _object_field_from_simplified(
+        self, fld: Field, data: Simplified
+    ) -> Any:
+        if fld.name not in data and fld.default is not _unset:
+            return _unset
+        elif fld.name not in data:
+            raise MissingRequiredFieldError(fld.name)
+
+        value = data[fld.name]
+        if value is None and fld.optional():
+            return None
+        inner_type = fld.inner_type()
+
+        _rconfig = getattr(inner_type, '_resource_config', None)
+        if _rconfig:
+            return _rconfig.object_from_simplified(value)
+        _fs = getattr(inner_type, 'from_simplified', None)
+        if _fs:
+            return _fs(value)
+
+        if fld.takes(list):
+            subtype = fld.list_element_type()
+            return [
+                self._object_sub_from_simplified(subtype, v) for v in value
+            ]
+        if fld.takes(dict):
+            ktype, vtype = fld.dict_element_types()
+            # keys must be simple types right now so we just
+            # cast it directly
+            return {
+                ktype(k): self._object_sub_from_simplified(vtype, v)
+                for k, v in value.items()
+            }
+
+        return inner_type(value)
+
+    @_xt
+    def _object_sub_from_simplified(
+        self, subtype: Any, data: Simplified
+    ) -> Any:
+        _rconfig = getattr(subtype, '_resource_config', None)
+        if _rconfig:
+            return _rconfig.object_from_simplified(data)
+        if _get_origin(subtype) in (list, List):
+            return list(data)
+        if _get_origin(subtype) in (dict, Dict):
+            return dict(data)
+        return subtype(data)
+
+    @_xt
+    def object_to_simplified(self, obj: Any) -> Simplified:
+        """Given a python object tagged as a resource type return the
+        unstructured data equivalent.
+        """
+        result: Simplified = {}
+        rt = getattr(obj, _RESOURCE_TYPE, None)
+        if rt is not None:
+            result[_RESOURCE_TYPE] = rt
+        for fld in self.fields.values():
+            self._object_field_to_simplified(obj, fld, result)
+        return result
+
+    @_xt
+    def _object_field_to_simplified(
+        self, obj: Any, fld: Field, data: Simplified
+    ) -> None:
+        value = getattr(obj, fld.name)
+        assert fld.optional() or value is not None
+        if (value is None and not fld.keep_none) or (
+            fld.quiet and value is not None and not value
+        ):
+            return
+
+        _rconfig = getattr(fld.inner_type(), '_resource_config', None)
+        if _rconfig:
+            data[fld.name] = _rconfig.object_to_simplified(value)
+            return
+        _ts = getattr(fld.inner_type(), 'to_simplified', None)
+        if _ts:
+            data[fld.name] = _ts(value)
+            return
+
+        if isinstance(value, list):
+            assert fld.takes(list)
+            subtype = fld.list_element_type()
+            data[fld.name] = [
+                self._object_sub_to_simplified(subtype, v) for v in value
+            ]
+            return
+        if isinstance(value, dict):
+            assert fld.takes(dict)
+            ktype, vtype = fld.dict_element_types()
+            data[fld.name] = {
+                ktype(k): self._object_sub_to_simplified(vtype, v)
+                for k, v in value.items()
+            }
+            return
+
+        if isinstance(value, str):
+            data[fld.name] = str(value)
+            return
+        if isinstance(value, (int, float)):
+            data[fld.name] = value
+            return
+        raise ResourceTypeError(f'unexpected type for field {fld.name}')
+
+    @_xt
+    def _object_sub_to_simplified(self, subtype: Any, value: Any) -> Any:
+        _rconfig = getattr(subtype, '_resource_config', None)
+        if _rconfig:
+            return _rconfig.object_to_simplified(value)
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, list):
+            return value
+        if isinstance(value, str):
+            return str(value)
+        if isinstance(value, (int, float)):
+            return value
+        raise ResourceTypeError(f'unexpected type: {type(value)}')
+
+    def __repr__(self) -> str:
+        return (
+            f'{self.__class__.__name__}<'
+            f'{self.type_name()}, conditional={self.conditional}>'
+        )
+
+    @classmethod
+    def create(cls, resource_cls: Any) -> Self:
+        """Constructor that creates a Resource for a given python class."""
+        resource = cls(resource_cls)
+        _customize = getattr(resource_cls, '_customize_resource', None)
+        if _customize is not None:
+            resource = _customize(resource)
+        return resource
+
+
+class Registry:
+    """Registry to track resource objects."""
+
+    def __init__(self) -> None:
+        self.resources: Dict[str, List[Resource]] = {}
+        self.types: Dict[Hashable, Resource] = {}
+
+    def enable(self, cls: Any) -> Resource:
+        """Given a python class create and record resource for it.  Return the
+        new resource.
+        """
+        resource = Resource.create(cls)
+        self.types[cls] = resource
+        return resource
+
+    def track(self, key: str, resource: Resource) -> None:
+        """Given a resource-type-name and a resource object, save these items
+        into the registry. A key may be repeated creating a "discriminating
+        union" so long as the resource type provides a condition function to
+        determine what resource to use.
+        """
+        if key not in self.resources:
+            self.resources[key] = []
+        self.resources[key].append(resource)
+        if len(self.resources[key]) > 1:
+            if any(not c.conditional for c in self.resources[key]):
+                raise ResourceTypeError(
+                    'multiplexed resources must be conditional'
+                )
+
+    def select(self, data: Simplified) -> Resource:
+        """Given an unstructured data object use the resource_type field and
+        any condition functions to return the resource object that matches.
+        """
+        try:
+            rt = data[_RESOURCE_TYPE]
+        except KeyError:
+            raise MissingResourceTypeError(data)
+        try:
+            matches = self.resources[rt]
+        except KeyError:
+            raise InvalidResourceTypeError(actual=rt)
+        if len(matches) == 1:
+            return matches[0]
+        for rc in matches:
+            if not rc._on_condition:
+                raise ResourceTypeError('resource not conditional')
+            if rc._on_condition(data):
+                return rc
+        raise ResourceTypeError('no resource type conditions met')
+
+
+class _ResourceType:
+    """A read-only property of a class acting as a resource type. When accessed,
+    returns the name of the resource type.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __get__(self, obj: Any, objtype: Any = None) -> str:
+        return self.name
+
+
+class _ResourceConfig:
+    """A read-only property of a class acting as a resource type that, when
+    accessed, returns the resource object.
+    """
+
+    def __init__(self, resource: Resource) -> None:
+        self.resource = resource
+
+    def __get__(self, obj: Any, objtype: Any = None) -> Resource:
+        return self.resource
+
+
+# _REGISTRY is our internal registry object
+_REGISTRY = Registry()
+
+
+# ---- decorators ----
+
+
+def _to_simplified(obj: Any) -> Simplified:
+    rc = getattr(obj, '_resource_config')
+    return rc.object_to_simplified(obj)
+
+
+def _make_resource(cls: Any, resource_name: str = '') -> Any:
+    cls = dataclasses.dataclass(cls)
+    rconfig = _REGISTRY.enable(cls)
+    cls._resource_config = _ResourceConfig(rconfig)
+    if resource_name:
+        cls.resource_type = _ResourceType(resource_name)
+        _REGISTRY.track(resource_name, rconfig)
+    if getattr(cls, 'to_simplified', None) is None:
+        cls.to_simplified = _to_simplified
+    return cls
+
+
+@dataclass_transform()
+def resource(resource_name: str) -> Any:
+    """Class-decorator that establishes a new dataclass/resource type.
+    These types can be converted from raw data using the `load` function.
+    """
+    assert resource_name
+
+    def _decorator(cls: Any) -> Any:
+        return _make_resource(cls, resource_name)
+
+    return _decorator
+
+
+@dataclass_transform()
+def component() -> Any:
+    """Class-decorator that establishes a new dataclass/resource type without a
+    top-level name. These types may be manually converted from raw or embedded
+    within a resource type.
+    """
+
+    def _decorator(cls: Any) -> Any:
+        return _make_resource(cls)
+
+    return _decorator
+
+
+# TODO: make customize validate the function and not just a wrapper over
+# staticmethod
+customize = staticmethod
+
+
+# --- resource load function ----
+
+
+@_xt
+def load(data: Simplified) -> List[Any]:
+    """Given a simple unstructured data object (python dict/list) containing
+    only other simple data types, use the `resource_type` metadata to
+    convert the input to a list of structured and typed objects.
+
+    The input may be:
+     * a single item: {"resource_type": "foo", ...} which will return
+       a single valued list
+     * a python list containing dicts like the above
+     * a dict containing the key "resources" that maps to a list containing dicts
+       like the 1st item
+    """
+    # Given a bare list/iterator. Assume it contains loadable objects.
+    if not isinstance(data, dict):
+        return list(chain.from_iterable(load(v) for v in data))
+    # Given a "list object"
+    if _RESOURCE_TYPE not in data and _RESOURCES in data:
+        rl = data[_RESOURCES]
+        if not isinstance(rl, list):
+            raise TypeError('expected resources list')
+        return list(chain.from_iterable(load(v) for v in rl))
+    # anything else must be a "self describing" object with a resource_type
+    # value
+    resource = _REGISTRY.select(data)
+    return [resource.object_from_simplified(data)]

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -1,0 +1,393 @@
+from typing import Dict, List, Optional, Union, cast
+
+import json
+
+import yaml
+
+from ceph.deployment.service_spec import PlacementSpec
+
+from . import resourcelib, validation
+from .enums import (
+    AuthMode,
+    CephFSStorageProvider,
+    Intent,
+    JoinSourceType,
+    UserGroupSourceType,
+)
+from .proto import Self, Simplified, checked
+
+
+def _get_intent(data: Simplified) -> Intent:
+    """Helper function that returns the intent value from a data dict."""
+    return Intent(data.get('intent', Intent.PRESENT))
+
+
+def _removed(data: Simplified) -> bool:
+    """Condition function returning true when the intent is removed."""
+    return _get_intent(data) == Intent.REMOVED
+
+
+def _present(data: Simplified) -> bool:
+    """Condition function returning true when the intent is present."""
+    return _get_intent(data) == Intent.PRESENT
+
+
+class _RBase:
+    # mypy doesn't currently (well?) support class decorators adding methods
+    # so we use a base class to add this method to all our resource classes.
+    def to_simplified(self) -> Simplified:
+        rc = getattr(self, '_resource_config')
+        return rc.object_to_simplified(self)
+
+
+@resourcelib.component()
+class CephFSStorage(_RBase):
+    """Description of where in a CephFS file system a share is located."""
+
+    volume: str
+    path: str = '/'
+    subvolumegroup: str = ''
+    subvolume: str = ''
+    provider: CephFSStorageProvider = CephFSStorageProvider.SAMBA_VFS
+
+    def __post_init__(self) -> None:
+        # Allow a shortcut form of <subvolgroup>/<subvol> in the subvolume
+        # field. If that's the case split it here and put the values in
+        # their proper locations.
+        if '/' in self.subvolume and not self.subvolumegroup:
+            try:
+                svg, sv = self.subvolume.split('/')
+                self.subvolumegroup = svg
+                self.subvolume = sv
+            except ValueError:
+                raise ValueError(
+                    'invalid subvolume value: {self.subvolume!r}'
+                )
+        # remove extra slashes, relative path components, etc.
+        self.path = validation.normalize_path(self.path)
+
+    def validate(self) -> None:
+        if not self.volume:
+            raise ValueError('volume requires a value')
+        if '/' in self.subvolumegroup:
+            raise ValueError(
+                'invalid subvolumegroup value: {self.subvolumegroup!r}'
+            )
+        if '/' in self.subvolume:
+            raise ValueError('invalid subvolume value: {self.subvolume!r}')
+        validation.check_path(self.path)
+        # TODO: validate volume/subvol/etc name (where defined in ceph?)
+
+    @resourcelib.customize
+    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+        rc.subvolumegroup.quiet = True
+        rc.subvolume.quiet = True
+        return rc
+
+
+@resourcelib.resource('ceph.smb.share')
+class RemovedShare(_RBase):
+    """Represents a share that has / will be removed."""
+
+    cluster_id: str
+    share_id: str
+    intent: Intent = Intent.REMOVED
+
+    def validate(self) -> None:
+        if not self.cluster_id:
+            raise ValueError('cluster_id requires a value')
+        validation.check_id(self.cluster_id)
+        if not self.share_id:
+            raise ValueError('share_id requires a value')
+        validation.check_id(self.share_id)
+
+    @resourcelib.customize
+    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+        rc.on_condition(_removed)
+        return rc
+
+
+@resourcelib.resource('ceph.smb.share')
+class Share(_RBase):
+    """Represents a share that should / currently exists."""
+
+    cluster_id: str
+    share_id: str
+    intent: Intent = Intent.PRESENT
+
+    name: str = ''
+    readonly: bool = False
+    browseable: bool = True
+    cephfs: Optional[CephFSStorage] = None
+
+    def __post_init__(self) -> None:
+        # if name is not given explicitly, take it from the share_id
+        if not self.name:
+            self.name = self.share_id
+
+    def validate(self) -> None:
+        if not self.cluster_id:
+            raise ValueError('cluster_id requires a value')
+        if not self.share_id:
+            raise ValueError('share_id requires a value')
+        validation.check_id(self.cluster_id)
+        validation.check_id(self.share_id)
+        validation.check_share_name(self.name)
+        if self.intent != Intent.PRESENT:
+            raise ValueError('Share must have present intent')
+        # currently only cephfs is supported
+        if self.cephfs is None:
+            raise ValueError('a cephfs configuration is required')
+
+    @property
+    def checked_cephfs(self) -> CephFSStorage:
+        """Return the .cephfs storage object or raise ValueError if None."""
+        return checked(self.cephfs)
+
+    @resourcelib.customize
+    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+        rc.on_condition(_present)
+        return rc
+
+
+@resourcelib.component()
+class JoinAuthValues(_RBase):
+    """Represents user/password values used to join to Active Directory."""
+
+    username: str
+    password: str
+
+
+@resourcelib.component()
+class JoinSource(_RBase):
+    """Represents data that can be used to join a system to Active Directory."""
+
+    source_type: JoinSourceType
+    auth: Optional[JoinAuthValues] = None
+    uri: str = ''
+    ref: str = ''
+
+    def validate(self) -> None:
+        if self.ref:
+            validation.check_id(self.ref)
+
+    @resourcelib.customize
+    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+        rc.uri.quiet = True
+        rc.ref.quiet = True
+        return rc
+
+
+@resourcelib.component()
+class UserGroupSettings(_RBase):
+    """Represents user and group data for a non-AD instance."""
+
+    users: List[Dict[str, str]]
+    groups: List[Dict[str, str]]
+
+
+@resourcelib.component()
+class UserGroupSource(_RBase):
+    """Represents data used to set up user/group settings for an instance."""
+
+    source_type: UserGroupSourceType
+    values: Optional[UserGroupSettings] = None
+    uri: str = ''
+    ref: str = ''
+
+    def validate(self) -> None:
+        if self.source_type == UserGroupSourceType.INLINE:
+            pfx = 'inline User/Group configuration'
+            if self.values is None:
+                raise ValueError(pfx + ' requires values')
+            if self.uri:
+                raise ValueError(pfx + ' does not take a uri')
+            if self.ref:
+                raise ValueError(pfx + ' does not take a ref value')
+        if self.source_type == UserGroupSourceType.HTTP_URI:
+            pfx = 'http User/Group configuration'
+            if not self.uri:
+                raise ValueError(pfx + ' requires a uri')
+            if self.values:
+                raise ValueError(pfx + ' does not take inline values')
+            if self.ref:
+                raise ValueError(pfx + ' does not take a ref value')
+        if self.source_type == UserGroupSourceType.RESOURCE:
+            pfx = 'resource reference User/Group configuration'
+            if not self.ref:
+                raise ValueError(pfx + ' requires a ref value')
+            if self.uri:
+                raise ValueError(pfx + ' does not take a uri')
+            if self.values:
+                raise ValueError(pfx + ' does not take inline values')
+
+    @resourcelib.customize
+    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+        rc.uri.quiet = True
+        rc.ref.quiet = True
+        return rc
+
+
+@resourcelib.component()
+class DomainSettings(_RBase):
+    """Represents general settings for a system joined to Active Directory."""
+
+    realm: str
+    join_sources: List[JoinSource]
+
+
+@resourcelib.resource('ceph.smb.cluster')
+class RemovedCluster(_RBase):
+    """Represents a cluster (instance) that is / should be removed."""
+
+    cluster_id: str
+    intent: Intent = Intent.REMOVED
+
+    @resourcelib.customize
+    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+        rc.on_condition(_removed)
+        return rc
+
+    def validate(self) -> None:
+        if not self.cluster_id:
+            raise ValueError('cluster_id requires a value')
+        validation.check_id(self.cluster_id)
+
+
+class WrappedPlacementSpec(PlacementSpec):
+    """A shim class allowing smb.resourcelib to structure/unstructure the
+    placement spec type and avoid re-implementing it here.
+    """
+
+    @classmethod
+    def from_simplified(cls, data: Simplified) -> Self:
+        # N.B. The resourcelib (re)structuring code explictly does not support
+        # methods named from_json, although in theory it could be argued
+        # they're the same.  The issue is that many of ceph's {to,from}_json
+        # calls take *dict*s, not actual JSON (strings). However, some do,
+        # making these both a misnomer and creating ambiguity. resourcelib
+        # refuses to guess.
+        #
+        # this cast is needed because a lot of classmethods in ceph are
+        # improperly typed. They are improperly typed because typing.Self
+        # didn't exist and the old correct way is a PITA to write (and
+        # remember).  Thus a lot of classmethods are return the exact class
+        # which is technically incorrect. This fine class is guilty of the same
+        # sin. :-)
+        return cast(Self, cls.from_json(data))
+
+    @classmethod
+    def wrap(cls, value: Optional[PlacementSpec]) -> Optional[Self]:
+        if value is None:
+            return None
+        value.__class__ = cls
+        return cast(Self, value)
+
+    def to_simplified(self) -> Simplified:
+        return self.to_json()
+
+
+@resourcelib.resource('ceph.smb.cluster')
+class Cluster(_RBase):
+    """Represents a cluster (instance) that is / should be present."""
+
+    cluster_id: str
+    auth_mode: AuthMode
+    intent: Intent = Intent.PRESENT
+    domain_settings: Optional[DomainSettings] = None
+    user_group_settings: Optional[List[UserGroupSource]] = None
+    custom_dns: Optional[List[str]] = None
+    # embedded orchestration placement spec
+    placement: Optional[WrappedPlacementSpec] = None
+
+    def validate(self) -> None:
+        if not self.cluster_id:
+            raise ValueError('cluster_id requires a value')
+        validation.check_id(self.cluster_id)
+        if self.intent != Intent.PRESENT:
+            raise ValueError('cluster requires present intent')
+        if self.auth_mode == AuthMode.ACTIVE_DIRECTORY:
+            if not self.domain_settings:
+                raise ValueError(
+                    'domain settings are required for active directory mode'
+                )
+            if self.user_group_settings:
+                raise ValueError(
+                    'user & group settings not supported for active directory mode'
+                )
+        if self.auth_mode == AuthMode.USER:
+            if not self.user_group_settings:
+                raise ValueError(
+                    'user & group settings required for user auth mode'
+                )
+            if self.domain_settings:
+                raise ValueError(
+                    'domain settings not supported for user auth mode'
+                )
+
+    @resourcelib.customize
+    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+        rc.on_condition(_present)
+        return rc
+
+
+@resourcelib.resource('ceph.smb.join.auth')
+class JoinAuth(_RBase):
+    """Represents metadata used to join a system to Active Directory."""
+
+    auth_id: str
+    intent: Intent = Intent.PRESENT
+    auth: Optional[JoinAuthValues] = None
+
+    def validate(self) -> None:
+        if not self.auth_id:
+            raise ValueError('auth_id requires a value')
+        validation.check_id(self.auth_id)
+
+
+@resourcelib.resource('ceph.smb.usersgroups')
+class UsersAndGroups(_RBase):
+    """Represents metadata used to set up users/groups for an instance."""
+
+    users_groups_id: str
+    intent: Intent = Intent.PRESENT
+    values: Optional[UserGroupSettings] = None
+
+    def validate(self) -> None:
+        if not self.users_groups_id:
+            raise ValueError('users_groups_id requires a value')
+        validation.check_id(self.users_groups_id)
+
+
+# SMBResource is a union of all valid top-level smb resource types.
+SMBResource = Union[
+    Cluster,
+    JoinAuth,
+    RemovedCluster,
+    RemovedShare,
+    Share,
+    UsersAndGroups,
+]
+
+
+def load_text(blob: str) -> List[SMBResource]:
+    """Given JSON or YAML return a list of SMBResource objects deserialized
+    from the input.
+    """
+    try:
+        data = yaml.safe_load(blob)
+    except ValueError:
+        pass
+    try:
+        data = json.loads(blob)
+    except ValueError:
+        pass
+    return load(data)
+
+
+def load(data: Simplified) -> List[SMBResource]:
+    """Given simple python types (unstructured data) return a list of
+    SMBResource objects that can be produced by mapping that data into
+    structured types.
+    """
+    return resourcelib.load(data)

--- a/src/pybind/mgr/smb/results.py
+++ b/src/pybind/mgr/smb/results.py
@@ -1,0 +1,92 @@
+from typing import Iterator, List, Optional
+
+import errno
+
+from .proto import Simplified, one
+from .resources import SMBResource
+
+_DOMAIN = 'domain'
+
+
+class Result:
+    """Result of applying a single smb resource update to the system."""
+
+    # Compatible with object formatter, thus suitable for being returned
+    # directly to mgr module.
+    def __init__(
+        self,
+        src: SMBResource,
+        success: bool,
+        msg: str = '',
+        status: Optional[Simplified] = None,
+    ) -> None:
+        self.src = src
+        self.success = success
+        self.msg = msg
+        self.status = status
+
+    def to_simplified(self) -> Simplified:
+        ds: Simplified = dict(self.status or {})
+        ds['resource'] = self.src.to_simplified()
+        ds['success'] = self.success
+        if self.msg:
+            ds['msg'] = self.msg
+        return ds
+
+    def mgr_return_value(self) -> int:
+        return 0 if self.success else -errno.EAGAIN
+
+    def mgr_status_value(self) -> str:
+        if self.success:
+            return ""
+        return "resource failed to apply (see response data for details)"
+
+
+class ErrorResult(Result, Exception):
+    """A Result subclass for wrapping an error condition."""
+
+    def __init__(
+        self,
+        src: SMBResource,
+        msg: str = '',
+        status: Optional[Simplified] = None,
+    ) -> None:
+        super().__init__(src, success=False, msg=msg, status=status)
+
+
+class ResultGroup:
+    """Result of applying multiple smb resource updates to the system."""
+
+    # Compatible with object formatter, thus suitable for being returned
+    # directly to mgr module.
+    def __init__(self) -> None:
+        self._contents: List[Result] = []
+
+    def append(self, result: Result) -> None:
+        self._contents.append(result)
+
+    def one(self) -> Result:
+        return one(self._contents)
+
+    def __iter__(self) -> Iterator[Result]:
+        return iter(self._contents)
+
+    @property
+    def success(self) -> bool:
+        return all(r.success for r in self._contents)
+
+    def to_simplified(self) -> Simplified:
+        return {
+            'success': self.success,
+            'results': [r.to_simplified() for r in self._contents],
+        }
+
+    def mgr_return_value(self) -> int:
+        return 0 if self.success else -errno.EAGAIN
+
+    def mgr_status_value(self) -> str:
+        if self.success:
+            return ""
+        ct = sum(0 if r.success else 1 for r in self._contents)
+        s = '' if ct <= 1 else 's'
+        return f"{ct} resource{s} failed to apply (see response data for details)"

--- a/src/pybind/mgr/smb/tests/test_enums.py
+++ b/src/pybind/mgr/smb/tests/test_enums.py
@@ -1,0 +1,26 @@
+import pytest
+
+import smb.enums
+
+
+@pytest.mark.parametrize(
+    "value, strval",
+    [
+        (smb.enums.CephFSStorageProvider.KERNEL_MOUNT, "kcephfs"),
+        (smb.enums.CephFSStorageProvider.SAMBA_VFS, "samba-vfs"),
+        (smb.enums.SubSystem.CEPHFS, "cephfs"),
+        (smb.enums.Intent.PRESENT, "present"),
+        (smb.enums.Intent.REMOVED, "removed"),
+        (smb.enums.State.CREATED, "created"),
+        (smb.enums.State.NOT_PRESENT, "not present"),
+        (smb.enums.State.PRESENT, "present"),
+        (smb.enums.State.REMOVED, "removed"),
+        (smb.enums.State.UPDATED, "updated"),
+        (smb.enums.AuthMode.USER, "user"),
+        (smb.enums.AuthMode.ACTIVE_DIRECTORY, "active-directory"),
+        (smb.enums.JoinSourceType.PASSWORD, "password"),
+        (smb.enums.UserGroupSourceType.INLINE, "inline"),
+    ],
+)
+def test_stringified(value, strval):
+    assert str(value) == strval

--- a/src/pybind/mgr/smb/tests/test_handler.py
+++ b/src/pybind/mgr/smb/tests/test_handler.py
@@ -1,0 +1,1053 @@
+import pytest
+
+import smb
+
+
+@pytest.fixture
+def thandler():
+    ext_store = smb.config_store.MemConfigStore()
+    return smb.handler.ClusterConfigHandler(
+        internal_store=smb.config_store.MemConfigStore(),
+        # it's completely valid to put the public and priv contents
+        # into a single store. Do that to simplify testing a bit.
+        public_store=ext_store,
+        priv_store=ext_store,
+    )
+
+
+def test_clusters_empty(thandler):
+    clusters = thandler.cluster_ids()
+    assert clusters == []
+
+
+def test_shares_empty(thandler):
+    clusters = thandler.share_ids()
+    assert clusters == []
+
+
+def test_internal_apply_cluster(thandler):
+    cluster = smb.resources.Cluster(
+        cluster_id='foo',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.INLINE,
+                values=smb.resources.UserGroupSettings(
+                    users=[],
+                    groups=[],
+                ),
+            ),
+        ],
+    )
+    rg = thandler.apply([cluster])
+    assert rg.success, rg.to_simplified()
+    assert ('clusters', 'foo') in thandler.internal_store.data
+
+
+def test_cluster_add(thandler):
+    cluster = smb.resources.Cluster(
+        cluster_id='foo',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.INLINE,
+                values=smb.resources.UserGroupSettings(
+                    users=[],
+                    groups=[],
+                ),
+            ),
+        ],
+    )
+    rg = thandler.apply([cluster])
+    assert rg.success, rg.to_simplified()
+
+    clusters = thandler.cluster_ids()
+    assert len(clusters) == 1
+    assert 'foo' in clusters
+
+
+def test_internal_apply_cluster_and_share(thandler):
+    cluster = smb.resources.Cluster(
+        cluster_id='foo',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.INLINE,
+                values=smb.resources.UserGroupSettings(
+                    users=[],
+                    groups=[],
+                ),
+            ),
+        ],
+    )
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='s1',
+        name='Ess One',
+        cephfs=smb.resources.CephFSStorage(
+            volume='cephfs',
+            path='/',
+        ),
+    )
+    rg = thandler.apply([cluster, share])
+    assert rg.success, rg.to_simplified()
+    assert ('clusters', 'foo') in thandler.internal_store.data
+    assert ('shares', 'foo.s1') in thandler.internal_store.data
+
+    shares = thandler.share_ids()
+    assert len(shares) == 1
+    assert ('foo', 's1') in shares
+
+
+def test_internal_apply_remove_cluster(thandler):
+    thandler.internal_store.overwrite(
+        {
+            "clusters.foo": {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'foo',
+                'auth_mode': 'user',
+                'intent': 'present',
+                'user_group_settings': [
+                    {
+                        'source_type': 'inline',
+                        'values': {'users': [], 'groups': []},
+                    }
+                ],
+            }
+        }
+    )
+
+    clusters = thandler.cluster_ids()
+    assert len(clusters) == 1
+    assert 'foo' in clusters
+
+    rmcluster = smb.resources.RemovedCluster(
+        cluster_id='foo',
+    )
+    rg = thandler.apply([rmcluster])
+    assert rg.success, rg.to_simplified()
+
+    clusters = thandler.cluster_ids()
+    assert len(clusters) == 0
+
+
+def test_internal_apply_remove_shares(thandler):
+    thandler.internal_store.overwrite(
+        {
+            'clusters.foo': {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'foo',
+                'auth_mode': 'user',
+                'intent': 'present',
+                'user_group_settings': [
+                    {
+                        'source_type': 'inline',
+                        'values': {'users': [], 'groups': []},
+                    }
+                ],
+            },
+            'shares.foo.s1': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'foo',
+                'share_id': 's1',
+                'intent': 'present',
+                'name': 'Ess One',
+                'readonly': False,
+                'browseable': True,
+                'cephfs': {
+                    'volume': 'cephfs',
+                    'path': '/',
+                    'provider': 'samba-vfs',
+                },
+            },
+            'shares.foo.stwo': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'foo',
+                'share_id': 'stwo',
+                'intent': 'present',
+                'name': 'Ess Two',
+                'readonly': False,
+                'browseable': True,
+                'cephfs': {
+                    'volume': 'cephfs',
+                    'path': '/two',
+                    'provider': 'samba-vfs',
+                },
+            },
+        }
+    )
+
+    shares = thandler.share_ids()
+    assert len(shares) == 2
+    assert ('foo', 's1') in shares
+    assert ('foo', 'stwo') in shares
+
+    rmshare1 = smb.resources.RemovedShare(
+        cluster_id='foo',
+        share_id='s1',
+    )
+    rg = thandler.apply([rmshare1])
+    assert rg.success, rg.to_simplified()
+
+    shares = thandler.share_ids()
+    assert len(shares) == 1
+
+    rmshare2 = smb.resources.RemovedShare(
+        cluster_id='foo',
+        share_id='stwo',
+    )
+    rg = thandler.apply([rmshare1, rmshare2])
+    assert rg.success, rg.to_simplified()
+
+    shares = thandler.share_ids()
+    assert len(shares) == 0
+
+    # check the results
+    rgs = rg.to_simplified()
+    assert rgs['success']
+    assert len(rgs['results']) == 2
+    assert rgs['results'][0]['success']
+    assert rgs['results'][0]['state'] == 'not present'
+    assert rgs['results'][1]['success']
+    assert rgs['results'][1]['state'] == 'removed'
+
+
+def test_internal_apply_add_joinauth(thandler):
+    thandler.internal_store.overwrite(
+        {
+            "clusters.foo": {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'foo',
+                'auth_mode': 'user',
+                'intent': 'present',
+                'user_group_settings': [
+                    {
+                        'source_type': 'inline',
+                        'values': {'users': [], 'groups': []},
+                    }
+                ],
+            }
+        }
+    )
+
+    assert len(thandler.join_auth_ids()) == 0
+    ja = smb.resources.JoinAuth(
+        auth_id='join1',
+        auth=smb.resources.JoinAuthValues(
+            username='testadmin',
+            password='Passw0rd',
+        ),
+    )
+    rg = thandler.apply([ja])
+    assert rg.success, rg.to_simplified()
+
+    assert len(thandler.join_auth_ids()) == 1
+
+
+def test_internal_apply_add_usergroups(thandler):
+    thandler.internal_store.overwrite(
+        {
+            "clusters.foo": {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'foo',
+                'auth_mode': 'user',
+                'intent': 'present',
+                'user_group_settings': [
+                    {
+                        'source_type': 'inline',
+                        'values': {'users': [], 'groups': []},
+                    }
+                ],
+            }
+        }
+    )
+
+    assert len(thandler.user_and_group_ids()) == 0
+    ja = smb.resources.UsersAndGroups(
+        users_groups_id='ug1',
+        values=smb.resources.UserGroupSettings(
+            users=[{"username": "foo"}],
+            groups=[],
+        ),
+    )
+    rg = thandler.apply([ja])
+    assert rg.success, rg.to_simplified()
+
+    assert len(thandler.user_and_group_ids()) == 1
+
+
+def test_generate_config_basic(thandler):
+    thandler.internal_store.overwrite(
+        {
+            'clusters.foo': {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'foo',
+                'auth_mode': 'user',
+                'intent': 'present',
+                'user_group_settings': [
+                    {
+                        'source_type': 'inline',
+                        'values': {'users': [], 'groups': []},
+                    }
+                ],
+            },
+            'shares.foo.s1': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'foo',
+                'share_id': 's1',
+                'intent': 'present',
+                'name': 'Ess One',
+                'readonly': False,
+                'browseable': True,
+                'cephfs': {
+                    'volume': 'cephfs',
+                    'path': '/',
+                    'provider': 'samba-vfs',
+                },
+            },
+            'shares.foo.stwo': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'foo',
+                'share_id': 'stwo',
+                'intent': 'present',
+                'name': 'Ess Two',
+                'readonly': False,
+                'browseable': True,
+                'cephfs': {
+                    'volume': 'cephfs',
+                    'path': '/two',
+                    'provider': 'samba-vfs',
+                },
+            },
+        }
+    )
+
+    cfg = thandler.generate_config('foo')
+    assert cfg
+
+
+def test_generate_config_ad(thandler):
+    thandler.internal_store.overwrite(
+        {
+            'clusters.foo': {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'foo',
+                'auth_mode': 'active-directory',
+                'intent': 'present',
+                'domain_settings': {
+                    'realm': 'dom1.example.com',
+                    'join_sources': [
+                        {
+                            'source_type': 'password',
+                            'auth': {
+                                'username': 'testadmin',
+                                'password': 'Passw0rd',
+                            },
+                        }
+                    ],
+                },
+            },
+            'shares.foo.s1': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'foo',
+                'share_id': 's1',
+                'intent': 'present',
+                'name': 'Ess One',
+                'readonly': False,
+                'browseable': True,
+                'cephfs': {
+                    'volume': 'cephfs',
+                    'path': '/',
+                    'provider': 'samba-vfs',
+                },
+            },
+            'shares.foo.stwo': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'foo',
+                'share_id': 'stwo',
+                'intent': 'present',
+                'name': 'Ess Two',
+                'readonly': False,
+                'browseable': True,
+                'cephfs': {
+                    'volume': 'cephfs',
+                    'path': '/two',
+                    'provider': 'samba-vfs',
+                },
+            },
+        }
+    )
+
+    cfg = thandler.generate_config('foo')
+    assert cfg
+    assert cfg['globals']['foo']['options']['realm'] == 'dom1.example.com'
+
+
+def test_error_result():
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='s1',
+        name='Ess One',
+        cephfs=smb.resources.CephFSStorage(
+            volume='cephfs',
+            path='/',
+        ),
+    )
+    err = smb.handler.ErrorResult(share, msg='test error')
+    assert isinstance(err, smb.handler.Result)
+    assert isinstance(err, Exception)
+
+    data = err.to_simplified()
+    assert data['resource']['cluster_id'] == 'foo'
+    assert data['msg'] == 'test error'
+
+
+def test_apply_type_error(thandler):
+    # a resource component, not valid on its own
+    r = smb.resources.CephFSStorage(
+        volume='cephfs',
+        path='/',
+    )
+    rg = thandler.apply([r])
+    assert not rg.success
+    assert rg.one().msg == 'not a valid smb resource'
+
+
+def test_apply_no_matching_cluster_error(thandler):
+    share = smb.resources.Share(
+        cluster_id='woops',
+        share_id='s1',
+        name='Ess One',
+        cephfs=smb.resources.CephFSStorage(
+            volume='cephfs',
+            path='/',
+        ),
+    )
+    rg = thandler.apply([share])
+    assert not rg.success
+
+
+def test_one():
+    assert smb.proto.one(['a']) == 'a'
+    with pytest.raises(ValueError):
+        smb.proto.one([])
+    with pytest.raises(ValueError):
+        smb.proto.one(['a', 'b'])
+
+
+def test_apply_full_cluster_create(thandler):
+    to_apply = [
+        smb.resources.JoinAuth(
+            auth_id='join1',
+            auth=smb.resources.JoinAuthValues(
+                username='testadmin',
+                password='Passw0rd',
+            ),
+        ),
+        smb.resources.Cluster(
+            cluster_id='mycluster1',
+            auth_mode=smb.enums.AuthMode.ACTIVE_DIRECTORY,
+            domain_settings=smb.resources.DomainSettings(
+                realm='MYDOMAIN.EXAMPLE.ORG',
+                join_sources=[
+                    smb.resources.JoinSource(
+                        source_type=smb.enums.JoinSourceType.RESOURCE,
+                        ref='join1',
+                    ),
+                ],
+            ),
+            custom_dns=['192.168.76.204'],
+        ),
+        smb.resources.Share(
+            cluster_id='mycluster1',
+            share_id='homedirs',
+            name='Home Directries',
+            cephfs=smb.resources.CephFSStorage(
+                volume='cephfs',
+                subvolume='homedirs',
+                path='/',
+            ),
+        ),
+        smb.resources.Share(
+            cluster_id='mycluster1',
+            share_id='archive',
+            cephfs=smb.resources.CephFSStorage(
+                volume='cephfs',
+                path='/archive',
+            ),
+        ),
+    ]
+    results = thandler.apply(to_apply)
+    assert results.success, results.to_simplified()
+    assert len(list(results)) == 4
+
+    assert 'mycluster1' in thandler.public_store.namespaces()
+    ekeys = list(thandler.public_store.contents('mycluster1'))
+    assert len(ekeys) == 4
+    assert 'cluster-info' in ekeys
+    assert 'config.smb' in ekeys
+    assert 'spec.smb' in ekeys
+    assert 'join.0.json' in ekeys
+
+    jdata = thandler.public_store['mycluster1', 'join.0.json'].get()
+    assert jdata == {'username': 'testadmin', 'password': 'Passw0rd'}
+    cidata = thandler.public_store['mycluster1', 'cluster-info'].get()
+    assert cidata['cluster_id'] == 'mycluster1'
+    cfdata = thandler.public_store['mycluster1', 'config.smb'].get()
+    assert 'mycluster1' in cfdata['configs']
+    assert 'mycluster1' in cfdata['globals']
+    assert len(cfdata['shares']) == 2
+    assert 'Home Directries' in cfdata['shares']
+    assert 'archive' in cfdata['shares']
+    ssdata = thandler.public_store['mycluster1', 'spec.smb'].get()
+    assert 'spec' in ssdata
+    assert ssdata['spec']['cluster_id'] == 'mycluster1'
+    assert ssdata['spec']['config_uri'] == 'mem:mycluster1/config.smb'
+    assert ssdata['spec']['features'] == ['domain']
+    assert ssdata['spec']['join_sources'] == ['mem:mycluster1/join.0.json']
+    assert ssdata['spec']['custom_dns'] == ['192.168.76.204']
+
+
+def test_apply_remove_share(thandler):
+    test_apply_full_cluster_create(thandler)
+    to_apply = [
+        smb.resources.RemovedShare(
+            cluster_id='mycluster1', share_id='archive'
+        )
+    ]
+
+    results = thandler.apply(to_apply)
+    assert results.success, results.to_simplified()
+    assert len(list(results)) == 1
+
+    assert 'mycluster1' in thandler.public_store.namespaces()
+    ekeys = list(thandler.public_store.contents('mycluster1'))
+    assert len(ekeys) == 4
+    assert 'cluster-info' in ekeys
+    assert 'config.smb' in ekeys
+    assert 'spec.smb' in ekeys
+    assert 'join.0.json' in ekeys
+
+    # we deleted the archive share, so we can assert that only the homedirs
+    # share is present in the config
+    cfdata = thandler.public_store['mycluster1', 'config.smb'].get()
+    assert 'mycluster1' in cfdata['configs']
+    assert 'mycluster1' in cfdata['globals']
+    assert len(cfdata['shares']) == 1
+    assert 'Home Directries' in cfdata['shares']
+
+
+def test_apply_update_password(thandler):
+    test_apply_full_cluster_create(thandler)
+    to_apply = [
+        smb.resources.JoinAuth(
+            auth_id='join1',
+            auth=smb.resources.JoinAuthValues(
+                username='testadmin',
+                password='Zm9vYmFyCg',
+            ),
+        ),
+    ]
+
+    results = thandler.apply(to_apply)
+    assert results.success, results.to_simplified()
+    assert len(list(results)) == 1
+
+    assert 'mycluster1' in thandler.public_store.namespaces()
+    ekeys = list(thandler.public_store.contents('mycluster1'))
+    assert len(ekeys) == 4
+    assert 'cluster-info' in ekeys
+    assert 'config.smb' in ekeys
+    assert 'spec.smb' in ekeys
+    assert 'join.0.json' in ekeys
+
+    # we changed the password value. the store should reflect that
+    jdata = thandler.public_store['mycluster1', 'join.0.json'].get()
+    assert jdata == {'username': 'testadmin', 'password': 'Zm9vYmFyCg'}
+
+
+def test_apply_update_cluster_inline_pw(thandler):
+    test_apply_full_cluster_create(thandler)
+    to_apply = [
+        smb.resources.Cluster(
+            cluster_id='mycluster1',
+            auth_mode=smb.enums.AuthMode.ACTIVE_DIRECTORY,
+            domain_settings=smb.resources.DomainSettings(
+                realm='MYDOMAIN.EXAMPLE.ORG',
+                join_sources=[
+                    smb.resources.JoinSource(
+                        source_type=smb.enums.JoinSourceType.RESOURCE,
+                        ref='join1',
+                    ),
+                    smb.resources.JoinSource(
+                        source_type=smb.enums.JoinSourceType.PASSWORD,
+                        auth=smb.resources.JoinAuthValues(
+                            username='Jimmy',
+                            password='j4mb0ree!',
+                        ),
+                    ),
+                ],
+            ),
+        ),
+    ]
+
+    results = thandler.apply(to_apply)
+    assert results.success, results.to_simplified()
+    assert len(list(results)) == 1
+
+    assert 'mycluster1' in thandler.public_store.namespaces()
+    ekeys = list(thandler.public_store.contents('mycluster1'))
+    assert len(ekeys) == 5
+    assert 'cluster-info' in ekeys
+    assert 'config.smb' in ekeys
+    assert 'spec.smb' in ekeys
+    assert 'join.0.json' in ekeys
+    assert 'join.1.json' in ekeys
+
+    # we changed the password value. the store should reflect that
+    jdata = thandler.public_store['mycluster1', 'join.0.json'].get()
+    assert jdata == {'username': 'testadmin', 'password': 'Passw0rd'}
+    # we changed the password value. the store should reflect that
+    jdata2 = thandler.public_store['mycluster1', 'join.1.json'].get()
+    assert jdata2 == {'username': 'Jimmy', 'password': 'j4mb0ree!'}
+
+
+def test_apply_add_second_cluster(thandler):
+    test_apply_full_cluster_create(thandler)
+    to_apply = [
+        smb.resources.Cluster(
+            cluster_id='coolcluster',
+            auth_mode=smb.enums.AuthMode.ACTIVE_DIRECTORY,
+            domain_settings=smb.resources.DomainSettings(
+                realm='YOURDOMAIN.EXAMPLE.ORG',
+                join_sources=[
+                    smb.resources.JoinSource(
+                        source_type=smb.enums.JoinSourceType.PASSWORD,
+                        auth=smb.resources.JoinAuthValues(
+                            username='Jimmy',
+                            password='j4mb0ree!',
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        smb.resources.Share(
+            cluster_id='coolcluster',
+            share_id='images',
+            cephfs=smb.resources.CephFSStorage(
+                volume='imgvol',
+                path='/',
+            ),
+        ),
+    ]
+
+    results = thandler.apply(to_apply)
+    assert results.success, results.to_simplified()
+    assert len(list(results)) == 2
+
+    assert 'mycluster1' in thandler.public_store.namespaces()
+    ekeys = list(thandler.public_store.contents('mycluster1'))
+    assert len(ekeys) == 4
+    assert 'cluster-info' in ekeys
+    assert 'config.smb' in ekeys
+    assert 'spec.smb' in ekeys
+    assert 'join.0.json' in ekeys
+
+    assert 'coolcluster' in thandler.public_store.namespaces()
+    ekeys = list(thandler.public_store.contents('coolcluster'))
+    assert len(ekeys) == 4
+    assert 'cluster-info' in ekeys
+    assert 'config.smb' in ekeys
+    assert 'spec.smb' in ekeys
+    assert 'join.0.json' in ekeys
+
+    jdata = thandler.public_store['coolcluster', 'join.0.json'].get()
+    assert jdata == {'username': 'Jimmy', 'password': 'j4mb0ree!'}
+    cidata = thandler.public_store['coolcluster', 'cluster-info'].get()
+    assert cidata['cluster_id'] == 'coolcluster'
+    cfdata = thandler.public_store['coolcluster', 'config.smb'].get()
+    assert 'coolcluster' in cfdata['configs']
+    assert 'coolcluster' in cfdata['globals']
+    assert len(cfdata['shares']) == 1
+    assert 'images' in cfdata['shares']
+    ssdata = thandler.public_store['coolcluster', 'spec.smb'].get()
+    assert 'spec' in ssdata
+    assert ssdata['spec']['cluster_id'] == 'coolcluster'
+    assert ssdata['spec']['config_uri'] == 'mem:coolcluster/config.smb'
+    assert ssdata['spec']['features'] == ['domain']
+    assert ssdata['spec']['join_sources'] == ['mem:coolcluster/join.0.json']
+
+
+def test_modify_cluster_only_touches_changed_cluster(thandler):
+    test_apply_add_second_cluster(thandler)
+
+    thandler.public_store.remove(('mycluster1', 'cluster-info'))
+    ekeys = list(thandler.public_store.contents('mycluster1'))
+    assert len(ekeys) == 3
+    thandler.public_store.remove(('coolcluster', 'cluster-info'))
+    ekeys = list(thandler.public_store.contents('coolcluster'))
+    assert len(ekeys) == 3
+
+    to_apply = [
+        smb.resources.Share(
+            cluster_id='coolcluster',
+            share_id='photos',
+            cephfs=smb.resources.CephFSStorage(
+                volume='imgvol',
+                path='/photos',
+            ),
+        ),
+    ]
+    results = thandler.apply(to_apply)
+    assert results.success, results.to_simplified()
+    assert len(list(results)) == 1
+
+    # we didn't make any changes to mycluster1 or it's shares. so
+    # we had no reason to update it... cluster-info should be missing
+    assert 'mycluster1' in thandler.public_store.namespaces()
+    ekeys = list(thandler.public_store.contents('mycluster1'))
+    assert len(ekeys) == 3
+    assert 'cluster-info' not in ekeys
+    assert 'config.smb' in ekeys
+    assert 'spec.smb' in ekeys
+    assert 'join.0.json' in ekeys
+
+    # we changed a share in coolcluster so we should have regenerated
+    # the cluster-info object
+    assert 'coolcluster' in thandler.public_store.namespaces()
+    ekeys = list(thandler.public_store.contents('coolcluster'))
+    assert len(ekeys) == 4
+    assert 'cluster-info' in ekeys
+    assert 'config.smb' in ekeys
+    assert 'spec.smb' in ekeys
+    assert 'join.0.json' in ekeys
+
+
+def test_apply_remove_cluster(thandler):
+    test_apply_full_cluster_create(thandler)
+    assert ('clusters', 'mycluster1') in thandler.internal_store.data
+    assert ('shares', 'mycluster1.archive') in thandler.internal_store.data
+    assert ('shares', 'mycluster1.homedirs') in thandler.internal_store.data
+
+    to_apply = [
+        smb.resources.RemovedCluster(
+            cluster_id='mycluster1',
+        ),
+        smb.resources.RemovedShare(
+            cluster_id='mycluster1', share_id='archive'
+        ),
+        smb.resources.RemovedShare(
+            cluster_id='mycluster1', share_id='homedirs'
+        ),
+    ]
+
+    results = thandler.apply(to_apply)
+    assert results.success, results.to_simplified()
+    assert len(list(results)) == 3
+
+    assert ('clusters', 'mycluster1') not in thandler.internal_store.data
+    assert (
+        'shares',
+        'mycluster1.archive',
+    ) not in thandler.internal_store.data
+    assert (
+        'shares',
+        'mycluster1.homedirs',
+    ) not in thandler.internal_store.data
+
+    # verify that mycluster1 is gone from the public store
+    assert 'mycluster1' not in thandler.public_store.namespaces()
+
+
+def test_apply_remove_all_clusters(thandler):
+    class FakeOrch:
+        def __init__(self):
+            self.deployed = set()
+
+        def submit_smb_spec(self, spec):
+            self.deployed.add(f'smb.{spec.service_id}')
+
+        def remove_smb_service(self, service_name):
+            assert service_name.startswith('smb.')
+            self.deployed.remove(service_name)
+
+    thandler._orch = FakeOrch()
+    test_apply_full_cluster_create(thandler)
+
+    to_apply = [
+        smb.resources.UsersAndGroups(
+            users_groups_id='ug1',
+            values=smb.resources.UserGroupSettings(
+                users=[{"username": "foo"}],
+                groups=[],
+            ),
+        ),
+        smb.resources.Cluster(
+            cluster_id='mycluster2',
+            auth_mode=smb.enums.AuthMode.USER,
+            user_group_settings=[
+                smb.resources.UserGroupSource(
+                    source_type=smb.resources.UserGroupSourceType.RESOURCE,
+                    ref='ug1',
+                ),
+            ],
+        ),
+        smb.resources.Cluster(
+            cluster_id='mycluster3',
+            auth_mode=smb.enums.AuthMode.USER,
+            user_group_settings=[
+                smb.resources.UserGroupSource(
+                    source_type=smb.resources.UserGroupSourceType.RESOURCE,
+                    ref='ug1',
+                ),
+            ],
+        ),
+        smb.resources.Share(
+            cluster_id='mycluster2',
+            share_id='m2',
+            cephfs=smb.resources.CephFSStorage(
+                volume='imgvol',
+                path='/',
+            ),
+        ),
+        smb.resources.Share(
+            cluster_id='mycluster3',
+            share_id='m3',
+            cephfs=smb.resources.CephFSStorage(
+                volume='imgvol',
+                path='/',
+            ),
+        ),
+    ]
+
+    results = thandler.apply(to_apply)
+    assert results.success, results.to_simplified()
+    assert ('clusters', 'mycluster1') in thandler.internal_store.data
+    assert ('clusters', 'mycluster2') in thandler.internal_store.data
+    assert ('clusters', 'mycluster3') in thandler.internal_store.data
+    assert thandler._orch.deployed == {
+        'smb.mycluster1',
+        'smb.mycluster2',
+        'smb.mycluster3',
+    }
+
+    to_apply = [
+        smb.resources.RemovedCluster(
+            cluster_id='mycluster1',
+        ),
+        smb.resources.RemovedShare(
+            cluster_id='mycluster1', share_id='archive'
+        ),
+        smb.resources.RemovedShare(
+            cluster_id='mycluster1', share_id='homedirs'
+        ),
+        smb.resources.RemovedCluster(
+            cluster_id='mycluster2',
+        ),
+        smb.resources.RemovedShare(cluster_id='mycluster2', share_id='m2'),
+        smb.resources.RemovedCluster(
+            cluster_id='mycluster3',
+        ),
+        smb.resources.RemovedShare(cluster_id='mycluster3', share_id='m3'),
+        smb.resources.UsersAndGroups(
+            users_groups_id='ug1',
+            intent=smb.enums.Intent.REMOVED,
+        ),
+    ]
+
+    results = thandler.apply(to_apply)
+    assert results.success, results.to_simplified()
+    all_ns = thandler.public_store.namespaces()
+    assert list(all_ns) == []
+    assert thandler._orch.deployed == set()
+
+
+def test_all_resources(thandler):
+    test_apply_add_second_cluster(thandler)
+    rall = thandler.all_resources()
+    assert len(rall) == 6
+    assert rall[0].resource_type == 'ceph.smb.cluster'
+    assert rall[1].resource_type == 'ceph.smb.share'
+    assert rall[2].resource_type == 'ceph.smb.share'
+    assert rall[3].resource_type == 'ceph.smb.cluster'
+    assert rall[4].resource_type == 'ceph.smb.share'
+    assert rall[5].resource_type == 'ceph.smb.join.auth'
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        # by single type
+        dict(
+            requests=['ceph.smb.cluster'],
+            check=[
+                {
+                    'resource_type': 'ceph.smb.cluster',
+                    'cluster_id': 'mycluster1',
+                },
+                {
+                    'resource_type': 'ceph.smb.cluster',
+                    'cluster_id': 'coolcluster',
+                },
+            ],
+        ),
+        dict(
+            requests=['ceph.smb.share'],
+            check=[
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'mycluster1',
+                    'share_id': 'homedirs',
+                },
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'mycluster1',
+                    'share_id': 'archive',
+                },
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'coolcluster',
+                    'share_id': 'images',
+                },
+            ],
+        ),
+        # by mixed type
+        dict(
+            requests=['ceph.smb.cluster', 'ceph.smb.share'],
+            check=[
+                {
+                    'resource_type': 'ceph.smb.cluster',
+                    'cluster_id': 'mycluster1',
+                },
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'mycluster1',
+                    'share_id': 'homedirs',
+                },
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'mycluster1',
+                    'share_id': 'archive',
+                },
+                {
+                    'resource_type': 'ceph.smb.cluster',
+                    'cluster_id': 'coolcluster',
+                },
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'coolcluster',
+                    'share_id': 'images',
+                },
+            ],
+        ),
+        dict(
+            requests=['ceph.smb.join.auth', 'ceph.smb.share'],
+            check=[
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'mycluster1',
+                    'share_id': 'homedirs',
+                },
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'mycluster1',
+                    'share_id': 'archive',
+                },
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'coolcluster',
+                    'share_id': 'images',
+                },
+                {
+                    'resource_type': 'ceph.smb.join.auth',
+                    'auth_id': 'join1',
+                },
+            ],
+        ),
+        # cluster with id
+        dict(
+            requests=['ceph.smb.cluster.coolcluster'],
+            check=[
+                {
+                    'resource_type': 'ceph.smb.cluster',
+                    'cluster_id': 'coolcluster',
+                },
+            ],
+        ),
+        # share with cluster id
+        dict(
+            requests=['ceph.smb.share.mycluster1'],
+            check=[
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'mycluster1',
+                    'share_id': 'homedirs',
+                },
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'mycluster1',
+                    'share_id': 'archive',
+                },
+            ],
+        ),
+        # share with cluster id, share id
+        dict(
+            requests=['ceph.smb.share.mycluster1.archive'],
+            check=[
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'mycluster1',
+                    'share_id': 'archive',
+                },
+            ],
+        ),
+        # miss
+        dict(requests=['ceph.smb.usersgroups'], check=[]),
+        # (for coverage sake)
+        dict(
+            requests=['ceph.smb.usersgroups'],
+            insert_ug=True,
+            check=[
+                {
+                    'resource_type': 'ceph.smb.usersgroups',
+                    'users_groups_id': 'ug1',
+                },
+            ],
+        ),
+    ],
+)
+def test_matching_resources(thandler, params):
+    test_apply_add_second_cluster(thandler)
+    if params.get('insert_ug'):
+        ja = smb.resources.UsersAndGroups(
+            users_groups_id='ug1',
+            values=smb.resources.UserGroupSettings(
+                users=[{"username": "foo"}],
+                groups=[],
+            ),
+        )
+        rg = thandler.apply([ja])
+        assert rg.success
+
+    rall = thandler.matching_resources(params['requests'])
+    check = params['check']
+    assert len(rall) == len(check)
+    for idx, (resource, chk) in enumerate(zip(rall, check)):
+        for k, v in chk.items():
+            assert (
+                getattr(resource, k) == v
+            ), f"resource.{k} != {v}, result #{idx}"
+
+
+@pytest.mark.parametrize(
+    'txt',
+    [
+        'foo.bar.baz',
+        'tic/tac/toe',
+        '',
+        'ceph.smb.cluster.funky.town.band',
+    ],
+)
+def test_invalid_resource_match_strs(thandler, txt):
+    with pytest.raises(ValueError):
+        thandler.matching_resources([txt])

--- a/src/pybind/mgr/smb/tests/test_rados_store.py
+++ b/src/pybind/mgr/smb/tests/test_rados_store.py
@@ -1,0 +1,116 @@
+from unittest import mock
+
+import smb.rados_store
+
+
+def rados_mock():
+    import rados
+
+    m = mock.MagicMock()
+    m._fake_store = {}
+    ioctx = m.open_ioctx.return_value
+
+    def _read(key, *args):
+        return m._fake_store[ioctx._current_ns, key].encode('utf8')
+
+    def _set_ns(ns):
+        ioctx._current_ns = ns
+
+    def _write_full(key, data):
+        m._fake_store[ioctx._current_ns, key] = data
+
+    def _list(*args):
+        return [mock.MagicMock(nspace=a, key=b) for a, b in m._fake_store]
+
+    def _stat(key):
+        if (ioctx._current_ns, key) not in m._fake_store:
+            raise rados.ObjectNotFound
+
+    def _remove_object(key):
+        del m._fake_store[ioctx._current_ns, key]
+
+    ioctx.__enter__.return_value = ioctx
+    ioctx.list_objects.side_effect = _list
+    ioctx.set_namespace.side_effect = _set_ns
+    ioctx.read.side_effect = _read
+    ioctx.write_full.side_effect = _write_full
+    ioctx.stat.side_effect = _stat
+    ioctx.remove_object.side_effect = _remove_object
+
+    m._fake_store[
+        'foo', 'one'
+    ] = """
+        {"mocked": true, "silly": "very", "name": "one"}
+    """
+    m._fake_store[
+        'bar', 'two'
+    ] = """
+        {"mocked": true, "silly": "very", "name": "two"}
+    """
+    m._fake_store[
+        'bar', 'three'
+    ] = """
+        {"mocked": true, "silly": "very", "name": "three"}
+    """
+
+    return m
+
+
+def test_mocked_rados_store_iteration():
+    r = rados_mock()
+    store = smb.rados_store.RADOSConfigStore(r)
+    ekeys = list(store)
+    assert ekeys == [('foo', 'one'), ('bar', 'two'), ('bar', 'three')]
+    assert sorted(store.namespaces()) == ['bar', 'foo']
+    assert list(store.contents('foo')) == ['one']
+    assert list(store.contents('bar')) == ['two', 'three']
+
+
+def test_mocked_rados_store_get_entry():
+    r = rados_mock()
+    store = smb.rados_store.RADOSConfigStore(r)
+    entry = store['foo', 'one']
+    assert entry.uri == 'rados://.smb/foo/one'
+    assert entry.full_key == ('foo', 'one')
+    data = entry.get()
+    assert isinstance(data, dict)
+    assert data['mocked']
+    assert data['silly'] == 'very'
+    assert data['name'] == 'one'
+
+
+def test_mocked_rados_store_set_get_entry():
+    r = rados_mock()
+    store = smb.rados_store.RADOSConfigStore(r)
+    entry = store['foo', 'four']
+    assert entry.uri == 'rados://.smb/foo/four'
+    assert entry.full_key == ('foo', 'four')
+    entry.set(
+        dict(
+            mocked=False,
+            silly='walks',
+            name='four',
+        )
+    )
+    assert list(store.contents('foo')) == ['one', 'four']
+
+
+def test_mocked_rados_store_entry_exists():
+    r = rados_mock()
+    store = smb.rados_store.RADOSConfigStore(r)
+    entry = store['bar', 'two']
+    assert entry.uri == 'rados://.smb/bar/two'
+    assert entry.full_key == ('bar', 'two')
+    assert entry.exists()
+
+    entry = store['bar', 'seven']
+    assert entry.uri == 'rados://.smb/bar/seven'
+    assert entry.full_key == ('bar', 'seven')
+    assert not entry.exists()
+
+
+def test_mocked_rados_store_entry_remove():
+    r = rados_mock()
+    store = smb.rados_store.RADOSConfigStore(r)
+    store.remove(('bar', 'three'))
+    assert list(store) == [('foo', 'one'), ('bar', 'two')]

--- a/src/pybind/mgr/smb/tests/test_resourcelib.py
+++ b/src/pybind/mgr/smb/tests/test_resourcelib.py
@@ -1,0 +1,454 @@
+from typing import Dict, List, Optional, Tuple
+
+import dataclasses
+import enum
+
+import pytest
+
+import smb.resourcelib
+
+
+class Thingy(str, enum.Enum):
+    STUFF = 'stuff'
+    JUNK = 'junk'
+    DEBRIS = 'debris'
+
+
+@dataclasses.dataclass
+class ReadMe:
+    foo: str
+    bar: int = 0
+    baz: float = 0.1
+    bingo: Optional[str] = None
+    quux: Optional[List[int]] = None
+    womble: Optional[Dict[str, str]] = None
+    waver: Optional[Tuple[int, str]] = None
+
+
+def test_resource_config_field_metadata():
+    rmc = smb.resourcelib.Resource.create(ReadMe)
+    assert not rmc.conditional
+    assert rmc.type_name() == 'ReadMe'
+
+    # did it load the fields
+    assert 'foo' in rmc.fields
+    assert 'womble' in rmc.fields
+    assert len(rmc.fields) == 7
+
+    # magic getattr fields (quiet is always unset by default)
+    assert not rmc.foo.quiet
+    # optional
+    assert not rmc.foo.optional()
+    assert not rmc.bar.optional()
+    assert rmc.bingo.optional()
+    assert rmc.womble.optional()
+    # inner type
+    assert rmc.foo.inner_type() == str
+    assert rmc.bingo.inner_type() == str
+    # takes
+    assert not rmc.foo.takes(str)  # takes only useful for container types
+    assert rmc.quux.takes(list)
+    assert rmc.womble.takes(dict)
+    assert rmc.waver.takes(tuple)
+    # list element type
+    assert rmc.quux.list_element_type() == int
+    # dict element types
+    assert rmc.womble.dict_element_types() == (str, str)
+
+    assert 'ReadMe' in repr(rmc)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        # very basic
+        {
+            'kwargs': {'foo': 'smile'},
+            'expected': {
+                'foo': 'smile',
+                'bar': 0,
+                'baz': 0.1,
+            },
+        },
+        # set some other scalar values
+        {
+            'kwargs': {'foo': 'smile', 'bar': 12, 'bingo': 'b18'},
+            'expected': {
+                'foo': 'smile',
+                'bar': 12,
+                'baz': 0.1,
+                'bingo': 'b18',
+            },
+        },
+        # a list value
+        {
+            'kwargs': {'foo': 'smile', 'bar': 12, 'quux': [3, 11]},
+            'expected': {
+                'foo': 'smile',
+                'bar': 12,
+                'baz': 0.1,
+                'quux': [3, 11],
+            },
+        },
+        # a dict value
+        {
+            'kwargs': {
+                'foo': 'smile',
+                'bar': 12,
+                'womble': {"test": "one", "be": "good"},
+            },
+            'expected': {
+                'foo': 'smile',
+                'bar': 12,
+                'baz': 0.1,
+                'womble': {"test": "one", "be": "good"},
+            },
+        },
+    ],
+)
+def test_basic_resource_config_to_simplified(params):
+    rmc = smb.resourcelib.Resource.create(ReadMe)
+    obj = ReadMe(*params.get('args', []), **params.get('kwargs', {}))
+    result = rmc.object_to_simplified(obj)
+    assert result == params['expected']
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        # very basic
+        {
+            "data": {
+                "foo": "hello",
+            },
+            "expected": ReadMe("hello"),
+        },
+        # two params
+        {
+            "data": {
+                "foo": "greetings",
+                "bar": 99,
+            },
+            "expected": ReadMe("greetings", bar=99),
+        },
+        # all scalars
+        {
+            "data": {
+                "foo": "aloha",
+                "bar": 101,
+                "baz": 3.14,
+                "bingo": "nameo",
+            },
+            "expected": ReadMe("aloha", bar=101, baz=3.14, bingo='nameo'),
+        },
+        # list and dict
+        {
+            "data": {
+                "foo": "icu",
+                "bar": 16,
+                "baz": 2.2,
+                "bingo": "yep",
+                "quux": [1, 5, 9],
+                "womble": {"something": "for everyone", "blank": ""},
+            },
+            "expected": ReadMe(
+                "icu",
+                bar=16,
+                baz=2.2,
+                bingo='yep',
+                quux=[1, 5, 9],
+                womble={"something": "for everyone", "blank": ""},
+            ),
+        },
+    ],
+)
+def test_basic_resource_config_from_simplified(params):
+    data = params['data']
+    rmc = smb.resourcelib.Resource.create(ReadMe)
+    result = rmc.object_from_simplified(data)
+    assert result == params['expected']
+
+
+def test_registry():
+    r = smb.resourcelib.Registry()
+    assert not r.resources
+    assert not r.types
+
+    @dataclasses.dataclass
+    class Foo:
+        name: str
+
+    resource = r.enable(Foo)
+    assert not r.resources
+    assert r.types
+
+    r.track('foo', resource)
+    assert r.resources
+    assert r.types
+
+    config2 = r.select({'resource_type': 'foo'})
+    assert config2 is resource
+
+    with pytest.raises(smb.resourcelib.MissingResourceTypeError):
+        r.select({})
+
+    with pytest.raises(smb.resourcelib.InvalidResourceTypeError):
+        r.select({'resource_type': 'oopsie'})
+
+    with pytest.raises(smb.resourcelib.ResourceTypeError):
+        cx = r.enable(ReadMe)
+        r.track('foo', cx)
+
+
+def test_registry_select_on_condition():
+    r = smb.resourcelib.Registry()
+
+    @dataclasses.dataclass
+    class A:
+        name: str
+
+        @staticmethod
+        def _condition(d):
+            return 'flavor' not in d and 'name' in d
+
+    @dataclasses.dataclass
+    class B:
+        name: str
+        flavor: str
+
+        @staticmethod
+        def _condition(d):
+            return 'flavor' in d
+
+    configa = r.enable(A)
+    configa.on_condition(A._condition)
+    configb = r.enable(B)
+    configb.on_condition(B._condition)
+
+    r.track('x', configa)
+    r.track('x', configb)
+
+    c = r.select({'resource_type': 'x', 'name': "joe", "flavor": "coffee"})
+    assert c is configb
+
+    c = r.select({'resource_type': 'x', 'name': "joe"})
+    assert c is configa
+
+    with pytest.raises(smb.resourcelib.ResourceTypeError):
+        r.select({'resource_type': 'x'})
+
+    # this should normally be impossible
+    configa._on_condition = None
+    configb._on_condition = None
+    with pytest.raises(smb.resourcelib.ResourceTypeError):
+        r.select({'resource_type': 'x'})
+
+
+@smb.resourcelib.component()
+class Worker:
+    name: str
+    age: int
+    role: Optional[str] = None
+
+    def validate(self):
+        if not self.name:
+            raise ValueError('name missing')
+        if self.age <= 0:
+            raise ValueError('invalid age')
+
+
+@smb.resourcelib.component()
+class Unit:
+    label: str
+    manager: Worker
+    full_timers: List[Worker]
+    interns: Optional[List[Worker]] = None
+
+
+@smb.resourcelib.resource('bigbiz')
+class BigBiz:
+    name: str
+    address: List[str]
+    ceo: Worker
+    units: Optional[List[Unit]] = None
+
+
+@smb.resourcelib.resource('smallbiz')
+class SmallBiz:
+    name: str
+    address: List[str]
+    people: List[Worker]
+
+
+def test_resource_round_trip():
+    r1 = BigBiz(
+        name='Mega Co',
+        address=['1010 Bigness Way', 'Metropolis', 'IL', '012345'],
+        ceo=Worker('F. Smith', 55),
+        units=[
+            Unit(
+                label='Sales',
+                manager=Worker('Al Pha', 42),
+                full_timers=[Worker('P. Rep', 33)],
+            ),
+            Unit(
+                label='Engineering',
+                manager=Worker('O. Mega', 42),
+                full_timers=[
+                    Worker('I. Contrib', 28),
+                    Worker('U. Needme', 29, role='QA'),
+                ],
+                interns=[Worker('J. Younya', 22)],
+            ),
+        ],
+    )
+
+    data = r1.to_simplified()
+    assert 'resource_type' in data
+
+    r2 = BigBiz._resource_config.object_from_simplified(data)
+    assert r1 == r2
+
+
+def test_resource_round_trip2():
+    r1 = SmallBiz(
+        name='Joes Diner',
+        address=['123 Main St', 'Smallville', 'IA', '048394'],
+        people=[
+            Worker('Joe', 44),
+            Worker('Lisa', 43),
+            Worker('Tina', 23),
+        ],
+    )
+
+    data = r1.to_simplified()
+    assert 'resource_type' in data
+
+    r2 = SmallBiz._resource_config.object_from_simplified(data)
+    assert r1 == r2
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        # small biz 1
+        {
+            'data': {
+                'resource_type': 'smallbiz',
+                'name': 'Le Shoppe',
+                'address': ['12 Fashion Way', 'Urbia', 'WA', '01209'],
+                'people': [
+                    {'name': 'Madelyn', 'age': 39},
+                    {'name': 'Mark', 'age': 39},
+                ],
+            },
+            'expect_types': [SmallBiz],
+        },
+        # big biz 1
+        {
+            'data': {
+                'resource_type': 'bigbiz',
+                'name': 'MegaLoMart',
+                'address': ['1 MegaLo Drive', 'Mango', 'TX', '22020'],
+                'ceo': {'name': 'D. B. Bawes', 'age': 61},
+            },
+            'expect_types': [BigBiz],
+        },
+        # raw list
+        {
+            'data': [
+                {
+                    'resource_type': 'smallbiz',
+                    'name': 'Le Shoppe',
+                    'address': ['12 Fashion Way', 'Urbia', 'WA', '01209'],
+                    'people': [
+                        {'name': 'Madelyn', 'age': 39},
+                        {'name': 'Mark', 'age': 39},
+                    ],
+                },
+                {
+                    'resource_type': 'bigbiz',
+                    'name': 'MegaLoMart',
+                    'address': ['1 MegaLo Drive', 'Mango', 'TX', '22020'],
+                    'ceo': {'name': 'D. B. Bawes', 'age': 61},
+                },
+            ],
+            'expect_types': [SmallBiz, BigBiz],
+        },
+        # list object
+        {
+            'data': {
+                'resources': [
+                    {
+                        'resource_type': 'smallbiz',
+                        'name': 'Le Shoppe',
+                        'address': ['12 Fashion Way', 'Urbia', 'WA', '01209'],
+                        'people': [
+                            {'name': 'Madelyn', 'age': 39},
+                            {'name': 'Mark', 'age': 39},
+                        ],
+                    },
+                    {
+                        'resource_type': 'bigbiz',
+                        'name': 'MegaLoMart',
+                        'address': ['1 MegaLo Drive', 'Mango', 'TX', '22020'],
+                        'ceo': {'name': 'D. B. Bawes', 'age': 61},
+                    },
+                ]
+            },
+            'expect_types': [SmallBiz, BigBiz],
+        },
+    ],
+)
+def test_load(params):
+    data = params['data']
+    objs = smb.resourcelib.load(data)
+    assert len(objs) == len(params['expect_types'])
+    for obj, expect_type in zip(objs, params['expect_types']):
+        assert isinstance(obj, expect_type)
+
+
+def test_load_validation_error():
+    data = {
+        'resource_type': 'smallbiz',
+        'name': 'Le Shoppe',
+        'address': ['12 Fashion Way', 'Urbia', 'WA', '01209'],
+        'people': [
+            {'name': 'Madelyn', 'age': 39},
+            {'name': '', 'age': 39},
+        ],
+    }
+    with pytest.raises(ValueError):
+        smb.resourcelib.load(data)
+
+
+def test_missing_field_error():
+    data = {
+        'resource_type': 'smallbiz',
+        'name': 'Le Shoppe',
+        'address': ['12 Fashion Way', 'Urbia', 'WA', '01209'],
+        'people': [
+            {'name': 'Madelyn', 'age': 39},
+            {'age': 39},
+        ],
+    }
+    with pytest.raises(smb.resourcelib.MissingRequiredFieldError):
+        smb.resourcelib.load(data)
+
+
+def test_load_invalid_resources_type():
+    data = {'resources': 55}
+    with pytest.raises(TypeError):
+        smb.resourcelib.load(data)
+
+
+def test_explicit_none_in_data():
+    data = {
+        'resource_type': 'bigbiz',
+        'name': 'MegaLoMart',
+        'address': ['1 MegaLo Drive', 'Mango', 'TX', '22020'],
+        'ceo': {'name': 'D. B. Bawes', 'age': 61},
+        'units': None,
+    }
+    obj = BigBiz._resource_config.object_from_simplified(data)
+    assert obj.units is None

--- a/src/pybind/mgr/smb/tests/test_resources.py
+++ b/src/pybind/mgr/smb/tests/test_resources.py
@@ -1,0 +1,638 @@
+import pytest
+
+import smb.resourcelib
+import smb.resources
+from smb import enums
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        # minimal share (removed)
+        {
+            'data': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'fakecluster1',
+                'share_id': 'myshare1',
+                'intent': 'removed',
+            },
+            'expected': [
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'fakecluster1',
+                    'share_id': 'myshare1',
+                    'intent': 'removed',
+                }
+            ],
+        },
+        # present share
+        {
+            'data': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'fakecluster2',
+                'share_id': 'myshare1',
+                'intent': 'present',
+                'browseable': False,
+                'cephfs': {
+                    'volume': 'cephfs',
+                },
+            },
+            'expected': [
+                {
+                    'resource_type': 'ceph.smb.share',
+                    'cluster_id': 'fakecluster2',
+                    'share_id': 'myshare1',
+                    'intent': 'present',
+                    'name': 'myshare1',
+                    'browseable': False,
+                    'readonly': False,
+                    'cephfs': {
+                        'volume': 'cephfs',
+                        'path': '/',
+                        'provider': 'samba-vfs',
+                    },
+                }
+            ],
+        },
+        # removed cluster
+        {
+            'data': {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'nocluster',
+                'intent': 'removed',
+            },
+            'expected': [
+                {
+                    'resource_type': 'ceph.smb.cluster',
+                    'cluster_id': 'nocluster',
+                    'intent': 'removed',
+                }
+            ],
+        },
+        # cluster
+        {
+            'data': {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'nocluster',
+                'auth_mode': 'active-directory',
+                'domain_settings': {
+                    'realm': 'FAKE.DOMAIN.TEST',
+                    'join_sources': [
+                        {'source_type': 'resource', 'ref': 'mydomauth1'},
+                    ],
+                },
+            },
+            'expected': [
+                {
+                    'resource_type': 'ceph.smb.cluster',
+                    'cluster_id': 'nocluster',
+                    'intent': 'present',
+                    'auth_mode': 'active-directory',
+                    'domain_settings': {
+                        'realm': 'FAKE.DOMAIN.TEST',
+                        'join_sources': [
+                            {'source_type': 'resource', 'ref': 'mydomauth1'},
+                        ],
+                    },
+                }
+            ],
+        },
+    ],
+)
+def test_load_simplify_resources(params):
+    data = params.get('data')
+    loaded = smb.resourcelib.load(data)
+    # test round tripping because asserting equality on the
+    # objects is not simple
+    sdata = [obj.to_simplified() for obj in loaded]
+    assert params['expected'] == sdata
+
+
+YAML1 = """
+resource_type: ceph.smb.cluster
+cluster_id: chacha
+auth_mode: active-directory
+domain_settings:
+  realm: CEPH.SINK.TEST
+  join_sources:
+    - source_type: resource
+      ref: bob
+    - source_type: password
+      auth:
+        username: Administrator
+        password: fallb4kP4ssw0rd
+---
+resource_type: ceph.smb.share
+cluster_id: chacha
+share_id: s1
+cephfs:
+  volume: cephfs
+  path: /
+---
+resource_type: ceph.smb.share
+cluster_id: chacha
+share_id: s2
+name: My Second Share
+cephfs:
+  volume: cephfs
+  subvolume: cool/beans
+---
+resource_type: ceph.smb.share
+cluster_id: chacha
+share_id: s0
+intent: removed
+# deleted this test share
+---
+resource_type: ceph.smb.join.auth
+auth_id: bob
+values:
+  username: BobTheAdmin
+  password: someJunkyPassw0rd
+---
+resource_type: ceph.smb.join.auth
+auth_id: alice
+intent: removed
+# alice left the company
+"""
+
+
+def test_load_yaml_resource_yaml1():
+    import yaml
+
+    loaded = smb.resourcelib.load(yaml.safe_load_all(YAML1))
+    assert len(loaded) == 6
+
+    assert isinstance(loaded[0], smb.resources.Cluster)
+    cluster = loaded[0]
+    assert cluster.cluster_id == 'chacha'
+    assert cluster.intent == enums.Intent.PRESENT
+    assert cluster.auth_mode == enums.AuthMode.ACTIVE_DIRECTORY
+    assert cluster.domain_settings.realm == 'CEPH.SINK.TEST'
+    assert len(cluster.domain_settings.join_sources) == 2
+    jsrc = cluster.domain_settings.join_sources
+    assert jsrc[0].source_type == enums.JoinSourceType.RESOURCE
+    assert jsrc[0].ref == 'bob'
+    assert jsrc[1].source_type == enums.JoinSourceType.PASSWORD
+    assert jsrc[1].auth.username == 'Administrator'
+    assert jsrc[1].auth.password == 'fallb4kP4ssw0rd'
+
+    assert isinstance(loaded[1], smb.resources.Share)
+    assert isinstance(loaded[2], smb.resources.Share)
+    assert isinstance(loaded[3], smb.resources.RemovedShare)
+    assert isinstance(loaded[4], smb.resources.JoinAuth)
+    assert isinstance(loaded[5], smb.resources.JoinAuth)
+
+
+YAML2 = """
+resource_type: ceph.smb.cluster
+cluster_id: rhumba
+auth_mode: user
+user_group_settings:
+  - source_type: resource
+    ref: rhumbausers
+custom_global_config:
+  "hostname lookups": yes
+placement:
+  hosts:
+    - cephnode0
+    - cephnode2
+    - cephnode4
+---
+resource_type: ceph.smb.share
+cluster_id: rhumba
+share_id: us1
+name: User Share 1
+cephfs:
+  volume: cephfs
+  path: /share1
+  subvolumegroup: sg1
+  subvolume: chevron
+---
+resource_type: ceph.smb.share
+cluster_id: rhumba
+share_id: us2
+name: Useful Stuff
+cephfs:
+  volume: volume2
+  subvolume: foo/bar
+  path: /things/and/stuff
+custom_config:
+  "hosts allow": "adminbox"
+---
+# the 'nope' share should not exist
+resource_type: ceph.smb.share
+cluster_id: rhumba
+share_id: nope
+intent: removed
+---
+resource_type: ceph.smb.usersgroups
+users_groups_id: rhumbausers
+intent: present
+values:
+  users:
+    - name: charlie
+      password: 7unaF1sh
+    - name: lucky
+      password: CH4rmz
+    - name: jgg
+      password: h0H0h0_gg
+  groups:
+    - name: mascots
+"""
+
+
+def test_load_yaml_resource_yaml2():
+    import yaml
+
+    loaded = smb.resourcelib.load(yaml.safe_load_all(YAML2))
+    assert len(loaded) == 5
+
+    assert isinstance(loaded[0], smb.resources.Cluster)
+    assert isinstance(loaded[1], smb.resources.Share)
+    assert isinstance(loaded[2], smb.resources.Share)
+    assert isinstance(loaded[3], smb.resources.RemovedShare)
+    assert isinstance(loaded[4], smb.resources.UsersAndGroups)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        # too many slashes in subvolumegroup
+        {
+            "yaml": """
+resource_type: ceph.smb.share
+cluster_id: blat
+share_id: bs1
+name: Bad Share 1
+cephfs:
+  volume: cephfs
+  path: /share1
+  subvolumegroup: foo/bar
+  subvolume: baz
+""",
+            "exc_type": ValueError,
+            "error": "invalid subvolumegroup",
+        },
+        # too many slashes in subvolume
+        {
+            "yaml": """
+resource_type: ceph.smb.share
+cluster_id: blat
+share_id: bs1
+name: Bad Share 1
+cephfs:
+  volume: cephfs
+  path: /share1
+  subvolumegroup: foo
+  subvolume: baz/qqqqq
+""",
+            "exc_type": ValueError,
+            "error": "invalid subvolume",
+        },
+        # too many slashes in subvolume (autosplit)
+        {
+            "yaml": """
+resource_type: ceph.smb.share
+cluster_id: blat
+share_id: bs1
+name: Bad Share 1
+cephfs:
+  volume: cephfs
+  path: /share1
+  subvolume: foo/baz/qqqqq
+""",
+            "exc_type": ValueError,
+            "error": "invalid subvolume",
+        },
+        # missing volume value
+        {
+            "yaml": """
+resource_type: ceph.smb.share
+cluster_id: blat
+share_id: bs1
+name: Bad Share 1
+cephfs:
+  volume: ""
+  path: /share1
+  subvolume: foo
+""",
+            "exc_type": ValueError,
+            "error": "volume",
+        },
+        # missing cluster_id value
+        {
+            "yaml": """
+resource_type: ceph.smb.share
+cluster_id: ""
+share_id: whee
+name: Bad Share 1
+cephfs:
+  volume: abc
+  path: /share1
+  subvolume: foo
+""",
+            "exc_type": ValueError,
+            "error": "cluster_id",
+        },
+        # missing share_id value
+        {
+            "yaml": """
+resource_type: ceph.smb.share
+cluster_id: blat
+share_id: ""
+name: Bad Share 1
+cephfs:
+  volume: abc
+  path: /share1
+  subvolume: foo
+""",
+            "exc_type": ValueError,
+            "error": "share_id",
+        },
+        # missing cluster settings
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: narf
+intent: present
+""",
+            "exc_type": smb.resourcelib.MissingRequiredFieldError,
+            "error": None,
+        },
+        # missing cluster_id
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: ""
+auth_mode: active-directory
+intent: present
+""",
+            "exc_type": ValueError,
+            "error": "cluster_id",
+        },
+        # missing domain settings
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: randolph
+intent: present
+auth_mode: active-directory
+domain_settings:
+""",
+            "exc_type": ValueError,
+            "error": "active directory",
+        },
+        # extra user/group settings
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: randolph
+intent: present
+auth_mode: active-directory
+domain_settings:
+  realm: CEPH.SINK.TEST
+  join_sources: []
+user_group_settings:
+  - source_type: resource
+    ref: rhumbausers
+""",
+            "exc_type": ValueError,
+            "error": "not supported",
+        },
+        # missing user/group settings
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: randolph
+intent: present
+auth_mode: user
+""",
+            "exc_type": ValueError,
+            "error": "required",
+        },
+        # extra domain settings
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: randolph
+intent: present
+auth_mode: user
+user_group_settings:
+  - source_type: resource
+    ref: rhumbausers
+domain_settings:
+  realm: CEPH.SINK.TEST
+  join_sources: []
+""",
+            "exc_type": ValueError,
+            "error": "not supported",
+        },
+        # u/g inline missing
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: randolph
+intent: present
+auth_mode: user
+user_group_settings:
+  - source_type: inline
+""",
+            "exc_type": ValueError,
+            "error": "requires values",
+        },
+        # u/g inline extra uri
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: randolph
+intent: present
+auth_mode: user
+user_group_settings:
+  - source_type: inline
+    values:
+      users: []
+      groups: []
+    uri: http://foo.bar.example.com/baz.txt
+""",
+            "exc_type": ValueError,
+            "error": "does not take",
+        },
+        # u/g inline extra ref
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: randolph
+intent: present
+auth_mode: user
+user_group_settings:
+  - source_type: inline
+    values:
+      users: []
+      groups: []
+    ref: xyz
+""",
+            "exc_type": ValueError,
+            "error": "does not take",
+        },
+        # u/g uri missing
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: randolph
+intent: present
+auth_mode: user
+user_group_settings:
+  - source_type: http_uri
+""",
+            "exc_type": ValueError,
+            "error": "requires",
+        },
+        # u/g uri extra values
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: randolph
+intent: present
+auth_mode: user
+user_group_settings:
+  - source_type: http_uri
+    values:
+      users: []
+      groups: []
+    uri: http://foo.bar.example.com/baz.txt
+""",
+            "exc_type": ValueError,
+            "error": "does not take",
+        },
+        # u/g uri extra ref
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: randolph
+intent: present
+auth_mode: user
+user_group_settings:
+  - source_type: http_uri
+    uri: http://boop.example.net
+    ref: xyz
+""",
+            "exc_type": ValueError,
+            "error": "does not take",
+        },
+        # u/g resource missing
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: randolph
+intent: present
+auth_mode: user
+user_group_settings:
+  - source_type: resource
+""",
+            "exc_type": ValueError,
+            "error": "requires",
+        },
+        # u/g resource extra values
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: randolph
+intent: present
+auth_mode: user
+user_group_settings:
+  - source_type: resource
+    ref: xyz
+    uri: http://example.net/foo
+""",
+            "exc_type": ValueError,
+            "error": "does not take",
+        },
+        # u/g resource extra resource
+        {
+            "yaml": """
+resource_type: ceph.smb.cluster
+cluster_id: randolph
+intent: present
+auth_mode: user
+user_group_settings:
+  - source_type: resource
+    ref: xyz
+    values:
+      users: []
+      groups: []
+""",
+            "exc_type": ValueError,
+            "error": "does not take",
+        },
+    ],
+)
+def test_load_error(params):
+    import yaml
+
+    data = yaml.safe_load_all(params['yaml'])
+    with pytest.raises(params['exc_type'], match=params['error']):
+        smb.resourcelib.load(data)
+
+
+def test_cluster_placement_1():
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.cluster
+cluster_id: rhumba
+auth_mode: user
+user_group_settings:
+  - source_type: resource
+    ref: rhumbausers
+custom_global_config:
+  "hostname lookups": yes
+placement:
+  hosts:
+    - cephnode0
+    - cephnode2
+    - cephnode4
+"""
+    data = yaml.safe_load_all(yaml_str)
+    loaded = smb.resources.load(data)
+    assert loaded
+    cluster = loaded[0]
+    assert cluster.placement is not None
+    assert len(cluster.placement.hosts) == 3
+
+    sd = cluster.to_simplified()
+    assert sd
+    assert 'placement' in sd
+    assert sd['placement'] == {
+        'hosts': ['cephnode0', 'cephnode2', 'cephnode4']
+    }
+
+
+def test_cluster_placement_2():
+    import yaml
+
+    yaml_str = """
+resource_type: ceph.smb.cluster
+cluster_id: rhumba
+auth_mode: user
+user_group_settings:
+  - source_type: resource
+    ref: rhumbausers
+custom_global_config:
+  "hostname lookups": yes
+placement:
+  count: 3
+  label: ilovesmb
+"""
+    data = yaml.safe_load_all(yaml_str)
+    loaded = smb.resources.load(data)
+    assert loaded
+    cluster = loaded[0]
+    assert cluster.placement is not None
+    assert len(cluster.placement.hosts) == 0
+    assert cluster.placement.label == 'ilovesmb'
+    assert cluster.placement.count == 3
+
+    sd = cluster.to_simplified()
+    assert sd
+    assert 'placement' in sd
+    assert sd['placement'] == {'count': 3, 'label': 'ilovesmb'}

--- a/src/pybind/mgr/smb/tests/test_smb.py
+++ b/src/pybind/mgr/smb/tests/test_smb.py
@@ -1,0 +1,602 @@
+import json
+
+import pytest
+
+import smb
+
+
+@pytest.fixture
+def tmodule():
+    internal_store = smb.config_store.MemConfigStore()
+    public_store = smb.config_store.MemConfigStore()
+    priv_store = smb.config_store.MemConfigStore()
+    return smb.module.Module(
+        'smb',
+        '',
+        '',
+        internal_store=internal_store,
+        public_store=public_store,
+        priv_store=priv_store,
+        path_resolver=smb.handler._FakePathResolver(),
+        authorizer=smb.handler._FakeAuthorizer(),
+        update_orchestration=False,
+    )
+
+
+def test_cluster_ls_empty(tmodule):
+    clusters = tmodule.cluster_ls()
+    assert clusters == []
+
+
+def test_share_ls_empty(tmodule):
+    clusters = tmodule.share_ls('foo')
+    assert clusters == []
+
+
+def test_internal_apply_cluster(tmodule):
+    cluster = smb.resources.Cluster(
+        cluster_id='foo',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.INLINE,
+                values=smb.resources.UserGroupSettings(
+                    users=[],
+                    groups=[],
+                ),
+            ),
+        ],
+    )
+    rg = tmodule._handler.apply([cluster])
+    assert rg.success, rg.to_simplified()
+    assert ('clusters', 'foo') in tmodule._internal_store.data
+
+
+def test_cluster_add_cluster_ls(tmodule):
+    cluster = smb.resources.Cluster(
+        cluster_id='foo',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.INLINE,
+                values=smb.resources.UserGroupSettings(
+                    users=[],
+                    groups=[],
+                ),
+            ),
+        ],
+    )
+    rg = tmodule._handler.apply([cluster])
+    assert rg.success, rg.to_simplified()
+
+    clusters = tmodule.cluster_ls()
+    assert len(clusters) == 1
+    assert 'foo' in clusters
+
+
+def test_internal_apply_cluster_and_share(tmodule):
+    cluster = smb.resources.Cluster(
+        cluster_id='foo',
+        auth_mode=smb.enums.AuthMode.USER,
+        user_group_settings=[
+            smb.resources.UserGroupSource(
+                source_type=smb.resources.UserGroupSourceType.INLINE,
+                values=smb.resources.UserGroupSettings(
+                    users=[],
+                    groups=[],
+                ),
+            ),
+        ],
+    )
+    share = smb.resources.Share(
+        cluster_id='foo',
+        share_id='s1',
+        name='Ess One',
+        cephfs=smb.resources.CephFSStorage(
+            volume='cephfs',
+            path='/',
+        ),
+    )
+    rg = tmodule._handler.apply([cluster, share])
+    assert rg.success, rg.to_simplified()
+    assert ('clusters', 'foo') in tmodule._internal_store.data
+    assert ('shares', 'foo.s1') in tmodule._internal_store.data
+
+    shares = tmodule.share_ls('foo')
+    assert len(shares) == 1
+    assert 's1' in shares
+
+
+def test_internal_apply_remove_cluster(tmodule):
+    tmodule._internal_store.overwrite(
+        {
+            "clusters.foo": {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'foo',
+                'auth_mode': 'user',
+                'intent': 'present',
+                'user_group_settings': [
+                    {
+                        'source_type': 'inline',
+                        'values': {'users': [], 'groups': []},
+                    }
+                ],
+            }
+        }
+    )
+
+    clusters = tmodule.cluster_ls()
+    assert len(clusters) == 1
+    assert 'foo' in clusters
+
+    rmcluster = smb.resources.RemovedCluster(
+        cluster_id='foo',
+    )
+    rg = tmodule._handler.apply([rmcluster])
+    assert rg.success, rg.to_simplified()
+
+    clusters = tmodule.cluster_ls()
+    assert len(clusters) == 0
+
+
+def test_internal_apply_remove_shares(tmodule):
+    tmodule._internal_store.overwrite(
+        {
+            'clusters.foo': {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'foo',
+                'auth_mode': 'user',
+                'intent': 'present',
+                'user_group_settings': [
+                    {
+                        'source_type': 'inline',
+                        'values': {'users': [], 'groups': []},
+                    }
+                ],
+            },
+            'shares.foo.s1': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'foo',
+                'share_id': 's1',
+                'intent': 'present',
+                'name': 'Ess One',
+                'readonly': False,
+                'browseable': True,
+                'cephfs': {
+                    'volume': 'cephfs',
+                    'path': '/',
+                    'provider': 'samba-vfs',
+                },
+            },
+            'shares.foo.stwo': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'foo',
+                'share_id': 'stwo',
+                'intent': 'present',
+                'name': 'Ess Two',
+                'readonly': False,
+                'browseable': True,
+                'cephfs': {
+                    'volume': 'cephfs',
+                    'path': '/two',
+                    'provider': 'samba-vfs',
+                },
+            },
+        }
+    )
+
+    shares = tmodule.share_ls('foo')
+    assert len(shares) == 2
+    assert 's1' in shares
+    assert 'stwo' in shares
+
+    rmshare1 = smb.resources.RemovedShare(
+        cluster_id='foo',
+        share_id='s1',
+    )
+    rg = tmodule._handler.apply([rmshare1])
+    assert rg.success, rg.to_simplified()
+
+    shares = tmodule.share_ls('foo')
+    assert len(shares) == 1
+
+    rmshare2 = smb.resources.RemovedShare(
+        cluster_id='foo',
+        share_id='stwo',
+    )
+    rg = tmodule._handler.apply([rmshare1, rmshare2])
+    assert rg.success, rg.to_simplified()
+
+    shares = tmodule.share_ls('foo')
+    assert len(shares) == 0
+
+    # check the results
+    rgs = rg.to_simplified()
+    assert rgs['success']
+    assert len(rgs['results']) == 2
+    assert rgs['results'][0]['success']
+    assert rgs['results'][0]['state'] == 'not present'
+    assert rgs['results'][1]['success']
+    assert rgs['results'][1]['state'] == 'removed'
+
+
+def test_internal_apply_add_joinauth(tmodule):
+    tmodule._internal_store.overwrite(
+        {
+            "clusters.foo": {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'foo',
+                'auth_mode': 'user',
+                'intent': 'present',
+                'user_group_settings': [
+                    {
+                        'source_type': 'inline',
+                        'values': {'users': [], 'groups': []},
+                    }
+                ],
+            }
+        }
+    )
+
+    assert len(tmodule._handler.join_auth_ids()) == 0
+    ja = smb.resources.JoinAuth(
+        auth_id='join1',
+        auth=smb.resources.JoinAuthValues(
+            username='testadmin',
+            password='Passw0rd',
+        ),
+    )
+    rg = tmodule._handler.apply([ja])
+    assert rg.success, rg.to_simplified()
+
+    assert len(tmodule._handler.join_auth_ids()) == 1
+
+
+def test_internal_apply_add_usergroups(tmodule):
+    tmodule._internal_store.overwrite(
+        {
+            "clusters.foo": {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'foo',
+                'auth_mode': 'user',
+                'intent': 'present',
+                'user_group_settings': [
+                    {
+                        'source_type': 'inline',
+                        'values': {'users': [], 'groups': []},
+                    }
+                ],
+            }
+        }
+    )
+
+    assert len(tmodule._handler.user_and_group_ids()) == 0
+    ja = smb.resources.UsersAndGroups(
+        users_groups_id='ug1',
+        values=smb.resources.UserGroupSettings(
+            users=[{"username": "foo"}],
+            groups=[],
+        ),
+    )
+    rg = tmodule._handler.apply([ja])
+    assert rg.success, rg.to_simplified()
+
+    assert len(tmodule._handler.user_and_group_ids()) == 1
+
+
+def _example_cfg_1(tmodule):
+    tmodule._internal_store.overwrite(
+        {
+            'clusters.foo': {
+                'resource_type': 'ceph.smb.cluster',
+                'cluster_id': 'foo',
+                'auth_mode': 'active-directory',
+                'intent': 'present',
+                'domain_settings': {
+                    'realm': 'dom1.example.com',
+                    'join_sources': [
+                        {
+                            'source_type': 'password',
+                            'auth': {
+                                'username': 'testadmin',
+                                'password': 'Passw0rd',
+                            },
+                        }
+                    ],
+                },
+            },
+            'shares.foo.s1': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'foo',
+                'share_id': 's1',
+                'intent': 'present',
+                'name': 'Ess One',
+                'readonly': False,
+                'browseable': True,
+                'cephfs': {
+                    'volume': 'cephfs',
+                    'path': '/',
+                    'provider': 'samba-vfs',
+                },
+            },
+            'shares.foo.stwo': {
+                'resource_type': 'ceph.smb.share',
+                'cluster_id': 'foo',
+                'share_id': 'stwo',
+                'intent': 'present',
+                'name': 'Ess Two',
+                'readonly': False,
+                'browseable': True,
+                'cephfs': {
+                    'volume': 'cephfs',
+                    'path': '/two',
+                    'provider': 'samba-vfs',
+                },
+            },
+        }
+    )
+
+
+def test_cmd_share_ls_json(tmodule):
+    _example_cfg_1(tmodule)
+
+    res, body, status = tmodule.share_ls.command('foo')
+    assert res == 0
+    bdata = json.loads(body)
+    assert 's1' in bdata
+    assert 'stwo' in bdata
+    assert not status
+
+
+def test_cmd_share_ls_yaml(tmodule):
+    _example_cfg_1(tmodule)
+
+    res, body, status = tmodule.share_ls.command('foo', format='yaml')
+    assert res == 0
+    assert '- s1\n' in body
+    assert '- stwo\n' in body
+    assert not status
+
+
+def test_cmd_share_rm(tmodule):
+    _example_cfg_1(tmodule)
+
+    res, body, status = tmodule.share_rm.command('foo', 'stwo')
+    assert res == 0
+    bdata = json.loads(body)
+    assert bdata['state'] == 'removed'
+
+    res, body, status = tmodule.share_rm.command('fake', 'curly')
+    assert res == 0
+    bdata = json.loads(body)
+    assert bdata['state'] == 'not present'
+
+
+def test_cmd_share_create(tmodule):
+    _example_cfg_1(tmodule)
+
+    res, body, status = tmodule.share_create.command(
+        cluster_id='foo',
+        share_id='nu1',
+        share_name='The Nu One',
+        path='/nu/one',
+        cephfs_volume='cephfs',
+    )
+    assert res == 0
+    bdata = json.loads(body)
+    assert bdata['state'] == 'created'
+
+
+def test_cmd_apply_share(tmodule):
+    _example_cfg_1(tmodule)
+
+    inbuf = json.dumps(
+        {
+            'resource_type': 'ceph.smb.share',
+            'cluster_id': 'foo',
+            'share_id': 'test1',
+            'cephfs': {
+                'volume': 'example',
+                'path': '/primrose',
+            },
+        }
+    )
+
+    res, body, status = tmodule.apply_resources.command(inbuf=inbuf)
+    assert res == 0
+    bdata = json.loads(body)
+    assert bdata["success"]
+    assert bdata["results"][0]["state"] == "created"
+
+
+def test_share_dump_config(tmodule):
+    _example_cfg_1(tmodule)
+
+    cfg = tmodule.dump_config('foo')
+    assert cfg == {
+        'samba-container-config': "v0",
+        'configs': {
+            'foo': {
+                'instance_name': 'foo',
+                'instance_features': [],
+                'shares': ['Ess One', 'Ess Two'],
+                'globals': ['default', 'foo'],
+            },
+        },
+        'shares': {
+            'Ess One': {
+                'options': {
+                    'path': '/',
+                    'read only': 'No',
+                    'browseable': 'Yes',
+                    'kernel share modes': 'no',
+                    'x:ceph:id': 'foo.s1',
+                    'vfs objects': 'ceph',
+                    'ceph:config_file': '/etc/ceph/ceph.conf',
+                    'ceph:filesystem': 'cephfs',
+                    'ceph:user_id': 'smb.fs.cluster.foo',
+                },
+            },
+            'Ess Two': {
+                'options': {
+                    'path': '/two',
+                    'read only': 'No',
+                    'browseable': 'Yes',
+                    'kernel share modes': 'no',
+                    'x:ceph:id': 'foo.stwo',
+                    'vfs objects': 'ceph',
+                    'ceph:config_file': '/etc/ceph/ceph.conf',
+                    'ceph:filesystem': 'cephfs',
+                    'ceph:user_id': 'smb.fs.cluster.foo',
+                },
+            },
+        },
+        'globals': {
+            'default': {
+                'options': {
+                    'server min protocol': 'SMB2',
+                    'load printers': 'No',
+                    'printing': 'bsd',
+                    'printcap name': '/dev/null',
+                    'disable spoolss': 'Yes',
+                },
+            },
+            'foo': {
+                'options': {
+                    'idmap config * : backend': 'autorid',
+                    'idmap config * : range': '2000-9999999',
+                    'realm': 'dom1.example.com',
+                    'security': 'ads',
+                    'workgroup': 'DOM1',
+                },
+            },
+        },
+    }
+
+
+def test_cluster_create_ad1(tmodule):
+    _example_cfg_1(tmodule)
+
+    result = tmodule.cluster_create(
+        'fizzle',
+        smb.enums.AuthMode.ACTIVE_DIRECTORY,
+        domain_realm='fizzle.example.net',
+        domain_join_user_pass=['Administrator%Passw0rd'],
+    )
+    assert result.success
+    assert result.status['state'] == 'created'
+    assert result.src.cluster_id == 'fizzle'
+    assert result.src.domain_settings.realm == 'fizzle.example.net'
+    assert len(result.src.domain_settings.join_sources) == 1
+    assert (
+        result.src.domain_settings.join_sources[0].source_type
+        == smb.enums.JoinSourceType.PASSWORD
+    )
+    assert (
+        result.src.domain_settings.join_sources[0].auth.username
+        == 'Administrator'
+    )
+    assert (
+        result.src.domain_settings.join_sources[0].auth.password == 'Passw0rd'
+    )
+
+
+def test_cluster_create_ad2(tmodule):
+    _example_cfg_1(tmodule)
+
+    ja = smb.resources.JoinAuth(
+        auth_id='jaad2',
+        auth=smb.resources.JoinAuthValues(
+            username='Administrator',
+            password='hunter2',
+        ),
+    )
+    rg = tmodule._handler.apply([ja])
+    assert rg.success, rg.to_simplified()
+
+    result = tmodule.cluster_create(
+        'sizzle',
+        smb.enums.AuthMode.ACTIVE_DIRECTORY,
+        domain_realm='sizzle.example.net',
+        domain_join_ref=['jaad2'],
+    )
+    assert result.success
+    assert result.status['state'] == 'created'
+    assert result.src.cluster_id == 'sizzle'
+    assert result.src.domain_settings.realm == 'sizzle.example.net'
+    assert len(result.src.domain_settings.join_sources) == 1
+    assert (
+        result.src.domain_settings.join_sources[0].source_type
+        == smb.enums.JoinSourceType.RESOURCE
+    )
+    assert result.src.domain_settings.join_sources[0].ref == 'jaad2'
+
+
+def test_cluster_create_user1(tmodule):
+    _example_cfg_1(tmodule)
+
+    ug = smb.resources.UsersAndGroups(
+        users_groups_id='ug1',
+        values=smb.resources.UserGroupSettings(
+            users=[{"username": "foo"}],
+            groups=[],
+        ),
+    )
+    rg = tmodule._handler.apply([ug])
+    assert rg.success, rg.to_simplified()
+
+    result = tmodule.cluster_create(
+        'dizzle',
+        smb.enums.AuthMode.USER,
+        user_group_ref=['ug1'],
+    )
+    assert result.success
+    assert result.status['state'] == 'created'
+    assert result.src.cluster_id == 'dizzle'
+    assert len(result.src.user_group_settings) == 1
+
+
+def test_cluster_create_badpass(tmodule):
+    _example_cfg_1(tmodule)
+
+    with pytest.raises(ValueError):
+        tmodule.cluster_create(
+            'fizzle',
+            smb.enums.AuthMode.ACTIVE_DIRECTORY,
+            domain_realm='fizzle.example.net',
+            domain_join_user_pass=['Administrator'],
+        )
+
+
+def test_cluster_rm(tmodule):
+    _example_cfg_1(tmodule)
+
+    result = tmodule.share_rm('foo', 'stwo')
+    assert result.success
+    result = tmodule.share_rm('foo', 's1')
+    assert result.success
+    result = tmodule.cluster_rm('foo')
+    assert result.success
+
+
+def test_dump_service_spec(tmodule):
+    _example_cfg_1(tmodule)
+    tmodule._public_store.overwrite(
+        {
+            'foo.config.smb': '',
+        }
+    )
+    tmodule._priv_store.overwrite(
+        {
+            'foo.join.2b9902c05d08bcba.json': '',
+            'foo.join.08129d4d3b8c37c7.json': '',
+        }
+    )
+
+    cfg = tmodule.dump_service_spec('foo')
+    assert cfg
+    assert cfg['service_id'] == 'foo'
+    assert cfg['spec']['cluster_id'] == 'foo'
+    assert cfg['spec']['features'] == ['domain']
+    assert cfg['spec']['config_uri'] == 'mem:foo/config.smb'
+    assert len(cfg['spec']['join_sources']) == 2

--- a/src/pybind/mgr/smb/tests/test_validation.py
+++ b/src/pybind/mgr/smb/tests/test_validation.py
@@ -1,0 +1,77 @@
+import pytest
+
+import smb.validation
+
+
+@pytest.mark.parametrize(
+    "value,valid",
+    [
+        ("cat", True),
+        ("m-o-u-s-e", True),
+        ("foo-", False),
+        ("-bar", False),
+        ("not-too-bad-1", True),
+        ("this-one-is-simply-too-long", False),
+        ("t1", True),
+        ("x", True),
+        ("", False),
+    ],
+)
+def test_valid_id(value, valid):
+    assert smb.validation.valid_id(value) == valid
+    if valid:
+        smb.validation.check_id(value)
+    else:
+        with pytest.raises(ValueError):
+            smb.validation.check_id(value)
+
+
+@pytest.mark.parametrize(
+    "value,valid",
+    [
+        ("cat", True),
+        ("m-o-u-s-e", True),
+        ("this-one-is-simply-fine-not-toolong", True),
+        ("t1", True),
+        ("x", True),
+        ("A Wonderful Share", True),
+        ("A_Very_Nice_Share", True),
+        (">>>!!!", False),
+        ("", False),
+        ("A %h Family", False),
+        ("A" * 64, True),
+        ("A" * 65, False),
+    ],
+)
+def test_valid_share_name(value, valid):
+    assert smb.validation.valid_share_name(value) == valid
+    if valid:
+        smb.validation.check_share_name(value)
+    else:
+        with pytest.raises(ValueError):
+            smb.validation.check_share_name(value)
+
+
+@pytest.mark.parametrize(
+    "value,valid",
+    [
+        ("cat", True),
+        ("animals/cat", True),
+        ("animals/cat", True),
+        ("./animals/cat", True),
+        ("/animals/cat", True),
+        ("/", True),
+        ("/animals/../cat", True),  # weird, but OK
+        ("../cat", False),
+        ("", False),
+        (".", False),
+        ("..", False),
+    ],
+)
+def test_valid_path(value, valid):
+    assert smb.validation.valid_path(value) == valid
+    if valid:
+        smb.validation.check_path(value)
+    else:
+        with pytest.raises(ValueError):
+            smb.validation.check_path(value)

--- a/src/pybind/mgr/smb/validation.py
+++ b/src/pybind/mgr/smb/validation.py
@@ -1,0 +1,62 @@
+import posixpath
+import re
+
+# Initially, this regex is pretty restrictive.  But I (JJM) find that
+# starting out more restricitive is better than not because it's generally
+# easier to relax strict rules then discover someone relies on lax rules
+# that fail somewhere and now you've got backwards-compatibilty issues
+# to worry about.
+#
+# The names are valid dns fragments as well since the cluster_id can be
+# combined with the hostname for a virtual hostname for the container.
+_name_re = re.compile('^[a-zA-Z0-9]($|[a-zA-Z0-9-]{,16}[a-zA-Z0-9]$)')
+
+# We might want to open up share names to non-special unicode chars too.
+# but as above it's easier to start strict.
+_share_re = re.compile('^[a-zA-Z0-9_][a-zA-Z0-9. _-]{,63}$')
+
+
+def valid_id(value: str) -> bool:
+    """Return true if value is a valid (cluster|share|etc) ID."""
+    return bool(_name_re.match(value))
+
+
+def check_id(value: str) -> None:
+    """Raise ValueError if value is not a valid ID."""
+    if not valid_id(value):
+        raise ValueError(f"{value:!r} is not a valid ID")
+
+
+def valid_share_name(value: str) -> bool:
+    """Return true if value is a valid share name."""
+    return bool(_share_re.match(value))
+
+
+def check_share_name(value: str) -> None:
+    """Raise ValueError if value is not a valid share name."""
+    if not valid_share_name(value):
+        raise ValueError(f"{value:!r} is not a valid share name")
+
+
+# alias for normpath so other smb libs can just import validation module
+normalize_path = posixpath.normpath
+
+
+def valid_path(value: str) -> bool:
+    """Return true if value is a valid path for a share."""
+    path = normalize_path(value)
+    # ensure that post-normalization there are no relative path elements or
+    # empty segments
+    if path == '/':
+        # special case / to refer to the root of the volume/subvolume.
+        # it is always valid.
+        return True
+    return not any(
+        p in ('.', '..', '') for p in path.lstrip('/').split(posixpath.sep)
+    )
+
+
+def check_path(value: str) -> None:
+    """Raise ValueError if value is not a valid share path."""
+    if not valid_path(value):
+        raise ValueError(f'{value!r} is not a valid share path')

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -106,6 +106,7 @@ commands =
            -m rgw \
            -m rook \
            -m selftest \
+           -m smb \
            -m snap_schedule \
            -m stats \
            -m status \
@@ -114,6 +115,7 @@ commands =
            -m test_orchestrator \
            -m volumes \
            -m zabbix
+
 
 [testenv:test]
 setenv = {[testenv]setenv}
@@ -173,7 +175,8 @@ modules =
     prometheus \
     rbd_support \
     rgw \
-    selftest
+    selftest \
+    smb
 commands =
     flake8 --config=tox.ini {posargs} \
       {posargs:{[testenv:flake8]modules}}

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -6,6 +6,8 @@ envlist =
     flake8
     jinjalint
     nooptional
+    check-black
+    check-isort
 skipsdist = true
 skip_missing_interpreters = true
 
@@ -187,3 +189,45 @@ deps =
     jinjaninja
 commands =
     jinja-ninja cephadm/templates
+
+
+# OPT-IN formatting with 'black'
+#  add your module to the modules list below to use automated formatting
+[black]
+deps = black>=23,<24
+options = -l78 -t py36 --skip-string-normalization
+modules = smb
+
+[testenv:check-black]
+deps = {[black]deps}
+commands =
+    black --check -q {[black]options} {[black]modules}
+
+[testenv:format-black]
+deps = {[black]deps}
+commands =
+    black {[black]options} {[black]modules}
+
+
+# OPT-IN import style formatting with 'isort'
+#  add your module to the modules list below to use automated import sorting
+[isortcfg]
+deps = isort
+modules = smb
+
+[isort]
+profile = black
+line_length = 78
+known_first_party = ceph,rados,rbd,cephfs,mgr,mgr_module,mgr_util,object_format
+known_typing = typing
+sections = FUTURE,TYPING,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+
+[testenv:check-isort]
+deps = {[isortcfg]deps}
+commands =
+    isort --check-only {[isortcfg]modules}
+
+[testenv:format-isort]
+deps = {[isortcfg]deps}
+commands =
+    isort {[isortcfg]modules}

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -2546,6 +2546,12 @@ class SMBSpec(ServiceSpec):
         # config-key store uri (example:
         # `rados:mon-config-key:smb/config/mycluster/join1.json`).
         join_sources: Optional[List[str]] = None,
+        # user_sources - a list of pseudo-uris that resolve to a (JSON) blob
+        # containing data the samba-container can use to create users (and/or
+        # groups). A ceph based samba container may typically use a rados uri
+        # or a mon config-key store uri (example:
+        # `rados:mon-config-key:smb/config/mycluster/join1.json`).
+        user_sources: Optional[List[str]] = None,
         # custom_dns -  a list of IP addresses that will be set up as custom
         # dns servers for the samba container.
         custom_dns: Optional[List[str]] = None,
@@ -2577,6 +2583,7 @@ class SMBSpec(ServiceSpec):
         self.features = features or []
         self.config_uri = config_uri
         self.join_sources = join_sources or []
+        self.user_sources = user_sources or []
         self.custom_dns = custom_dns or []
         self.include_ceph_users = include_ceph_users or []
         self.validate()


### PR DESCRIPTION
<s>Depends on #55068 </s>
<s>Depends on #56274 </s>

This PR adds the core of a new `smb` manager module. The module is inspired by the `nfs` module as well as prior work in cephadm, samba, the samba-operator for kubernetes and others. It builds upon and currently requires cephadm to orchestrate smb services using samba containers.

This preliminary version is missing a few obvious features but the fundamentals are largely there. You can create and remove "clusters" (currently only single smbd instances) like nfs. You can create and remove "shares" like the nfs module's "exports". AD-compatibility is already present in this version, albeit without a lot of configuration options - so it may not suite all domains exactly yet.

## CLI Interface

There are two ways interacting with the smb module using the `ceph` CLI
command. The traditional mode uses commands like:
```
  ceph smb cluster create foo active-directory --domain-realm=foo.example.org --domain-join-user-pass=Administrator%Passw0rd
  ceph smb share create foo myshare1 --share-name='My Favorite Share' --cephfs-volume=cephfs --path=/my/stuff
```
and

```
  ceph smb share rm foo myshare1
```

The alternative is to use the `ceph smb apply` command to ingest configuration
resources that use a declarative style. This is inspired by the `ceph orch`
workflow and `ceph nfs export apply`. Example:

```
  ceph smb apply -i - <<EOF
  ---
  resource_type: ceph.smb.cluster
  cluster_id: foo
  auth_mode: active-directory
  domain_settings:
    realm: foo.example.com
    join_sources:
      - source_type: password
        auth:
          username: Administrator
          password: Passw0rd
  ---
  resource_type: ceph.smb.share
  cluster_id: foo
  share_id: myshare1
  cephfs:
    volume: cephfs
    path: /my/stuff
  EOF
```

To remove resources using the apply command, set the intent value to 'removed'.

```
  ceph smb apply -i - <<EOF
  ---
  resource_type: ceph.smb.share
  intent: removed
  cluster_id: foo
  share_id: myshare1
  EOF
```

## Declarative mode

There are four resource types:
* `ceph.smb.cluster`
* `ceph.smb.share`
* `ceph.smb.join.auth`
* `ceph.smb.usersgroups`

The `ceph.smb.cluster` resource type defines properties that impact an entire
cluster, even if that's a cluster of one node. This includes what domain the
cluster might belong to.

The `ceph.smb.share` resource type defines properites of a single SMB share.  A
share is always part of one cluster. A share's id is a short unique string.  A
share's name is the string that is shared with clients. If a share name is not
explicitly defined the share's name is the same as the share's id.  Shares
expose part of a cephfs file system. A share must always spcecify what cephfs
volume and path to use. Optionally, the share can refer to a subvolume (and/or
subvolumegroup) by name instead of figuring out that path first. A example YAML
block looks a bit something like this:
```
resource_type: ceph.smb.share
cluster_id: clustera
share_id: pictures
name: "Staff Photo Album"
cephfs:
  volume: cephfs
  path: /pictures
  subvolumegroup: userdata
  subvolume: employees
```

As a shortcut, in both the YAML and on the command lines a subvolume `y`
belonging to a subvolumegroup `x` can be specified as `x/y` using the
`subvolume:` field or `--subvolume=` cli option.


The `ceph.smb.join.auth` resource type contains user information needed to
join an Active Directory domain. This information can be specified inside the
cluster resource or as a `ceph.smb.join.auth` to seperate the two items.
The values provided to the join auth must be a `username` and `password` for
a user with sufficient rights to join a system to an AD domain.
It is recommended to create a user on the domain with the minimal rights needed
for this purpose alone.

The `ceph.smb.usersgroups` resource defines users and groups that wil be
set up within the cluster when using a standalone (not joined to AD) cluster.
This information can be kept separate from the cluster for easier modification
and sharing the same users with multiple clusters.


Resources can be viewed with `ceph smb show`. The show subcommand can be
provided with resource type as in `ceph smb show ceph.smb.share` or resource
type plus id strings in the form `<resource_type>.<id1>[.<id2>]`.


## NOTES

* The cluster is not sent to cephadm for orchestration until at least one share
  is defined. The short version is that the cluster needs extra information
  about the volume and we don't know what volume to use until we have at least
  one share. If this proves to be too confusing or a big issue we can probably
  figure out a workaround if needed.


## Critical TODOs prior to leaving 'draft':
* Increase unit test coverage
* Add teuthology tests
* Test against some more realistic AD domains
* Initial documentation



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), sorta
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
