### PR TITLE
squid:  mds: some request errors come from errno.h rather than fs_types.h

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3396,7 +3396,7 @@ bool Server::check_dir_max_entries(const MDRequestRef& mdr, CDir *in)
                    in->inode->get_projected_inode()->dirstat.nsubdirs;
   if (dir_max_entries && size >= dir_max_entries) {
     dout(10) << "entries per dir " << *in << " size exceeds " << dir_max_entries << " (ENOSPC)" << dendl;
-    respond_to_request(mdr, -ENOSPC);
+    respond_to_request(mdr, -CEPHFS_ENOSPC);
     return false;
   }
   return true;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65275

---

backport of https://github.com/ceph/ceph/pull/55647
parent tracker: https://tracker.ceph.com/issues/64490

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh