### PR TITLE
fix: Increase the parameter for MON to actively release memory

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -871,6 +871,10 @@ int main(int argc, const char **argv)
     derr << "done compacting" << dendl;
   }
 
+  if (ceph_using_tcmalloc() && g_conf()->mon_tcmalloc_aggressive_mem_decommit) {
+    ceph_heap_set_numeric_property("tcmalloc.aggressive_memory_decommit", 1);
+  }
+
   // bind
   err = msgr->bindv(bind_addrs, public_addrs);
   if (err < 0) {

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -2070,6 +2070,16 @@ options:
   services:
   - mon
   with_legacy: true
+# actively release memory
+- name: mon_tcmalloc_aggressive_mem_decommit
+  type: bool
+  level: advanced
+  default: true
+  fmt_desc: tcmalloc.aggressive_memory_decommit,
+    actively release memory to OS.
+  services:
+  - mon
+  with_legacy: true
 # required of mon, mds, osd daemons
 - name: auth_cluster_required
   type: str

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -262,7 +262,13 @@ COMMAND("tell "
 	"send a command to a specific daemon", "mon", "rw")
 COMMAND_WITH_FLAG("version", "show mon daemon version", "mon", "r",
                   FLAG(TELL))
-
+COMMAND_WITH_FLAG("set_heap_property name=property,type=CephString name=value,type=CephInt",
+    "update malloc extension heap property",
+    "mon","rw",FLAG(TELL))
+COMMAND_WITH_FLAG("get_heap_property name=property,type=CephString",
+    "get malloc extension heap property",
+    "mon","r",FLAG(TELL))
+	
 COMMAND("node ls "
 	"name=type,type=CephChoices,strings=all|osd|mon|mds|mgr,req=false",
 	"list all nodes in cluster [type]", "mon", "r")

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -467,6 +467,47 @@ int Monitor::do_admin_command(
       cmd_vec.push_back(val);
     }
     ceph_heap_profiler_handle_command(cmd_vec, out);
+  } else if (command == "set_heap_property") {
+    string property;
+    int64_t value = 0;
+    string error;
+    bool success = false;
+    if (!cmd_getval(cmdmap, "property", property)) {
+      error = "unable to get property";
+      success = false;
+    } else if (!cmd_getval(cmdmap, "value", value)) {
+      error = "unable to get value";
+      success = false;
+    } else if (value < 0) {
+      error = "negative value not allowed";
+      success = false;
+    } else if (!ceph_heap_set_numeric_property(property.c_str(), (size_t)value)) {
+      error = "invalid property";
+      success = false;
+    } else {
+      success = true;
+    }
+    out << "set_heap_property result:" << std::endl;
+    out << "  error: " << error << std::endl;
+    out << "  success: " << (success ? "true" : "false") << std::endl;
+  } else if (command == "get_heap_property") {
+    string property;
+    size_t value = 0;
+    string error;
+    bool success = false;
+    if (!cmd_getval(cmdmap, "property", property)) {
+      error = "unable to get property";
+      success = false;
+    } else if (!ceph_heap_get_numeric_property(property.c_str(), &value)) {
+      error = "invalid property";
+      success = false;
+    } else {
+      success = true;
+    }
+    out << "get_heap_property result:" << std::endl;
+    out << "  error: " << error << std::endl;
+    out << "  success: " << (success ? "true" : "false") << std::endl;
+    out << "  value: " << value << std::endl;    
   } else if (command == "compact") {
     dout(1) << "triggering manual compaction" << dendl;
     auto start = ceph::coarse_mono_clock::now();


### PR DESCRIPTION
1.Add the mon_tcmalloc_aggressive_mem_decommit parameter to mon,
  allowing mon to actively release memory when this parameter is set to true.
2.add function of get_heap_property and set_heap_property to mon,
  allowing mon to implement priority queue and dynamic memory allocation features.

Fixes: https://tracker.ceph.com/issues/65034





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
