### PR TITLE
squid: mgr/dashboard: fix empty tags 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -61,6 +61,7 @@ export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewC
   kmsVaultConfig = false;
   s3VaultConfig = false;
   tags: Record<string, string>[] = [];
+  dirtyTags = false;
   tagConfig = [
     {
       attribute: 'key'
@@ -437,6 +438,7 @@ export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewC
 
   deleteTag(index: number) {
     this.tags.splice(index, 1);
+    this.dirtyTags = true;
     this.bucketForm.markAsDirty();
     this.bucketForm.updateValueAndValidity();
   }
@@ -447,11 +449,13 @@ export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewC
     } else {
       this.tags.push(tag);
     }
+    this.dirtyTags = true;
     this.bucketForm.markAsDirty();
     this.bucketForm.updateValueAndValidity();
   }
 
   private tagsToXML(tags: Record<string, string>[]): string {
+    if (!this.dirtyTags && tags.length === 0) return '';
     let xml = '<Tagging><TagSet>';
     for (const tag of tags) {
       xml += '<Tag>';


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65109

---

backport of https://github.com/ceph/ceph/pull/56183
parent tracker: https://tracker.ceph.com/issues/64911

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh