### PR TITLE
osd, mgr, scripts: support 'deep_scrub' command format and use it in the relevant scripts

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1271,7 +1271,8 @@ def osd_scrub_pgs(ctx, config):
         try:
             manager.raw_cluster_cmd('tell', 'osd.' + id_, 'config', 'set',
                                     'osd_debug_deep_scrub_sleep', '0');
-            manager.raw_cluster_cmd('osd', 'deep-scrub', id_)
+            # using the old (deprecated) format, catering for mixed clusters
+            manager.raw_cluster_cmd('osd', 'deep_scrub', id_)
         except run.CommandFailedError:
             pass
     prev_good = 0
@@ -1303,7 +1304,7 @@ def osd_scrub_pgs(ctx, config):
                     # request was missed.  do not do it every time because
                     # the scrub may be in progress or not reported yet and
                     # we will starve progress.
-                    manager.raw_cluster_cmd('tell', pgid, 'deep-scrub')
+                    manager.raw_cluster_cmd('tell', pgid, 'deep_scrub')
             if gap_cnt > retries:
                 raise RuntimeError('Exiting scrub checking -- not all pgs scrubbed.')
         if loop:

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -1053,7 +1053,7 @@ def main():
     if parsed_args.block:
         if (len(childargs) >= 2 and
                 childargs[0] == 'osd' and
-                childargs[1] in ['deep-scrub', 'scrub']):
+                childargs[1] in ['deep-scrub', 'scrub', 'deep_scrub']):
             block = True
             waitdata = get_scrub_timestamps(childargs)
 

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1298,6 +1298,7 @@ bool DaemonServer::_handle_command(
     return true;
   } else if (prefix == "osd scrub" ||
 	      prefix == "osd deep-scrub" ||
+	      prefix == "osd deep_scrub" ||
 	      prefix == "osd repair") {
     string whostr;
     cmd_getval(cmdctx->cmdmap, "who", whostr);
@@ -1331,6 +1332,7 @@ bool DaemonServer::_handle_command(
       }
     }
     set<int> sent_osds, failed_osds;
+    const bool deep = (pvec.back() == "deep-scrub" || pvec.back() == "deep_scrub");
     for (auto osd : osds) {
       vector<spg_t> spgs;
       epoch_t epoch;
@@ -1358,7 +1360,7 @@ bool DaemonServer::_handle_command(
                                            epoch,
                                            spgs,
                                            pvec.back() == "repair",
-                                           pvec.back() == "deep-scrub"));
+                                           deep));
         }
       }
     }

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -170,6 +170,10 @@ COMMAND("osd deep-scrub " \
 	"name=who,type=CephString", \
 	"initiate deep scrub on osd <who>, or use <all|any> to deep scrub all", \
         "osd", "rw")
+COMMAND("osd deep_scrub " \
+	"name=who,type=CephString", \
+	"deprecated", \
+        "osd", "rw")
 COMMAND("osd repair " \
 	"name=who,type=CephString", \
 	"initiate repair on osd <who>, or use <all|any> to repair all", \

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2692,6 +2692,7 @@ void OSD::asok_command(
       prefix == "list_unfound" ||
       prefix == "scrub" ||
       prefix == "deep-scrub" ||
+      prefix == "deep_scrub" || // deprecated. Required for pre-Squid upgrade tests
       prefix == "schedule-scrub" ||      ///< dev/tests only!
       prefix == "schedule-deep-scrub"    ///< dev/tests only!
     ) {
@@ -4456,6 +4457,15 @@ void OSD::final_init()
     asok_hook,
     "");
   ceph_assert(r == 0);
+  // a deprecated form of the above. Required for
+  // upgrade compatibility & upgrade testing.
+  r = admin_socket->register_command(
+    "pg "
+    "name=pgid,type=CephPgid "
+    "name=cmd,type=CephChoices,strings=deep_scrub",
+    asok_hook,
+    "");
+  ceph_assert(r == 0);
   // new form: tell <pgid> <cmd> for both cli and rest
   r = admin_socket->register_command(
     "query",
@@ -4493,6 +4503,14 @@ void OSD::final_init()
     "name=pgid,type=CephPgid,req=false",
     asok_hook,
     "Trigger a deep scrub");
+  ceph_assert(r == 0);
+  // a deprecated form of the above. Required for
+  // upgrade compatibility & upgrade testing.
+  r = admin_socket->register_command(
+    "deep_scrub "
+    "name=pgid,type=CephPgid,req=false",
+    asok_hook,
+    "deprecated! use 'deep-scrub' instead");
   ceph_assert(r == 0);
   // debug/test commands (faking the timestamps)
   r = admin_socket->register_command(

--- a/src/pybind/mgr/restful/common.py
+++ b/src/pybind/mgr/restful/common.py
@@ -6,7 +6,7 @@ OSD_FLAGS = [
 
 # Implemented osd commands
 OSD_IMPLEMENTED_COMMANDS = [
-    'scrub', 'deep-scrub', 'repair'
+    'scrub', 'deep-scrub', 'deep_scrub', 'repair'
 ]
 
 # Valid values for the 'var' argument to 'ceph osd pool set'


### PR DESCRIPTION
While 'deep-scrub' is the new command argument format (and
'deep_scrub' is deprecated, we must deal with mixed clusters.

This PR:
- restores the 'deep_scrub' command format in the osd (as
  a working but deprecated alternative);
- restore support for both formats in the manager;
- revert ceph.py to using 'deep_scrub' for compatibility
  with pre-Squid daemons;
