### PR TITLE
mds/quiesce: validate awaitability of quiesce requests.

### DIFF
--- a/src/test/mds/TestQuiesceDb.cc
+++ b/src/test/mds/TestQuiesceDb.cc
@@ -514,8 +514,10 @@ TEST_F(QuiesceDbTest, QuiesceRequestValidation)
           << bool(expiration) << ", await: " 
           << bool(await) << ", roots.size(): " << roots.size();
       } else {
-        // if set id is provided, all goes
-        if (set_id) {
+        if (!r.is_awaitable() && r.await) {
+          EXPECT_FALSE(r.is_valid());
+        } else if (set_id) {
+          // if set id is provided, all goes
           EXPECT_TRUE(r.is_valid())
             << "op: " << r.op_string() << ", set_id: " << bool(set_id) 
             << ", if_version: " << bool(if_version) 


### PR DESCRIPTION
A minor issue has been reported by the QE, that `--await` was accepted on a `--cancel` operation and affected the result code.
This change defines strict "awaitability" of quiesce db operations and validates that `--await` is only accepted on operations that support it. 

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
