### PR TITLE
test: do not consider warning from Sanitizer as fatal

### DIFF
--- a/src/test/ceph_crypto.cc
+++ b/src/test/ceph_crypto.cc
@@ -270,7 +270,15 @@ void do_simple_crypto() {
 
 #if GTEST_HAS_DEATH_TEST && !defined(_WIN32)
 TEST_F(ForkDeathTest, MD5) {
-  ASSERT_EXIT(do_simple_crypto(), ::testing::ExitedWithCode(0), "^$");
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+  // sanitizer warns like:
+  // ==3798016==Running thread 3797882 was not suspended. False leaks are possible.
+  // but we should not take it as a fatal error.
+  const std::string matcher = ".*False leaks are possible.*");
+#else
+  const std::string matcher = "^$";
+#endif
+  ASSERT_EXIT(do_simple_crypto(), ::testing::ExitedWithCode(0), matcher);
 }
 #endif // GTEST_HAS_DEATH_TEST && !defined(_WIN32)
 


### PR DESCRIPTION
with sanitizer enabled, unittest_ceph_crypto fails like

```
[ RUN      ] ForkDeathTest.MD5

[WARNING] /home/jenkins-build/build/workspace/ceph-pull-requests/src/googletest/googletest/src/gtest-death-test.cc:1121:: Death tests use fork(), which is unsafe particularly in a threaded context. For this test, Google Test detected 3 threads. See https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#death-tests-and-threads for more explanation and suggested solutions, especially if this is the last message you see before your test times out.
/home/jenkins-build/build/workspace/ceph-pull-requests/src/test/ceph_crypto.cc:273: Failure
Death test: do_simple_crypto()
    Result: died but not with expected error.
  Expected: contains regular expression "^$"
Actual msg:
[  DEATH   ] ==3798016==Running thread 3797882 was not suspended. False leaks are possible.
[  DEATH   ] ==3798016==Running thread 3797885 was not suspended. False leaks are possible.
[  DEATH   ]
[  FAILED  ] ForkDeathTest.MD5 (119 ms)
```

but this error message should not considered as an indication of fatal error. so, in this change, instead of matching the output with a regex of "^$", we use a matcher to match with the error message if sanitizer is enabled.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
