### PR TITLE
squid: mgr/dashboard: fix M retention frequency display

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/retention-frequency.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/retention-frequency.enum.ts
@@ -1,8 +1,9 @@
 export enum RetentionFrequency {
+  Minutely = 'm',
   Hourly = 'h',
   Daily = 'd',
   Weekly = 'w',
-  Monthly = 'm',
+  Monthly = 'M',
   Yearly = 'y',
   'lastest snapshots' = 'n'
 }
@@ -11,7 +12,8 @@ export enum RetentionFrequencyCopy {
   h = 'Hourly',
   d = 'Daily',
   w = 'Weekly',
-  m = 'Monthly',
+  M = 'Monthly',
+  m = 'Minutely',
   y = 'Yearly',
   n = 'lastest snapshots'
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65037

---

backport of https://github.com/ceph/ceph/pull/56284
parent tracker: https://tracker.ceph.com/issues/64982

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh