### PR TITLE
quincy: qa/cephfs: ignorelist clog of MDS_UP_LESS_THAN_MAX

### DIFF
--- a/qa/cephfs/overrides/ignorelist_health.yaml
+++ b/qa/cephfs/overrides/ignorelist_health.yaml
@@ -8,6 +8,7 @@ overrides:
       - \(FS_WITH_FAILED_MDS\)
       - \(MDS_DAMAGE\)
       - \(MDS_ALL_DOWN\)
+      - filesystem is online with fewer MDS than max_mds
       - \(MDS_UP_LESS_THAN_MAX\)
       - \(FS_INLINE_DATA_DEPRECATED\)
       - \(POOL_APP_NOT_ENABLED\)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65062

---

backport of https://github.com/ceph/ceph/pull/56298
parent tracker: https://tracker.ceph.com/issues/64986

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh