### PR TITLE
reef: mon: do not log MON_DOWN if monitor uptime is less than threshold

### DIFF
--- a/qa/cephfs/conf/mon.yaml
+++ b/qa/cephfs/conf/mon.yaml
@@ -4,3 +4,5 @@ overrides:
       mon:
         mon op complaint time: 120
         mon warn on pool no app: false
+        # cephadm can take up to 5 minutes to bring up remaining mons
+        mon down mkfs grace: 300

--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -266,7 +266,8 @@ class HealthTest(DashboardTestCase):
                 'state': str,
                 # @TODO: What type should be expected here?
                 'sync_provider': JList(JAny(none=True)),
-                'stretch_mode': bool
+                'stretch_mode': bool,
+                'uptime': int,
             }),
             'osd_map': JObj({
                 # @TODO: define schema for crush map and osd_metadata, among

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -55,6 +55,15 @@ options:
   default: 1_min
   services:
   - mon
+- name: mon_down_uptime_grace
+  type: secs
+  level: advanced
+  desc: Period in seconds that the cluster may have a mon down after this (leader) monitor comes up.
+  default: 1_min
+  services:
+  - mon
+  flags:
+  - runtime
 - name: mon_mgr_beacon_grace
   type: secs
   level: advanced

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2665,6 +2665,7 @@ void Monitor::get_mon_status(Formatter *f)
   f->dump_int("rank", rank);
   f->dump_string("state", get_state_name());
   f->dump_int("election_epoch", get_epoch());
+  f->dump_int("uptime", get_uptime().count());
 
   f->open_array_section("quorum");
   for (set<int>::iterator p = quorum.begin(); p != quorum.end(); ++p) {

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -1099,6 +1099,18 @@ public:
   }
 
   bool is_keyring_required();
+
+public:
+  ceph::coarse_mono_time get_starttime() const {
+    return starttime;
+  }
+  std::chrono::milliseconds get_uptime() const {
+    auto now = ceph::coarse_mono_clock::now();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(now-starttime);
+  }
+
+private:
+  ceph::coarse_mono_time const starttime = coarse_mono_clock::now();
 };
 
 #define CEPH_MON_FEATURE_INCOMPAT_BASE CompatSet::Feature (1, "initial feature set (~v.18)")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65082

---

backport of https://github.com/ceph/ceph/pull/56271
parent tracker: https://tracker.ceph.com/issues/64968

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh