### PR TITLE
crush: use std::vector instead of variable length arrays

### DIFF
--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1610,14 +1610,14 @@ public:
   void do_rule(int rule, int x, std::vector<int>& out, int maxout,
 	       const WeightVector& weight,
 	       uint64_t choose_args_index) const {
-    int rawout[maxout];
-    char work[crush_work_size(crush, maxout)];
-    crush_init_workspace(crush, work);
+    std::vector<int> rawout(maxout);
+    std::vector<char> work(crush_work_size(crush, maxout));
+    crush_init_workspace(crush, std::data(work));
     crush_choose_arg_map arg_map = choose_args_get_with_fallback(
       choose_args_index);
-    int numrep = crush_do_rule(crush, rule, x, rawout, maxout,
+    int numrep = crush_do_rule(crush, rule, x, std::data(rawout), maxout,
 			       std::data(weight), std::size(weight),
-			       work, arg_map.args);
+			       std::data(work), arg_map.args);
     if (numrep < 0)
       numrep = 0;
     out.resize(numrep);


### PR DESCRIPTION
despite that variable length arrays (VLA for short) has been around for a long time, it is an extension supported by GCC and Clang, and is not a part of C++ standard, its implementation allocates the dynamically sized array on stack, hence is a source of potential stack overflow.

when compiling with Clang, it complains. so in this change, we switch to std::vector<>, which is defined by the C++ standard, and it allocates the storage on heap, so it is immune to the possible stack overflow problem.

```
/home/kefu/dev/ceph/src/crush/CrushWrapper.h:1613:16: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
 1613 |     int rawout[maxout];
      |                ^~~~~~
/home/kefu/dev/ceph/src/crush/CrushWrapper.h:1613:16: note: function parameter 'maxout' with unknown value cannot be used in a constant expression
/home/kefu/dev/ceph/src/crush/CrushWrapper.h:1610:60: note: declared here
 1610 |   void do_rule(int rule, int x, std::vector<int>& out, int maxout,
      |                                                            ^
/home/kefu/dev/ceph/src/crush/CrushWrapper.h:1614:15: warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]
 1614 |     char work[crush_work_size(crush, maxout)];
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kefu/dev/ceph/src/crush/CrushWrapper.h:1614:31: note: implicit use of 'this' pointer is only allowed within the evaluation of a call to a 'constexpr' member function
 1614 |     char work[crush_work_size(crush, maxout)];
      |                               ^
2 warnings generated.
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
