### PR TITLE
test: fix the leakages of `CephContext` identified by LeakSanitizer

### DIFF
--- a/src/test/common/test_context.cc
+++ b/src/test/common/test_context.cc
@@ -30,7 +30,7 @@ using namespace std;
 
 TEST(CephContext, do_command)
 {
-  CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_CLIENT))->get();
+  boost::intrusive_ptr<CephContext> cct{new CephContext(CEPH_ENTITY_TYPE_CLIENT), false};
 
   cct->_conf->cluster = "ceph";
 
@@ -89,12 +89,11 @@ TEST(CephContext, do_command)
     string s(out.c_str(), out.length());
     EXPECT_EQ("<config_diff_get><diff><key><default></default><override>" + value + "</override><final>value</final></key><rbd_default_features><default>61</default><final>61</final></rbd_default_features><rbd_qos_exclude_ops><default>0</default><final>0</final></rbd_qos_exclude_ops></diff></config_diff_get>", s);
   }
-  cct->put();
 }
 
 TEST(CephContext, experimental_features)
 {
-  CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_CLIENT))->get();
+  boost::intrusive_ptr<CephContext> cct{new CephContext(CEPH_ENTITY_TYPE_CLIENT), false};
 
   cct->_conf->cluster = "ceph";
 

--- a/src/test/common/test_fault_injector.cc
+++ b/src/test/common/test_fault_injector.cc
@@ -40,8 +40,9 @@ class Fixture : public testing::Test {
  protected:
   void SetUp() override {
     CephInitParameters params(CEPH_ENTITY_TYPE_CLIENT);
-    cct = common_preinit(params, CODE_ENVIRONMENT_UTILITY,
-                         CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+    cct.reset(common_preinit(params, CODE_ENVIRONMENT_UTILITY,
+			     CINIT_FLAG_NO_DEFAULT_CONFIG_FILE),
+	      false);
     prefix.emplace(cct.get(), ceph_subsys_context);
   }
   void TearDown() override {

--- a/src/test/common/test_util.cc
+++ b/src/test/common/test_util.cc
@@ -31,12 +31,12 @@ TEST(util, collect_sys_info)
 
   map<string, string> sys_info;
 
-  CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_CLIENT))->get();
-  collect_sys_info(&sys_info, cct);
+  boost::intrusive_ptr<CephContext> cct{new CephContext(CEPH_ENTITY_TYPE_CLIENT), false};
+
+  collect_sys_info(&sys_info, cct.get());
 
   ASSERT_TRUE(sys_info.find("distro") != sys_info.end());
   ASSERT_TRUE(sys_info.find("distro_description") != sys_info.end());
-
-  cct->put();
 }
+
 #endif

--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -703,7 +703,7 @@ TEST(pick_address, find_ip_in_subnet_list)
   ipv4(&a_two, "10.2.1.123");
   ipv6(&a_three, "2001:1234:5678:90ab::cdef");
 
-  boost::intrusive_ptr<CephContext> cct = new CephContext(CEPH_ENTITY_TYPE_OSD);
+  boost::intrusive_ptr<CephContext> cct{new CephContext(CEPH_ENTITY_TYPE_OSD), false};
 
   // match by network
   result = find_ip_in_subnet_list(


### PR DESCRIPTION
before this change, we increment the refcount when constructing `cct` instrusive_ptr, but nobody owns this smart pointer. also, `CephContext` 's constructor set its refcount to 1. so, when the test finishes, the refcount is 1, and this leads to a leakage of the `CephContext` instance. and the leakages are identified by LeakSanitizer.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
