### PR TITLE
squid: rgw/pubsub: CreateTopic validates topic name

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -111,6 +111,9 @@ CephFS: Disallow delegating preallocated inode ranges to clients. Config
   See https://docs.ceph.com/en/latest/rados/operations/balancer/ for more information.
 * CephFS: Full support for subvolumes and subvolume groups is now available
   for snap_schedule Manager module.
+* RGW: The SNS CreateTopic API now enforces the same topic naming requirements as AWS:
+  Topic names must be made up of only uppercase and lowercase ASCII letters, numbers,
+  underscores, and hyphens, and must be between 1 and 256 characters long.
 * RBD: When diffing against the beginning of time (`fromsnapname == NULL`) in
   fast-diff mode (`whole_object == true` with `fast-diff` image feature enabled
   and valid), diff-iterate is now guaranteed to execute locally if exclusive

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <boost/tokenizer.hpp>
 #include <optional>
+#include <regex>
 #include "rgw_iam_policy.h"
 #include "rgw_rest_pubsub.h"
 #include "rgw_pubsub_push.h"
@@ -53,6 +54,23 @@ bool validate_and_update_endpoint_secret(rgw_pubsub_dest& dest, CephContext *cct
         ldout(cct, 1) << "endpoint validation error: sending secrets over insecure transport" << dendl;
         return false;
       }
+  }
+  return true;
+}
+
+bool validate_topic_name(const std::string& name, std::string& message)
+{
+  constexpr size_t max_topic_name_length = 256;
+  if (name.size() > max_topic_name_length) {
+    message = "Name cannot be longer than 256 characters";
+    return false;
+  }
+
+  std::regex pattern("[A-Za-z0-9_-]+");
+  if (!std::regex_match(name, pattern)) {
+    message = "Name must be made up of only uppercase and lowercase "
+        "ASCII letters, numbers, underscores, and hyphens";
+    return false;
   }
   return true;
 }
@@ -133,8 +151,7 @@ class RGWPSCreateTopicOp : public RGWOp {
 
   int get_params() {
     topic_name = s->info.args.get("Name");
-    if (topic_name.empty()) {
-      ldpp_dout(this, 1) << "CreateTopic Action 'Name' argument is missing" << dendl;
+    if (!validate_topic_name(topic_name, s->err.message)) {
       return -EINVAL;
     }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65292

---

backport of https://github.com/ceph/ceph/pull/56562
parent tracker: https://tracker.ceph.com/issues/65212

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh