### PR TITLE
crimson/osd/osd.h: declare osdmap after OSDSingletonState

### DIFF
--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -80,7 +80,6 @@ class OSD final : public crimson::net::Dispatcher,
   std::unique_ptr<crimson::mgr::Client> mgrc;
 
   // TODO: use a wrapper for ObjectStore
-  OSDMapService::cached_map_t osdmap;
   crimson::os::FuturizedStore& store;
 
   /// _first_ epoch we were marked up (after this process started)
@@ -121,6 +120,8 @@ class OSD final : public crimson::net::Dispatcher,
   seastar::sharded<OSDSingletonState> osd_singleton_state;
   seastar::sharded<OSDState> osd_states;
   seastar::sharded<ShardServices> shard_services;
+
+  OSDMapService::cached_map_t osdmap;
 
   crimson::osd::PGShardManager pg_shard_manager;
 


### PR DESCRIPTION
Otherwise, destructing the osdmap cached_map_t tries to manipulate OSDSingletonState::osdmaps after it has already been destroyed.

Fixes: https://tracker.ceph.com/issues/64935

https://pulpito.ceph.com/sjust-2024-03-21_02:35:36-crimson-rados-wip-sjust-crimson-testing-2024-03-20-distro-default-smithi/

Failures unrelated, caused by existing known bugs.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
