### PR TITLE
squid: osd/scrub: no "slow response" warning for queued reservations

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -520,17 +520,6 @@ options:
     stats (inc. scrub/block duration) every this many seconds.
   default: 120
   with_legacy: false
-- name: osd_scrub_slow_reservation_response
-  type: millisecs
-  level: advanced
-  desc: Maximum wait (milliseconds) for scrub reservations before issuing a cluster-log warning
-  long_desc: Waiting too long for a replica to respond to scrub resource reservation request.
-    Disable by setting to a very large value.
-  default: 30000
-  min: 500
-  see_also:
-  - osd_scrub_reservation_timeout
-  with_legacy: false
 - name: osd_scrub_reservation_timeout
   type: millisecs
   level: advanced
@@ -540,8 +529,6 @@ options:
     to a very large value.
   default: 300000
   min: 2000
-  see_also:
-  - osd_scrub_slow_reservation_response
   with_legacy: false
 - name: osd_scrub_disable_reservation_queuing
   type: bool

--- a/src/osd/scrubber/scrub_reservations.h
+++ b/src/osd/scrubber/scrub_reservations.h
@@ -90,10 +90,6 @@ class ReplicaReservations {
    */
   reservation_nonce_t& m_last_request_sent_nonce;
 
-  /// the 'slow response' timeout (in milliseconds) - as configured.
-  /// Doubles as a 'do once' flag for the warning.
-  std::chrono::milliseconds m_slow_response_warn_timeout;
-
   /// access to the performance counters container relevant to this scrub
   /// parameters
   PerfCounters& m_perf_set;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65072

parent tracker: https://tracker.ceph.com/issues/64869

backport of https://github.com/ceph/ceph/pull/56337

original description:

When sending a "queued reservation" request (the new default), the OSD
will not respond until the reservation is granted.  This can take a
long time, and the client should not be warned about a "slow response".

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
