### PR TITLE
rgw/cloud: Handle RGWRESTStreamS3PutObj initialization failures

### DIFF
--- a/src/rgw/driver/rados/rgw_sync_module_aws.cc
+++ b/src/rgw/driver/rados/rgw_sync_module_aws.cc
@@ -821,6 +821,7 @@ public:
   int init() override {
     /* init output connection */
     RGWRESTStreamS3PutObj *out_req{nullptr};
+    int ret = -1;
 
     if (multipart.is_multipart) {
       char buf[32];
@@ -828,9 +829,13 @@ public:
       rgw_http_param_pair params[] = { { "uploadId", multipart.upload_id.c_str() },
                                        { "partNumber", buf },
                                        { nullptr, nullptr } };
-      target->conn->put_obj_send_init(dest_obj, params, &out_req);
+      ret = target->conn->put_obj_send_init(dest_obj, params, &out_req);
     } else {
-      target->conn->put_obj_send_init(dest_obj, nullptr, &out_req);
+      ret = target->conn->put_obj_send_init(dest_obj, nullptr, &out_req);
+    }
+
+    if (ret < 0 || !out_req) {
+      return ret;
     }
 
     set_req(out_req);


### PR DESCRIPTION
With the recent code added to handle connection errors (commit#e200499bb3c5703862b92a4d7fb534d98601f1bf), RGWRESTStreamS3PutObj initialization could fail at times if there were any failed requests to the cloud endpoint within CONN_STATUS_EXPIRE_SECS period.

This fix is to handle such errors and abort the transition/sync requests which can be retried later by LC/Sync worker threads.

Signed-off-by: Soumya Koduri <skoduri@redhat.com>
Fixes: https://tracker.ceph.com/issues/65251

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
