### PR TITLE
common/pick_address: check if address in subnet all public address

### DIFF
--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -644,15 +644,24 @@ bool is_addr_in_subnet(
 {
   const auto nets = get_str_list(networks);
   ceph_assert(!nets.empty());
-  const auto &net = nets.front();
-  struct ifaddrs ifa;
+
   unsigned ipv = CEPH_PICK_ADDRESS_IPV4;
   struct sockaddr_in public_addr;
-
-  ifa.ifa_next = nullptr;
-  ifa.ifa_addr = (struct sockaddr*)&public_addr;
   public_addr.sin_family = AF_INET;
-  inet_pton(AF_INET, addr.c_str(), &public_addr.sin_addr);
 
-  return matches_with_net(cct, ifa, net, ipv);
+  if(inet_pton(AF_INET, addr.c_str(), &public_addr.sin_addr) != 1) {
+    lderr(cct) << "unable to convert chosen address to string: " << addr << dendl;
+    return false;
+  }
+
+  for (const auto &net : nets) {
+    struct ifaddrs ifa;
+    memset(&ifa, 0, sizeof(ifa));
+    ifa.ifa_next = nullptr;
+    ifa.ifa_addr = (struct sockaddr*)&public_addr;
+    if(matches_with_net(cct, ifa, net, ipv)) {
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
When mon trying to check if osd joining within subnet address, it will check only the first subnet and not the rest of the subnets. this fix will loop over all the other subnet for checks.

Fixes: https://tracker.ceph.com/issues/65186





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
