### PR TITLE
rgw/sts: correcting authentication in case s3 ops are directed to a primary from secondary after assumerole.

### DIFF
--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -18,5 +18,7 @@ overrides:
         rgw sync obj etag verify: true
         rgw sync meta inject err probability: 0.1
         rgw sync data inject err probability: 0.1
+        rgw s3 auth use sts: true
+        rgw sts key: abcdefghijklmnoq
   rgw:
     compression type: random

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -924,6 +924,9 @@ void rgw::auth::RoleApplier::modify_request_state(const DoutPrefixProvider *dpp,
   for (auto& it : token_attrs.token_claims) {
     s->token_claims.emplace_back(it);
   }
+  if (is_system_request) {
+    s->system_request = true;
+  }
 }
 
 rgw::auth::Engine::result_t

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -720,14 +720,17 @@ public:
 protected:
   Role role;
   TokenAttrs token_attrs;
+  bool is_system_request;
 
 public:
 
   RoleApplier(CephContext* const cct,
                const Role& role,
-               const TokenAttrs& token_attrs)
+               const TokenAttrs& token_attrs,
+               bool is_system_request)
     : role(role),
-      token_attrs(token_attrs) {}
+      token_attrs(token_attrs),
+      is_system_request(is_system_request) {}
 
   uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override {
     return 0;
@@ -755,7 +758,8 @@ public:
     virtual aplptr_t create_apl_role( CephContext* cct,
                                       const req_state* s,
                                       const rgw::auth::RoleApplier::Role& role,
-                                      const rgw::auth::RoleApplier::TokenAttrs& token_attrs) const = 0;
+                                      const rgw::auth::RoleApplier::TokenAttrs& token_attrs,
+                                      bool is_system_request) const = 0;
     };
 };
 

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -67,9 +67,10 @@ class STSAuthStrategy : public rgw::auth::Strategy,
   aplptr_t create_apl_role(CephContext* const cct,
                             const req_state* const s,
                             const rgw::auth::RoleApplier::Role& role,
-                            const rgw::auth::RoleApplier::TokenAttrs& token_attrs) const override {
+                            const rgw::auth::RoleApplier::TokenAttrs& token_attrs,
+                            bool is_system_request) const override {
     auto apl = rgw::auth::add_sysreq(cct, driver, s,
-      rgw::auth::RoleApplier(cct, role, token_attrs));
+      rgw::auth::RoleApplier(cct, role, token_attrs, is_system_request));
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -6421,6 +6421,7 @@ rgw::auth::s3::STSEngine::authenticate(
   const req_state* const s,
   optional_yield y) const
 {
+  bool is_system_request{false};
   if (! s->info.args.exists("x-amz-security-token") &&
       ! s->info.env->exists("HTTP_X_AMZ_SECURITY_TOKEN") &&
       s->auth.s3_postobj_creds.x_amz_security_token.empty()) {
@@ -6432,10 +6433,36 @@ rgw::auth::s3::STSEngine::authenticate(
     return result_t::reject(ret);
   }
   //Authentication
+  std::string secret_access_key;
   //Check if access key is not the same passed in by client
   if (token.access_key_id != _access_key_id) {
-    ldpp_dout(dpp, 0) << "Invalid access key" << dendl;
-    return result_t::reject(-EPERM);
+    /* In case the request is forwarded from secondary in case of multi-site,
+      we by-pass authentication using the session token credentials,
+      instead we use the system user's credentials that was used to sign
+      this request */
+    std::unique_ptr<rgw::sal::User> user;
+    const std::string access_key_id(_access_key_id);
+    if (driver->get_user_by_access_key(dpp, access_key_id, y, &user) < 0) {
+        ldpp_dout(dpp, 5) << "error reading user info, uid=" << access_key_id
+                << " can't authenticate" << dendl;
+        return result_t::reject(-ERR_INVALID_ACCESS_KEY);
+    }
+    // only allow system users as this could be a forwarded request from secondary
+    if (user->get_info().system) {
+      const auto iter = user->get_info().access_keys.find(access_key_id);
+      if (iter == std::end(user->get_info().access_keys)) {
+        ldpp_dout(dpp, 0) << "ERROR: access key not encoded in user info" << dendl;
+        return result_t::reject(-EPERM);
+      }
+      const RGWAccessKey& k = iter->second;
+      secret_access_key = k.key;
+      is_system_request = true;
+    } else {
+      ldpp_dout(dpp, 0) << "Invalid access key" << dendl;
+      return result_t::reject(-EPERM);
+    }
+  } else {
+    secret_access_key = token.secret_access_key;
   }
   //Check if the token has expired
   if (! token.expiration.empty()) {
@@ -6456,7 +6483,7 @@ rgw::auth::s3::STSEngine::authenticate(
   }
   //Check for signature mismatch
   const VersionAbstractor::server_signature_t server_signature = \
-    signature_factory(cct, token.secret_access_key, string_to_sign);
+    signature_factory(cct, secret_access_key, string_to_sign);
   auto compare = signature.compare(server_signature);
 
   ldpp_dout(dpp, 15) << "string_to_sign="
@@ -6515,8 +6542,8 @@ rgw::auth::s3::STSEngine::authenticate(
     t_attrs.token_claims = std::move(token.token_claims);
     t_attrs.token_issued_at = std::move(token.issued_at);
     t_attrs.principal_tags = std::move(token.principal_tags);
-    auto apl = role_apl_factory->create_apl_role(cct, s, r, t_attrs);
-    return result_t::grant(std::move(apl), completer_factory(token.secret_access_key));
+    auto apl = role_apl_factory->create_apl_role(cct, s, r, t_attrs, is_system_request);
+    return result_t::grant(std::move(apl), completer_factory(secret_access_key));
   } else { // This is for all local users of type TYPE_RGW or TYPE_NONE
     string subuser;
     auto apl = local_apl_factory->create_apl_local(cct, s, user->get_info(), subuser, token.perm_mask, std::string(_access_key_id));

--- a/src/test/rgw/rgw_multi/conn.py
+++ b/src/test/rgw/rgw_multi/conn.py
@@ -1,7 +1,9 @@
 import boto
 import boto.s3.connection
 import boto.iam.connection
+import boto.sts.connection
 import boto3
+from boto.regioninfo import RegionInfo
 
 def get_gateway_connection(gateway, credentials):
     """ connect to the given gateway """
@@ -41,6 +43,19 @@ def get_gateway_iam_connection(gateway, credentials):
                 is_secure = False)
     return gateway.iam_connection
 
+def get_gateway_sts_connection(gateway, credentials):
+    """ connect to sts api of the given gateway """
+    if gateway.sts_connection is None:
+        sts_region = RegionInfo(name='', endpoint=gateway.host, connection='STSConnection')
+        gateway.sts_connection = boto.connect_sts(
+                aws_access_key_id = credentials.access_key,
+                aws_secret_access_key = credentials.secret,
+                port = gateway.port,
+                region = sts_region,
+                is_secure = False,
+                validate_certs=False,)
+    return gateway.sts_connection
+
 
 def get_gateway_s3_client(gateway, credentials, region):
   """ connect to boto3 s3 client api of the given gateway """
@@ -62,3 +77,13 @@ def get_gateway_sns_client(gateway, credentials, region):
                                         aws_secret_access_key=credentials.secret,
                                         region_name=region)
   return gateway.sns_client
+
+def get_gateway_temp_s3_client(gateway, credentials, session_token, region):
+  """ connect to boto3 s3 client api using temporary credntials """
+  gateway.temp_s3_client = boto3.client('s3',
+                        endpoint_url='http://' + gateway.host + ':' + str(gateway.port),
+                        aws_access_key_id=credentials.access_key,
+                        aws_secret_access_key=credentials.secret,
+                        aws_session_token = session_token,
+                        region_name=region)
+  return gateway.temp_s3_client

--- a/src/test/rgw/rgw_multi/multisite.py
+++ b/src/test/rgw/rgw_multi/multisite.py
@@ -3,7 +3,7 @@ from io import StringIO
 
 import json
 
-from .conn import get_gateway_connection, get_gateway_iam_connection, get_gateway_secure_connection, get_gateway_s3_client, get_gateway_sns_client
+from .conn import get_gateway_connection, get_gateway_iam_connection, get_gateway_secure_connection, get_gateway_s3_client, get_gateway_sns_client, get_gateway_sts_connection, get_gateway_temp_s3_client
 
 class Cluster:
     """ interface to run commands against a distinct ceph cluster """
@@ -29,6 +29,7 @@ class Gateway:
         self.iam_connection = None
         self.s3_client = None
         self.sns_client = None
+        self.sts_connection = None
 
     @abstractmethod
     def start(self, args = []):
@@ -174,11 +175,11 @@ class Zone(SystemObject, SystemObject.CreateDelete, SystemObject.GetSet, SystemO
     def has_roles(self):
         return True
 
-    def get_conn(self, credentials):
-        return ZoneConn(self, credentials) # not implemented, but can be used
+    def get_conn(self, credentials, alt_user_credentials):
+        return ZoneConn(self, credentials, alt_user_credentials) # not implemented, but can be used
 
 class ZoneConn(object):
-    def __init__(self, zone, credentials):
+    def __init__(self, zone, credentials, alt_user_credentials):
         self.zone = zone
         self.name = zone.name
         """ connect to the zone's first gateway """
@@ -187,21 +188,29 @@ class ZoneConn(object):
         else:
             self.credentials = credentials
 
+        if isinstance(alt_user_credentials, list):
+            self.alt_user_creds = alt_user_credentials[0]
+        else:
+            self.alt_user_creds = alt_user_credentials
+
         if self.zone.gateways is not None:
             self.conn = get_gateway_connection(self.zone.gateways[0], self.credentials)
             self.secure_conn = get_gateway_secure_connection(self.zone.gateways[0], self.credentials)
 
             self.iam_conn = get_gateway_iam_connection(self.zone.gateways[0], self.credentials)
+            self.sts_conn = get_gateway_sts_connection(self.zone.gateways[0], self.alt_user_creds)
             region = "" if self.zone.zonegroup is None else self.zone.zonegroup.name
+            self.region = region
             self.s3_client = get_gateway_s3_client(self.zone.gateways[0], self.credentials, region)
             self.sns_client = get_gateway_sns_client(self.zone.gateways[0], self.credentials,region)
-
+            self.temp_s3_client = None
             # create connections for the rest of the gateways (if exist)
             for gw in list(self.zone.gateways):
                 get_gateway_connection(gw, self.credentials)
                 get_gateway_secure_connection(gw, self.credentials)
 
                 get_gateway_iam_connection(gw, self.credentials)
+                get_gateway_sts_connection(gw, self.alt_user_creds)
 
 
     def get_connection(self):
@@ -209,6 +218,13 @@ class ZoneConn(object):
 
     def get_iam_connection(self):
         return self.iam_conn
+
+    def get_sts_connection(self):
+        return self.sts_conn
+
+    def get_temp_s3_connection(self, credentials, session_token):
+        self.temp_s3_client = get_gateway_temp_s3_client(self.zone.gateways[0], credentials, session_token, self.region)
+        return self.temp_s3_client
 
     def get_bucket(self, bucket_name, credentials):
         raise NotImplementedError

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -41,18 +41,24 @@ class Config:
 # implementations of these interfaces by calling init_multi()
 realm = None
 user = None
+alt_user = None
 config = None
-def init_multi(_realm, _user, _config=None):
+def init_multi(_realm, _user, _alt_user, _config=None):
     global realm
     realm = _realm
     global user
     user = _user
+    global alt_user
+    alt_user = _alt_user
     global config
     config = _config or Config()
     realm_meta_checkpoint(realm)
 
 def get_user():
     return user.id if user is not None else ''
+
+def get_alt_user():
+    return alt_user.id if alt_user is not None else ''
 
 def get_tenant():
     return config.tenant if config is not None and config.tenant is not None else ''
@@ -472,7 +478,7 @@ class ZonegroupConns:
         self.master_zone = None
 
         for z in zonegroup.zones:
-            zone_conn = z.get_conn(user.credentials)
+            zone_conn = z.get_conn(user.credentials, alt_user.credentials)
             self.zones.append(zone_conn)
             if z.is_read_only():
                 self.ro_zones.append(zone_conn)
@@ -642,6 +648,9 @@ def check_bucket_eq(zone_conn1, zone_conn2, bucket):
 def check_role_eq(zone_conn1, zone_conn2, role):
     if zone_conn2.zone.has_roles():
         zone_conn2.check_role_eq(zone_conn1, role['create_role_response']['create_role_result']['role']['role_name'])
+
+def test_assume_role_bucket_create(zone_conn, bucket, role_arn, session_name):
+    zone_conn.assume_role_create_bucket(bucket, role_arn, session_name)
 
 def test_object_sync():
     zonegroup = realm.master_zonegroup()
@@ -1800,6 +1809,33 @@ def test_role_delete_sync():
         assert(not zone.has_role(role_name))
         log.info(f'success, zone: {zone.name} does not have role: {role_name}')
 
+
+def test_assume_role_after_sync():
+    zonegroup = realm.master_zonegroup()
+    zonegroup_conns = ZonegroupConns(zonegroup)
+    role_name = gen_role_name()
+    log.info('create role zone=%s name=%s', zonegroup_conns.master_zone.name, role_name)
+    policy_document = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam:::user/alt_tester\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+    role = zonegroup_conns.master_zone.create_role("", role_name, policy_document, "")
+    policy_document = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Resource\":\"*\",\"Action\":\"s3:*\"}]}"
+    zonegroup_conns.master_zone.put_role_policy(role_name, "Policy1", policy_document)
+
+    zonegroup_meta_checkpoint(zonegroup)
+
+    for zone in zonegroup_conns.zones:
+        log.info(f'checking if zone: {zone.name} has role: {role_name}')
+        assert(zone.has_role(role_name))
+        log.info(f'success, zone: {zone.name} has role: {role_name}')
+    
+    for zone in zonegroup_conns.zones:
+        if zone == zonegroup_conns.master_zone:
+            log.info(f'creating bucket in primary zone')
+            bucket = "bucket1"
+            test_assume_role_bucket_create(zone, bucket, role['create_role_response']['create_role_result']['role']['arn'], "primary")
+        if zone != zonegroup_conns.master_zone:
+            log.info(f'creating bucket in secondary zone')
+            bucket = "bucket2"
+            test_assume_role_bucket_create(zone, bucket, role['create_role_response']['create_role_result']['role']['arn'], "secondary")
 
 @attr('data_sync_init')
 def test_bucket_full_sync_after_data_sync_init():

--- a/src/test/rgw/rgw_multi/zone_cloud.py
+++ b/src/test/rgw/rgw_multi/zone_cloud.py
@@ -261,8 +261,8 @@ class CloudZone(Zone):
         return False
 
     class Conn(ZoneConn):
-        def __init__(self, zone, credentials):
-            super(CloudZone.Conn, self).__init__(zone, credentials)
+        def __init__(self, zone, credentials, alt_user_credentials):
+            super(CloudZone.Conn, self).__init__(zone, credentials, alt_user_credentials)
 
         def get_bucket(self, bucket_name):
             return CloudZoneBucket(self, self.zone.target_path, bucket_name)
@@ -310,6 +310,9 @@ class CloudZone(Zone):
         def has_role(self, role_name):
             assert False
 
+        def put_role_policy(self, rolename, policyname, policy_document):
+            assert False
+
         def create_topic(self, topicname, attributes):
             assert False
 
@@ -331,8 +334,11 @@ class CloudZone(Zone):
         def list_notifications(self, bucket_name):
             assert False
 
-    def get_conn(self, credentials):
-        return self.Conn(self, credentials)
+        def assume_role(self, role_arn, session_name, policy, duration_seconds):
+            assert False
+
+    def get_conn(self, credentials, alt_user_credentials):
+        return self.Conn(self, credentials, alt_user_credentials)
 
 
 class CloudZoneConfig:

--- a/src/test/rgw/rgw_multi/zone_es.py
+++ b/src/test/rgw/rgw_multi/zone_es.py
@@ -203,8 +203,8 @@ class ESZone(Zone):
         return False
 
     class Conn(ZoneConn):
-        def __init__(self, zone, credentials):
-            super(ESZone.Conn, self).__init__(zone, credentials)
+        def __init__(self, zone, credentials, alt_user_credentials):
+            super(ESZone.Conn, self).__init__(zone, credentials, alt_user_credentials)
 
         def get_bucket(self, bucket_name):
             return ESZoneBucket(self, bucket_name, self.conn)
@@ -252,6 +252,9 @@ class ESZone(Zone):
         def has_role(self, role_name):
             assert False
 
+        def put_role_policy(self, rolename, policyname, policy_document):
+            assert False
+
         def create_topic(self, topicname, attributes):
             assert False
 
@@ -273,8 +276,11 @@ class ESZone(Zone):
         def list_notifications(self, bucket_name):
             assert False
 
-    def get_conn(self, credentials):
-        return self.Conn(self, credentials)
+        def assume_role(self, role_arn, session_name, policy, duration_seconds):
+            assert False
+
+    def get_conn(self, credentials, alt_user_credentials):
+        return self.Conn(self, credentials, alt_user_credentials)
 
 
 class ESZoneConfig:

--- a/src/test/rgw/rgw_multi/zone_rados.py
+++ b/src/test/rgw/rgw_multi/zone_rados.py
@@ -46,8 +46,8 @@ class RadosZone(Zone):
 
 
     class Conn(ZoneConn):
-        def __init__(self, zone, credentials):
-            super(RadosZone.Conn, self).__init__(zone, credentials)
+        def __init__(self, zone, credentials, alt_user_credentials):
+            super(RadosZone.Conn, self).__init__(zone, credentials, alt_user_credentials)
 
         def get_bucket(self, name):
             return self.conn.get_bucket(name)
@@ -142,6 +142,11 @@ class RadosZone(Zone):
                 return False
             return True
 
+        def put_role_policy(self, rolename, policyname, policy_document):
+            if policy_document is None:
+                policy_document = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Resource\":\"*\",\"Action\":\"s3:*\"}]}"
+            return self.iam_conn.put_role_policy(rolename, policyname, policy_document)
+
         def create_topic(self, topicname, attributes):
             result = self.sns_client.create_topic(Name=topicname, Attributes=attributes)
             self.topic_arn = result['TopicArn']
@@ -170,6 +175,13 @@ class RadosZone(Zone):
               return out['TopicConfigurations']
             return []
 
-    def get_conn(self, credentials):
-        return self.Conn(self, credentials)
+        def assume_role_create_bucket(self, bucket, role_arn, session_name):
+            assumed_role_object = self.sts_conn.assume_role(role_arn, session_name)
+            assumed_role_credentials = assumed_role_object.credentials
+            credentials = Credentials(assumed_role_credentials.access_key, assumed_role_credentials.secret_key)
+            self.get_temp_s3_connection(credentials, assumed_role_credentials.session_token)
+            self.temp_s3_client.create_bucket(Bucket=bucket)
+
+    def get_conn(self, credentials, alt_user_credentials):
+        return self.Conn(self, credentials, alt_user_credentials)
 

--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -248,6 +248,9 @@ def init(parse_args):
     user_creds = gen_credentials()
     user = multisite.User('tester', tenant=args.tenant)
 
+    alt_user_creds = gen_credentials()
+    alt_user = multisite.User('alt_tester', tenant=args.tenant)
+
     realm = multisite.Realm('r')
     if bootstrap:
         # create the realm on c1
@@ -385,6 +388,10 @@ def init(parse_args):
                     arg = ['--display-name', '"Test User"', '--caps', 'roles=*']
                     arg += user_creds.credential_args()
                     user.create(zone, arg)
+                    #create alt user
+                    arg = ['--display-name', '"Alt Test User"']
+                    arg += alt_user_creds.credential_args()
+                    alt_user.create(zone, arg)
                 else:
                     # read users and update keys
                     admin_user.info(zone)
@@ -392,6 +399,9 @@ def init(parse_args):
                     arg = []
                     user.info(zone, arg)
                     user_creds = user.credentials[0]
+                    arg = []
+                    alt_user.info(zone, arg)
+                    alt_user_creds = alt_user.credentials[0]
 
     if not bootstrap:
         period.get(c1)
@@ -400,7 +410,7 @@ def init(parse_args):
                     checkpoint_delay=args.checkpoint_delay,
                     reconfigure_delay=args.reconfigure_delay,
                     tenant=args.tenant)
-    init_multi(realm, user, config)
+    init_multi(realm, user, alt_user, config)
 
 def setup_module():
     init(False)


### PR DESCRIPTION
rgw/sts: by-passing authentication using temp creds
in case the request is forwarded from secondary in a multi-site setup. authenticating with the system user creds of which are used to sign the request.
Permissions are still derived from the role.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
