### PR TITLE
squid: qa/upgrade/quincy: bump ubuntu from 20->22

### DIFF
--- a/qa/suites/orch/cephadm/upgrade/1-start-distro/1-start-ubuntu_22.04.yaml
+++ b/qa/suites/orch/cephadm/upgrade/1-start-distro/1-start-ubuntu_22.04.yaml
@@ -1,5 +1,5 @@
 os_type: ubuntu
-os_version: "20.04"
+os_version: "22.04"
 
 tasks:
 - cephadm:

--- a/qa/suites/rgw/upgrade/1-install/quincy/distro$/ubuntu_20.04.yaml
+++ b/qa/suites/rgw/upgrade/1-install/quincy/distro$/ubuntu_20.04.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/ubuntu_20.04.yaml

--- a/qa/suites/rgw/upgrade/1-install/quincy/distro$/ubuntu_latest.yaml
+++ b/qa/suites/rgw/upgrade/1-install/quincy/distro$/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/ubuntu_latest.yaml

--- a/qa/suites/upgrade/quincy-x/filestore-remove-check/ubuntu_20.04.yaml
+++ b/qa/suites/upgrade/quincy-x/filestore-remove-check/ubuntu_20.04.yaml
@@ -1,9 +1,0 @@
-os_type: ubuntu
-os_version: "20.04"
-# the normal ubuntu 20.04 kernel (5.4.0-88-generic currently) have a bug that prevents the nvme_loop
-# from behaving.  I think it is this:
-#   https://lkml.org/lkml/2020/9/21/1456
-# (at least, that is the symptom: nvme nvme1: Connect command failed, error wo/DNR bit: 880)
-overrides:
-  kernel:
-    hwe: true

--- a/qa/suites/upgrade/quincy-x/filestore-remove-check/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/quincy-x/filestore-remove-check/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+.qa/distros/supported/ubuntu_latest.yaml


### PR DESCRIPTION
> remove the last vestiges of ubuntu focal from qa suites

backport of https://github.com/ceph/ceph/pull/55976 (no tracker issue)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
