### PR TITLE
quincy: qa/cephfs: add mgr debugging

### DIFF
--- a/qa/cephfs/conf/mgr.yaml
+++ b/qa/cephfs/conf/mgr.yaml
@@ -1,0 +1,7 @@
+overrides:
+  ceph:
+    conf:
+      mgr:
+        debug client: 20
+        debug mgr: 20
+        debug ms: 1


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66633

---

backport of https://github.com/ceph/ceph/pull/56296
parent tracker: https://tracker.ceph.com/issues/64985

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh