### PR TITLE
squid: mds: do not dispatch aborted internal requests

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -9818,6 +9818,11 @@ void MDCache::dispatch_request(const MDRequestRef& mdr)
   } else if (mdr->peer_request) {
     mds->server->dispatch_peer_request(mdr);
   } else {
+    if (mdr->aborted) {
+      mdr->aborted = false;
+      request_kill(mdr);
+      return;
+    }
     switch (mdr->internal_op) {
     case CEPH_MDS_OP_QUIESCE_PATH:
       dispatch_quiesce_path(mdr);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65214

---

backport of https://github.com/ceph/ceph/pull/56536
parent tracker: https://tracker.ceph.com/issues/65182

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh