### PR TITLE
crimson/os/seastore: alloc mapping with refcount when rewriting logical extents

### DIFF
--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -801,6 +801,9 @@ public:
     return safe_then_interruptible(std::forward<Args>(args)...);
   }
 
+  auto discard_result() noexcept {
+    return si_then([](auto &&) {});
+  }
 
   template<bool interruptible = true, typename ValueInterruptCondT, typename ErrorVisitorT,
 	   typename U = T, std::enable_if_t<!std::is_void_v<U> && interruptible, int> = 0>

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1412,7 +1412,7 @@ SegmentCleaner::scan_extents_ret SegmentCleaner::scan_no_tail_segment(
       cursor,
       segment_header.segment_nonce,
       segments.get_segment_size(),
-      handler).discard_result();
+      handler);
   }).safe_then([this, segment_id, segment_header] {
     init_mark_segment_closed(
       segment_id,

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.cc
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.cc
@@ -188,7 +188,7 @@ Journal::replay_ret CircularBoundedJournal::replay_segment(
         cursor,
 	cjs.get_cbj_header().magic,
         std::numeric_limits<size_t>::max(),
-        dhandler).safe_then([](auto){}
+        dhandler
       ).handle_error(
         replay_ertr::pass_further{},
         crimson::ct_error::assert_all{

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -219,7 +219,7 @@ SegmentedJournal::scan_last_segment(
       cursor,
       nonce,
       std::numeric_limits<std::size_t>::max(),
-      handler).discard_result();
+      handler);
   });
 }
 
@@ -312,7 +312,7 @@ SegmentedJournal::replay_segment(
 	cursor,
 	header.segment_nonce,
 	std::numeric_limits<size_t>::max(),
-	dhandler).safe_then([](auto){}
+	dhandler
       ).handle_error(
 	replay_ertr::pass_further{},
 	crimson::ct_error::assert_all{

--- a/src/crimson/os/seastore/lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager.cc
@@ -22,7 +22,7 @@ LBAManager::update_mappings(
       extent->get_paddr(),
       nullptr	// all the extents should have already been
 		// added to the fixed_kv_btree
-    );
+    ).discard_result();
   });
 }
 

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -103,7 +103,7 @@ public:
     extent_len_t len) = 0;
 
   struct ref_update_result_t {
-    unsigned refcount = 0;
+    extent_ref_count_t refcount = 0;
     pladdr_t addr;
     extent_len_t length = 0;
   };

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -87,7 +87,8 @@ public:
     laddr_t hint,
     extent_len_t len,
     paddr_t addr,
