### PR TITLE
squid: python: mypy version bump

### DIFF
--- a/src/mypy-constrains.txt
+++ b/src/mypy-constrains.txt
@@ -2,7 +2,7 @@
 # Unfortunately this means we have to manually update those 
 # packages regularly. 
 
-mypy==0.981
+mypy==1.1.1
 
 # global
 types-python-dateutil==0.1.3

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -57,6 +57,9 @@ class SpecialHostLabels(str, Enum):
     def to_json(self) -> str:
         return self.value
 
+    def __str__(self) -> str:
+        return self.value
+
 
 def name_to_config_section(name: str) -> ConfEntity:
     """

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -103,10 +103,10 @@ commands =
            -m progress \
            -m prometheus \
            -m rbd_support \
-	   -m rgw \
+           -m rgw \
            -m rook \
-           -m snap_schedule \
            -m selftest \
+           -m snap_schedule \
            -m stats \
            -m status \
            -m telegraf \

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py3,
-    mypy,
+    py3
+    mypy
     fix
     flake8
     jinjalint

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -65,12 +65,11 @@ commands =
     pytest {posargs:cephadm/tests/test_ssh.py}
 
 
-[testenv:mypy]
+[testenv:{,py37-,py38-,py39-,py310-}mypy]
 setenv =
     MYPYPATH = {toxinidir}/..
 passenv =
     MYPYPATH
-basepython = python3
 deps =
     -rrequirements.txt
     -c{toxinidir}/../../mypy-constrains.txt


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/56274

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
