### PR TITLE
test/on_exit: use static variables for on_exit hooks

### DIFF
--- a/src/test/on_exit.cc
+++ b/src/test/on_exit.cc
@@ -26,13 +26,11 @@ static void func_scope(void)
 {
   OnExitManager mgr;
 
-  int *inc_1 = (int*)malloc(sizeof(*inc_1));
-  *inc_1 = 5;
-  mgr.add_callback(add, inc_1);
+  static int inc_1 = 5;
+  mgr.add_callback(add, &inc_1);
 
-  int *inc_2 = (int*)malloc(sizeof(*inc_2));
-  *inc_2 = 3;
-  mgr.add_callback(add, inc_2);
+  static int inc_2 = 3;
+  mgr.add_callback(add, &inc_2);
 }
 
 // shared between processes
@@ -84,9 +82,8 @@ int main(int argc, char **argv)
     // exits by returning from main. The parent checks the value after the
     // child exits via the memory map.
     ceph_assert(*shared_val == 0);
-    int *new_val = (int*)malloc(sizeof(*new_val));
-    *new_val = MAIN_SCOPE_VAL;
-    main_scope_mgr.add_callback(main_scope_cb, new_val);
+    static int new_val = MAIN_SCOPE_VAL;
+    main_scope_mgr.add_callback(main_scope_cb, &new_val);
     return 0;
   }
 
@@ -104,9 +101,8 @@ int main(int argc, char **argv)
     // child adds a callback to the static scope callback manager and then
     // exits via exit().
     ceph_assert(*shared_val == 0);
-    int *new_val = (int*)malloc(sizeof(*new_val));
-    *new_val = EXIT_FUNC_VAL;
-    exit_func_mgr.add_callback(exit_func_cb, new_val);
+    static int new_val = EXIT_FUNC_VAL;
+    exit_func_mgr.add_callback(exit_func_cb, &new_val);
     call_exit();
     ceph_abort();
   }


### PR DESCRIPTION
before this change, we allocate memory chunks using malloc(), but
we never free them. and LeakSanitizer points this out

```
Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x5588bfe532de in malloc (/home/jenkins-build/build/workspace/ceph-pull-requests/build/bin/unittest_on_exit+0xa52de) (BuildId: 7c7a92bf5719592938c5307214bcd9b080bd847f)
    https://github.com/tchaikov/ceph/pull/1 0x5588bfe911d7 in func_scope() /home/jenkins-build/build/workspace/ceph-pull-requests/src/test/on_exit.cc:33:22
    https://github.com/tchaikov/ceph/pull/2 0x5588bfe90804 in main /home/jenkins-build/build/workspace/ceph-pull-requests/src/test/on_exit.cc:64:3
    https://github.com/tchaikov/ceph/pull/3 0x7f23081c1d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x5588bfe532de in malloc (/home/jenkins-build/build/workspace/ceph-pull-requests/build/bin/unittest_on_exit+0xa52de) (BuildId: 7c7a92bf5719592938c5307214bcd9b080bd847f)
    https://github.com/tchaikov/ceph/pull/1 0x5588bfe91160 in func_scope() /home/jenkins-build/build/workspace/ceph-pull-requests/src/test/on_exit.cc:29:22
    https://github.com/tchaikov/ceph/pull/2 0x5588bfe90804 in main /home/jenkins-build/build/workspace/ceph-pull-requests/src/test/on_exit.cc:64:3
    https://github.com/tchaikov/ceph/pull/3 0x7f23081c1d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
```

in this change, instead of allocating the variables using `malloc()`,
we keep them in static variables, so that they can be accessed by
`OnExitManager` even if it is a static variable.
with this change, the memory leak reports for this source file go away.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
