### PR TITLE
doc/start/os-recommendations: remove 16.2.z support for CentOS 7

### DIFF
--- a/doc/start/os-recommendations.rst
+++ b/doc/start/os-recommendations.rst
@@ -43,11 +43,10 @@ distribution that includes a supported kernel and supported system startup
 framework, for example ``sysvinit`` or ``systemd``. Ceph is sometimes ported to
 non-Linux systems but these are not supported by the core Ceph effort.
 
-
 +---------------+---------------+------------------+------------------+------------------+
 |               | Reef (18.2.z) | Quincy (17.2.z)  | Pacific (16.2.z) | Octopus (15.2.z) |
 +===============+===============+==================+==================+==================+
-| Centos 7      |               |                  |         A        |      B           |
+| Centos 7      |               |                  |                  |      B           |
 +---------------+---------------+------------------+------------------+------------------+
 | Centos 8      |               |                  |                  |                  |
 +---------------+---------------+------------------+------------------+------------------+


### PR DESCRIPTION
This shows Ceph 16.2.z support on CentOS 7 as A.
But I did not find the Ceph 16.2.z package for CentOS 7 at https://download.ceph.com/ .
And the cephadm tool also prompts that Ceph 16.y.z cannot run on CentOS 7.

```shell
$ cat /etc/redhat-release 
CentOS Linux release 7.3.1611 (Core) 

$ uname -r
5.4.54-2.0.4.std7c.el7.x86_64
 
$ cephadm add-repo --version 16.2.15
ERROR: Ceph does not support 16.y.z or later for this version of this linux distro and therefore cannot add a repo for it
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
