### PR TITLE
reef: qa/suites/fs/workload: enable snap_schedule early

### DIFF
--- a/qa/cephfs/begin/3-modules.yaml
+++ b/qa/cephfs/begin/3-modules.yaml
@@ -1,0 +1,19 @@
+# Enable mgr modules now before any CephFS mounts are created by the mgr.  This
+# avoids the potential race of the mgr mounting CephFS and then getting failed
+# over by the monitors before the monitors have a chance to note the new client
+# session from the mgr beacon. In that case, the monitors will not blocklist
+# that client mount automatically so the MDS will eventually do the eviction
+# (and create a cluster log warning which we want to avoid).
+#
+# Note: ideally the mgr would gently stop mgr modules before respawning so that
+# the client mounts can be unmounted but this caused issues historically with
+# modules like the dashboard so an abrupt restart was chosen instead.
+
+mgrmodules:
+  sequential:
+    - print: "Enabling mgr modules"
+    # other fragments append to this
+
+tasks:
+  - sequential:
+      - mgrmodules

--- a/qa/suites/fs/workload/begin/3-modules.yaml
+++ b/qa/suites/fs/workload/begin/3-modules.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin/3-modules.yaml

--- a/qa/suites/fs/workload/tasks/3-snaps/yes.yaml
+++ b/qa/suites/fs/workload/tasks/3-snaps/yes.yaml
@@ -1,3 +1,10 @@
+mgrmodules:
+  sequential:
+    - exec:
+        mon.a:
+          - ceph mgr module enable snap_schedule
+          - ceph config set mgr mgr/snap_schedule/allow_m_granularity true
+          - ceph config set mgr mgr/snap_schedule/dump_on_update true
 overrides:
   ceph:
     conf:
@@ -12,9 +19,6 @@ overrides:
 tasks:
 - exec:
     mon.a:
-      - ceph mgr module enable snap_schedule
-      - ceph config set mgr mgr/snap_schedule/allow_m_granularity true
-      - ceph config set mgr mgr/snap_schedule/dump_on_update true
       - ceph fs snap-schedule add --fs=cephfs --path=/ --snap_schedule=1m
       - ceph fs snap-schedule retention add --fs=cephfs --path=/ --retention-spec-or-period=6m3h
       - ceph fs snap-schedule status --fs=cephfs --path=/


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65092

---

backport of https://github.com/ceph/ceph/pull/56354
parent tracker: https://tracker.ceph.com/issues/64988

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh