### PR TITLE
mgr/dashboard: replace deprecated table panel in grafana with a newer table panel

### DIFF
--- a/monitoring/ceph-mixin/dashboards/osd.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/osd.libsonnet
@@ -90,19 +90,70 @@ local g = import 'grafonnet/grafana.libsonnet';
           ),
         ],
       ),
-      $.addTableSchema(
-        '$datasource',
-        "This table shows the osd's that are delivering the 10 highest read latencies within the cluster",
-        { col: 2, desc: true },
-        [
-          $.overviewStyle('OSD ID', 'ceph_daemon', 'string', 'short'),
-          $.overviewStyle('Latency (ms)', 'Value', 'number', 'none'),
-          $.overviewStyle('', '/.*/', 'hidden', 'short'),
+
+      $.addTableExtended(
+        datasource='${datasource}',
+        title='Highest READ Latencies',
+        gridPosition={ h: 8, w: 4, x: 8, y: 0 },
+        options={
+          footer: {
+            fields: '',
+            reducer: ['sum'],
+            countRows: false,
+            enablePagination: false,
+            show: false,
+          },
+          frameIndex: 1,
+          showHeader: true,
+        },
+        custom={ align: 'null', cellOptions: { type: 'auto' }, filterable: true, inspect: false },
+        thresholds={
+          mode: 'absolute',
+          steps: [
+            { color: 'green', value: null },
+            { color: 'red', value: 80 },
+          ],
+        },
+        overrides=[
+          {
+            matcher: { id: 'byName', options: 'ceph_daemon' },
+            properties: [
+              { id: 'displayName', value: 'OSD ID' },
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value' },
+            properties: [
+              { id: 'displayName', value: 'Latency (ms)' },
+              { id: 'unit', value: 'none' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
         ],
-        'Highest READ Latencies',
-        'table'
+        pluginVersion='10.4.0'
       )
-      .addTarget(
+      .addTransformations([
+        {
+          id: 'merge',
+          options: { reducers: [] },
+        },
+        {
+          id: 'organize',
+          options: {
+            excludeByName: {
+              Time: true,
+              cluster: true,
+            },
+            indexByName: {},
+            renameByName: {},
+            includeByName: {},
+          },
+        },
+      ]).addTarget(
         $.addTargetSchema(
           |||
             topk(10,
@@ -120,7 +171,8 @@ local g = import 'grafonnet/grafana.libsonnet';
           1,
           true
         )
-      ) + { gridPos: { x: 8, y: 0, w: 4, h: 8 } },
+      ),
+
       $.simpleGraphPanel(
         {
           '@95%ile write': '#e0752d',
@@ -165,21 +217,80 @@ local g = import 'grafonnet/grafana.libsonnet';
           ),
         ],
       ),
-      $.addTableSchema(
-        '$datasource',
-        "This table shows the osd's that are delivering the 10 highest write latencies within the cluster",
-        { col: 2, desc: true },
-        [
-          $.overviewStyle(
-            'OSD ID', 'ceph_daemon', 'string', 'short'
-          ),
-          $.overviewStyle('Latency (ms)', 'Value', 'number', 'none'),
-          $.overviewStyle('', '/.*/', 'hidden', 'short'),
+
+      $.addTableExtended(
+        datasource='${datasource}',
+        title='Highest WRITE Latencies',
+        description="This table shows the osd's that are delivering the 10 highest write latencies within the cluster",
+        gridPosition={ h: 8, w: 4, x: 20, y: 0 },
+        options={
+          footer: {
+            fields: '',
+            reducer: ['sum'],
+            countRows: false,
+            enablePagination: false,
+            show: false,
+          },
+          frameIndex: 1,
+          showHeader: true,
+        },
+        custom={ align: 'null', cellOptions: { type: 'auto' }, filterable: true, inspect: false },
+        thresholds={
+          mode: 'absolute',
+          steps: [
+            { color: 'green', value: null },
+            { color: 'red', value: 80 },
+          ],
+        },
+        overrides=[
+          {
+            matcher: { id: 'byName', options: 'ceph_daemon' },
+            properties: [
+              { id: 'displayName', value: 'OSD ID' },
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value' },
+            properties: [
+              { id: 'displayName', value: 'Latency (ms)' },
+              { id: 'unit', value: 'none' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value' },
+            properties: [
+              { id: 'mappings', value: [{ type: 'value', options: { NaN: { text: '0.00', index: 0 } } }] },
+              { id: 'unit', value: 'none' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
         ],
-        'Highest WRITE Latencies',
-        'table'
+        pluginVersion='10.4.0'
       )
-      .addTarget(
+      .addTransformations([
+        {
+          id: 'merge',
+          options: { reducers: [] },
+        },
+        {
+          id: 'organize',
+          options: {
+            excludeByName: {
+              Time: true,
+              cluster: true,
+            },
+            indexByName: {},
+            renameByName: {},
+            includeByName: {},
+          },
+        },
+      ]).addTarget(
         $.addTargetSchema(
           |||
             topk(10,
@@ -195,7 +306,8 @@ local g = import 'grafonnet/grafana.libsonnet';
           1,
           true
         )
-      ) + { gridPos: { x: 20, y: 0, w: 4, h: 8 } },
+      ),
+
       $.pieChartPanel('OSD Types Summary', '', '$datasource', { x: 0, y: 8, w: 4, h: 8 }, 'table', 'bottom', true, ['percent'], { mode: 'single', sort: 'none' }, 'pie', ['percent', 'value'], 'palette-classic')
       .addTarget(
         $.addTargetSchema('count by (device_class) (ceph_osd_metadata{%(matchers)s})' % $.matchers(), '{{device_class}}')
@@ -291,19 +403,75 @@ local g = import 'grafonnet/grafana.libsonnet';
       .addTargets([$.addTargetSchema(
         'round(sum(rate(ceph_pool_wr{%(matchers)s}[$__rate_interval])))' % $.matchers(), 'Writes'
       )]),
-      $.addTableSchema(
-        '$datasource',
-        'This table shows the 10 OSDs with the highest number of slow ops',
-        { col: 2, desc: true },
-        [
-          $.overviewStyle('OSD ID', 'ceph_daemon', 'string', 'short'),
-          $.overviewStyle('Slow Ops', 'Value', 'number', 'none'),
-          $.overviewStyle('', '/.*/', 'hidden', 'short'),
+
+      $.addTableExtended(
+        datasource='${datasource}',
+        title='Top Slow Ops',
+        description='This table shows the 10 OSDs with the highest number of slow ops',
+        gridPosition={ h: 8, w: 5, x: 0, y: 25 },
+        options={
+          footer: {
+            fields: '',
+            reducer: ['sum'],
+            countRows: false,
+            enablePagination: false,
+            show: false,
+          },
+          frameIndex: 1,
+          showHeader: true,
+        },
+        custom={ align: 'null', cellOptions: { type: 'auto' }, filterable: true, inspect: false },
+        thresholds={
+          mode: 'absolute',
+          steps: [
+            { color: 'green', value: null },
+            { color: 'red', value: 80 },
+          ],
+        },
+        overrides=[
+          {
+            matcher: { id: 'byName', options: 'ceph_daemon' },
+            properties: [
+              { id: 'displayName', value: 'OSD ID' },
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value' },
+            properties: [
+              { id: 'displayName', value: 'Slow Ops' },
+              { id: 'unit', value: 'none' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
         ],
-        'Top Slow Ops',
-        'table'
+        pluginVersion='10.4.0'
       )
-      .addTarget(
+      .addTransformations([
+        {
+          id: 'merge',
+          options: { reducers: [] },
+        },
+        {
+          id: 'organize',
+          options: {
+            excludeByName: {
+              Time: true,
+              __name__: true,
+              instance: true,
+              job: true,
+              type: true,
+              cluster: true,
+            },
+            indexByName: {},
+            renameByName: {},
+            includeByName: {},
+          },
+        },
+      ]).addTarget(
         $.addTargetSchema(
           |||
             topk(10,
@@ -315,7 +483,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           1,
           true
         )
-      ) + { gridPos: { x: 0, y: 20, w: 4, h: 8 } },
+      ),
     ]),
   'osd-device-details.json':
     local OsdDeviceDetailsPanel(title,

--- a/monitoring/ceph-mixin/dashboards/piechart_panel.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/piechart_panel.libsonnet
@@ -23,7 +23,9 @@
     tooltip={},
     pieType='pie',
     values=[],
-    colorMode='auto'
+    colorMode='auto',
+    overrides=[],
+    reduceOptions={},
   ):: {
     type: 'piechart',
     [if description != null then 'description']: description,
@@ -41,6 +43,7 @@
       pieType: pieType,
       tooltip: tooltip,
       displayLabels: displayLabels,
+      reduceOptions: reduceOptions,
     },
     fieldConfig: {
       defaults: {
@@ -54,7 +57,7 @@
           },
         },
       },
-      overrides: [],
+      overrides: overrides,
     },
     targets: [
     ],

--- a/monitoring/ceph-mixin/dashboards/pool.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/pool.libsonnet
@@ -158,36 +158,264 @@ local g = import 'grafonnet/grafana.libsonnet';
         3,
         3
       ),
-      $.addTableSchema(
-        '$datasource',
-        '',
-        { col: 5, desc: true },
-        [
-          $.overviewStyle('', 'Time', 'hidden', 'short'),
-          $.overviewStyle('', 'instance', 'hidden', 'short'),
-          $.overviewStyle('', 'job', 'hidden', 'short'),
-          $.overviewStyle('Pool Name', 'name', 'string', 'short'),
-          $.overviewStyle('Pool ID', 'pool_id', 'hidden', 'none'),
-          $.overviewStyle('Compression Factor', 'Value #A', 'number', 'none'),
-          $.overviewStyle('% Used', 'Value #D', 'number', 'percentunit', 'value', ['70', '85']),
-          $.overviewStyle('Usable Free', 'Value #B', 'number', 'bytes'),
-          $.overviewStyle('Compression Eligibility', 'Value #C', 'number', 'percent'),
-          $.overviewStyle('Compression Savings', 'Value #E', 'number', 'bytes'),
-          $.overviewStyle('Growth (5d)', 'Value #F', 'number', 'bytes', 'value', ['0', '0']),
-          $.overviewStyle('IOPS', 'Value #G', 'number', 'none'),
-          $.overviewStyle('Bandwidth', 'Value #H', 'number', 'Bps'),
-          $.overviewStyle('', '__name__', 'hidden', 'short'),
-          $.overviewStyle('', 'type', 'hidden', 'short'),
-          $.overviewStyle('', 'compression_mode', 'hidden', 'short'),
-          $.overviewStyle('Type', 'description', 'string', 'short'),
-          $.overviewStyle('Stored', 'Value #J', 'number', 'bytes'),
-          $.overviewStyle('', 'Value #I', 'hidden', 'short'),
-          $.overviewStyle('Compression', 'Value #K', 'string', 'short', null, [], [{ text: 'ON', value: '1' }]),
+
+      $.addTableExtended(
+        datasource='${datasource}',
+        title='Pool Overview',
+        gridPosition={ h: 6, w: 24, x: 0, y: 3 },
+        options={
+          footer: {
+            fields: '',
+            reducer: ['sum'],
+            countRows: false,
+            enablePagination: false,
+            show: false,
+          },
+          frameIndex: 1,
+          showHeader: true,
+        },
+        custom={ align: 'auto', cellOptions: { type: 'auto' }, filterable: true, inspect: false },
+        thresholds={
+          mode: 'absolute',
+          steps: [
+            { color: 'green', value: null },
+            { color: 'red', value: 80 },
+          ],
+        },
+        overrides=[
+          {
+            matcher: { id: 'byName', options: 'Time' },
+            properties: [
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'instance' },
+            properties: [
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'job' },
+            properties: [
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'name' },
+            properties: [
+              { id: 'displayName', value: 'Pool Name' },
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'pool_id' },
+            properties: [
+              { id: 'displayName', value: 'Pool ID' },
+              { id: 'unit', value: 'none' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value #A' },
+            properties: [
+              { id: 'displayName', value: 'Compression Factor' },
+              { id: 'unit', value: 'none' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value #D' },
+            properties: [
+              { id: 'displayName', value: '% Used' },
+              { id: 'unit', value: 'percentunit' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.cellOptions', value: { type: 'color-text' } },
+              {
+                id: 'thresholds',
+                value: {
+                  mode: 'absolute',
+                  steps: [
+                    {
+                      color: 'rgba(245, 54, 54, 0.9)',
+                      value: null,
+                    },
+                    {
+                      color: 'rgba(237, 129, 40, 0.89)',
+                      value: 70,
+                    },
+                    {
+                      color: 'rgba(50, 172, 45, 0.97)',
+                      value: 85,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value #B' },
+            properties: [
+              { id: 'displayName', value: 'Usable Free' },
+              { id: 'unit', value: 'bytes' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value #C' },
+            properties: [
+              { id: 'displayName', value: 'Compression Eligibility' },
+              { id: 'unit', value: 'percent' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value #E' },
+            properties: [
+              { id: 'displayName', value: 'Compression Savings' },
+              { id: 'unit', value: 'bytes' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value #F' },
+            properties: [
+              { id: 'displayName', value: 'Growth (5d)' },
+              { id: 'unit', value: 'bytes' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.cellOptions', value: { type: 'color-text' } },
+              {
+                id: 'thresholds',
+                value: {
+                  mode: 'absolute',
+                  steps: [
+                    {
+                      color: 'rgba(245, 54, 54, 0.9)',
+                      value: null,
+                    },
+                    {
+                      color: 'rgba(237, 129, 40, 0.89)',
+                      value: 70,
+                    },
+                    {
+                      color: 'rgba(50, 172, 45, 0.97)',
+                      value: 85,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value #G' },
+            properties: [
+              { id: 'displayName', value: 'IOPS' },
+              { id: 'unit', value: 'none' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value #H' },
+            properties: [
+              { id: 'displayName', value: 'Bandwidth' },
+              { id: 'unit', value: 'Bps' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: '__name__' },
+            properties: [
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'type' },
+            properties: [
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'compression_mode' },
+            properties: [
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'description' },
+            properties: [
+              { id: 'displayName', value: 'Type' },
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value #J' },
+            properties: [
+              { id: 'displayName', value: 'Stored' },
+              { id: 'unit', value: 'bytes' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value #I' },
+            properties: [
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value #K' },
+            properties: [
+              { id: 'displayName', value: 'Compression' },
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+            ],
+          },
         ],
-        'Pool Overview',
-        'table'
+        pluginVersion='10.4.0'
       )
-      .addTargets(
+      .addTransformations([
+        {
+          id: 'merge',
+          options: {},
+        },
+        {
+          id: 'seriesToRows',
+          options: {},
+        },
+        {
+          id: 'organize',
+          options: {
+            excludeByName: {
+              Time: true,
+              'Value #A': true,
+              instance: true,
+              job: true,
+              pool_id: true,
+              'Value #B': false,
+              'Value #C': true,
+              __name__: true,
+              compression_mode: true,
+              type: true,
+              'Value #I': true,
+              'Value #K': true,
+              'Value #D': false,
+              'Value #E': true,
+              cluster: true,
+            },
+            indexByName: {},
+            renameByName: {},
+            includeByName: {},
+          },
+        },
+      ]).addTargets(
         [
           $.addTargetSchema(
             |||
@@ -286,7 +514,8 @@ local g = import 'grafonnet/grafana.libsonnet';
           ),
           $.addTargetSchema('', 'L', '', '', null),
         ]
-      ) + { gridPos: { x: 0, y: 3, w: 24, h: 6 } },
+      ),
+
       $.simpleGraphPanel(
         {},
         'Top $topk Client IOPS by Pool',

--- a/monitoring/ceph-mixin/dashboards/rbd.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/rbd.libsonnet
@@ -257,20 +257,68 @@ local info_rbd_stats = std.join(
         8,
         7
       ),
-      $.addTableSchema(
-        '$datasource',
-        info_rbd_stats,
-        { col: 3, desc: true },
-        [
-          $.overviewStyle('Pool', 'pool', 'string', 'short'),
-          $.overviewStyle('Image', 'image', 'string', 'short'),
-          $.overviewStyle('IOPS', 'Value', 'number', 'iops'),
-          $.overviewStyle('', '/.*/', 'hidden', 'short'),
+
+      $.addTableExtended(
+        datasource='${datasource}',
+        title='Highest IOPS',
+        description='RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.',
+        gridPosition={ h: 7, w: 8, x: 0, y: 7 },
+        options={
+          footer: {
+            fields: '',
+            reducer: ['sum'],
+            countRows: false,
+            enablePagination: false,
+            show: false,
+          },
+          frameIndex: 1,
+          showHeader: true,
+        },
+        custom={ align: 'null', cellOptions: { type: 'auto' }, filterable: true, inspect: false },
+        thresholds={
+          mode: 'absolute',
+          steps: [
+            { color: 'green', value: null },
+            { color: 'red', value: 80 },
+          ],
+        },
+        overrides=[
+          {
+            matcher: { id: 'byName', options: 'pool' },
+            properties: [
+              { id: 'displayName', value: 'Pool' },
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'image' },
+            properties: [
+              { id: 'displayName', value: 'Image' },
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value' },
+            properties: [
+              { id: 'displayName', value: 'IOPS' },
+              { id: 'unit', value: 'iops' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
         ],
-        'Highest IOPS',
-        'table'
+        pluginVersion='10.4.0'
       )
-      .addTarget(
+      .addTransformations([
+        {
+          id: 'merge',
+          options: { reducers: [] },
+        },
+      ]).addTarget(
         $.addTargetSchema(
           |||
             topk(10,
@@ -287,21 +335,69 @@ local info_rbd_stats = std.join(
           1,
           true
         )
-      ) + { gridPos: { x: 0, y: 7, w: 8, h: 7 } },
-      $.addTableSchema(
-        '$datasource',
-        info_rbd_stats,
-        { col: 3, desc: true },
-        [
-          $.overviewStyle('Pool', 'pool', 'string', 'short'),
-          $.overviewStyle('Image', 'image', 'string', 'short'),
-          $.overviewStyle('Throughput', 'Value', 'number', 'Bps'),
-          $.overviewStyle('', '/.*/', 'hidden', 'short'),
+      ),
+
+      $.addTableExtended(
+        datasource='${datasource}',
+        title='Highest Throughput',
+        description='RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.',
+        gridPosition={ h: 7, w: 8, x: 8, y: 7 },
+        options={
+          footer: {
+            fields: '',
+            reducer: ['sum'],
+            countRows: false,
+            enablePagination: false,
+            show: false,
+          },
+          frameIndex: 1,
+          showHeader: true,
+        },
+        custom={ align: 'null', cellOptions: { type: 'auto' }, filterable: true, inspect: false },
+        thresholds={
+          mode: 'absolute',
+          steps: [
+            { color: 'green', value: null },
+            { color: 'red', value: 80 },
+          ],
+        },
+        overrides=[
+          {
+            matcher: { id: 'byName', options: 'pool' },
+            properties: [
+              { id: 'displayName', value: 'Pool' },
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'image' },
+            properties: [
+              { id: 'displayName', value: 'Image' },
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value' },
+            properties: [
+              { id: 'displayName', value: 'Throughput' },
+              { id: 'unit', value: 'Bps' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
         ],
-        'Highest Throughput',
-        'table'
+        pluginVersion='10.4.0'
       )
-      .addTarget(
+      .addTransformations([
+        {
+          id: 'merge',
+          options: { reducers: [] },
+        },
+      ]).addTarget(
         $.addTargetSchema(
           |||
             topk(10,
@@ -318,21 +414,69 @@ local info_rbd_stats = std.join(
           1,
           true
         )
-      ) + { gridPos: { x: 8, y: 7, w: 8, h: 7 } },
-      $.addTableSchema(
-        '$datasource',
-        info_rbd_stats,
-        { col: 3, desc: true },
-        [
-          $.overviewStyle('Pool', 'pool', 'string', 'short'),
-          $.overviewStyle('Image', 'image', 'string', 'short'),
-          $.overviewStyle('Latency', 'Value', 'number', 'ns'),
-          $.overviewStyle('', '/.*/', 'hidden', 'short'),
+      ),
+
+      $.addTableExtended(
+        datasource='${datasource}',
+        title='Highest Latency',
+        description='RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.',
+        gridPosition={ h: 7, w: 8, x: 16, y: 7 },
+        options={
+          footer: {
+            fields: '',
+            reducer: ['sum'],
+            countRows: false,
+            enablePagination: false,
+            show: false,
+          },
+          frameIndex: 1,
+          showHeader: true,
+        },
+        custom={ align: 'null', cellOptions: { type: 'auto' }, filterable: true, inspect: false },
+        thresholds={
+          mode: 'absolute',
+          steps: [
+            { color: 'green', value: null },
+            { color: 'red', value: 80 },
+          ],
+        },
+        overrides=[
+          {
+            matcher: { id: 'byName', options: 'pool' },
+            properties: [
+              { id: 'displayName', value: 'Pool' },
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'image' },
+            properties: [
+              { id: 'displayName', value: 'Image' },
+              { id: 'unit', value: 'short' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
+          {
+            matcher: { id: 'byName', options: 'Value' },
+            properties: [
+              { id: 'displayName', value: 'Latency' },
+              { id: 'unit', value: 'ns' },
+              { id: 'decimals', value: 2 },
+              { id: 'custom.align', value: null },
+            ],
+          },
         ],
-        'Highest Latency',
-        'table'
+        pluginVersion='10.4.0'
       )
-      .addTarget(
+      .addTransformations([
+        {
+          id: 'merge',
+          options: { reducers: [] },
+        },
+      ]).addTarget(
         $.addTargetSchema(
           |||
             topk(10,
@@ -349,6 +493,6 @@ local info_rbd_stats = std.join(
           1,
           true
         )
-      ) + { gridPos: { x: 16, y: 7, w: 8, h: 7 } },
+      ),
     ]),
 }

--- a/monitoring/ceph-mixin/dashboards/rgw.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/rgw.libsonnet
@@ -825,15 +825,52 @@ local u = import 'utils.libsonnet';
           ),
         ]
       ),
-      $.simplePieChart(
-        {
-          GETs: '#7eb26d',
-          'Other (HEAD,POST,DELETE)': '#447ebc',
-          PUTs: '#eab839',
-          Requests: '#3f2b5b',
-          Failures: '#bf1b00',
-        }, '', 'Workload Breakdown'
-      )
+
+      $.pieChartPanel('Workload Breakdown',
+                      '',
+                      '$datasource',
+                      { x: 20, y: 1, w: 4, h: 8 },
+                      'table',
+                      'bottom',
+                      true,
+                      [],
+                      { mode: 'single', sort: 'none' },
+                      'pie',
+                      ['percent', 'value'],
+                      'palette-classic',
+                      overrides=[
+                        {
+                          matcher: { id: 'byName', options: 'Failures' },
+                          properties: [
+                            { id: 'color', value: { mode: 'fixed', fixedColor: '#bf1b00' } },
+                          ],
+                        },
+                        {
+                          matcher: { id: 'byName', options: 'GETs' },
+                          properties: [
+                            { id: 'color', value: { mode: 'fixed', fixedColor: '#7eb26d' } },
+                          ],
+                        },
+                        {
+                          matcher: { id: 'byName', options: 'Other (HEAD,POST,DELETE)' },
+                          properties: [
+                            { id: 'color', value: { mode: 'fixed', fixedColor: '#447ebc' } },
+                          ],
+                        },
+                        {
+                          matcher: { id: 'byName', options: 'PUTs' },
+                          properties: [
+                            { id: 'color', value: { mode: 'fixed', fixedColor: '#eab839' } },
+                          ],
+                        },
+                        {
+                          matcher: { id: 'byName', options: 'Requests' },
+                          properties: [
+                            { id: 'color', value: { mode: 'fixed', fixedColor: '#3f2b5b' } },
+                          ],
+                        },
+                      ],
+                      reduceOptions={ values: false, calcs: ['lastNotNull'], fields: '' })
       .addTarget($.addTargetSchema(
         |||
           rate(ceph_rgw_failed_req{%(matchers)s}[$__rate_interval]) *
@@ -867,6 +904,6 @@ local u = import 'utils.libsonnet';
             ceph_rgw_metadata{%(matchers)s, ceph_daemon=~"$rgw_servers"}
         ||| % $.matchers(),
         'Other (DELETE,LIST) {{ceph_daemon}}'
-      )) + { gridPos: { x: 20, y: 1, w: 4, h: 8 } },
+      )),
     ]),
 }

--- a/monitoring/ceph-mixin/dashboards/utils.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/utils.libsonnet
@@ -196,14 +196,6 @@ local timeSeries = import 'timeseries_panel.libsonnet';
                         title=title,
                         valueName=valueName),
 
-  addTableSchema(datasource, description, sort, styles, title, transform)::
-    g.tablePanel.new(datasource=datasource,
-                     description=description,
-                     sort=sort,
-                     styles=styles,
-                     title=title,
-                     transform=transform),
-
   addStyle(alias,
            colorMode,
            colors,
@@ -661,7 +653,9 @@ local timeSeries = import 'timeseries_panel.libsonnet';
     tooltip={},
     pieType='pie',
     values=[],
-    colorMode='auto'
+    colorMode='auto',
+    overrides=[],
+    reduceOptions={},
   )::
     pieChartPanel.new(
       title,
@@ -675,7 +669,9 @@ local timeSeries = import 'timeseries_panel.libsonnet';
       tooltip=tooltip,
       pieType=pieType,
       values=values,
-      colorMode=colorMode
+      colorMode=colorMode,
+      overrides=overrides,
+      reduceOptions=reduceOptions,
     ),
 
   heatMapPanel(

--- a/monitoring/ceph-mixin/dashboards_out/host-details.json
+++ b/monitoring/ceph-mixin/dashboards_out/host-details.json
@@ -1203,73 +1203,105 @@
       },
       {
          "columns": [ ],
-         "datasource": "$datasource",
-         "description": "This table shows the 10 hosts with the highest number of slow ops",
+         "datasource": "${datasource}",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "align": "null",
+                  "cellOptions": {
+                     "type": "auto"
+                  },
+                  "filterable": true,
+                  "inspect": false
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "instance"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Instance"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Slow Ops"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "none"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               }
+            ]
+         },
          "gridPos": {
             "h": 8,
-            "w": 4,
+            "w": 6,
             "x": 0,
-            "y": 40
+            "y": 30
          },
          "id": 15,
          "links": [ ],
-         "sort": {
-            "col": 2,
-            "desc": true
+         "options": {
+            "footer": {
+               "countRows": false,
+               "enablePagination": false,
+               "fields": "",
+               "reducer": [
+                  "sum"
+               ],
+               "show": false
+            },
+            "frameIndex": 1,
+            "showHeader": true
          },
-         "styles": [
-            {
-               "alias": "Instance",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "instance",
-               "thresholds": [ ],
-               "type": "string",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Slow Ops",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "none",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "/.*/",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            }
-         ],
+         "pluginVersion": "10.4.0",
+         "styles": "",
          "targets": [
             {
                "expr": "topk(10,\n  (sum by (instance)(ceph_daemon_health_metrics{type=\"SLOW_OPS\", ceph_daemon=~\"osd.*\"}))\n)\n",
@@ -1283,7 +1315,20 @@
          "timeFrom": null,
          "timeShift": null,
          "title": "Top Slow Ops per Host",
-         "transform": "table",
+         "transformations": [
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "cluster": true
+                  },
+                  "includeByName": { },
+                  "indexByName": { },
+                  "renameByName": { }
+               }
+            }
+         ],
          "type": "table"
       }
    ],

--- a/monitoring/ceph-mixin/dashboards_out/osds-overview.json
+++ b/monitoring/ceph-mixin/dashboards_out/osds-overview.json
@@ -162,8 +162,82 @@
       },
       {
          "columns": [ ],
-         "datasource": "$datasource",
-         "description": "This table shows the osd's that are delivering the 10 highest read latencies within the cluster",
+         "datasource": "${datasource}",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "align": "null",
+                  "cellOptions": {
+                     "type": "auto"
+                  },
+                  "filterable": true,
+                  "inspect": false
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "ceph_daemon"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "OSD ID"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Latency (ms)"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "none"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               }
+            ]
+         },
          "gridPos": {
             "h": 8,
             "w": 4,
@@ -172,63 +246,21 @@
          },
          "id": 3,
          "links": [ ],
-         "sort": {
-            "col": 2,
-            "desc": true
+         "options": {
+            "footer": {
+               "countRows": false,
+               "enablePagination": false,
+               "fields": "",
+               "reducer": [
+                  "sum"
+               ],
+               "show": false
+            },
+            "frameIndex": 1,
+            "showHeader": true
          },
-         "styles": [
-            {
-               "alias": "OSD ID",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "ceph_daemon",
-               "thresholds": [ ],
-               "type": "string",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Latency (ms)",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "none",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "/.*/",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            }
-         ],
+         "pluginVersion": "10.4.0",
+         "styles": "",
          "targets": [
             {
                "expr": "topk(10,\n  (sort(\n    (\n      rate(ceph_osd_op_r_latency_sum{job=~\"$job\"}[$__rate_interval]) /\n        on (ceph_daemon) rate(ceph_osd_op_r_latency_count{job=~\"$job\"}[$__rate_interval]) *\n        1000\n    )\n  ))\n)\n",
@@ -242,7 +274,26 @@
          "timeFrom": null,
          "timeShift": null,
          "title": "Highest READ Latencies",
-         "transform": "table",
+         "transformations": [
+            {
+               "id": "merge",
+               "options": {
+                  "reducers": [ ]
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "cluster": true
+                  },
+                  "includeByName": { },
+                  "indexByName": { },
+                  "renameByName": { }
+               }
+            }
+         ],
          "type": "table"
       },
       {
@@ -358,8 +409,117 @@
       },
       {
          "columns": [ ],
-         "datasource": "$datasource",
+         "datasource": "${datasource}",
          "description": "This table shows the osd's that are delivering the 10 highest write latencies within the cluster",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "align": "null",
+                  "cellOptions": {
+                     "type": "auto"
+                  },
+                  "filterable": true,
+                  "inspect": false
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "ceph_daemon"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "OSD ID"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Latency (ms)"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "none"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "mappings",
+                        "value": [
+                           {
+                              "options": {
+                                 "NaN": {
+                                    "index": 0,
+                                    "text": "0.00"
+                                 }
+                              },
+                              "type": "value"
+                           }
+                        ]
+                     },
+                     {
+                        "id": "unit",
+                        "value": "none"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               }
+            ]
+         },
          "gridPos": {
             "h": 8,
             "w": 4,
@@ -368,63 +528,21 @@
          },
          "id": 5,
          "links": [ ],
-         "sort": {
-            "col": 2,
-            "desc": true
+         "options": {
+            "footer": {
+               "countRows": false,
+               "enablePagination": false,
+               "fields": "",
+               "reducer": [
+                  "sum"
+               ],
+               "show": false
+            },
+            "frameIndex": 1,
+            "showHeader": true
          },
-         "styles": [
-            {
-               "alias": "OSD ID",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "ceph_daemon",
-               "thresholds": [ ],
-               "type": "string",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Latency (ms)",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "none",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "/.*/",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            }
-         ],
+         "pluginVersion": "10.4.0",
+         "styles": "",
          "targets": [
             {
                "expr": "topk(10,\n  (sort(\n    (rate(ceph_osd_op_w_latency_sum{job=~\"$job\"}[$__rate_interval]) /\n      on (ceph_daemon) rate(ceph_osd_op_w_latency_count{job=~\"$job\"}[$__rate_interval]) *\n      1000)\n  ))\n)\n",
@@ -438,7 +556,26 @@
          "timeFrom": null,
          "timeShift": null,
          "title": "Highest WRITE Latencies",
-         "transform": "table",
+         "transformations": [
+            {
+               "id": "merge",
+               "options": {
+                  "reducers": [ ]
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "cluster": true
+                  },
+                  "includeByName": { },
+                  "indexByName": { },
+                  "renameByName": { }
+               }
+            }
+         ],
          "type": "table"
       },
       {
@@ -482,6 +619,7 @@
                ]
             },
             "pieType": "pie",
+            "reduceOptions": { },
             "tooltip": {
                "mode": "single",
                "sort": "none"
@@ -540,6 +678,7 @@
                ]
             },
             "pieType": "pie",
+            "reduceOptions": { },
             "tooltip": {
                "mode": "single",
                "sort": "none"
@@ -605,6 +744,7 @@
                ]
             },
             "pieType": "pie",
+            "reduceOptions": { },
             "tooltip": {
                "mode": "single",
                "sort": "none"
@@ -978,73 +1118,106 @@
       },
       {
          "columns": [ ],
-         "datasource": "$datasource",
+         "datasource": "${datasource}",
          "description": "This table shows the 10 OSDs with the highest number of slow ops",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "align": "null",
+                  "cellOptions": {
+                     "type": "auto"
+                  },
+                  "filterable": true,
+                  "inspect": false
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "ceph_daemon"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "OSD ID"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Slow Ops"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "none"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               }
+            ]
+         },
          "gridPos": {
             "h": 8,
-            "w": 4,
+            "w": 5,
             "x": 0,
-            "y": 20
+            "y": 25
          },
          "id": 13,
          "links": [ ],
-         "sort": {
-            "col": 2,
-            "desc": true
+         "options": {
+            "footer": {
+               "countRows": false,
+               "enablePagination": false,
+               "fields": "",
+               "reducer": [
+                  "sum"
+               ],
+               "show": false
+            },
+            "frameIndex": 1,
+            "showHeader": true
          },
-         "styles": [
-            {
-               "alias": "OSD ID",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "ceph_daemon",
-               "thresholds": [ ],
-               "type": "string",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Slow Ops",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "none",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "/.*/",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            }
-         ],
+         "pluginVersion": "10.4.0",
+         "styles": "",
          "targets": [
             {
                "expr": "topk(10,\n  (ceph_daemon_health_metrics{type=\"SLOW_OPS\", ceph_daemon=~\"osd.*\"})\n)\n",
@@ -1058,7 +1231,30 @@
          "timeFrom": null,
          "timeShift": null,
          "title": "Top Slow Ops",
-         "transform": "table",
+         "transformations": [
+            {
+               "id": "merge",
+               "options": {
+                  "reducers": [ ]
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "__name__": true,
+                     "cluster": true,
+                     "instance": true,
+                     "job": true,
+                     "type": true
+                  },
+                  "includeByName": { },
+                  "indexByName": { },
+                  "renameByName": { }
+               }
+            }
+         ],
          "type": "table"
       }
    ],

--- a/monitoring/ceph-mixin/dashboards_out/pool-overview.json
+++ b/monitoring/ceph-mixin/dashboards_out/pool-overview.json
@@ -684,8 +684,458 @@
       },
       {
          "columns": [ ],
-         "datasource": "$datasource",
-         "description": "",
+         "datasource": "${datasource}",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "align": "auto",
+                  "cellOptions": {
+                     "type": "auto"
+                  },
+                  "filterable": true,
+                  "inspect": false
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Time"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "instance"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "job"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "name"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Pool Name"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "pool_id"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Pool ID"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "none"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value #A"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Compression Factor"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "none"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value #D"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "% Used"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "percentunit"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.cellOptions",
+                        "value": {
+                           "type": "color-text"
+                        }
+                     },
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "rgba(245, 54, 54, 0.9)",
+                                 "value": null
+                              },
+                              {
+                                 "color": "rgba(237, 129, 40, 0.89)",
+                                 "value": 70
+                              },
+                              {
+                                 "color": "rgba(50, 172, 45, 0.97)",
+                                 "value": 85
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value #B"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Usable Free"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "bytes"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value #C"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Compression Eligibility"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "percent"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value #E"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Compression Savings"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "bytes"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value #F"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Growth (5d)"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "bytes"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.cellOptions",
+                        "value": {
+                           "type": "color-text"
+                        }
+                     },
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "rgba(245, 54, 54, 0.9)",
+                                 "value": null
+                              },
+                              {
+                                 "color": "rgba(237, 129, 40, 0.89)",
+                                 "value": 70
+                              },
+                              {
+                                 "color": "rgba(50, 172, 45, 0.97)",
+                                 "value": 85
+                              }
+                           ]
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value #G"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "IOPS"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "none"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value #H"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Bandwidth"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "Bps"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "__name__"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "type"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "compression_mode"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "description"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Type"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value #J"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Stored"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "bytes"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value #I"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value #K"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Compression"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     }
+                  ]
+               }
+            ]
+         },
          "gridPos": {
             "h": 6,
             "w": 24,
@@ -694,363 +1144,21 @@
          },
          "id": 10,
          "links": [ ],
-         "sort": {
-            "col": 5,
-            "desc": true
+         "options": {
+            "footer": {
+               "countRows": false,
+               "enablePagination": false,
+               "fields": "",
+               "reducer": [
+                  "sum"
+               ],
+               "show": false
+            },
+            "frameIndex": 1,
+            "showHeader": true
          },
-         "styles": [
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Time",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "instance",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "job",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Pool Name",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "name",
-               "thresholds": [ ],
-               "type": "string",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Pool ID",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "pool_id",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "none",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Compression Factor",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value #A",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "none",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "% Used",
-               "colorMode": "value",
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value #D",
-               "thresholds": [
-                  "70",
-                  "85"
-               ],
-               "type": "number",
-               "unit": "percentunit",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Usable Free",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value #B",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "bytes",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Compression Eligibility",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value #C",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "percent",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Compression Savings",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value #E",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "bytes",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Growth (5d)",
-               "colorMode": "value",
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value #F",
-               "thresholds": [
-                  "0",
-                  "0"
-               ],
-               "type": "number",
-               "unit": "bytes",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "IOPS",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value #G",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "none",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Bandwidth",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value #H",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "Bps",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "__name__",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "type",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "compression_mode",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Type",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "description",
-               "thresholds": [ ],
-               "type": "string",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Stored",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value #J",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "bytes",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value #I",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Compression",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value #K",
-               "thresholds": [ ],
-               "type": "string",
-               "unit": "short",
-               "valueMaps": [
-                  {
-                     "text": "ON",
-                     "value": "1"
-                  }
-               ]
-            }
-         ],
+         "pluginVersion": "10.4.0",
+         "styles": "",
          "targets": [
             {
                "expr": "(\n  ceph_pool_compress_under_bytes{job=~\"$job\"} /\n    ceph_pool_compress_bytes_used{job=~\"$job\"} > 0\n) and on(pool_id) (\n  (\n    (ceph_pool_compress_under_bytes{job=~\"$job\"} > 0) /\n      ceph_pool_stored_raw{job=~\"$job\"}\n  ) * 100 > 0.5\n)\n",
@@ -1151,7 +1259,41 @@
          "timeFrom": null,
          "timeShift": null,
          "title": "Pool Overview",
-         "transform": "table",
+         "transformations": [
+            {
+               "id": "merge",
+               "options": { }
+            },
+            {
+               "id": "seriesToRows",
+               "options": { }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Value #A": true,
+                     "Value #B": false,
+                     "Value #C": true,
+                     "Value #D": false,
+                     "Value #E": true,
+                     "Value #I": true,
+                     "Value #K": true,
+                     "__name__": true,
+                     "cluster": true,
+                     "compression_mode": true,
+                     "instance": true,
+                     "job": true,
+                     "pool_id": true,
+                     "type": true
+                  },
+                  "includeByName": { },
+                  "indexByName": { },
+                  "renameByName": { }
+               }
+            }
+         ],
          "type": "table"
       },
       {

--- a/monitoring/ceph-mixin/dashboards_out/radosgw-detail.json
+++ b/monitoring/ceph-mixin/dashboards_out/radosgw-detail.json
@@ -389,15 +389,100 @@
          ]
       },
       {
-         "aliasColors": {
-            "Failures": "#bf1b00",
-            "GETs": "#7eb26d",
-            "Other (HEAD,POST,DELETE)": "#447ebc",
-            "PUTs": "#eab839",
-            "Requests": "#3f2b5b"
-         },
          "datasource": "$datasource",
          "description": "",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  }
+               },
+               "mappings": [ ]
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Failures"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "#bf1b00",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "GETs"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "#7eb26d",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Other (HEAD,POST,DELETE)"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "#447ebc",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "PUTs"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "#eab839",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Requests"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "#3f2b5b",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
          "gridPos": {
             "h": 8,
             "w": 4,
@@ -405,13 +490,31 @@
             "y": 1
          },
          "id": 6,
-         "legend": {
-            "percentage": true,
-            "show": true,
-            "values": true
+         "options": {
+            "displayLabels": [ ],
+            "legend": {
+               "calcs": [ ],
+               "displayMode": "table",
+               "placement": "bottom",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "fields": "",
+               "values": false
+            },
+            "tooltip": {
+               "mode": "single",
+               "sort": "none"
+            }
          },
-         "legendType": "Under graph",
-         "pieType": "pie",
          "targets": [
             {
                "expr": "rate(ceph_rgw_failed_req{job=~\"$job\"}[$__rate_interval]) *\n  on (instance_id) group_left (ceph_daemon) ceph_rgw_metadata{job=~\"$job\", ceph_daemon=~\"$rgw_servers\"}\n",
@@ -443,8 +546,7 @@
             }
          ],
          "title": "Workload Breakdown",
-         "type": "grafana-piechart-panel",
-         "valueName": "current"
+         "type": "piechart"
       }
    ],
    "refresh": "30s",

--- a/monitoring/ceph-mixin/dashboards_out/rbd-details.json
+++ b/monitoring/ceph-mixin/dashboards_out/rbd-details.json
@@ -43,7 +43,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "fieldConfig": {
             "defaults": {
                "custom": {
@@ -145,7 +145,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "fieldConfig": {
             "defaults": {
                "custom": {
@@ -247,7 +247,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "fieldConfig": {
             "defaults": {
                "custom": {

--- a/monitoring/ceph-mixin/dashboards_out/rbd-overview.json
+++ b/monitoring/ceph-mixin/dashboards_out/rbd-overview.json
@@ -55,7 +55,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "fieldConfig": {
             "defaults": {
                "custom": {
@@ -157,7 +157,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "fieldConfig": {
             "defaults": {
                "custom": {
@@ -259,7 +259,7 @@
          "dashLength": 10,
          "dashes": false,
          "datasource": "$datasource",
-         "description": "",
+         "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
          "fieldConfig": {
             "defaults": {
                "custom": {
@@ -357,8 +357,107 @@
       },
       {
          "columns": [ ],
-         "datasource": "$datasource",
+         "datasource": "${datasource}",
          "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "align": "null",
+                  "cellOptions": {
+                     "type": "auto"
+                  },
+                  "filterable": true,
+                  "inspect": false
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "pool"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Pool"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "image"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Image"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "IOPS"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "iops"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               }
+            ]
+         },
          "gridPos": {
             "h": 7,
             "w": 8,
@@ -367,80 +466,21 @@
          },
          "id": 5,
          "links": [ ],
-         "sort": {
-            "col": 3,
-            "desc": true
+         "options": {
+            "footer": {
+               "countRows": false,
+               "enablePagination": false,
+               "fields": "",
+               "reducer": [
+                  "sum"
+               ],
+               "show": false
+            },
+            "frameIndex": 1,
+            "showHeader": true
          },
-         "styles": [
-            {
-               "alias": "Pool",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "pool",
-               "thresholds": [ ],
-               "type": "string",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Image",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "image",
-               "thresholds": [ ],
-               "type": "string",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "IOPS",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "iops",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "/.*/",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            }
-         ],
+         "pluginVersion": "10.4.0",
+         "styles": "",
          "targets": [
             {
                "expr": "topk(10,\n  (\n    sort((\n      rate(ceph_rbd_write_ops{job=~\"$job\"}[$__rate_interval]) +\n        on (image, pool, namespace) rate(ceph_rbd_read_ops{job=~\"$job\"}[$__rate_interval])\n    ))\n  )\n)\n",
@@ -454,13 +494,119 @@
          "timeFrom": null,
          "timeShift": null,
          "title": "Highest IOPS",
-         "transform": "table",
+         "transformations": [
+            {
+               "id": "merge",
+               "options": {
+                  "reducers": [ ]
+               }
+            }
+         ],
          "type": "table"
       },
       {
          "columns": [ ],
-         "datasource": "$datasource",
+         "datasource": "${datasource}",
          "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "align": "null",
+                  "cellOptions": {
+                     "type": "auto"
+                  },
+                  "filterable": true,
+                  "inspect": false
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "pool"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Pool"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "image"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Image"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Throughput"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "Bps"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               }
+            ]
+         },
          "gridPos": {
             "h": 7,
             "w": 8,
@@ -469,80 +615,21 @@
          },
          "id": 6,
          "links": [ ],
-         "sort": {
-            "col": 3,
-            "desc": true
+         "options": {
+            "footer": {
+               "countRows": false,
+               "enablePagination": false,
+               "fields": "",
+               "reducer": [
+                  "sum"
+               ],
+               "show": false
+            },
+            "frameIndex": 1,
+            "showHeader": true
          },
-         "styles": [
-            {
-               "alias": "Pool",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "pool",
-               "thresholds": [ ],
-               "type": "string",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Image",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "image",
-               "thresholds": [ ],
-               "type": "string",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Throughput",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "Bps",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "/.*/",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            }
-         ],
+         "pluginVersion": "10.4.0",
+         "styles": "",
          "targets": [
             {
                "expr": "topk(10,\n  sort(\n    sum(\n      rate(ceph_rbd_read_bytes{job=~\"$job\"}[$__rate_interval]) +\n        rate(ceph_rbd_write_bytes{job=~\"$job\"}[$__rate_interval])\n    ) by (pool, image, namespace)\n  )\n)\n",
@@ -556,13 +643,119 @@
          "timeFrom": null,
          "timeShift": null,
          "title": "Highest Throughput",
-         "transform": "table",
+         "transformations": [
+            {
+               "id": "merge",
+               "options": {
+                  "reducers": [ ]
+               }
+            }
+         ],
          "type": "table"
       },
       {
          "columns": [ ],
-         "datasource": "$datasource",
+         "datasource": "${datasource}",
          "description": "RBD per-image IO statistics are disabled by default.\n\nPlease refer to https://docs.ceph.com/en/latest/mgr/prometheus/#rbd-io-statistics for information about how to enable those optionally.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "align": "null",
+                  "cellOptions": {
+                     "type": "auto"
+                  },
+                  "filterable": true,
+                  "inspect": false
+               },
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "pool"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Pool"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "image"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Image"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "short"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Value"
+                  },
+                  "properties": [
+                     {
+                        "id": "displayName",
+                        "value": "Latency"
+                     },
+                     {
+                        "id": "unit",
+                        "value": "ns"
+                     },
+                     {
+                        "id": "decimals",
+                        "value": 2
+                     },
+                     {
+                        "id": "custom.align",
+                        "value": null
+                     }
+                  ]
+               }
+            ]
+         },
          "gridPos": {
             "h": 7,
             "w": 8,
@@ -571,80 +764,21 @@
          },
          "id": 7,
          "links": [ ],
-         "sort": {
-            "col": 3,
-            "desc": true
+         "options": {
+            "footer": {
+               "countRows": false,
+               "enablePagination": false,
+               "fields": "",
+               "reducer": [
+                  "sum"
+               ],
+               "show": false
+            },
+            "frameIndex": 1,
+            "showHeader": true
          },
-         "styles": [
-            {
-               "alias": "Pool",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "pool",
-               "thresholds": [ ],
-               "type": "string",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Image",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "image",
-               "thresholds": [ ],
-               "type": "string",
-               "unit": "short",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "Latency",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "Value",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "ns",
-               "valueMaps": [ ]
-            },
-            {
-               "alias": "",
-               "colorMode": null,
-               "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-               ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "mappingType": 1,
-               "pattern": "/.*/",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short",
-               "valueMaps": [ ]
-            }
-         ],
+         "pluginVersion": "10.4.0",
+         "styles": "",
          "targets": [
             {
                "expr": "topk(10,\n  sum(\n    rate(ceph_rbd_write_latency_sum{job=~\"$job\"}[$__rate_interval]) /\n      clamp_min(rate(ceph_rbd_write_latency_count{job=~\"$job\"}[$__rate_interval]), 1) +\n      rate(ceph_rbd_read_latency_sum{job=~\"$job\"}[$__rate_interval]) /\n      clamp_min(rate(ceph_rbd_read_latency_count{job=~\"$job\"}[$__rate_interval]), 1)\n  ) by (pool, image, namespace)\n)\n",
@@ -658,7 +792,14 @@
          "timeFrom": null,
          "timeShift": null,
          "title": "Highest Latency",
-         "transform": "table",
+         "transformations": [
+            {
+               "id": "merge",
+               "options": {
+                  "reducers": [ ]
+               }
+            }
+         ],
          "type": "table"
       }
    ],


### PR DESCRIPTION
Since the grafana table panel is deprectaed in the latest grafana versions, the existing panels should be replaced with the newer table panel

Before:

![Screenshot from 2024-03-28 10-26-08](https://github.com/ceph/ceph/assets/66050535/23db12fa-3804-40c1-8cf3-cd42842fc577)

After:

![Screenshot from 2024-04-02 11-49-57](https://github.com/ceph/ceph/assets/66050535/a24569c8-35ff-411a-a9a2-c5a7a0938c62)



Before:

![Screenshot from 2024-04-02 11-37-47](https://github.com/ceph/ceph/assets/66050535/fdb3bbac-1235-434a-b127-9627a586d3b2)



After:

![Screenshot from 2024-04-02 12-19-40](https://github.com/ceph/ceph/assets/66050535/e01b2a8b-d850-43d0-8917-562cb40a5d61)


Before:

![Screenshot from 2024-03-28 10-27-36](https://github.com/ceph/ceph/assets/66050535/5e923dc5-fe38-4dca-88b6-d97b2c9788c2)

After:

![Screenshot from 2024-04-02 12-20-21](https://github.com/ceph/ceph/assets/66050535/254e7a64-6a2c-482b-8f30-6bcea78de0d6)


Before:

![Screenshot from 2024-03-28 10-27-59](https://github.com/ceph/ceph/assets/66050535/3982cc13-1c94-41b8-bd4e-92e92a189fc2)

After:

![Screenshot from 2024-03-28 14-38-13](https://github.com/ceph/ceph/assets/66050535/1f09085c-95b3-4dc2-8a58-3454be02552e)





Fixes: https://tracker.ceph.com/issues/65174





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
