### PR TITLE
test/objectstore: honor WITH_BLUESTORE config for dependent tests

### DIFF
--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -7175,7 +7175,6 @@ INSTANTIATE_TEST_SUITE_P(
     deferred_test_t{4 * 1024, 16 * 1024, 32 * 1024, 32 * 1024},
     deferred_test_t{4 * 1024, 16 * 1024, 64 * 1024, 128 * 1024}
   ));
-#endif
 
 class DeferredReplayTest : public DeferredWriteTest {
 };
@@ -7362,7 +7361,6 @@ TEST_P(DeferredReplayTest, DeferredReplayInReadOnly) {
   ASSERT_EQ(1, logger->get(l_bluestore_submitted_deferred_writes));
 }
 
-#if defined(WITH_BLUESTORE)
 INSTANTIATE_TEST_SUITE_P(
   BlueStore,
   DeferredReplayTest,


### PR DESCRIPTION

Honor `WITH_BLUESTORE` config for dependent tests. Otherwise, the tests fail to compile due to missing defines of `l_bluestore_*`

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
