### PR TITLE
rgw: Close datalog write hole

### DIFF
--- a/src/cls/CMakeLists.txt
+++ b/src/cls/CMakeLists.txt
@@ -372,3 +372,13 @@ set_target_properties(cls_test_remote_reads PROPERTIES
   INSTALL_RPATH ""
   CXX_VISIBILITY_PRESET hidden)
 install(TARGETS cls_test_remote_reads DESTINATION ${cls_dir})
+
+# cls_sem_set
+set(cls_sem_set_srcs sem_set/module.cc)
+add_library(cls_sem_set SHARED ${cls_sem_set_srcs})
+set_target_properties(cls_sem_set PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH ""
+  CXX_VISIBILITY_PRESET hidden)
+install(TARGETS cls_sem_set DESTINATION ${cls_dir})

--- a/src/cls/log/cls_log.cc
+++ b/src/cls/log/cls_log.cc
@@ -25,7 +25,7 @@ CLS_NAME(log)
 static string log_index_prefix = "1_";
 
 
-static int write_log_entry(cls_method_context_t hctx, string& index, cls_log_entry& entry)
+static int write_log_entry(cls_method_context_t hctx, string& index, cls::log::entry& entry)
 {
   bufferlist bl;
   encode(entry, bl);
@@ -46,7 +46,7 @@ static void get_index_time_prefix(ceph::real_time ts, string& index)
   index = log_index_prefix + buf;
 }
 
-static int read_header(cls_method_context_t hctx, cls_log_header& header)
+static int read_header(cls_method_context_t hctx, cls::log::header& header)
 {
   bufferlist header_bl;
 
@@ -55,7 +55,7 @@ static int read_header(cls_method_context_t hctx, cls_log_header& header)
     return ret;
 
   if (header_bl.length() == 0) {
-    header = cls_log_header();
+    header = cls::log::header();
     return 0;
   }
 
@@ -69,7 +69,7 @@ static int read_header(cls_method_context_t hctx, cls_log_header& header)
   return 0;
 }
 
-static int write_header(cls_method_context_t hctx, cls_log_header& header)
+static int write_header(cls_method_context_t hctx, cls::log::header& header)
 {
   bufferlist header_bl;
   encode(header, header_bl);
@@ -96,22 +96,22 @@ static int cls_log_add(cls_method_context_t hctx, bufferlist *in, bufferlist *ou
 {
   auto in_iter = in->cbegin();
 
-  cls_log_add_op op;
+  cls::log::ops::add_op op;
   try {
     decode(op, in_iter);
   } catch (ceph::buffer::error& err) {
-    CLS_LOG(1, "ERROR: cls_log_add_op(): failed to decode op");
+    CLS_LOG(1, "ERROR: cls::log::ops::add_op(): failed to decode op");
     return -EINVAL;
   }
 
-  cls_log_header header;
+  cls::log::header header;
 
   int ret = read_header(hctx, header);
   if (ret < 0)
     return ret;
 
   for (auto iter = op.entries.begin(); iter != op.entries.end(); ++iter) {
-    cls_log_entry& entry = *iter;
+    cls::log::entry& entry = *iter;
 
     string index;
 
@@ -150,11 +150,11 @@ static int cls_log_list(cls_method_context_t hctx, bufferlist *in, bufferlist *o
 {
   auto in_iter = in->cbegin();
 
-  cls_log_list_op op;
+  cls::log::ops::list_op op;
   try {
     decode(op, in_iter);
   } catch (ceph::buffer::error& err) {
-    CLS_LOG(1, "ERROR: cls_log_list_op(): failed to decode op");
+    CLS_LOG(1, "ERROR: cls::log::ops::list_op(): failed to decode op");
     return -EINVAL;
   }
 
@@ -178,7 +178,7 @@ static int cls_log_list(cls_method_context_t hctx, bufferlist *in, bufferlist *o
   if (!max_entries || max_entries > MAX_ENTRIES)
     max_entries = MAX_ENTRIES;
 
-  cls_log_list_ret ret;
+  cls::log::ops::list_ret ret;
 
   int rc = cls_cxx_map_get_vals(hctx, from_index, log_index_prefix, max_entries, &keys, &ret.truncated);
   if (rc < 0)
@@ -200,7 +200,7 @@ static int cls_log_list(cls_method_context_t hctx, bufferlist *in, bufferlist *o
     bufferlist& bl = iter->second;
     auto biter = bl.cbegin();
     try {
-      cls_log_entry e;
+      cls::log::entry e;
       decode(e, biter);
       entries.push_back(e);
     } catch (ceph::buffer::error& err) {
@@ -220,7 +220,7 @@ static int cls_log_trim(cls_method_context_t hctx, bufferlist *in, bufferlist *o
 {
   auto in_iter = in->cbegin();
 
-  cls_log_trim_op op;
+  cls::log::ops::trim_op op;
   try {
     decode(op, in_iter);
   } catch (ceph::buffer::error& err) {
@@ -284,15 +284,15 @@ static int cls_log_info(cls_method_context_t hctx, bufferlist *in, bufferlist *o
 {
   auto in_iter = in->cbegin();
 
-  cls_log_info_op op;
+  cls::log::ops::info_op op;
   try {
     decode(op, in_iter);
   } catch (ceph::buffer::error& err) {
-    CLS_LOG(1, "ERROR: cls_log_add_op(): failed to decode op");
+    CLS_LOG(1, "ERROR: cls::log::ops::add_op(): failed to decode op");
     return -EINVAL;
   }
 
-  cls_log_info_ret ret;
+  cls::log::ops::info_ret ret;
 
   int rc = read_header(hctx, ret.header);
   if (rc < 0)

--- a/src/cls/log/cls_log_client.cc
+++ b/src/cls/log/cls_log_client.cc
@@ -34,8 +34,8 @@ void cls_log_add(librados::ObjectWriteOperation& op, cls_log_entry& entry)
   op.exec("log", "add", in);
 }
 
-void cls_log_add_prepare_entry(cls_log_entry& entry, const utime_t& timestamp,
-                 const string& section, const string& name, bufferlist& bl)
+void cls_log_add_prepare_entry(cls_log_entry& entry, ceph::real_time timestamp,
+			       const string& section, const string& name, bufferlist& bl)
 {
   entry.timestamp = timestamp;
   entry.section = section;
@@ -43,7 +43,7 @@ void cls_log_add_prepare_entry(cls_log_entry& entry, const utime_t& timestamp,
   entry.data = bl;
 }
 
-void cls_log_add(librados::ObjectWriteOperation& op, const utime_t& timestamp,
+void cls_log_add(librados::ObjectWriteOperation& op, ceph::real_time timestamp,
                  const string& section, const string& name, bufferlist& bl)
 {
   cls_log_entry entry;
@@ -52,8 +52,8 @@ void cls_log_add(librados::ObjectWriteOperation& op, const utime_t& timestamp,
   cls_log_add(op, entry);
 }
 
-void cls_log_trim(librados::ObjectWriteOperation& op, const utime_t& from_time, const utime_t& to_time,
-                  const string& from_marker, const string& to_marker)
+void cls_log_trim(librados::ObjectWriteOperation& op, ceph::real_time from_time,
+		  ceph::real_time to_time, const string& from_marker, const string& to_marker)
 {
   bufferlist in;
   cls_log_trim_op call;
@@ -65,7 +65,8 @@ void cls_log_trim(librados::ObjectWriteOperation& op, const utime_t& from_time, 
   op.exec("log", "trim", in);
 }
 
-int cls_log_trim(librados::IoCtx& io_ctx, const string& oid, const utime_t& from_time, const utime_t& to_time,
+int cls_log_trim(librados::IoCtx& io_ctx, const string& oid,
+		 ceph::real_time from_time, ceph::real_time to_time,
                  const string& from_marker, const string& to_marker)
 {
   bool done = false;
@@ -113,8 +114,8 @@ public:
   }
 };
 
-void cls_log_list(librados::ObjectReadOperation& op, const utime_t& from,
-		  const utime_t& to, const string& in_marker, int max_entries,
+void cls_log_list(librados::ObjectReadOperation& op, ceph::real_time from,
+		  ceph::real_time to, const string& in_marker, int max_entries,
 		  vector<cls_log_entry>& entries,
                   string *out_marker, bool *truncated)
 {

--- a/src/cls/log/cls_log_client.cc
+++ b/src/cls/log/cls_log_client.cc
@@ -7,7 +7,7 @@
 #include "include/compat.h"
 
 
-using std::list;
+using std::vector;
 using std::string;
 
 using ceph::bufferlist;
@@ -16,7 +16,7 @@ using namespace librados;
 
 
 
-void cls_log_add(librados::ObjectWriteOperation& op, list<cls_log_entry>& entries, bool monotonic_inc)
+void cls_log_add(librados::ObjectWriteOperation& op, vector<cls_log_entry>& entries, bool monotonic_inc)
 {
   bufferlist in;
   cls_log_add_op call;
@@ -88,11 +88,11 @@ int cls_log_trim(librados::IoCtx& io_ctx, const string& oid, const utime_t& from
 }
 
 class LogListCtx : public ObjectOperationCompletion {
-  list<cls_log_entry> *entries;
+  vector<cls_log_entry> *entries;
   string *marker;
   bool *truncated;
 public:
-  LogListCtx(list<cls_log_entry> *_entries, string *_marker, bool *_truncated) :
+  LogListCtx(vector<cls_log_entry> *_entries, string *_marker, bool *_truncated) :
                                       entries(_entries), marker(_marker), truncated(_truncated) {}
   void handle_completion(int r, bufferlist& outbl) override {
     if (r >= 0) {
@@ -115,7 +115,7 @@ public:
 
 void cls_log_list(librados::ObjectReadOperation& op, const utime_t& from,
 		  const utime_t& to, const string& in_marker, int max_entries,
-		  list<cls_log_entry>& entries,
+		  vector<cls_log_entry>& entries,
                   string *out_marker, bool *truncated)
 {
   bufferlist inbl;

--- a/src/cls/log/cls_log_client.h
+++ b/src/cls/log/cls_log_client.h
@@ -11,18 +11,18 @@
  * log objclass
  */
 
-void cls_log_add_prepare_entry(cls_log_entry& entry, ceph::real_time timestamp,
+void cls_log_add_prepare_entry(cls::log::entry& entry, ceph::real_time timestamp,
 			       const std::string& section,
 			       const std::string& name, ceph::buffer::list& bl);
 
-void cls_log_add(librados::ObjectWriteOperation& op, std::vector<cls_log_entry>& entries, bool monotonic_inc);
-void cls_log_add(librados::ObjectWriteOperation& op, cls_log_entry& entry);
+void cls_log_add(librados::ObjectWriteOperation& op, std::vector<cls::log::entry>& entries, bool monotonic_inc);
+void cls_log_add(librados::ObjectWriteOperation& op, cls::log::entry& entry);
 void cls_log_add(librados::ObjectWriteOperation& op, ceph::real_time timestamp,
                  const std::string& section, const std::string& name, ceph::buffer::list& bl);
 
 void cls_log_list(librados::ObjectReadOperation& op, ceph::real_time from,
 		  ceph::real_time to, const std::string& in_marker,
-		  int max_entries, std::vector<cls_log_entry>& entries,
+		  int max_entries, std::vector<cls::log::entry>& entries,
                   std::string *out_marker, bool *truncated);
 
 void cls_log_trim(librados::ObjectWriteOperation& op, ceph::real_time from_time,
@@ -37,6 +37,6 @@ int cls_log_trim(librados::IoCtx& io_ctx, const std::string& oid,
                  const std::string& from_marker, const std::string& to_marker);
 #endif
 
-void cls_log_info(librados::ObjectReadOperation& op, cls_log_header *header);
+void cls_log_info(librados::ObjectReadOperation& op, cls::log::header* header);
 
 #endif

--- a/src/cls/log/cls_log_client.h
+++ b/src/cls/log/cls_log_client.h
@@ -14,14 +14,14 @@
 void cls_log_add_prepare_entry(cls_log_entry& entry, const utime_t& timestamp,
                  const std::string& section, const std::string& name, ceph::buffer::list& bl);
 
-void cls_log_add(librados::ObjectWriteOperation& op, std::list<cls_log_entry>& entries, bool monotonic_inc);
+void cls_log_add(librados::ObjectWriteOperation& op, std::vector<cls_log_entry>& entries, bool monotonic_inc);
 void cls_log_add(librados::ObjectWriteOperation& op, cls_log_entry& entry);
 void cls_log_add(librados::ObjectWriteOperation& op, const utime_t& timestamp,
                  const std::string& section, const std::string& name, ceph::buffer::list& bl);
 
 void cls_log_list(librados::ObjectReadOperation& op, const utime_t& from,
 		  const utime_t& to, const std::string& in_marker,
-		  int max_entries, std::list<cls_log_entry>& entries,
+		  int max_entries, std::vector<cls_log_entry>& entries,
                   std::string *out_marker, bool *truncated);
 
 void cls_log_trim(librados::ObjectWriteOperation& op, const utime_t& from_time, const utime_t& to_time,

--- a/src/cls/log/cls_log_client.h
+++ b/src/cls/log/cls_log_client.h
@@ -11,26 +11,29 @@
  * log objclass
  */
 
-void cls_log_add_prepare_entry(cls_log_entry& entry, const utime_t& timestamp,
-                 const std::string& section, const std::string& name, ceph::buffer::list& bl);
+void cls_log_add_prepare_entry(cls_log_entry& entry, ceph::real_time timestamp,
+			       const std::string& section,
+			       const std::string& name, ceph::buffer::list& bl);
 
 void cls_log_add(librados::ObjectWriteOperation& op, std::vector<cls_log_entry>& entries, bool monotonic_inc);
 void cls_log_add(librados::ObjectWriteOperation& op, cls_log_entry& entry);
-void cls_log_add(librados::ObjectWriteOperation& op, const utime_t& timestamp,
+void cls_log_add(librados::ObjectWriteOperation& op, ceph::real_time timestamp,
                  const std::string& section, const std::string& name, ceph::buffer::list& bl);
 
-void cls_log_list(librados::ObjectReadOperation& op, const utime_t& from,
-		  const utime_t& to, const std::string& in_marker,
+void cls_log_list(librados::ObjectReadOperation& op, ceph::real_time from,
+		  ceph::real_time to, const std::string& in_marker,
 		  int max_entries, std::vector<cls_log_entry>& entries,
                   std::string *out_marker, bool *truncated);
 
-void cls_log_trim(librados::ObjectWriteOperation& op, const utime_t& from_time, const utime_t& to_time,
-                  const std::string& from_marker, const std::string& to_marker);
+void cls_log_trim(librados::ObjectWriteOperation& op, ceph::real_time from_time,
+		  ceph::real_time to_time, const std::string& from_marker,
+		  const std::string& to_marker);
 
 // these overloads which call io_ctx.operate() should not be called in the rgw.
 // rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
 #ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_log_trim(librados::IoCtx& io_ctx, const std::string& oid, const utime_t& from_time, const utime_t& to_time,
+int cls_log_trim(librados::IoCtx& io_ctx, const std::string& oid,
+		 ceph::real_time from_time, ceph::real_time to_time,
                  const std::string& from_marker, const std::string& to_marker);
 #endif
 

--- a/src/cls/log/cls_log_ops.h
+++ b/src/cls/log/cls_log_ops.h
@@ -35,13 +35,14 @@ struct cls_log_add_op {
   }
 
   static void generate_test_instances(std::list<cls_log_add_op *>& l) {
+    using namespace std::literals;
     l.push_back(new cls_log_add_op);
     l.push_back(new cls_log_add_op);
     l.back()->entries.push_back(cls_log_entry());
     l.back()->entries.push_back(cls_log_entry());
     l.back()->entries.back().section = "section";
     l.back()->entries.back().name = "name";
-    l.back()->entries.back().timestamp = utime_t(1, 2);
+    l.back()->entries.back().timestamp = ceph::real_time{1s + 2ns};
     l.back()->entries.back().data.append("data");
     l.back()->entries.back().id = "id";
   }
@@ -49,9 +50,9 @@ struct cls_log_add_op {
 WRITE_CLASS_ENCODER(cls_log_add_op)
 
 struct cls_log_list_op {
-  utime_t from_time;
+  ceph::real_time from_time;
   std::string marker; /* if not empty, overrides from_time */
-  utime_t to_time; /* not inclusive */
+  ceph::real_time to_time; /* not inclusive */
   int max_entries; /* upperbound to returned num of entries
                       might return less than that and still be truncated */
 
@@ -82,11 +83,12 @@ struct cls_log_list_op {
     f->dump_int("max_entries", max_entries);
   }
   static void generate_test_instances(std::list<cls_log_list_op*>& ls) {
+    using namespace std::literals;
     ls.push_back(new cls_log_list_op);
     ls.push_back(new cls_log_list_op);
-    ls.back()->from_time = utime_t(1, 2);
+    ls.back()->from_time = ceph::real_time{1s + 2ns};
     ls.back()->marker = "marker";
-    ls.back()->to_time = utime_t(3, 4);
+    ls.back()->to_time = ceph::real_time{3s + 4ns};
     ls.back()->max_entries = 5;
   }
 };
@@ -121,13 +123,14 @@ struct cls_log_list_ret {
     f->dump_bool("truncated", truncated);
   }
   static void generate_test_instances(std::list<cls_log_list_ret*>& ls) {
+    using namespace std::literals;
     ls.push_back(new cls_log_list_ret);
     ls.push_back(new cls_log_list_ret);
     ls.back()->entries.push_back(cls_log_entry());
     ls.back()->entries.push_back(cls_log_entry());
     ls.back()->entries.back().section = "section";
     ls.back()->entries.back().name = "name";
-    ls.back()->entries.back().timestamp = utime_t(1, 2);
+    ls.back()->entries.back().timestamp = ceph::real_time{1s + 2ns};
     ls.back()->entries.back().data.append("data");
     ls.back()->entries.back().id = "id";
     ls.back()->marker = "marker";
@@ -142,8 +145,8 @@ WRITE_CLASS_ENCODER(cls_log_list_ret)
  * -ENODATA when done, so caller needs to repeat sending request until that.
  */
 struct cls_log_trim_op {
-  utime_t from_time;
-  utime_t to_time; /* inclusive */
+  ceph::real_time from_time;
+  ceph::real_time to_time; /* inclusive */
   std::string from_marker;
   std::string to_marker;
 
@@ -175,10 +178,11 @@ struct cls_log_trim_op {
     f->dump_string("to_marker", to_marker);
   }
   static void generate_test_instances(std::list<cls_log_trim_op*>& ls) {
+    using namespace std::literals;
     ls.push_back(new cls_log_trim_op);
     ls.push_back(new cls_log_trim_op);
-    ls.back()->from_time = utime_t(1, 2);
-    ls.back()->to_time = utime_t(3, 4);
+    ls.back()->from_time = ceph::real_time{1s + 2ns};
+    ls.back()->to_time = ceph::real_time(3s + 4ns);
     ls.back()->from_marker = "from_marker";
     ls.back()->to_marker = "to_marker";
   }

--- a/src/cls/log/cls_log_ops.h
+++ b/src/cls/log/cls_log_ops.h
@@ -4,14 +4,20 @@
 #ifndef CEPH_CLS_LOG_OPS_H
 #define CEPH_CLS_LOG_OPS_H
 
+#include <string>
+#include <vector>
+
 #include "common/ceph_json.h"
+#include "common/ceph_time.h"
+
 #include "cls_log_types.h"
 
-struct cls_log_add_op {
-  std::vector<cls_log_entry> entries;
-  bool monotonic_inc;
+namespace cls::log::ops {
+struct add_op {
+  std::vector<entry> entries;
+  bool monotonic_inc = true;
 
-  cls_log_add_op() : monotonic_inc(true) {}
+  add_op() = default;
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
@@ -34,12 +40,12 @@ struct cls_log_add_op {
     encode_json("monotonic_inc", monotonic_inc, f);
   }
 
-  static void generate_test_instances(std::list<cls_log_add_op *>& l) {
+  static void generate_test_instances(std::list<add_op *>& l) {
     using namespace std::literals;
-    l.push_back(new cls_log_add_op);
-    l.push_back(new cls_log_add_op);
-    l.back()->entries.push_back(cls_log_entry());
-    l.back()->entries.push_back(cls_log_entry());
+    l.push_back(new add_op);
+    l.push_back(new add_op);
+    l.back()->entries.push_back(entry{});
+    l.back()->entries.push_back(entry{});
     l.back()->entries.back().section = "section";
     l.back()->entries.back().name = "name";
     l.back()->entries.back().timestamp = ceph::real_time{1s + 2ns};
@@ -47,16 +53,16 @@ struct cls_log_add_op {
     l.back()->entries.back().id = "id";
   }
 };
-WRITE_CLASS_ENCODER(cls_log_add_op)
+WRITE_CLASS_ENCODER(add_op)
 
-struct cls_log_list_op {
+struct list_op {
   ceph::real_time from_time;
   std::string marker; /* if not empty, overrides from_time */
   ceph::real_time to_time; /* not inclusive */
-  int max_entries; /* upperbound to returned num of entries
-                      might return less than that and still be truncated */
+  int max_entries = 0; /* upperbound to returned num of entries
+			  might return less than that and still be truncated */
 
-  cls_log_list_op() : max_entries(0) {}
+  list_op() = default;
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
@@ -82,24 +88,24 @@ struct cls_log_list_op {
     f->dump_stream("to_time") << to_time;
     f->dump_int("max_entries", max_entries);
   }
-  static void generate_test_instances(std::list<cls_log_list_op*>& ls) {
+  static void generate_test_instances(std::list<list_op*>& ls) {
     using namespace std::literals;
-    ls.push_back(new cls_log_list_op);
-    ls.push_back(new cls_log_list_op);
+    ls.push_back(new list_op);
+    ls.push_back(new list_op);
     ls.back()->from_time = ceph::real_time{1s + 2ns};
     ls.back()->marker = "marker";
     ls.back()->to_time = ceph::real_time{3s + 4ns};
     ls.back()->max_entries = 5;
   }
 };
-WRITE_CLASS_ENCODER(cls_log_list_op)
+WRITE_CLASS_ENCODER(list_op)
 
-struct cls_log_list_ret {
-  std::vector<cls_log_entry> entries;
+struct list_ret {
+  std::vector<entry> entries;
   std::string marker;
   bool truncated;
 
-  cls_log_list_ret() : truncated(false) {}
+  list_ret() : truncated(false) {}
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
@@ -122,12 +128,12 @@ struct cls_log_list_ret {
     f->dump_string("marker", marker);
     f->dump_bool("truncated", truncated);
   }
-  static void generate_test_instances(std::list<cls_log_list_ret*>& ls) {
+  static void generate_test_instances(std::list<list_ret*>& ls) {
     using namespace std::literals;
-    ls.push_back(new cls_log_list_ret);
-    ls.push_back(new cls_log_list_ret);
-    ls.back()->entries.push_back(cls_log_entry());
-    ls.back()->entries.push_back(cls_log_entry());
+    ls.push_back(new list_ret);
+    ls.push_back(new list_ret);
+    ls.back()->entries.push_back(entry{});
+    ls.back()->entries.push_back(entry{});
     ls.back()->entries.back().section = "section";
     ls.back()->entries.back().name = "name";
     ls.back()->entries.back().timestamp = ceph::real_time{1s + 2ns};
@@ -137,20 +143,19 @@ struct cls_log_list_ret {
     ls.back()->truncated = true;
   }
 };
-WRITE_CLASS_ENCODER(cls_log_list_ret)
-
+WRITE_CLASS_ENCODER(list_ret)
 
 /*
  * operation will return 0 when successfully removed but not done. Will return
  * -ENODATA when done, so caller needs to repeat sending request until that.
  */
-struct cls_log_trim_op {
+struct trim_op {
   ceph::real_time from_time;
   ceph::real_time to_time; /* inclusive */
   std::string from_marker;
   std::string to_marker;
 
-  cls_log_trim_op() {}
+  trim_op() = default;
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
@@ -177,20 +182,20 @@ struct cls_log_trim_op {
     f->dump_string("from_marker", from_marker);
     f->dump_string("to_marker", to_marker);
   }
-  static void generate_test_instances(std::list<cls_log_trim_op*>& ls) {
+  static void generate_test_instances(std::list<trim_op*>& ls) {
     using namespace std::literals;
-    ls.push_back(new cls_log_trim_op);
-    ls.push_back(new cls_log_trim_op);
+    ls.push_back(new trim_op);
+    ls.push_back(new trim_op);
     ls.back()->from_time = ceph::real_time{1s + 2ns};
     ls.back()->to_time = ceph::real_time(3s + 4ns);
     ls.back()->from_marker = "from_marker";
     ls.back()->to_marker = "to_marker";
   }
 };
-WRITE_CLASS_ENCODER(cls_log_trim_op)
+WRITE_CLASS_ENCODER(trim_op)
 
-struct cls_log_info_op {
-  cls_log_info_op() {}
+struct info_op {
+  info_op() = default;
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
@@ -207,27 +212,28 @@ struct cls_log_info_op {
   void dump(ceph::Formatter* f) const {
   }
 
-  static void generate_test_instances(std::list<cls_log_info_op*>& ls) {
-    ls.push_back(new cls_log_info_op);
+  static void generate_test_instances(std::list<info_op*>& ls) {
+    ls.push_back(new info_op);
   }
 };
-WRITE_CLASS_ENCODER(cls_log_info_op)
+WRITE_CLASS_ENCODER(info_op)
 
-struct cls_log_info_ret {
-  cls_log_header header;
+struct info_ret {
+  cls::log::header header;
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
-    encode(header, bl);
+    encode(this->header, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(1, bl);
-    decode(header, bl);
+    decode(this->header, bl);
     DECODE_FINISH(bl);
   }
 };
-WRITE_CLASS_ENCODER(cls_log_info_ret)
+WRITE_CLASS_ENCODER(info_ret)
+} // namespace cls::log::ops
 
 #endif

--- a/src/cls/log/cls_log_ops.h
+++ b/src/cls/log/cls_log_ops.h
@@ -8,7 +8,7 @@
 #include "cls_log_types.h"
 
 struct cls_log_add_op {
-  std::list<cls_log_entry> entries;
+  std::vector<cls_log_entry> entries;
   bool monotonic_inc;
 
   cls_log_add_op() : monotonic_inc(true) {}
@@ -93,7 +93,7 @@ struct cls_log_list_op {
 WRITE_CLASS_ENCODER(cls_log_list_op)
 
 struct cls_log_list_ret {
-  std::list<cls_log_entry> entries;
+  std::vector<cls_log_entry> entries;
   std::string marker;
   bool truncated;
 

--- a/src/cls/log/cls_log_types.h
+++ b/src/cls/log/cls_log_types.h
@@ -17,17 +17,18 @@
 class JSONObj;
 class JSONDecoder;
 
-struct cls_log_entry {
+namespace cls::log {
+struct entry {
   std::string id;
   std::string section;
   std::string name;
   ceph::real_time timestamp;
   ceph::buffer::list data;
 
-  cls_log_entry() = default;
+  entry() = default;
 
-  cls_log_entry(ceph::real_time timestamp, std::string section,
-		std::string name, ceph::buffer::list&& data)
+  entry(ceph::real_time timestamp, std::string section,
+	std::string name, ceph::buffer::list&& data)
     : section(std::move(section)), name(std::move(name)),
       timestamp(timestamp), data(std::move(data)) {}
 
@@ -68,9 +69,9 @@ struct cls_log_entry {
     JSONDecoder::decode_json("id", id, obj);
   }
 
-  static void generate_test_instances(std::list<cls_log_entry *>& l) {
-    l.push_back(new cls_log_entry{});
-    l.push_back(new cls_log_entry);
+  static void generate_test_instances(std::list<cls::log::entry *>& l) {
+    l.push_back(new cls::log::entry{});
+    l.push_back(new cls::log::entry);
     l.back()->id = "test_id";
     l.back()->section = "test_section";
     l.back()->name = "test_name";
@@ -80,9 +81,9 @@ struct cls_log_entry {
     l.back()->data = bl;
   }
 };
-WRITE_CLASS_ENCODER(cls_log_entry)
+WRITE_CLASS_ENCODER(entry)
 
-struct cls_log_header {
+struct header {
   std::string max_marker;
   ceph::real_time max_time;
 
@@ -99,25 +100,20 @@ struct cls_log_header {
     decode(max_time, bl);
     DECODE_FINISH(bl);
   }
+
   void dump(ceph::Formatter* f) const {
     f->dump_string("max_marker", max_marker);
     f->dump_stream("max_time") << max_time;
   }
-  static void generate_test_instances(std::list<cls_log_header*>& o) {
-    o.push_back(new cls_log_header);
-    o.push_back(new cls_log_header);
+  static void generate_test_instances(std::list<header*>& o) {
+    o.push_back(new header);
+    o.push_back(new header);
     o.back()->max_marker = "test_marker";
     o.back()->max_time = ceph::real_clock::zero();
   }
+  friend auto operator <=>(const header&, const header&) = default;
 };
-inline bool operator ==(const cls_log_header& lhs, const cls_log_header& rhs) {
-  return (lhs.max_marker == rhs.max_marker &&
-	  lhs.max_time == rhs.max_time);
-}
-inline bool operator !=(const cls_log_header& lhs, const cls_log_header& rhs) {
-  return !(lhs == rhs);
-}
-WRITE_CLASS_ENCODER(cls_log_header)
-
+WRITE_CLASS_ENCODER(header)
+} // namespace cls::log
 
 #endif

--- a/src/cls/log/cls_log_types.h
+++ b/src/cls/log/cls_log_types.h
@@ -3,9 +3,11 @@
 #ifndef CEPH_CLS_LOG_TYPES_H
 #define CEPH_CLS_LOG_TYPES_H
 
+#include <string>
+
+#include "include/buffer.h"
 #include "include/encoding.h"
 #include "include/types.h"
-
 #include "include/utime.h"
 
 #include "common/ceph_json.h"
@@ -14,7 +16,6 @@
 class JSONObj;
 class JSONDecoder;
 
-
 struct cls_log_entry {
   std::string id;
   std::string section;
@@ -22,7 +23,17 @@ struct cls_log_entry {
   utime_t timestamp;
   ceph::buffer::list data;
 
-  cls_log_entry() {}
+  cls_log_entry() = default;
+
+  cls_log_entry(ceph::real_time timestamp, std::string section,
+		std::string name, ceph::buffer::list&& data)
+    : section(std::move(section)), name(std::move(name)),
+      timestamp(utime_t(timestamp)), data(std::move(data)) {}
+
+  cls_log_entry(utime_t timestamp, std::string section,
+		std::string name, ceph::buffer::list&& data)
+    : section(std::move(section)), name(std::move(name)), timestamp(timestamp),
+      data(std::move(data)) {}
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);

--- a/src/cls/sem_set/DESIGN.md
+++ b/src/cls/sem_set/DESIGN.md
@@ -1,0 +1,133 @@
+# Closing the RGWDataChangesLog write hole #
+
+The Cause: The 'window' optimization creates a situation where some
+changes exist only in RAM until a timer expires. If an RGW crashes
+after a write, the data log entry might never be made.
+
+## Requirements ##
+
+* We need to handle syncing to multiple zones
+* Some zones may not sync some buckets
+* We need to maintain a strict ordering within the shard, with shards
+  with the oldest un-swnc activity coming at the top of the listing
+* We need to coalesce writes within a shard
+* Spurious entries are permitted (but should be infrequent). They
+  impact efficiency, not correctness.
+
+## Definitions ##
+
+* `RGWDataChangesLog`: The class implementing the datalog
+  functionality.
+* `cur_cycle`: The current working set of entries that will be written
+  to FIFO at the close of the window.
+* `add_entry`: The function in the datalog API to write an entry.
+* `renew_entries`: Function run periodically to write an entry to FIFO
+  for every bucketshard in `cur_cycle`.
+* `recover`: Proposed function to complete initiated but incomplete datalog writes.
+* semaphore object: Proposed object on the OSD holding a count for
+  every bucketshard, sharded the same as datalog shards.
+* bs1, ...: Arbitrary bucket shards
+
+## Current Proposal ##
+
+* Make `add_entry` a transaction.
+* Reify `cur_cycle` on the OSD in the semaphore object.
+* Add a `recover` function to be run at startup.
+* Keep the window optimization.
+
+
+### RGWDataChangesLog ###
+
+* When `add_entry` is called with bs1:
+    + If `cur_cycle` does not contain bs1, increment bs1's count in
+      the semaphore object
+	+ Otherwise, proceed as we do currently.
+* In `renew_entries`, after the FIFO entry for a given shard has been
+  written, decrement the count associated with that bucket shard on
+  the semaphore object.
+* In `recover`:
+    1. Read the semaphore object, keeping bucketshards and counts in
+       memory (`unordered_map`).
+	2. For every bucketshard, write an entry into the FIFO.
+    3. Send a notification on the semaphore object
+    4. On receiving a notification, RGWDataChangesLog will send
+       `cur_cycle` as the response.
+    5. On successful notify, go through each response and decrement
+       each bucketshard in the unordered map.  (e.g. if three RGWs
+       respond with bs1 in their `cur_cycle`, bs1 will be decremented
+       thrice)
+	6. For each entry in the unordered map, decrement on the semaphore
+       object only if the object's count is greater than 0.
+    7. If the `notify` operation errors, don't decrement anything.
+* Have some task call `compress` on a regular basis (Daily? Hourly?),
+  to keep seldom used or deleted bucket shards from slowing down
+  listing
+
+
+### CLS module requirements ###
+
+* Our back-end data store will be omap. We will use exactly one
+  key/value pair for every bucketshard in the system
+* To avoid the performance problems of deletes and reinsertions, don't
+  delete keys when they fall to zero, just set their value to 0.
+
+#### Operations ####
+
+* increment([bucketshard, ...]) -> {}:
+    - For each bucketshard, look up the given key in omap. If it
+      exists, set the value to one more than is currently
+      there. Otherwise create it with a value of 1.
+        + decrement([bucketshard, ...]) -> {}:
+    - For each bucketshard, look it up in omap. If it does not exist
+      or the value is 0, error. Otherwise write decremented value.
+    - Should it actually error or do we want saturating arithmetic at
+      0? Given that the recovery design proposed below allows values
+      to remain spuriously non-decremented but tries to rule out
+      spurious decrements, we likely want to have the system scream
+      bloody murder if we underflow.
+        + list(cursor?) -> ([(entry, count), ...], cursor):
+    - Return entries starting from cursor. Skip any with a semaphore of 0.
+        + compress(cursor?) -> cursor?:
+            - Go through and delete all entries with a 0 count.
+            - Return cursor if we can't fit more calls the operation
+              and need another go-round
+
+## Analysis ##
+
+* Casey's semaphore idea solves the race between `add_entry` and
+  `renew_entries` within a single process and between RGWs on
+  different hosts
+* The use of watch/notify solves the potential race between `recover`
+  and other RGWs, ensuring that we won't delete someone else's
+  transaction.
+* As described, notify fails safe, as we don't decrement semaphores on
+  error. This can lead to spurious recover in the future, but that's
+  not harmful.
+* In general, unpaired increments are considered acceptable, as
+  they'll tend toward zero over time through recovery.
+* Watch/Notify seems a better choice than locking, as it can't
+  introduce a stall on `add_entry`.
+* `increment`/`decrement` take a vector of bucketshards so they're
+  ready to support batching.
+* We will never have more omap entries than we do bucketshards in the
+  system, and the operations are eventually all read-modify-write. Not
+  deleting saves us from the worst pathologies of omap.
+
+## Questions ##
+
+* Do we want to shard the semaphore object?
+    - [casey] yes, for write parallelism. we don't want all object
+      writes to serialize on a single rados object
+
+* What happens when we delete buckets? Would we need to clean up the
+  asociated bucketshards and delete them?
+    - [casey] same comes up for bucket reshards, where we add :gen to
+     these bucket-shard-gen keys i do think we want to delete keys
+     after they reach 0. ideally we'd do this in batches rocksdb
+     deletes suck because they leave lots of tombstones behind, but
+     that mainly effects listing performance. here we only list for
+     recovery, and recovery only wants to see entries with count > 0
+
+* Is a separate `compress` function really necessary? It might be
+  worth doing test runs between a version that just deletes inline and
+  one that uses a separate compress step.

--- a/src/cls/sem_set/module.cc
+++ b/src/cls/sem_set/module.cc
@@ -1,0 +1,235 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <concepts>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <string_view>
+
+#include "include/rados/objclass.h"
+
+#include "common/config_proxy.h"
+
+#include "cls/sem_set/ops.h"
+
+#include "objclass/objclass.h"
+
+
+namespace buffer = ::ceph::buffer;
+namespace ss = ::cls::sem_set;
+
+using namespace std::literals;
+
+namespace {
+/// So we don't clash with other OMAP keys.
+inline constexpr auto PREFIX = "CLS_SEM_SET_"sv;
+
+/// Returns a value encoded in a bufferlist
+template<std::default_initializable T>
+inline auto from_bl(const buffer::list& bl)
+{
+  using ceph::decode;
+  T t;
+  auto bi = bl.begin();
+  decode(t, bi);
+  return t;
+}
+
+int increment(cls_method_context_t hctx, buffer::list *in, buffer::list *out)
+{
+  CLS_LOG(10, "%s", __PRETTY_FUNCTION__);
+
+  ss::increment op;
+  try {
+    auto iter = in->cbegin();
+    decode(op, iter);
+  } catch (const std::exception& e) {
+    CLS_ERR("ERROR: %s:%d failed to decode request: %s", __PRETTY_FUNCTION__,
+            __LINE__, e.what());
+    return -EINVAL;
+  }
+
+  const auto& max_omap = cls_get_config(hctx).get_val<std::uint64_t>(
+    "osd_max_omap_entries_per_request"sv);
+  if (op.keys.size() > max_omap) {
+    CLS_ERR("ERROR: %s:%d too many keys: %zu", __PRETTY_FUNCTION__,
+	    __LINE__, op.keys.size());
+    return -E2BIG;
+  }
+
+  for (const auto& key_ : op.keys) try {
+      buffer::list valbl;
+      auto key = std::string(PREFIX) + key_;
+      auto r = cls_cxx_map_get_val(hctx, key, &valbl);
+      std::uint64_t sem = 0;
+      if (r >= 0) {
+	sem = from_bl<std::uint64_t>(valbl);
+	valbl.clear();
+      } else if (r == -ENOENT) {
+	sem = 0;
+      } else {
+        CLS_ERR("ERROR: %s:%d failed to read semaphore: r=%d",
+                __PRETTY_FUNCTION__, __LINE__, r);
+        return r;
+      }
+      ceph::encode(sem + 1, valbl);
+      r = cls_cxx_map_set_val(hctx, key, &valbl);
+      if (r < 0) {
+        CLS_ERR("ERROR: %s:%d failed to update semaphore: r=%d",
+                __PRETTY_FUNCTION__, __LINE__, r);
+        return r;
+      }
+    } catch (const std::exception& e) {
+      CLS_ERR("CAN'T HAPPEN: %s:%d failed to decode semaphore: %s",
+              __PRETTY_FUNCTION__, __LINE__, e.what());
+      return -EIO;
+    }
+
+  return 0;
+}
+
+int decrement(cls_method_context_t hctx, buffer::list *in, buffer::list *out)
+{
+  CLS_LOG(10, "%s", __PRETTY_FUNCTION__);
+
+  ss::decrement op;
+  try {
+    auto iter = in->cbegin();
+    decode(op, iter);
+  } catch (const std::exception& e) {
+    CLS_ERR("ERROR: %s:%d failed to decode request: %s", __PRETTY_FUNCTION__,
+            __LINE__, e.what());
+    return -EINVAL;
+  }
+
+  const auto& max_omap = cls_get_config(hctx).get_val<std::uint64_t>(
+    "osd_max_omap_entries_per_request"sv);
+  if (op.keys.size() > max_omap) {
+    CLS_ERR("ERROR: %s:%d too many keys: %zu", __PRETTY_FUNCTION__,
+	    __LINE__, op.keys.size());
+    return -E2BIG;
+  }
+
+  for (const auto& key_ : op.keys) try {
+      buffer::list valbl;
+      auto key = std::string(PREFIX) + key_;
+      auto r = cls_cxx_map_get_val(hctx, key, &valbl);
+      if (r < 0) {
+        CLS_ERR("ERROR: %s:%d failed to read semaphore: r=%d",
+                __PRETTY_FUNCTION__, __LINE__, r);
+        return r;
+      }
+      auto sem = from_bl<std::uint64_t>(valbl);
+      if (sem > 1) {
+	--sem;
+        valbl.clear();
+        ceph::encode(sem, valbl);
+        r = cls_cxx_map_set_val(hctx, key, &valbl);
+        if (r < 0) {
+          CLS_ERR("ERROR: %s:%d failed to update semaphore: r=%d",
+                  __PRETTY_FUNCTION__, __LINE__, r);
+          return r;
+        }
+      } else {
+        r = cls_cxx_map_remove_key(hctx, key);
+        if (r < 0) {
+          CLS_ERR("ERROR: %s:%d failed to remove key %s: r=%d",
+                  __PRETTY_FUNCTION__, __LINE__, key.c_str(), r);
+          return r;
+        }
+      }
+    } catch (const std::exception& e) {
+      CLS_ERR("CORRUPTION: %s:%d failed to decode semaphore: %s",
+              __PRETTY_FUNCTION__, __LINE__, e.what());
+      return -EIO;
+    }
+
+  return 0;
+}
+
+int list(cls_method_context_t hctx, buffer::list *in, buffer::list *out)
+{
+  CLS_LOG(10, "%s", __PRETTY_FUNCTION__);
+
+  ss::list_op op;
+  try {
+    auto iter = in->cbegin();
+    decode(op, iter);
+  } catch (const std::exception& e) {
+    CLS_ERR("ERROR: %s:%d failed to decode request: %s", __PRETTY_FUNCTION__,
+            __LINE__, e.what());
+    return -EINVAL;
+  }
+
+  auto count = op.count;
+  const auto& max_omap = cls_get_config(hctx).get_val<std::uint64_t>(
+    "osd_max_omap_entries_per_request"sv);
+  if (count > max_omap) {
+    // We clamp rather than error, here, since a lister can just
+    // continue listing with the supplied cursor.
+    count = max_omap;
+  }
+  ss::list_ret res;
+  res.cursor = op.cursor;
+
+  while (count > 0) {
+    std::map<std::string, ceph::buffer::list> vals;
+    bool more = false;
+    auto r = cls_cxx_map_get_vals(hctx,
+				  res.cursor ? *res.cursor : std::string{},
+				  std::string(PREFIX), count,
+				  &vals, &more);
+    if (r < 0) {
+      CLS_ERR("ERROR: %s:%d failed to read semaphore: r=%d",
+              __PRETTY_FUNCTION__, __LINE__, r);
+      return r;
+    }
+
+    count = vals.size() <= count ? count - vals.size() : 0;
+
+    if (!vals.empty()) {
+      res.cursor = (--vals.end())->first;
+    }
+    for (auto&& [key_, valbl] : vals) {
+      res.kvs.emplace(std::piecewise_construct,
+                      std::forward_as_tuple(std::move(key_), PREFIX.size()),
+                      std::forward_as_tuple(from_bl<std::uint64_t>(valbl)));
+    }
+    if (!more) {
+      res.cursor.reset();
+      break;
+    }
+  }
+
+  encode(res, *out);
+  return 0;
+}
+} // namespace (anonymous)
+
+CLS_INIT(sem_set)
+{
+  cls_handle_t h_class;
+  cls_method_handle_t h_increment;
+  cls_method_handle_t h_decrement;
+  cls_method_handle_t h_list;
+
+  cls_register(ss::CLASS, &h_class);
+  cls_register_cxx_method(h_class, ss::INCREMENT,
+                          CLS_METHOD_RD | CLS_METHOD_WR,
+                          &increment, &h_increment);
+
+  cls_register_cxx_method(h_class, ss::INCREMENT,
+                          CLS_METHOD_RD | CLS_METHOD_WR,
+                          &decrement, &h_increment);
+
+  cls_register_cxx_method(h_class, ss::DECREMENT,
+                          CLS_METHOD_RD | CLS_METHOD_WR,
+                          &decrement, &h_decrement);
+
+  cls_register_cxx_method(h_class, ss::LIST,
+                          CLS_METHOD_RD,
+                          &list, &h_list);
+
+  return;
+}

--- a/src/cls/sem_set/ops.h
+++ b/src/cls/sem_set/ops.h
@@ -1,0 +1,99 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <cstdint>
+#include <initializer_list>
+#include <iterator>
+#include <string>
+#include <unordered_set>
+#include <unordered_map>
+
+#include "include/encoding.h"
+
+namespace cls::sem_set {
+namespace buffer = ceph::buffer;
+
+/// Input to increment and decrement operations
+struct incdec {
+  std::unordered_set<std::string> keys;
+
+  incdec() = default;
+
+  incdec(std::string s)
+    : keys({std::move(s)}) {}
+
+  incdec(std::initializer_list<std::string> l)
+    : keys(l) {}
+
+  template<std::input_iterator I>
+  incdec(I begin, I end)
+    requires std::is_convertible_v<typename I::value_type, std::string>
+    : keys(begin, end) {}
+
+  void encode(buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(keys, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(keys, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(incdec);
+
+using increment = incdec;
+using decrement = incdec;
+
+struct list_op {
+  std::uint64_t count;
+  std::optional<std::string> cursor;
+
+  void encode(buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(count, bl);
+    encode(cursor, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(count, bl);
+    decode(cursor, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(list_op);
+
+struct list_ret {
+  std::unordered_map<std::string, std::uint64_t> kvs;
+  std::optional<std::string> cursor;
+
+  list_ret() = default;
+
+  void encode(buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(kvs, bl);
+    encode(cursor, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(kvs, bl);
+    decode(cursor, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(list_ret);
+
+inline constexpr auto CLASS = "sem_set";
+inline constexpr auto INCREMENT = "increment";
+inline constexpr auto DECREMENT = "decrement";
+inline constexpr auto LIST = "list";
+
+} // namespace cls::sem_set

--- a/src/cls/version/cls_version_types.h
+++ b/src/cls/version/cls_version_types.h
@@ -4,8 +4,14 @@
 #ifndef CEPH_CLS_VERSION_TYPES_H
 #define CEPH_CLS_VERSION_TYPES_H
 
+#include <cstdint>
+#include <iostream>
+#include <list>
+#include <string>
+
 #include "include/encoding.h"
 #include "include/types.h"
+
 
 class JSONObj;
 
@@ -62,6 +68,10 @@ struct obj_version {
   static void generate_test_instances(std::list<obj_version*>& o);
 };
 WRITE_CLASS_ENCODER(obj_version)
+
+inline std::ostream& operator <<(std::ostream& m, const obj_version& v) {
+  return m << v.tag << ":" << v.ver;
+}
 
 enum VersionCond {
   VER_COND_NONE =      0,

--- a/src/cls/version/cls_version_types.h
+++ b/src/cls/version/cls_version_types.h
@@ -17,10 +17,12 @@ class JSONObj;
 
 
 struct obj_version {
-  uint64_t ver;
+  uint64_t ver = 0;
   std::string tag;
 
-  obj_version() : ver(0) {}
+  obj_version() = default;
+  obj_version(uint64_t ver, std::string tag)
+    : ver(ver), tag(std::move(tag)) {}
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);

--- a/src/common/async/async_call.h
+++ b/src/common/async/async_call.h
@@ -1,0 +1,215 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+/// \file common/async/async_call.h
+///
+/// \brief Wait for functions to run on arbitrary executors
+
+#include <concepts>
+#include <type_traits>
+
+#include <boost/asio/compose.hpp>
+#include <boost/asio/defer.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/post.hpp>
+
+namespace ceph::async {
+/// \brief Dispatch a function on another executor and wait for it to
+/// finish
+///
+/// Useful with strands and similar
+///
+/// \param executor The executor on which to call the function
+/// \param f The function to call
+/// \param token Boost.Asio completion token
+/// \param ioe Parameter pack of executors and I/O Objects to keep live
+///
+/// \return The return value of `f` in a way appropriate to the
+/// completion token. See Boost.Asio documentation.
+template<std::invocable<> F,
+	 boost::asio::completion_token_for<
+	   void(std::invoke_result_t<F>)> CompletionToken,
+	 typename ...IOE>
+auto async_dispatch(auto executor, F&& f, CompletionToken&& token, IOE&& ...ioe)
+{
+  namespace asio = boost::asio;
+  return asio::async_compose<
+    CompletionToken,
+    void(std::invoke_result_t<F>)>(
+      [&executor, f = std::move(f)] (auto& self) mutable {
+	asio::dispatch(
+	  executor,
+	  [f = std::move(f), self = std::move(self)]() mutable {
+	    self.complete(std::invoke(f));
+	  });
+      }, token, executor, std::forward<IOE>(ioe)...);
+}
+
+/// \brief Dispatch a function on another executor and wait for it to
+/// finish
+///
+/// Useful with strands and similar
+///
+/// \param executor The executor on which to call the function
+/// \param f The function to call
+/// \param token Boost.Asio completion token
+/// \param ioe Parameter pack of executors and I/O Objects to keep live
+///
+/// \return The return value of `f` in a way appropriate to the
+/// completion token. See Boost.Asio documentation.
+template<std::invocable<> F,
+	 boost::asio::completion_token_for<void()> CompletionToken,
+	 typename ...IOE,
+	 typename = std::enable_if_t<std::is_void_v<std::invoke_result_t<F>>>>
+auto async_dispatch(auto executor, F&& f, CompletionToken&& token, IOE&& ...ioe)
+{
+  namespace asio = boost::asio;
+  return asio::async_compose<
+    CompletionToken, void()>(
+      [&executor, f = std::move(f)] (auto& self) mutable {
+	asio::dispatch(
+	  executor,
+	  [f = std::move(f), self = std::move(self)]() mutable {
+	    std::invoke(f);
+	    self.complete();
+	  });
+      }, token, executor, std::forward<IOE>(ioe)...);
+}
+
+/// \brief Post a function on another executor and wait for it to
+/// finish
+///
+/// Useful with strands and similar
+///
+/// \param executor The executor on which to call the function
+/// \param f The function to call
+/// \param token Boost.Asio completion token
+/// \param ioe Parameter pack of executors and I/O Objects to keep live
+///
+/// \return The return value of `f` in a way appropriate to the
+/// completion token. See Boost.Asio documentation.
+template<std::invocable<> F,
+	 boost::asio::completion_token_for<
+	   void(std::invoke_result_t<F>)> CompletionToken,
+	 typename ...IOE>
+auto async_post(auto executor, F&& f, CompletionToken&& token, IOE&& ...ioe)
+{
+  namespace asio = boost::asio;
+  return asio::async_compose<
+    CompletionToken,
+    void(std::invoke_result_t<F>)>(
+      [&executor, f = std::move(f)] (auto& self) mutable {
+	asio::post(
+	  executor,
+	  [f = std::move(f), self = std::move(self)]() mutable {
+	    self.complete(std::invoke(f));
+	  });
+      }, token, executor, std::forward<IOE>(ioe)...);
+}
+
+/// \brief Post a function on another executor and wait for it to
+/// finish
+///
+/// Useful with strands and similar
+///
+/// \param executor The executor on which to call the function
+/// \param f The function to call
+/// \param token Boost.Asio completion token
+/// \param ioe Parameter pack of executors and I/O Objects to keep live
+///
+/// \return The return value of `f` in a way appropriate to the
+/// completion token. See Boost.Asio documentation.
+template<std::invocable<> F,
+	 boost::asio::completion_token_for<void()> CompletionToken,
+	 typename ...IOE,
+	 typename = std::enable_if_t<std::is_void_v<std::invoke_result_t<F>>>>
+auto async_post(auto executor, F&& f, CompletionToken&& token, IOE&& ...ioe)
+{
+  namespace asio = boost::asio;
+  return asio::async_compose<
+    CompletionToken, void()>(
+      [&executor, f = std::move(f)] (auto& self) mutable {
+	asio::post(
+	  executor,
+	  [f = std::move(f), self = std::move(self)]() mutable {
+	    std::invoke(f);
+	    self.complete();
+	  });
+      }, token, executor, std::forward<IOE>(ioe)...);
+}
+
+/// \brief Defer a function on another executor and wait for it to
+/// finish
+///
+/// Useful with strands and similar
+///
+/// \param executor The executor on which to call the function
+/// \param f The function to call
+/// \param token Boost.Asio completion token
+/// \param ioe Parameter pack of executors and I/O Objects to keep live
+///
+/// \return The return value of `f` in a way appropriate to the
+/// completion token. See Boost.Asio documentation.
+template<std::invocable<> F,
+	 boost::asio::completion_token_for<
+	   void(std::invoke_result_t<F>)> CompletionToken,
+	 typename ...IOE>
+auto async_defer(auto executor, F&& f, CompletionToken&& token, IOE&& ...ioe)
+{
+  namespace asio = boost::asio;
+  return asio::async_compose<
+    CompletionToken,
+    void(std::invoke_result_t<F>)>(
+      [&executor, f = std::move(f)] (auto& self) mutable {
+	asio::defer(
+	  executor,
+	  [f = std::move(f), self = std::move(self)]() mutable {
+	    self.complete(std::invoke(f));
+	  });
+      }, token, executor, std::forward<IOE>(ioe)...);
+}
+
+/// \brief Defer a function on another executor and wait for it to
+/// finish
+///
+/// Useful with strands and similar
+///
+/// \param executor The executor on which to call the function
+/// \param f The function to call
+/// \param token Boost.Asio completion token
+/// \param ioe Parameter pack of executors and I/O Objects to keep live
+///
+/// \return The return value of `f` in a way appropriate to the
+/// completion token. See Boost.Asio documentation.
+template<std::invocable<> F,
+	 boost::asio::completion_token_for<void()> CompletionToken,
+	 typename ...IOE,
+	 typename = std::enable_if_t<std::is_void_v<std::invoke_result_t<F>>>>
+auto async_defer(auto executor, F&& f, CompletionToken&& token, IOE&& ...ioe)
+{
+  namespace asio = boost::asio;
+  return asio::async_compose<
+    CompletionToken, void()>(
+      [&executor, f = std::move(f)] (auto& self) mutable {
+	asio::defer(
+	  executor,
+	  [f = std::move(f), self = std::move(self)]() mutable {
+	    std::invoke(f);
+	    self.complete();
+	  });
+      }, token, executor, std::forward<IOE>(ioe)...);
+}
+}

--- a/src/common/async/async_cond.h
+++ b/src/common/async/async_cond.h
@@ -1,0 +1,163 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+/// \file common/async/async_cond.h
+
+#include <cassert>
+#include <concepts>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include <boost/asio/any_completion_handler.hpp>
+#include <boost/asio/append.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/consign.hpp>
+#include <boost/asio/strand.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+
+#include <boost/system/error_code.hpp>
+
+namespace ceph::async {
+/// \brief A non-blocking condition variable
+///
+/// This is effectively a condition variable, but rather than
+/// blocking, the `wait` function takes an Asio completion token and
+/// invokes the associated handler on wakeup.
+template<typename Executor>
+class async_cond {
+  Executor executor;
+  std::mutex m;
+  bool done = false;
+  std::vector<std::pair<
+    boost::asio::any_completion_handler<
+    void(boost::system::error_code)>, std::unique_lock<std::mutex>*>> handlers;
+
+public:
+
+  /// \brief Constructor
+  ///
+  /// \param executor The executor on which to post handlers.
+  async_cond(Executor executor)
+    : executor(executor) {}
+
+  /// \brief Destructor
+  ///
+  /// Will call `reset`, dispatching all handlers with
+  /// `asio::error::operation_aborted`.
+  ~async_cond() {
+    reset();
+  }
+
+  async_cond(const async_cond&) = delete;
+  async_cond& operator =(const async_cond&) = delete;
+  async_cond(async_cond&&) = delete;
+  async_cond& operator =(async_cond&&) = delete;
+
+
+  /// \brief Wait for notification
+  ///
+  /// This will dispatch the handler for the provided completion token
+  /// when `notify` is called. If `notify` has already been called,
+  /// dispatch immediately.
+  ///
+  /// \param token Boost.Asio completion token.
+  ///
+  /// \returns Whatever is appropriate to the completion token. See
+  /// Boost.Asio documentation.
+  template<boost::asio::completion_token_for<void(boost::system::error_code)>
+	   CompletionToken>
+  auto wait(std::unique_lock<std::mutex>& caller_lock, CompletionToken&& token) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    assert(caller_lock.owns_lock());
+    auto consigned = asio::consign(
+      std::forward<CompletionToken>(token), asio::make_work_guard(
+	asio::get_associated_executor(token, get_executor())));
+    return asio::async_initiate<decltype(consigned), void(sys::error_code)>(
+      [this, &caller_lock](auto handler) {
+	std::unique_lock l(m);
+	if (done) {
+	  caller_lock.unlock();
+	  asio::post(executor,
+		     [handler = std::move(handler), &caller_lock]() mutable {
+		       caller_lock.lock();
+		       std::move(handler)(sys::error_code{});
+		     });
+	} else {
+	  handlers.emplace_back(std::move(handler), &caller_lock);
+	  caller_lock.unlock();
+	}
+      }, consigned);
+  }
+
+  /// \brief Dispatch all handlers currently waiting
+  ///
+  /// Dispatches all handlers currently waiting. After this function
+  /// is called, any new calls to `wait` will return immediately.
+  void notify() {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    std::unique_lock l(m);
+    done = true;
+    if (!handlers.empty()) {
+      auto workhandlers = std::move(handlers);
+      handlers.resize(0);
+      l.unlock();
+      for (auto&& [handler, lock] : workhandlers) {
+	asio::post(executor,
+		   [handler = std::move(handler), lock]() mutable {
+		     lock->lock();
+		     std::move(handler)(sys::error_code{});
+		   });
+
+      }
+    }
+  }
+
+  /// \brief Dispatch all handlers currently waiting with an error
+  ///
+  /// This wakes all handlers currently waiting and dispatches them with
+  /// `asio::error::operation_aborted`.
+  void reset() {
+    namespace asio = boost::asio;
+    std::unique_lock l(m);
+    done = false;
+    if (!handlers.empty()) {
+      auto workhandlers = std::move(handlers);
+      handlers.resize(0);
+      l.unlock();
+      for (auto&& [handler, lock] : workhandlers) {
+	asio::post(executor,
+		   [handler = std::move(handler), lock]() mutable {
+		     lock->lock();
+		     std::move(handler)(asio::error::operation_aborted);
+		   });
+
+      }
+    }
+  }
+
+  /// \brief Type of the executor we dispatch on
+  using executor_type = Executor;
+
+  /// \brief Return the executor we dispatch on
+  auto get_executor() const {
+    return executor;
+  }
+};
+}

--- a/src/common/async/async_yield.h
+++ b/src/common/async/async_yield.h
@@ -1,0 +1,64 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+/// \file common/async/async_yield.h
+///
+/// \brief Contains the `async_yield` function
+
+#include <concepts>
+#include <exception>
+#include <type_traits>
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/compose.hpp>
+#include <boost/asio/co_spawn.hpp>
+
+#include <spawn/spawn.hpp>
+
+namespace ceph::async {
+
+/// \brief Call yielding function and wait for it to complete
+///
+/// For calling into stackful coroutines from C++20 coroutines or similar.
+///
+/// \param executor The executor on which to call the function
+/// \param f The function to call, must take yield_context
+/// \param token Boost.Asio completion token
+/// \param ioe Parameter pack of executors and I/O Objects to keep live
+///
+/// \return The return value of `f` in a way appropriate to the
+/// completion token. See Boost.Asio documentation.
+template<typename YieldContext,
+	 std::invocable<YieldContext> F,
+	 boost::asio::completion_token_for<
+	   void(std::invoke_result_t<F, YieldContext>)> CompletionToken,
+	 typename ...IOE>
+auto async_yield(auto executor, F&& f, CompletionToken&& token, IOE&& ...ioe)
+{
+  namespace asio = boost::asio;
+  return asio::async_compose<
+    CompletionToken,
+    void(std::invoke_result_t<F, YieldContext>)>(
+      [&executor, f = std::move(f)](auto& self) mutable {
+	spawn::spawn(
+	  executor,
+	  [f = std::move(f), self = std::move(self)]
+	  (YieldContext y) mutable {
+	    self.complete(f(y));
+	  });
+      }, token, executor, std::forward<IOE>(ioe)...);
+}
+}

--- a/src/common/async/coro_aiocomplete.h
+++ b/src/common/async/coro_aiocomplete.h
@@ -1,0 +1,134 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+/// \file common/async/coro_aiocomplete.h
+///
+/// \brief Contains the `coro_aiocomplete` function for briding C++20
+/// coroutines to librados::AioCompletion.
+
+#include <concepts>
+#include <exception>
+#include <type_traits>
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+
+#include <boost/system/error_code.hpp>
+
+#include "include/rados/librados.hpp"
+
+#include "common/dout.h"
+#include "common/error_code.h"
+
+#include "librados/AioCompletionImpl.h"
+
+namespace ceph::async {
+namespace detail {
+inline void do_complete_aiocompletion(const DoutPrefixProvider* dpp,
+                                      librados::AioCompletion* c,
+                                      std::exception_ptr eptr, int r)
+{
+  namespace sys = boost::system;
+  if (!eptr) {
+    librados::CB_AioCompleteAndSafe{c->pc}(r);
+  } else try {
+      std::rethrow_exception(eptr);
+    } catch (const sys::system_error& e) {
+      if (dpp) {
+	ldpp_dout(dpp, 1) << "coro_aicomplete: Got system_error: " << e.what()
+			  << ", passing to AioCompletionHandler as "
+			  << ceph::from_error_code(e.code()) << dendl;
+      }
+      librados::CB_AioCompleteAndSafe{c->pc}(ceph::from_error_code(e.code()));
+    } catch (const std::exception& e) {
+      if (dpp) {
+	ldpp_dout(dpp, 1) << "coro_aicomplete: Got exception: " << e.what()
+			  << ", passing to AioCompletionHandler as EFAULT"
+			  << dendl;
+      }
+      librados::CB_AioCompleteAndSafe{c->pc}(-EFAULT);
+    }
+}
+}
+
+/// \brief Call coroutine, completing with RADOS AIoCompletion
+///
+/// For bridging between C++20 coroutines and librados::AioCompletion
+///
+/// \param dpp DoutPrefixProvider, may be null.
+/// \param executor The executor on which to call the function
+/// \param coro An awaitable, must return void
+/// \param c The AioCompletion
+template<typename AwaitExecutor>
+void coro_aiocomplete(const DoutPrefixProvider* dpp,
+		      auto executor,
+		      boost::asio::awaitable<void, AwaitExecutor>&& coro,
+		      librados::AioCompletion* c)
+{
+  namespace asio = boost::asio;
+  asio::co_spawn(
+    executor, std::move(coro),
+    [dpp, c](std::exception_ptr eptr) {
+      detail::do_complete_aiocompletion(dpp, c, eptr, 0);
+    });
+}
+
+/// \brief Call coroutine, completing with RADOS AIoCompletion
+///
+/// For bridging between C++20 coroutines and librados::AioCompletion
+///
+/// \param dpp DoutPrefixProvider, may be null.
+/// \param executor The executor on which to call the function
+/// \param coro An awaitable, must return int
+/// \param c The AioCompletion
+template<typename AwaitExecutor>
+void coro_aiocomplete(const DoutPrefixProvider* dpp,
+		      auto executor,
+		      boost::asio::awaitable<int, AwaitExecutor>&& coro,
+		      librados::AioCompletion* c)
+{
+  namespace asio = boost::asio;
+  asio::co_spawn(
+    executor, std::move(coro),
+    [dpp, c](std::exception_ptr eptr, int r) {
+      detail::do_complete_aiocompletion(dpp, c, eptr, r);
+    });
+}
+
+/// \brief Call coroutine, completing with RADOS AIoCompletion
+///
+/// For bridging between C++20 coroutines and librados::AioCompletion
+///
+/// \param dpp DoutPrefixProvider, may be null.
+/// \param executor The executor on which to call the function
+/// \param coro An awaitable, must return boost::system::error_code
+/// \param c The AioCompletion
+template <typename AwaitExecutor>
+void coro_aiocomplete(const DoutPrefixProvider* dpp, auto executor,
+		      boost::asio::awaitable<boost::system::error_code,
+		                             AwaitExecutor>&& coro,
+		      librados::AioCompletion* c)
+{
+  namespace asio = boost::asio;
+  namespace sys = boost::system;
+  asio::co_spawn(
+    executor, std::move(coro),
+    [dpp, c](std::exception_ptr eptr, sys::error_code ec) {
+      detail::do_complete_aiocompletion(dpp, c, eptr,
+					ceph::from_error_code(ec));
+    });
+}
+}

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -557,14 +557,14 @@ options:
   type: str
   level: advanced
   default: cephfs hello journal lock log numops otp rbd refcount rgw rgw_gc timeindex
-    user version cas cmpomap queue 2pc_queue fifo
+    user version cas cmpomap queue 2pc_queue fifo sem_set
   with_legacy: true
 # list of object classes with default execute perm (allow all: *)
 - name: osd_class_default_list
   type: str
   level: advanced
   default: cephfs hello journal lock log numops otp rbd refcount rgw rgw_gc timeindex
-    user version cas cmpomap queue 2pc_queue fifo
+    user version cas cmpomap queue 2pc_queue fifo sem_set
   with_legacy: true
 - name: osd_agent_max_ops
   type: int

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -51,6 +51,7 @@ extern "C" {
 #include <optional>
 #include <ostream>
 #include <iomanip>
+#include <span>
 
 
 #include "include/unordered_map.h"
@@ -91,6 +92,8 @@ template<class A, class B>
 inline std::ostream& operator<<(std::ostream&out, const std::pair<A,B>& v);
 template<class A, class Alloc>
 inline std::ostream& operator<<(std::ostream& out, const std::vector<A,Alloc>& v);
+template<class T, std::size_t Extent>
+inline std::ostream& operator<<(std::ostream& out, const std::span<T, Extent>& s);
 template<class A, std::size_t N, class Alloc>
 inline std::ostream& operator<<(std::ostream& out, const boost::container::small_vector<A,N,Alloc>& v);
 template<class A, class Comp, class Alloc>
@@ -136,6 +139,19 @@ inline std::ostream& operator<<(std::ostream& out, const std::vector<A,Alloc>& v
   bool first = true;
   out << "[";
   for (const auto& p : v) {
+    if (!first) out << ",";
+    out << p;
+    first = false;
+  }
+  out << "]";
+  return out;
+}
+
+template<class T, std::size_t Extent>
+inline std::ostream& operator<<(std::ostream& out, const std::span<T, Extent>& s) {
+  bool first = true;
+  out << "[";
+  for (const auto& p : s) {
     if (!first) out << ",";
     out << p;
     first = false;

--- a/src/neorados/CMakeLists.txt
+++ b/src/neorados/CMakeLists.txt
@@ -13,29 +13,3 @@ add_library(libneorados STATIC
 target_link_libraries(libneorados PRIVATE
   osdc ceph-common cls_lock_client ${FMT_LIB}
   ${BLKID_LIBRARIES} ${CRYPTO_LIBS} ${EXTRALIBS})
-
-# if(ENABLE_SHARED)
-#   add_library(libneorados ${CEPH_SHARED}
-#     $<TARGET_OBJECTS:neorados_api_obj>
-#     $<TARGET_OBJECTS:neorados_objs>
-#     $<TARGET_OBJECTS:common_buffer_obj>)
-#   set_target_properties(libneorados PROPERTIES
-#     OUTPUT_NAME RADOS
-#     VERSION 0.0.1
-#     SOVERSION 1
-#     CXX_VISIBILITY_PRESET hidden
-#     VISIBILITY_INLINES_HIDDEN ON)
-#   if(NOT APPLE)
-#     set_property(TARGET libneorados APPEND_STRING PROPERTY
-#       LINK_FLAGS " -Wl,--exclude-libs,ALL")
-#   endif()
-# else(ENABLE_SHARED)
-#   add_library(libneorados STATIC
-#     $<TARGET_OBJECTS:neorados_api_obj>
-#     $<TARGET_OBJECTS:neorados_objs>)
-# endif(ENABLE_SHARED)
-# target_link_libraries(libneorados PRIVATE
-#   osdc ceph-common cls_lock_client
-#   ${BLKID_LIBRARIES} ${CRYPTO_LIBS} ${EXTRALIBS})
-# target_link_libraries(libneorados ${rados_libs})
-# install(TARGETS libneorados DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/neorados/cls/common.h
+++ b/src/neorados/cls/common.h
@@ -1,0 +1,156 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * See file COPYING for license information.
+ *
+ */
+
+#pragma once
+
+#include <concepts>
+#include <coroutine>
+#include <cstddef>
+#include <string>
+#include <type_traits>
+#include <tuple>
+
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/deferred.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include <boost/asio/experimental/co_composed.hpp>
+
+#include <boost/system/error_code.hpp>
+#include <boost/system/system_error.hpp>
+
+#include "include/neorados/RADOS.hpp"
+
+#include "include/buffer.h"
+#include "include/encoding.h"
+
+/// \file neorados/cls/common.h
+///
+/// \brief Helpers for writing simple CLS clients
+///
+/// For writing functions that call out to the OSD, perform a CLS
+/// call, and return its data in a user friendly way, we need to
+/// coordinate asynchronous operation with decoding and returning the
+/// relevant data.
+///
+/// Ideally, these functions will help.
+
+namespace neorados::cls {
+namespace detail {
+template<typename...>
+struct return_sig;
+
+template<typename T>
+struct return_sig<T> {
+using type = void(boost::system::error_code, T);
+};
+template<typename ...Ts>
+struct return_sig<std::tuple<Ts...>> {
+  using type = void(boost::system::error_code, Ts...);
+};
+
+template<typename... Ts>
+using return_sig_t = typename return_sig<Ts...>::type;
+
+template<typename T>
+auto maybecat(boost::system::error_code ec,
+	      T&& t)
+{
+  return std::make_tuple(ec, std::forward<T>(t));
+}
+
+template<typename ...Ts>
+auto maybecat(boost::system::error_code ec,
+	      std::tuple<Ts...>&& ts)
+{
+  return std::tuple_cat(std::tuple(ec),
+			std::move(ts));
+}
+} // namespace detail
+
+/// \brief Perform a CLS read operation and return the result
+///
+/// Asynchronously call into the OSD, decode its response and
+/// pass it to a supplied function that extracts the relevant
+/// information.
+///
+/// \tparam Rep The type of the CLS operation's result that will be
+///             passed to `f`
+///
+/// \param r RADOS handle
+/// \param oid Object name
+/// \param ioc IOContext locator
+/// \param cls Name of the object class
+/// \param method Object class method to call
+/// \param req Request (parameters to the class method). Pass nullptr if there
+///            is no request structure.
+/// \param f Function to extract/process call result
+/// \param token Boost.Asio CompletionToken
+///
+/// \return The relevant data in a way appropriate to the completion
+/// token. See Boost.Asio documentation. The signature is
+/// void(error_code, T) if f returns a non-tuple, and
+/// void(error_code, Ts...) if f returns a tuple.
+template<std::default_initializable Rep, typename Req,
+	 std::invocable<Rep&&> F,
+	 std::default_initializable Ret = std::invoke_result_t<F&&, Rep&&>,
+	 boost::asio::completion_token_for<
+	   detail::return_sig_t<Ret>> CompletionToken>
+auto exec(
+  RADOS& r,
+  Object oid,
+  IOContext ioc,
+  std::string cls,
+  std::string method,
+  const Req& req,
+  F&& f,
+  CompletionToken&& token)
+{
+  namespace asio = boost::asio;
+  namespace buffer = ceph::buffer;
+  using boost::system::error_code;
+  using boost::system::system_error;
+
+  buffer::list in;
+  if (!std::is_same_v<Req, std::nullptr_t>) {
+    encode(req, in);
+  }
+  return asio::async_initiate<CompletionToken, detail::return_sig_t<Ret>>
+    (asio::experimental::co_composed<detail::return_sig_t<Ret>>
+     ([](auto state, RADOS& r, Object oid, IOContext ioc, std::string cls,
+	 std::string method, buffer::list in, F&& f) -> void {
+       try {
+	 ReadOp op;
+	 buffer::list out;
+	 error_code ec;
+	 op.exec(cls, method, std::move(in), &out, &ec);
+	 co_await r.execute(std::move(oid), std::move(ioc), std::move(op),
+			    nullptr, asio::deferred);
+	 if (ec) {
+	   co_return detail::maybecat(ec, Ret{});
+	 }
+	 Rep rep;
+	 decode(rep, out);
+	 co_return detail::maybecat(error_code{},
+				    std::invoke(std::forward<F>(f),
+						std::move(rep)));
+       } catch (const system_error& e) {
+	 co_return detail::maybecat(e.code(), Ret{});
+       }
+     }, r.get_executor()),
+     token, std::ref(r), std::move(oid), std::move(ioc), std::move(cls),
+     std::move(method), std::move(in), std::forward<F>(f));
+}
+} // namespace neorados::cls

--- a/src/neorados/cls/fifo.h
+++ b/src/neorados/cls/fifo.h
@@ -1,0 +1,1713 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * See file COPYING for license information.
+ *
+ */
+
+#pragma once
+
+/// \file neorados/cls/fifo.h
+///
+/// \brief NeoRADOS interface to FIFO class
+///
+/// The `fifo` object class stores a queue structured log across
+/// multiple OSDs. Each FIFO comprises a head object with metadata
+/// such as the current head and tail objects, as well as a set of
+/// data objects, containing a bunch of entries. New entries may be
+/// pushed at the head and trimmed at the tail. Entries may be
+/// retrieved for processing with the `list` operation. Each entry
+/// comes with a marker that may be used to trim up to (inclusively)
+/// that object once processing is complete. The head object is the
+/// notional 'name' of the FIFO, provided at creation or opening time.
+
+#include <cerrno>
+#include <coroutine>
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include <boost/asio/as_tuple.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/deferred.hpp>
+
+#include <boost/asio/experimental/co_composed.hpp>
+
+#include <boost/system/error_code.hpp>
+#include <boost/system/system_error.hpp>
+
+#include "include/buffer.h"
+#include "include/neorados/RADOS.hpp"
+
+#include "common/debug.h"
+#include "common/strtol.h"
+
+#include "neorados/cls/common.h"
+
+#include "cls/fifo/cls_fifo_types.h"
+#include "cls/fifo/cls_fifo_ops.h"
+
+namespace neorados::cls::fifo {
+/// Entries to be returned by the list operation
+struct entry {
+  /// Data stored in the entry
+  ceph::buffer::list data;
+  /// Marker (for trimming, continuing list operations)
+  std::string marker;
+  /// Time stored (set by the OSD)
+  ceph::real_time mtime;
+};
+
+inline std::ostream& operator <<(std::ostream& m, const entry& e) {
+  return m << "[data: " << e.data
+	   << ", marker: " << e.marker
+	   << ", mtime: " << e.mtime << "]";
+}
+
+/// This is the FIFO client class. It handles the logic of keeping
+/// state synchronized with that on the server, journal processing,
+/// and multipart push.
+class FIFO {
+  friend class FIFOtest;
+  /// A marker is a part number and byte offset used to indicate an
+  /// entry.
+  struct marker {
+    std::int64_t num = 0;
+    std::uint64_t ofs = 0;
+
+    /// Default constructor
+    marker() = default;
+
+    /// Construct from part and offset
+    ///
+    /// \param num Part number
+    /// \param ofs Offset within the part
+    marker(std::int64_t num, std::uint64_t ofs) : num(num), ofs(ofs) {}
+
+    /// Return a string representation of the marker
+    std::string to_string() {
+      return fmt::format("{:0>20}:{:0>20}", num, ofs);
+    }
+  };
+
+  /// Maximum number of retries if we run into a conflict. Limited to
+  /// keep us from locking up if we never hit the end condition.
+  static constexpr auto MAX_RACE_RETRIES = 10;
+
+  /// RADOS handle
+  neorados::RADOS& rados;
+  /// Head object
+  const neorados::Object obj;
+  /// Locator
+  const neorados::IOContext ioc;
+  /// Total size of the part header.
+  std::uint32_t part_header_size;
+  /// The additional space required to store an entry, above the size
+  /// of the entry itself.
+  std::uint32_t part_entry_overhead;
+  /// Local copy of FIFO data
+  rados::cls::fifo::info info;
+
+  /// Mutex protecting local data;
+  std::mutex m;
+
+  /// Constructor
+  ///
+  /// \param rados RADOS handle
+  /// \param obj Head object
+  /// \param ioc Locator
+  /// \param part_header_size Total size of the part header.
+  /// \param part_entry_overhead The additional space required to
+  ///                            store an entry, above the size of the
+  ///                            entry itself.
+  FIFO(neorados::RADOS& rados,
+       neorados::Object obj,
+       neorados::IOContext ioc,
+       std::uint32_t part_header_size,
+       std::uint32_t part_entry_overhead,
+       rados::cls::fifo::info info)
+    : rados(rados), obj(std::move(obj)), ioc(std::move(ioc)),
+      part_header_size(part_header_size),
+      part_entry_overhead(part_entry_overhead),
+      info(std::move(info)) {}
+
+  /// \name Primitives
+  ///
+  /// Low-level coroutininized operations in the FIFO objclass.
+  ///@{
+
+public:
+  /// \brief Retrieve FIFO metadata
+  ///
+  /// \param rados RADOS handle
+  /// \param obj Head object for FIFO
+  /// \param ioc Locator
+  /// \param token Boost.Asio CompletionToken
+  /// \param objv Operation will fail if FIFO is not at this version
+  ///
+  /// \return The metadata info, part header size, and entry overhead
+  /// in a way appropriate to the completion token.
+  template<boost::asio::completion_token_for<
+    void(boost::system::error_code, rados::cls::fifo::info,
+	 uint32_t, uint32_t)> CompletionToken>
+  static auto get_meta(neorados::RADOS& rados,
+		       neorados::Object obj,
+		       neorados::IOContext ioc,
+		       std::optional<rados::cls::fifo::objv> objv,
+		       CompletionToken&& token) {
+    namespace fifo = rados::cls::fifo;
+    neorados::ReadOp op;
+    fifo::op::get_meta gm;
+    gm.version = objv;
+    return exec<fifo::op::get_meta_reply>(
+      rados, std::move(obj), std::move(ioc),
+      fifo::op::CLASS, fifo::op::GET_META, std::move(gm),
+      [](fifo::op::get_meta_reply&& ret) {
+	return std::make_tuple(std::move(ret.info),
+			       ret.part_header_size,
+			       ret.part_entry_overhead);
+      }, std::forward<CompletionToken>(token));
+  }
+
+private:
+  /// \brief Retrieve part info
+  ///
+  /// \param part_num Number of part to query
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return The part info in a way appropriate to the completion token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code, rados::cls::fifo::part_header)>
+	   CompletionToken>
+  auto get_part_info(std::int64_t part_num,
+		     CompletionToken&& token) {
+    namespace fifo = rados::cls::fifo;
+    std::unique_lock l(m);
+    Object part_oid = info.part_oid(part_num);;
+    l.unlock();
+
+    return exec<fifo::op::get_part_info_reply>(
+      rados, std::move(std::move(part_oid)), ioc,
+      fifo::op::CLASS, fifo::op::GET_PART_INFO,
+      fifo::op::get_part_info{},
+      [](fifo::op::get_part_info_reply&& ret) {
+	return std::move(ret.header);
+      }, std::forward<CompletionToken>(token));
+  }
+
+
+  /// \brief Create a new part object
+  ///
+  /// \param part_num Part number
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Nothing, but may error in a way appropriate to the
+  /// completion token.
+  template<boost::asio::completion_token_for<
+    void(boost::system::error_code)> CompletionToken>
+  auto create_part(std::int64_t part_num, CompletionToken&& token) {
+    namespace fifo = rados::cls::fifo;
+    namespace buffer = ceph::buffer;
+    neorados::WriteOp op;
+    op.create(false); /* We don't need exclusivity, part_init ensures we're
+			 creating from the same journal entry. */
+    std::unique_lock l(m);
+    fifo::op::init_part ip;
+    ip.params = info.params;
+    buffer::list in;
+    encode(ip, in);
+    op.exec(fifo::op::CLASS, fifo::op::INIT_PART, std::move(in));
+    auto oid = info.part_oid(part_num);
+    l.unlock();
+    return rados.execute(oid, ioc, std::move(op),
+			 std::forward<CompletionToken>(token));
+  }
+
+  /// \brief Remove a part object
+  ///
+  /// \param part_num Part number
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Nothing, but may error in a way appropriate to the
+  /// completion token.
+  template<boost::asio::completion_token_for<
+    void(boost::system::error_code)> CompletionToken>
+  auto remove_part(std::int64_t part_num, CompletionToken&& token) {
+    namespace fifo = rados::cls::fifo;
+    namespace buffer = ceph::buffer;
+    neorados::WriteOp op;
+    op.remove();
+    std::unique_lock l(m);
+    auto oid = info.part_oid(part_num);
+    l.unlock();
+    return rados.execute(oid, ioc, std::move(op),
+			 std::forward<CompletionToken>(token));
+  }
+
+  /// \brief Update objclass FIFO metadata
+  ///
+  /// \param objv Current metadata version (objclass will error on mismatch)
+  /// \param update Changes to make to metadata
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Nothing, but may error in a way appropriate to the
+  /// completion token.
+  template<boost::asio::completion_token_for<
+    void(boost::system::error_code)> CompletionToken>
+  auto update_meta(const rados::cls::fifo::objv& objv,
+		   const rados::cls::fifo::update& update,
+		   CompletionToken&& token) {
+    namespace fifo = rados::cls::fifo;
+    namespace buffer = ceph::buffer;
+    neorados::WriteOp op;
+    fifo::op::update_meta um;
+
+    um.version = objv;
+    um.tail_part_num = update.tail_part_num();
+    um.head_part_num = update.head_part_num();
+    um.min_push_part_num = update.min_push_part_num();
+    um.max_push_part_num = update.max_push_part_num();
+    um.journal_entries_add = std::move(update).journal_entries_add();
+    um.journal_entries_rm = std::move(update).journal_entries_rm();
+
+    buffer::list in;
+    encode(um, in);
+    op.exec(fifo::op::CLASS, fifo::op::UPDATE_META, std::move(in));
+    return rados.execute(obj, ioc, std::move(op),
+			 std::forward<CompletionToken>(token));
+  }
+
+  /// \brief Create FIFO head object
+  ///
+  /// \param rados RADOS handle
+  /// \param obj Head object for the FIFO
+  /// \param ioc Locator
+  /// \param objv Version (error if FIFO exists and this doesn't match)
+  /// \param oid_prefix Prefix for all object names
+  /// \param exclusive If true, error if object already exists
+  /// \param max_part_size Max size of part objects
+  /// \param max_entry_size Max size of entries
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Nothing, but may error in a way appropriate to the
+  /// completion token.
+  template<boost::asio::completion_token_for<
+    void(boost::system::error_code)> CompletionToken>
+  static auto create_meta(neorados::RADOS& rados,
+			  neorados::Object obj,
+			  neorados::IOContext ioc,
+			  std::optional<rados::cls::fifo::objv> objv,
+			  std::optional<std::string> oid_prefix,
+			  bool exclusive,
+			  std::uint64_t max_part_size,
+			  std::uint64_t max_entry_size,
+			  CompletionToken&& token) {
+    namespace fifo = rados::cls::fifo;
+    namespace buffer = ceph::buffer;
+    neorados::WriteOp op;
+    fifo::op::create_meta cm;
+
+    cm.id = obj;
+    cm.version = objv;
+    cm.oid_prefix = oid_prefix;
+    cm.max_part_size = max_part_size;
+    cm.max_entry_size = max_entry_size;
+    cm.exclusive = exclusive;
+
+    buffer::list in;
+    encode(cm, in);
+    op.exec(fifo::op::CLASS, fifo::op::CREATE_META, in);
+    return rados.execute(std::move(obj), std::move(ioc), std::move(op),
+			 std::forward<CompletionToken>(token));
+  }
+
+  /// \brief Push some entries to a given part
+  ///
+  /// \param dpp Prefix for debug prints
+  /// \param entries Entries to push
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Possibly errors in a way appropriate to the completion
+  /// token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code, int)> CompletionToken>
+  auto push_entries(const DoutPrefixProvider* dpp,
+		    std::deque<ceph::buffer::list> entries,
+		    CompletionToken&& token) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    namespace fifo = rados::cls::fifo;
+    namespace buffer = ceph::buffer;
+    return asio::async_initiate<CompletionToken, void(sys::error_code, int)>
+      (asio::experimental::co_composed<void(sys::error_code, int)>
+       ([](auto state, const DoutPrefixProvider* dpp,
+	   std::deque<buffer::list> entries, FIFO* f) -> void {
+	 try {
+	   state.throw_if_cancelled(true);
+	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+
+	   std::unique_lock l(f->m);
+	   auto head_part_num = f->info.head_part_num;
+	   auto oid = f->info.part_oid(head_part_num);
+	   l.unlock();
+
+	   WriteOp op;
+	   op.assert_exists();
+
+	   fifo::op::push_part pp;
+
+	   pp.data_bufs = std::move(entries);
+	   pp.total_len = 0;
+
+           for (const auto &bl : pp.data_bufs)
+             pp.total_len += bl.length();
+
+           buffer::list in;
+           encode(pp, in);
+           int pushes;
+           op.exec(fifo::op::CLASS, fifo::op::PUSH_PART, in,
+                   [&pushes](sys::error_code, int r, const buffer::list &) {
+                     pushes = r;
+                   });
+           op.returnvec();
+           co_await f->rados.execute(std::move(oid), f->ioc, std::move(op),
+                                     asio::deferred);
+           co_return {sys::error_code{}, pushes};
+	 } catch (const sys::system_error& e) {
+	   ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " push entries failed: " << e.what() << dendl;
+	   co_return {e.code(), 0};
+	 }
+       }, rados.get_executor()),
+       token, dpp, std::move(entries), this);
+  }
+
+  /// \brief List entries from a given part
+  ///
+  /// \param dpp Prefix provider for debug logging
+  /// \param part_num Part number to list
+  /// \param ofs Offset from which to list
+  /// \param result Span giving space for results
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return A subspan containing results, a bool indicating whether there
+  ///         are more entries within the part, and a bool indicating whether
+  ///         the part is full all in a way appropriate to the completion
+  ///         token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code, std::span<entry>, bool, bool)>
+	   CompletionToken>
+  auto list_part(const DoutPrefixProvider* dpp,
+		 std::int64_t part_num, std::uint64_t ofs,
+		 std::span<entry> result,
+		 CompletionToken&& token) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    namespace fifo = rados::cls::fifo;
+    namespace buffer = ceph::buffer;
+    return asio::async_initiate<
+      CompletionToken, void(sys::error_code, std::span<entry>, bool, bool)>
+      (asio::experimental::co_composed<
+       void(sys::error_code, std::span<entry>, bool, bool)>
+       ([](auto state, const DoutPrefixProvider* dpp, std::int64_t part_num,
+	   std::uint64_t ofs,std::span<entry> result,
+	   FIFO* f) -> void {
+	 try {
+	   state.throw_if_cancelled(true);
+	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+
+	   std::unique_lock l(f->m);
+	   auto oid = f->info.part_oid(part_num);
+	   l.unlock();
+
+	   ReadOp op;
+	   fifo::op::list_part lp;
+
+	   lp.ofs = ofs;
+	   lp.max_entries = result.size();
+
+	   buffer::list in;
+	   encode(lp, in);
+	   buffer::list bl;
+	   op.exec(fifo::op::CLASS, fifo::op::LIST_PART, in, &bl, nullptr);
+	   co_await f->rados.execute(oid, f->ioc, std::move(op), nullptr,
+				     asio::deferred);
+	   bool more, full_part;
+	   {
+	     ceph::buffer::list::const_iterator bi = bl.begin();
+	     DECODE_START(1, bi);
+	     std::string tag;
+	     decode(tag, bi);
+	     uint32_t len;
+	     decode(len, bi);
+	     if (len > result.size()) {
+	       throw buffer::end_of_buffer{};
+	     }
+	     result = result.first(len);
+	     for (auto i = 0u; i < len; ++i) {
+	       fifo::part_list_entry entry;
+	       decode(entry, bi);
+	       result[i] = {.data = std::move(entry.data),
+			    .marker = marker{part_num, entry.ofs}.to_string(),
+			    .mtime = entry.mtime};
+	     }
+	     decode(more, bi);
+	     decode(full_part, bi);
+	     DECODE_FINISH(bi);
+	   }
+	   co_return {sys::error_code{}, std::move(result), more, full_part};
+       } catch (const sys::system_error& e) {
+	   if (e.code() != sys::errc::no_such_file_or_directory) {
+	     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " list entries failed: " << e.what() << dendl;
+	   }
+	 co_return {e.code(), std::span<entry>{}, false, false};
+       }
+       }, rados.get_executor()),
+       token, dpp, part_num, ofs, std::move(result), this);
+  }
+
+  /// \brief Trim entries on a given part
+  ///
+  /// \param dpp Prefix provider for debug logging
+  /// \param part_num Part to trim
+  /// \param ofs Offset to which to trim
+  /// \param exclusive If true, exclude end of range from trim
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Possibly errors in a way appropriate to the completion
+  /// token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code)> CompletionToken>
+  auto trim_part(const DoutPrefixProvider* dpp,
+		 std::int64_t part_num,
+		 std::uint64_t ofs,
+		 bool exclusive,
+		 CompletionToken&& token) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    namespace fifo = rados::cls::fifo;
+    namespace buffer = ceph::buffer;
+    return asio::async_initiate<CompletionToken, void(sys::error_code)>
+      (asio::experimental::co_composed<void(sys::error_code)>
+       ([](auto state, const DoutPrefixProvider* dpp,
+	   int64_t part_num, uint64_t ofs, bool exclusive, FIFO* f) -> void {
+	 try {
+	   state.throw_if_cancelled(true);
+	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+
+	   std::unique_lock l(f->m);
+	   auto oid = f->info.part_oid(part_num);
+	   l.unlock();
+
+	   WriteOp op;
+	   fifo::op::trim_part tp;
+
+	   tp.ofs = ofs;
+	   tp.exclusive = exclusive;
+
+	   buffer::list in;
+	   encode(tp, in);
+	   op.exec(fifo::op::CLASS, fifo::op::TRIM_PART, in);
+           co_await f->rados.execute(std::move(oid), f->ioc, std::move(op),
+                                     asio::deferred);
+	   co_return sys::error_code{};
+	 } catch (const sys::system_error& e) {
+	   ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " trim part failed: " << e.what() << dendl;
+	   co_return e.code();
+	 }
+       }, rados.get_executor()),
+       token, dpp, part_num, ofs, exclusive, this);
+  }
+
+  ///@}
+
+  /// \name Logics
+  ///
+  /// Internal logic used to implement the public interface
+  ///
+  ///@{
+
+  /// \brief Convert a string to a marker
+  ///
+  /// This is not a free function since an empty string always refers
+  /// to the tail part.
+  ///
+  /// \param s String representation of the marker
+  /// \param l Ownership of mutex
+  ///
+  /// \returns The marker or nullopt if the string representation is invalid
+  std::optional<marker> to_marker(std::string_view s,
+				  std::unique_lock<std::mutex>& l) {
+    assert(l.owns_lock());
+    marker m;
+    if (s.empty()) {
+      m.num = info.tail_part_num;
+      m.ofs = 0;
+      return m;
+    }
+
+    auto pos = s.find(':');
+    if (pos == s.npos) {
+      return std::nullopt;
+    }
+
+    auto num = s.substr(0, pos);
+    auto ofs = s.substr(pos + 1);
+
+    auto n = ceph::parse<decltype(m.num)>(num);
+    if (!n) {
+      return std::nullopt;
+    }
+    m.num = *n;
+    auto o = ceph::parse<decltype(m.ofs)>(ofs);
+    if (!o) {
+      return std::nullopt;
+    }
+    m.ofs = *o;
+    return m;
+  }
+
+  /// \brief Force re-read of metadata
+  ///
+  /// \param dpp Prefix provider for debug logging
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Possibly errors in a way appropriate to the completion
+  /// token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code)> CompletionToken>
+  auto read_meta(const DoutPrefixProvider* dpp,
+		 CompletionToken&& token) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    return asio::async_initiate<CompletionToken, void(sys::error_code)>
+      (asio::experimental::co_composed<void(sys::error_code)>
+     ([](auto state, const DoutPrefixProvider* dpp,
+	 FIFO* f) -> void {
+       try {
+	 state.throw_if_cancelled(true);
+	 state.reset_cancellation_state(asio::enable_terminal_cancellation());
+
+	 ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			    << " entering" << dendl;
+	 auto [info, part_header_size, part_entry_overhead]
+	   = co_await get_meta(f->rados, f->obj, f->ioc, std::nullopt,
+			       asio::deferred);
+	 std::unique_lock l(f->m);
+	 if (info.version.same_or_later(f->info.version)) {
+	   f->info = std::move(info);
+	   f->part_header_size = part_header_size;
+	   f->part_entry_overhead = part_entry_overhead;
+	 }
+       } catch (const sys::system_error& e) {
+	 ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			    << " read_meta failed: " << e.what() << dendl;
+	 co_return e.code();
+       }
+       co_return sys::error_code{};
+     }, rados.get_executor()),
+       token, dpp, this);
+  }
+
+  /// \brief Update local metadata
+  ///
+  /// \param dpp Debugging prefix provider
+  /// \param objv Current metadata version (objclass will error on mismatch)
+  /// \param update Changes to make to metadata
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \exception boost::system::system_error equivalent to
+  /// boost::system::errc::operation_canceled on version mismatch.
+  void apply_update(const DoutPrefixProvider *dpp,
+		    rados::cls::fifo::info* info,
+		    const rados::cls::fifo::objv& objv,
+		    const rados::cls::fifo::update& update) {
+    ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		       << " entering" << dendl;
+    std::unique_lock l(m);
+    if (objv != info->version) {
+      ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " version mismatch, canceling" << dendl;
+      throw boost::system::system_error(ECANCELED,
+					boost::system::generic_category());
+    }
+
+    info->apply_update(update);
+  }
+
+  /// \brief Update metadata locally and in the objclass
+  ///
+  /// \param dpp Debug prefix provider
+  /// \param update The update to apply
+  /// \param objv Current object version
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return True if the operation was canceled. false otherwise in a
+  /// way appropriate to the completion token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code, bool)> CompletionToken>
+  auto update_meta(const DoutPrefixProvider* dpp,
+		   rados::cls::fifo::update update,
+		   rados::cls::fifo::objv version,
+		   CompletionToken&& token) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    namespace fifo = rados::cls::fifo;
+    return asio::async_initiate<CompletionToken, void(sys::error_code, bool)>
+      (asio::experimental::co_composed<void(sys::error_code, bool)>
+     ([](auto state, const DoutPrefixProvider* dpp,
+	 fifo::update update, fifo::objv version,
+	 FIFO* f) -> void {
+       try {
+	 state.throw_if_cancelled(true);
+	 state.reset_cancellation_state(asio::enable_terminal_cancellation());
+
+	 ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			    << " entering" << dendl;
+
+	 auto [ec] = co_await f->update_meta(version, update,
+					     asio::as_tuple(asio::deferred));
+	 bool canceled;
+	 if (ec && ec != sys::errc::operation_canceled) {
+	   throw sys::system_error(ec);
+	 }
+	 canceled = (ec == sys::errc::operation_canceled);
+	 if (!canceled) {
+	   try {
+	     f->apply_update(dpp, &f->info, version, update);
+	   } catch (const sys::system_error& e) {
+	     if (e.code() == sys::errc::operation_canceled) {
+	       canceled = true;
+	     } else {
+	       throw;
+	     }
+	   }
+	 }
+	 if (canceled) {
+	   co_await f->read_meta(dpp, asio::deferred);
+	 }
+	 if (canceled) {
+           ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " canceled" << dendl;
+	 }
+	 co_return {sys::error_code{}, canceled};
+       } catch (const sys::system_error& e) {
+	 ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			    << " failed with error: " << e.what() << dendl;
+	 co_return {e.code(), false};
+       }
+     }, rados.get_executor()),
+       token, dpp, std::move(update), std::move(version), this);
+  }
+
+  /// \brief Process the journal
+  ///
+  /// \param dpp Debug prefix provider
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Nothing, but may error in a way appropriate to the
+  /// completion token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code)> CompletionToken>
+  auto process_journal(const DoutPrefixProvider* dpp,
+		       CompletionToken&& token) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    namespace fifo = rados::cls::fifo;
+    return asio::async_initiate<CompletionToken, void(sys::error_code)>
+      (asio::experimental::co_composed<void(sys::error_code)>
+     ([](auto state, const DoutPrefixProvider* dpp, FIFO* f) -> void {
+       try {
+	 state.throw_if_cancelled(true);
+	 state.reset_cancellation_state(asio::enable_terminal_cancellation());
+
+	 ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			    << " entering." << dendl;
+	 std::vector<fifo::journal_entry> processed;
+
+	 std::unique_lock l(f->m);
+	 auto tmpjournal = f->info.journal;
+	 auto new_tail = f->info.tail_part_num;
+	 auto new_head = f->info.head_part_num;
+	 auto new_max = f->info.max_push_part_num;
+	 l.unlock();
+
+	 for (auto& entry : tmpjournal) {
+	   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " processing entry: entry=" << entry
+			      << dendl;
+	   switch (entry.op) {
+	     using enum fifo::journal_entry::Op;
+	   case create:
+	     ldpp_dout(dpp, 10) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " Creating part " << entry.part_num << dendl;
+	     co_await f->create_part(entry.part_num, asio::deferred);
+	     if (entry.part_num > new_max) {
+	       new_max = entry.part_num;
+	     }
+	     break;
+	   case set_head:
+	     ldpp_dout(dpp, 10) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " Setting head to " << entry.part_num << dendl;
+	     if (entry.part_num > new_head) {
+	       new_head = entry.part_num;
+	     }
+	     break;
+	   case remove:
+	     try {
+	       ldpp_dout(dpp, 10) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				  << " Removing part " << entry.part_num
+				  << dendl;
+
+	       co_await f->remove_part(entry.part_num, asio::deferred);
+	       if (entry.part_num >= new_tail) {
+		 new_tail = entry.part_num + 1;
+	       }
+	     } catch (const sys::system_error& e) {
+	       if (e.code() != sys::errc::no_such_file_or_directory) {
+		 throw;
+	       }
+	     }
+	     break;
+	   default:
+	     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " unknown journaled op: entry=" << entry
+				<< dendl;
+	     throw sys::system_error{EINVAL, sys::generic_category()};
+	   }
+
+	   processed.push_back(std::move(entry));
+	 }
+
+	 // Postprocess
+	 bool canceled = true;
+
+	 for (auto i = 0; canceled && i < MAX_RACE_RETRIES; ++i) {
+	   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " postprocessing: i=" << i << dendl;
+
+	   std::optional<std::int64_t> tail_part_num;
+	   std::optional<std::int64_t> head_part_num;
+	   std::optional<std::int64_t> max_part_num;
+
+           std::unique_lock l(f->m);
+           auto objv = f->info.version;
+           if (new_tail > tail_part_num)
+             tail_part_num = new_tail;
+           if (new_head > f->info.head_part_num)
+             head_part_num = new_head;
+           if (new_max > f->info.max_push_part_num)
+	     max_part_num = new_max;
+           l.unlock();
+
+           if (processed.empty() && !tail_part_num && !max_part_num) {
+             ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+                                << " nothing to update any more: i=" << i
+                                << dendl;
+             canceled = false;
+             break;
+	   }
+	   auto u = fifo::update().tail_part_num(tail_part_num)
+	     .head_part_num(head_part_num).max_push_part_num(max_part_num)
+	     .journal_entries_rm(processed);
+	   ldpp_dout(dpp, 10) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " Calling update_meta: update=" << u
+			      << dendl;
+
+	   canceled = co_await f->update_meta(dpp, u, objv, asio::deferred);
+	   if (canceled) {
+	     std::vector<fifo::journal_entry> new_processed;
+	     std::unique_lock l(f->m);
+	     ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " update canceled, retrying: i=" << i
+				<< dendl;
+	     for (auto& e : processed) {
+	       if (f->info.journal.contains(e)) {
+		 new_processed.push_back(e);
+	       }
+	     }
+	     processed = std::move(new_processed);
+	   }
+	 }
+	 if (canceled) {
+	   ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " canceled too many times, giving up" << dendl;
+	   throw sys::system_error(ECANCELED, sys::generic_category());
+	 }
+       } catch (const sys::system_error& e) {
+	 ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			    << " process_journal failed" << ":" << e.what()
+			    << dendl;
+	 co_return e.code();
+       }
+       co_return sys::error_code{};
+     }, rados.get_executor()),
+       token, dpp, this);
+  }
+
+  /// \brief Create a new part
+  ///
+  /// And possibly set it as head
+  ///
+  /// \param dpp Debug prefix provider
+  /// \param new_part_num New part to create
+  /// \param is_head True if part is to be new head
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Nothing, but may error in a way appropriate to the
+  /// completion token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code)> CompletionToken>
+  auto prepare_new_part(const DoutPrefixProvider* dpp,
+			std::int64_t new_part_num, bool is_head,
+			CompletionToken&& token) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    namespace fifo = rados::cls::fifo;
+    return asio::async_initiate<CompletionToken, void(sys::error_code)>
+      (asio::experimental::co_composed<void(sys::error_code)>
+       ([](auto state, const DoutPrefixProvider* dpp,
+	   std::int64_t new_part_num, bool is_head, FIFO* f) -> void {
+	 try {
+	   state.throw_if_cancelled(true);
+	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+
+
+	   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " entering" << dendl;
+	   std::unique_lock l(f->m);
+	   using enum fifo::journal_entry::Op;
+	   std::vector<fifo::journal_entry> jentries{{create, new_part_num}};
+	   if (f->info.journal.contains({create, new_part_num}) &&
+	       (!is_head || f->info.journal.contains({set_head, new_part_num}))) {
+	     l.unlock();
+	     ldpp_dout(dpp, 5)
+		 << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " new part journaled, but not processed"
+		 << dendl;
+	     co_await f->process_journal(dpp, asio::deferred);
+	     co_return sys::error_code{};
+	   }
+	   auto version = f->info.version;
+
+	   if (is_head) {
+	     ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " needs new head" << dendl;
+	     jentries.push_back({set_head, new_part_num});
+	   }
+	   l.unlock();
+
+	   bool canceled = true;
+	   for (auto i = 0; canceled && i < MAX_RACE_RETRIES; ++i) {
+	     canceled = false;
+	     ldpp_dout(dpp, 20)
+		 << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " updating metadata: i=" << i << dendl;
+	     auto u = fifo::update{}.journal_entries_add(jentries);
+	     canceled = co_await f->update_meta(dpp, u, version,
+						asio::deferred);
+	     if (canceled) {
+	       std::unique_lock l(f->m);
+	       version = f->info.version;
+	       auto found = (f->info.journal.contains({create, new_part_num}) ||
+			     f->info.journal.contains({set_head, new_part_num}));
+	       if ((f->info.max_push_part_num >= new_part_num &&
+		    f->info.head_part_num >= new_part_num)) {
+		 ldpp_dout(dpp, 20)
+		     << __PRETTY_FUNCTION__ << ":" << __LINE__
+		     << " raced, but journaled and processed: i=" << i
+		     << dendl;
+		 co_return sys::error_code{};
+	       }
+	       if (found) {
+		 ldpp_dout(dpp, 20)
+		     << __PRETTY_FUNCTION__ << ":" << __LINE__
+		     << " raced, journaled but not processed: i=" << i
+		     << dendl;
+		 canceled = false;
+	       }
+	       l.unlock();
+	     }
+	   }
+	   if (canceled) {
+	     ldpp_dout(dpp, -1)
+		 << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " canceled too many times, giving up" << dendl;
+	     throw sys::system_error{ECANCELED, sys::generic_category()};
+	   }
+	   co_await f->process_journal(dpp, asio::deferred);
+	   co_return sys::error_code{};
+	 } catch (const sys::system_error& e) {
+	   ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " prepare_new_part failed: " << e.what()
+			      << dendl;
+	   co_return e.code();
+	 }
+       }, rados.get_executor()),
+       token, dpp, new_part_num, is_head, this);
+  }
+
+  /// \brief Set a new part as head
+  ///
+  /// In practice we create a new part and set it as head in one go.
+  ///
+  /// \param dpp Debug prefix provider
+  /// \param new_head_part_num New head part number
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Nothing, but may error in a way appropriate to the
+  /// completion token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code)> CompletionToken>
+  auto prepare_new_head(const DoutPrefixProvider* dpp,
+			std::int64_t new_head_part_num,
+			CompletionToken&& token) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    namespace fifo = rados::cls::fifo;
+    return asio::async_initiate<CompletionToken, void(sys::error_code)>
+      (asio::experimental::co_composed<void(sys::error_code)>
+       ([](auto state, const DoutPrefixProvider* dpp,
+	   std::int64_t new_head_part_num, FIFO* f) -> void {
+	 try {
+	   state.throw_if_cancelled(true);
+	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+
+	   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " entering" << dendl;
+	   std::unique_lock l(f->m);
+	   auto max_push_part_num = f->info.max_push_part_num;
+	   auto version = f->info.version;
+	   l.unlock();
+
+	   if (max_push_part_num < new_head_part_num) {
+	     ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " need new part" << dendl;
+	     co_await f->prepare_new_part(dpp, new_head_part_num, true,
+					  asio::deferred);
+	     std::unique_lock l(f->m);
+	     if (f->info.max_push_part_num < new_head_part_num) {
+	       ldpp_dout(dpp, -1)
+		 << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " inconsistency, push part less than head part."
+		 << dendl;
+	       throw sys::system_error(EIO, sys::generic_category());
+	     }
+	     l.unlock();
+	   }
+
+	   using enum fifo::journal_entry::Op;
+	   fifo::journal_entry jentry;
+	   jentry.op = set_head;
+	   jentry.part_num = new_head_part_num;
+
+	   bool canceled = true;
+	   for (auto i = 0; canceled && i < MAX_RACE_RETRIES; ++i) {
+	     canceled = false;
+	     ldpp_dout(dpp, 20)
+		 << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " updating metadata: i=" << i << dendl;
+	     auto u = fifo::update{}.journal_entries_add({{jentry}});
+	     canceled = co_await f->update_meta(dpp, u, version,
+						asio::deferred);
+	     if (canceled) {
+	       std::unique_lock l(f->m);
+	       auto found =
+		   (f->info.journal.contains({create, new_head_part_num}) ||
+		    f->info.journal.contains({set_head, new_head_part_num}));
+	       version = f->info.version;
+	       if ((f->info.head_part_num >= new_head_part_num)) {
+		 ldpp_dout(dpp, 20)
+		     << __PRETTY_FUNCTION__ << ":" << __LINE__
+		     << " raced, but journaled and processed: i=" << i
+		     << dendl;
+		 co_return sys::error_code{};
+	       }
+	       if (found) {
+		 ldpp_dout(dpp, 20)
+		     << __PRETTY_FUNCTION__ << ":" << __LINE__
+		     << " raced, journaled but not processed: i=" << i
+		     << dendl;
+		 canceled = false;
+	       }
+	       l.unlock();
+	     }
+	   }
+	   if (canceled) {
+	     ldpp_dout(dpp, -1)
+		 << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " canceled too many times, giving up" << dendl;
+	     throw sys::system_error(ECANCELED, sys::generic_category());
+	   }
+	   co_await f->process_journal(dpp, asio::deferred);
+	   co_return sys::error_code{};
+	 } catch (const sys::system_error& e) {
+	   ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " prepare_new_head failed: " << e.what()
+			      << dendl;
+	   co_return e.code();
+	 }
+       }, rados.get_executor()),
+       token, dpp, new_head_part_num, this);
+  }
+
+  ///@}
+
+
+public:
+
+  FIFO(const FIFO&) = delete;
+  FIFO& operator =(const FIFO&) = delete;
+  FIFO(FIFO&&) = delete;
+  FIFO& operator =(FIFO&&) = delete;
+
+  /// \brief Open an existing FIFO
+  ///
+  /// \param dpp Prefix provider for debug logging
+  /// \param rados RADOS handle
+  /// \param obj Head object for FIFO
+  /// \param ioc Locator
+  /// \param token Boost.Asio CompletionToken
+  /// \param objv Operation will fail if FIFO is not at this version
+  /// \param probe If true, the caller is probing the existence of the
+  ///              FIFO. Don't print errors if we can't find it.
+  ///
+  /// \return A `unique_ptr` to the open FIFO in a way appropriate to
+  /// the completion token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code, std::unique_ptr<FIFO>)>
+	   CompletionToken>
+  static auto open(const DoutPrefixProvider* dpp,
+		   neorados::RADOS& rados,
+		   neorados::Object obj,
+		   neorados::IOContext ioc,
+		   CompletionToken&& token,
+		   std::optional<rados::cls::fifo::objv> objv = std::nullopt,
+		   bool probe = false) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    return asio::async_initiate<CompletionToken,
+				void(sys::error_code, std::unique_ptr<FIFO>)>
+      (asio::experimental::co_composed<void(sys::error_code, std::unique_ptr<FIFO>)>
+       ([](auto state, const DoutPrefixProvider* dpp, neorados::RADOS& rados,
+	   neorados::Object obj, neorados::IOContext ioc,
+	   std::optional<rados::cls::fifo::objv> objv, bool probe) -> void {
+	 try {
+	   state.throw_if_cancelled(true);
+	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+	   ldpp_dout(dpp, 20)
+	     << __PRETTY_FUNCTION__ << ":" << __LINE__
+	     << " entering" << dendl;
+	   auto [info, size, over] = co_await get_meta(rados, obj, ioc, objv,
+						     asio::deferred);
+	   std::unique_ptr<FIFO> f(new FIFO(rados,
+					    std::move(obj),
+					    std::move(ioc),
+					    size, over, std::move(info)));
+	   probe = 0;
+
+	   // If there are journal entries, process them, in case
+	   // someone crashed mid-transaction.
+	   if (!info.journal.empty()) {
+	     ldpp_dout(dpp, 20)
+	       << __PRETTY_FUNCTION__ << ":" << __LINE__
+	       << " processing leftover journal" << dendl;
+	     co_await f->process_journal(dpp, asio::deferred);
+	   }
+	   co_return {sys::error_code{}, std::move(f)};
+	 } catch (const sys::system_error& e) {
+	   if (!probe ||
+	       (probe && !(e.code() == sys::errc::no_such_file_or_directory ||
+			   e.code() == sys::errc::no_message_available))) {
+	     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " open failed:" << e.what() << dendl;
+	   }
+	   co_return {e.code(), std::unique_ptr<FIFO>{}};
+	 }
+       }, rados.get_executor()),
+       token, dpp, std::ref(rados), std::move(obj), std::move(ioc),
+       std::move(objv), probe);
+  }
+
+  /// \brief Create and open a FIFO
+  ///
+  /// \param dpp Prefix provider for debug logging
+  /// \param rados RADOS handle
+  /// \param obj Head object for FIFO
+  /// \param ioc Locator
+  /// \param token Boost.Asio CompletionToken
+  /// \param objv Operation will fail if FIFO exists and is not at this version
+  /// \param oid_prefix Prefix for all objects
+  /// \param exclusive Fail if the FIFO already exists
+  /// \param max_part_size Maximum allowed size of parts
+  /// \param max_entry_size Maximum allowed size of entries
+  ///
+  /// \return A `unique_ptr` to the open FIFO in a way appropriate to
+  /// the completion token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code, std::unique_ptr<FIFO>)>
+	   CompletionToken>
+  static auto create(const DoutPrefixProvider* dpp,
+		     neorados::RADOS& rados,
+		     neorados::Object obj,
+		     neorados::IOContext ioc,
+		     CompletionToken&& token,
+		     std::optional<rados::cls::fifo::objv> objv = std::nullopt,
+		     std::optional<std::string> oid_prefix = std::nullopt,
+		     bool exclusive = false,
+		     std::uint64_t max_part_size = default_max_part_size,
+		     std::uint64_t max_entry_size = default_max_entry_size) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    return asio::async_initiate<CompletionToken,
+				void(sys::error_code, std::unique_ptr<FIFO>)>
+      (asio::experimental::co_composed<void(sys::error_code,
+                                            std::unique_ptr<FIFO>)>
+       ([](auto state, const DoutPrefixProvider* dpp, neorados::RADOS& rados,
+	   neorados::Object obj, neorados::IOContext ioc,
+	   std::optional<rados::cls::fifo::objv> objv,
+	   std::optional<std::string> oid_prefix, bool exclusive,
+	   std::uint64_t max_part_size, std::uint64_t max_entry_size) -> void {
+	 try {
+	   state.throw_if_cancelled(true);
+	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+
+	   ldpp_dout(dpp, 20)
+	     << __PRETTY_FUNCTION__ << ":" << __LINE__
+	     << " entering" << dendl;
+	   ldpp_dout(dpp, 10)
+	     << __PRETTY_FUNCTION__ << ":" << __LINE__
+	     << " Calling create_meta" << dendl;
+	   co_await create_meta(rados, obj, ioc, objv, oid_prefix, exclusive,
+				max_part_size, max_entry_size, asio::deferred);
+	   auto f = co_await open(dpp, rados, std::move(obj), std::move(ioc),
+				  asio::deferred, objv);
+	   co_return std::make_tuple(sys::error_code{}, std::move(f));
+	 } catch (const sys::system_error& e) {
+	   ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " create failed: " << e.what() << dendl;
+	   co_return {e.code(), std::unique_ptr<FIFO>{}};
+	 }
+       }, rados.get_executor()),
+       token, dpp, std::ref(rados), std::move(obj), std::move(ioc),
+       std::move(objv), std::move(oid_prefix), exclusive, max_part_size,
+       max_entry_size);
+  }
+
+  /// \brief Push entries to the FIFO
+  ///
+  /// \param dpp Prefix provider for debug logging
+  /// \param entries Vector of entries
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Nothing, but may error in a way appropriate to the
+  /// completion token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code)> CompletionToken>
+  auto push(const DoutPrefixProvider* dpp,
+	    std::deque<ceph::buffer::list> entries,
+	    CompletionToken&& token) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    namespace buffer = ceph::buffer;
+    return asio::async_initiate<CompletionToken,
+				void(sys::error_code)>
+      (asio::experimental::co_composed<void(sys::error_code)>
+       ([](auto state, const DoutPrefixProvider* dpp,
+	   std::deque<buffer::list> remaining, FIFO* f) -> void {
+	 try {
+	   state.throw_if_cancelled(true);
+	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+
+	   std::unique_lock l(f->m);
+	   auto max_entry_size = f->info.params.max_entry_size;
+	   auto need_new_head = f->info.need_new_head();
+	   auto head_part_num = f->info.head_part_num;
+	   l.unlock();
+	   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " entering" << dendl;
+	   if (remaining.empty()) {
+	     ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " empty push, returning success" << dendl;
+	     co_return sys::error_code{};
+	   }
+
+	   // Validate sizes
+	   for (const auto& bl : remaining) {
+	     if (bl.length() > max_entry_size) {
+	       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				  << " entry bigger than max_entry_size"
+				  << dendl;
+	       co_return sys::error_code{E2BIG, sys::generic_category()};
+	     }
+	   }
+
+	   if (need_new_head) {
+	     ldpp_dout(dpp, 10) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " need new head: "
+				<< head_part_num + 1 << dendl;
+	     co_await f->prepare_new_head(dpp, head_part_num + 1, asio::deferred);
+	   }
+
+	   std::deque<buffer::list> batch;
+
+	   uint64_t batch_len = 0;
+	   auto retries = 0;
+	   bool canceled = true;
+	   while ((!remaining.empty() || !batch.empty()) &&
+		  (retries <= MAX_RACE_RETRIES)) {
+	     ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " preparing push: remaining=" << remaining.size()
+				<< " batch=" << batch.size() << " retries=" << retries
+				<< dendl;
+	     std::unique_lock l(f->m);
+	     head_part_num = f->info.head_part_num;
+	     auto max_part_size = f->info.params.max_part_size;
+	     auto overhead = f->part_entry_overhead;
+	     l.unlock();
+
+	     while (!remaining.empty() &&
+		    (remaining.front().length() + batch_len <= max_part_size)) {
+	       /* We can send entries with data_len up to max_entry_size,
+		  however, we want to also account the overhead when
+		  dealing with multiple entries. Previous check doesn't
+		  account for overhead on purpose. */
+	       batch_len += remaining.front().length() + overhead;
+	       batch.push_back(std::move(remaining.front()));
+	       remaining.pop_front();
+	     }
+	     ldpp_dout(dpp, 20)
+	       << __PRETTY_FUNCTION__ << ":" << __LINE__
+	       << " prepared push: remaining=" << remaining.size()
+	       << " batch=" << batch.size() << " retries=" << retries
+	       << " batch_len=" << batch_len << dendl;
+
+	     auto [ec, n] =
+	       co_await f->push_entries(dpp, batch,
+					asio::as_tuple(asio::deferred));
+	     if (ec == sys::errc::result_out_of_range) {
+	       canceled = true;
+	       ++retries;
+	       ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				  << " need new head " << head_part_num + 1
+				  << dendl;
+	       co_await f->prepare_new_head(dpp, head_part_num + 1,
+					    asio::deferred);
+	       continue;
+	     } else if (ec == sys::errc::no_such_file_or_directory) {
+	       ldpp_dout(dpp, 20)
+		 << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " racing client trimmed part, rereading metadata "
+		 << dendl;
+	       canceled = true;
+	       ++retries;
+	       co_await f->read_meta(dpp, asio::deferred);
+	       continue;
+	     } else if (ec) {
+	       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				  << " push_entries failed: " << ec.message()
+				  << dendl;
+	       throw sys::system_error(ec);
+	     }
+	     assert(n >= 0);
+	     // Made forward progress!
+	     canceled = false;
+	     retries = 0;
+	     batch_len = 0;
+	     if (n == ssize(batch)) {
+	       batch.clear();
+	     } else  {
+	       batch.erase(batch.begin(), batch.begin() + n);
+	       for (const auto& b : batch) {
+		 batch_len +=  b.length() + overhead;
+	       }
+	     }
+	   }
+	   if (canceled) {
+	     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " canceled too many times, giving up."
+				<< dendl;
+	     co_return sys::error_code{ECANCELED, sys::generic_category()};
+	   }
+	   co_return sys::error_code{};
+	 } catch (const sys::system_error& e) {
+	   ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " push failed: " << e.what() << dendl;
+	   co_return e.code();
+	 }
+       }, rados.get_executor()),
+       token, dpp, std::move(entries), this);
+  }
+
+  /// \brief Push an entry to the FIFO
+  ///
+  /// \param dpp Prefix provider for debug logging
+  /// \param entries Entries to push
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Nothing, but may error in a way appropriate to the
+  /// completion token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code)> CompletionToken>
+  auto push(const DoutPrefixProvider* dpp,
+	    std::span<ceph::buffer::list> entries,
+	    CompletionToken&& token) {
+    namespace buffer = ceph::buffer;
+    std::deque<buffer::list> deque{std::make_move_iterator(entries.begin()),
+				   std::make_move_iterator(entries.end())};
+    return push(dpp, std::move(deque), std::forward<CompletionToken>(token));
+  }
+
+  /// \brief Push an entry to the FIFO
+  ///
+  /// \param dpp Prefix provider for debug logging
+  /// \param entry Entry to push
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Nothing, but may error in a way appropriate to the
+  /// completion token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code)> CompletionToken>
+  auto push(const DoutPrefixProvider* dpp,
+	    ceph::buffer::list entry,
+	    CompletionToken&& token) {
+    namespace buffer = ceph::buffer;
+    std::deque<buffer::list> entries;
+    entries.push_back(std::move(entry));
+    return push(dpp, std::move(entries), std::forward<CompletionToken>(token));
+  }
+
+  /// \brief List entries in the FIFO
+  ///
+  /// \param dpp Prefix provider for debug logging
+  /// \param markstr Marker to resume listing
+  /// \param entries Space for entries
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return (span<entry>, marker) where the span is long enough to hold
+  ///         returned entries, and marker is non-null if the listing was
+  ///         incomplete, in a way appropriate to the completion token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code, std::span<entry>,
+                  std::optional<std::string>)> CompletionToken>
+  auto list(const DoutPrefixProvider* dpp,
+	    std::optional<std::string> markstr,
+	    std::span<entry> entries,
+	    CompletionToken&& token) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    return asio::async_initiate<CompletionToken,
+				void(sys::error_code, std::span<entry>,
+                                     std::optional<std::string>)>
+      (asio::experimental::co_composed<void(sys::error_code,
+                                            std::span<entry>,
+                                            std::optional<std::string>)>
+       ([](auto state, const DoutPrefixProvider* dpp,
+	   std::optional<std::string> markstr, std::span<entry> entries,
+	   FIFO* f) -> void {
+	 try {
+	   state.throw_if_cancelled(true);
+	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+
+	   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " entering" << dendl;
+	   std::unique_lock l(f->m);
+	   std::int64_t part_num = f->info.tail_part_num;
+	   std::uint64_t ofs = 0;
+	   if (markstr) {
+	     auto marker = f->to_marker(*markstr, l);
+	     if (!marker) {
+	       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				  << " invalid marker string: " << markstr
+				  << dendl;
+	       throw sys::system_error{EINVAL, sys::generic_category()};
+	     }
+	     part_num = marker->num;
+	     ofs = marker->ofs;
+	   }
+	   l.unlock();
+
+	   bool more = false;
+
+	   auto entries_left = entries;
+
+	   while (entries_left.size() > 0) {
+	     more = false;
+	     ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " entries_left.size()="
+				<< entries_left.size() << dendl;
+	     auto [ec, res, part_more, part_full] =
+	       co_await f->list_part(dpp, part_num, ofs, entries_left,
+				     asio::as_tuple(asio::deferred));
+	     if (ec == sys::errc::no_such_file_or_directory) {
+	       ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				  << " missing part, rereading metadata"
+				  << dendl;
+	       co_await f->read_meta(dpp, asio::deferred);
+	       std::unique_lock l(f->m);
+	       if (part_num < f->info.tail_part_num) {
+		 /* raced with trim? restart */
+		 ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				    << " raced with trim, restarting" << dendl;
+		 entries_left = entries;
+		 part_num = f->info.tail_part_num;
+		 l.unlock();
+		 ofs = 0;
+		 continue;
+	       }
+	       l.unlock();
+	       ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				  << " assuming part was not written yet, "
+				  << "so end of data" << dendl;
+	       break;
+	     } else if (ec) {
+	       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				  << " list_entries failed: " << ec.message()
+				  << dendl;
+	       throw sys::system_error(ec);
+	     }
+	     more = part_full || part_more;
+	     entries_left = entries_left.last(entries_left.size() - res.size());
+
+	     if (!part_full) {
+	       ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				  << " head part is not full, so we can assume "
+				  << "we're done" << dendl;
+	       break;
+	     }
+	     if (!part_more) {
+	       ++part_num;
+	       ofs = 0;
+	     }
+	   }
+	   std::optional<std::string> marker;
+	   if (entries_left.size() > 0) {
+	     entries = entries.first(entries.size() - entries_left.size());
+	   }
+	   if (more && !entries.empty()) {
+	     marker = entries.back().marker;
+	   }
+	   co_return {sys::error_code{}, std::move(entries), std::move(marker)};
+	 } catch (const sys::system_error& e) {
+	   ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " list failed: " << e.what() << dendl;
+	   co_return {e.code(), std::span<entry>{}, std::nullopt};
+	 }
+       }, rados.get_executor()),
+       token, dpp, std::move(markstr), std::move(entries), this);
+  }
+
+  /// \brief Push entries to the FIFO
+  ///
+  /// \param dpp Prefix provider for debug logging
+  /// \param marker Marker to which to trim
+  /// \param exclusive If true, exclude the marked element from trim,
+  ///                  if false, trim it.
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return Nothing, but may error in a way appropriate to the
+  /// completion token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code)> CompletionToken>
+  auto trim(const DoutPrefixProvider* dpp,
+	    std::string marker, bool exclusive,
+	    CompletionToken&& token) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    namespace fifo = rados::cls::fifo;
+    return asio::async_initiate<CompletionToken,
+				void(sys::error_code)>
+      (asio::experimental::co_composed<void(sys::error_code)>
+       ([](auto state, const DoutPrefixProvider* dpp,
+	   std::string markstr, bool exclusive, FIFO* f) -> void {
+	 try {
+	   state.throw_if_cancelled(true);
+	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+
+	   ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " entering" << dendl;
+	   bool overshoot = false;
+	   std::unique_lock l(f->m);
+	   auto marker = f->to_marker(markstr, l);
+	   if (!marker) {
+	     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " invalid marker string: " << markstr
+				<< dendl;
+	     throw sys::system_error{EINVAL, sys::generic_category()};
+	   }
+	   auto part_num = marker->num;
+	   auto ofs = marker->ofs;
+	   auto hn = f->info.head_part_num;
+	   const auto max_part_size = f->info.params.max_part_size;
+	   if (part_num > hn) {
+	     l.unlock();
+	     co_await f->read_meta(dpp, asio::deferred);
+	     l.lock();
+	     hn = f->info.head_part_num;
+	     if (part_num > hn) {
+	       overshoot = true;
+	       part_num = hn;
+	       ofs = max_part_size;
+	     }
+	   }
+	   if (part_num < f->info.tail_part_num) {
+	     throw sys::system_error(ENODATA, sys::generic_category());
+	   }
+	   auto pn = f->info.tail_part_num;
+	   l.unlock();
+
+	   while (pn < part_num) {
+	     ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " pn=" << pn << dendl;
+	     auto [ec] = co_await f->trim_part(dpp, pn, max_part_size, false,
+					       asio::as_tuple(asio::deferred));
+	     if (ec && ec == sys::errc::no_such_file_or_directory) {
+	       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				  << " trim_part failed: " << ec.message()
+				  << dendl;
+	       throw sys::system_error(ec);
+	     }
+	     ++pn;
+	   }
+
+	   auto [ec] = co_await f->trim_part(dpp, pn, ofs, exclusive,
+					     asio::as_tuple(asio::deferred));
+	   if (ec && ec == sys::errc::no_such_file_or_directory) {
+	     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " trim_part failed: " << ec.message()
+				<< dendl;
+	     throw sys::system_error(ec);
+	   }
+
+	   l.lock();
+	   auto tail_part_num = f->info.tail_part_num;
+	   auto objv = f->info.version;
+	   l.unlock();
+	   bool canceled = tail_part_num < part_num;
+	   int retries = 0;
+	   while ((tail_part_num < part_num) &&
+		  canceled &&
+		  (retries <= MAX_RACE_RETRIES)) {
+             canceled = co_await f->update_meta(dpp, fifo::update{}
+                                                .tail_part_num(part_num),
+						objv, asio::deferred);
+	     if (canceled) {
+	       ldpp_dout(dpp, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				  << " canceled: retries=" << retries
+				  << dendl;
+	       l.lock();
+	       tail_part_num = f->info.tail_part_num;
+	       objv = f->info.version;
+	       l.unlock();
+	       ++retries;
+	     }
+	   }
+	   if (canceled) {
+	     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+				<< " canceled too many times, giving up"
+				<< dendl;
+	     throw sys::system_error(EIO, sys::generic_category());
+	   }
+	   co_return (overshoot ?
+		      sys::error_code{ENODATA, sys::generic_category()} :
+		      sys::error_code{});
+	   co_return sys::error_code{};
+	 } catch (const sys::system_error& e) {
+	   ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " trim failed: " << e.what() << dendl;
+	   co_return e.code();
+	 }
+       }, rados.get_executor()),
+       token, dpp, std::move(marker), exclusive, this);
+  }
+
+  static constexpr auto max_list_entries =
+    rados::cls::fifo::op::MAX_LIST_ENTRIES;
+
+  /// The default maximum size of every part object (that is, every
+  /// object holding entries)
+  static constexpr std::uint64_t default_max_part_size = 4 * 1024 * 1024;
+
+  /// The default maximum entry size
+  static constexpr std::uint64_t default_max_entry_size = 32 * 1024;
+
+  /// Return a marker comparing less than any other marker.
+  static auto min_marker() {
+    return marker{std::numeric_limits<decltype(marker::num)>::max(),
+                  std::numeric_limits<decltype(marker::ofs)>::max()}
+      .to_string();
+  }
+
+  /// Return a marker comparing greater than any other marker.
+  static auto max_marker() {
+    return marker{std::numeric_limits<decltype(marker::num)>::max(),
+                  std::numeric_limits<decltype(marker::ofs)>::max()}
+      .to_string();
+  }
+
+  /// \brief Get information on the last entry
+  ///
+  /// \param dpp Prefix provider for debug logging
+  /// \param token Boost.Asio CompletionToken
+  ///
+  /// \return {marker, time} for the latest entry in a way appropriate
+  /// to the completion token.
+  template<boost::asio::completion_token_for<
+	     void(boost::system::error_code, std::string, ceph::real_time)>
+	   CompletionToken>
+  auto last_entry_info(const DoutPrefixProvider* dpp,
+		       CompletionToken&& token) {
+    namespace asio = boost::asio;
+    namespace sys = boost::system;
+    namespace buffer = ceph::buffer;
+    return asio::async_initiate<
+      CompletionToken, void(sys::error_code, std::string, ceph::real_time)>
+      (asio::experimental::co_composed<
+	void(sys::error_code, std::string, ceph::real_time)>
+       ([](auto state, const DoutPrefixProvider* dpp,
+	   FIFO* f) -> void {
+	 try {
+	   state.throw_if_cancelled(true);
+	   state.reset_cancellation_state(asio::enable_terminal_cancellation());
+
+	   co_await f->read_meta(dpp, asio::deferred);
+	   std::unique_lock l(f->m);
+	   auto head_part_num = f->info.head_part_num;
+	   l.unlock();
+
+	   if (head_part_num < 0) {
+	     co_return {sys::error_code{}, std::string{},
+	                ceph::real_clock::zero()};
+	   } else {
+	     auto header =
+	       co_await f->get_part_info(head_part_num, asio::deferred);
+	     co_return {sys::error_code{},
+	                marker{head_part_num, header.last_ofs}.to_string(),
+	                header.max_time};
+	   }
+	 } catch (const sys::system_error& e) {
+	   ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			      << " push failed: " << e.what() << dendl;
+	   co_return {e.code(), std::string{}, ceph::real_time{}};
+	 }
+       }, rados.get_executor()),
+       token, dpp, this);
+  }
+};
+} // namespace neorados::cls::fifo {

--- a/src/neorados/cls/log.h
+++ b/src/neorados/cls/log.h
@@ -1,0 +1,415 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * See file COPYING for license information.
+ *
+ */
+
+#pragma once
+
+/// \file neodrados/cls/log.h
+///
+/// \brief NeoRADOS interface to OMAP based log class
+///
+/// The `log` object class stores a time-indexed series of entries in
+/// the OMAP of a given object.
+
+#include <span>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include <boost/asio/experimental/co_composed.hpp>
+
+#include <boost/system/error_code.hpp>
+#include <boost/system/errc.hpp>
+
+#include "include/buffer.h"
+
+#include "include/neorados/RADOS.hpp"
+
+#include "common/ceph_time.h"
+
+#include "cls/log/cls_log_ops.h"
+#include "cls/log/cls_log_types.h"
+
+#include "common.h"
+
+namespace neorados::cls::log {
+using ::cls::log::entry;
+using ::cls::log::header;
+static constexpr auto max_list_entries = 1000u;
+
+/// \brief Push entries to the log
+///
+/// Append a call to a write operation that adds a set of entries to the log
+///
+/// \param entries Entries to push
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto add(std::vector<entry> entries)
+{
+  buffer::list in;
+  ::cls::log::ops::add_op call;
+  call.entries = std::move(entries);
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec("log", "add", in);
+  }};
+}
+
+/// \brief Push an entry to the log
+///
+/// Append a call to a write operation that adds an entry to the log
+///
+/// \param entry Entry to push
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto add(entry e)
+{
+  bufferlist in;
+  ::cls::log::ops::add_op call;
+  call.entries.push_back(std::move(e));
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec("log", "add", in);
+  }};
+}
+
+/// \brief Push an entry to the log
+///
+/// Append a call to a write operation that adds an entry to the log
+///
+/// \param timestamp Timestamp of the log entry
+/// \param section Annotation string included in the entry
+/// \param name Log entry name
+/// \param bl Data held in the log entry
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto add(ceph::real_time timestamp, std::string section,
+			      std::string name, buffer::list&& bl)
+{
+  bufferlist in;
+  ::cls::log::ops::add_op call;
+  call.entries.emplace_back(timestamp, std::move(section),
+			    std::move(name), std::move(bl));
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec("log", "add", in);
+  }};
+}
+
+/// \brief List log entries
+///
+/// Append a call to a read operation that lists log entries
+///
+/// \param from Start of range
+/// \param to End of range
+/// \param in_marker Point to resume truncated listing
+/// \param entries Span giving location to store entries
+/// \param result Span giving entries actually stored
+/// \param marker Place to store marker to resume truncated listing
+/// \param truncated Place to store truncation status (true means
+///                  there's more to list)
+///
+/// \return The ClsReadOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto list(ceph::real_time from, ceph::real_time to,
+			       std::optional<std::string> in_marker,
+			       std::span<entry> entries, std::span<entry>* result,
+			       std::optional<std::string>* const out_marker)
+{
+  using boost::system::error_code;
+  bufferlist in;
+  ::cls::log::ops::list_op call;
+  call.from_time = from;
+  call.to_time = to;
+  call.marker = std::move(in_marker).value_or("");
+  call.max_entries = entries.size();
+
+  encode(call, in);
+  return ClsReadOp{[entries, result, out_marker,
+		    in = std::move(in)](ReadOp& op) {
+    op.exec("log", "list", in,
+	    [entries, result, out_marker](error_code ec, const buffer::list& bl) {
+	      ::cls::log::ops::list_ret ret;
+	      if (!ec) {
+		auto iter = bl.cbegin();
+		decode(ret, iter);
+		if (result) {
+		  *result = entries.first(ret.entries.size());
+		  std::move(ret.entries.begin(), ret.entries.end(),
+			    entries.begin());
+		}
+		if (out_marker) {
+		  *out_marker = (ret.truncated ?
+				 std::move(ret.marker) :
+				 std::optional<std::string>{});
+		}
+	      }
+	    });
+  }};
+}
+
+/// \brief List log entries
+///
+/// Execute an asynchronous operation that lists log entries
+///
+/// \param r RADOS handle
+/// \param o Object associated with log
+/// \param ioc Object locator context
+/// \param from Start of range
+/// \param to End of range
+/// \param in_marker Point to resume truncated listing
+///
+/// \return (entries, marker) in a way appropriate to the
+/// completion token. See Boost.Asio documentation.
+template<boost::asio::completion_token_for<
+	   void(boost::system::error_code, std::span<entry>,
+                std::optional<std::string>)> CompletionToken>
+auto list(RADOS& r, Object o, IOContext ioc, ceph::real_time from,
+	  ceph::real_time to, std::optional<std::string> in_marker,
+	  std::span<entry> entries, CompletionToken&& token)
+{
+  using namespace std::literals;
+  ::cls::log::ops::list_op req;
+  req.from_time = from;
+  req.to_time = to;
+  req.marker = std::move(in_marker).value_or("");
+  req.max_entries = entries.size();
+  return exec<::cls::log::ops::list_ret>(
+    r, std::move(o), std::move(ioc),
+    "log"s, "list"s, req,
+    [entries](const ::cls::log::ops::list_ret& ret) {
+      auto res = entries.first(ret.entries.size());
+      std::move(ret.entries.begin(), ret.entries.end(),
+		res.begin());
+      std::optional<std::string> marker;
+      if (ret.truncated) {
+	marker = std::move(ret.marker);
+      }
+      return std::make_tuple(res, std::move(marker));
+    }, std::forward<CompletionToken>(token));
+}
+
+/// \brief Get log header
+///
+/// Append a call to a read operation that returns the log header
+///
+/// \param header Place to store the log header
+///
+/// \return The ClsReadOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto info(header* const header)
+{
+  using boost::system::error_code;
+  buffer::list in;
+  ::cls::log::ops::info_op call;
+
+  encode(call, in);
+
+  return ClsReadOp{[header, in = std::move(in)](ReadOp& op) {
+    op.exec("log", "info", in,
+	    [header](error_code ec,
+		     const buffer::list& bl) {
+	      ::cls::log::ops::info_ret ret;
+	      if (!ec) {
+		auto iter = bl.cbegin();
+		decode(ret, iter);
+		if (header)
+		*header = std::move(ret.header);
+	      }
+	    });
+  }};
+}
+
+/// \brief Get log header
+///
+/// Execute an asynchronous operation that returns the log header
+///
+/// \param r RADOS handle
+/// \param o Object associated with log
+/// \param ioc Object locator context
+///
+/// \return The log header in a way appropriate to the completion
+/// token. See Boost.Asio documentation.
+template<typename CompletionToken>
+auto info(RADOS& r, Object o, IOContext ioc, CompletionToken&& token)
+{
+  using namespace std::literals;
+  return exec<::cls::log::ops::info_ret>(
+    r, std::move(o), std::move(ioc),
+    "log"s, "info"s, ::cls::log::ops::info_op{},
+    [](const ::cls::log::ops::info_ret& ret) {
+      return ret.header;
+    }, std::forward<CompletionToken>(token));
+}
+
+// Since trim uses the string markers and ignores the time if the
+// string markers are present, there's no benefit to having a function
+// that takes both.
+
+/// \brief Trim entries from the log
+///
+/// Append a call to a write operation that trims a range of entries
+/// from the log.
+///
+/// \param from_time Start of range, based on the timestamp supplied to add
+/// \param to_time End of range, based on the timestamp supplied to add
+///
+/// \warning This operation may succeed even if not all entries have been trimmed.
+/// to ensure completion, call repeatedly until the operation returns
+/// boost::system::errc::no_message_available
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto trim(ceph::real_time from_time,
+			       ceph::real_time to_time)
+{
+  bufferlist in;
+  ::cls::log::ops::trim_op call;
+  call.from_time = from_time;
+  call.to_time = to_time;
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec("log", "trim", in);
+  }};
+}
+
+/// \brief Beginning marker for trim
+///
+/// A before-the-beginning marker for log entries, comparing less than
+/// any possible entry.
+inline constexpr std::string begin_marker{""};
+
+/// \brief End marker for trim
+///
+/// An after-the-end marker for log entries, comparing greater than
+/// any possible entry.
+inline constexpr std::string end_marker{"9"};
+
+/// \brief Trim entries from the log
+///
+/// Append a call to a write operation that trims a range of entries
+/// from the log.
+///
+/// \param from_marker Start of range, based on markers from list
+/// \param to_marker End of range, based on markers from list
+///
+/// \note Use \ref begin_marker to trim everything up to a given point.
+/// Use \ref end_marker to trim everything after a given point. Use them
+/// both together to trim all entries.
+///
+/// \warning This operation may succeed even if not all entries have been trimmed.
+/// to ensure completion, call repeatedly until the operation returns
+/// boost::system::errc::no_message_available
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto trim(std::string from_marker, std::string to_marker)
+{
+  bufferlist in;
+  ::cls::log::ops::trim_op call;
+  call.from_marker = std::move(from_marker);
+  call.to_marker = std::move(to_marker);
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec("log", "trim", in);
+  }};
+}
+
+/// \brief Trim entries from the log
+///
+/// Execute an asynchronous operation that trims a range of entries
+/// from the log.
+///
+/// \param op Write operation to modify
+/// \param from_marker Start of range, based on markers from list
+/// \param to_marker End of range, based on markers from list
+///
+/// \note Use \ref begin_marker to trim everything up to a given point.
+/// Use \ref end_marker to trim everything after a given point. Use them
+/// both together to trim all entries.
+///
+/// \return As appropriate to the completion token. See Boost.Asio
+/// documentation.
+template<typename CompletionToken>
+auto trim(RADOS& r, Object oid, IOContext ioc, std::string from_marker,
+	  std::string to_marker, CompletionToken&& token)
+{
+  namespace asio = boost::asio;
+  using boost::system::error_code;
+  using boost::system::system_error;
+  using ceph::real_time;
+  using boost::system::errc::no_message_available;
+
+  return asio::async_initiate<CompletionToken,
+			      void(error_code)>
+    (asio::experimental::co_composed<void(error_code)>
+     ([](auto state, RADOS& r, Object oid, IOContext ioc,
+	 std::string from_marker, std::string to_marker) -> void {
+       try {
+	 for (;;) {
+	   co_await r.execute(oid, ioc,
+			      WriteOp{}.exec(trim(from_marker, to_marker)),
+			      asio::deferred);
+	 }
+       } catch (const system_error& e) {
+	 if (e.code() != no_message_available) {
+	   co_return e.code();
+	 }
+       }
+       co_return error_code{};
+     }, r.get_executor()),
+     token, std::ref(r), std::move(oid), std::move(ioc),
+     std::move(from_marker), std::move(to_marker));
+}
+
+/// \brief Trim entries from the log
+///
+/// Execute an asynchronous operation that trims a range of entries
+/// from the log.
+///
+/// \param op Write operation to modify
+/// \param from_time Start of range, based on the timestamp supplied to add
+/// \param to_time End of range, based on the timestamp supplied to add
+///
+/// \return As appropriate to the completion token. See Boost.Asio
+/// documentation.
+template<typename CompletionToken>
+auto trim(RADOS& r, Object oid, IOContext ioc, ceph::real_time from_time,
+	  ceph::real_time to_time, CompletionToken&& token)
+{
+  namespace asio = boost::asio;
+  using boost::system::error_code;
+  using boost::system::system_error;
+  using ceph::real_time;
+  using boost::system::errc::no_message_available;
+
+  return asio::async_initiate<CompletionToken,
+			      void(error_code)>
+    (asio::experimental::co_composed<void(error_code)>
+     ([](auto state, RADOS& r, Object oid, IOContext ioc,
+	 real_time from_time, real_time to_time) -> void {
+       try {
+	 for (;;) {
+	   
+	   co_await r.execute(oid, ioc, WriteOp{}.exec(trim(from_time, to_time)),
+			      asio::deferred);
+	 }
+       } catch (const system_error& e) {
+	 if (e.code() != no_message_available) {
+	   co_return e.code();
+	 }
+       }
+       co_return error_code{};
+     }, r.get_executor()),
+     token, std::ref(r), std::move(oid), std::move(ioc), from_time, to_time);
+}
+} // namespace neorados::cls::log

--- a/src/neorados/cls/sem_set.h
+++ b/src/neorados/cls/sem_set.h
@@ -1,0 +1,266 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2024 IBM
+ *
+ * See file COPYING for license information.
+ *
+ */
+
+#pragma once
+
+/// \file neodrados/cls/sem_set.h
+///
+/// \brief NeoRADOS interface to semaphore set class
+///
+/// The `sem_set` object class stores a set of strings with associated
+/// semaphores in OMAP.
+
+#include <cstdint>
+#include <initializer_list>
+#include <string>
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include <boost/asio/experimental/co_composed.hpp>
+
+#include <boost/system/error_code.hpp>
+#include <boost/system/errc.hpp>
+
+#include "include/buffer.h"
+
+#include "include/neorados/RADOS.hpp"
+
+#include "common/ceph_context.h"
+
+#include "cls/sem_set/ops.h"
+
+#include "common.h"
+
+namespace neorados::cls::sem_set {
+
+/// \brief The maximum number of keys per op
+///
+/// Get the maximum number of keys that can be sent in a single
+/// increment or decrement operation
+///
+/// \param entries Entries to push
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto max_entries(RADOS& rados) {
+  using namespace std::literals;
+  return rados.cct()->_conf.get_val<std::uint64_t>(
+    "osd_max_omap_entries_per_request"sv);
+}
+
+/// \brief Increment semaphore
+///
+/// Append a call to a write operation that increments the semaphore
+/// on a key.
+///
+/// \param key Key to increment
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto increment(std::string key)
+{
+  namespace ss = ::cls::sem_set;
+  buffer::list in;
+  ss::increment call{std::move(key)};
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec(ss::CLASS, ss::INCREMENT, in);
+  }};
+}
+
+/// \brief Increment semaphores
+///
+/// Append a call to a write operation that increments the semaphores
+/// on a set of keys.
+///
+/// \param keys Keys to increment
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto increment(std::initializer_list<std::string> keys)
+{
+  namespace ss = ::cls::sem_set;
+  buffer::list in;
+  ss::increment call{keys};
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec(ss::CLASS, ss::INCREMENT, in);
+  }};
+}
+
+/// \brief Increment semaphores
+///
+/// Append a call to a write operation that increments the semaphores
+/// on a set of keys.
+///
+/// \param keys Keys to increment
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+template<std::input_iterator I>
+[[nodiscard]] inline auto increment(I begin, I end)
+  requires std::is_convertible_v<typename I::value_type, std::string>
+{
+  namespace ss = ::cls::sem_set;
+  buffer::list in;
+  ss::increment call{begin, end};
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec(ss::CLASS, ss::INCREMENT, in);
+  }};
+}
+
+/// \brief Decrement semaphore
+///
+/// Append a call to a write operation that decrements the semaphore
+/// on a key.
+///
+/// \param key Key to decrement
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto decrement(std::string key)
+{
+  namespace ss = ::cls::sem_set;
+  buffer::list in;
+  ss::decrement call{std::move(key)};
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec(ss::CLASS, ss::DECREMENT, in);
+  }};
+}
+
+/// \brief Decrement semaphores
+///
+/// Append a call to a write operation that decrements the semaphores
+/// on a set of keys.
+///
+/// \param keys Keys to decrement
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto decrement(std::initializer_list<std::string> keys)
+{
+  namespace ss = ::cls::sem_set;
+  buffer::list in;
+  ss::decrement call{keys};
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec(ss::CLASS, ss::DECREMENT, in);
+  }};
+}
+
+/// \brief decrement semaphores
+///
+/// Append a call to a write operation that decrements the semaphores
+/// on a set of keys.
+///
+/// \param keys Keys to decrement
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+template<std::input_iterator I>
+[[nodiscard]] inline auto decrement(I begin, I end)
+  requires std::is_convertible_v<typename I::value_type, std::string>
+{
+  namespace ss = ::cls::sem_set;
+  buffer::list in;
+  ss::decrement call{begin, end};
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec(ss::CLASS, ss::DECREMENT, in);
+  }};
+}
+
+/// \brief List keys and semaphores
+///
+/// Append a call to a read operation that lists keys and semaphores
+///
+/// \note This *appends* to the `entries`, it does not *clear* it.
+///
+/// \param count Number of entries to fetch
+/// \param cursor Where to start
+/// \param entries Unordered list to which entries are appended
+/// \param new_cursor Where to start for the next iteration, empty if completed
+///
+/// \return The ClsReadOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto list(
+  std::uint64_t count,
+  std::optional<std::string> cursor,
+  std::unordered_map<std::string, std::uint64_t>* const entries,
+  std::optional<std::string>* const new_cursor)
+{
+  namespace ss = ::cls::sem_set;
+  using boost::system::error_code;
+  buffer::list in;
+  ::cls::sem_set::list_op call;
+  call.count = count;
+  call.cursor = std::move(cursor);
+
+  encode(call, in);
+  return ClsReadOp{[entries, new_cursor,
+		    in = std::move(in)](ReadOp& op) {
+    op.exec(ss::CLASS, ss::LIST, in,
+	    [entries, new_cursor](error_code ec, const buffer::list& bl) {
+	      ss::list_ret ret;
+	      if (!ec) {
+		auto iter = bl.cbegin();
+		decode(ret, iter);
+		if (entries) {
+		  entries->reserve(entries->size() + ret.kvs.size());
+		  entries->merge(std::move(ret.kvs));
+		}
+		if (new_cursor) {
+		  *new_cursor = std::move(ret.cursor);
+		}
+	      }
+	    });
+  }};
+}
+
+/// \brief List keys and semaphores
+///
+/// Append a call to a read operation that lists keys and semaphores
+///
+/// \param count Number of entries to fetch
+/// \param cursor Where to start
+/// \param out Output iterator
+/// \param new_cursor Where to start for the next iteration, empty if completed
+///
+/// \return The ClsReadOp to be passed to WriteOp::exec
+template<std::output_iterator<std::pair<std::string, std::uint64_t>> I>
+[[nodiscard]] inline auto list(std::uint64_t count,
+			       std::optional<std::string> cursor,
+			       I output,
+			       std::optional<std::string>* const new_cursor)
+{
+  namespace ss = ::cls::sem_set;
+  using boost::system::error_code;
+  buffer::list in;
+  ::cls::sem_set::list_op call;
+  call.count = count;
+  call.cursor = std::move(cursor);
+
+  encode(call, in);
+  return ClsReadOp{[output, new_cursor,
+		    in = std::move(in)](ReadOp& op) {
+    op.exec(ss::CLASS, ss::LIST, in,
+	    [output, new_cursor](error_code ec, const buffer::list& bl) {
+	      ss::list_ret ret;
+	      if (!ec) {
+		auto iter = bl.cbegin();
+		decode(ret, iter);
+		std::move(ret.kvs.begin(), ret.kvs.end(), output);
+		if (new_cursor) {
+		  *new_cursor = std::move(ret.cursor);
+		}
+	      }
+	    });
+  }};
+}
+} // namespace neorados::cls::sem_set

--- a/src/neorados/cls/version.h
+++ b/src/neorados/cls/version.h
@@ -1,0 +1,179 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * See file COPYING for license information.
+ *
+ */
+
+#pragma once
+
+/// \file neorados/cls/version.h
+///
+/// \brief NeoRADOS interface to object versioning class
+///
+/// The `version` object class stores a version in the extended
+/// attributes of an object to help coordinate multiple writers. This
+/// version comprises a byte string and an integer. The integers are
+/// comparable and can be compared with the operators in
+/// `VersionCond`. The byte strings are incomparable. Two versions
+/// with different strings will always conflict.
+
+#include <coroutine>
+#include <string>
+#include <utility>
+
+#include <boost/asio/async_result.hpp>
+#include <boost/system/error_code.hpp>
+
+#include "include/neorados/RADOS.hpp"
+
+#include "cls/version/cls_version_ops.h"
+#include "cls/version/cls_version_types.h"
+
+#include "neorados/cls/common.h"
+
+namespace neorados::cls::version {
+/// \brief Set the object version
+///
+/// Append a call to a write operation to set the object's version.
+///
+/// \param ver Version to set
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto set(const obj_version& ver)
+{
+  buffer::list in;
+  cls_version_set_op call;
+  call.objv = ver;
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec("version", "set", in);
+  }};
+}
+
+/// \brief Unconditional increment version
+///
+/// Append a call to a write operation to increment the integral
+/// portion of a version.
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto inc()
+{
+  buffer::list in;
+  cls_version_inc_op call;
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec("version", "inc", in);
+  }};
+}
+
+/// \brief Conditionally increment version
+///
+/// Append a call to a write operation to increment the object's
+/// version if condition is met. If the condition is not met, the
+/// operation fails with `std::errc::resource_unavailable_try_again`.
+///
+/// \param ver Version to compare stored object version against
+/// \param cond Comparison operator
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline auto inc(const obj_version& objv, const VersionCond cond)
+{
+  buffer::list in;
+  cls_version_inc_op call;
+  call.objv = objv;
+
+  obj_version_cond c;
+  c.cond = cond;
+  c.ver = objv;
+
+  call.conds.push_back(c);
+
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)](WriteOp& op) {
+    op.exec("version", "inc_conds", in);
+  }};
+}
+
+/// \brief Assert condition on stored version
+///
+/// Append a call to an operation that verifies the stored version has
+/// the specified relationship to the supplied version. If the
+/// condition is not met, the operation fails with `std::errc::canceled`.
+///
+/// \param ver Version to compare stored object version against
+/// \param cond Comparison operator
+///
+/// \return The ClsOp to be passed to {Read,Write}Op::exec
+[[nodiscard]] inline auto check(const obj_version& ver, const VersionCond cond)
+{
+  buffer::list in;
+  cls_version_check_op call;
+  call.objv = ver;
+
+  obj_version_cond c;
+  c.cond = cond;
+  c.ver = ver;
+
+  call.conds.push_back(c);
+
+  encode(call, in);
+  return ClsOp{[in = std::move(in)](Op& op) {
+    op.exec("version", "check_conds", in);
+  }};
+}
+
+/// \brief Read the stored object version
+///
+/// Append a call to a read operation that reads the stored version.
+///
+/// \param objv Location to store the version
+///
+/// \return The ClsReadOp to be passed to ReadOp::exec
+[[nodiscard]] inline auto read(obj_version* const objv)
+{
+  using boost::system::error_code;
+  return ClsReadOp{[objv](Op& op) {
+    op.exec("version", "read", {},
+	    [objv](error_code ec,
+		   const buffer::list& bl) {
+	      cls_version_read_ret ret;
+	      if (!ec) {
+		auto iter = bl.cbegin();
+		decode(ret, iter);
+		if (objv)
+		  *objv = std::move(ret.objv);
+	      }
+	    });
+  }};
+}
+
+/// \brief Read the stored object version
+///
+/// Execute an asynchronous operation that reads the stored version.
+///
+/// \param r RADOS handle
+/// \param o Object to query
+/// \param ioc IOContext determining the object location
+/// \param token Boost.Asio CompletionToken
+///
+/// \return The object version in a way appropriate to the completion
+/// token. See Boost.Asio documentation.
+template<boost::asio::completion_token_for<
+	   void(boost::system::error_code, obj_version)> CompletionToken>
+inline auto read(RADOS& r, Object o, IOContext ioc,
+		 CompletionToken&& token)
+{
+  using namespace std::literals;
+  return exec<cls_version_read_ret>(
+    r, std::move(o), std::move(ioc),
+    "version"s, "read"s, nullptr,
+    [](cls_version_read_ret&& ret) {
+      return std::move(ret.objv);
+    }, std::forward<CompletionToken>(token));
+}
+} // namespace neorados::cls::version

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -194,7 +194,9 @@ set(librgw_common_srcs
   driver/rados/rgw_user.cc
   driver/rados/rgw_zone.cc
   driver/rados/sync_fairness.cc
-  driver/rados/topic.cc)
+  driver/rados/topic.cc
+  driver/rados/rgw_neorados.cc
+)
 
 list(APPEND librgw_common_srcs
   driver/immutable_config/store.cc

--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -995,7 +995,7 @@ int RGWContinuousLeaseCR::operate(const DoutPrefixProvider *dpp)
 }
 
 RGWRadosTimelogAddCR::RGWRadosTimelogAddCR(const DoutPrefixProvider *_dpp, rgw::sal::RadosStore* _store, const string& _oid,
-                      const cls_log_entry& entry) : RGWSimpleCoroutine(_store->ctx()),
+                      const cls::log::entry& entry) : RGWSimpleCoroutine(_store->ctx()),
                                                 dpp(_dpp),
                                                 store(_store),
                                                 oid(_oid), cn(NULL)

--- a/src/rgw/driver/rados/rgw_cr_rados.h
+++ b/src/rgw/driver/rados/rgw_cr_rados.h
@@ -1519,7 +1519,7 @@ public:
 class RGWRadosTimelogAddCR : public RGWSimpleCoroutine {
   const DoutPrefixProvider *dpp;
   rgw::sal::RadosStore* store;
-  std::list<cls_log_entry> entries;
+  std::vector<cls_log_entry> entries;
 
   std::string oid;
 

--- a/src/rgw/driver/rados/rgw_cr_rados.h
+++ b/src/rgw/driver/rados/rgw_cr_rados.h
@@ -1519,7 +1519,7 @@ public:
 class RGWRadosTimelogAddCR : public RGWSimpleCoroutine {
   const DoutPrefixProvider *dpp;
   rgw::sal::RadosStore* store;
-  std::vector<cls_log_entry> entries;
+  std::vector<cls::log::entry> entries;
 
   std::string oid;
 
@@ -1527,7 +1527,7 @@ class RGWRadosTimelogAddCR : public RGWSimpleCoroutine {
 
 public:
   RGWRadosTimelogAddCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* _store, const std::string& _oid,
-		        const cls_log_entry& entry);
+		        const cls::log::entry& entry);
 
   int send_request(const DoutPrefixProvider *dpp) override;
   int request_complete() override;

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -98,7 +98,7 @@ void rgw_data_notify_entry::decode_json(JSONObj *obj) {
 }
 
 class RGWDataChangesOmap final : public RGWDataChangesBE {
-  using centries = std::list<cls_log_entry>;
+  using centries = std::vector<cls_log_entry>;
   std::vector<std::string> oids;
 
 public:
@@ -154,7 +154,7 @@ public:
 	   std::optional<std::string_view> marker,
 	   std::string* out_marker, bool* truncated,
 	   optional_yield y) override {
-    std::list<cls_log_entry> log_entries;
+    std::vector<cls_log_entry> log_entries;
     lr::ObjectReadOperation op;
     cls_log_list(op, {}, {}, std::string(marker.value_or("")),
 		 max_entries, log_entries, out_marker, truncated);
@@ -235,7 +235,7 @@ public:
   }
   int is_empty(const DoutPrefixProvider *dpp, optional_yield y) override {
     for (auto shard = 0u; shard < oids.size(); ++shard) {
-      std::list<cls_log_entry> log_entries;
+      std::vector<cls_log_entry> log_entries;
       lr::ObjectReadOperation op;
       std::string out_marker;
       bool truncated;

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -122,7 +122,7 @@ public:
     }
 
     cls_log_entry e;
-    cls_log_add_prepare_entry(e, utime_t(ut), {}, key, entry);
+    cls_log_add_prepare_entry(e, ut, {}, key, entry);
     std::get<centries>(out).push_back(std::move(e));
   }
   int push(const DoutPrefixProvider *dpp, int index, entries&& items, optional_yield y) override {
@@ -140,7 +140,7 @@ public:
 	   const std::string& key, ceph::buffer::list&& bl,
 	   optional_yield y) override {
     lr::ObjectWriteOperation op;
-    cls_log_add(op, utime_t(now), {}, key, bl);
+    cls_log_add(op, now, {}, key, bl);
     auto r = rgw_rados_operate(dpp, ioctx, oids[index], &op, y);
     if (r < 0) {
       ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
@@ -172,7 +172,7 @@ public:
     for (auto iter = log_entries.begin(); iter != log_entries.end(); ++iter) {
       rgw_data_change_log_entry log_entry;
       log_entry.log_id = iter->id;
-      auto rt = iter->timestamp.to_real_time();
+      auto rt = iter->timestamp;
       log_entry.log_timestamp = rt;
       auto liter = iter->data.cbegin();
       try {
@@ -200,7 +200,7 @@ public:
 		 << cpp_strerror(-r) << dendl;
     } else {
       info->marker = header.max_marker;
-      info->last_update = header.max_time.to_real_time();
+      info->last_update = header.max_time;
     }
     return r;
   }

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -98,7 +98,7 @@ void rgw_data_notify_entry::decode_json(JSONObj *obj) {
 }
 
 class RGWDataChangesOmap final : public RGWDataChangesBE {
-  using centries = std::vector<cls_log_entry>;
+  using centries = std::vector<cls::log::entry>;
   std::vector<std::string> oids;
 
 public:
@@ -121,7 +121,7 @@ public:
       out = centries();
     }
 
-    cls_log_entry e;
+    cls::log::entry e;
     cls_log_add_prepare_entry(e, ut, {}, key, entry);
     std::get<centries>(out).push_back(std::move(e));
   }
@@ -154,7 +154,7 @@ public:
 	   std::optional<std::string_view> marker,
 	   std::string* out_marker, bool* truncated,
 	   optional_yield y) override {
-    std::vector<cls_log_entry> log_entries;
+    std::vector<cls::log::entry> log_entries;
     lr::ObjectReadOperation op;
     cls_log_list(op, {}, {}, std::string(marker.value_or("")),
 		 max_entries, log_entries, out_marker, truncated);
@@ -189,7 +189,7 @@ public:
   }
   int get_info(const DoutPrefixProvider *dpp, int index,
 	       RGWDataChangesLogInfo *info, optional_yield y) override {
-    cls_log_header header;
+    cls::log::header header;
     lr::ObjectReadOperation op;
     cls_log_info(op, &header);
     auto r = rgw_rados_operate(dpp, ioctx, oids[index], &op, nullptr, y);
@@ -235,7 +235,7 @@ public:
   }
   int is_empty(const DoutPrefixProvider *dpp, optional_yield y) override {
     for (auto shard = 0u; shard < oids.size(); ++shard) {
-      std::vector<cls_log_entry> log_entries;
+      std::vector<cls::log::entry> log_entries;
       lr::ObjectReadOperation op;
       std::string out_marker;
       bool truncated;
@@ -539,7 +539,7 @@ int RGWDataChangesLog::renew_entries(const DoutPrefixProvider *dpp)
   if (!zone->log_data)
     return 0;
 
-  /* we can't keep the bucket name as part of the cls_log_entry, and we need
+  /* we can't keep the bucket name as part of the cls::log::entry, and we need
    * it later, so we keep two lists under the map */
   bc::flat_map<int, std::pair<std::vector<BucketGen>,
 			      RGWDataChangesBE::entries>> m;

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -20,6 +20,7 @@
 #include "rgw_datalog.h"
 #include "rgw_log_backing.h"
 #include "rgw_tools.h"
+#include "rgw_sal_rados.h"
 
 #define dout_context g_ceph_context
 static constexpr auto dout_subsys = ceph_subsys_rgw;
@@ -488,7 +489,7 @@ bs::error_code DataLogBackends::handle_empty_to(uint64_t new_tail) noexcept {
 
 int RGWDataChangesLog::start(const DoutPrefixProvider *dpp, const RGWZone* _zone,
 			     const RGWZoneParams& zoneparams,
-			     librados::Rados* lr)
+			     rgw::sal::RadosStore* store)
 {
   zone = _zone;
   ceph_assert(zone);
@@ -497,7 +498,7 @@ int RGWDataChangesLog::start(const DoutPrefixProvider *dpp, const RGWZone* _zone
   // Should be guaranteed by `set_enum_allowed`
   ceph_assert(defbacking);
   auto log_pool = zoneparams.log_pool;
-  auto r = rgw_init_ioctx(dpp, lr, log_pool, ioctx, true, false);
+  auto r = rgw_init_ioctx(dpp, store->getRados()->get_rados_handle(), log_pool, ioctx, true, false);
   if (r < 0) {
     ldpp_dout(dpp, -1) << __PRETTY_FUNCTION__
 	       << ": Failed to initialized ioctx, r=" << r

--- a/src/rgw/driver/rados/rgw_datalog.h
+++ b/src/rgw/driver/rados/rgw_datalog.h
@@ -357,7 +357,7 @@ protected:
     return datalog.get_oid(gen_id, shard_id);
   }
 public:
-  using entries = std::variant<std::list<cls_log_entry>,
+  using entries = std::variant<std::vector<cls_log_entry>,
 			       std::vector<ceph::buffer::list>>;
 
   const uint64_t gen_id;

--- a/src/rgw/driver/rados/rgw_datalog.h
+++ b/src/rgw/driver/rados/rgw_datalog.h
@@ -186,9 +186,6 @@ public:
 		   std::string_view marker, optional_yield y);
   void trim_entries(const DoutPrefixProvider *dpp, int shard_id, std::string_view marker,
 		    librados::AioCompletion* c);
-  void set_zero(RGWDataChangesBE* be) {
-    emplace(0, be);
-  }
 
   bs::error_code handle_init(entries_t e) noexcept override;
   bs::error_code handle_new_gens(entries_t e) noexcept override;

--- a/src/rgw/driver/rados/rgw_datalog.h
+++ b/src/rgw/driver/rados/rgw_datalog.h
@@ -33,7 +33,6 @@
 #include "common/RefCountedObj.h"
 
 #include "cls/log/cls_log_types.h"
-
 #include "rgw_basic_types.h"
 #include "rgw_log_backing.h"
 #include "rgw_sync_policy.h"
@@ -357,7 +356,7 @@ protected:
     return datalog.get_oid(gen_id, shard_id);
   }
 public:
-  using entries = std::variant<std::vector<cls_log_entry>,
+  using entries = std::variant<std::vector<cls::log::entry>,
 			       std::vector<ceph::buffer::list>>;
 
   const uint64_t gen_id;

--- a/src/rgw/driver/rados/rgw_datalog.h
+++ b/src/rgw/driver/rados/rgw_datalog.h
@@ -295,7 +295,7 @@ public:
   ~RGWDataChangesLog();
 
   int start(const DoutPrefixProvider *dpp, const RGWZone* _zone, const RGWZoneParams& zoneparams,
-	    librados::Rados* lr);
+	    rgw::sal::RadosStore* store);
   int choose_oid(const rgw_bucket_shard& bs);
   int add_entry(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
 		const rgw::bucket_log_layout_generation& gen, int shard_id,

--- a/src/rgw/driver/rados/rgw_datalog.h
+++ b/src/rgw/driver/rados/rgw_datalog.h
@@ -6,10 +6,14 @@
 #include <cstdint>
 #include <list>
 #include <memory>
+#include <mutex>
+#include <span>
 #include <string>
 #include <string_view>
 #include <variant>
 #include <vector>
+
+#include <boost/asio/steady_timer.hpp>
 
 #include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>
@@ -18,12 +22,15 @@
 
 #include <fmt/format.h>
 
-#include "common/async/yield_context.h"
+#include "include/neorados/RADOS.hpp"
+
 #include "include/buffer.h"
 #include "include/encoding.h"
 #include "include/function2.hpp"
 
-#include "include/rados/librados.hpp"
+#include "common/async/async_cond.h"
+#include "common/async/blocked_completion.h"
+#include "common/async/yield_context.h"
 
 #include "common/ceph_context.h"
 #include "common/ceph_json.h"
@@ -35,16 +42,27 @@
 #include "cls/log/cls_log_types.h"
 #include "rgw_basic_types.h"
 #include "rgw_log_backing.h"
+#include "rgw_neorados.h"
 #include "rgw_sync_policy.h"
 #include "rgw_zone.h"
 #include "rgw_trim_bilog.h"
 
+namespace asio = boost::asio;
 namespace bc = boost::container;
 
 enum DataLogEntityType {
   ENTITY_TYPE_UNKNOWN = 0,
   ENTITY_TYPE_BUCKET = 1,
 };
+inline std::ostream& operator <<(std::ostream& m,
+				 const DataLogEntityType& t) {
+  switch (t) {
+  case ENTITY_TYPE_BUCKET:
+    return m << "bucket";
+  default:
+    return m << "unknown";
+  }
+}
 
 struct rgw_data_change {
   DataLogEntityType entity_type;
@@ -84,6 +102,13 @@ struct rgw_data_change {
   static void generate_test_instances(std::list<rgw_data_change *>& l);
 };
 WRITE_CLASS_ENCODER(rgw_data_change)
+inline std::ostream& operator <<(std::ostream& m,
+				 const rgw_data_change& c) {
+  return m << "[entity_type: " << c.entity_type
+	   << ", key: " << c.key
+	   << ", timestamp: " << c.timestamp
+	   << ", gen: " << c.gen << "]";
+}
 
 struct rgw_data_change_log_entry {
   std::string log_id;
@@ -110,6 +135,12 @@ struct rgw_data_change_log_entry {
   void decode_json(JSONObj* obj);
 };
 WRITE_CLASS_ENCODER(rgw_data_change_log_entry)
+inline std::ostream& operator <<(std::ostream& m,
+				 const rgw_data_change_log_entry& e) {
+  return m << "[log_id: " << e.log_id
+	   << ", log_timestamp: " << e.log_timestamp
+	   << ", entry: " << e.entry << "]";
+}
 
 struct RGWDataChangesLogInfo {
   std::string marker;
@@ -163,12 +194,13 @@ class DataLogBackends final
   std::mutex m;
   RGWDataChangesLog& datalog;
 
-  DataLogBackends(librados::IoCtx& ioctx,
-		  std::string oid,
+  DataLogBackends(neorados::RADOS& rados,
+		  const neorados::Object oid,
+		  const neorados::IOContext& loc,
 		  fu2::unique_function<std::string(
 		    uint64_t, int) const>&& get_oid,
 		  int shards, RGWDataChangesLog& datalog) noexcept
-    : logback_generations(ioctx, oid, std::move(get_oid),
+    : logback_generations(rados, oid, loc, std::move(get_oid),
 			  shards), datalog(datalog) {}
 public:
 
@@ -178,22 +210,19 @@ public:
     --i;
     return i->second;
   }
-  int list(const DoutPrefixProvider *dpp, int shard, int max_entries,
-	   std::vector<rgw_data_change_log_entry>& entries,
-	   std::string_view marker, std::string* out_marker, bool* truncated,
-	   optional_yield y);
-  int trim_entries(const DoutPrefixProvider *dpp, int shard_id,
-		   std::string_view marker, optional_yield y);
-  void trim_entries(const DoutPrefixProvider *dpp, int shard_id, std::string_view marker,
-		    librados::AioCompletion* c);
+  asio::awaitable<std::tuple<std::span<rgw_data_change_log_entry>,
+			     std::optional<std::string>>>
+  list(const DoutPrefixProvider *dpp, int shard,
+       std::span<rgw_data_change_log_entry> entries,
+       std::optional<std::string> marker);
+  asio::awaitable<void> trim_entries(const DoutPrefixProvider *dpp, int shard_id,
+				     std::string_view marker);
+  void handle_init(entries_t e) override;
+  void handle_new_gens(entries_t e) override;
+  void handle_empty_to(uint64_t new_tail) override;
 
-  bs::error_code handle_init(entries_t e) noexcept override;
-  bs::error_code handle_new_gens(entries_t e) noexcept override;
-  bs::error_code handle_empty_to(uint64_t new_tail) noexcept override;
-
-  int trim_generations(const DoutPrefixProvider *dpp,
-		       std::optional<uint64_t>& through,
-		       optional_yield y);
+  asio::awaitable<void> trim_generations(const DoutPrefixProvider *dpp,
+					 std::optional<uint64_t>& through);
 };
 
 struct BucketGen {
@@ -231,7 +260,8 @@ inline bool operator <(const BucketGen& l, const BucketGen& r) {
 class RGWDataChangesLog {
   friend DataLogBackends;
   CephContext *cct;
-  librados::IoCtx ioctx;
+  rgw::sal::RadosStore* store = nullptr;
+  neorados::IOContext loc;
   rgw::BucketChangeObserver *observer = nullptr;
   const RGWZone* zone;
   std::unique_ptr<DataLogBackends> bes;
@@ -246,9 +276,8 @@ class RGWDataChangesLog {
   }
   std::string prefix;
 
-  ceph::mutex lock = ceph::make_mutex("RGWDataChangesLog::lock");
-  ceph::shared_mutex modified_lock =
-    ceph::make_shared_mutex("RGWDataChangesLog::modified_lock");
+  std::mutex lock;
+  std::shared_mutex modified_lock;
   bc::flat_map<int, bc::flat_set<rgw_data_notify_entry>> modified_shards;
 
   std::atomic<bool> down_flag = { false };
@@ -258,8 +287,11 @@ class RGWDataChangesLog {
     ceph::real_time cur_expiration;
     ceph::real_time cur_sent;
     bool pending = false;
-    RefCountedCond* cond = nullptr;
-    ceph::mutex lock = ceph::make_mutex("RGWDataChangesLog::ChangeStatus");
+    ceph::async::async_cond<boost::asio::io_context::executor_type> cond;
+    std::mutex lock;
+
+    ChangeStatus(boost::asio::io_context::executor_type executor)
+      : cond(executor) {}
   };
 
   using ChangeStatusPtr = std::shared_ptr<ChangeStatus>;
@@ -275,16 +307,16 @@ class RGWDataChangesLog {
 		      uint64_t gen,
 		      ceph::real_time expiration);
 
-  ceph::mutex renew_lock = ceph::make_mutex("ChangesRenewThread::lock");
-  ceph::condition_variable renew_cond;
-  void renew_run() noexcept;
+  std::optional<asio::steady_timer> renew_timer;
+  asio::awaitable<void> renew_run();
   void renew_stop();
-  std::thread renew_thread;
 
-  std::function<bool(const rgw_bucket& bucket, optional_yield y, const DoutPrefixProvider *dpp)> bucket_filter;
+  std::function<bool(const rgw_bucket& bucket, optional_yield y,
+                     const DoutPrefixProvider *dpp)> bucket_filter;
   bool going_down() const;
-  bool filter_bucket(const DoutPrefixProvider *dpp, const rgw_bucket& bucket, optional_yield y) const;
-  int renew_entries(const DoutPrefixProvider *dpp);
+  asio::awaitable<bool> filter_bucket(const DoutPrefixProvider* dpp,
+				      const rgw_bucket& bucket) const;
+  asio::awaitable<void> renew_entries(const DoutPrefixProvider *dpp);
 
 public:
 
@@ -294,9 +326,14 @@ public:
   int start(const DoutPrefixProvider *dpp, const RGWZone* _zone, const RGWZoneParams& zoneparams,
 	    rgw::sal::RadosStore* store);
   int choose_oid(const rgw_bucket_shard& bs);
-  int add_entry(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
-		const rgw::bucket_log_layout_generation& gen, int shard_id,
-		optional_yield y);
+  asio::awaitable<void> add_entry(const DoutPrefixProvider *dpp,
+				  const RGWBucketInfo& bucket_info,
+				  const rgw::bucket_log_layout_generation& gen,
+				  int shard_id);
+  int add_entry(const DoutPrefixProvider *dpp,
+		const RGWBucketInfo& bucket_info,
+		const rgw::bucket_log_layout_generation& gen,
+		int shard_id, optional_yield y);
   int get_log_shard_id(rgw_bucket& bucket, int shard_id);
   int list_entries(const DoutPrefixProvider *dpp, int shard, int max_entries,
 		   std::vector<rgw_data_change_log_entry>& entries,
@@ -304,8 +341,8 @@ public:
 		   bool* truncated, optional_yield y);
   int trim_entries(const DoutPrefixProvider *dpp, int shard_id,
 		   std::string_view marker, optional_yield y);
-  int trim_entries(const DoutPrefixProvider *dpp, int shard_id, std::string_view marker,
-		   librados::AioCompletion* c); // :(
+  int trim_entries(const DoutPrefixProvider *dpp, int shard_id,
+		    std::string_view marker, librados::AioCompletion* c);
   int get_info(const DoutPrefixProvider *dpp, int shard_id,
 	       RGWDataChangesLogInfo *info, optional_yield y);
 
@@ -345,9 +382,11 @@ public:
 
 class RGWDataChangesBE : public boost::intrusive_ref_counter<RGWDataChangesBE> {
 protected:
-  librados::IoCtx& ioctx;
-  CephContext* const cct;
+  neorados::RADOS& r;
+  neorados::IOContext loc;
   RGWDataChangesLog& datalog;
+
+  CephContext* cct{r.cct()};
 
   std::string get_oid(int shard_id) {
     return datalog.get_oid(gen_id, shard_id);
@@ -358,34 +397,31 @@ public:
 
   const uint64_t gen_id;
 
-  RGWDataChangesBE(librados::IoCtx& ioctx,
+  RGWDataChangesBE(neorados::RADOS& r,
+		   neorados::IOContext loc,
 		   RGWDataChangesLog& datalog,
 		   uint64_t gen_id)
-    : ioctx(ioctx), cct(static_cast<CephContext*>(ioctx.cct())),
-      datalog(datalog), gen_id(gen_id) {}
+    : r(r), loc(std::move(loc)), datalog(datalog), gen_id(gen_id) {}
   virtual ~RGWDataChangesBE() = default;
 
-  virtual void prepare(ceph::real_time now,
-		       const std::string& key,
-		       ceph::buffer::list&& entry,
-		       entries& out) = 0;
-  virtual int push(const DoutPrefixProvider *dpp, int index, entries&& items,
-		   optional_yield y) = 0;
-  virtual int push(const DoutPrefixProvider *dpp, int index, ceph::real_time now,
-		   const std::string& key, ceph::buffer::list&& bl,
-		   optional_yield y) = 0;
-  virtual int list(const DoutPrefixProvider *dpp, int shard, int max_entries,
-		   std::vector<rgw_data_change_log_entry>& entries,
-		   std::optional<std::string_view> marker,
-		   std::string* out_marker, bool* truncated,
-		   optional_yield y) = 0;
-  virtual int get_info(const DoutPrefixProvider *dpp, int index,
-		       RGWDataChangesLogInfo *info, optional_yield y) = 0;
-  virtual int trim(const DoutPrefixProvider *dpp, int index,
-		   std::string_view marker, optional_yield y) = 0;
-  virtual int trim(const DoutPrefixProvider *dpp, int index,
-		   std::string_view marker, librados::AioCompletion* c) = 0;
+  virtual void prepare(ceph::real_time now, const std::string& key,
+		       ceph::buffer::list&& entry, entries& out) = 0;
+  virtual asio::awaitable<void> push(const DoutPrefixProvider *dpp, int index,
+				     entries&& items) = 0;
+  virtual asio::awaitable<void> push(const DoutPrefixProvider *dpp, int index,
+				     ceph::real_time now,
+				     const std::string& key,
+				     ceph::buffer::list&& bl) = 0;
+  virtual asio::awaitable<std::tuple<std::span<rgw_data_change_log_entry>,
+			     std::optional<std::string>>>
+  list(const DoutPrefixProvider* dpp, int shard,
+       std::span<rgw_data_change_log_entry> entries,
+       std::optional<std::string> marker) = 0;
+  virtual asio::awaitable<RGWDataChangesLogInfo>
+  get_info(const DoutPrefixProvider *dpp, int index) = 0;
+  virtual asio::awaitable<void> trim(const DoutPrefixProvider *dpp, int index,
+				     std::string_view marker) = 0;
   virtual std::string_view max_marker() const = 0;
   // 1 on empty, 0 on non-empty, negative on error.
-  virtual int is_empty(const DoutPrefixProvider *dpp, optional_yield y) = 0;
+  virtual asio::awaitable<bool> is_empty(const DoutPrefixProvider *dpp) = 0;
 };

--- a/src/rgw/driver/rados/rgw_metadata.cc
+++ b/src/rgw/driver/rados/rgw_metadata.cc
@@ -137,7 +137,7 @@ int RGWMetadataLog::get_info(const DoutPrefixProvider *dpp, int shard_id, RGWMet
     return ret;
 
   info->marker = header.max_marker;
-  info->last_update = header.max_time.to_real_time();
+  info->last_update = header.max_time;
 
   return 0;
 }

--- a/src/rgw/driver/rados/rgw_metadata.cc
+++ b/src/rgw/driver/rados/rgw_metadata.cc
@@ -65,7 +65,7 @@ int RGWMetadataLog::get_shard_id(const string& hash_key, int *shard_id)
   return 0;
 }
 
-int RGWMetadataLog::store_entries_in_shard(const DoutPrefixProvider *dpp, list<cls_log_entry>& entries, int shard_id, librados::AioCompletion *completion)
+int RGWMetadataLog::store_entries_in_shard(const DoutPrefixProvider *dpp, vector<cls_log_entry>& entries, int shard_id, librados::AioCompletion *completion)
 {
   string oid;
 
@@ -96,7 +96,7 @@ void RGWMetadataLog::complete_list_entries(void *handle) {
 
 int RGWMetadataLog::list_entries(const DoutPrefixProvider *dpp, void *handle,
 				 int max_entries,
-				 list<cls_log_entry>& entries,
+				 vector<cls_log_entry>& entries,
 				 string *last_marker,
 				 bool *truncated,
 				 optional_yield y) {

--- a/src/rgw/driver/rados/rgw_metadata.cc
+++ b/src/rgw/driver/rados/rgw_metadata.cc
@@ -65,7 +65,7 @@ int RGWMetadataLog::get_shard_id(const string& hash_key, int *shard_id)
   return 0;
 }
 
-int RGWMetadataLog::store_entries_in_shard(const DoutPrefixProvider *dpp, vector<cls_log_entry>& entries, int shard_id, librados::AioCompletion *completion)
+int RGWMetadataLog::store_entries_in_shard(const DoutPrefixProvider *dpp, vector<cls::log::entry>& entries, int shard_id, librados::AioCompletion *completion)
 {
   string oid;
 
@@ -96,7 +96,7 @@ void RGWMetadataLog::complete_list_entries(void *handle) {
 
 int RGWMetadataLog::list_entries(const DoutPrefixProvider *dpp, void *handle,
 				 int max_entries,
-				 vector<cls_log_entry>& entries,
+				 vector<cls::log::entry>& entries,
 				 string *last_marker,
 				 bool *truncated,
 				 optional_yield y) {
@@ -130,7 +130,7 @@ int RGWMetadataLog::get_info(const DoutPrefixProvider *dpp, int shard_id, RGWMet
   string oid;
   get_shard_oid(shard_id, oid);
 
-  cls_log_header header;
+  cls::log::header header;
 
   int ret = svc.cls->timelog.info(dpp, oid, &header, y);
   if ((ret < 0) && (ret != -ENOENT))

--- a/src/rgw/driver/rados/rgw_metadata.h
+++ b/src/rgw/driver/rados/rgw_metadata.h
@@ -260,7 +260,7 @@ public:
 
   std::string get_marker(void *handle);
 
-  void dump_log_entry(cls_log_entry& entry, Formatter *f);
+  void dump_log_entry(cls::log::entry& entry, Formatter *f);
 
   void get_sections(std::list<std::string>& sections);
 

--- a/src/rgw/driver/rados/rgw_neorados.cc
+++ b/src/rgw/driver/rados/rgw_neorados.cc
@@ -1,0 +1,172 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#include "rgw_neorados.h"
+
+#include <coroutine>
+#include <vector>
+
+#include <fmt/format.h>
+
+namespace rgw::neorados {
+namespace sys = boost::system;
+
+asio::awaitable<void> set_mostly_omap(const DoutPrefixProvider* dpp,
+                                      RADOS& rados, std::string_view name)
+{
+  // set pg_autoscale_bias
+  try {
+    auto bias = rados.cct()->_conf.get_val<double>(
+      "rgw_rados_pool_autoscale_bias");
+    std::vector<std::string> biascommand{
+      {fmt::format(R"({{"prefix": "osd pool set", "pool": "{}", )"
+                   R"("var": "pg_autoscale_bias", "val": "{}"}})",
+                   name, bias)}
+    };
+    co_await rados.mon_command(std::move(biascommand), {}, nullptr, nullptr,
+                               asio::use_awaitable);
+  } catch (const std::exception& e) {
+    ldpp_dout(dpp, 2) << "rgw::neorados::set_mostly_omap: mon_command to set "
+                      <<  "autoscale bias failed with error: "
+                      << e.what() << dendl;
+    throw;
+  }
+  try {
+    // set recovery_priority
+    auto p = rados.cct()->_conf.get_val<uint64_t>(
+      "rgw_rados_pool_recovery_priority");
+    std::vector<std::string> recoverycommand{
+      {fmt::format(R"({{"prefix": "osd pool set", "pool": "{}", )"
+                   R"("var": "recovery_priority": "{}"}})",
+                   name, p)}
+    };
+    co_await rados.mon_command(std::move(recoverycommand), {}, nullptr, nullptr,
+                               asio::use_awaitable);
+  } catch (const std::exception& e) {
+    ldpp_dout(dpp, 2) << "rgw::neorados::set_mostly_omap: mon_command to set "
+                      <<  "recovery priority failed with error: "
+                      << e.what() << dendl;
+  }
+  co_return;
+}
+
+asio::awaitable<void> create_pool(const DoutPrefixProvider* dpp,
+				  RADOS& rados, const std::string& name)
+{
+  bool already_exists = false;
+  try {
+    co_await rados.create_pool(std::string(name), std::nullopt,
+                               asio::use_awaitable);
+  } catch (const sys::system_error& e) {
+    if (e.code() == sys::errc::result_out_of_range) {
+      ldpp_dout(dpp, 0)
+        << "init_iocontext: ERROR: RADOS::create_pool failed with " << e.what()
+        << " (this can be due to a pool or placement group misconfiguration, "
+        "e.g. pg_num < pgp_num or mon_max_pg_per_osd exceeded)" << dendl;
+    } else if (e.code() == sys::errc::file_exists) {
+      already_exists = true;
+    } else {
+      ldpp_dout(dpp, 2) << "rgw::neorados::create_pool: RADOS::create_pool "
+                        <<  "failed with error: " << e.what() << dendl;
+      throw;
+    }
+  } catch (const std::exception& e) {
+    ldpp_dout(dpp, 2) << "rgw::neorados::create_pool: RADOS::create_pool "
+                      <<  "failed with error: " << e.what() << dendl;
+    throw;
+  }
+  if (already_exists) {
+    co_return;
+  }
+  try {
+    co_await rados.enable_application(name, pg_pool_t::APPLICATION_NAME_RGW,
+                                      false, asio::use_awaitable);
+  } catch (const sys::system_error& e) {
+    if (e.code() != sys::errc::operation_not_supported) {
+      ldpp_dout(dpp, 2) << "rgw::neorados::create_pool: RADOS::set_application "
+                        <<  "failed with error: " << e.what() << dendl;
+      throw;
+    }
+  } catch (const std::exception& e) {
+    ldpp_dout(dpp, 2) << "rgw::neorados::create_pool: RADOS::set_application "
+                      <<  "failed with error: " << e.what() << dendl;
+    throw;
+  }
+  co_return;
+}
+asio::awaitable<void> create_pool(const DoutPrefixProvider* dpp,
+				  RADOS& rados, const std::string& name,
+				  mostly_omap_t)
+{
+  co_await create_pool(dpp, rados, name);
+  co_await set_mostly_omap(dpp, rados, name);
+  co_return;
+}
+
+asio::awaitable<IOContext> init_iocontext(const DoutPrefixProvider* dpp,
+					  RADOS& rados, const rgw_pool& pool)
+{
+  IOContext ioc;
+  try {
+    ioc.set_pool(co_await rados.lookup_pool(pool.name, asio::use_awaitable));
+  } catch (const std::exception& e) {
+    ldpp_dout(dpp, 2) << "rgw::neorados::init_ioctx: RADOS::lookup_pool "
+                      <<  "failed with error: " << e.what() << dendl;
+    throw;
+  }
+  ioc.set_ns(pool.ns);
+  co_return ioc;
+}
+
+asio::awaitable<IOContext> init_iocontext(const DoutPrefixProvider* dpp,
+					  RADOS& rados, const rgw_pool& pool,
+					  create_t)
+{
+  bool must_create = false;
+  IOContext ioc;
+  try {
+    ioc.set_pool(co_await rados.lookup_pool(pool.name, asio::use_awaitable));
+  } catch (const sys::system_error& e) {
+    if (e.code() == sys::errc::no_such_file_or_directory) {
+      must_create = true;
+    } else {
+      ldpp_dout(dpp, 2) << "rgw::neorados::init_ioctx: RADOS::lookup_pool "
+                        <<  "failed with error: " << e.what() << dendl;
+      throw;
+    }
+  } catch (const std::exception& e) {
+    ldpp_dout(dpp, 2) << "rgw::neorados::init_ioctx: RADOS::lookup_pool "
+                      <<  "failed with error: " << e.what() << dendl;
+    throw;
+  }
+  if (must_create) {
+    co_await create_pool(dpp, rados, pool.name);
+    try {
+      ioc.set_pool(co_await rados.lookup_pool(pool.name, asio::use_awaitable));
+    } catch (const std::exception& e) {
+      ldpp_dout(dpp, 2) << "rgw::neorados::init_ioctx: RADOS::lookup_pool "
+                        <<  "failed with error: " << e.what() << dendl;
+      throw;
+    }
+  }
+
+  ioc.set_ns(pool.ns);
+  co_return ioc;
+}
+
+asio::awaitable<IOContext> init_iocontext(const DoutPrefixProvider* dpp,
+					  RADOS& rados, const rgw_pool& pool,
+					  create_t, mostly_omap_t)
+{
+  auto ioc = co_await init_iocontext(dpp, rados, pool, create);
+  co_await set_mostly_omap(dpp, rados, pool.name);
+  co_return ioc;
+}
+
+asio::awaitable<IOContext> init_iocontext(const DoutPrefixProvider* dpp,
+					  RADOS& rados, const rgw_pool& pool,
+					  mostly_omap_t, create_t)
+{
+  return init_iocontext(dpp, rados, pool, create, mostly_omap);
+}
+}

--- a/src/rgw/driver/rados/rgw_neorados.h
+++ b/src/rgw/driver/rados/rgw_neorados.h
@@ -1,0 +1,54 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#pragma once
+
+#include <coroutine>
+#include <string_view>
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include <boost/system/detail/errc.hpp>
+
+#include "include/neorados/RADOS.hpp"
+
+#include "common/dout.h"
+
+#include "osd/osd_types.h"
+
+#include "rgw_obj_types.h"
+#include "rgw_pool_types.h"
+
+namespace rgw::neorados {
+using namespace ::neorados;
+namespace asio = boost::asio;
+
+struct mostly_omap_t {};
+inline constexpr mostly_omap_t mostly_omap;
+
+struct create_t {};
+inline constexpr create_t create;
+
+asio::awaitable<void> set_mostly_omap(const DoutPrefixProvider* dpp,
+				      RADOS& rados, std::string_view name);
+
+asio::awaitable<void> create_pool(const DoutPrefixProvider* dpp,
+				  RADOS& rados, const std::string& name);
+asio::awaitable<void> create_pool(const DoutPrefixProvider* dpp,
+				  RADOS& rados, const std::string& name,
+				  mostly_omap_t);
+
+asio::awaitable<IOContext> init_iocontext(const DoutPrefixProvider* dpp,
+					  RADOS& rados, const rgw_pool& pool);
+asio::awaitable<IOContext> init_iocontext(const DoutPrefixProvider* dpp,
+					  RADOS& rados, const rgw_pool& pool,
+					  create_t);
+asio::awaitable<IOContext> init_iocontext(const DoutPrefixProvider* dpp,
+					  RADOS& rados, const rgw_pool& pool,
+					  create_t, mostly_omap_t);
+asio::awaitable<IOContext> init_iocontext(const DoutPrefixProvider* dpp,
+					  RADOS& rados, const rgw_pool& pool,
+					  mostly_omap_t, create_t);
+}

--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -19,6 +19,7 @@
 #include "services/svc_zone.h"
 #include "common/dout.h"
 #include <chrono>
+#include "librados/AioCompletionImpl.h"
 
 #define dout_subsys ceph_subsys_rgw_notification
 

--- a/src/rgw/driver/rados/rgw_rest_log.cc
+++ b/src/rgw/driver/rados/rgw_rest_log.cc
@@ -111,7 +111,7 @@ void RGWOp_MDLog_List::send_response() {
     s->formatter->open_array_section("entries");
     for (auto iter = entries.begin();
 	 iter != entries.end(); ++iter) {
-      cls_log_entry& entry = *iter;
+      auto& entry = *iter;
       static_cast<rgw::sal::RadosStore*>(driver)->ctl()->meta.mgr->dump_log_entry(entry, s->formatter);
       flusher.flush();
     }

--- a/src/rgw/driver/rados/rgw_rest_log.cc
+++ b/src/rgw/driver/rados/rgw_rest_log.cc
@@ -109,7 +109,7 @@ void RGWOp_MDLog_List::send_response() {
   s->formatter->dump_bool("truncated", truncated);
   {
     s->formatter->open_array_section("entries");
-    for (list<cls_log_entry>::iterator iter = entries.begin();
+    for (auto iter = entries.begin();
 	 iter != entries.end(); ++iter) {
       cls_log_entry& entry = *iter;
       static_cast<rgw::sal::RadosStore*>(driver)->ctl()->meta.mgr->dump_log_entry(entry, s->formatter);

--- a/src/rgw/driver/rados/rgw_rest_log.h
+++ b/src/rgw/driver/rados/rgw_rest_log.h
@@ -88,7 +88,7 @@ public:
 };
 
 class RGWOp_MDLog_List : public RGWRESTOp {
-  std::list<cls_log_entry> entries;
+  std::vector<cls_log_entry> entries;
   std::string last_marker;
   bool truncated;
 public:

--- a/src/rgw/driver/rados/rgw_rest_log.h
+++ b/src/rgw/driver/rados/rgw_rest_log.h
@@ -88,7 +88,7 @@ public:
 };
 
 class RGWOp_MDLog_List : public RGWRESTOp {
-  std::vector<cls_log_entry> entries;
+  std::vector<cls::log::entry> entries;
   std::string last_marker;
   bool truncated;
 public:

--- a/src/rgw/driver/rados/rgw_service.cc
+++ b/src/rgw/driver/rados/rgw_service.cc
@@ -151,7 +151,7 @@ int RGWServices_Def::init(CephContext *cct,
 
     r = datalog_rados->start(dpp, &zone->get_zone(),
 			     zone->get_zone_params(),
-			     driver->getRados()->get_rados_handle());
+			     driver);
     if (r < 0) {
       ldpp_dout(dpp, 0) << "ERROR: failed to start datalog_rados service (" << cpp_strerror(-r) << dendl;
       return r;

--- a/src/rgw/driver/rados/rgw_sync.cc
+++ b/src/rgw/driver/rados/rgw_sync.cc
@@ -1875,7 +1875,7 @@ public:
               continue;
             }
             tn->log(20, SSTR("log_entry: " << log_iter->id << ":" << log_iter->section << ":" << log_iter->name << ":" << log_iter->timestamp));
-            if (!marker_tracker->start(log_iter->id, 0, log_iter->timestamp.to_real_time())) {
+            if (!marker_tracker->start(log_iter->id, 0, log_iter->timestamp)) {
               ldpp_dout(sync_env->dpp, 0) << "ERROR: cannot start syncing " << log_iter->id << ". Duplicate entry?" << dendl;
             } else {
               raw_key = log_iter->section + ":" + log_iter->name;
@@ -2481,7 +2481,7 @@ int RGWCloneMetaLogCoroutine::state_read_shard_status()
         }
       } else {
         shard_info.marker = header.max_marker;
-        shard_info.last_update = header.max_time.to_real_time();
+        shard_info.last_update = header.max_time;
       }
       // wake up parent stack
       io_complete();
@@ -2591,7 +2591,7 @@ int RGWCloneMetaLogCoroutine::state_store_mdlog_entries()
     dest_entry.id = entry.id;
     dest_entry.section = entry.section;
     dest_entry.name = entry.name;
-    dest_entry.timestamp = utime_t(entry.timestamp);
+    dest_entry.timestamp = entry.timestamp;
   
     encode(entry.log_data, dest_entry.data);
 

--- a/src/rgw/driver/rados/rgw_sync.cc
+++ b/src/rgw/driver/rados/rgw_sync.cc
@@ -399,7 +399,7 @@ protected:
   }
 public:
   string marker;
-  list<cls_log_entry> entries;
+  vector<cls_log_entry> entries;
   bool truncated;
 
   RGWAsyncReadMDLogEntries(const DoutPrefixProvider *dpp, RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
@@ -416,7 +416,7 @@ class RGWReadMDLogEntriesCR : public RGWSimpleCoroutine {
   string marker;
   string *pmarker;
   int max_entries;
-  list<cls_log_entry> *entries;
+  vector<cls_log_entry> *entries;
   bool *truncated;
 
   RGWAsyncReadMDLogEntries *req{nullptr};
@@ -424,7 +424,7 @@ class RGWReadMDLogEntriesCR : public RGWSimpleCoroutine {
 public:
   RGWReadMDLogEntriesCR(RGWMetaSyncEnv *_sync_env, RGWMetadataLog* mdlog,
                         int _shard_id, string*_marker, int _max_entries,
-                        list<cls_log_entry> *_entries, bool *_truncated)
+                        vector<cls_log_entry> *_entries, bool *_truncated)
     : RGWSimpleCoroutine(_sync_env->cct), sync_env(_sync_env), mdlog(mdlog),
       shard_id(_shard_id), pmarker(_marker), max_entries(_max_entries),
       entries(_entries), truncated(_truncated) {}
@@ -1450,8 +1450,8 @@ class RGWMetaSyncShardCR : public RGWCoroutine {
 
   RGWMetaSyncShardMarkerTrack *marker_tracker = nullptr;
 
-  list<cls_log_entry> log_entries;
-  list<cls_log_entry>::iterator log_iter;
+  vector<cls_log_entry> log_entries;
+  decltype(log_entries)::iterator log_iter;
   bool truncated = false;
 
   string mdlog_marker;
@@ -2580,7 +2580,7 @@ int RGWCloneMetaLogCoroutine::state_receive_rest_response()
 
 int RGWCloneMetaLogCoroutine::state_store_mdlog_entries()
 {
-  list<cls_log_entry> dest_entries;
+  vector<cls_log_entry> dest_entries;
 
   vector<rgw_mdlog_entry>::iterator iter;
   for (iter = data.entries.begin(); iter != data.entries.end(); ++iter) {

--- a/src/rgw/driver/rados/rgw_sync.cc
+++ b/src/rgw/driver/rados/rgw_sync.cc
@@ -39,7 +39,7 @@ string RGWSyncErrorLogger::get_shard_oid(const string& oid_prefix, int shard_id)
 }
 
 RGWCoroutine *RGWSyncErrorLogger::log_error_cr(const DoutPrefixProvider *dpp, const string& source_zone, const string& section, const string& name, uint32_t error_code, const string& message) {
-  cls_log_entry entry;
+  cls::log::entry entry;
 
   rgw_sync_error_info info(source_zone, error_code, message);
   bufferlist bl;
@@ -399,7 +399,7 @@ protected:
   }
 public:
   string marker;
-  vector<cls_log_entry> entries;
+  vector<cls::log::entry> entries;
   bool truncated;
 
   RGWAsyncReadMDLogEntries(const DoutPrefixProvider *dpp, RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
@@ -416,7 +416,7 @@ class RGWReadMDLogEntriesCR : public RGWSimpleCoroutine {
   string marker;
   string *pmarker;
   int max_entries;
-  vector<cls_log_entry> *entries;
+  vector<cls::log::entry> *entries;
   bool *truncated;
 
   RGWAsyncReadMDLogEntries *req{nullptr};
@@ -424,7 +424,7 @@ class RGWReadMDLogEntriesCR : public RGWSimpleCoroutine {
 public:
   RGWReadMDLogEntriesCR(RGWMetaSyncEnv *_sync_env, RGWMetadataLog* mdlog,
                         int _shard_id, string*_marker, int _max_entries,
-                        vector<cls_log_entry> *_entries, bool *_truncated)
+                        vector<cls::log::entry> *_entries, bool *_truncated)
     : RGWSimpleCoroutine(_sync_env->cct), sync_env(_sync_env), mdlog(mdlog),
       shard_id(_shard_id), pmarker(_marker), max_entries(_max_entries),
       entries(_entries), truncated(_truncated) {}
@@ -1450,7 +1450,7 @@ class RGWMetaSyncShardCR : public RGWCoroutine {
 
   RGWMetaSyncShardMarkerTrack *marker_tracker = nullptr;
 
-  vector<cls_log_entry> log_entries;
+  vector<cls::log::entry> log_entries;
   decltype(log_entries)::iterator log_iter;
   bool truncated = false;
 
@@ -2473,7 +2473,7 @@ int RGWCloneMetaLogCoroutine::state_read_shard_status()
   const bool add_ref = false; // default constructs with refs=1
 
   completion.reset(new RGWMetadataLogInfoCompletion(
-    [this](int ret, const cls_log_header& header) {
+    [this](int ret, const cls::log::header& header) {
       if (ret < 0) {
         if (ret != -ENOENT) {
           ldpp_dout(sync_env->dpp, 1) << "ERROR: failed to read mdlog info with "
@@ -2580,14 +2580,14 @@ int RGWCloneMetaLogCoroutine::state_receive_rest_response()
 
 int RGWCloneMetaLogCoroutine::state_store_mdlog_entries()
 {
-  vector<cls_log_entry> dest_entries;
+  vector<cls::log::entry> dest_entries;
 
   vector<rgw_mdlog_entry>::iterator iter;
   for (iter = data.entries.begin(); iter != data.entries.end(); ++iter) {
     rgw_mdlog_entry& entry = *iter;
     ldpp_dout(sync_env->dpp, 20) << "entry: name=" << entry.name << dendl;
 
-    cls_log_entry dest_entry;
+    cls::log::entry dest_entry;
     dest_entry.id = entry.id;
     dest_entry.section = entry.section;
     dest_entry.name = entry.name;

--- a/src/rgw/driver/rados/rgw_sync.h
+++ b/src/rgw/driver/rados/rgw_sync.h
@@ -44,7 +44,7 @@ struct rgw_mdlog_entry {
     id = le.id;
     section = le.section;
     name = le.name;
-    timestamp = le.timestamp.to_real_time();
+    timestamp = le.timestamp;
     try {
       auto iter = le.data.cbegin();
       decode(log_data, iter);

--- a/src/rgw/driver/rados/rgw_sync.h
+++ b/src/rgw/driver/rados/rgw_sync.h
@@ -40,7 +40,7 @@ struct rgw_mdlog_entry {
 
   void decode_json(JSONObj *obj);
 
-  bool convert_from(cls_log_entry& le) {
+  bool convert_from(cls::log::entry& le) {
     id = le.id;
     section = le.section;
     name = le.name;

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -4,6 +4,7 @@
 #include "auth/AuthRegistry.h"
 
 #include "common/errno.h"
+#include "librados/AioCompletionImpl.h"
 #include "librados/librados_asio.h"
 
 #include "include/stringify.h"

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8988,7 +8988,7 @@ next:
     formatter->open_array_section("entries");
     for (; i < g_ceph_context->_conf->rgw_md_log_max_shards; i++) {
       void *handle;
-      vector<cls_log_entry> entries;
+      vector<cls::log::entry> entries;
 
       meta_log->init_list_entries(i, {}, {}, marker, &handle);
       bool truncated;
@@ -9000,7 +9000,7 @@ next:
         }
 
         for (auto iter = entries.begin(); iter != entries.end(); ++iter) {
-          cls_log_entry& entry = *iter;
+          cls::log::entry& entry = *iter;
           static_cast<rgw::sal::RadosStore*>(driver)->ctl()->meta.mgr->dump_log_entry(entry, formatter.get());
         }
         formatter->flush(cout);
@@ -9602,7 +9602,7 @@ next:
       string oid = RGWSyncErrorLogger::get_shard_oid(RGW_SYNC_ERROR_LOG_SHARD_PREFIX, shard_id);
 
       do {
-        vector<cls_log_entry> entries;
+        vector<cls::log::entry> entries;
         ret = static_cast<rgw::sal::RadosStore*>(driver)->svc()->cls->timelog.list(dpp(), oid, {}, {}, max_entries - count, entries, marker, &marker, &truncated,
 					      null_yield);
 	if (ret == -ENOENT) {
@@ -10172,7 +10172,7 @@ next:
 
     formatter->open_array_section("entries");
     for (; i < g_ceph_context->_conf->rgw_data_log_num_shards; i++) {
-      vector<cls_log_entry> entries;
+      vector<cls::log::entry> entries;
 
       RGWDataChangesLogInfo info;
       static_cast<rgw::sal::RadosStore*>(driver)->svc()->

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8988,7 +8988,7 @@ next:
     formatter->open_array_section("entries");
     for (; i < g_ceph_context->_conf->rgw_md_log_max_shards; i++) {
       void *handle;
-      list<cls_log_entry> entries;
+      vector<cls_log_entry> entries;
 
       meta_log->init_list_entries(i, {}, {}, marker, &handle);
       bool truncated;
@@ -8999,7 +8999,7 @@ next:
           return -ret;
         }
 
-        for (list<cls_log_entry>::iterator iter = entries.begin(); iter != entries.end(); ++iter) {
+        for (auto iter = entries.begin(); iter != entries.end(); ++iter) {
           cls_log_entry& entry = *iter;
           static_cast<rgw::sal::RadosStore*>(driver)->ctl()->meta.mgr->dump_log_entry(entry, formatter.get());
         }
@@ -9602,7 +9602,7 @@ next:
       string oid = RGWSyncErrorLogger::get_shard_oid(RGW_SYNC_ERROR_LOG_SHARD_PREFIX, shard_id);
 
       do {
-        list<cls_log_entry> entries;
+        vector<cls_log_entry> entries;
         ret = static_cast<rgw::sal::RadosStore*>(driver)->svc()->cls->timelog.list(dpp(), oid, {}, {}, max_entries - count, entries, marker, &marker, &truncated,
 					      null_yield);
 	if (ret == -ENOENT) {
@@ -10172,7 +10172,7 @@ next:
 
     formatter->open_array_section("entries");
     for (; i < g_ceph_context->_conf->rgw_data_log_num_shards; i++) {
-      list<cls_log_entry> entries;
+      vector<cls_log_entry> entries;
 
       RGWDataChangesLogInfo info;
       static_cast<rgw::sal::RadosStore*>(driver)->svc()->

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -873,12 +873,6 @@ struct RGWObjVersionTracker {
   void generate_new_write_ver(CephContext* cct);
 };
 
-inline std::ostream& operator<<(std::ostream& out, const obj_version &v)
-{
-  out << v.tag << ":" << v.ver;
-  return out;
-}
-
 inline std::ostream& operator<<(std::ostream& out, const RGWObjVersionTracker &ot)
 {
   out << "{r=" << ot.read_version << ",w=" << ot.write_version << "}";

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -105,7 +105,7 @@ public:
 
   int add_entry(const DoutPrefixProvider *dpp, const std::string& hash_key, const std::string& section, const std::string& key, bufferlist& bl, optional_yield y);
   int get_shard_id(const std::string& hash_key, int *shard_id);
-  int store_entries_in_shard(const DoutPrefixProvider *dpp, std::list<cls_log_entry>& entries, int shard_id, librados::AioCompletion *completion);
+  int store_entries_in_shard(const DoutPrefixProvider *dpp, std::vector<cls_log_entry>& entries, int shard_id, librados::AioCompletion *completion);
 
   struct LogListCtx {
     int cur_shard;
@@ -127,7 +127,7 @@ public:
   int list_entries(const DoutPrefixProvider *dpp,
                    void *handle,
                    int max_entries,
-                   std::list<cls_log_entry>& entries,
+                   std::vector<cls_log_entry>& entries,
 		   std::string *out_marker,
 		   bool *truncated,
 		   optional_yield y);

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -38,9 +38,9 @@ class RGWCompletionManager;
 
 class RGWMetadataLogInfoCompletion : public RefCountedObject {
  public:
-  using info_callback_t = std::function<void(int, const cls_log_header&)>;
+  using info_callback_t = std::function<void(int, const cls::log::header&)>;
  private:
-  cls_log_header header;
+  cls::log::header header;
   rgw_rados_ref io_obj;
   librados::AioCompletion *completion;
   std::mutex mutex; //< protects callback between cancel/complete
@@ -50,7 +50,7 @@ class RGWMetadataLogInfoCompletion : public RefCountedObject {
   ~RGWMetadataLogInfoCompletion() override;
 
   rgw_rados_ref& get_io_obj() { return io_obj; }
-  cls_log_header& get_header() { return header; }
+  cls::log::header& get_header() { return header; }
   librados::AioCompletion* get_completion() { return completion; }
 
   void finish(librados::completion_t cb) {
@@ -105,7 +105,7 @@ public:
 
   int add_entry(const DoutPrefixProvider *dpp, const std::string& hash_key, const std::string& section, const std::string& key, bufferlist& bl, optional_yield y);
   int get_shard_id(const std::string& hash_key, int *shard_id);
-  int store_entries_in_shard(const DoutPrefixProvider *dpp, std::vector<cls_log_entry>& entries, int shard_id, librados::AioCompletion *completion);
+  int store_entries_in_shard(const DoutPrefixProvider *dpp, std::vector<cls::log::entry>& entries, int shard_id, librados::AioCompletion *completion);
 
   struct LogListCtx {
     int cur_shard;
@@ -127,7 +127,7 @@ public:
   int list_entries(const DoutPrefixProvider *dpp,
                    void *handle,
                    int max_entries,
-                   std::vector<cls_log_entry>& entries,
+                   std::vector<cls::log::entry>& entries,
 		   std::string *out_marker,
 		   bool *truncated,
 		   optional_yield y);

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -670,7 +670,8 @@ void RGWMetadataManager::dump_log_entry(cls_log_entry& entry, Formatter *f)
   f->dump_string("id", entry.id);
   f->dump_string("section", entry.section);
   f->dump_string("name", entry.name);
-  entry.timestamp.gmtime_nsec(f->dump_stream("timestamp"));
+  utime_t ts(entry.timestamp);
+  ts.gmtime_nsec(f->dump_stream("timestamp"));
 
   try {
     RGWMetadataLogData log_data;

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -664,7 +664,7 @@ string RGWMetadataManager::get_marker(void *handle)
   return h->handler->get_marker(h->handle);
 }
 
-void RGWMetadataManager::dump_log_entry(cls_log_entry& entry, Formatter *f)
+void RGWMetadataManager::dump_log_entry(cls::log::entry& entry, Formatter *f)
 {
   f->open_object_section("entry");
   f->dump_string("id", entry.id);

--- a/src/rgw/services/svc_cls.cc
+++ b/src/rgw/services/svc_cls.cc
@@ -280,9 +280,9 @@ int RGWSI_Cls::TimeLog::add(const DoutPrefixProvider *dpp,
   return obj.operate(dpp, &op, y);
 }
 
-int RGWSI_Cls::TimeLog::add(const DoutPrefixProvider *dpp, 
+int RGWSI_Cls::TimeLog::add(const DoutPrefixProvider *dpp,
                             const string& oid,
-                            std::list<cls_log_entry>& entries,
+                            std::vector<cls_log_entry>& entries,
                             librados::AioCompletion *completion,
                             bool monotonic_inc,
                             optional_yield y)
@@ -309,7 +309,7 @@ int RGWSI_Cls::TimeLog::list(const DoutPrefixProvider *dpp,
                              const string& oid,
                              const real_time& start_time,
                              const real_time& end_time,
-                             int max_entries, std::list<cls_log_entry>& entries,
+                             int max_entries, std::vector<cls_log_entry>& entries,
                              const string& marker,
                              string *out_marker,
                              bool *truncated,

--- a/src/rgw/services/svc_cls.cc
+++ b/src/rgw/services/svc_cls.cc
@@ -244,7 +244,7 @@ int RGWSI_Cls::MFA::list_mfa(const DoutPrefixProvider *dpp, const string& oid, l
   return 0;
 }
 
-void RGWSI_Cls::TimeLog::prepare_entry(cls_log_entry& entry,
+void RGWSI_Cls::TimeLog::prepare_entry(cls::log::entry& entry,
                                        const real_time& ut,
                                        const string& section,
                                        const string& key,
@@ -281,7 +281,7 @@ int RGWSI_Cls::TimeLog::add(const DoutPrefixProvider *dpp,
 
 int RGWSI_Cls::TimeLog::add(const DoutPrefixProvider *dpp,
                             const string& oid,
-                            std::vector<cls_log_entry>& entries,
+                            std::vector<cls::log::entry>& entries,
                             librados::AioCompletion *completion,
                             bool monotonic_inc,
                             optional_yield y)
@@ -308,7 +308,7 @@ int RGWSI_Cls::TimeLog::list(const DoutPrefixProvider *dpp,
                              const string& oid,
                              const real_time& start_time,
                              const real_time& end_time,
-                             int max_entries, std::vector<cls_log_entry>& entries,
+                             int max_entries, std::vector<cls::log::entry>& entries,
                              const string& marker,
                              string *out_marker,
                              bool *truncated,
@@ -337,7 +337,7 @@ int RGWSI_Cls::TimeLog::list(const DoutPrefixProvider *dpp,
 
 int RGWSI_Cls::TimeLog::info(const DoutPrefixProvider *dpp, 
                              const string& oid,
-                             cls_log_header *header,
+                             cls::log::header *header,
                              optional_yield y)
 {
   rgw_rados_ref obj;
@@ -363,7 +363,7 @@ int RGWSI_Cls::TimeLog::info(const DoutPrefixProvider *dpp,
 int RGWSI_Cls::TimeLog::info_async(const DoutPrefixProvider *dpp,
                                    rgw_rados_ref& obj,
                                    const string& oid,
-                                   cls_log_header *header,
+                                   cls::log::header *header,
                                    librados::AioCompletion *completion)
 {
   int r = init_obj(dpp, oid, obj);

--- a/src/rgw/services/svc_cls.cc
+++ b/src/rgw/services/svc_cls.cc
@@ -250,7 +250,7 @@ void RGWSI_Cls::TimeLog::prepare_entry(cls_log_entry& entry,
                                        const string& key,
                                        bufferlist& bl)
 {
-  cls_log_add_prepare_entry(entry, utime_t(ut), section, key, bl);
+  cls_log_add_prepare_entry(entry, ut, section, key, bl);
 }
 
 int RGWSI_Cls::TimeLog::init_obj(const DoutPrefixProvider *dpp, const string& oid, rgw_rados_ref& obj)
@@ -274,8 +274,7 @@ int RGWSI_Cls::TimeLog::add(const DoutPrefixProvider *dpp,
   }
 
   librados::ObjectWriteOperation op;
-  utime_t t(ut);
-  cls_log_add(op, t, section, key, bl);
+  cls_log_add(op, ut, section, key, bl);
 
   return obj.operate(dpp, &op, y);
 }
@@ -324,10 +323,7 @@ int RGWSI_Cls::TimeLog::list(const DoutPrefixProvider *dpp,
 
   librados::ObjectReadOperation op;
 
-  utime_t st(start_time);
-  utime_t et(end_time);
-
-  cls_log_list(op, st, et, marker, max_entries, entries,
+  cls_log_list(op, start_time, end_time, marker, max_entries, entries,
 	       out_marker, truncated);
 
   bufferlist obl;
@@ -402,11 +398,8 @@ int RGWSI_Cls::TimeLog::trim(const DoutPrefixProvider *dpp,
     return r;
   }
 
-  utime_t st(start_time);
-  utime_t et(end_time);
-
   librados::ObjectWriteOperation op;
-  cls_log_trim(op, st, et, from_marker, to_marker);
+  cls_log_trim(op, start_time, end_time, from_marker, to_marker);
 
   if (!completion) {
     r = obj.operate(dpp, &op, y);

--- a/src/rgw/services/svc_cls.h
+++ b/src/rgw/services/svc_cls.h
@@ -80,7 +80,7 @@ public:
   public:
     TimeLog(CephContext *cct): ClsSubService(cct) {}
 
-    void prepare_entry(cls_log_entry& entry,
+    void prepare_entry(cls::log::entry& entry,
                        const real_time& ut,
                        const std::string& section,
                        const std::string& key,
@@ -94,7 +94,7 @@ public:
             optional_yield y);
     int add(const DoutPrefixProvider *dpp, 
             const std::string& oid,
-            std::vector<cls_log_entry>& entries,
+            std::vector<cls::log::entry>& entries,
             librados::AioCompletion *completion,
             bool monotonic_inc,
             optional_yield y);
@@ -102,19 +102,19 @@ public:
              const std::string& oid,
              const real_time& start_time,
              const real_time& end_time,
-             int max_entries, std::vector<cls_log_entry>& entries,
+             int max_entries, std::vector<cls::log::entry>& entries,
              const std::string& marker,
              std::string *out_marker,
              bool *truncated,
              optional_yield y);
     int info(const DoutPrefixProvider *dpp, 
              const std::string& oid,
-             cls_log_header *header,
+             cls::log::header *header,
              optional_yield y);
     int info_async(const DoutPrefixProvider *dpp,
                    rgw_rados_ref& obj,
                    const std::string& oid,
-                   cls_log_header *header,
+                   cls::log::header *header,
                    librados::AioCompletion *completion);
     int trim(const DoutPrefixProvider *dpp, 
              const std::string& oid,

--- a/src/rgw/services/svc_cls.h
+++ b/src/rgw/services/svc_cls.h
@@ -94,7 +94,7 @@ public:
             optional_yield y);
     int add(const DoutPrefixProvider *dpp, 
             const std::string& oid,
-            std::list<cls_log_entry>& entries,
+            std::vector<cls_log_entry>& entries,
             librados::AioCompletion *completion,
             bool monotonic_inc,
             optional_yield y);
@@ -102,7 +102,7 @@ public:
              const std::string& oid,
              const real_time& start_time,
              const real_time& end_time,
-             int max_entries, std::list<cls_log_entry>& entries,
+             int max_entries, std::vector<cls_log_entry>& entries,
              const std::string& marker,
              std::string *out_marker,
              bool *truncated,

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -54,6 +54,7 @@ if(NOT WIN32)
   add_subdirectory(cls_queue)
   add_subdirectory(cls_2pc_queue)
   add_subdirectory(cls_cmpomap)
+  add_subdirectory(cls_fifo)
   add_subdirectory(journal)
 
   add_subdirectory(erasure-code)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -55,6 +55,7 @@ if(NOT WIN32)
   add_subdirectory(cls_2pc_queue)
   add_subdirectory(cls_cmpomap)
   add_subdirectory(cls_fifo)
+  add_subdirectory(cls_sem_set)
   add_subdirectory(journal)
 
   add_subdirectory(erasure-code)

--- a/src/test/cls_fifo/CMakeLists.txt
+++ b/src/test/cls_fifo/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(ceph_test_neocls_fifo
+  ceph_test_neocls_fifo.cc
+  )
+target_link_libraries(ceph_test_neocls_fifo
+  libneorados
+  ${BLKID_LIBRARIES}
+  ${CMAKE_DL_LIBS}
+  ${CRYPTO_LIBS}
+  ${EXTRALIBS}
+  neoradostest-support
+  ${UNITTEST_LIBS}
+  )
+install(TARGETS
+  ceph_test_neocls_fifo
+  DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/cls_fifo/ceph_test_neocls_fifo.cc
+++ b/src/test/cls_fifo/ceph_test_neocls_fifo.cc
@@ -1,0 +1,674 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * See file COPYING for license information.
+ *
+ */
+
+#include "neorados/cls/fifo.h"
+
+#include <array>
+#include <boost/system/detail/errc.hpp>
+#include <coroutine>
+#include <memory>
+#include <new>
+#include <string_view>
+#include <utility>
+
+#include <boost/asio/post.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include <boost/system/errc.hpp>
+#include <boost/system/error_code.hpp>
+
+#include "include/neorados/RADOS.hpp"
+
+#include "cls/version/cls_version_types.h"
+
+#include "test/neorados/common_tests.h"
+
+#include "gtest/gtest.h"
+
+namespace asio = boost::asio;
+namespace sys = boost::system;
+namespace buffer = ceph::buffer;
+namespace fifo = neorados::cls::fifo;
+
+using namespace std::literals;
+
+namespace neorados::cls::fifo {
+class FIFOtest {
+public:
+  template<typename... Args>
+  static auto create_meta(Args&&... args) {
+    return FIFO::create_meta(std::forward<Args>(args)...);
+  }
+
+  template<typename... Args>
+  static auto get_meta(Args&&... args) {
+    return FIFO::get_meta(std::forward<Args>(args)...);
+  }
+
+  template<typename... Args>
+  static auto read_meta(fifo::FIFO& f, Args&&... args) {
+    return f.read_meta(std::forward<Args>(args)...);
+  }
+
+  static auto meta(fifo::FIFO& f) {
+    return f.info;
+  }
+
+  template<typename... Args>
+  static auto get_part_info(fifo::FIFO& f, Args&&... args) {
+    return f.get_part_info(std::forward<Args>(args)...);
+  }
+
+  static auto get_part_layout_info(fifo::FIFO& f) {
+    return std::make_tuple(f.part_header_size, f.part_entry_overhead);
+  }
+
+};
+}
+
+using fifo::FIFOtest;
+
+auto cct = new CephContext(CEPH_ENTITY_TYPE_CLIENT);
+const DoutPrefix dp(cct, 1, "test legacy cls fifo: ");
+
+CORO_TEST_F(cls_fifo, create, NeoRadosTest)
+{
+  std::string_view fifo_id = "fifo";
+
+
+  sys::error_code ec;
+  co_await FIFOtest::create_meta(rados(), fifo_id, pool(), std::nullopt,
+                                 std::nullopt, false, 0,
+                                 fifo::FIFO::default_max_entry_size,
+                                 asio::redirect_error(asio::use_awaitable, ec));
+  EXPECT_EQ(sys::errc::invalid_argument, ec);
+  co_await FIFOtest::create_meta(rados(), fifo_id, pool(), std::nullopt,
+                                 std::nullopt, false,
+                                 fifo::FIFO::default_max_part_size, 0,
+                                 asio::redirect_error(asio::use_awaitable, ec));
+
+  EXPECT_EQ(sys::errc::invalid_argument, ec);
+  co_await FIFOtest::create_meta(rados(), fifo_id, pool(), std::nullopt,
+                                 std::nullopt, false,
+                                 fifo::FIFO::default_max_part_size,
+                                 fifo::FIFO::default_max_entry_size,
+                                 asio::redirect_error(asio::use_awaitable, ec));
+  EXPECT_FALSE(ec);
+  neorados::ReadOp op;
+  std::uint64_t size;
+  op.stat(&size, nullptr);
+  co_await execute(fifo_id, std::move(op), nullptr);
+  EXPECT_GT(size, 0);
+  /* test idempotency */
+  co_await FIFOtest::create_meta(rados(), fifo_id, pool(), std::nullopt,
+                                 std::nullopt, false,
+                                 fifo::FIFO::default_max_part_size,
+                                 fifo::FIFO::default_max_entry_size,
+                                 asio::redirect_error(asio::use_awaitable, ec));
+  EXPECT_FALSE(ec);
+}
+
+CORO_TEST_F(cls_fifo, get_info, NeoRadosTest)
+{
+  std::string_view fifo_id = "fifo";
+
+  co_await FIFOtest::create_meta(rados(), fifo_id, pool(), std::nullopt,
+                                 std::nullopt, false,
+                                 fifo::FIFO::default_max_part_size,
+                                 fifo::FIFO::default_max_entry_size,
+                                 asio::use_awaitable);
+  auto [info, part_header_size, part_entry_overhead] =
+    co_await FIFOtest::get_meta(rados(), fifo_id, pool(), std::nullopt,
+                                asio::use_awaitable);
+  EXPECT_GT(part_header_size, 0);
+  EXPECT_GT(part_entry_overhead, 0);
+  EXPECT_FALSE(info.version.instance.empty());
+
+  std::tie(info, part_header_size, part_entry_overhead) =
+    co_await FIFOtest::get_meta(rados(), fifo_id, pool(), info.version,
+                                asio::use_awaitable);
+
+
+  decltype(info.version) objv;
+  objv.instance = "foo";
+  objv.ver = 12;
+
+  sys::error_code ec;
+  std::tie(info, part_header_size, part_entry_overhead) =
+    co_await FIFOtest::get_meta(rados(), fifo_id, pool(), objv,
+                                asio::redirect_error(asio::use_awaitable, ec));
+
+  EXPECT_EQ(sys::errc::operation_canceled, ec);
+}
+
+CORO_TEST_F(fifo, open_default, NeoRadosTest)
+{
+  std::string_view fifo_id = "fifo";
+
+  auto f = co_await fifo::FIFO::create(&dp, rados(), fifo_id, pool(),
+                                       asio::use_awaitable);
+  // force reading from backend
+  co_await FIFOtest::read_meta(*f, &dp, asio::use_awaitable);
+  auto info = FIFOtest::meta(*f);
+  EXPECT_EQ(info.id, fifo_id);
+}
+
+CORO_TEST_F(fifo, open_params, NeoRadosTest)
+{
+  std::string_view fifo_id = "fifo";
+
+  const std::uint64_t max_part_size = 10 * 1024;
+  const std::uint64_t max_entry_size = 128;
+  auto oid_prefix = "foo.123."s;
+  rados::cls::fifo::objv objv;
+  objv.instance = "fooz"s;
+  objv.ver = 10;
+
+  auto f = co_await fifo::FIFO::create(&dp, rados(), fifo_id, pool(),
+                                       asio::use_awaitable,
+                                       objv, oid_prefix, false,
+                                       max_part_size, max_entry_size);
+
+  // force reading from backend
+  co_await FIFOtest::read_meta(*f, &dp, asio::use_awaitable);
+  auto info = FIFOtest::meta(*f);
+  EXPECT_EQ(info.id, fifo_id);
+  EXPECT_EQ(info.params.max_part_size, max_part_size);
+  EXPECT_EQ(info.params.max_entry_size, max_entry_size);
+  EXPECT_EQ(info.version, objv);
+}
+
+template<class T>
+inline T decode_entry(const fifo::entry& entry)
+{
+  T val;
+  auto iter = entry.data.cbegin();
+  decode(val, iter);
+  return std::move(val);
+}
+
+CORO_TEST_F(fifo, push_list_trim, NeoRadosTest)
+{
+  std::string_view fifo_id = "fifo";
+
+  auto f = co_await fifo::FIFO::create(&dp, rados(), fifo_id, pool(),
+                                       asio::use_awaitable);
+  static constexpr auto max_entries = 10u;
+  for (auto i = 0u; i < max_entries; ++i) {
+    buffer::list bl;
+    encode(i, bl);
+    co_await f->push(&dp, std::move(bl), asio::use_awaitable);
+  }
+
+  std::array<fifo::entry, max_entries> entries;
+  /* get entries one by one */
+  std::optional<std::string> inmark;
+  for (auto i = 0u; i < max_entries; ++i) {
+    auto [result, marker] =
+      co_await f->list(&dp, inmark, std::span{entries}.first(1),
+		       asio::use_awaitable);
+    bool expected_marker = (i != (max_entries - 1));
+    EXPECT_EQ(expected_marker, !!marker);
+    EXPECT_EQ(1, result.size());
+
+    auto val = decode_entry<std::uint32_t>(result.front());
+
+    EXPECT_EQ(i, val);
+    inmark = marker;
+  }
+
+  /* get all entries at once */
+  std::array<std::string, max_entries> markers;
+
+  std::uint32_t min_entry = 0;
+  auto [res, marker] = co_await f->list(&dp, {}, entries,
+                                        asio::use_awaitable);
+
+  EXPECT_FALSE(marker);
+  EXPECT_EQ(max_entries, res.size());
+  for (auto i = 0u; i < max_entries; ++i) {
+    auto val = decode_entry<std::uint32_t>(res[i]);
+    markers[i] = res[i].marker;
+    EXPECT_EQ(i, val);
+  }
+
+  /* trim one entry */
+  co_await f->trim(&dp, markers[min_entry], false, asio::use_awaitable);
+  ++min_entry;
+
+  std::tie(res, marker) = co_await f->list(&dp, {}, entries,
+                                           asio::use_awaitable);
+
+  EXPECT_FALSE(marker);
+  EXPECT_EQ(max_entries - min_entry, res.size());
+
+  for (auto i = min_entry; i < max_entries; ++i) {
+    auto val = decode_entry<std::uint32_t>(res[i - min_entry]);
+    markers[i - min_entry] = res[i - min_entry].marker;
+    EXPECT_EQ(i, val);
+  }
+}
+
+CORO_TEST_F(fifo, push_too_big, NeoRadosTest)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+  std::string_view fifo_id = "fifo";
+
+  auto f = co_await fifo::FIFO::create(&dp, rados(), fifo_id, pool(),
+                                       asio::use_awaitable, std::nullopt,
+				       std::nullopt, false, max_part_size,
+				       max_entry_size);
+
+  std::array<char, max_entry_size + 1> buf;
+  buf.fill('\0');
+  buffer::list bl;
+  bl.append(buf.data(), sizeof(buf));
+
+  sys::error_code ec;
+  co_await f->push(&dp, bl, asio::redirect_error(asio::use_awaitable, ec));
+  EXPECT_EQ(sys::errc::argument_list_too_long, ec);
+}
+
+CORO_TEST_F(fifo, multiple_parts, NeoRadosTest)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+  std::string_view fifo_id = "fifo";
+
+  auto f = co_await fifo::FIFO::create(&dp, rados(), fifo_id, pool(),
+                                       asio::use_awaitable, std::nullopt,
+				       std::nullopt, false, max_part_size,
+				       max_entry_size);
+  std::array<char, max_entry_size> buf;
+  buf.fill('\0');
+  const auto [part_header_size, part_entry_overhead] =
+    FIFOtest::get_part_layout_info(*f);
+  const auto entries_per_part = ((max_part_size - part_header_size) /
+				 (max_entry_size + part_entry_overhead));
+  const auto max_entries = entries_per_part * 4 + 1;
+  /* push enough entries */
+  for (auto i = 0u; i < max_entries; ++i) {
+    buffer::list bl;
+    *std::launder(reinterpret_cast<int*>(buf.data())) = i;
+    bl.append(buf.data(), sizeof(buf));
+    co_await f->push(&dp, bl, asio::use_awaitable);
+  }
+
+  auto info = FIFOtest::meta(*f);
+  EXPECT_EQ(info.id, fifo_id);
+  /* head should have advanced */
+  EXPECT_GT(info.head_part_num, 0);
+
+  std::vector<fifo::entry> entries{max_entries};
+  {
+    /* list all at once */
+    auto [result, marker] = co_await f->list(&dp, {}, entries,
+					     asio::use_awaitable);
+
+    EXPECT_FALSE(marker);
+    EXPECT_EQ(max_entries, result.size());
+
+    for (auto i = 0u; i < max_entries; ++i) {
+      auto& bl = result[i].data;
+      EXPECT_EQ(i, *std::launder(reinterpret_cast<int*>(bl.c_str())));
+    }
+  }
+
+  std::optional<std::string> marker;
+  /* get entries one by one */
+  for (auto i = 0u; i < max_entries; ++i) {
+    std::span<fifo::entry> result;
+    std::tie(result, marker) = co_await f->list(&dp, marker,
+						std::span(entries).first(1),
+						asio::use_awaitable);
+
+    EXPECT_EQ(1, result.size());
+    const bool expected_more = (i != (max_entries - 1));
+    EXPECT_EQ(expected_more, !!marker);
+
+    auto& e = result.front();
+    auto& bl = e.data;
+    EXPECT_EQ(i, *std::launder(reinterpret_cast<int*>(bl.c_str())));
+  }
+
+  /* trim one at a time */
+  marker.reset();
+  for (auto i = 0u; i < max_entries; ++i) {
+    /* read single entry */
+    std::span<fifo::entry> result;
+    std::tie(result, marker) = co_await f->list(&dp, {},
+						std::span(entries).first(1),
+						asio::use_awaitable);
+    EXPECT_EQ(result.size(), 1);
+    const bool expected_more = (i != (max_entries - 1));
+    EXPECT_EQ(expected_more, !!marker);
+
+    /* trim one entry */
+    co_await f->trim(&dp, result.front().marker, false, asio::use_awaitable);
+
+    /* check tail */
+    info = FIFOtest::meta(*f);
+
+    EXPECT_EQ(info.tail_part_num, i / entries_per_part);
+
+    /* try to read all again, see how many entries left */
+    std::tie(result, marker) = co_await f->list(&dp, marker, entries,
+						asio::use_awaitable);
+    EXPECT_EQ(max_entries - i - 1, result.size());
+    EXPECT_FALSE(!!marker);
+  }
+
+  /* tail now should point at head */
+  info = FIFOtest::meta(*f);
+  EXPECT_EQ(info.head_part_num, info.tail_part_num);
+
+  /* check old tails are removed */
+  for (auto i = 0; i < info.tail_part_num; ++i) {
+    sys::error_code ec;
+    co_await FIFOtest::get_part_info(*f, i, asio::redirect_error(
+				       asio::use_awaitable, ec));
+    EXPECT_EQ(sys::errc::no_such_file_or_directory, ec);
+  }
+  /* check current tail exists */
+  co_await FIFOtest::get_part_info(*f, info.tail_part_num, asio::use_awaitable);
+}
+
+CORO_TEST_F(fifo, two_pushers, NeoRadosTest)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+  std::string_view fifo_id = "fifo";
+
+  auto f1 = co_await fifo::FIFO::create(&dp, rados(), fifo_id, pool(),
+					asio::use_awaitable, std::nullopt,
+					std::nullopt, false, max_part_size,
+					max_entry_size);
+  std::array<char, max_entry_size> buf;
+  buf.fill('\0');
+  const auto [part_header_size, part_entry_overhead] =
+    FIFOtest::get_part_layout_info(*f1);
+  const auto entries_per_part = ((max_part_size - part_header_size) /
+				 (max_entry_size + part_entry_overhead));
+  const auto max_entries = entries_per_part * 4 + 1;
+
+
+  auto f2 = co_await fifo::FIFO::open(&dp, rados(), fifo_id, pool(),
+				      asio::use_awaitable);
+  std::vector fifos{f1.get(), f2.get()};
+
+  for (auto i = 0u; i < max_entries; ++i) {
+    buffer::list bl;
+    *std::launder(reinterpret_cast<int*>(buf.data())) = i;
+    bl.append(buf.data(), sizeof(buf));
+    auto f = fifos[i % fifos.size()];
+    co_await f->push(&dp, bl, asio::use_awaitable);
+  }
+
+  /* list all by both */
+  std::vector<fifo::entry> entries{max_entries};
+  auto [result, marker] = co_await f1->list(&dp, std::nullopt, entries,
+					    asio::use_awaitable);
+  EXPECT_FALSE(marker);
+  EXPECT_EQ(max_entries, result.size());
+
+  std::tie(result, marker) = co_await f2->list(&dp, std::nullopt, entries,
+					       asio::use_awaitable);
+  EXPECT_FALSE(marker);
+  EXPECT_EQ(max_entries, result.size());
+
+  for (auto i = 0u; i < max_entries; ++i) {
+    auto& bl = result[i].data;
+    EXPECT_EQ(i, *std::launder(reinterpret_cast<int*>(bl.c_str())));
+  }
+}
+
+CORO_TEST_F(fifo, two_pushers_trim, NeoRadosTest)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+  std::string_view fifo_id = "fifo";
+
+  auto f1 = co_await fifo::FIFO::create(&dp, rados(), fifo_id, pool(),
+					asio::use_awaitable, std::nullopt,
+					std::nullopt, false, max_part_size,
+					max_entry_size);
+  std::array<char, max_entry_size> buf;
+  buf.fill('\0');
+  const auto [part_header_size, part_entry_overhead] =
+    FIFOtest::get_part_layout_info(*f1);
+  const auto entries_per_part = ((max_part_size - part_header_size) /
+				 (max_entry_size + part_entry_overhead));
+  const auto max_entries = entries_per_part * 4 + 1;
+
+
+  auto f2 = co_await fifo::FIFO::open(&dp, rados(), fifo_id, pool(),
+				      asio::use_awaitable);
+  /* push one entry to f2 and the rest to f1 */
+  for (auto i = 0u; i < max_entries; ++i) {
+    buffer::list bl;
+    *std::launder(reinterpret_cast<int*>(buf.data())) = i;
+    bl.append(buf.data(), sizeof(buf));
+    auto& f = (i < 1 ? f2 : f1);
+    co_await f->push(&dp, bl, asio::use_awaitable);
+  }
+
+  /* trim half by fifo1 */
+  auto num = max_entries / 2;
+  std::vector<fifo::entry> entries{max_entries};
+  auto [result, marker] = co_await f1->list(&dp, std::nullopt,
+					    std::span(entries).first(num),
+					    asio::use_awaitable);
+  EXPECT_TRUE(marker);
+  EXPECT_EQ(num, result.size());
+
+  for (auto i = 0u; i < num; ++i) {
+    auto& bl = result[i].data;
+    EXPECT_EQ(i, *std::launder(reinterpret_cast<int*>(bl.c_str())));
+  }
+
+  auto& entry = result[num - 1];
+  EXPECT_EQ(marker, entry.marker);
+  co_await f1->trim(&dp, *marker, false, asio::use_awaitable);
+  /* list what's left by fifo2 */
+
+  const auto left = max_entries - num;
+  std::tie(result, marker) = co_await f2->list(&dp, *marker,
+					       std::span(entries).first(left),
+					       asio::use_awaitable);
+
+  EXPECT_EQ(left, result.size());
+  EXPECT_FALSE(marker);
+
+  for (auto i = num; i < max_entries; ++i) {
+    auto& bl = result[i - num].data;
+    EXPECT_EQ(i, *std::launder(reinterpret_cast<int*>(bl.c_str())));
+  }
+}
+
+CORO_TEST_F(fifo, push_batch, NeoRadosTest)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+  std::string_view fifo_id = "fifo";
+
+  auto f = co_await fifo::FIFO::create(&dp, rados(), fifo_id, pool(),
+				       asio::use_awaitable, std::nullopt,
+				       std::nullopt, false, max_part_size,
+				       max_entry_size);
+  std::array<char, max_entry_size> buf;
+  buf.fill('\0');
+  const auto [part_header_size, part_entry_overhead] =
+    FIFOtest::get_part_layout_info(*f);
+  const auto entries_per_part = ((max_part_size - part_header_size) /
+				 (max_entry_size + part_entry_overhead));
+  const auto max_entries = entries_per_part * 4 + 1;
+
+
+  std::deque<buffer::list> bufs;
+  for (auto i = 0u; i < max_entries; ++i) {
+    buffer::list bl;
+    *std::launder(reinterpret_cast<int*>(buf.data())) = i;
+    bl.append(buf.data(), sizeof(buf));
+    bufs.push_back(bl);
+  }
+  EXPECT_EQ(max_entries, bufs.size());
+  co_await f->push(&dp, std::move(bufs), asio::use_awaitable);
+
+  /* list all */
+  std::vector<fifo::entry> entries{max_entries};
+  auto [result, marker] = co_await f->list(&dp, std::nullopt, entries,
+					   asio::use_awaitable);
+  EXPECT_FALSE(marker);
+  EXPECT_EQ(max_entries, result.size());
+  for (auto i = 0u; i < max_entries; ++i) {
+    auto& bl = result[i].data;
+    EXPECT_EQ(i, *std::launder(reinterpret_cast<int*>(bl.c_str())));
+  }
+  auto info = FIFOtest::meta(*f);
+  EXPECT_EQ(info.head_part_num, 4);
+}
+
+CORO_TEST_F(fifo, trim_exclusive, NeoRadosTest)
+{
+  std::string_view fifo_id = "fifo";
+  auto f = co_await fifo::FIFO::create(&dp, rados(), fifo_id, pool(),
+				       asio::use_awaitable);
+
+  static constexpr auto max_entries = 10u;
+  for (auto i = 0u; i < max_entries; ++i) {
+    buffer::list bl;
+    encode(i, bl);
+    co_await f->push(&dp, std::move(bl), asio::use_awaitable);
+  }
+
+  std::array<fifo::entry, max_entries> entries;
+  auto [result, marker] = co_await f->list(&dp, std::nullopt,
+					   std::span{entries}.first(1),
+					   asio::use_awaitable);
+  auto val = decode_entry<std::uint32_t>(result.front());
+  EXPECT_EQ(0, val);
+  EXPECT_EQ(*marker, result.front().marker);
+
+  co_await f->trim(&dp, *marker, true, asio::use_awaitable);
+
+  std::tie(result, marker) = co_await f->list(&dp, std::nullopt, entries,
+					      asio::use_awaitable);
+  val = decode_entry<std::uint32_t>(result.front());
+  EXPECT_EQ(0, val);
+  co_await f->trim(&dp, result[4].marker, true, asio::use_awaitable);
+
+  std::tie(result, marker) = co_await f->list(&dp, std::nullopt, entries,
+					      asio::use_awaitable);
+  val = decode_entry<std::uint32_t>(result.front());
+  EXPECT_EQ(4, val);
+  co_await f->trim(&dp, result.back().marker, true, asio::use_awaitable);
+
+  std::tie(result, marker) = co_await f->list(&dp, std::nullopt, entries,
+					      asio::use_awaitable);
+  val = decode_entry<std::uint32_t>(result.front());
+  EXPECT_EQ(1, result.size());
+  EXPECT_EQ(max_entries - 1, val);
+}
+
+CORO_TEST_F(fifo, trim_all, NeoRadosTest)
+{
+  std::string_view fifo_id = "fifo";
+  auto f = co_await fifo::FIFO::create(&dp, rados(), fifo_id, pool(),
+				       asio::use_awaitable);
+
+  static constexpr auto max_entries = 10u;
+  for (auto i = 0u; i < max_entries; ++i) {
+    buffer::list bl;
+    encode(i, bl);
+    co_await f->push(&dp, std::move(bl), asio::use_awaitable);
+  }
+
+  sys::error_code ec;
+  co_await f->trim(&dp, f->max_marker(), false,
+		   asio::redirect_error(asio::use_awaitable, ec));
+  EXPECT_EQ(sys::errc::no_message_available, ec);
+
+  std::array<fifo::entry, max_entries> entries;
+  auto [result, marker] = co_await f->list(&dp, std::nullopt, entries,
+					   asio::use_awaitable);
+  EXPECT_TRUE(result.empty());
+  EXPECT_FALSE(marker);
+}
+
+TEST(neocls_fifo_bare, lambdata)
+{
+  asio::io_context c;
+
+  std::optional<neorados::RADOS> rados;
+  neorados::IOContext pool;
+  std::string_view fifo_id = "fifo";
+  std::unique_ptr<fifo::FIFO> f;
+  static constexpr auto max_entries = 10u;
+  std::array<fifo::entry, max_entries> list_entries;
+  bool completed = false;
+  neorados::RADOS::Builder{}.build(
+    c,
+    [&](sys::error_code ec, neorados::RADOS r_) {
+      ASSERT_FALSE(ec);
+      rados = std::move(r_);
+      create_pool(
+	*rados, get_temp_pool_name(),
+	[&](sys::error_code ec, int64_t poolid) {
+	  ASSERT_FALSE(ec);
+	  pool.set_pool(poolid);
+	  fifo::FIFO::create(
+	    &dp, *rados, fifo_id, pool,
+	    [&](sys::error_code ec, std::unique_ptr<fifo::FIFO> f_) {
+	      ASSERT_FALSE(ec);
+	      f = std::move(f_);
+	      std::array<buffer::list, max_entries> entries;
+	      for (auto i = 0u; i < max_entries; ++i) {
+		encode(i, entries[i]);
+	      }
+	      f->push(
+		&dp, entries,
+		[&](sys::error_code ec) {
+		  ASSERT_FALSE(ec);
+		  f->list(
+		    &dp, std::nullopt, list_entries,
+		    [&](sys::error_code ec, std::span<fifo::entry> result,
+			std::optional<std::string> marker) {
+		      ASSERT_FALSE(ec);
+		      ASSERT_EQ(max_entries, result.size());
+		      ASSERT_FALSE(marker);
+		      for (auto i = 0u; i < max_entries; ++i) {
+			auto val = decode_entry<std::uint32_t>(result[i]);
+			EXPECT_EQ(i, val);
+		      }
+		      f->trim(
+			&dp, f->max_marker(), false,
+			[&](sys::error_code ec) {
+			  ASSERT_EQ(sys::errc::no_message_available, ec);
+			  f->list(
+			    &dp, std::nullopt, list_entries,
+			    [&](sys::error_code ec, std::span<fifo::entry> result,
+				std::optional<std::string> marker) {
+			      ASSERT_FALSE(ec);
+			      ASSERT_TRUE(result.empty());
+			      ASSERT_FALSE(marker);
+			      completed = true;
+			    });
+			});
+		    });
+		});
+	    });
+	});
+    });
+  c.run();
+  ASSERT_TRUE(completed);
+}

--- a/src/test/cls_log/CMakeLists.txt
+++ b/src/test/cls_log/CMakeLists.txt
@@ -14,3 +14,19 @@ target_link_libraries(ceph_test_cls_log
 install(TARGETS
   ceph_test_cls_log
   DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+add_executable(ceph_test_neocls_log
+  test_neocls_log.cc
+  )
+target_link_libraries(ceph_test_neocls_log
+  libneorados
+  ${BLKID_LIBRARIES}
+  ${CMAKE_DL_LIBS}
+  ${CRYPTO_LIBS}
+  ${EXTRALIBS}
+  neoradostest-support
+  ${UNITTEST_LIBS}
+  )
+install(TARGETS
+  ceph_test_neocls_log
+  DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/cls_log/test_cls_log.cc
+++ b/src/test/cls_log/test_cls_log.cc
@@ -116,7 +116,7 @@ void check_entry(cls_log_entry& entry, utime_t& start_time, int i, bool modified
 static int log_list(librados::IoCtx& ioctx, const std::string& oid,
                     utime_t& from, utime_t& to,
                     const string& in_marker, int max_entries,
-                    list<cls_log_entry>& entries,
+                    vector<cls_log_entry>& entries,
                     string *out_marker, bool *truncated)
 {
   librados::ObjectReadOperation rop;
@@ -128,7 +128,7 @@ static int log_list(librados::IoCtx& ioctx, const std::string& oid,
 
 static int log_list(librados::IoCtx& ioctx, const std::string& oid,
                     utime_t& from, utime_t& to, int max_entries,
-                    list<cls_log_entry>& entries, bool *truncated)
+                    vector<cls_log_entry>& entries, bool *truncated)
 {
   std::string marker;
   return log_list(ioctx, oid, from, to, marker, max_entries,
@@ -136,7 +136,7 @@ static int log_list(librados::IoCtx& ioctx, const std::string& oid,
 }
 
 static int log_list(librados::IoCtx& ioctx, const std::string& oid,
-                    list<cls_log_entry>& entries)
+                    vector<cls_log_entry>& entries)
 {
   utime_t from, to;
   bool truncated{false};
@@ -156,7 +156,7 @@ TEST_F(cls_log, test_log_add_same_time)
   utime_t to_time = get_time(start_time, 1, true);
   generate_log(ioctx, oid, 10, start_time, false);
 
-  list<cls_log_entry> entries;
+  vector<cls_log_entry> entries;
   bool truncated;
 
   /* check list */
@@ -166,7 +166,7 @@ TEST_F(cls_log, test_log_add_same_time)
     ASSERT_EQ(10, (int)entries.size());
     ASSERT_EQ(0, (int)truncated);
   }
-  list<cls_log_entry>::iterator iter;
+  vector<cls_log_entry>::iterator iter;
 
   /* need to sort returned entries, all were using the same time as key */
   map<int, cls_log_entry> check_ents;
@@ -216,7 +216,7 @@ TEST_F(cls_log, test_log_add_different_time)
   utime_t start_time = ceph_clock_now();
   generate_log(ioctx, oid, 10, start_time, true);
 
-  list<cls_log_entry> entries;
+  vector<cls_log_entry> entries;
   bool truncated;
 
   utime_t to_time = utime_t(start_time.sec() + 10, start_time.nsec());
@@ -229,7 +229,7 @@ TEST_F(cls_log, test_log_add_different_time)
     ASSERT_EQ(0, (int)truncated);
   }
 
-  list<cls_log_entry>::iterator iter;
+  vector<cls_log_entry>::iterator iter;
 
   /* returned entries should be sorted by time */
   map<int, cls_log_entry> check_ents;
@@ -301,7 +301,7 @@ TEST_F(cls_log, trim_by_time)
   utime_t start_time = ceph_clock_now();
   generate_log(ioctx, oid, 10, start_time, true);
 
-  list<cls_log_entry> entries;
+  vector<cls_log_entry> entries;
   bool truncated;
 
   /* check list */
@@ -335,7 +335,7 @@ TEST_F(cls_log, trim_by_marker)
   utime_t zero_time;
   std::vector<cls_log_entry> log1;
   {
-    list<cls_log_entry> entries;
+    vector<cls_log_entry> entries;
     ASSERT_EQ(0, log_list(ioctx, oid, entries));
     ASSERT_EQ(10u, entries.size());
 
@@ -347,7 +347,7 @@ TEST_F(cls_log, trim_by_marker)
     const std::string from = "";
     const std::string to = log1[0].id;
     ASSERT_EQ(0, do_log_trim(ioctx, oid, from, to));
-    list<cls_log_entry> entries;
+    vector<cls_log_entry> entries;
     ASSERT_EQ(0, log_list(ioctx, oid, entries));
     ASSERT_EQ(9u, entries.size());
     EXPECT_EQ(log1[1].id, entries.begin()->id);
@@ -358,7 +358,7 @@ TEST_F(cls_log, trim_by_marker)
     const std::string from = log1[8].id;
     const std::string to = "9";
     ASSERT_EQ(0, do_log_trim(ioctx, oid, from, to));
-    list<cls_log_entry> entries;
+    vector<cls_log_entry> entries;
     ASSERT_EQ(0, log_list(ioctx, oid, entries));
     ASSERT_EQ(8u, entries.size());
     EXPECT_EQ(log1[8].id, entries.rbegin()->id);
@@ -369,7 +369,7 @@ TEST_F(cls_log, trim_by_marker)
     const std::string from = log1[3].id;
     const std::string to = log1[4].id;
     ASSERT_EQ(0, do_log_trim(ioctx, oid, from, to));
-    list<cls_log_entry> entries;
+    vector<cls_log_entry> entries;
     ASSERT_EQ(0, log_list(ioctx, oid, entries));
     ASSERT_EQ(7u, entries.size());
     ASSERT_EQ(-ENODATA, do_log_trim(ioctx, oid, from, to));
@@ -379,7 +379,7 @@ TEST_F(cls_log, trim_by_marker)
     const std::string from = "";
     const std::string to = "9";
     ASSERT_EQ(0, do_log_trim(ioctx, oid, from, to));
-    list<cls_log_entry> entries;
+    vector<cls_log_entry> entries;
     ASSERT_EQ(0, log_list(ioctx, oid, entries));
     ASSERT_EQ(0u, entries.size());
     ASSERT_EQ(-ENODATA, do_log_trim(ioctx, oid, from, to));

--- a/src/test/cls_log/test_cls_log.cc
+++ b/src/test/cls_log/test_cls_log.cc
@@ -5,8 +5,7 @@
 #include "cls/log/cls_log_types.h"
 #include "cls/log/cls_log_client.h"
 
-#include "include/utime.h"
-#include "common/Clock.h"
+#include "common/ceph_time.h"
 #include "global/global_context.h"
 
 #include "gtest/gtest.h"
@@ -17,6 +16,10 @@
 #include <vector>
 
 using namespace std;
+using namespace std::literals;
+
+using ceph::real_time;
+using ceph::real_clock;
 
 /// creates a temporary pool and initializes an IoCtx for each test
 class cls_log : public ::testing::Test {
@@ -52,7 +55,7 @@ static int read_bl(bufferlist& bl, int *i)
   return 0;
 }
 
-void add_log(librados::ObjectWriteOperation *op, utime_t& timestamp, string& section, string&name, int i)
+void add_log(librados::ObjectWriteOperation *op, real_time timestamp, string& section, string&name, int i)
 {
   bufferlist bl;
   encode(i, bl);
@@ -70,7 +73,7 @@ string get_name(int i)
   return name_prefix + buf;
 }
 
-void generate_log(librados::IoCtx& ioctx, string& oid, int max, utime_t& start_time, bool modify_time)
+void generate_log(librados::IoCtx& ioctx, string& oid, int max, real_time start_time, bool modify_time)
 {
   string section = "global";
 
@@ -80,11 +83,10 @@ void generate_log(librados::IoCtx& ioctx, string& oid, int max, utime_t& start_t
 
   for (i = 0; i < max; i++) {
     // coverity[store_truncates_time_t:SUPPRESS]
-    uint32_t secs = start_time.sec();
+    auto ts = start_time;
     if (modify_time)
-      secs += i;
+      ts += i * 1s;
 
-    utime_t ts(secs, start_time.nsec());
     string name = get_name(i);
 
     add_log(&op, ts, section, name, i);
@@ -93,20 +95,17 @@ void generate_log(librados::IoCtx& ioctx, string& oid, int max, utime_t& start_t
   ASSERT_EQ(0, ioctx.operate(oid, &op));
 }
 
-utime_t get_time(utime_t& start_time, int i, bool modify_time)
+real_time get_time(real_time start_time, int i, bool modify_time)
 {
   // coverity[store_truncates_time_t:SUPPRESS]
-  uint32_t secs = start_time.sec();
-  if (modify_time)
-    secs += i;
-  return utime_t(secs, start_time.nsec());
+  return modify_time ? start_time + (i * 1s) : start_time;
 }
 
-void check_entry(cls_log_entry& entry, utime_t& start_time, int i, bool modified_time)
+void check_entry(cls_log_entry& entry, real_time start_time, int i, bool modified_time)
 {
   string section = "global";
   string name = get_name(i);
-  utime_t ts = get_time(start_time, i, modified_time);
+  auto ts = get_time(start_time, i, modified_time);
 
   ASSERT_EQ(section, entry.section);
   ASSERT_EQ(name, entry.name);
@@ -114,7 +113,7 @@ void check_entry(cls_log_entry& entry, utime_t& start_time, int i, bool modified
 }
 
 static int log_list(librados::IoCtx& ioctx, const std::string& oid,
-                    utime_t& from, utime_t& to,
+                    real_time from, real_time to,
                     const string& in_marker, int max_entries,
                     vector<cls_log_entry>& entries,
                     string *out_marker, bool *truncated)
@@ -127,7 +126,7 @@ static int log_list(librados::IoCtx& ioctx, const std::string& oid,
 }
 
 static int log_list(librados::IoCtx& ioctx, const std::string& oid,
-                    utime_t& from, utime_t& to, int max_entries,
+                    real_time from, real_time to, int max_entries,
                     vector<cls_log_entry>& entries, bool *truncated)
 {
   std::string marker;
@@ -138,7 +137,7 @@ static int log_list(librados::IoCtx& ioctx, const std::string& oid,
 static int log_list(librados::IoCtx& ioctx, const std::string& oid,
                     vector<cls_log_entry>& entries)
 {
-  utime_t from, to;
+  real_time from, to;
   bool truncated{false};
   return log_list(ioctx, oid, from, to, 0, entries, &truncated);
 }
@@ -152,8 +151,8 @@ TEST_F(cls_log, test_log_add_same_time)
   ASSERT_EQ(0, ioctx.create(oid, true));
 
   /* generate log */
-  utime_t start_time = ceph_clock_now();
-  utime_t to_time = get_time(start_time, 1, true);
+  auto start_time = real_clock::now();
+  auto to_time = get_time(start_time, 1, true);
   generate_log(ioctx, oid, 10, start_time, false);
 
   vector<cls_log_entry> entries;
@@ -213,13 +212,13 @@ TEST_F(cls_log, test_log_add_different_time)
   ASSERT_EQ(0, ioctx.create(oid, true));
 
   /* generate log */
-  utime_t start_time = ceph_clock_now();
+  auto start_time = real_clock::now();
   generate_log(ioctx, oid, 10, start_time, true);
 
   vector<cls_log_entry> entries;
   bool truncated;
 
-  utime_t to_time = utime_t(start_time.sec() + 10, start_time.nsec());
+  auto to_time = start_time + (10 * 1s);
 
   {
     /* check list */
@@ -250,7 +249,7 @@ TEST_F(cls_log, test_log_add_different_time)
 
   /* check list again with shifted time */
   {
-    utime_t next_time = get_time(start_time, 1, true);
+    auto next_time = get_time(start_time, 1, true);
     ASSERT_EQ(0, log_list(ioctx, oid, next_time, to_time, 0,
                           entries, &truncated));
     ASSERT_EQ(9u, entries.size());
@@ -282,7 +281,7 @@ int do_log_trim(librados::IoCtx& ioctx, const std::string& oid,
 }
 
 int do_log_trim(librados::IoCtx& ioctx, const std::string& oid,
-                const utime_t& from_time, const utime_t& to_time)
+                real_time from_time, real_time to_time)
 {
   librados::ObjectWriteOperation op;
   cls_log_trim(op, from_time, to_time, "", "");
@@ -298,7 +297,7 @@ TEST_F(cls_log, trim_by_time)
   ASSERT_EQ(0, ioctx.create(oid, true));
 
   /* generate log */
-  utime_t start_time = ceph_clock_now();
+  auto start_time = real_clock::now();
   generate_log(ioctx, oid, 10, start_time, true);
 
   vector<cls_log_entry> entries;
@@ -307,12 +306,12 @@ TEST_F(cls_log, trim_by_time)
   /* check list */
 
   /* trim */
-  utime_t to_time = get_time(start_time, 10, true);
+  auto to_time = get_time(start_time, 10, true);
 
   for (int i = 0; i < 10; i++) {
-    utime_t trim_time = get_time(start_time, i, true);
+    auto trim_time = get_time(start_time, i, true);
 
-    utime_t zero_time;
+    real_time zero_time;
 
     ASSERT_EQ(0, do_log_trim(ioctx, oid, zero_time, trim_time));
     ASSERT_EQ(-ENODATA, do_log_trim(ioctx, oid, zero_time, trim_time));
@@ -329,10 +328,9 @@ TEST_F(cls_log, trim_by_marker)
   string oid = "obj";
   ASSERT_EQ(0, ioctx.create(oid, true));
 
-  utime_t start_time = ceph_clock_now();
+  auto start_time = real_clock::now();
   generate_log(ioctx, oid, 10, start_time, true);
 
-  utime_t zero_time;
   std::vector<cls_log_entry> log1;
   {
     vector<cls_log_entry> entries;

--- a/src/test/cls_log/test_neocls_log.cc
+++ b/src/test/cls_log/test_neocls_log.cc
@@ -1,0 +1,497 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * See file COPYING for license information.
+ *
+ */
+
+#include "neorados/cls/log.h"
+
+#include <coroutine>
+#include <chrono>
+#include <map>
+#include <string>
+#include <string_view>
+
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/asio/redirect_error.hpp>
+
+#include <boost/system/errc.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <fmt/format.h>
+
+#include "include/neorados/RADOS.hpp"
+
+#include "cls/version/cls_version_types.h"
+
+#include "test/neorados/common_tests.h"
+
+#include "gtest/gtest.h"
+
+using namespace std::literals;
+
+namespace chrono = std::chrono;
+
+namespace asio = boost::asio;
+
+namespace buffer = ceph::buffer;
+
+using boost::system::error_code;
+using boost::system::system_error;
+using boost::system::errc::no_message_available;
+using ceph::real_clock;
+using ceph::real_time;
+
+using neorados::RADOS;
+using neorados::IOContext;
+using neorados::Object;
+using neorados::WriteOp;
+using neorados::ReadOp;
+
+namespace l = neorados::cls::log;
+
+inline constexpr auto section = "global"s;
+inline constexpr auto oid = "obj"sv;
+
+template<typename T>
+auto encode(const T& v)
+{
+  using ceph::encode;
+  buffer::list bl;
+  encode(v, bl);
+  return bl;
+}
+
+template<typename T>
+auto decode(const buffer::list& bl)
+{
+  using ceph::decode;
+  T v;
+  auto bi = bl.cbegin();
+  decode(v, bi);
+  return v;
+}
+
+auto get_time(real_time start_time, chrono::seconds i, bool modify_time)
+{
+  return modify_time ? start_time + i : start_time;
+}
+
+auto get_name(int i)
+{
+  static constexpr auto prefix = "data-source-"sv;
+  return fmt::format("{}{}", prefix, i);
+}
+
+template<boost::asio::completion_token_for<void(error_code)> CompletionToken>
+auto generate_log(RADOS& r, Object oid, IOContext ioc,
+		  int max, real_time start_time,
+		  bool modify_time, CompletionToken&& token)
+{
+// In this case, the warning is spurious as the 'mismatched' `operator
+// new` calls directly into the matching `operator new`, returning its
+// result.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+  return asio::async_initiate<CompletionToken, void(error_code)>
+    (asio::experimental::co_composed<void(error_code)>
+     ([](auto state, RADOS& r, Object oid, IOContext ioc,
+	 int max, real_time start_time, bool modify_time) -> void {
+       static constexpr auto maxops = 50;
+       try {
+	 for (auto i = 0; i < max;) {
+	   std::vector<l::entry> entries;
+	   for (auto ops = 0; (ops < maxops) && (i < max); ++i, ++ops) {
+	     entries.emplace_back(get_time(start_time, i * 1s, modify_time),
+				  section, get_name(i), encode(i));
+	   }
+	   co_await r.execute(oid, ioc, WriteOp{}.exec(l::add(std::move(entries))),
+			      asio::deferred);
+	 }
+       } catch (const system_error& e) {
+	 co_return {e.code()};
+       }
+       co_return {error_code{}};
+     }, r.get_executor()),
+     token, std::ref(r), std::move(oid),
+     std::move(ioc), max, start_time, modify_time);
+#pragma GCC diagnostic pop
+}
+
+void check_entry(const l::entry& entry, real_time start_time,
+		 int i, bool modified_time)
+{
+  auto name = get_name(i);
+  auto ts = get_time(start_time, i * 1s, modified_time);
+
+  ASSERT_EQ(section, entry.section);
+  ASSERT_EQ(name, entry.name);
+  ASSERT_EQ(ts, entry.timestamp);
+}
+
+template<boost::asio::completion_token_for<void(error_code)> CompletionToken>
+auto check_log(RADOS& r, Object oid, IOContext ioc, real_time start_time,
+	       int max, CompletionToken&& token)
+{
+// In this case, the warning is spurious as the 'mismatched' `operator
+// new` calls directly into the matching `operator new`, returning its
+// result.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+  return asio::async_initiate<CompletionToken, void(error_code)>
+    (asio::experimental::co_composed<void(error_code)>
+     ([](auto state, RADOS& rados, Object oid, IOContext ioc,
+	 real_time start_time, int max) -> void {
+       try {
+	 std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+	 std::optional<std::string> marker;
+	 int i = 0;
+	 do {
+	   std::span<l::entry> result;
+	   std::tie(result, marker) =
+	     co_await neorados::cls::log::list(rados, oid, ioc, {}, {},
+					       marker, entries,
+					       asio::deferred);
+	   for (const auto& entry : result) {
+	     auto num = decode<int>(entry.data);
+	     EXPECT_EQ(i, num);
+	     check_entry(entry, start_time, i, true);
+	     ++i;
+	   }
+	 } while (marker);
+	 EXPECT_EQ(i, max);
+       } catch (const system_error& e) {
+	 co_return {e.code()};
+       }
+       co_return {error_code{}};
+     }, r.get_executor()),
+     token, std::ref(r), std::move(oid),
+     std::move(ioc), start_time, max);
+#pragma GCC diagnostic pop
+}
+
+template<typename CompletionToken>
+auto trim(RADOS& rados, Object oid, const IOContext ioc,
+	  real_time from, real_time to, CompletionToken&& token)
+{
+  return rados.execute(std::move(oid), std::move(ioc),
+		       WriteOp{}.exec(l::trim(from, to)),
+		       std::forward<CompletionToken>(token));
+}
+
+template<typename CompletionToken>
+auto trim(RADOS& rados, Object oid, IOContext ioc,
+	  std::string from, std::string to, CompletionToken&& token)
+{
+  return rados.execute(std::move(oid), std::move(ioc),
+		       WriteOp{}.exec(l::trim(std::move(from), std::move(to))),
+		       std::forward<CompletionToken>(token));
+}
+
+template<typename CompletionToken>
+auto list(RADOS& rados, Object oid, IOContext ioc,
+	  std::span<l::entry> entries, std::span<l::entry>* result,
+	  CompletionToken&& token)
+{
+  return rados.execute(oid, ioc,
+		       ReadOp{}.exec(l::list({}, {}, {}, entries, result, nullptr)),
+		       nullptr, asio::use_awaitable);
+}
+
+template<typename CompletionToken>
+auto list(RADOS& rados, Object oid, IOContext ioc,
+	  real_time from, real_time to,
+	  std::optional<std::string> in_marker,
+	  std::span<l::entry> entries, std::span<l::entry>* result,
+	  std::optional<std::string>* marker, CompletionToken&& token)
+{
+  return rados.execute(
+    oid, ioc,
+    ReadOp{}.exec(l::list(from, to, std::move(in_marker), entries, result, marker)),
+    nullptr, asio::use_awaitable);
+}
+
+CORO_TEST_F(neocls_log, test_log_add_same_time, NeoRadosTest)
+{
+  co_await create_obj(oid);
+
+  auto start_time = real_clock::now();
+  auto to_time = start_time + 1s;
+  co_await generate_log(rados(), oid, pool(), 10, start_time, false,
+			asio::use_awaitable);
+
+  std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+  auto [res, marker] =
+    co_await neorados::cls::log::list(rados(), oid, pool(), start_time, to_time,
+				      {}, entries, asio::use_awaitable);
+  EXPECT_EQ(10u, res.size());
+  EXPECT_FALSE(marker);
+
+  /* need to sort returned entries, all were using the same time as key */
+  std::map<int, l::entry> check_ents;
+
+  for (const auto& entry : res) {
+    auto num = decode<int>(entry.data);
+    check_ents[num] = entry;
+  }
+
+  EXPECT_EQ(10u, check_ents.size());
+
+  decltype(check_ents)::iterator ei;
+  int i;
+
+  for (i = 0, ei = check_ents.begin(); i < 10; i++, ++ei) {
+    const auto& entry = ei->second;
+
+    EXPECT_EQ(i, ei->first);
+    check_entry(entry, start_time, i, false);
+  }
+
+
+  res = std::span{entries}.first(1);
+  co_await list(rados(), oid, pool(), start_time, to_time, {},
+		res, &res, &marker, asio::use_awaitable);
+
+  EXPECT_EQ(1u, res.size());
+  EXPECT_TRUE(marker);
+}
+
+CORO_TEST_F(neocls_log, test_log_add_different_time, NeoRadosTest)
+{
+  co_await create_obj(oid);
+
+  /* generate log */
+  auto start_time = real_clock::now();
+  co_await generate_log(rados(), oid, pool(), 10, start_time, true,
+			asio::use_awaitable);
+
+  std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+  std::optional<std::string> marker;
+  std::span<l::entry> result;
+
+  auto to_time = start_time + (10 * 1s);
+
+  {
+    /* check list */
+    std::tie(result, marker) =
+      co_await neorados::cls::log::list(rados(), oid, pool(), start_time,
+					to_time, {}, entries,
+					asio::use_awaitable);
+    EXPECT_EQ(10u, result.size());
+    EXPECT_FALSE(marker);
+  }
+
+  decltype(result)::iterator iter;
+  int i;
+
+  for (i = 0, iter = result.begin(); iter != result.end(); ++iter, ++i) {
+    auto& entry = *iter;
+    auto num = decode<int>(entry.data);
+    EXPECT_EQ(i, num);
+    check_entry(entry, start_time, i, true);
+  }
+
+  /* check list again with shifted time */
+  {
+    auto next_time = get_time(start_time, 1s, true);
+    std::tie(result, marker) =
+      co_await neorados::cls::log::list(rados(), oid, pool(), next_time,
+					to_time, {}, entries,
+					asio::use_awaitable);
+
+    EXPECT_EQ(9u, result.size());
+    EXPECT_FALSE(marker);
+  }
+
+  i = 0;
+  marker.reset();
+  do {
+    auto old_marker = std::move(marker);
+    std::tie(result, marker) =
+      co_await neorados::cls::log::list(rados(), oid, pool(), start_time, to_time,
+					old_marker, std::span{entries}.first(1),
+					asio::use_awaitable);
+    EXPECT_NE(old_marker, marker);
+    EXPECT_EQ(1u, result.size());
+
+    ++i;
+    EXPECT_GE(10, i);
+  } while (marker);
+
+  EXPECT_EQ(10, i);
+}
+
+CORO_TEST_F(neocls_log, trim_by_time, NeoRadosTest)
+{
+  co_await create_obj(oid);
+
+  /* generate log */
+  auto start_time = real_clock::now();
+  co_await generate_log(rados(), oid, pool(), 10, start_time, true,
+			asio::use_awaitable);
+
+  std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+  std::optional<std::string> marker;
+
+  /* trim */
+  auto to_time = get_time(start_time, 10s, true);
+
+  for (int i = 0; i < 10; i++) {
+    auto trim_time = get_time(start_time, i * 1s, true);
+    co_await trim(rados(), oid, pool(), {}, trim_time, asio::use_awaitable);
+    error_code ec;
+    co_await trim(rados(), oid, pool(), {}, trim_time,
+		  asio::redirect_error(asio::use_awaitable, ec));
+    EXPECT_EQ(no_message_available, ec);
+
+    std::span<l::entry> result;
+    co_await list(rados(), oid, pool(), start_time, to_time, {},
+		  entries, &result, &marker, asio::use_awaitable);
+    EXPECT_EQ(9u - i, result.size());
+    EXPECT_FALSE(marker);
+  }
+}
+
+CORO_TEST_F(neocls_log, trim_by_marker, NeoRadosTest)
+{
+  co_await create_obj(oid);
+
+  auto start_time = real_clock::now();
+  co_await generate_log(rados(), oid, pool(), 10, start_time, true,
+			asio::use_awaitable);
+  std::vector<l::entry> log1;
+  {
+    std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+    std::span<l::entry> result;
+    co_await list(rados(), oid, pool(), entries, &result, asio::use_awaitable);
+    EXPECT_EQ(10u, result.size());
+    log1.assign(std::make_move_iterator(result.begin()),
+                std::make_move_iterator(result.end()));
+  }
+  // trim front of log
+  {
+    const std::string from = neorados::cls::log::begin_marker;
+    const std::string to = log1[0].id;
+    co_await trim(rados(), oid, pool(), from, to, asio::use_awaitable);
+
+    std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+    std::span<l::entry> result;
+    co_await list(rados(), oid, pool(), entries, &result, asio::use_awaitable);
+
+    EXPECT_EQ(9u, result.size());
+    EXPECT_EQ(log1[1].id, result.begin()->id);
+
+    error_code ec;
+    co_await trim(rados(), oid, pool(), from, to,
+		  asio::redirect_error(asio::use_awaitable, ec));
+    EXPECT_EQ(no_message_available, ec);
+  }
+  // trim back of log
+  {
+    const std::string from = log1[8].id;
+    const std::string to = neorados::cls::log::end_marker;
+    co_await trim(rados(), oid, pool(), from, to, asio::use_awaitable);
+
+    std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+    std::span<l::entry> result;
+    co_await list(rados(), oid, pool(), entries, &result, asio::use_awaitable);
+    EXPECT_EQ(8u, result.size());
+    EXPECT_EQ(log1[8].id, result.rbegin()->id);
+
+    error_code ec;
+    co_await trim(rados(), oid, pool(), from, to,
+		  asio::redirect_error(asio::use_awaitable, ec));
+    EXPECT_EQ(no_message_available, ec);
+  }
+  // trim a key from the middle
+  {
+    const std::string from = log1[3].id;
+    const std::string to = log1[4].id;
+    co_await trim(rados(), oid, pool(), from, to, asio::use_awaitable);
+
+    std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+    std::span<l::entry> result;
+
+    EXPECT_EQ(7u, result.size());
+
+    error_code ec;
+    co_await trim(rados(), oid, pool(), from, to,
+		  asio::redirect_error(asio::use_awaitable, ec));
+    EXPECT_EQ(no_message_available, ec);
+  }
+  // trim full log
+  {
+    const std::string from = neorados::cls::log::begin_marker;
+    const std::string to = neorados::cls::log::end_marker;
+    co_await trim(rados(), oid, pool(), from, to, asio::use_awaitable);
+
+    std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+    std::span<l::entry> result;
+    co_await list(rados(), oid, pool(), entries, &result, asio::use_awaitable);
+    EXPECT_EQ(0u, result.size());
+
+    error_code ec;
+    co_await trim(rados(), oid, pool(), from, to,
+		  asio::redirect_error(asio::use_awaitable, ec));
+    EXPECT_EQ(no_message_available, ec);
+  }
+}
+
+TEST(neocls_log_bare, lambdata)
+{
+  asio::io_context c;
+
+  std::string_view oid = "obj";
+
+  const auto now = real_clock::now();
+  static constexpr auto max = 10'000;
+
+  std::optional<neorados::RADOS> rados;
+  neorados::IOContext pool;
+  std::vector<l::entry> entries{neorados::cls::log::max_list_entries};
+
+  bool completed = false;
+  neorados::RADOS::Builder{}.build(c, [&](error_code ec, neorados::RADOS r_) {
+    ASSERT_FALSE(ec);
+    rados = std::move(r_);
+    create_pool(
+      *rados, get_temp_pool_name(),
+      [&](error_code ec, int64_t poolid) {
+	ASSERT_FALSE(ec);
+	pool.set_pool(poolid);
+	generate_log(
+	  *rados, oid, pool, max, now, true,
+	  [&](error_code ec) {
+	    ASSERT_FALSE(ec);
+	    check_log(
+	      *rados, oid, pool, now, max,
+	      [&](error_code ec) {
+		ASSERT_FALSE(ec);
+		neorados::cls::log::trim(
+		  *rados, oid, pool, neorados::cls::log::begin_marker,
+		  neorados::cls::log::end_marker,
+		  [&](error_code ec) {
+		    ASSERT_FALSE(ec);
+		    l::list(
+		      *rados, oid, pool, {}, {}, {}, entries,
+		      [&](error_code ec,
+			  std::span<l::entry> result,
+			  std::optional<std::string> marker) {
+			ASSERT_FALSE(ec);
+			ASSERT_FALSE(marker);
+			ASSERT_EQ(0u, result.size());
+			completed = true;
+		      });
+		  });
+	      });
+	  });
+      });
+  });
+  c.run();
+  ASSERT_TRUE(completed);
+}

--- a/src/test/cls_sem_set/CMakeLists.txt
+++ b/src/test/cls_sem_set/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(ceph_test_cls_sem_set
+  test_cls_sem_set.cc
+  )
+target_link_libraries(ceph_test_cls_sem_set
+  libneorados
+  ${BLKID_LIBRARIES}
+  ${CMAKE_DL_LIBS}
+  ${CRYPTO_LIBS}
+  ${EXTRALIBS}
+  neoradostest-support
+  ${UNITTEST_LIBS}
+  )
+install(TARGETS
+  ceph_test_cls_sem_set
+  DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/cls_sem_set/test_cls_sem_set.cc
+++ b/src/test/cls_sem_set/test_cls_sem_set.cc
@@ -1,0 +1,226 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * See file COPYING for license information.
+ *
+ */
+
+#include "neorados/cls/sem_set.h"
+
+#include <boost/system/detail/errc.hpp>
+#include <coroutine>
+#include <string>
+
+#include <boost/system/errc.hpp>
+
+#include <fmt/format.h>
+
+#include "gtest/gtest.h"
+
+#include "include/neorados/RADOS.hpp"
+
+#include "test/neorados/common_tests.h"
+
+namespace sem_set = neorados::cls::sem_set;
+namespace sys = boost::system;
+
+using neorados::ReadOp;
+using neorados::WriteOp;
+
+using namespace std::literals;
+
+/// Increment semaphore multiple times. Decrement the same number of
+/// times. Decrement once more and expect an error.
+CORO_TEST_F(cls_sem_set, inc_dec, NeoRadosTest)
+{
+  std::string_view oid = "obj";
+  co_await create_obj(oid);
+
+  auto key = "foo";
+  for (auto i = 0; i < 10; ++i) {
+    co_await execute(oid, WriteOp{}.exec(sem_set::increment(key)));
+  }
+  for (auto i = 0; i < 10; ++i) {
+    co_await execute(oid, WriteOp{}.exec(sem_set::decrement(key)));
+  }
+
+  co_await expect_error_code(
+    execute(oid, WriteOp{}.exec(sem_set::decrement(key))),
+    sys::errc::no_such_file_or_directory);
+  co_return;
+}
+
+// TODO: Uncomment when we get a GCC everywhere that doesn't crash
+// when compiling it.
+
+// /// Increment semaphore multiple times. Decrement the same number of
+// /// times. Decrement once more and expect an error. But this time use
+// /// the initializer list definition and two keys.
+// CORO_TEST_F(cls_sem_set, inc_dec_init_list, NeoRadosTest)
+// {
+//   std::string_view oid = "obj";
+//   co_await create_obj(oid);
+
+//   auto key1 = "foo";
+//   auto key2 = "bar";
+//   for (auto i = 0; i < 10; ++i) {
+//     co_await execute(oid, WriteOp{}.exec(sem_set::increment({key1, key2})));
+//   }
+//   for (auto i = 0; i < 10; ++i) {
+//     co_await execute(oid, WriteOp{}.exec(sem_set::decrement({key1, key2})));
+//   }
+
+//   co_await expect_error_code(
+//     execute(oid, WriteOp{}.exec(sem_set::decrement({key1, key2}))),
+//     sys::errc::no_such_file_or_directory);
+//   co_return;
+// }
+
+/// Send too many keys to increment, expecting an error. Then send too
+/// many keys to decrement, expecting an error.
+CORO_TEST_F(cls_sem_set, inc_dec_overflow, NeoRadosTest)
+{
+  std::string_view oid = "obj";
+  co_await create_obj(oid);
+  const auto max = sem_set::max_entries(rados());
+
+  std::unordered_set<std::string> strings;
+  for (auto i = 0u; i < 2 * max; ++i) {
+    strings.insert(fmt::format("key{}", i));
+  }
+
+  co_await expect_error_code(
+    execute(oid, WriteOp{}.exec(sem_set::increment(strings.begin(),
+                                                   strings.end()))),
+    sys::errc::argument_list_too_long);
+  co_await expect_error_code(
+    execute(oid, WriteOp{}.exec(sem_set::decrement(strings.begin(),
+                                                   strings.end()))),
+    sys::errc::argument_list_too_long);
+}
+
+
+/// Write the maximum number of keys we can return in one listing. Do
+/// one listing and ensure that the returned cursor is empty (thus
+/// showing list returned all values.) Repeat twice more to give
+/// coverage to the other two definitions of list.
+CORO_TEST_F(cls_sem_set, list_small, NeoRadosTest)
+{
+  std::string_view oid = "obj";
+  co_await create_obj(oid);
+  const auto max = sem_set::max_entries(rados());
+
+  std::unordered_set<std::string> ref;
+  for (auto i = 0u; i < max; ++i) {
+    ref.insert(fmt::format("key{}", i));
+  }
+  co_await execute(oid, WriteOp{}.exec(sem_set::increment(ref.begin(),
+                                                          ref.end())));
+  {
+    std::unordered_map<std::string, std::uint64_t> res;
+    std::optional<std::string> cursor;
+    co_await execute(oid, ReadOp{}.exec(sem_set::list(max, std::nullopt,
+                                                      &res, &cursor)));
+    EXPECT_FALSE(cursor);
+    for (const auto& [key, value] : res) {
+      EXPECT_TRUE(ref.contains(key));
+    }
+    for (const auto& key : ref) {
+      EXPECT_TRUE(res.contains(key));
+    }
+  }
+  {
+    std::map<std::string, std::uint64_t> res;
+    std::optional<std::string> cursor;
+    co_await execute(oid, ReadOp{}.exec(
+                       sem_set::list(max, std::nullopt,
+                                     std::inserter(res, res.end()), &cursor)));
+    EXPECT_FALSE(cursor);
+    for (const auto& [key, value] : res) {
+      EXPECT_TRUE(ref.contains(key));
+    }
+    for (const auto& key : ref) {
+      EXPECT_TRUE(res.contains(key));
+    }
+  }
+  {
+    std::vector<std::pair<std::string, std::uint64_t>> res;
+    std::optional<std::string> cursor;
+    co_await execute(oid, ReadOp{}.exec(
+                       sem_set::list(max, std::nullopt,
+                                     std::inserter(res, res.end()), &cursor)));
+    EXPECT_FALSE(cursor);
+    for (const auto& [key, value] : res) {
+      EXPECT_TRUE(ref.contains(key));
+    }
+    EXPECT_EQ(ref.size(), res.size());
+  }
+}
+
+/// Write the maximum number of keys we can return in one listing
+/// several times.  Do an iterated listing to test cursor
+/// functionality and append. Check that we have all of and only the
+/// keys we should. Repeat for the other two list functions.
+CORO_TEST_F(cls_sem_set, list_large, NeoRadosTest)
+{
+  std::string_view oid = "obj";
+  co_await create_obj(oid);
+  const auto max = sem_set::max_entries(rados());
+
+  std::unordered_set<std::string> ref;
+  for (auto i = 0u; i < 4; ++i) {
+    std::unordered_set<std::string> part;
+    for (auto j = 0u; j < max; ++j) {
+      part.insert(fmt::format("key{}", (i * max) + j));
+    }
+    co_await execute(oid, WriteOp{}.exec(sem_set::increment(part.begin(),
+                                                            part.end())));
+    ref.merge(std::move(part));
+  }
+  EXPECT_EQ(4 * max, ref.size());
+  std::optional<std::string> cookie;
+
+  std::unordered_map<std::string, std::uint64_t> res_um;
+  do {
+    co_await execute(oid, ReadOp{}.exec(
+                       sem_set::list(max, cookie, &res_um, &cookie)));
+  } while (cookie);
+  for (const auto& [key, value] : res_um) {
+    EXPECT_TRUE(ref.contains(key));
+  }
+  for (const auto& key : ref) {
+    EXPECT_TRUE(res_um.contains(key));
+  }
+
+  std::map<std::string, std::uint64_t> res_m;
+  cookie.reset();
+  do {
+    co_await execute(oid, ReadOp{}.exec(
+                       sem_set::list(max, cookie,
+                                     std::inserter(res_m, res_m.end()),
+                                     &cookie)));
+  } while (cookie);
+  for (const auto& [key, value] : res_m) {
+    EXPECT_TRUE(ref.contains(key));
+  }
+  for (const auto& key : ref) {
+    EXPECT_TRUE(res_m.contains(key));
+  }
+
+  std::vector<std::pair<std::string, std::uint64_t>> res_v;
+  cookie.reset();
+  do {
+    co_await execute(oid, ReadOp{}.exec(
+                       sem_set::list(max, cookie,
+                                     std::inserter(res_v, res_v.end()),
+                                     &cookie)));
+  } while (cookie);
+  for (const auto& [key, value] : res_v) {
+    EXPECT_TRUE(ref.contains(key));
+  }
+  EXPECT_EQ(ref.size(), res_v.size());
+}

--- a/src/test/cls_version/CMakeLists.txt
+++ b/src/test/cls_version/CMakeLists.txt
@@ -14,3 +14,19 @@ target_link_libraries(ceph_test_cls_version
   radostest-cxx
   )
 
+
+add_executable(ceph_test_neocls_version
+  test_neocls_version.cc
+  )
+target_link_libraries(ceph_test_neocls_version
+  libneorados
+  ${BLKID_LIBRARIES}
+  ${CMAKE_DL_LIBS}
+  ${CRYPTO_LIBS}
+  ${EXTRALIBS}
+  neoradostest-support
+  ${UNITTEST_LIBS}
+  )
+install(TARGETS
+  ceph_test_neocls_version
+  DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/cls_version/test_neocls_version.cc
+++ b/src/test/cls_version/test_neocls_version.cc
@@ -1,0 +1,236 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * See file COPYING for license information.
+ *
+ */
+
+#include "neorados/cls/version.h"
+
+#include <boost/asio/post.hpp>
+#include <coroutine>
+#include <memory>
+#include <string_view>
+#include <utility>
+
+#include <boost/asio/use_awaitable.hpp>
+
+#include <boost/system/errc.hpp>
+#include <boost/system/error_code.hpp>
+
+#include "include/neorados/RADOS.hpp"
+
+#include "cls/version/cls_version_types.h"
+
+#include "test/neorados/common_tests.h"
+
+#include "gtest/gtest.h"
+
+namespace asio = boost::asio;
+namespace version = neorados::cls::version;
+using neorados::ReadOp;
+using neorados::WriteOp;
+
+using boost::system::error_code;
+using boost::system::errc::operation_canceled;
+
+CORO_TEST_F(neocls_version, test_version_inc_read, NeoRadosTest)
+{
+  std::string_view oid = "obj";
+  co_await create_obj(oid);
+
+  auto ver = co_await version::read(rados(), oid, pool(), asio::use_awaitable);
+  EXPECT_EQ(0u, ver.ver);
+  EXPECT_EQ(0u, ver.tag.size());
+
+  // Increment version
+  co_await execute(oid, WriteOp{}.exec(version::inc()));
+
+  ver = co_await version::read(rados(), oid, pool(), asio::use_awaitable);
+  EXPECT_GT(ver.ver, 0u);
+  EXPECT_NE(0u, ver.tag.size());
+
+  co_await execute(oid, WriteOp{}.exec(version::inc()));
+
+  auto ver2 = co_await version::read(rados(), oid, pool(), asio::use_awaitable);
+
+  EXPECT_GT(ver2.ver, ver.ver);
+  EXPECT_EQ(0u, ver2.tag.compare(ver.tag));
+
+  obj_version ver3;
+  co_await execute(oid, ReadOp{}.exec(version::read(&ver3)));
+  EXPECT_EQ(ver2.ver, ver3.ver);
+  EXPECT_EQ(1u, ver2.compare(&ver3));
+  co_return;
+}
+
+CORO_TEST_F(neocls_version, test_version_set, NeoRadosTest)
+{
+  std::string_view oid = "obj";
+  co_await create_obj(oid);
+
+  auto ver = co_await version::read(rados(), oid, pool(), asio::use_awaitable);
+  EXPECT_EQ(0u, ver.ver);
+  EXPECT_EQ(0u, ver.tag.size());
+
+  ver.ver = 123;
+  ver.tag = "foo";
+
+  // Set version
+  co_await execute(oid, WriteOp{}.exec(version::set(ver)));
+
+  auto ver2 = co_await version::read(rados(), oid, pool(), asio::use_awaitable);
+
+  EXPECT_EQ(ver2.ver, ver.ver);
+  EXPECT_EQ(0, ver2.tag.compare(ver.tag));
+  co_return;
+}
+
+CORO_TEST_F(neocls_version, test_version_inc_cond, NeoRadosTest)
+{
+  std::string_view oid = "obj";
+  co_await create_obj(oid);
+
+  auto ver = co_await version::read(rados(), oid, pool(), asio::use_awaitable);
+
+  EXPECT_EQ(0u, ver.ver);
+  EXPECT_EQ(0u, ver.tag.size());
+
+  // Increment version
+  co_await execute(oid, WriteOp{}.exec(version::inc()));
+  ver = co_await version::read(rados(), oid, pool(), asio::use_awaitable);
+  EXPECT_GT(ver.ver, 0u);
+  EXPECT_NE(0, ver.tag.size());
+
+  auto cond_ver = ver;
+
+  co_await execute(oid, WriteOp{}.exec(version::inc()));
+
+  auto ver2 = co_await version::read(rados(), oid, pool(), asio::use_awaitable);
+  EXPECT_GT(ver2.ver, ver.ver);
+  EXPECT_EQ(0u, ver2.tag.compare(ver.tag));
+
+  // Now check various condition tests
+  co_await execute(oid, WriteOp{}.exec(version::inc(cond_ver, VER_COND_NONE)));
+
+  ver2 = co_await version::read(rados(), oid, pool(), asio::use_awaitable);
+  EXPECT_GT(ver2.ver, ver.ver);
+  EXPECT_EQ(0u, ver2.tag.compare(ver.tag));
+
+  // A bunch of conditions that should fail
+  co_await expect_error_code(
+    execute(oid, WriteOp{}.exec(version::inc(cond_ver, VER_COND_EQ))),
+    operation_canceled);
+
+  co_await expect_error_code(
+    execute(oid, WriteOp{}.exec(version::inc(cond_ver, VER_COND_LT))),
+    operation_canceled);
+
+  co_await expect_error_code(
+    execute(oid, WriteOp{}.exec(version::inc(cond_ver, VER_COND_LE))),
+    operation_canceled);
+
+  co_await expect_error_code(
+    execute(oid, WriteOp{}.exec(version::inc(cond_ver, VER_COND_TAG_NE))),
+    operation_canceled);
+
+  ver2 = co_await version::read(rados(), oid, pool(), asio::use_awaitable);
+  EXPECT_GT(ver2.ver, ver.ver);
+  EXPECT_EQ(0u, ver2.tag.compare(ver.tag));
+
+  /* a bunch of conditions that should succeed */
+  co_await execute(oid, WriteOp{}.exec(version::inc(ver2, VER_COND_EQ)));
+  co_await execute(oid, WriteOp{}.exec(version::inc(cond_ver, VER_COND_GT)));
+  co_await execute(oid, WriteOp{}.exec(version::inc(cond_ver, VER_COND_GE)));
+
+  co_await execute(oid, WriteOp{}
+                   .exec(version::inc(cond_ver, VER_COND_TAG_EQ)));
+}
+
+CORO_TEST_F(neocls_version, test_version_inc_check, NeoRadosTest)
+{
+  std::string_view oid = "obj";
+  co_await create_obj(oid);
+
+  auto ver = co_await version::read(rados(), oid, pool(), asio::use_awaitable);
+  EXPECT_EQ(0u, ver.ver);
+  EXPECT_EQ(0u, ver.tag.size());
+
+  // Increment version
+  co_await execute(oid, WriteOp{}.exec(version::inc()));
+
+  ver = co_await version::read(rados(), oid, pool(), asio::use_awaitable);
+  EXPECT_GT(ver.ver, 0u);
+  EXPECT_NE(0u, ver.tag.size());
+
+  obj_version cond_ver = ver;
+
+  // a bunch of conditions that should succeed
+  co_await execute(oid, ReadOp{}.exec(version::check(cond_ver, VER_COND_EQ)));
+
+  co_await execute(oid, ReadOp{}.exec(version::check(cond_ver, VER_COND_GE)));
+
+  co_await execute(oid, ReadOp{}.exec(version::check(cond_ver, VER_COND_LE)));
+
+  co_await execute(oid, ReadOp{}
+                   .exec(version::check(cond_ver, VER_COND_TAG_EQ)));
+
+  co_await execute(oid, WriteOp{}.exec(version::inc()));
+
+  auto ver2 = co_await version::read(rados(), oid, pool(), asio::use_awaitable);
+  EXPECT_GT(ver2.ver, ver.ver);
+  EXPECT_EQ(0, ver2.tag.compare(ver.tag));
+
+  // A bunch of conditions that should fail
+  co_await expect_error_code(
+    execute(oid, ReadOp{}.exec(version::check(ver, VER_COND_LT))),
+    operation_canceled);
+
+  co_await expect_error_code(
+    execute(oid, ReadOp{}.exec(version::check(ver, VER_COND_LE))),
+    operation_canceled);
+
+  co_await expect_error_code(
+    execute(oid, ReadOp{}.exec(version::check(ver, VER_COND_TAG_NE))),
+    operation_canceled);
+}
+
+TEST(neocls_version_bare, lambdata)
+{
+  asio::io_context c;
+
+  std::string_view oid = "obj";
+
+  obj_version iver{123, "foo"};
+  obj_version ever;
+
+  std::optional<neorados::RADOS> rados;
+  neorados::IOContext pool;
+  neorados::RADOS::Builder{}.build(c, [&](error_code ec, neorados::RADOS r_) {
+    ASSERT_FALSE(ec);
+    rados = std::move(r_);
+    create_pool(*rados, get_temp_pool_name(),
+		[&](error_code ec, int64_t poolid) {
+		  ASSERT_FALSE(ec);
+		  pool.set_pool(poolid);
+		  neorados::WriteOp op;
+		  op.create(true);
+		  op.exec(version::set(iver));
+		  rados->execute(oid, pool, std::move(op), [&](error_code ec) {
+		    ASSERT_FALSE(ec);
+		    version::read(*rados, oid, pool,
+				  [&](error_code ec, obj_version over) {
+				    ASSERT_FALSE(ec);
+				    ASSERT_EQ(iver, over);
+				    ever = over;
+				  });
+		  });
+		});
+  });
+  c.run();
+  ASSERT_EQ(iver, ever);
+}

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -400,3 +400,7 @@ add_executable(unittest_async_call test_async_call.cc)
 target_link_libraries(unittest_async_call librados ceph-common Boost::system
   spawn GTest::GTest)
 add_ceph_unittest(unittest_async_call)
+
+add_executable(unittest_async_cond test_async_cond.cc)
+target_link_libraries(unittest_async_cond GTest::GTest)
+add_ceph_unittest(unittest_async_cond)

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -395,3 +395,8 @@ if(WITH_SYSTEMD)
   target_link_libraries(unittest_journald_logger ceph-common)
   add_ceph_unittest(unittest_journald_logger)
 endif()
+
+add_executable(unittest_async_call test_async_call.cc)
+target_link_libraries(unittest_async_call librados ceph-common Boost::system
+  spawn GTest::GTest)
+add_ceph_unittest(unittest_async_call)

--- a/src/test/common/test_async_call.cc
+++ b/src/test/common/test_async_call.cc
@@ -1,0 +1,312 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "common/async/async_call.h"
+#include "common/async/async_yield.h"
+#include "common/async/coro_aiocomplete.h"
+
+#include <cerrno>
+#include <chrono>
+#include <functional>
+#include <exception>
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include <boost/system/error_code.hpp>
+#include <boost/system/errc.hpp>
+#include <boost/system/system_error.hpp>
+
+#include <spawn/spawn.hpp>
+
+#include <gtest/gtest.h>
+
+namespace asio = boost::asio;
+namespace chrono = std::chrono;
+namespace sys = boost::system;
+using namespace std::literals;
+
+using ceph::async::async_dispatch;
+using ceph::async::async_post;
+using ceph::async::async_defer;
+using ceph::async::async_yield;
+using ceph::async::coro_aiocomplete;
+
+inline constexpr auto dur = 50ms;
+
+template<typename Rep, typename Period>
+asio::awaitable<chrono::duration<Rep, Period>>
+wait_for(chrono::duration<Rep, Period> dur)
+{
+  asio::steady_timer timer{co_await asio::this_coro::executor, dur};
+  co_await timer.async_wait(asio::use_awaitable);
+  co_return dur;
+}
+
+template<typename Rep, typename Period>
+chrono::duration<Rep, Period> wait_for(auto executor,
+				       chrono::duration<Rep, Period> dur,
+				       spawn::yield_context y)
+{
+  asio::steady_timer timer{executor, dur};
+  timer.async_wait(y);
+  return dur;
+}
+
+TEST(Yield2Coro, Yield2Coro)
+{
+  asio::io_context c;
+  spawn::spawn(c, [&](spawn::yield_context y) {
+    auto start = chrono::steady_clock::now();
+    auto [eptr, d] = asio::co_spawn(c.get_executor(), wait_for(dur), y);
+    auto end = chrono::steady_clock::now();
+    ASSERT_GE(end, start + dur);
+    ASSERT_EQ(dur, d);
+  });
+  c.run();
+}
+
+TEST(Return, Coro2Yield)
+{
+  asio::io_context c;
+  asio::co_spawn(c, [&]() -> asio::awaitable<void> {
+      auto start = chrono::steady_clock::now();
+      auto d = co_await async_yield<spawn::yield_context>(
+	co_await asio::this_coro::executor,
+	[&c](spawn::yield_context y) {
+	  return wait_for(c.get_executor(),dur, y);
+	}, asio::use_awaitable);
+      auto end = chrono::steady_clock::now();
+      EXPECT_GE(end, start + dur);
+      EXPECT_EQ(dur, d);
+      co_return;
+    }, [](std::exception_ptr e) {
+      if (e) std::rethrow_exception(e);
+    });
+  c.run();
+}
+
+TEST(AsyncDispatch, AsyncCall)
+{
+  asio::io_context c;
+  asio::co_spawn(c, [&]() -> asio::awaitable<void> {
+      auto strand = asio::make_strand(c.get_executor());
+      auto x = co_await async_dispatch(
+	strand, [] {return 55;}, asio::use_awaitable);
+      EXPECT_EQ(x, 55);
+      co_return;
+    }, [](std::exception_ptr e) {
+      if (e) std::rethrow_exception(e);
+    });
+  c.run();
+}
+
+TEST(AsyncPost, AsyncCall)
+{
+  asio::io_context c;
+  asio::co_spawn(c, [&]() -> asio::awaitable<void> {
+      auto strand = asio::make_strand(c.get_executor());
+      auto x = co_await async_post(
+	strand, [] {return 55;}, asio::use_awaitable);
+      EXPECT_EQ(x, 55);
+      co_return;
+    }, [](std::exception_ptr e) {
+      if (e) std::rethrow_exception(e);
+    });
+  c.run();
+}
+
+TEST(AsyncDefer, AsyncCall)
+{
+  asio::io_context c;
+  asio::co_spawn(c, [&]() -> asio::awaitable<void> {
+      auto strand = asio::make_strand(c.get_executor());
+      auto x = co_await async_defer(
+	strand, [] {return 55;}, asio::use_awaitable);
+      EXPECT_EQ(x, 55);
+      co_return;
+    }, [](std::exception_ptr e) {
+      if (e) std::rethrow_exception(e);
+    });
+  c.run();
+}
+
+TEST(AsyncDispatchVoid, AsyncCall)
+{
+  asio::io_context c;
+  asio::co_spawn(c, [&]() -> asio::awaitable<void> {
+      auto strand = asio::make_strand(c.get_executor());
+      co_await async_dispatch(
+	strand, [] {return;}, asio::use_awaitable);
+      co_return;
+    }, [](std::exception_ptr e) {
+      if (e) std::rethrow_exception(e);
+    });
+  c.run();
+}
+
+TEST(AsyncPostVoid, AsyncCall)
+{
+  asio::io_context c;
+  asio::co_spawn(c, [&]() -> asio::awaitable<void> {
+      auto strand = asio::make_strand(c.get_executor());
+      co_await async_post(
+	strand, [] {return;}, asio::use_awaitable);
+      co_return;
+    }, [](std::exception_ptr e) {
+      if (e) std::rethrow_exception(e);
+    });
+  c.run();
+}
+
+TEST(AsyncDeferVoid, AsyncCall)
+{
+  asio::io_context c;
+  asio::co_spawn(c, [&]() -> asio::awaitable<void> {
+      auto strand = asio::make_strand(c.get_executor());
+      co_await async_defer(
+	strand, [] {return;}, asio::use_awaitable);
+      co_return;
+    }, [](std::exception_ptr e) {
+      if (e) std::rethrow_exception(e);
+    });
+  c.run();
+}
+
+TEST(VoidSucc, AioComplete)
+{
+  auto lrc = librados::Rados::aio_create_completion();
+  asio::io_context c;
+  coro_aiocomplete(
+    nullptr, c.get_executor(),
+    []() -> asio::awaitable<void> {
+      co_return;
+    }(), lrc);
+  c.run();
+  lrc->wait_for_complete();
+  auto r = lrc->get_return_value();
+  ASSERT_EQ(0, r);
+}
+
+TEST(VoidExcept, AioComplete)
+{
+  auto lrc = librados::Rados::aio_create_completion();
+  asio::io_context c;
+  coro_aiocomplete(
+    nullptr, c.get_executor(),
+    []() -> asio::awaitable<void> {
+      throw sys::system_error{ENOENT, sys::generic_category()};
+      co_return;
+    }(), lrc);
+  c.run();
+  lrc->wait_for_complete();
+  auto r = lrc->get_return_value();
+  ASSERT_EQ(-ENOENT, r);
+}
+
+TEST(VoidUnknownExcept, AioComplete)
+{
+  auto lrc = librados::Rados::aio_create_completion();
+  asio::io_context c;
+  coro_aiocomplete(
+    nullptr, c.get_executor(),
+    []() -> asio::awaitable<void> {
+      throw std::exception{};
+      co_return;
+    }(), lrc);
+  c.run();
+  lrc->wait_for_complete();
+  auto r = lrc->get_return_value();
+  ASSERT_EQ(-EFAULT, r);
+}
+
+TEST(IntSucc, AioComplete)
+{
+  auto lrc = librados::Rados::aio_create_completion();
+  asio::io_context c;
+  coro_aiocomplete(
+    nullptr, c.get_executor(),
+    []() -> asio::awaitable<int> {
+      co_return -42;
+    }(), lrc);
+  c.run();
+  lrc->wait_for_complete();
+  auto r = lrc->get_return_value();
+  ASSERT_EQ(-42, r);
+}
+
+TEST(IntExcept, AioComplete)
+{
+  auto lrc = librados::Rados::aio_create_completion();
+  asio::io_context c;
+  coro_aiocomplete(
+    nullptr, c.get_executor(),
+    []() -> asio::awaitable<int> {
+      throw sys::system_error{ENOENT, sys::generic_category()};
+      co_return -42;
+    }(), lrc);
+  c.run();
+  lrc->wait_for_complete();
+  auto r = lrc->get_return_value();
+  ASSERT_EQ(-ENOENT, r);
+}
+
+TEST(SysSucc, AioComplete)
+{
+  auto lrc = librados::Rados::aio_create_completion();
+  asio::io_context c;
+  coro_aiocomplete(
+    nullptr, c.get_executor(),
+    []() -> asio::awaitable<sys::error_code> {
+      co_return sys::error_code{};
+    }(), lrc);
+  c.run();
+  lrc->wait_for_complete();
+  auto r = lrc->get_return_value();
+  ASSERT_EQ(0, r);
+}
+
+TEST(SysFail, AioComplete)
+{
+  auto lrc = librados::Rados::aio_create_completion();
+  asio::io_context c;
+  coro_aiocomplete(
+    nullptr, c.get_executor(),
+    []() -> asio::awaitable<sys::error_code> {
+      co_return sys::error_code{ENOENT, sys::generic_category()};
+    }(), lrc);
+  c.run();
+  lrc->wait_for_complete();
+  auto r = lrc->get_return_value();
+  ASSERT_EQ(-ENOENT, r);
+}
+
+TEST(SysExcept, AioComplete)
+{
+  auto lrc = librados::Rados::aio_create_completion();
+  asio::io_context c;
+  coro_aiocomplete(
+    nullptr, c.get_executor(),
+    []() -> asio::awaitable<sys::error_code> {
+      throw sys::system_error{ENOENT, sys::generic_category()};
+      co_return sys::error_code{EBADF, sys::generic_category()};
+    }(), lrc);
+  c.run();
+  lrc->wait_for_complete();
+  auto r = lrc->get_return_value();
+  ASSERT_EQ(-ENOENT, r);
+}

--- a/src/test/common/test_async_cond.cc
+++ b/src/test/common/test_async_cond.cc
@@ -1,0 +1,102 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 IBM
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "common/async/async_cond.h"
+
+#include <coroutine>
+
+#include <boost/asio/io_context.hpp>
+
+#include <gtest/gtest.h>
+
+namespace asio = boost::asio;
+namespace sys = boost::system;
+
+namespace async = ceph::async;
+
+enum response : int {
+  error, success
+};
+
+std::mutex m;
+
+struct waiter {
+  std::unique_lock<std::mutex> l{m};
+  int* i;
+
+  waiter(int* i) : i(i) {}
+
+  void operator ()(sys::error_code ec) {
+    EXPECT_TRUE(l.owns_lock());
+    *i = ec ? error : success;
+    l.unlock();
+    delete this;
+  }
+};
+
+
+TEST(async_cond, lambdata)
+{
+  asio::io_context io_context;
+  async::async_cond cond(io_context.get_executor());
+  std::array<int, 5> data;
+  data.fill(0xdeadbeef);
+
+
+  for (auto i = 0; i < std::ssize(data); ++i) {
+    auto c = new waiter(data.data() + i);
+    cond.wait(c->l, std::ref(*c));
+  }
+  cond.notify();
+  io_context.run();
+  for (const auto& d : data) {
+    ASSERT_EQ(success, d);
+  }
+}
+
+TEST(async_cond, lambdataReset)
+{
+  asio::io_context io_context;
+  async::async_cond cond(io_context.get_executor());
+  std::array<int, 5> data;
+  data.fill(0xdeadbeef);
+
+  for (auto i = 0; i < std::ssize(data); ++i) {
+    auto c = new waiter(data.data() + i);
+    cond.wait(c->l, std::ref(*c));
+  }
+  cond.reset();
+  io_context.run();
+  for (const auto& d : data) {
+    ASSERT_EQ(error, d);
+  }
+}
+
+TEST(async_cond, lambdataAlreadyComplete)
+{
+  asio::io_context io_context;
+  async::async_cond cond(io_context.get_executor());
+  std::array<int, 5> data;
+  data.fill(0xdeadbeef);
+
+  cond.notify();
+  for (auto i = 0; i < std::ssize(data); ++i) {
+    auto c = new waiter(data.data() + i);
+    cond.wait(c->l, std::ref(*c));
+  }
+  io_context.run();
+  for (const auto& d : data) {
+    ASSERT_EQ(success, d);
+  }
+}

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -286,7 +286,10 @@ add_executable(unittest_log_backing test_log_backing.cc)
 target_include_directories(unittest_log_backing
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw"
   SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/rgw/store/rados")
-target_link_libraries(unittest_log_backing radostest-cxx ${UNITTEST_LIBS}
+target_link_libraries(unittest_log_backing
+  libneorados
+  neoradostest-support
+  ${UNITTEST_LIBS}
   ${rgw_libs})
 
 add_executable(unittest_rgw_lua test_rgw_lua.cc)

--- a/src/test/rgw/test_log_backing.cc
+++ b/src/test/rgw/test_log_backing.cc
@@ -14,176 +14,99 @@
 
 #include "rgw_log_backing.h"
 
-#include <cerrno>
+#include <coroutine>
 #include <iostream>
 #include <string_view>
 
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+#include <boost/system/errc.hpp>
+#include <boost/system/error_code.hpp>
+
 #include <fmt/format.h>
 
-#include "include/types.h"
-#include "include/rados/librados.hpp"
+#include "include/neorados/RADOS.hpp"
 
-#include "test/librados/test_cxx.h"
-#include "global/global_context.h"
+#include "neorados/cls/fifo.h"
+#include "neorados/cls/log.h"
 
-#include "cls/log/cls_log_client.h"
-
-#include "rgw_tools.h"
-#include "cls_fifo_legacy.h"
+#include "test/neorados/common_tests.h"
 
 #include "gtest/gtest.h"
 
-namespace lr = librados;
-namespace cb = ceph::buffer;
-namespace fifo = rados::cls::fifo;
-namespace RCf = rgw::cls::fifo;
+namespace asio = boost::asio;
+namespace buffer = ceph::buffer;
 
-auto cct = new CephContext(CEPH_ENTITY_TYPE_CLIENT);
-const DoutPrefix dp(cct, 1, "test log backing: ");
+namespace fifo = neorados::cls::fifo;
+namespace logn = neorados::cls::log;
 
-class LogBacking : public testing::Test {
-protected:
-  static constexpr int SHARDS = 3;
-  const std::string pool_name = get_temp_pool_name();
-  lr::Rados rados;
-  lr::IoCtx ioctx;
-  lr::Rados rados2;
-  lr::IoCtx ioctx2;
+namespace {
+inline constexpr int SHARDS = 3;
+std::string get_oid(uint64_t gen_id, int i) {
+  return (gen_id > 0 ?
+	  fmt::format("shard@G{}.{}", gen_id, i) :
+	  fmt::format("shard.{}", i));
+}
 
-  void SetUp() override {
-    ASSERT_EQ("", create_one_pool_pp(pool_name, rados));
-    ASSERT_EQ(0, rados.ioctx_create(pool_name.c_str(), ioctx));
-    connect_cluster_pp(rados2);
-    ASSERT_EQ(0, rados2.ioctx_create(pool_name.c_str(), ioctx2));
-  }
-  void TearDown() override {
-    destroy_one_pool_pp(pool_name, rados);
-  }
-
-  std::string get_oid(uint64_t gen_id, int i) const {
-    return (gen_id > 0 ?
-	    fmt::format("shard@G{}.{}", gen_id, i) :
-	    fmt::format("shard.{}", i));
-  }
-
-  void make_omap() {
-    for (int i = 0; i < SHARDS; ++i) {
-      using ceph::encode;
-      lr::ObjectWriteOperation op;
-      cb::list bl;
-      encode(i, bl);
-      cls_log_add(op, ceph::real_clock::now(), {}, "meow", bl);
-      auto r = rgw_rados_operate(&dp, ioctx, get_oid(0, i), &op, null_yield);
-      ASSERT_GE(r, 0);
-    }
-  }
-
-  void add_omap(int i) {
+asio::awaitable<void> make_omap(neorados::RADOS& rados,
+				const neorados::IOContext& loc) {
+  for (int i = 0; i < SHARDS; ++i) {
     using ceph::encode;
-    lr::ObjectWriteOperation op;
-    cb::list bl;
+    neorados::WriteOp op;
+    buffer::list bl;
     encode(i, bl);
-    cls_log_add(op, ceph::real_clock::now(), {}, "meow", bl);
-    auto r = rgw_rados_operate(&dp, ioctx, get_oid(0, i), &op, null_yield);
-    ASSERT_GE(r, 0);
+    op.exec(logn::add(ceph::real_clock::now(), {}, "meow", std::move(bl)));
+    co_await rados.execute(get_oid(0, i), loc, std::move(op),
+			   asio::use_awaitable);
   }
-
-  void empty_omap() {
-    for (int i = 0; i < SHARDS; ++i) {
-      auto oid = get_oid(0, i);
-      std::string to_marker;
-      {
-	lr::ObjectReadOperation op;
-	std::vector<cls::log::entry> entries;
-	bool truncated = false;
-	cls_log_list(op, {}, {}, {}, 1, entries, &to_marker, &truncated);
-	auto r = rgw_rados_operate(&dp, ioctx, oid, &op, nullptr, null_yield);
-	ASSERT_GE(r, 0);
-	ASSERT_FALSE(entries.empty());
-      }
-      {
-	lr::ObjectWriteOperation op;
-	cls_log_trim(op, {}, {}, {}, to_marker);
-	auto r = rgw_rados_operate(&dp, ioctx, oid, &op, null_yield);
-	ASSERT_GE(r, 0);
-      }
-      {
-	lr::ObjectReadOperation op;
-	std::vector<cls::log::entry> entries;
-	bool truncated = false;
-	cls_log_list(op, {}, {}, {}, 1, entries, &to_marker, &truncated);
-	auto r = rgw_rados_operate(&dp, ioctx, oid, &op, nullptr, null_yield);
-	ASSERT_GE(r, 0);
-	ASSERT_TRUE(entries.empty());
-      }
-    }
-  }
-
-  void make_fifo()
-    {
-      for (int i = 0; i < SHARDS; ++i) {
-	std::unique_ptr<RCf::FIFO> fifo;
-	auto r = RCf::FIFO::create(&dp, ioctx, get_oid(0, i), &fifo, null_yield);
-	ASSERT_EQ(0, r);
-	ASSERT_TRUE(fifo);
-      }
-    }
-
-  void add_fifo(int i)
-    {
-      using ceph::encode;
-      std::unique_ptr<RCf::FIFO> fifo;
-      auto r = RCf::FIFO::open(&dp, ioctx, get_oid(0, i), &fifo, null_yield);
-      ASSERT_GE(0, r);
-      ASSERT_TRUE(fifo);
-      cb::list bl;
-      encode(i, bl);
-      r = fifo->push(&dp, bl, null_yield);
-      ASSERT_GE(0, r);
-    }
-
-  void assert_empty() {
-    std::vector<lr::ObjectItem> result;
-    lr::ObjectCursor next;
-    auto r = ioctx.object_list(ioctx.object_list_begin(), ioctx.object_list_end(),
-			       100, {}, &result, &next);
-    ASSERT_GE(r, 0);
-    ASSERT_TRUE(result.empty());
-  }
-};
-
-TEST_F(LogBacking, TestOmap)
-{
-  make_omap();
-  auto stat = log_backing_type(&dp, ioctx, log_type::fifo, SHARDS,
-			       [this](int shard){ return get_oid(0, shard); },
-			       null_yield);
-  ASSERT_EQ(log_type::omap, *stat);
+  co_return;
 }
 
-TEST_F(LogBacking, TestOmapEmpty)
-{
-  auto stat = log_backing_type(&dp, ioctx, log_type::omap, SHARDS,
-			       [this](int shard){ return get_oid(0, shard); },
-			       null_yield);
-  ASSERT_EQ(log_type::omap, *stat);
+asio::awaitable<void> make_fifo(const DoutPrefixProvider* dpp,
+				neorados::RADOS& rados,
+                                const neorados::IOContext& loc) {
+  for (int i = 0; i < SHARDS; ++i) {
+    auto fifo = co_await fifo::FIFO::create(dpp, rados, get_oid(0, i), loc,
+					    asio::use_awaitable);
+    EXPECT_TRUE(fifo);
+  }
+}
 }
 
-TEST_F(LogBacking, TestFIFO)
+CORO_TEST_F(LogBacking, TestOmap, NeoRadosTest)
 {
-  make_fifo();
-  auto stat = log_backing_type(&dp, ioctx, log_type::fifo, SHARDS,
-			       [this](int shard){ return get_oid(0, shard); },
-			       null_yield);
-  ASSERT_EQ(log_type::fifo, *stat);
+  co_await make_omap(rados(), pool());
+  auto stat = co_await log_backing_type(
+    dpp(), rados(), pool(), log_type::fifo, SHARDS,
+    [](int shard){ return get_oid(0, shard); });
+  EXPECT_EQ(log_type::omap, stat);
 }
 
-TEST_F(LogBacking, TestFIFOEmpty)
+
+CORO_TEST_F(LogBacking, TestOmapEmpty, NeoRadosTest)
 {
-  auto stat = log_backing_type(&dp, ioctx, log_type::fifo, SHARDS,
-			       [this](int shard){ return get_oid(0, shard); },
-			       null_yield);
-  ASSERT_EQ(log_type::fifo, *stat);
+  auto stat = co_await log_backing_type(
+    dpp(), rados(), pool(), log_type::omap, SHARDS,
+    [](int shard){ return get_oid(0, shard); });
+  EXPECT_EQ(log_type::omap, stat);
+}
+
+CORO_TEST_F(LogBacking, TestFIFO, NeoRadosTest)
+{
+  co_await make_fifo(dpp(), rados(), pool());
+  auto stat = co_await log_backing_type(
+    dpp(), rados(), pool(), log_type::fifo, SHARDS,
+    [](int shard){ return get_oid(0, shard); });
+  EXPECT_EQ(log_type::fifo, stat);
+}
+
+CORO_TEST_F(LogBacking, TestFIFOEmpty, NeoRadosTest)
+{
+  auto stat = co_await log_backing_type(
+    dpp(), rados(), pool(), log_type::fifo, SHARDS,
+    [](int shard){ return get_oid(0, shard); });
+  EXPECT_EQ(log_type::fifo, stat);
 }
 
 TEST(CursorGen, RoundTrip) {
@@ -212,153 +135,134 @@ public:
 
   using logback_generations::logback_generations;
 
-  bs::error_code handle_init(entries_t e) noexcept {
+  void handle_init(entries_t e) override {
     got_entries = e;
-    return {};
   }
 
-  bs::error_code handle_new_gens(entries_t e) noexcept  {
+  void handle_new_gens(entries_t e) override {
     got_entries = e;
-    return {};
   }
 
-  bs::error_code handle_empty_to(uint64_t new_tail) noexcept {
+  void handle_empty_to(uint64_t new_tail) override {
     tail = new_tail;
-    return {};
   }
 };
 
-TEST_F(LogBacking, GenerationSingle)
-{
-  auto lgr = logback_generations::init<generations>(
-    &dp, ioctx, "foobar", [this](uint64_t gen_id, int shard) {
-      return get_oid(gen_id, shard);
-    }, SHARDS, log_type::fifo, null_yield);
-  ASSERT_TRUE(lgr);
+CORO_TEST_F(LogBacking, GenerationSingle, NeoRadosTest) {
+  auto lg = co_await logback_generations::init<generations>(
+    dpp(), rados(), "foobar", pool(), &get_oid, SHARDS, log_type::fifo);
 
-  auto lg = std::move(*lgr);
+  EXPECT_FALSE(lg->got_entries.empty());
+  EXPECT_EQ(0, lg->got_entries.begin()->first);
 
-  ASSERT_EQ(0, lg->got_entries.begin()->first);
+  EXPECT_EQ(0, lg->got_entries[0].gen_id);
+  EXPECT_EQ(log_type::fifo, lg->got_entries[0].type);
+  EXPECT_FALSE(lg->got_entries[0].pruned);
 
-  ASSERT_EQ(0, lg->got_entries[0].gen_id);
-  ASSERT_EQ(log_type::fifo, lg->got_entries[0].type);
-  ASSERT_FALSE(lg->got_entries[0].pruned);
+  EXPECT_THROW({
+      co_await lg->empty_to(dpp(), 0);
+    }, sys::system_error);
 
-  auto ec = lg->empty_to(&dp, 0, null_yield);
-  ASSERT_TRUE(ec);
 
   lg.reset();
 
-  lg = *logback_generations::init<generations>(
-    &dp, ioctx, "foobar", [this](uint64_t gen_id, int shard) {
-      return get_oid(gen_id, shard);
-    }, SHARDS, log_type::fifo, null_yield);
+  lg = co_await logback_generations::init<generations>(
+    dpp(), rados(), "foobar", pool(), &get_oid, SHARDS, log_type::fifo);
 
-  ASSERT_EQ(0, lg->got_entries.begin()->first);
+  EXPECT_EQ(0, lg->got_entries.begin()->first);
 
-  ASSERT_EQ(0, lg->got_entries[0].gen_id);
-  ASSERT_EQ(log_type::fifo, lg->got_entries[0].type);
-  ASSERT_FALSE(lg->got_entries[0].pruned);
+  EXPECT_EQ(0, lg->got_entries[0].gen_id);
+  EXPECT_EQ(log_type::fifo, lg->got_entries[0].type);
+  EXPECT_FALSE(lg->got_entries[0].pruned);
 
   lg->got_entries.clear();
 
-  ec = lg->new_backing(&dp, log_type::omap, null_yield);
-  ASSERT_FALSE(ec);
+  co_await lg->new_backing(dpp(), log_type::omap);
 
-  ASSERT_EQ(1, lg->got_entries.size());
-  ASSERT_EQ(1, lg->got_entries[1].gen_id);
-  ASSERT_EQ(log_type::omap, lg->got_entries[1].type);
-  ASSERT_FALSE(lg->got_entries[1].pruned);
-
-  lg.reset();
-
-  lg = *logback_generations::init<generations>(
-    &dp, ioctx, "foobar", [this](uint64_t gen_id, int shard) {
-      return get_oid(gen_id, shard);
-    }, SHARDS, log_type::fifo, null_yield);
-
-  ASSERT_EQ(2, lg->got_entries.size());
-  ASSERT_EQ(0, lg->got_entries[0].gen_id);
-  ASSERT_EQ(log_type::fifo, lg->got_entries[0].type);
-  ASSERT_FALSE(lg->got_entries[0].pruned);
-
-  ASSERT_EQ(1, lg->got_entries[1].gen_id);
-  ASSERT_EQ(log_type::omap, lg->got_entries[1].type);
-  ASSERT_FALSE(lg->got_entries[1].pruned);
-
-  ec = lg->empty_to(&dp, 0, null_yield);
-  ASSERT_FALSE(ec);
-
-  ASSERT_EQ(0, *lg->tail);
+  EXPECT_EQ(1, lg->got_entries.size());
+  EXPECT_EQ(1, lg->got_entries[1].gen_id);
+  EXPECT_EQ(log_type::omap, lg->got_entries[1].type);
+  EXPECT_FALSE(lg->got_entries[1].pruned);
 
   lg.reset();
 
-  lg = *logback_generations::init<generations>(
-    &dp, ioctx, "foobar", [this](uint64_t gen_id, int shard) {
-      return get_oid(gen_id, shard);
-    }, SHARDS, log_type::fifo, null_yield);
+  lg = co_await logback_generations::init<generations>(
+    dpp(), rados(), "foobar", pool(), &get_oid, SHARDS, log_type::fifo);
 
-  ASSERT_EQ(1, lg->got_entries.size());
-  ASSERT_EQ(1, lg->got_entries[1].gen_id);
-  ASSERT_EQ(log_type::omap, lg->got_entries[1].type);
-  ASSERT_FALSE(lg->got_entries[1].pruned);
+  EXPECT_EQ(2, lg->got_entries.size());
+  EXPECT_EQ(0, lg->got_entries[0].gen_id);
+  EXPECT_EQ(log_type::fifo, lg->got_entries[0].type);
+  EXPECT_FALSE(lg->got_entries[0].pruned);
+
+  EXPECT_EQ(1, lg->got_entries[1].gen_id);
+  EXPECT_EQ(log_type::omap, lg->got_entries[1].type);
+  EXPECT_FALSE(lg->got_entries[1].pruned);
+
+  co_await lg->empty_to(dpp(), 0);
+
+  EXPECT_EQ(0, *lg->tail);
+
+  lg.reset();
+
+  lg = co_await logback_generations::init<generations>(
+    dpp(), rados(), "foobar", pool(), &get_oid, SHARDS, log_type::fifo);
+
+  EXPECT_EQ(1, lg->got_entries.size());
+  EXPECT_EQ(1, lg->got_entries[1].gen_id);
+  EXPECT_EQ(log_type::omap, lg->got_entries[1].type);
+  EXPECT_FALSE(lg->got_entries[1].pruned);
 }
 
-TEST_F(LogBacking, GenerationWN)
-{
-  auto lg1 = *logback_generations::init<generations>(
-    &dp, ioctx, "foobar", [this](uint64_t gen_id, int shard) {
-      return get_oid(gen_id, shard);
-    }, SHARDS, log_type::fifo, null_yield);
+CORO_TEST_F(LogBacking, GenerationWN, NeoRadosTest) {
+  auto lg1 = co_await logback_generations::init<generations>(
+    dpp(), rados(), "foobar", pool(), &get_oid, SHARDS, log_type::fifo);
 
-  auto ec = lg1->new_backing(&dp, log_type::omap, null_yield);
-  ASSERT_FALSE(ec);
+  co_await lg1->new_backing(dpp(), log_type::omap);
 
-  ASSERT_EQ(1, lg1->got_entries.size());
-  ASSERT_EQ(1, lg1->got_entries[1].gen_id);
-  ASSERT_EQ(log_type::omap, lg1->got_entries[1].type);
-  ASSERT_FALSE(lg1->got_entries[1].pruned);
+  EXPECT_EQ(1, lg1->got_entries.size());
+  EXPECT_EQ(1, lg1->got_entries[1].gen_id);
+  EXPECT_EQ(log_type::omap, lg1->got_entries[1].type);
+  EXPECT_FALSE(lg1->got_entries[1].pruned);
 
   lg1->got_entries.clear();
 
-  auto lg2 = *logback_generations::init<generations>(
-    &dp, ioctx2, "foobar", [this](uint64_t gen_id, int shard) {
-      return get_oid(gen_id, shard);
-    }, SHARDS, log_type::fifo, null_yield);
+  auto rados2 = co_await neorados::RADOS::Builder{}
+    .build(asio_context, boost::asio::use_awaitable);
 
-  ASSERT_EQ(2, lg2->got_entries.size());
+  auto lg2 = co_await logback_generations::init<generations>(
+    dpp(), rados2, "foobar", pool(), &get_oid, SHARDS, log_type::fifo);
 
-  ASSERT_EQ(0, lg2->got_entries[0].gen_id);
-  ASSERT_EQ(log_type::fifo, lg2->got_entries[0].type);
-  ASSERT_FALSE(lg2->got_entries[0].pruned);
+  EXPECT_EQ(2, lg2->got_entries.size());
 
-  ASSERT_EQ(1, lg2->got_entries[1].gen_id);
-  ASSERT_EQ(log_type::omap, lg2->got_entries[1].type);
-  ASSERT_FALSE(lg2->got_entries[1].pruned);
+  EXPECT_EQ(0, lg2->got_entries[0].gen_id);
+  EXPECT_EQ(log_type::fifo, lg2->got_entries[0].type);
+  EXPECT_FALSE(lg2->got_entries[0].pruned);
+
+  EXPECT_EQ(1, lg2->got_entries[1].gen_id);
+  EXPECT_EQ(log_type::omap, lg2->got_entries[1].type);
+  EXPECT_FALSE(lg2->got_entries[1].pruned);
 
   lg2->got_entries.clear();
 
-  ec = lg1->new_backing(&dp, log_type::fifo, null_yield);
-  ASSERT_FALSE(ec);
+  co_await lg1->new_backing(dpp(), log_type::fifo);
 
-  ASSERT_EQ(1, lg1->got_entries.size());
-  ASSERT_EQ(2, lg1->got_entries[2].gen_id);
-  ASSERT_EQ(log_type::fifo, lg1->got_entries[2].type);
-  ASSERT_FALSE(lg1->got_entries[2].pruned);
+  EXPECT_EQ(1, lg1->got_entries.size());
+  EXPECT_EQ(2, lg1->got_entries[2].gen_id);
+  EXPECT_EQ(log_type::fifo, lg1->got_entries[2].type);
+  EXPECT_FALSE(lg1->got_entries[2].pruned);
 
-  ASSERT_EQ(1, lg2->got_entries.size());
-  ASSERT_EQ(2, lg2->got_entries[2].gen_id);
-  ASSERT_EQ(log_type::fifo, lg2->got_entries[2].type);
-  ASSERT_FALSE(lg2->got_entries[2].pruned);
+  EXPECT_EQ(1, lg2->got_entries.size());
+  EXPECT_EQ(2, lg2->got_entries[2].gen_id);
+  EXPECT_EQ(log_type::fifo, lg2->got_entries[2].type);
+  EXPECT_FALSE(lg2->got_entries[2].pruned);
 
   lg1->got_entries.clear();
   lg2->got_entries.clear();
 
-  ec = lg2->empty_to(&dp, 1, null_yield);
-  ASSERT_FALSE(ec);
+  co_await lg2->empty_to(dpp(), 1);
 
-  ASSERT_EQ(1, *lg1->tail);
-  ASSERT_EQ(1, *lg2->tail);
+  EXPECT_EQ(1, *lg1->tail);
+  EXPECT_EQ(1, *lg2->tail);
 
   lg1->tail.reset();
   lg2->tail.reset();

--- a/src/test/rgw/test_log_backing.cc
+++ b/src/test/rgw/test_log_backing.cc
@@ -94,7 +94,7 @@ protected:
       std::string to_marker;
       {
 	lr::ObjectReadOperation op;
-	std::list<cls_log_entry> entries;
+	std::vector<cls_log_entry> entries;
 	bool truncated = false;
 	cls_log_list(op, {}, {}, {}, 1, entries, &to_marker, &truncated);
 	auto r = rgw_rados_operate(&dp, ioctx, oid, &op, nullptr, null_yield);
@@ -109,7 +109,7 @@ protected:
       }
       {
 	lr::ObjectReadOperation op;
-	std::list<cls_log_entry> entries;
+	std::vector<cls_log_entry> entries;
 	bool truncated = false;
 	cls_log_list(op, {}, {}, {}, 1, entries, &to_marker, &truncated);
 	auto r = rgw_rados_operate(&dp, ioctx, oid, &op, nullptr, null_yield);

--- a/src/test/rgw/test_log_backing.cc
+++ b/src/test/rgw/test_log_backing.cc
@@ -94,7 +94,7 @@ protected:
       std::string to_marker;
       {
 	lr::ObjectReadOperation op;
-	std::vector<cls_log_entry> entries;
+	std::vector<cls::log::entry> entries;
 	bool truncated = false;
 	cls_log_list(op, {}, {}, {}, 1, entries, &to_marker, &truncated);
 	auto r = rgw_rados_operate(&dp, ioctx, oid, &op, nullptr, null_yield);
@@ -109,7 +109,7 @@ protected:
       }
       {
 	lr::ObjectReadOperation op;
-	std::vector<cls_log_entry> entries;
+	std::vector<cls::log::entry> entries;
 	bool truncated = false;
 	cls_log_list(op, {}, {}, {}, 1, entries, &to_marker, &truncated);
 	auto r = rgw_rados_operate(&dp, ioctx, oid, &op, nullptr, null_yield);

--- a/src/test/rgw/test_log_backing.cc
+++ b/src/test/rgw/test_log_backing.cc
@@ -72,7 +72,7 @@ protected:
       lr::ObjectWriteOperation op;
       cb::list bl;
       encode(i, bl);
-      cls_log_add(op, ceph_clock_now(), {}, "meow", bl);
+      cls_log_add(op, ceph::real_clock::now(), {}, "meow", bl);
       auto r = rgw_rados_operate(&dp, ioctx, get_oid(0, i), &op, null_yield);
       ASSERT_GE(r, 0);
     }
@@ -83,7 +83,7 @@ protected:
     lr::ObjectWriteOperation op;
     cb::list bl;
     encode(i, bl);
-    cls_log_add(op, ceph_clock_now(), {}, "meow", bl);
+    cls_log_add(op, ceph::real_clock::now(), {}, "meow", bl);
     auto r = rgw_rados_operate(&dp, ioctx, get_oid(0, i), &op, null_yield);
     ASSERT_GE(r, 0);
   }

--- a/src/tools/ceph-dencoder/common_types.h
+++ b/src/tools/ceph-dencoder/common_types.h
@@ -155,13 +155,13 @@ TYPE(cls_2pc_reservation)
 TYPE_NONDETERMINISTIC(cls_2pc_urgent_data)
 
 #include "cls/log/cls_log_types.h"
-TYPE(cls_log_header)
+TYPE(cls::log::header)
 
 #include "cls/log/cls_log_ops.h"
-TYPE(cls_log_info_op)
-TYPE(cls_log_list_op)
-TYPE(cls_log_list_ret)
-TYPE(cls_log_trim_op)
+TYPE(cls::log::ops::info_op)
+TYPE(cls::log::ops::list_op)
+TYPE(cls::log::ops::list_ret)
+TYPE(cls::log::ops::trim_op)
 
 #include "cls/version/cls_version_ops.h"
 TYPE(cls_version_check_op)

--- a/src/tools/ceph-dencoder/rgw_types.h
+++ b/src/tools/ceph-dencoder/rgw_types.h
@@ -33,10 +33,10 @@ TYPE(RGWCacheNotifyInfo)
 TYPE(RGWLifecycleConfiguration)
 
 #include "cls/log/cls_log_types.h"
-TYPE(cls_log_entry)
+TYPE(cls::log::entry)
 
 #include "cls/log/cls_log_ops.h"
-TYPE(cls_log_add_op)
+TYPE(cls::log::ops::add_op)
 
 #include "cls/rgw/cls_rgw_types.h"
 TYPE(rgw_bucket_pending_info)


### PR DESCRIPTION
A specter is haunting RGW.

The specter of objects not syncing if RGW crashes between adding them to to the set of bucketshards to be refreshed and actually writing the entry into FIFO.

This PR will close that write hole.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
