### PR TITLE
src/rgw: Fix storage class of multipart object

### DIFF
--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -515,6 +515,7 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
 
   RGWRados::Object::Write obj_op(&op_target);
   obj_op.meta.set_mtime = set_mtime;
+  obj_op.meta.manifest = &manifest;
   obj_op.meta.mtime = mtime;
   obj_op.meta.owner = owner;
   obj_op.meta.delete_at = delete_at;


### PR DESCRIPTION
Corrected storage class of multipart objects to match the storage class of completed object. The fix here is to assigns the `manifest` in MultipartObjectProcessor, so later on, storage class metadata included in manifest will be written in accordance with the multipart object.

Fixes: https://tracker.ceph.com/issues/63428
Signed-off-by: Huy Nguyen <huynp1999@gmail.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
