### PR TITLE
crimson/osd/pg: use pgmeta_oid for snapmapper

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -1166,10 +1166,6 @@ static PG::interruptible_future<hobject_t> pgls_filter(
   }
 }
 
-static inline bool is_snapmapper_oid(const hobject_t &obj) {
-  return obj.oid.name == SNAPMAPPER_OID;
-}
-
 static PG::interruptible_future<ceph::bufferlist> do_pgnls_common(
   const hobject_t& pg_start,
   const hobject_t& pg_end,
@@ -1190,13 +1186,6 @@ static PG::interruptible_future<ceph::bufferlist> do_pgnls_common(
     [&backend, filter, nspace](auto&& ret)
     -> PG::interruptible_future<std::tuple<std::vector<hobject_t>, hobject_t>> {
       auto& [objects, next] = ret;
-      auto is_snapmapper = [](const hobject_t &obj) {
-	if (is_snapmapper_oid(obj)) {
-	  return false;
-	} else {
-	  return true;
-	}
-      };
       auto in_my_namespace = [&nspace](const hobject_t& obj) {
         using crimson::common::local_conf;
         if (obj.get_namespace() == local_conf()->osd_hit_set_namespace) {
@@ -1224,8 +1213,7 @@ static PG::interruptible_future<ceph::bufferlist> do_pgnls_common(
         }
       };
 
-      auto range = objects | boost::adaptors::filtered(is_snapmapper)
-			   | boost::adaptors::filtered(in_my_namespace)
+      auto range = objects | boost::adaptors::filtered(in_my_namespace)
                            | boost::adaptors::transformed(to_pglsed);
       logger().debug("do_pgnls_common: finishing the 1st stage of pgls");
       return seastar::when_all_succeed(std::begin(range),
@@ -1358,9 +1346,6 @@ static PG::interruptible_future<ceph::bufferlist> do_pgls_common(
         PG::interruptor::map_reduce(std::move(objects),
           [&backend, filter, nspace](const hobject_t& obj)
 	  -> PG::interruptible_future<hobject_t>{
-	    if (is_snapmapper_oid(obj)) {
-	      return seastar::make_ready_future<hobject_t>();
-	    }
             if (obj.get_namespace() == nspace) {
               if (filter) {
                 return pgls_filter(*filter, backend, obj);

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -136,7 +136,7 @@ PG::PG(
     osdriver(
       &shard_services.get_store(),
       coll_ref,
-      make_snapmapper_oid()),
+      pgmeta_oid),
     snap_mapper(
       this->shard_services.get_cct(),
       &osdriver,
@@ -608,15 +608,7 @@ seastar::future<> PG::init(
     role, newup, new_up_primary, newacting,
     new_acting_primary, history, pi, t);
   assert(coll_ref);
-  return shard_services.get_store().exists(
-    get_collection_ref(), make_snapmapper_oid()
-  ).safe_then([&t, this](bool existed) {
-      if (!existed) {
-        t.touch(coll_ref->get_cid(), make_snapmapper_oid());
-      }
-    },
-    ::crimson::ct_error::assert_all{"unexpected eio"}
-  );
+  return seastar::now();
 }
 
 seastar::future<> PG::read_state(crimson::os::FuturizedStore::Shard* store)

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -41,8 +41,6 @@
 #include "crimson/osd/object_context_loader.h"
 #include "crimson/osd/scrub/pg_scrubber.h"
 
-#define SNAPMAPPER_OID "snapmapper"
-
 class MQuery;
 class OSDMap;
 class PGBackend;
@@ -649,16 +647,6 @@ public:
 private:
   OSDriver osdriver;
   SnapMapper snap_mapper;
-  ghobject_t make_snapmapper_oid() const {
-    return ghobject_t(hobject_t(
-      sobject_t(
-       object_t(SNAPMAPPER_OID),
-       0),
-      std::string(),
-      pgid.ps(),
-      pgid.pool(),
-      std::string()));
-  }
 public:
   // PeeringListener
   void publish_stats_to_osd() final;


### PR DESCRIPTION
Using a new object for snapmapper is tricky.  The only existing object like this is the pg meta object, which is special-cased in a variety of places through the osd.  It also happens to have the nice property that it's not expressible through a normal rados operation -- rados objects are not allowed to have empty names.

This snapmapper object, on the other hand, could actually be the target of a user read or write (though it's unlikely to happen by accident). In order to do this correctly, the existing special cases for the pgmeta object would need to be generalized and the normal user IO path would need to disallow mutations (and maybe reads since these objects wouldn't follow normal rules).

Instead, let's just stick these keys into the pgmeta object and save ourselves a lot of work.

Fixes: https://tracker.ceph.com/issues/64975

https://pulpito.ceph.com/sjust-2024-03-21_02:35:36-crimson-rados-wip-sjust-crimson-testing-2024-03-20-distro-default-smithi/

Failures unrelated, caused by existing known bugs.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
