### PR TITLE
quincy: mgr/dashboard: make ceph logo redirect to dashboard

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -13,7 +13,7 @@
       </button>
 
       <a class="navbar-brand ms-2"
-         href="#">
+         routerLink="/dashboard">
         <img src="assets/Ceph_Ceph_Logo_with_text_white.svg"
              alt="Ceph" />
       </a>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65206

---

backport of https://github.com/ceph/ceph/pull/56516
parent tracker: https://tracker.ceph.com/issues/64734

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh