### PR TITLE
mgr/dashboard: modernize REST API infra

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/_rest_controller.py
+++ b/src/pybind/mgr/dashboard/controllers/_rest_controller.py
@@ -13,7 +13,37 @@ from ._permissions import _set_func_permissions
 from ._version import APIVersion
 
 
-class RESTController(BaseController, skip_registry=True):
+class APIDocMeta(type):
+    @property
+    def doc_info(cls):
+        try:
+            return cls.__doc_info
+        except AttributeError:
+            tag = None
+            tag_descr = None
+            if cls.__doc__ is not None:
+                doc = cls.__doc__.strip()
+
+                # tag: description
+                if ":" in doc:
+                    tag, tag_descr = map(str.strip, doc.split(":", 1))
+                # tag\n\n description
+                elif "\n\n" in doc:
+                    tag, tag_descr = map(str.strip, doc.split("\n\n", 1))
+                else:
+                    tag_descr = doc
+
+            return {
+                'tag': tag,
+                'tag_descr': tag_descr
+            }
+
+    @doc_info.setter
+    def doc_info(cls, value):
+        cls.__doc_info = value
+
+
+class RESTController(BaseController, skip_registry=True, metaclass=APIDocMeta):
     """
     Base class for providing a RESTful interface to a resource.
 

--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -13,8 +13,12 @@ except ImportError:
     pass
 else:
     @APIRouter("/nvmeof/gateway", Scope.NVME_OF)
-    @APIDoc("NVMe-oF Gateway Management API", "NVMe-oF Gateway")
     class NVMeoFGateway(RESTController):
+        """
+        NVMe-oF Gateway
+
+        NVMe-oF Gateway Management API
+        """
         @EndpointDoc("Get information about the NVMeoF gateway")
         @map_model(model.GatewayInfo)
         @handle_nvmeof_error
@@ -24,8 +28,10 @@ else:
             )
 
     @APIRouter("/nvmeof/subsystem", Scope.NVME_OF)
-    @APIDoc("NVMe-oF Subsystem Management API", "NVMe-oF Subsystem")
     class NVMeoFSubsystem(RESTController):
+        """
+        NVMe-oF Subsystem: NVMe-oF Subsystem Management API
+        """
         @EndpointDoc("List all NVMeoF subsystems")
         @map_collection(model.Subsystem, pick="subsystems")
         @handle_nvmeof_error
@@ -79,8 +85,10 @@ else:
             )
 
     @APIRouter("/nvmeof/subsystem/{nqn}/listener", Scope.NVME_OF)
-    @APIDoc("NVMe-oF Subsystem Listener Management API", "NVMe-oF Subsystem Listener")
     class NVMeoFListener(RESTController):
+        """
+        NVMe-oF Subsystem Listener: NVMe-oF Subsystem Listener Management API
+        """
         @EndpointDoc(
             "List all NVMeoF listeners",
             parameters={"nqn": Param(str, "NVMeoF subsystem NQN")},
@@ -143,8 +151,10 @@ else:
             )
 
     @APIRouter("/nvmeof/subsystem/{nqn}/namespace", Scope.NVME_OF)
-    @APIDoc("NVMe-oF Subsystem Namespace Management API", "NVMe-oF Subsystem Namespace")
     class NVMeoFNamespace(RESTController):
+        """
+        NVMe-oF Subsystem Namespace: NVMe-oF Subsystem Namespace Management API
+        """
         @EndpointDoc(
             "List all NVMeoF namespaces in a subsystem",
             parameters={"nqn": Param(str, "NVMeoF subsystem NQN")},
@@ -306,9 +316,12 @@ else:
             )
 
     @APIRouter("/nvmeof/subsystem/{nqn}/host", Scope.NVME_OF)
-    @APIDoc("NVMe-oF Subsystem Host Allowlist Management API",
-            "NVMe-oF Subsystem Host Allowlist")
     class NVMeoFHost(RESTController):
+        """
+        NVMe-oF Subsystem Host Allowlist:
+
+        NVMe-oF Subsystem Host Allowlist Management API
+        """
         @EndpointDoc(
             "List all allowed hosts for an NVMeoF subsystem",
             parameters={"nqn": Param(str, "NVMeoF subsystem NQN")},
@@ -356,8 +369,10 @@ else:
             )
 
     @APIRouter("/nvmeof/subsystem/{nqn}/connection", Scope.NVME_OF)
-    @APIDoc("NVMe-oF Subsystem Connection Management API", "NVMe-oF Subsystem Connection")
     class NVMeoFConnection(RESTController):
+        """
+        NVMe-oF Subsystem Connection: NVMe-oF Subsystem Connection Management API
+        """
         @EndpointDoc(
             "List all NVMeoF Subsystem Connections",
             parameters={"nqn": Param(str, "NVMeoF subsystem NQN")},


### PR DESCRIPTION
The goal of this work is to adapt the REST API infrastructure to the current state of art, taking inspiration from modern RESST frameworks like [FastAPI](https://fastapi.tiangolo.com/).

The Ceph Dashboard API was initially conceived under Python 2.7, which lacked many of the features available today that especially useful for generating OpenAPI specs. Essentially, Python `typing`, type hints and type reflection.

So goals for this work are:
* Remove the need of custom decorators (`Endpoint`, `DocEndpoint`, `ApiEndpoint`, etc), and infer documentation strings from docstrings, and data types from type hints.
* Improve the quality of the OpenAPI spec by adding return types, responses, models and others.
* Reduce the amount of boilerplate code required
* Increase the type-safety at the different stages of the code:
  * Automatically convert types like JSON Bool or Number to Python `bool` or `int` or `float`.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
