### PR TITLE
squid: mgr/dashboard: s/active_mds/active_nfs in fs attach form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mount-details/cephfs-mount-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-mount-details/cephfs-mount-details.component.ts
@@ -21,7 +21,7 @@ export class CephfsMountDetailsComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.mount = `sudo mount -t ceph <CLIENT_USER>@${this.mountData?.fsId}.${this.mountData?.fsName}=${this.mountData?.rootPath} ${this.MOUNT_DIRECTORY}`;
     this.fuse = `sudo ceph-fuse  ${this.MOUNT_DIRECTORY} -r ${this.mountData?.rootPath} --client_mds_namespace=${this.mountData?.fsName}`;
-    this.nfs = `sudo mount -t nfs -o port=<PORT> <IP of active_mds daemon>:<export_name> ${this.MOUNT_DIRECTORY}`;
+    this.nfs = `sudo mount -t nfs -o port=<PORT> <IP of active_nfs daemon>:<export_name> ${this.MOUNT_DIRECTORY}`;
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65191

---

backport of https://github.com/ceph/ceph/pull/56504
parent tracker: https://tracker.ceph.com/issues/65173

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh