### PR TITLE
squid: cmake/AddCephTest: bind crimson unittest to different cores

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,7 +608,7 @@ option(PG_DEBUG_REFS "PG Ref debugging is enabled" OFF)
 
 option(WITH_TESTS "enable the build of ceph-test package scripts/binaries" ON)
 set(UNIT_TESTS_BUILT ${WITH_TESTS})
-set(CEPH_TEST_TIMEOUT 3600 CACHE STRING 
+set(CEPH_TEST_TIMEOUT 7200 CACHE STRING
   "Maximum time before a CTest gets killed" )
 
 # fio

--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -19,7 +19,6 @@ function(add_ceph_test test_name test_path)
     PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}:${CMAKE_SOURCE_DIR}/src:$ENV{PATH}
     PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules/lib.3:${CMAKE_SOURCE_DIR}/src/pybind
     CEPH_BUILD_VIRTUALENV=${CEPH_BUILD_VIRTUALENV})
-  # none of the tests should take more than 1 hour to complete
   set_property(TEST ${test_name}
     PROPERTY TIMEOUT ${CEPH_TEST_TIMEOUT})
 endfunction()

--- a/src/test/crimson/ctest_utils.h
+++ b/src/test/crimson/ctest_utils.h
@@ -1,0 +1,78 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <regex>
+#include <string>
+#include <vector>
+
+#include <boost/algorithm/string.hpp>
+#include <fmt/format.h>
+#include <seastar/core/resource.hh>
+#include <seastar/core/app-template.hh>
+
+struct ctest_resource {
+  int id;
+  int slots;
+  ctest_resource(int id, int slots) : id(id), slots(slots) {}
+};
+
+static std::vector<ctest_resource> parse_ctest_resources(const std::string& resource_spec) {
+  std::vector<std::string> resources;
+  boost::split(resources, resource_spec, boost::is_any_of(";"));
+  std::regex res_regex("id:([0-9]+),slots:([0-9]+)");
+  std::vector<ctest_resource> ctest_resources;
+  for (auto& resource : resources) {
+    std::smatch matched;
+    if (std::regex_match(resource, matched, res_regex)) {
+      int id = std::stoi(matched[1].str());
+      int slots = std::stoi(matched[2].str());
+      ctest_resources.emplace_back(id, slots);
+    }
+  }
+  return ctest_resources;
+}
+
+static std::optional<seastar::resource::cpuset> get_cpuset_from_ctest_resource_group() {
+  int nr_groups = 0;
+  auto group_count = std::getenv("CTEST_RESOURCE_GROUP_COUNT");
+  if (group_count != nullptr) {
+    nr_groups = std::stoi(group_count);
+  } else {
+    return {};
+  }
+
+  seastar::resource::cpuset cpuset;
+  for (int num = 0; num < nr_groups; num++) {
+    std::string resource_type_name;
+    fmt::format_to(std::back_inserter(resource_type_name), "CTEST_RESOURCE_GROUP_{}", num);
+    // only a single resource type is supported for now
+    std::string resource_type = std::getenv(resource_type_name.data());
+    if (resource_type == "cpus") {
+      std::transform(resource_type.begin(), resource_type.end(), resource_type.begin(), ::toupper);
+      std::string resource_group;
+      fmt::format_to(std::back_inserter(resource_group), "CTEST_RESOURCE_GROUP_{}_{}", num, resource_type);
+      std::string resource_spec = std::getenv(resource_group.data());
+      for (auto& resource : parse_ctest_resources(resource_spec)) {
+        // each id has a single cpu slot
+        cpuset.insert(resource.id);
+      }
+    } else {
+      fmt::print(std::cerr, "unsupported resource type: {}", resource_type);
+    }
+  }
+  return cpuset;
+}
+
+static seastar::app_template::seastar_options get_smp_opts_from_ctest() {
+  seastar::app_template::seastar_options opts;
+  auto cpuset = get_cpuset_from_ctest_resource_group();
+  if (cpuset) {
+    opts.smp_opts.cpuset.set_value(*cpuset);
+  }
+  return opts;
+}

--- a/src/test/crimson/seastar_runner.h
+++ b/src/test/crimson/seastar_runner.h
@@ -13,6 +13,8 @@
 #include <seastar/core/alien.hh>
 #include <seastar/core/thread.hh>
 
+#include "test/crimson/ctest_utils.h"
+
 struct SeastarRunner {
   static constexpr eventfd_t APP_RUNNING = 1;
   static constexpr eventfd_t APP_NOT_RUN = 2;
@@ -26,7 +28,7 @@ struct SeastarRunner {
   bool begin_signaled = false;
 
   SeastarRunner() :
-    begin_fd{seastar::file_desc::eventfd(0, 0)} {}
+    app{get_smp_opts_from_ctest()}, begin_fd{seastar::file_desc::eventfd(0, 0)} {}
 
   ~SeastarRunner() {}
 

--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -8,6 +8,7 @@
 #include "crimson/net/Connection.h"
 #include "crimson/net/Dispatcher.h"
 #include "crimson/net/Messenger.h"
+#include "test/crimson/ctest_utils.h"
 
 #include <seastar/core/alien.hh>
 #include <seastar/core/app-template.hh>
@@ -266,7 +267,7 @@ int main(int argc, char** argv)
   }
 
   auto count = vm["count"].as<unsigned>();
-  seastar::app_template app;
+  seastar::app_template app{get_smp_opts_from_ctest()};
   SeastarContext sc;
   auto job = sc.with_seastar([&] {
     auto fut = seastar::alien::submit_to(app.alien(), 0, [addr, role, count] {

--- a/src/test/crimson/test_alienstore_thread_pool.cc
+++ b/src/test/crimson/test_alienstore_thread_pool.cc
@@ -6,6 +6,7 @@
 #include "crimson/common/config_proxy.h"
 #include "crimson/os/alienstore/thread_pool.h"
 #include "include/msgr.h"
+#include "test/crimson/ctest_utils.h"
 
 using namespace std::chrono_literals;
 using ThreadPool = crimson::os::ThreadPool;
@@ -37,7 +38,7 @@ seastar::future<> test_void_return(ThreadPool& tp) {
 
 int main(int argc, char** argv)
 {
-  seastar::app_template app;
+  seastar::app_template app{get_smp_opts_from_ctest()};
   return app.run(argc, argv, [] {
     std::vector<const char*> args;
     std::string cluster;

--- a/src/test/crimson/test_buffer.cc
+++ b/src/test/crimson/test_buffer.cc
@@ -3,6 +3,7 @@
 #include <seastar/core/future-util.hh>
 #include <seastar/core/reactor.hh>
 #include "include/buffer.h"
+#include "test/crimson/ctest_utils.h"
 
 // allocate a foreign buffer on each cpu, collect them all into a bufferlist,
 // and destruct it on this cpu
@@ -36,7 +37,7 @@ seastar::future<> test_foreign_bufferlist()
 
 int main(int argc, char** argv)
 {
-  seastar::app_template app;
+  seastar::app_template app{get_smp_opts_from_ctest()};
   return app.run(argc, argv, [] {
     return seastar::now().then(
       &test_foreign_bufferlist

--- a/src/test/crimson/test_config.cc
+++ b/src/test/crimson/test_config.cc
@@ -6,6 +6,7 @@
 #include "common/ceph_argparse.h"
 #include "common/config_obs.h"
 #include "crimson/common/config_proxy.h"
+#include "test/crimson/ctest_utils.h"
 
 using namespace std::literals;
 using Config = crimson::common::ConfigProxy;
@@ -88,7 +89,7 @@ static seastar::future<> test_config()
 
 int main(int argc, char** argv)
 {
-  seastar::app_template app;
+  seastar::app_template app{get_smp_opts_from_ctest()};
   return app.run(argc, argv, [&] {
     return test_config().then([] {
       std::cout << "All tests succeeded" << std::endl;

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -29,6 +29,7 @@
 #include <seastar/core/with_timeout.hh>
 
 #include "test_messenger.h"
+#include "test/crimson/ctest_utils.h"
 
 using namespace std::chrono_literals;
 namespace bpo = boost::program_options;
@@ -3845,7 +3846,7 @@ seastar::future<int> do_test(seastar::app_template& app)
 
 int main(int argc, char** argv)
 {
-  seastar::app_template app;
+  seastar::app_template app{get_smp_opts_from_ctest()};
   app.add_options()
     ("verbose,v", bpo::value<bool>()->default_value(false),
      "chatty if true")

--- a/src/test/crimson/test_messenger_thrash.cc
+++ b/src/test/crimson/test_messenger_thrash.cc
@@ -20,6 +20,7 @@
 #include "crimson/net/Connection.h"
 #include "crimson/net/Dispatcher.h"
 #include "crimson/net/Messenger.h"
+#include "test/crimson/ctest_utils.h"
 
 using namespace std::chrono_literals;
 namespace bpo = boost::program_options;
@@ -662,7 +663,7 @@ seastar::future<int> do_test(seastar::app_template& app)
 
 int main(int argc, char** argv)
 {
-  seastar::app_template app;
+  seastar::app_template app{get_smp_opts_from_ctest()};
   app.add_options()
     ("verbose,v", bpo::value<bool>()->default_value(false),
      "chatty if true");

--- a/src/test/crimson/test_monc.cc
+++ b/src/test/crimson/test_monc.cc
@@ -5,6 +5,7 @@
 #include "crimson/mon/MonClient.h"
 #include "crimson/net/Connection.h"
 #include "crimson/net/Messenger.h"
+#include "test/crimson/ctest_utils.h"
 
 using Config = crimson::common::ConfigProxy;
 using MonClient = crimson::mon::Client;
@@ -63,7 +64,7 @@ static seastar::future<> test_monc()
 
 int main(int argc, char** argv)
 {
-  seastar::app_template app;
+  seastar::app_template app{get_smp_opts_from_ctest()};
   return app.run(argc, argv, [&] {
     return test_monc().then([] {
       std::cout << "All tests succeeded" << std::endl;

--- a/src/test/crimson/test_perfcounters.cc
+++ b/src/test/crimson/test_perfcounters.cc
@@ -6,6 +6,7 @@
 #include "common/Formatter.h"
 #include "common/perf_counters.h"
 #include "crimson/common/perf_counters_collection.h"
+#include "test/crimson/ctest_utils.h"
 
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sharded.hh>
@@ -47,7 +48,7 @@ static seastar::future<> test_perfcounters(){
 
 int main(int argc, char** argv)
 {
-  seastar::app_template app;
+  seastar::app_template app{get_smp_opts_from_ctest()};
   return app.run(argc, argv, [&] {
     return test_perfcounters().then([] {
       std::cout << "All tests succeeded" << std::endl;

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -14,6 +14,7 @@
 #include "crimson/net/Errors.h"
 #include "crimson/net/Fwd.h"
 #include "crimson/net/Socket.h"
+#include "test/crimson/ctest_utils.h"
 
 using crimson::common::local_conf;
 
@@ -552,7 +553,7 @@ seastar::future<int> do_test(seastar::app_template& app)
 
 int main(int argc, char** argv)
 {
-  seastar::app_template app;
+  seastar::app_template app{get_smp_opts_from_ctest()};
   return app.run(argc, argv, [&app] {
     return do_test(app);
   });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65164

---

backport of https://github.com/ceph/ceph/pull/55328
parent tracker: https://tracker.ceph.com/issues/64117

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh