### PR TITLE
quincy: mgr/dashboard: replace piechart plugin charts with native pie chart panel

### DIFF
--- a/monitoring/ceph-mixin/dashboards/osd.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/osd.libsonnet
@@ -1,5 +1,6 @@
 local g = import 'grafonnet/grafana.libsonnet';
 
+
 (import 'utils.libsonnet') {
   'osds-overview.json':
     $.dashboardSchema(
@@ -195,28 +196,18 @@ local g = import 'grafonnet/grafana.libsonnet';
           true
         )
       ) + { gridPos: { x: 20, y: 0, w: 4, h: 8 } },
-      $.simplePieChart(
-        {}, '', 'OSD Types Summary'
-      )
+      $.pieChartPanel('OSD Types Summary', '', '$datasource', { x: 0, y: 8, w: 4, h: 8 }, 'table', 'bottom', true, ['percent'], { mode: 'single', sort: 'none' }, 'pie', ['percent', 'value'], 'palette-classic')
       .addTarget(
         $.addTargetSchema('count by (device_class) (ceph_osd_metadata{%(matchers)s})' % $.matchers(), '{{device_class}}')
-      ) + { gridPos: { x: 0, y: 8, w: 4, h: 8 } },
-      $.simplePieChart(
-        { 'Non-Encrypted': '#E5AC0E' }, '', 'OSD Objectstore Types'
-      )
-      .addTarget(
-        $.addTargetSchema(
-          'count(ceph_bluefs_wal_total_bytes{%(matchers)s})' % $.matchers(), 'bluestore', 'time_series', 2
-        )
-      )
-      .addTarget(
-        $.addTargetSchema(
-          'absent(ceph_bluefs_wal_total_bytes{%(matchers)s}) * count(ceph_osd_metadata{%(matchers)s})' % $.matchers(), 'filestore', 'time_series', 2
-        )
-      ) + { gridPos: { x: 4, y: 8, w: 4, h: 8 } },
-      $.simplePieChart(
-        {}, 'The pie chart shows the various OSD sizes used within the cluster', 'OSD Size Summary'
-      )
+      ),
+      $.pieChartPanel('OSD Objectstore Types', '', '$datasource', { x: 4, y: 8, w: 4, h: 8 }, 'table', 'bottom', true, ['percent'], { mode: 'single', sort: 'none' }, 'pie', ['percent', 'value'], 'palette-classic')
+      .addTarget($.addTargetSchema(
+        'count(ceph_bluefs_wal_total_bytes{%(matchers)s})' % $.matchers(), 'bluestore', 'time_series', 2
+      ))
+      .addTarget($.addTargetSchema(
+        'absent(ceph_bluefs_wal_total_bytes{job=~"$job"}) * count(ceph_osd_metadata{job=~"$job"})' % $.matchers(), 'filestore', 'time_series', 2
+      )),
+      $.pieChartPanel('OSD Size Summary', 'The pie chart shows the various OSD sizes used within the cluster', '$datasource', { x: 8, y: 8, w: 4, h: 8 }, 'table', 'bottom', true, ['percent'], { mode: 'single', sort: 'none' }, 'pie', ['percent', 'value'], 'palette-classic')
       .addTarget($.addTargetSchema(
         'count(ceph_osd_stat_bytes{%(matchers)s} < 1099511627776)' % $.matchers(), '<1TB', 'time_series', 2
       ))
@@ -243,7 +234,7 @@ local g = import 'grafonnet/grafana.libsonnet';
       ))
       .addTarget($.addTargetSchema(
         'count(ceph_osd_stat_bytes{%(matchers)s} >= 13194139533312)' % $.matchers(), '<12TB+', 'time_series', 2
-      )) + { gridPos: { x: 8, y: 8, w: 4, h: 8 } },
+      )),
       g.graphPanel.new(bars=true,
                        datasource='$datasource',
                        title='Distribution of PGs per OSD',

--- a/monitoring/ceph-mixin/dashboards/piechart_panel.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/piechart_panel.libsonnet
@@ -1,0 +1,70 @@
+{
+  /**
+   * Creates a pie chart panel.
+   *
+   * @name pieChartPanel.new
+   *
+   * @param title The title of the pie chart panel.
+   * @param description (default `''`) Description of the panel
+   * @param datasource (optional) Datasource
+   * @param pieType (default `'pie'`) Type of pie chart (one of pie or donut)
+   *
+   * @method addTarget(target) Adds a target object.
+   */
+  new(
+    title,
+    description='',
+    datasource=null,
+    gridPos={},
+    displayMode='table',
+    placement='bottom',
+    showLegend=true,
+    displayLabels=[],
+    tooltip={},
+    pieType='pie',
+    values=[],
+    colorMode='auto'
+  ):: {
+    type: 'piechart',
+    [if description != null then 'description']: description,
+    title: title,
+    gridPos: gridPos,
+    datasource: datasource,
+    options: {
+      legend: {
+        calcs: [],
+        values: values,
+        displayMode: displayMode,
+        placement: placement,
+        showLegend: showLegend,
+      },
+      pieType: pieType,
+      tooltip: tooltip,
+      displayLabels: displayLabels,
+    },
+    fieldConfig: {
+      defaults: {
+        color: { mode: colorMode },
+        mappings: [],
+        custom: {
+          hideFrom: {
+            legend: false,
+            tooltip: false,
+            viz: false,
+          },
+        },
+      },
+      overrides: [],
+    },
+    targets: [
+    ],
+    _nextTarget:: 0,
+    addTarget(target):: self {
+      // automatically ref id in added targets.
+      local nextTarget = super._nextTarget,
+      _nextTarget: nextTarget + 1,
+      targets+: [target { refId: std.char(std.codepoint('A') + nextTarget) }],
+    },
+    addTargets(targets):: std.foldl(function(p, t) p.addTarget(t), targets, self),
+  },
+}

--- a/monitoring/ceph-mixin/dashboards/utils.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/utils.libsonnet
@@ -1,4 +1,5 @@
 local g = import 'grafonnet/grafana.libsonnet';
+local pieChartPanel = import 'piechart_panel.libsonnet';
 
 {
   _config:: error 'must provide _config',
@@ -330,4 +331,33 @@ local g = import 'grafonnet/grafana.libsonnet';
                         'pie',
                         title,
                         'current'),
+
+  pieChartPanel(
+    title,
+    description='',
+    datasource=null,
+    gridPos={},
+    displayMode='table',
+    placement='bottom',
+    showLegend=true,
+    displayLabels=[],
+    tooltip={},
+    pieType='pie',
+    values=[],
+    colorMode='auto'
+  )::
+    pieChartPanel.new(
+      title,
+      description=description,
+      datasource=datasource,
+      gridPos=gridPos,
+      displayMode=displayMode,
+      placement=placement,
+      showLegend=showLegend,
+      displayLabels=displayLabels,
+      tooltip=tooltip,
+      pieType=pieType,
+      values=values,
+      colorMode=colorMode
+    ),
 }

--- a/monitoring/ceph-mixin/dashboards_out/osds-overview.json
+++ b/monitoring/ceph-mixin/dashboards_out/osds-overview.json
@@ -424,9 +424,24 @@
          "type": "table"
       },
       {
-         "aliasColors": { },
          "datasource": "$datasource",
          "description": "",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  }
+               },
+               "mappings": [ ]
+            },
+            "overrides": [ ]
+         },
          "gridPos": {
             "h": 8,
             "w": 4,
@@ -434,13 +449,26 @@
             "y": 8
          },
          "id": 6,
-         "legend": {
-            "percentage": true,
-            "show": true,
-            "values": true
+         "options": {
+            "displayLabels": [
+               "percent"
+            ],
+            "legend": {
+               "calcs": [ ],
+               "displayMode": "table",
+               "placement": "bottom",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "pieType": "pie",
+            "tooltip": {
+               "mode": "single",
+               "sort": "none"
+            }
          },
-         "legendType": "Under graph",
-         "pieType": "pie",
          "targets": [
             {
                "expr": "count by (device_class) (ceph_osd_metadata{job=~\"$job\"})",
@@ -451,15 +479,27 @@
             }
          ],
          "title": "OSD Types Summary",
-         "type": "grafana-piechart-panel",
-         "valueName": "current"
+         "type": "piechart"
       },
       {
-         "aliasColors": {
-            "Non-Encrypted": "#E5AC0E"
-         },
          "datasource": "$datasource",
          "description": "",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  }
+               },
+               "mappings": [ ]
+            },
+            "overrides": [ ]
+         },
          "gridPos": {
             "h": 8,
             "w": 4,
@@ -467,13 +507,26 @@
             "y": 8
          },
          "id": 7,
-         "legend": {
-            "percentage": true,
-            "show": true,
-            "values": true
+         "options": {
+            "displayLabels": [
+               "percent"
+            ],
+            "legend": {
+               "calcs": [ ],
+               "displayMode": "table",
+               "placement": "bottom",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "pieType": "pie",
+            "tooltip": {
+               "mode": "single",
+               "sort": "none"
+            }
          },
-         "legendType": "Under graph",
-         "pieType": "pie",
          "targets": [
             {
                "expr": "count(ceph_bluefs_wal_total_bytes{job=~\"$job\"})",
@@ -491,13 +544,27 @@
             }
          ],
          "title": "OSD Objectstore Types",
-         "type": "grafana-piechart-panel",
-         "valueName": "current"
+         "type": "piechart"
       },
       {
-         "aliasColors": { },
          "datasource": "$datasource",
          "description": "The pie chart shows the various OSD sizes used within the cluster",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  }
+               },
+               "mappings": [ ]
+            },
+            "overrides": [ ]
+         },
          "gridPos": {
             "h": 8,
             "w": 4,
@@ -505,13 +572,26 @@
             "y": 8
          },
          "id": 8,
-         "legend": {
-            "percentage": true,
-            "show": true,
-            "values": true
+         "options": {
+            "displayLabels": [
+               "percent"
+            ],
+            "legend": {
+               "calcs": [ ],
+               "displayMode": "table",
+               "placement": "bottom",
+               "showLegend": true,
+               "values": [
+                  "percent",
+                  "value"
+               ]
+            },
+            "pieType": "pie",
+            "tooltip": {
+               "mode": "single",
+               "sort": "none"
+            }
          },
-         "legendType": "Under graph",
-         "pieType": "pie",
          "targets": [
             {
                "expr": "count(ceph_osd_stat_bytes{job=~\"$job\"} < 1099511627776)",
@@ -578,8 +658,7 @@
             }
          ],
          "title": "OSD Size Summary",
-         "type": "grafana-piechart-panel",
-         "valueName": "current"
+         "type": "piechart"
       },
       {
          "aliasColors": { },


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65287

---

backport of https://github.com/ceph/ceph/pull/55757
parent tracker: https://tracker.ceph.com/issues/64579

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh