### PR TITLE
quincy: mgr/dashboard/frontend:Ceph dashboard supports multiple languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -666,7 +666,7 @@ if(WITH_SYSTEM_NPM)
     message(FATAL_ERROR "Can't find npm.")
   endif()
 endif()
-set(DASHBOARD_FRONTEND_LANGS "" CACHE STRING
+set(DASHBOARD_FRONTEND_LANGS "ALL" CACHE STRING
   "List of comma separated ceph-dashboard frontend languages to build. \
   Use value `ALL` to build all languages")
 CMAKE_DEPENDENT_OPTION(WITH_MGR_ROOK_CLIENT "Enable the mgr's Rook support" ON

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -24,7 +24,6 @@
 %bcond_with zbd
 %bcond_with cmake_verbose_logging
 %bcond_without ceph_test_package
-%bcond_without mgr_dashboard_frontend_support_multi_language
 %ifarch s390
 %bcond_with tcmalloc
 %else
@@ -458,9 +457,6 @@ BuildRequires:  libnuma-devel
 %endif
 %if 0%{?rhel} >= 8
 BuildRequires:  /usr/bin/pathfix.py
-%endif
-%if 0%{with mgr_dashboard_frontend_support_multi_language}
-BuildRequires:  npm
 %endif
 
 %description
@@ -1334,13 +1330,7 @@ cmake .. \
     -DSYSTEMD_SYSTEM_UNIT_DIR:PATH=%{_unitdir} \
     -DWITH_MANPAGE:BOOL=ON \
     -DWITH_PYTHON3:STRING=%{python3_version} \
-%if 0%{with mgr_dashboard_frontend_support_multi_language}
-    -DWITH_MGR_DASHBOARD_FRONTEND:BOOL=ON \
-    -DDASHBOARD_FRONTEND_LANGS:STRING="cs,de,es,fr,id,it,ja,ko,pl,zh-Hans,zh-Hant,pt" \
-    -DWITH_SYSTEM_NPM:BOOL=ON \
-%else
     -DWITH_MGR_DASHBOARD_FRONTEND:BOOL=OFF \
-%endif
 %if 0%{?suse_version}
     -DWITH_RADOSGW_SELECT_PARQUET:BOOL=OFF \
 %endif

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -24,6 +24,7 @@
 %bcond_with zbd
 %bcond_with cmake_verbose_logging
 %bcond_without ceph_test_package
+%bcond_without mgr_dashboard_frontend_support_multi_language
 %ifarch s390
 %bcond_with tcmalloc
 %else
@@ -457,6 +458,9 @@ BuildRequires:  libnuma-devel
 %endif
 %if 0%{?rhel} >= 8
 BuildRequires:  /usr/bin/pathfix.py
+%endif
+%if 0%{with mgr_dashboard_frontend_support_multi_language}
+BuildRequires:  npm
 %endif
 
 %description
@@ -1330,7 +1334,13 @@ cmake .. \
     -DSYSTEMD_SYSTEM_UNIT_DIR:PATH=%{_unitdir} \
     -DWITH_MANPAGE:BOOL=ON \
     -DWITH_PYTHON3:STRING=%{python3_version} \
+%if 0%{with mgr_dashboard_frontend_support_multi_language}
+    -DWITH_MGR_DASHBOARD_FRONTEND:BOOL=ON \
+    -DDASHBOARD_FRONTEND_LANGS:STRING="cs,de,es,fr,id,it,ja,ko,pl,zh-Hans,zh-Hant,pt" \
+    -DWITH_SYSTEM_NPM:BOOL=ON \
+%else
     -DWITH_MGR_DASHBOARD_FRONTEND:BOOL=OFF \
+%endif
 %if 0%{?suse_version}
     -DWITH_RADOSGW_SELECT_PARQUET:BOOL=OFF \
 %endif

--- a/make-dist
+++ b/make-dist
@@ -138,9 +138,9 @@ build_dashboard_frontend() {
   . $TEMP_DIR/bin/activate
   NG_CLI_ANALYTICS=false timeout 1h npm ci
   echo "Building ceph-dashboard frontend with build:localize script";
-  # we need to use "--" because so that "--prod" survives accross all
-  # scripts redirections inside package.json
-  npm run build:localize -- --prod
+  # we need to use "--" because so that "--configuration production"
+  # survives accross all scripts redirections inside package.json
+  DASHBOARD_FRONTEND_LANGS="ALL" npm run build:localize -- --configuration production
   deactivate
   cd $CURR_DIR
   rm -rf $TEMP_DIR

--- a/src/pybind/mgr/dashboard/frontend/cd.js
+++ b/src/pybind/mgr/dashboard/frontend/cd.js
@@ -46,6 +46,7 @@ function prepareLocales() {
   }
 
   let langs = process.env.DASHBOARD_FRONTEND_LANGS || '';
+  langs = langs.replace(/\"\'/g, '')
   if (langs == 'ALL') {
     logger(`Preparing build of all languages.`);
     return;

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/language.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/language.e2e-spec.ts
@@ -14,6 +14,6 @@ describe('Shared pages', () => {
 
   it('should check all available languages', () => {
     language.getLanguageBtn().click();
-    language.getAllLanguages().should('have.length', 1).should('contain.text', 'English');
+    language.getAllLanguages().should('have.length', 13).should('contain.text', 'English');
   });
 });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65026

---

backport of https://github.com/ceph/ceph/pull/52617
parent tracker: https://tracker.ceph.com/issues/58653

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh