### PR TITLE
crimson/os/seastore: avoid new allocation when overwriting data in RBM for performance

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -121,5 +121,5 @@ options:
 - name: seastore_data_delta_based_overwrite
   type: size
   level: dev
-  desc: overwrite the existing data block based on delta if the original size is smaller than the value, otherwise do overwrite based on remapping, set to 0 to enforce the remap-based overwrite.
+  desc: overwrite the existing data block based on delta if the overwrite size is equal to or less than the value, otherwise do overwrite based on remapping, set to 0 to enforce the remap-based overwrite.
   default: 0

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -547,11 +547,11 @@ public:
   }
 
   /// Get ref to raw buffer
-  bufferptr &get_bptr() {
+  virtual bufferptr &get_bptr() {
     assert(ptr.has_value());
     return *ptr;
   }
-  const bufferptr &get_bptr() const {
+  virtual const bufferptr &get_bptr() const {
     assert(ptr.has_value());
     return *ptr;
   }
@@ -646,11 +646,6 @@ private:
 
   bool is_linked() {
     return extent_index_hook.is_linked();
-  }
-
-  /// set bufferptr
-  void set_bptr(ceph::bufferptr &&nptr) {
-    ptr = nptr;
   }
 
   /// hook for intrusive ref list (mainly dirty or lru list)
@@ -797,6 +792,11 @@ protected:
       prior_poffset = poffset;
     }
     poffset = offset;
+  }
+
+  /// set bufferptr
+  void set_bptr(ceph::bufferptr &&nptr) {
+    ptr = nptr;
   }
 
   /**

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -297,6 +297,7 @@ overwrite_ops_t prepare_ops_list(
   interval_set<uint64_t> pre_alloc_addr_removed, pre_alloc_addr_remapped;
   if (delta_based_overwrite_max_extent_size) {
     for (auto &r : ops.to_remove) {
+      // TODO: Introduce LBAMapping::is_data_stable() to include EXIST_CLEAN extents
       if (r->is_stable() && !r->is_zero_reserved()) {
 	pre_alloc_addr_removed.insert(r->get_key(), r->get_length());
 

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -269,11 +269,11 @@ struct object_data_handler_test_t:
     return tm_teardown();
   }
 
-  void set_overwrite_threshold() {
+  void enable_delta_based_overwrite() {
     crimson::common::local_conf().set_val("seastore_data_delta_based_overwrite",
       "16777216").get();
   }
-  void unset_overwrite_threshold() {
+  void disable_delta_based_overwrite() {
     crimson::common::local_conf().set_val("seastore_data_delta_based_overwrite", "0").get();
   }
 
@@ -468,8 +468,9 @@ TEST_P(object_data_handler_test_t, multi_write)
 TEST_P(object_data_handler_test_t, delta_over_multi_write)
 {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     test_multi_write();
+    disable_delta_based_overwrite();
   });
 }
 
@@ -483,8 +484,9 @@ TEST_P(object_data_handler_test_t, write_hole)
 TEST_P(object_data_handler_test_t, delta_over_write_hole)
 {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     test_write_hole();
+    disable_delta_based_overwrite();
   });
 }
 
@@ -498,9 +500,9 @@ TEST_P(object_data_handler_test_t, overwrite_single)
 TEST_P(object_data_handler_test_t, delta_over_overwrite_single)
 {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     test_overwrite_single();
-    unset_overwrite_threshold();
+    disable_delta_based_overwrite();
   });
 }
 
@@ -514,9 +516,9 @@ TEST_P(object_data_handler_test_t, overwrite_double)
 TEST_P(object_data_handler_test_t, delta_over_overwrite_double)
 {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     test_overwrite_double();
-    unset_overwrite_threshold();
+    disable_delta_based_overwrite();
   });
 }
 
@@ -530,9 +532,9 @@ TEST_P(object_data_handler_test_t, overwrite_partial)
 TEST_P(object_data_handler_test_t, delta_over_overwrite_partial)
 {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     test_overwrite_partial();
-    unset_overwrite_threshold();
+    disable_delta_based_overwrite();
   });
 }
 
@@ -546,9 +548,9 @@ TEST_P(object_data_handler_test_t, unaligned_write)
 TEST_P(object_data_handler_test_t, delta_over_unaligned_write)
 {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     test_unaligned_write();
-    unset_overwrite_threshold();
+    disable_delta_based_overwrite();
   });
 }
 
@@ -562,9 +564,9 @@ TEST_P(object_data_handler_test_t, unaligned_overwrite)
 TEST_P(object_data_handler_test_t, delta_over_unaligned_overwrite)
 {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     test_unaligned_overwrite();
-    unset_overwrite_threshold();
+    disable_delta_based_overwrite();
   });
 }
 
@@ -578,9 +580,9 @@ TEST_P(object_data_handler_test_t, truncate)
 TEST_P(object_data_handler_test_t, delta_over_truncate)
 {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     test_truncate();
-    unset_overwrite_threshold();
+    disable_delta_based_overwrite();
   });
 }
 
@@ -592,9 +594,9 @@ TEST_P(object_data_handler_test_t, no_remap) {
 
 TEST_P(object_data_handler_test_t, no_overwrite) {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     write_same();
-    unset_overwrite_threshold();
+    disable_delta_based_overwrite();
   });
 }
 
@@ -618,13 +620,13 @@ TEST_P(object_data_handler_test_t, remap_left) {
 
 TEST_P(object_data_handler_test_t, overwrite_right) {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     write_right();
 
     auto pins = get_mappings(0, 128<<10);
     EXPECT_EQ(pins.size(), 1);
     read(0, 128<<10);
-    unset_overwrite_threshold();
+    disable_delta_based_overwrite();
   });
 }
 
@@ -648,12 +650,12 @@ TEST_P(object_data_handler_test_t, remap_right) {
 
 TEST_P(object_data_handler_test_t, overwrite_left) {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     write_left();
     auto pins = get_mappings(0, 128<<10);
     EXPECT_EQ(pins.size(), 1);
     read(0, 128<<10);
-    unset_overwrite_threshold();
+    disable_delta_based_overwrite();
   });
 }
 
@@ -676,12 +678,12 @@ TEST_P(object_data_handler_test_t, remap_right_left) {
 
 TEST_P(object_data_handler_test_t, overwrite_right_left) {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     write_right_left();
     auto pins = get_mappings(0, 128<<10);
     EXPECT_EQ(pins.size(), 1);
     read(0, 128<<10);
-    unset_overwrite_threshold();
+    disable_delta_based_overwrite();
   });
 }
 
@@ -704,12 +706,12 @@ TEST_P(object_data_handler_test_t, multiple_remap) {
 
 TEST_P(object_data_handler_test_t, multiple_overwrite) {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     multiple_write();
     auto pins = get_mappings(0, 128<<10);
     EXPECT_EQ(pins.size(), 1);
     read(0, 128<<10);
-    unset_overwrite_threshold();
+    disable_delta_based_overwrite();
   });
 }
 
@@ -718,7 +720,7 @@ TEST_P(object_data_handler_test_t, random_overwrite) {
   constexpr size_t BSIZE = 4<<10;
   constexpr size_t BLOCKS = TOTAL / BSIZE;
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     size_t wsize = std::uniform_int_distribution<>(10, BSIZE - 1)(gen);
     uint8_t div[3] = {1, 2, 4};
     uint8_t block_num = div[std::uniform_int_distribution<>(0, 2)(gen)];
@@ -741,13 +743,13 @@ TEST_P(object_data_handler_test_t, random_overwrite) {
       logger().info("random_writes: {} done replaying/checking", i);
     }
     read(0, 4<<20);
-    unset_overwrite_threshold();
+    disable_delta_based_overwrite();
   });
 }
 
 TEST_P(object_data_handler_test_t, overwrite_then_read_within_transaction) {
   run_async([this] {
-    set_overwrite_threshold();
+    enable_delta_based_overwrite();
     auto t = create_mutate_transaction();
     auto base = 4096 * 4;
     auto len = 4096 * 6;
@@ -827,7 +829,7 @@ TEST_P(object_data_handler_test_t, overwrite_then_read_within_transaction) {
 	4096));
     EXPECT_EQ(committed.length(), pending.length());
     EXPECT_NE(committed, pending);
-    unset_overwrite_threshold();
+    disable_delta_based_overwrite();
   });
 }
 


### PR DESCRIPTION
In 4K random write test, after seastore is filled up by 4MB extents, current implementation performs deep copy in duplicate_for_write(), resulting in significant performance degradation by 80%.
Therefore, this commit changes the deep copy behavior for bufferptr during the overwrite situation to shallow copy, leaving the original data untouched.


Signed-off-by: Myoungwon Oh <myoungwon.oh@samsung.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
