### PR TITLE
run-make-check: add time statistics of make check phase

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -80,12 +80,23 @@ function main() {
         return 1
     fi
     # uses run-make.sh to install-deps
+    local start_prepare=$(date +%s)
+    echo "run-make-check: start make check"
     FOR_MAKE_CHECK=1 prepare
+    local end_prepare=$(date +%s)
+    echo "run-make-check: finish prepare, duration $(($end_prepare - $start_prepare)) sec"
     configure "$@"
+    local end_configure=$(date +%s)
+    echo "run-make-check: finish configure, duration $(($end_configure - $end_prepare)) sec"
     in_jenkins && echo "CI_DEBUG: Running 'build tests'"
     build tests
+    local end_build=$(date +%s)
+    echo "run-make-check: finish build, duration $(($end_build - $end_configure)) sec"
     echo "make check: successful build on $(git rev-parse HEAD)"
     FOR_MAKE_CHECK=1 run
+    local end_makecheck=$(date +%s)
+    echo "run-make-check: finish tests, duration $(($end_makecheck - $end_build)) sec"
+    echo "run-make-check: finish make check, duration $(($end_makecheck - $start_prepare)) sec"
 }
 
 if [ "$0" = "$BASH_SOURCE" ]; then


### PR DESCRIPTION
When make check times out, we can check the duration of each phase, and it helps to diagnose.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
