### PR TITLE
reef: mgr/dashboard: fix cephfs name validation

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.html
@@ -35,7 +35,7 @@
                   i18n>This field is required!</span>
             <span *ngIf="form.showError('name', formDir, 'pattern')"
                   class="invalid-feedback"
-                  i18n>File System name should start with a letter and can only contain letters, numbers, '.', '-' or '_'</span>
+                  i18n>File System name should start with a letter or dot (.) and can only contain letters, numbers, '.', '-' or '_'</span>
           </div>
         </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.spec.ts
@@ -42,7 +42,15 @@ describe('CephfsVolumeFormComponent', () => {
   });
 
   it('should validate proper names', fakeAsync(() => {
-    const validNames = ['test', 'test1234', 'test_1234', 'test-1234', 'test.1234', 'test12test'];
+    const validNames = [
+      'test',
+      'test1234',
+      'test_1234',
+      'test-1234',
+      'test.1234',
+      'test12test',
+      '.test'
+    ];
     const invalidNames = ['1234', 'test@', 'test)'];
 
     for (const validName of validNames) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.ts
@@ -82,7 +82,10 @@ export class CephfsVolumeFormComponent extends CdForm implements OnInit {
     });
     this.form = this.formBuilder.group({
       name: new FormControl('', {
-        validators: [Validators.pattern(/^[a-zA-Z][.A-Za-z0-9_-]+$/), Validators.required]
+        validators: [
+          Validators.pattern(/^(?:[.][A-Za-z0-9_-]+|[A-Za-z][.A-Za-z0-9_-]*)$/),
+          Validators.required
+        ]
       }),
       placement: ['hosts'],
       hosts: [[]],


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65165

---

backport of https://github.com/ceph/ceph/pull/56463
parent tracker: https://tracker.ceph.com/issues/65143

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh