### PR TITLE
reef: qa/cephfs: ignorelist clog of MDS_UP_LESS_THAN_MAX

### DIFF
--- a/qa/cephfs/overrides/ignorelist_health.yaml
+++ b/qa/cephfs/overrides/ignorelist_health.yaml
@@ -10,6 +10,7 @@ overrides:
       - MDS_FAILED
       - MDS_INSUFFICIENT_STANDBY
       - MDS_UP_LESS_THAN_MAX
+      - filesystem is online with fewer MDS than max_mds
       - POOL_APP_NOT_ENABLED
       - overall HEALTH_
       - Replacing daemon


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65061

---

backport of https://github.com/ceph/ceph/pull/56298
parent tracker: https://tracker.ceph.com/issues/64986

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh