### PR TITLE
[DNM] rgw: allow zone to sync from itself (cross bucket sync)

### DIFF
--- a/src/rgw/driver/rados/rgw_bucket_sync.h
+++ b/src/rgw/driver/rados/rgw_bucket_sync.h
@@ -317,6 +317,9 @@ class RGWBucketSyncPolicyHandler {
     return !sources.empty() || !resolved_sources.empty();
   }
 
+  void allow_local_sync(RGWSI_Zone *zone_svc,
+                         rgw_sync_policy_info& policy);
+
   RGWBucketSyncPolicyHandler(const RGWBucketSyncPolicyHandler *_parent,
                              const RGWBucketInfo& _bucket_info,
                              std::map<std::string, bufferlist>&& _bucket_attrs);

--- a/src/rgw/driver/rados/rgw_cr_rados.h
+++ b/src/rgw/driver/rados/rgw_cr_rados.h
@@ -1572,20 +1572,18 @@ class RGWAsyncStatObj : public RGWAsyncRadosRequest {
   const DoutPrefixProvider *dpp;
   rgw::sal::RadosStore* store;
   RGWBucketInfo bucket_info;
-  rgw_obj obj;
+  rgw_obj_key key;
   uint64_t *psize;
   real_time *pmtime;
-  uint64_t *pepoch;
-  RGWObjVersionTracker *objv_tracker;
+  std::map<std::string, bufferlist> *pattrs;
 protected:
   int _send_request(const DoutPrefixProvider *dpp) override;
 public:
   RGWAsyncStatObj(const DoutPrefixProvider *dpp, RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* store,
-                  const RGWBucketInfo& _bucket_info, const rgw_obj& obj, uint64_t *psize = nullptr,
-                  real_time *pmtime = nullptr, uint64_t *pepoch = nullptr,
-                  RGWObjVersionTracker *objv_tracker = nullptr)
-	  : RGWAsyncRadosRequest(caller, cn), dpp(dpp), store(store), obj(obj), psize(psize),
-	  pmtime(pmtime), pepoch(pepoch), objv_tracker(objv_tracker) {}
+                  const RGWBucketInfo& _bucket_info, const rgw_obj_key& key, uint64_t *psize,
+                  real_time *pmtime, std::map<std::string, bufferlist> *pattrs)
+	  : RGWAsyncRadosRequest(caller, cn), dpp(dpp), store(store), key(key), psize(psize),
+	  pmtime(pmtime), pattrs(pattrs) {}
 };
 
 class RGWStatObjCR : public RGWSimpleCoroutine {
@@ -1593,17 +1591,15 @@ class RGWStatObjCR : public RGWSimpleCoroutine {
   rgw::sal::RadosStore* store;
   RGWAsyncRadosProcessor *async_rados;
   RGWBucketInfo bucket_info;
-  rgw_obj obj;
+  rgw_obj_key key;
   uint64_t *psize;
   real_time *pmtime;
-  uint64_t *pepoch;
-  RGWObjVersionTracker *objv_tracker;
+  std::map<std::string, bufferlist> *pattrs;
   RGWAsyncStatObj *req = nullptr;
  public:
   RGWStatObjCR(const DoutPrefixProvider *dpp, RGWAsyncRadosProcessor *async_rados, rgw::sal::RadosStore* store,
-	  const RGWBucketInfo& _bucket_info, const rgw_obj& obj, uint64_t *psize = nullptr,
-	  real_time* pmtime = nullptr, uint64_t *pepoch = nullptr,
-	  RGWObjVersionTracker *objv_tracker = nullptr);
+	  const RGWBucketInfo& _bucket_info, const rgw_obj_key& key, uint64_t *psize = nullptr,
+	  real_time* pmtime = nullptr, std::map<std::string, bufferlist> *pattrs = nullptr);
   ~RGWStatObjCR() override {
     request_cleanup();
   }

--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -653,9 +653,12 @@ int RGWDataChangesLog::add_entry(const DoutPrefixProvider *dpp,
 				 const rgw::bucket_log_layout_generation& gen,
 				 int shard_id, optional_yield y)
 {
+#warning FIXME
+#if 0
   if (!zone->log_data) {
     return 0;
   }
+#endif
 
   auto& bucket = bucket_info.bucket;
 

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -76,7 +76,10 @@ bool RGWSI_Zone::zone_syncs_from(const RGWZone& source_zone) const
       break;
     }
   }
-  return found && target_zone.syncs_from(source_zone.name) &&
+
+#warning conditional
+  bool can_sync_from = found && (target_zone.syncs_from(source_zone.name) || target_zone.id == source_zone.id);
+  return can_sync_from &&
          sync_modules_svc->get_manager()->supports_data_export(source_zone.tier_type);
 }
 
@@ -347,9 +350,12 @@ int RGWSI_Zone::do_start(optional_yield y, const DoutPrefixProvider *dpp)
   for (const auto& ziter : zonegroup->zones) {
     const rgw_zone_id& id = ziter.first;
     const RGWZone& z = ziter.second;
+#warning make this conditional
+#if 0
     if (id == zone_id()) {
       continue;
     }
+#endif
     if (z.endpoints.empty()) {
       ldpp_dout(dpp, 0) << "WARNING: can't generate connection for zone " << z.id << " id " << z.name << ": no endpoints defined" << dendl;
       continue;
@@ -729,7 +735,10 @@ bool RGWSI_Zone::need_to_sync() const
 
 bool RGWSI_Zone::need_to_log_data() const
 {
-  return (zone_public_config->log_data && sync_module_exports_data());
+#warning FIXME
+#if 1
+  return ((1 || zone_public_config->log_data) && sync_module_exports_data());
+#endif
 }
 
 bool RGWSI_Zone::is_meta_master() const


### PR DESCRIPTION
Enable zone sync to happen from itself. This is probably not the most efficient way to achieve cross bucket sync (within the same zone) functionality, however, it a very minimal change.
Would need to be conditionally enabled.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
