### PR TITLE
reef: pybind/mgr/devicehealth: skip legacy objects that cannot be loaded

### DIFF
--- a/qa/tasks/mgr/mgr_test_case.py
+++ b/qa/tasks/mgr/mgr_test_case.py
@@ -29,8 +29,11 @@ class MgrCluster(CephCluster):
     def mgr_stop(self, mgr_id):
         self.mgr_daemons[mgr_id].stop()
 
-    def mgr_fail(self, mgr_id):
-        self.mon_manager.raw_cluster_cmd("mgr", "fail", mgr_id)
+    def mgr_fail(self, mgr_id=None):
+        if mgr_id is None:
+            self.mon_manager.raw_cluster_cmd("mgr", "fail")
+        else:
+            self.mon_manager.raw_cluster_cmd("mgr", "fail", mgr_id)
 
     def mgr_restart(self, mgr_id):
         self.mgr_daemons[mgr_id].restart()

--- a/qa/tasks/mgr/mgr_test_case.py
+++ b/qa/tasks/mgr/mgr_test_case.py
@@ -77,6 +77,8 @@ class MgrTestCase(CephTestCase):
         for daemon in cls.mgr_cluster.mgr_daemons.values():
             daemon.stop()
 
+        cls.mgr_cluster.mon_manager.raw_cluster_cmd("mgr", "set", "down", "false")
+
         for mgr_id in cls.mgr_cluster.mgr_ids:
             cls.mgr_cluster.mgr_fail(mgr_id)
 

--- a/qa/tasks/mgr/test_cli.py
+++ b/qa/tasks/mgr/test_cli.py
@@ -1,0 +1,32 @@
+import logging
+
+from .mgr_test_case import MgrTestCase
+
+log = logging.getLogger(__name__)
+
+
+class TestCLI(MgrTestCase):
+    MGRS_REQUIRED = 2
+
+    def setUp(self):
+        super(TestCLI, self).setUp()
+        self.setup_mgrs()
+
+    def test_set_down(self):
+        """
+        That setting the down flag prevents a standby from promoting.
+        """
+
+        with self.assert_cluster_log("Activating manager daemon", present=False):
+            self.mgr_cluster.mon_manager.raw_cluster_cmd('mgr', 'set', 'down', 'true')
+            self.wait_until_true(lambda: self.mgr_cluster.get_active_id() == "", timeout=60)
+
+    def test_set_down_off(self):
+        """
+        That removing the down flag allows a standby to promote.
+        """
+
+        with self.assert_cluster_log("Activating manager daemon"):
+            self.mgr_cluster.mon_manager.raw_cluster_cmd('mgr', 'set', 'down', 'true')
+            self.wait_until_true(lambda: self.mgr_cluster.get_active_id() == "", timeout=60)
+            self.mgr_cluster.mon_manager.raw_cluster_cmd('mgr', 'set', 'down', 'false')

--- a/qa/tasks/mgr/test_devicehealth.py
+++ b/qa/tasks/mgr/test_devicehealth.py
@@ -1,0 +1,33 @@
+from io import StringIO
+import logging
+
+from .mgr_test_case import MgrTestCase
+
+log = logging.getLogger(__name__)
+
+
+class TestDeviceHealth(MgrTestCase):
+    MGRS_REQUIRED = 1
+
+    def setUp(self):
+        super(TestDeviceHealth, self).setUp()
+        self.setup_mgrs()
+
+    def tearDown(self):
+        self.mgr_cluster.mon_manager.raw_cluster_cmd('mgr', 'set', 'down', 'true')
+        self.mgr_cluster.mon_manager.raw_cluster_cmd('config', 'set', 'mon', 'mon_allow_pool_delete', 'true')
+        self.mgr_cluster.mon_manager.raw_cluster_cmd('osd', 'pool', 'rm', '.mgr', '.mgr', '--yes-i-really-really-mean-it-not-faking')
+        self.mgr_cluster.mon_manager.raw_cluster_cmd('mgr', 'set', 'down', 'false')
+
+    def test_legacy_upgrade_snap(self):
+        """
+        """
+
+        o = "ABC_DEADB33F_FA"
+        self.mon_manager.do_rados(["put", o, "-"], pool=".mgr", stdin=StringIO("junk"))
+        self.mon_manager.do_rados(["mksnap", "foo"], pool=".mgr")
+        self.mon_manager.do_rados(["rm", o], pool=".mgr")
+        self.mgr_cluster.mgr_fail()
+
+        with self.assert_cluster_log("Unhandled exception from module 'devicehealth' while running", present=False):
+            self.wait_until_true(lambda: self.mgr_cluster.get_active_id() is not None, timeout=60)

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -225,6 +225,10 @@ public:
   epoch_t epoch = 0;
   epoch_t last_failure_osd_epoch = 0;
 
+
+  static const uint64_t FLAG_DOWN = (1<<0);
+  uint64_t flags = 0;
+
   /// global_id of the ceph-mgr instance selected as a leader
   uint64_t active_gid = 0;
   /// server address reported by the leader once it is active
@@ -401,7 +405,7 @@ public:
       ENCODE_FINISH(bl);
       return;
     }
-    ENCODE_START(12, 6, bl);
+    ENCODE_START(13, 6, bl);
     encode(epoch, bl);
     encode(active_addrs, bl, features);
     encode(active_gid, bl);
@@ -425,13 +429,14 @@ public:
     // backwards compatible messsage for older monitors.
     encode(clients_addrs, bl, features);
     encode(clients_names, bl, features);
+    encode(flags, bl);
     ENCODE_FINISH(bl);
     return;
   }
 
   void decode(ceph::buffer::list::const_iterator& p)
   {
-    DECODE_START(12, p);
+    DECODE_START(13, p);
     decode(epoch, p);
     decode(active_addrs, p);
     decode(active_gid, p);
@@ -498,11 +503,15 @@ public:
 	}
       }
     }
+    if (struct_v >= 13) {
+      decode(flags, p);
+    }
     DECODE_FINISH(p);
   }
 
   void dump(ceph::Formatter *f) const {
     f->dump_int("epoch", epoch);
+    f->dump_int("flags", flags);
     f->dump_int("active_gid", get_active_gid());
     f->dump_string("active_name", get_active_name());
     f->dump_object("active_addrs", active_addrs);

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -21,8 +21,9 @@
 #include "MgrMap.h"
 #include "PaxosService.h"
 #include "MonCommand.h"
+#include "CommandHandler.h"
 
-class MgrMonitor: public PaxosService
+class MgrMonitor: public PaxosService, public CommandHandler
 {
   MgrMap map;
   MgrMap pending_map;

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1288,6 +1288,10 @@ COMMAND("mgr dump "
 	"name=epoch,type=CephInt,range=0,req=false",
 	"dump the latest MgrMap",
 	"mgr", "r")
+COMMAND("mgr set "
+	"name=var,type=CephChoices,strings=down "
+	"name=val,type=CephString ",
+	"set mgr parameter <var> to <val>", "mgr", "rw")
 COMMAND("mgr fail name=who,type=CephString,req=false",
 	"treat the named manager daemon as failed", "mgr", "rw")
 COMMAND("mgr module ls",

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -327,6 +327,11 @@ CREATE TABLE DeviceHealthMetrics (
                         count += 1
                 except json.decoder.JSONDecodeError:
                     pass
+                except rados.ObjectNotFound:
+                    # https://tracker.ceph.com/issues/63882
+                    # Sometimes an object appears in the pool listing but cannot be interacted with?
+                    self.log.debug(f"object {obj} does not exist because it is deleted in HEAD")
+                    pass
                 if count >= 10:
                     break
             done = count < 10


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65153

---

backport of https://github.com/ceph/ceph/pull/54987
parent tracker: https://tracker.ceph.com/issues/63882

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh