### PR TITLE
squid: mon/OSDMonitor: fix rmsnap command

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -13084,6 +13084,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     if (sn) {
       pp->remove_snap(sn);
       pp->set_snap_epoch(pending_inc.epoch);
+      pending_inc.new_removed_snaps[pool].insert(sn);
       ss << "removed pool " << poolstr << " snap " << snapname;
     } else {
       ss << "already removed pool " << poolstr << " snap " << snapname;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -404,6 +404,10 @@ private:
   MOSDMap *build_incremental(epoch_t first, epoch_t last, uint64_t features);
   void send_full(MonOpRequestRef op);
   void send_incremental(MonOpRequestRef op, epoch_t first);
+
+  bool remove_pool_snap(std::string_view snapname,
+                        pg_pool_t &pp, int64_t pool);
+
 public:
   /**
    * Make sure the existing (up) OSDs support the given features


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65097

---

backport of https://github.com/ceph/ceph/pull/55841
parent tracker: https://tracker.ceph.com/issues/64646

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh