### PR TITLE
Revert "mgr: use un-deprecated APIs to initialize Python interpretor"

### DIFF
--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -51,6 +51,7 @@ class PyModule
   mutable ceph::mutex lock = ceph::make_mutex("PyModule::lock");
 private:
   const std::string module_name;
+  std::string get_site_packages();
   int load_subclass_of(const char* class_name, PyObject** py_class);
 
   // Did the MgrMap identify this module as one that should run?

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -14,7 +14,6 @@
 #include "PyModuleRegistry.h"
 
 #include <filesystem>
-#include <boost/scope_exit.hpp>
 
 #include "include/stringify.h"
 #include "common/errno.h"
@@ -47,74 +46,14 @@ void PyModuleRegistry::init()
 
   // Set up global python interpreter
 #define WCHAR(s) L ## #s
-#if PY_VERSION_HEX >= 0x03080000
-  PyConfig py_config;
-  // do not enable isolated mode, otherwise we would not be able to have access
-  // to the site packages. since we cannot import any module before initializing
-  // the interpreter, we would not be able to use "site" module for retrieving
-  // the path to site packager. we import "site" module for retrieving
-  // sitepackages in Python < 3.8 though, this does not apply to the
-  // initialization with PyConfig.
-  PyConfig_InitPythonConfig(&py_config);
-  BOOST_SCOPE_EXIT_ALL(&py_config) {
-    PyConfig_Clear(&py_config);
-  };
-#if PY_VERSION_HEX >= 0x030b0000
-  py_config.safe_path = 0;
-#endif
-  py_config.parse_argv = 0;
-  py_config.configure_c_stdio = 0;
-  py_config.install_signal_handlers = 0;
-  py_config.pathconfig_warnings = 0;
-  // site_import is 1 by default, but set it explicitly as we do import
-  // site packages manually for Python < 3.8
-  py_config.site_import = 1;
-
-  PyStatus status;
-  status = PyConfig_SetString(&py_config, &py_config.program_name, WCHAR(MGR_PYTHON_EXECUTABLE));
-  ceph_assertf(!PyStatus_Exception(status), "PyConfig_SetString: %s:%s", status.func, status.err_msg);
-  // Some python modules do not cope with an unpopulated argv, so lets
-  // fake one.  This step also picks up site-packages into sys.path.
-  const wchar_t* argv[] = {L"ceph-mgr"};
-  status = PyConfig_SetArgv(&py_config, 1, (wchar_t *const *)argv);
-  ceph_assertf(!PyStatus_Exception(status), "PyConfig_SetArgv: %s:%s", status.func, status.err_msg);
-  // Add more modules
-  if (g_conf().get_val<bool>("daemonize")) {
-    PyImport_AppendInittab("ceph_logger", PyModule::init_ceph_logger);
-  }
-  PyImport_AppendInittab("ceph_module", PyModule::init_ceph_module);
-  // Configure sys.path to include mgr_module_path
-  auto pythonpath_env = g_conf().get_val<std::string>("mgr_module_path");
-  if (const char* pythonpath = getenv("PYTHONPATH")) {
-    pythonpath_env += ":";
-    pythonpath_env += pythonpath;
-  }
-  status = PyConfig_SetBytesString(&py_config, &py_config.pythonpath_env, pythonpath_env.data());
-  ceph_assertf(!PyStatus_Exception(status), "PyConfig_SetBytesString: %s:%s", status.func, status.err_msg);
-  dout(10) << "set PYTHONPATH to " << std::quoted(pythonpath_env) << dendl;
-  status = Py_InitializeFromConfig(&py_config);
-  ceph_assertf(!PyStatus_Exception(status), "Py_InitializeFromConfig: %s:%s", status.func, status.err_msg);
-#else
   Py_SetProgramName(const_cast<wchar_t*>(WCHAR(MGR_PYTHON_EXECUTABLE)));
+#undef WCHAR
   // Add more modules
   if (g_conf().get_val<bool>("daemonize")) {
     PyImport_AppendInittab("ceph_logger", PyModule::init_ceph_logger);
   }
   PyImport_AppendInittab("ceph_module", PyModule::init_ceph_module);
   Py_InitializeEx(0);
-  const wchar_t *argv[] = {L"ceph-mgr"};
-  PySys_SetArgv(1, (wchar_t**)argv);
-
-  std::string paths = (g_conf().get_val<std::string>("mgr_module_path") + ':' +
-		       get_site_packages() + ':');
-  std::wstring sys_path(begin(paths), end(paths));
-  sys_path += Py_GetPath();
-  PySys_SetPath(const_cast<wchar_t*>(sys_path.c_str()));
-  dout(10) << "Computed sys.path '"
-	   << std::string(begin(sys_path), end(sys_path)) << "'" << dendl;
-#endif // PY_VERSION_HEX >= 0x03080000
-#undef WCHAR
-
 #if PY_VERSION_HEX < 0x03090000
   // Let CPython know that we will be calling it back from other
   // threads in future.
@@ -276,72 +215,6 @@ void PyModuleRegistry::active_start(
     dout(4) << "Starting " << i.first << dendl;
     active_modules->start_one(i.second);
   }
-}
-
-std::string PyModuleRegistry::get_site_packages()
-{
-  std::stringstream site_packages;
-
-  // CPython doesn't auto-add site-packages dirs to sys.path for us,
-  // but it does provide a module that we can ask for them.
-  auto site_module = PyImport_ImportModule("site");
-  ceph_assert(site_module);
-
-  auto site_packages_fn = PyObject_GetAttrString(site_module, "getsitepackages");
-  if (site_packages_fn != nullptr) {
-    auto site_packages_list = PyObject_CallObject(site_packages_fn, nullptr);
-    ceph_assert(site_packages_list);
-
-    auto n = PyList_Size(site_packages_list);
-    for (Py_ssize_t i = 0; i < n; ++i) {
-      if (i != 0) {
-        site_packages << ":";
-      }
-      site_packages << PyUnicode_AsUTF8(PyList_GetItem(site_packages_list, i));
-    }
-
-    Py_DECREF(site_packages_list);
-    Py_DECREF(site_packages_fn);
-  } else {
-    // Fall back to generating our own site-packages paths by imitating
-    // what the standard site.py does.  This is annoying but it lets us
-    // run inside virtualenvs :-/
-
-    auto site_packages_fn = PyObject_GetAttrString(site_module, "addsitepackages");
-    ceph_assert(site_packages_fn);
-
-    auto known_paths = PySet_New(nullptr);
-    auto pArgs = PyTuple_Pack(1, known_paths);
-    PyObject_CallObject(site_packages_fn, pArgs);
-    Py_DECREF(pArgs);
-    Py_DECREF(known_paths);
-    Py_DECREF(site_packages_fn);
-
-    auto sys_module = PyImport_ImportModule("sys");
-    ceph_assert(sys_module);
-    auto sys_path = PyObject_GetAttrString(sys_module, "path");
-    ceph_assert(sys_path);
-
-    dout(1) << "sys.path:" << dendl;
-    auto n = PyList_Size(sys_path);
-    bool first = true;
-    for (Py_ssize_t i = 0; i < n; ++i) {
-      dout(1) << "  " << PyUnicode_AsUTF8(PyList_GetItem(sys_path, i)) << dendl;
-      if (first) {
-        first = false;
-      } else {
-        site_packages << ":";
-      }
-      site_packages << PyUnicode_AsUTF8(PyList_GetItem(sys_path, i));
-    }
-
-    Py_DECREF(sys_path);
-    Py_DECREF(sys_module);
-  }
-
-  Py_DECREF(site_module);
-
-  return site_packages.str();
 }
 
 std::vector<std::string> PyModuleRegistry::probe_modules(const std::string &path) const

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -55,7 +55,6 @@ private:
   // before ClusterState exists.
   MgrMap mgr_map;
 
-  static std::string get_site_packages();
   /**
    * Discover python modules from local disk
    */


### PR DESCRIPTION
This reverts commit https://github.com/ceph/ceph/commit/8dffa8707dc665eb7ca6e2f48fa34e0fa8ac5b51, reversing
changes made to https://github.com/ceph/ceph/commit/80374da12bcc708d1fa306484842b3f97ac42acb.

This commit broke the import of the "mgr_module" module
within the python modules in the mgr at least on python 3.6.8
that we currently use in our centos 8 stream based containers

Failures would look like (removing beginning of log lines)

Loading python module 'alerts'
Module not found: 'mgr_module'
Class not found in module 'alerts'
Error loading module 'alerts': (22) Invalid argument

---

Larger set of mgr logs after bootstrapping a cluster with a main branch CI build container image

```
Apr 01 11:05:40 vm-00 ceph-mgr[19125]: mgr[py] Loading python module 'alerts'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 2024-04-01T15:05:40.513+0000 7fc482b39200 -1 mgr[py] Module not found: 'mgr_module'
Apr 01 11:05:40 vm-00 ceph-mgr[19125]: mgr[py] Module not found: 'mgr_module'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 2024-04-01T15:05:40.513+0000 7fc482b39200 -1 mgr[py] ModuleNotFoundError: No module named 'mgr_module'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 
Apr 01 11:05:40 vm-00 ceph-mgr[19125]: mgr[py] ModuleNotFoundError: No module named 'mgr_module'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 2024-04-01T15:05:40.530+0000 7fc482b39200 -1 mgr[py] Class not found in module 'alerts'
Apr 01 11:05:40 vm-00 ceph-mgr[19125]: mgr[py] Class not found in module 'alerts'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 2024-04-01T15:05:40.530+0000 7fc482b39200 -1 mgr[py] Error loading module 'alerts': (22) Invalid argument
Apr 01 11:05:40 vm-00 ceph-mgr[19125]: mgr[py] Error loading module 'alerts': (22) Invalid argument
Apr 01 11:05:40 vm-00 ceph-mgr[19125]: mgr[py] Loading python module 'balancer'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 2024-04-01T15:05:40.580+0000 7fc482b39200 -1 mgr[py] Module not found: 'mgr_module'
Apr 01 11:05:40 vm-00 ceph-mgr[19125]: mgr[py] Module not found: 'mgr_module'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 2024-04-01T15:05:40.580+0000 7fc482b39200 -1 mgr[py] ModuleNotFoundError: No module named 'mgr_module'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 
Apr 01 11:05:40 vm-00 ceph-mgr[19125]: mgr[py] ModuleNotFoundError: No module named 'mgr_module'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 2024-04-01T15:05:40.590+0000 7fc482b39200 -1 mgr[py] Class not found in module 'balancer'
Apr 01 11:05:40 vm-00 ceph-mgr[19125]: mgr[py] Class not found in module 'balancer'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 2024-04-01T15:05:40.590+0000 7fc482b39200 -1 mgr[py] Error loading module 'balancer': (22) Invalid argument
Apr 01 11:05:40 vm-00 ceph-mgr[19125]: mgr[py] Error loading module 'balancer': (22) Invalid argument
Apr 01 11:05:40 vm-00 ceph-mgr[19125]: mgr[py] Loading python module 'cephadm'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 2024-04-01T15:05:40.652+0000 7fc482b39200 -1 mgr[py] Module not found: 'mgr_module'
Apr 01 11:05:40 vm-00 ceph-mgr[19125]: mgr[py] Module not found: 'mgr_module'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 2024-04-01T15:05:40.652+0000 7fc482b39200 -1 mgr[py] ModuleNotFoundError: No module named 'mgr_module'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 
Apr 01 11:05:40 vm-00 ceph-mgr[19125]: mgr[py] ModuleNotFoundError: No module named 'mgr_module'
Apr 01 11:05:40 vm-00 ceph-46e92f9a-f039-11ee-af20-525400946525-mgr-vm-00-bttboc[19121]: 2024-04-01T15:05:40.665+0000 7fc482b39200 -1 mgr[py] Class not found in module 'cephadm'
```

which appeared in main very recently. Opened this PR to test the revert.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
