### PR TITLE
reef: mgr/dashboard: fix clone unique validator for name validation

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.ts
@@ -275,14 +275,15 @@ export class CephfsSubvolumeSnapshotsListComponent implements OnInit, OnChanges 
           ],
           required: true,
           errors: {
-            pattern: $localize`Allowed characters are letters, numbers, '.', '-', '+', ':' or '_'`
+            pattern: $localize`Allowed characters are letters, numbers, '.', '-', '+', ':' or '_'`,
+            notUnique: $localize`A subvolume or clone with this name already exists.`
           }
         },
         {
           type: 'select',
           name: 'groupName',
           value: this.activeGroupName,
-          label: $localize`Group Name`,
+          label: $localize`Group name`,
           typeConfig: {
             options: allGroups
           }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65196

---

backport of https://github.com/ceph/ceph/pull/56468
parent tracker: https://tracker.ceph.com/issues/65145

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh