### PR TITLE
pybind: support RHEL8, whose default python is python 3.6.8

### DIFF
--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -117,7 +117,8 @@ def check_sanity():
             extra_preargs=['-iquote{path}'.format(path=os.path.join(CEPH_SRC_DIR, 'include'))]
         )
 
-        if ldflags := os.environ.get('LDFLAGS'):
+        ldflags = os.environ.get('LDFLAGS')
+        if ldflags:
             extra_postargs = ldflags.split()
         else:
             extra_postargs = None

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -112,7 +112,8 @@ def check_sanity():
             sources=[tmp_file],
             output_dir=tmp_dir
         )
-        if ldflags := os.environ.get('LDFLAGS'):
+        ldflags = os.environ.get('LDFLAGS')
+        if ldflags:
             extra_postargs = ldflags.split()
         else:
             extra_postargs = None

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -116,7 +116,8 @@ def check_sanity():
             output_dir=tmp_dir
         )
 
-        if ldflags := os.environ.get('LDFLAGS'):
+        ldflags = os.environ.get('LDFLAGS')
+        if ldflags:
             extra_postargs = ldflags.split()
         else:
             extra_postargs = None

--- a/src/pybind/rgw/setup.py
+++ b/src/pybind/rgw/setup.py
@@ -116,7 +116,8 @@ def check_sanity():
             output_dir=tmp_dir,
         )
 
-        if ldflags := os.environ.get('LDFLAGS'):
+        ldflags = os.environ.get('LDFLAGS')
+        if ldflags:
             extra_postargs = ldflags.split()
         else:
             extra_postargs = None


### PR DESCRIPTION
# pybind: support RHEL8, whose default python is python 3.6.8

It seems the shaman CentOS8 builders, which serve as the base for container images, aren't current with the ":=" syntax. Amend to support RHEL8, whose default python is python 3.6.8.

- commit: f68248944815acbf5fb08ef66f36da6d5baef824
- PR: #56241

# Error example 
from https://shaman.ceph.com/builds/ceph/ceph-nvmeof-mon/27188b78bdbaa3c33de518b8514906de629e774a/default/388913/

```shell
  File "/home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/19.0.0-2505-g27188b78/rpm/el8/BUILD/ceph-19.0.0-2505-g27188b78/src/pybind/cephfs/setup.py", line 120
    if ldflags := os.environ.get('LDFLAGS'):
                ^
SyntaxError: invalid syntax
```
