### PR TITLE
cpatch: add --run-before command line option

### DIFF
--- a/src/script/cpatch.py
+++ b/src/script/cpatch.py
@@ -221,6 +221,10 @@ class CLIContext:
     def cephadm_build_args(self):
         return list(self._cli.cephadm_build_arg or [])
 
+    @property
+    def run_before_commands(self):
+        return list(self._cli.run_before or [])
+
     def build_components(self):
         if self._cli.components:
             return self._cli.components
@@ -314,6 +318,11 @@ class CLIContext:
             "-A",
             action="append",
             help="Pass additional arguments to cephadm build script.",
+        )
+        parser.add_argument(
+            "--run-before",
+            action="append",
+            help="Add a RUN command before other actions"
         )
         # selectors
         component_selections = [
@@ -441,6 +450,8 @@ class Builder:
     def build(self):
         """Build the container image."""
         dlines = [f"FROM {self._ctx.base_image}"]
+        for cmd in self._ctx.run_before_commands:
+            dlines.append(f'RUN {cmd}')
         jcount = len(self._jobs)
         for idx, (component, job) in enumerate(self._jobs):
             num = idx + 1

--- a/src/script/cpatch.py
+++ b/src/script/cpatch.py
@@ -467,8 +467,10 @@ class Builder:
     def _container_build(self):
         log.info("Building container image")
         cmd = [self._ctx.engine, "build", "--tag", self._ctx.target, "."]
+        cmd.append('--net=host')
         if self._ctx.root_build:
             cmd.insert(0, "sudo")
+        log.debug("Container build command: %r", cmd)
         _run(cmd, cwd=self._workdir).check_returncode()
 
     def _build_tar(


### PR DESCRIPTION
Add a `--run-before` command line argument to cpatch.py that allows
commands to be executed before doing any other layer generation.
This supports actions like customizing packages installed in the
image. Something that can be handy when developing new features.

I've been using this hack when working on the smb mgr module PR successfully.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
  - [x] Dev tool
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Dev tool

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
