### PR TITLE
mgr/dashboard: Filter alerts based on cluster fsid and do not allow to connect clusters with version less than hub cluster in multi-cluster

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/multi_cluster.py
+++ b/src/pybind/mgr/dashboard/controllers/multi_cluster.py
@@ -128,6 +128,16 @@ class MultiCluster(RESTController):
 
     def check_cluster_connection(self, url, payload, username, ssl_verify, ssl_certificate):
         try:
+            hub_cluster_version = mgr.version.split('ceph version ')[1]
+            multi_cluster_content = self._proxy('GET', url, 'api/multi-cluster/get_config',
+                                                verify=ssl_verify, cert=ssl_certificate)
+            if 'status' in multi_cluster_content and multi_cluster_content['status'] == '404 Not Found':   # noqa E501 #pylint: disable=line-too-long
+                raise DashboardException(msg=f'The ceph cluster you are attempting to connect \
+                                         to does not support the multi-cluster feature. \
+                                         Please ensure that the cluster you are connecting \
+                                         to is upgraded to { hub_cluster_version } to enable the \
+                                         multi-cluster functionality.',
+                                         code='invalid_version', component='multi-cluster')
             content = self._proxy('POST', url, 'api/auth', payload=payload,
                                   verify=ssl_verify, cert=ssl_certificate)
             if 'token' not in content:

--- a/src/pybind/mgr/dashboard/controllers/prometheus.py
+++ b/src/pybind/mgr/dashboard/controllers/prometheus.py
@@ -126,7 +126,13 @@ class PrometheusRESTController(RESTController):
 @APIRouter('/prometheus', Scope.PROMETHEUS)
 @APIDoc("Prometheus Management API", "Prometheus")
 class Prometheus(PrometheusRESTController):
-    def list(self, **params):
+    def list(self, cluster_filter=False, **params):
+        if cluster_filter:
+            try:
+                fsid = mgr.get('config')['fsid']
+            except KeyError:
+                raise DashboardException("Cluster fsid not found", component='prometheus')
+            return self.alert_proxy('GET', f'/alerts?filter=cluster={fsid}', params)
         return self.alert_proxy('GET', '/alerts', params)
 
     @RESTController.Collection(method='GET')

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster.component.html
@@ -86,7 +86,7 @@
                      [fullHeight]="true"
                      *ngIf="queriesResults.CLUSTER_COUNT && queriesResults.CLUSTER_COUNT[0]">
               <span class="text-center">
-                <h3 *ngIf="queriesResults['HEALTH_ERROR_COUNT'][0][1] === '0' && queriesResults['HEALTH_WARNING_COUNT'][0][1] === '0'">{{ queriesResults.CLUSTER_COUNT[0][1] }}</h3>
+                <h3 *ngIf="queriesResults['HEALTH_ERROR_COUNT'][0][1] === '0' && queriesResults['HEALTH_OK_COUNT'][0][1] === '0' && queriesResults['HEALTH_WARNING_COUNT'][0][1] === '0'">{{ queriesResults.CLUSTER_COUNT[0][1] }}</h3>
                 <h3 class="text-danger"
                     *ngIf="queriesResults.HEALTH_ERROR_COUNT[0][1] !== '0'">
                   <i [ngClass]="icons.danger"></i>
@@ -96,6 +96,16 @@
                     *ngIf="queriesResults.HEALTH_WARNING_COUNT[0][1] !== '0'">
                   <i [ngClass]="icons.warning"></i>
                     {{ queriesResults.HEALTH_WARNING_COUNT[0][1] }}
+                </h3>
+                <h3 class="text-danger"
+                    *ngIf="queriesResults.HEALTH_ERROR_COUNT[0][1] !== '0'">
+                  <i [ngClass]="icons.danger"></i>
+                  {{ queriesResults.HEALTH_ERROR_COUNT[0][1] }}
+                </h3>
+                <h3 class="text-success"
+                    *ngIf="queriesResults.HEALTH_OK_COUNT[0][1] !== '0'">
+                  <i [ngClass]="icons.success"></i>
+                    {{ queriesResults.HEALTH_OK_COUNT[0][1] }}
                 </h3>
               </span>
             </cd-card>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.spec.ts
@@ -14,6 +14,8 @@ import { TableActionsComponent } from '~/app/shared/datatable/table-actions/tabl
 import { SharedModule } from '~/app/shared/shared.module';
 import { configureTestBed, PermissionHelper } from '~/testing/unit-test-helper';
 import { ActiveAlertListComponent } from './active-alert-list.component';
+import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.service';
+import { of } from 'rxjs';
 
 describe('ActiveAlertListComponent', () => {
   let component: ActiveAlertListComponent;
@@ -37,6 +39,8 @@ describe('ActiveAlertListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ActiveAlertListComponent);
     component = fixture.componentInstance;
+    let prometheusAlertService = TestBed.inject(PrometheusAlertService);
+    spyOn(prometheusAlertService, 'getAlerts').and.callFake(() => of([]));
   });
 
   it('should create', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/active-alert-list/active-alert-list.component.ts
@@ -105,6 +105,7 @@ export class ActiveAlertListComponent extends PrometheusListHelper implements On
         cellTemplate: this.externalLinkTpl
       }
     ];
+    this.prometheusAlertService.getAlerts(true);
   }
 
   updateSelection(selection: CdTableSelection) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.spec.ts
@@ -141,13 +141,7 @@ describe('Dashbord Component', () => {
     schemas: [NO_ERRORS_SCHEMA],
     providers: [
       { provide: SummaryService, useClass: SummaryServiceMock },
-      {
-        provide: PrometheusAlertService,
-        useValue: {
-          activeCriticalAlerts: 2,
-          activeWarningAlerts: 1
-        }
-      },
+      PrometheusAlertService,
       CssHelper,
       PgCategoryService
     ]
@@ -169,11 +163,14 @@ describe('Dashbord Component', () => {
     orchestratorService = TestBed.inject(OrchestratorService);
     getHealthSpy = spyOn(TestBed.inject(HealthService), 'getMinimalHealth');
     getHealthSpy.and.returnValue(of(healthPayload));
-    spyOn(TestBed.inject(PrometheusService), 'ifAlertmanagerConfigured').and.callFake((fn) => fn());
     getAlertsSpy = spyOn(TestBed.inject(PrometheusService), 'getAlerts');
     getAlertsSpy.and.returnValue(of(alertsPayload));
     component.prometheusAlertService.alerts = alertsPayload;
     component.isAlertmanagerConfigured = true;
+    let prometheusAlertService = TestBed.inject(PrometheusAlertService);
+    spyOn(prometheusAlertService, 'getAlerts').and.callFake(() => of([]));
+    prometheusAlertService.activeCriticalAlerts = 2;
+    prometheusAlertService.activeWarningAlerts = 1;
   });
 
   it('should create', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.ts
@@ -120,6 +120,7 @@ export class DashboardV3Component extends PrometheusListHelper implements OnInit
     this.getDetailsCardData();
     this.getTelemetryReport();
     this.managedByConfig$ = this.settingsService.getValues('MANAGED_BY_CLUSTERS');
+    this.prometheusAlertService.getAlerts(true);
   }
 
   getTelemetryText(): string {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/prometheus.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/prometheus.service.spec.ts
@@ -30,7 +30,7 @@ describe('PrometheusService', () => {
 
   it('should get alerts', () => {
     service.getAlerts().subscribe();
-    const req = httpTesting.expectOne('api/prometheus');
+    const req = httpTesting.expectOne('api/prometheus?cluster_filter=false');
     expect(req.request.method).toBe('GET');
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/prometheus.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/prometheus.service.ts
@@ -58,7 +58,8 @@ export class PrometheusService {
     this.disableSetting(this.settingsKey.prometheus);
   }
 
-  getAlerts(params = {}): Observable<AlertmanagerAlert[]> {
+  getAlerts(clusterFilteredAlerts = false, params = {}): Observable<AlertmanagerAlert[]> {
+    params['cluster_filter'] = clusterFilteredAlerts;
     return this.http.get<AlertmanagerAlert[]>(this.baseURL, { params });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.ts
@@ -154,7 +154,7 @@ export class NotificationsSidebarComponent implements OnInit, OnDestroy {
   }
 
   private triggerPrometheusAlerts() {
-    this.prometheusAlertService.refresh();
+    this.prometheusAlertService.refresh(true);
     this.prometheusNotificationService.refresh();
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.ts
@@ -26,9 +26,9 @@ export class PrometheusAlertService {
     private prometheusService: PrometheusService
   ) {}
 
-  getAlerts() {
+  getAlerts(clusterFilteredAlerts?: boolean) {
     this.prometheusService.ifAlertmanagerConfigured(() => {
-      this.prometheusService.getAlerts().subscribe(
+      this.prometheusService.getAlerts(clusterFilteredAlerts).subscribe(
         (alerts) => this.handleAlerts(alerts),
         (resp) => {
           if ([404, 504].includes(resp.status)) {
@@ -54,8 +54,8 @@ export class PrometheusAlertService {
     });
   }
 
-  refresh() {
-    this.getAlerts();
+  refresh(clusterFilteredAlerts?: boolean) {
+    this.getAlerts(clusterFilteredAlerts);
     this.getRules();
   }
 

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -10300,7 +10300,12 @@ paths:
       - Pool
   /api/prometheus:
     get:
-      parameters: []
+      parameters:
+      - default: false
+        in: query
+        name: cluster_filter
+        schema:
+          type: boolean
       responses:
         '200':
           content:


### PR DESCRIPTION
1. Since we have a new `cluster` variable in the prometheus metrics , we need to filter the alerts based on the cluster fsid.
2. Do not allow to connect clusters with version less than 7.1 in multi-cluster

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