-    LogicalCachedExtent &nextent) = 0;
+    LogicalCachedExtent &nextent,
+    extent_ref_count_t refcount = EXTENT_DEFAULT_REF_COUNT) = 0;
 
   virtual alloc_extent_ret clone_mapping(
     Transaction &t,
@@ -187,7 +188,7 @@ public:
    * update lba mapping for a delayed allocated extent
    */
   using update_mapping_iertr = base_iertr;
-  using update_mapping_ret = base_iertr::future<>;
+  using update_mapping_ret = base_iertr::future<extent_ref_count_t>;
   virtual update_mapping_ret update_mapping(
     Transaction& t,
     laddr_t laddr,
@@ -203,7 +204,7 @@ public:
    * update lba mappings for delayed allocated extents
    */
   using update_mappings_iertr = update_mapping_iertr;
-  using update_mappings_ret = update_mapping_ret;
+  using update_mappings_ret = update_mappings_iertr::future<>;
   update_mappings_ret update_mappings(
     Transaction& t,
     const std::list<LogicalCachedExtentRef>& extents);

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -704,15 +704,11 @@ BtreeLBAManager::update_refcount(
       );
     }
     return fut.si_then([map_value, mapping=std::move(mapping)]
-		       (auto removed) mutable {
+		       (auto decref_intermediate_res) mutable {
       if (map_value.pladdr.is_laddr()
-	  && removed) {
+	  && decref_intermediate_res) {
 	return update_refcount_ret_bare_t{
-	  ref_update_result_t{
-	    map_value.refcount,
-	    removed->addr,
-	    removed->length
-	  },
+	  *decref_intermediate_res,
 	  std::move(mapping)
 	};
       } else {

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -221,7 +221,8 @@ public:
       len,
       P_ADDR_ZERO,
       P_ADDR_NULL,
-      nullptr);
+      nullptr,
+      EXTENT_DEFAULT_REF_COUNT);
   }
 
   alloc_extent_ret clone_mapping(
@@ -240,7 +241,8 @@ public:
       len,
       intermediate_key,
       actual_addr,
-      nullptr
+      nullptr,
+      EXTENT_DEFAULT_REF_COUNT
     ).si_then([&t, this, intermediate_base](auto indirect_mapping) {
       assert(indirect_mapping->is_indirect());
       return update_refcount(t, intermediate_base, 1, false
@@ -265,7 +267,8 @@ public:
     laddr_t hint,
     extent_len_t len,
     paddr_t addr,
-    LogicalCachedExtent &ext) final
+    LogicalCachedExtent &ext,
+    extent_ref_count_t refcount = EXTENT_DEFAULT_REF_COUNT) final
   {
     return _alloc_extent(
       t,
@@ -273,7 +276,8 @@ public:
       len,
       addr,
       P_ADDR_NULL,
-      &ext);
+      &ext,
+      refcount);
   }
 
   ref_ret decref_extent(
@@ -406,7 +410,8 @@ private:
     extent_len_t len,
     pladdr_t addr,
     paddr_t actual_addr,
-    LogicalCachedExtent*);
+    LogicalCachedExtent*,
+    extent_ref_count_t refcount);
 
   using _get_mapping_ret = get_mapping_iertr::future<BtreeLBAMappingRef>;
   _get_mapping_ret _get_mapping(

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -35,14 +35,14 @@ struct lba_map_val_t {
   extent_len_t len = 0;  ///< length of mapping
   pladdr_t pladdr;         ///< physical addr of mapping or
 			   //	laddr of a physical lba mapping(see btree_lba_manager.h)
-  uint32_t refcount = 0; ///< refcount
+  extent_ref_count_t refcount = 0; ///< refcount
   uint32_t checksum = 0; ///< checksum of original block written at paddr (TODO)
 
   lba_map_val_t() = default;
   lba_map_val_t(
     extent_len_t len,
     pladdr_t pladdr,
-    uint32_t refcount,
+    extent_ref_count_t refcount,
     uint32_t checksum)
     : len(len), pladdr(pladdr), refcount(refcount), checksum(checksum) {}
   bool operator==(const lba_map_val_t&) const = default;
@@ -121,7 +121,7 @@ constexpr size_t LEAF_NODE_CAPACITY = 140;
 struct lba_map_val_le_t {
   extent_len_le_t len = init_extent_len_le(0);
   pladdr_le_t pladdr;
-  ceph_le32 refcount{0};
+  extent_ref_count_le_t refcount{0};
   ceph_le32 checksum{0};
 
   lba_map_val_le_t() = default;

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -499,8 +499,7 @@ ObjectDataHandler::write_ret do_removals(
       return ctx.tm.remove(
 	ctx.t,
 	pin->get_key()
-      ).si_then(
-	[](auto){},
+      ).discard_result().handle_error_interruptible(
 	ObjectDataHandler::write_iertr::pass_further{},
 	crimson::ct_error::assert_all{
 	  "object_data_handler::do_removals invalid error"

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.cc
@@ -41,7 +41,7 @@ dec_ref_ret dec_ref(omap_context_t oc, T&& addr) {
     crimson::ct_error::assert_all{
       "Invalid error in OMapInnerNode helper dec_ref"
     }
-  ).si_then([](auto &&e) {});
+  ).discard_result();
 }
 
 /**

--- a/src/crimson/os/seastore/record_scanner.cc
+++ b/src/crimson/os/seastore/record_scanner.cc
@@ -98,10 +98,8 @@ RecordScanner::scan_valid_records(
 	  return seastar::stop_iteration::no;
 	}
       });
-    }).safe_then([retref=std::move(retref)]() mutable -> scan_valid_records_ret {
-      return scan_valid_records_ret(
-	scan_valid_records_ertr::ready_future_marker{},
-	std::move(*retref));
+    }).safe_then([retref=std::move(retref)] {
+      return scan_valid_records_ertr::make_ready_future();
     });
 }
 

--- a/src/crimson/os/seastore/record_scanner.h
+++ b/src/crimson/os/seastore/record_scanner.h
@@ -14,8 +14,7 @@ class RecordScanner {
 public:
   using read_ertr = SegmentManager::read_ertr;
   using scan_valid_records_ertr = read_ertr;
-  using scan_valid_records_ret = scan_valid_records_ertr::future<
-    size_t>;
+  using scan_valid_records_ret = scan_valid_records_ertr::future<>;
   using found_record_handler_t = std::function<
     scan_valid_records_ertr::future<>(
       record_locator_t record_locator,

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1142,6 +1142,11 @@ inline extent_len_le_t init_extent_len_le(extent_len_t len) {
   return ceph_le32(len);
 }
 
+using extent_ref_count_t = uint32_t;
+constexpr extent_ref_count_t EXTENT_DEFAULT_REF_COUNT = 1;
+
+using extent_ref_count_le_t = ceph_le32;
+
 struct laddr_list_t : std::list<std::pair<laddr_t, extent_len_t>> {
   template <typename... T>
   laddr_list_t(T&&... args)

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -233,7 +233,7 @@ public:
 
 
   using ref_iertr = LBAManager::ref_iertr;
-  using ref_ret = ref_iertr::future<unsigned>;
+  using ref_ret = ref_iertr::future<extent_ref_count_t>;
 
 #ifdef UNIT_TESTS_BUILT
   /// Add refcount for ref

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -28,7 +28,7 @@ seastar::future<> TMDriver::write(
         [this, offset, &ptr](auto& t)
       {
         return tm->remove(t, offset
-        ).si_then([](auto){}).handle_error_interruptible(
+        ).discard_result().handle_error_interruptible(
           crimson::ct_error::enoent::handle([](auto) { return seastar::now(); }),
           crimson::ct_error::pass_further_all{}
         ).si_then([this, offset, &t, &ptr] {

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -100,7 +100,7 @@ struct cache_test_t : public seastar_test_suite_t {
           return cache->mkfs(t);
         }).safe_then([this, &ref_t] {
           return submit_transaction(std::move(ref_t)
-          ).then([](auto p) {});
+          ).discard_result();
         });
       });
     }).handle_error(


### PR DESCRIPTION
The refcount of split extents should be consistent with the original's refcount.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
