### PR TITLE
quincy: mon/OSDMonitor: fix rmsnap command

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -12957,6 +12957,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     if (sn) {
       pp->remove_snap(sn);
       pp->set_snap_epoch(pending_inc.epoch);
+      pending_inc.new_removed_snaps[pool].insert(sn);
       ss << "removed pool " << poolstr << " snap " << snapname;
     } else {
       ss << "already removed pool " << poolstr << " snap " << snapname;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4591,6 +4591,17 @@ void OSDMonitor::send_incremental(epoch_t first,
   }
 }
 
+bool OSDMonitor::remove_pool_snap(std::string_view snapname,
+                                  pg_pool_t &pp, int64_t pool) {
+  snapid_t snapid = pp.snap_exists(snapname);
+  if (snapid) {
+    pp.remove_snap(snapid);
+    pending_inc.new_removed_snaps[pool].insert(snapid);
+    return true;
+  }
+  return false;
+};
+
 int OSDMonitor::get_version(version_t ver, bufferlist& bl)
 {
   return get_version(ver, mon.get_quorum_con_features(), bl);
@@ -12953,11 +12964,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       pp = &pending_inc.new_pools[pool];
       *pp = *p;
     }
-    snapid_t sn = pp->snap_exists(snapname.c_str());
-    if (sn) {
-      pp->remove_snap(sn);
+    if (remove_pool_snap(snapname, *pp, pool)) {
       pp->set_snap_epoch(pending_inc.epoch);
-      pending_inc.new_removed_snaps[pool].insert(sn);
       ss << "removed pool " << poolstr << " snap " << snapname;
     } else {
       ss << "already removed pool " << poolstr << " snap " << snapname;
@@ -14173,10 +14181,7 @@ bool OSDMonitor::prepare_pool_op(MonOpRequestRef op)
 
   case POOL_OP_DELETE_SNAP:
     {
-      snapid_t s = pp.snap_exists(m->name.c_str());
-      if (s) {
-	pp.remove_snap(s);
-	pending_inc.new_removed_snaps[m->pool].insert(s);
+      if (remove_pool_snap(m->name, pp, m->pool)) {
 	changed = true;
       }
     }

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -405,6 +405,10 @@ private:
   MOSDMap *build_incremental(epoch_t first, epoch_t last, uint64_t features);
   void send_full(MonOpRequestRef op);
   void send_incremental(MonOpRequestRef op, epoch_t first);
+
+  bool remove_pool_snap(std::string_view snapname,
+                        pg_pool_t &pp, int64_t pool);
+
 public:
   /**
    * Make sure the existing (up) OSDs support the given features


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65095

---

backport of https://github.com/ceph/ceph/pull/55841
parent tracker: https://tracker.ceph.com/issues/64646

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh