### PR TITLE
test/mon/test_config_map: fix leaks identified by LeakSanitizer

### DIFF
--- a/src/test/mon/test_config_map.cc
+++ b/src/test/mon/test_config_map.cc
@@ -4,6 +4,7 @@
 #include "mon/ConfigMap.h"
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include "crush/CrushWrapper.h"
 #include "common/ceph_context.h"
@@ -90,7 +91,7 @@ TEST(ConfigMap, result_sections)
 {
   ConfigMap cm;
   boost::intrusive_ptr<CephContext> cct{new CephContext(CEPH_ENTITY_TYPE_CLIENT), false};
-  auto crush = new CrushWrapper;
+  auto crush = std::make_unique<CrushWrapper>();
   crush->finalize();
 
   int r;
@@ -124,19 +125,19 @@ TEST(ConfigMap, result_sections)
   EntityName n;
   n.set(CEPH_ENTITY_TYPE_MON, "a");
   auto c = cm.generate_entity_map(
-    n, {}, crush, "none", nullptr);
+    n, {}, crush.get(), "none", nullptr);
   ASSERT_EQ(1, c.size());
   ASSERT_EQ("a", c["foo"]);
 
   n.set(CEPH_ENTITY_TYPE_MON, "b");
   c = cm.generate_entity_map(
-    n, {}, crush, "none", nullptr);
+    n, {}, crush.get(), "none", nullptr);
   ASSERT_EQ(1, c.size());
   ASSERT_EQ("m", c["foo"]);
 
   n.set(CEPH_ENTITY_TYPE_MDS, "c");
   c = cm.generate_entity_map(
-    n, {}, crush, "none", nullptr);
+    n, {}, crush.get(), "none", nullptr);
   ASSERT_EQ(1, c.size());
   ASSERT_EQ("g", c["foo"]);
 }

--- a/src/test/mon/test_config_map.cc
+++ b/src/test/mon/test_config_map.cc
@@ -55,11 +55,11 @@ TEST(ConfigMap, parse_key)
 TEST(ConfigMap, add_option)
 {
   ConfigMap cm;
-  auto cct = new CephContext(CEPH_ENTITY_TYPE_MON);
+  boost::intrusive_ptr<CephContext> cct{new CephContext(CEPH_ENTITY_TYPE_CLIENT), false};
   int r;
 
   r = cm.add_option(
-    cct, "foo", "global", "fooval",
+    cct.get(), "foo", "global", "fooval",
     [&](const std::string& name) {
       return nullptr;
     });
@@ -67,7 +67,7 @@ TEST(ConfigMap, add_option)
   ASSERT_EQ(1, cm.global.options.size());
 
   r = cm.add_option(
-    cct, "foo", "mon", "fooval",
+    cct.get(), "foo", "mon", "fooval",
     [&](const std::string& name) {
       return nullptr;
     });
@@ -76,7 +76,7 @@ TEST(ConfigMap, add_option)
   ASSERT_EQ(1, cm.by_type["mon"].options.size());
   
   r = cm.add_option(
-    cct, "foo", "mon.a", "fooval",
+    cct.get(), "foo", "mon.a", "fooval",
     [&](const std::string& name) {
       return nullptr;
     });
@@ -89,14 +89,14 @@ TEST(ConfigMap, add_option)
 TEST(ConfigMap, result_sections)
 {
   ConfigMap cm;
-  auto cct = new CephContext(CEPH_ENTITY_TYPE_MON);
+  boost::intrusive_ptr<CephContext> cct{new CephContext(CEPH_ENTITY_TYPE_CLIENT), false};
   auto crush = new CrushWrapper;
   crush->finalize();
 
   int r;
 
   r = cm.add_option(
-    cct, "foo", "global", "g",
+    cct.get(), "foo", "global", "g",
     [&](const std::string& name) {
       return nullptr;
     });
@@ -104,7 +104,7 @@ TEST(ConfigMap, result_sections)
   ASSERT_EQ(1, cm.global.options.size());
 
   r = cm.add_option(
-    cct, "foo", "mon", "m",
+    cct.get(), "foo", "mon", "m",
     [&](const std::string& name) {
       return nullptr;
     });
@@ -113,7 +113,7 @@ TEST(ConfigMap, result_sections)
   ASSERT_EQ(1, cm.by_type["mon"].options.size());
 
   r = cm.add_option(
-    cct, "foo", "mon.a", "a",
+    cct.get(), "foo", "mon.a", "a",
     [&](const std::string& name) {
       return nullptr;
     });


### PR DESCRIPTION
in this test, we allocates `CephContext` and `CrushWrapper` with new, but we never free them. so in this series, let's free them. this should pave the road to a clean run with ASan enabled. after which, the genuine issues should surface.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
