### PR TITLE
reef: qa/suites/fs/nfs: use standard health ignorelist

### DIFF
--- a/qa/suites/fs/nfs/overrides/ignorelist_health.yaml
+++ b/qa/suites/fs/nfs/overrides/ignorelist_health.yaml
@@ -1,13 +1,1 @@
-overrides:
-  ceph:
-    log-ignorelist:
-      - overall HEALTH_
-      - \(FS_DEGRADED\)
-      - \(MDS_FAILED\)
-      - \(MDS_DEGRADED\)
-      - \(FS_WITH_FAILED_MDS\)
-      - \(MDS_DAMAGE\)
-      - \(MDS_ALL_DOWN\)
-      - \(MDS_UP_LESS_THAN_MAX\)
-      - \(FS_INLINE_DATA_DEPRECATED\)
-      - \(OSD_DOWN\)
+.qa/cephfs/overrides/ignorelist_health.yaml


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65058

---

backport of https://github.com/ceph/ceph/pull/56299
parent tracker: https://tracker.ceph.com/issues/64987

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh