### PR TITLE
reef: mgr/dashboard: rm warning/error threshold for cpu usage

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
@@ -94,9 +94,6 @@
   <cd-usage-bar [total]="total"
                 [calculatePerc]="false"
                 [used]="row.cpu_percentage"
-                [isBinary]="false"
-                [warningThreshold]="warningThreshold"
-                [errorThreshold]="errorThreshold">
+                [isBinary]="false">
   </cd-usage-bar>
 </ng-template>
-

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.html
@@ -29,7 +29,7 @@
      data-placement="left"
      [ngbTooltip]="usageTooltipTpl">
   <div class="progress-bar bg-info"
-       [ngClass]="{'bg-warning': (warningThreshold >= 0) && (usedPercentage/100 >= warningThreshold), 'bg-danger': (errorThreshold >= 0) && (usedPercentage/100 >= errorThreshold)}"
+       [ngClass]="{'bg-warning': warningThreshold && (warningThreshold >= 0) && (usedPercentage/100 >= warningThreshold), 'bg-danger': errorThreshold && (errorThreshold >= 0) && (usedPercentage/100 >= errorThreshold)}"
        role="progressbar"
        [attr.aria-label]="{ title }"
        i18n-aria-label="The title of this usage bar is { title }"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.ts
@@ -13,9 +13,9 @@ export class UsageBarComponent implements OnChanges {
   @Input()
   used: any;
   @Input()
-  warningThreshold: number;
+  warningThreshold?: number;
   @Input()
-  errorThreshold: number;
+  errorThreshold?: number;
   @Input()
   isBinary = true;
   @Input()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65103

---

backport of https://github.com/ceph/ceph/pull/56295
parent tracker: https://tracker.ceph.com/issues/58838

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh