### PR TITLE
exporter: fix regex for rgw sync metrics

### DIFF
--- a/src/exporter/DaemonMetricCollector.h
+++ b/src/exporter/DaemonMetricCollector.h
@@ -35,20 +35,23 @@ public:
   void main();
   std::string get_metrics();
   labels_t get_extra_labels(std::string daemon_name);
-
-private:
+  void dump_asok_metrics(bool sort_metrics, int64_t counter_prio,
+                         bool sockClientsPing, std::string &dump_response,
+                         std::string &schema_response,
+                         bool config_show_response);
   std::map<std::string, AdminSocketClient> clients;
   std::string metrics;
+  std::pair<labels_t, std::string> add_fixed_name_metrics(std::string metric_name);
+
+private:
   std::mutex metrics_mutex;
   std::unique_ptr<MetricsBuilder> builder;
   void update_sockets();
   void request_loop(boost::asio::steady_timer &timer);
 
-  void dump_asok_metrics();
   void dump_asok_metric(boost::json::object perf_info,
                         boost::json::value perf_values, std::string name,
                         labels_t labels);
-  std::pair<labels_t, std::string> add_fixed_name_metrics(std::string metric_name);
   void get_process_metrics(std::vector<std::pair<std::string, int>> daemon_pids);
   std::string asok_request(AdminSocketClient &asok, std::string command, std::string daemon_name);
 };

--- a/src/test/exporter/test_exporter.cc
+++ b/src/test/exporter/test_exporter.cc
@@ -1,12 +1,29 @@
+#include "common/ceph_argparse.h"
+#include "common/config.h"
+#include "common/config_proxy.h"
+#include <gmock/gmock.h>
 #include "gtest/gtest.h"
+#include "common/ceph_context.h"
+#include "global/global_context.h"
+#include "global/global_init.h"
 #include "exporter/util.h"
 #include "exporter/DaemonMetricCollector.h"
 
+#include <regex>
 #include <string>
 #include <vector>
 #include <utility>
 
 typedef std::map<std::string, std::string> labels_t;
+using ::testing::DoAll;
+using ::testing::Return;
+using ::testing::Pointee;
+using ::testing::Matcher;
+using ::testing::_;
+using ::testing::SetArgReferee;
+using ::testing::Invoke;
+using ::testing::WithArgs;
+using ::testing::AtLeast;
 
 // 17.2.6's memento mori:
 // This data was gathered from the python implementation of the promethize method
@@ -657,6 +674,23 @@ static std::vector<std::pair<std::string, std::string>> promethize_data = {
   {"rocksdb.submit_sync_latency_sum", "ceph_rocksdb_submit_sync_latency_sum"}
 };
 
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  auto args = argv_to_vec(argc, argv);
+
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
+                         CODE_ENVIRONMENT_UTILITY, CINIT_FLAG_NO_MON_CONFIG);
+
+  g_conf().set_val("exporter_sort_metrics", "true");
+  g_conf().set_val("exporter_prio_limit", "5");
+  common_init_finish(g_ceph_context);
+
+  int r = RUN_ALL_TESTS();
+  return r;
+}
+
 TEST(Exporter, promethize) {
   for (auto &test_case : promethize_data) {
     std::string path = test_case.first;
@@ -691,4 +725,38 @@ TEST(Exporter, check_labels_and_metric_name) {
   // This is a special case, the daemon name is not of the required size for fetching instance_id.
   // So no labels should be added.
   ASSERT_TRUE(fail_result.empty());
+}
+
+TEST(Exporter, add_fixed_name_metrics) {
+    std::vector<std::string> metrics = {
+      "ceph_data_sync_from_zone2-zg1-realm1_fetch_bytes",
+      "ceph_data_sync_from_zone2-zg1-realm1_fetch_bytes_sum",
+      "ceph_data_sync_from_zone2-zg1-realm1_poll_latency_sum",
+    };
+    std::vector<std::string> expected_metrics = {
+      "ceph_data_sync_from_zone_fetch_bytes",
+      "ceph_data_sync_from_zone_fetch_bytes_sum",
+      "ceph_data_sync_from_zone_poll_latency_sum",
+    };
+    std::string metric_name;
+    std::pair<labels_t, std::string> new_metric;
+    labels_t expected_labels;
+    std::string expected_metric_name;
+    for (std::size_t index = 0; index < metrics.size(); ++index) {
+        std::string &metric_name = metrics[index];
+        DaemonMetricCollector &collector = collector_instance();
+        auto new_metric = collector.add_fixed_name_metrics(metric_name);
+        expected_labels = {{"source_zone", "\"zone2-zg1-realm1\""}};
+        std::string expected_metric_name = expected_metrics[index];
+        EXPECT_EQ(new_metric.first, expected_labels);
+        ASSERT_EQ(new_metric.second, expected_metric_name);
+    }
+
+    metric_name = "ceph_data_sync_from_zone2_fetch_bytes_count";
+    DaemonMetricCollector &collector = collector_instance();
+    new_metric = collector.add_fixed_name_metrics(metric_name);
+    expected_labels = {{"source_zone", "\"zone2\""}};
+    expected_metric_name = "ceph_data_sync_from_zone_fetch_bytes_count";
+    EXPECT_EQ(new_metric.first, expected_labels);
+    ASSERT_TRUE(new_metric.second == expected_metric_name);
 }


### PR DESCRIPTION
Before:
![Screenshot from 2024-04-03 15-29-19](https://github.com/ceph/ceph/assets/23611106/f9a79b9a-d748-4911-abf3-8ad0c5f18f44)

After: 
Grafana Dashboard for RGW sync overview now shows data
![Screenshot from 2024-03-23 03-12-36](https://github.com/ceph/ceph/assets/23611106/0b3e2075-87d6-403a-946c-b2e5e6b5f22b)

Prometheus metrics fixed
![Screenshot from 2024-03-23 03-11-32](https://github.com/ceph/ceph/assets/23611106/bb9fdac7-8570-42a7-bf3b-aef57d5fe9d1)


Fixes: https://tracker.ceph.com/issues/65091





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
