### PR TITLE
squid: crimson: add crimson-osd rpm and deb runtime dependencies for protobuf inherited from seastar

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -882,6 +882,9 @@ Provides:	ceph-test:/usr/bin/ceph-osdomap-tool
 Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
 Requires:	sudo
 Requires:	libstoragemgmt
+%if 0%{with seastar}
+Requires:	protobuf
+%endif
 %if 0%{?weak_deps}
 Recommends:	ceph-volume = %{_epoch_prefix}%{version}-%{release}
 %endif

--- a/debian/control
+++ b/debian/control
@@ -389,6 +389,7 @@ Depends: ceph-base (= ${binary:Version}),
          ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends},
+         libprotobuf23 <pkg.ceph.crimson>,
 Replaces: ceph (<< 10),
           ceph-test (<< 12.2.2-14),
           ceph-osd (<< 17.0.0)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65127

---

backport of https://github.com/ceph/ceph/pull/56203
parent tracker: https://tracker.ceph.com/issues/65123

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh