### PR TITLE
squid: python: allow unit tests to use tox default envs

### DIFF
--- a/src/cephadm/CMakeLists.txt
+++ b/src/cephadm/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(WITH_TESTS)
   include(AddCephTest)
-  add_tox_test(cephadm TOX_ENVS py3 mypy flake8)
+  add_tox_test(cephadm TOX_ENVS __tox_defaults__)
 endif()
 
 set(bin_target_file ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cephadm)

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,6 +5,8 @@ envlist =
     fix
     flake8
 skipsdist = true
+# REMINDER: run `tox -e format-black` to apply black formatting
+# with the exact same specs as `check-black` expects.
 
 [flake8]
 max-line-length = 100

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -21,15 +21,6 @@ exclude =
     .eggs
 statistics = True
 
-[autopep8]
-addopts =
-    --max-line-length {[flake8]max-line-length} \
-    --ignore "{[flake8]ignore}" \
-    --exclude "{[flake8]exclude}" \
-    --in-place \
-    --recursive \
-    --ignore-local-config
-
 [testenv]
 skip_install=true
 deps =

--- a/src/script/run_tox.sh
+++ b/src/script/run_tox.sh
@@ -125,7 +125,11 @@ function main() {
     export CEPH_BUILD_DIR=$build_dir
     # use the wheelhouse prepared by install-deps.sh
     export PIP_FIND_LINKS="$tox_path/wheelhouse"
-    tox -c $tox_path/tox.ini -e "$tox_envs" "$@"
+    tox_cmd=(tox -c $tox_path/tox.ini)
+    if [ "$tox_envs" != "__tox_defaults__" ]; then
+        tox_cmd+=("-e" "$tox_envs")
+    fi
+    "${tox_cmd[@]}" "$@"
 }
 
 main "$@"


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/56304



<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
