### PR TITLE
squid: mds: skip sr moves when target is an unlinked dir

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3481,7 +3481,7 @@ void CInode::remove_client_cap(client_t client)
 
 void CInode::move_to_realm(SnapRealm *realm)
 {
-  dout(10) << __func__ << " joining realm " << *realm
+  dout(20) << __func__ << " joining realm " << *realm
 	   << ", leaving realm " << *containing_realm << dendl;
   for (auto& p : client_caps) {
     containing_realm->remove_cap(p.first, &p.second);

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -972,17 +972,34 @@ CInode *CInode::get_parent_inode()
   return NULL;
 }
 
-bool CInode::is_ancestor_of(const CInode *other) const
+bool CInode::is_ancestor_of(const CInode *other, std::unordered_map<CInode const*,bool>* visited) const
 {
+  std::vector<CInode const*> my_visited = {};
   while (other) {
-    if (other == this)
+    if (visited && other->is_dir()) {
+      if (auto it = visited->find(other); it != visited->end()) {
+        for (auto& in : my_visited) {
+          (*visited)[in] = it->second;
+        }
+        return it->second;
+      }
+      my_visited.push_back(other);  /* N.B.: this being non-empty means visited is assumed non-null */
+    }
+    if (other == this) {
+      for (auto& in : my_visited) {
+        (*visited)[in] = true;
+      }
       return true;
+    }
     const CDentry *pdn = other->get_oldest_parent_dn();
     if (!pdn) {
       ceph_assert(other->is_base());
       break;
     }
     other = pdn->get_dir()->get_inode();
+  }
+  for (auto& in : my_visited) {
+    (*visited)[in] = false;
   }
   return false;
 }

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -714,7 +714,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   }
 
   // -- misc -- 
-  bool is_ancestor_of(const CInode *other) const;
+  bool is_ancestor_of(const CInode *other, std::unordered_map<CInode const*,bool>* visited=nullptr) const;
   bool is_projected_ancestor_of(const CInode *other) const;
 
   void make_path_string(std::string& s, bool projected=false, const CDentry *use_parent=NULL) const;

--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -348,6 +348,7 @@ void SnapRealm::split_at(SnapRealm *child)
   }
 
   // split inodes_with_caps
+  uint64_t count = 0;
   for (auto p = inodes_with_caps.begin(); !p.end(); ) {
     CInode *in = *p;
     ++p;
@@ -355,10 +356,13 @@ void SnapRealm::split_at(SnapRealm *child)
     if (child->inode->is_ancestor_of(in)) {
       dout(25) << " child gets " << *in << dendl;
       in->move_to_realm(child);
+      ++count;
     } else {
       dout(25) << "    keeping " << *in << dendl;
     }
   }
+
+  dout(10) << __func__ << ": split " << count << " inodes" << dendl;
 }
 
 void SnapRealm::merge_to(SnapRealm *newparent)

--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -353,10 +353,10 @@ void SnapRealm::split_at(SnapRealm *child)
     ++p;
     // does inode fall within the child realm?
     if (child->inode->is_ancestor_of(in)) {
-      dout(20) << " child gets " << *in << dendl;
+      dout(25) << " child gets " << *in << dendl;
       in->move_to_realm(child);
     } else {
-      dout(20) << "    keeping " << *in << dendl;
+      dout(25) << "    keeping " << *in << dendl;
     }
   }
 }

--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -309,7 +309,7 @@ void SnapRealm::adjust_parent()
 
 void SnapRealm::split_at(SnapRealm *child)
 {
-  dout(10) << "split_at " << *child 
+  dout(10) << __func__ << ": " << *child
 	   << " on " << *child->inode << dendl;
 
   if (inode->is_mdsdir() || !child->inode->is_dir()) {

--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -328,6 +328,19 @@ void SnapRealm::split_at(SnapRealm *child)
 
   // it's a dir.
 
+  if (child->inode->get_projected_parent_dir()->inode->is_stray()) {
+    if (child->inode->containing_realm) {
+      dout(10) << " moving unlinked directory inode" << dendl;
+      child->inode->move_to_realm(child);
+    } else {
+      /* This shouldn't happen because an unlinked directory will have caps
+       * issued to the caller executing rmdir (for today's clients).
+       */
+      dout(10) << " skipping unlinked directory inode w/o caps" << dendl;
+    }
+    return;
+  }
+
   // split open_children
   if (!open_children.empty()) {
     dout(10) << " open_children are " << open_children << dendl;

--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -329,7 +329,9 @@ void SnapRealm::split_at(SnapRealm *child)
   // it's a dir.
 
   // split open_children
-  dout(10) << " open_children are " << open_children << dendl;
+  if (!open_children.empty()) {
+    dout(10) << " open_children are " << open_children << dendl;
+  }
   for (set<SnapRealm*>::iterator p = open_children.begin();
        p != open_children.end(); ) {
     SnapRealm *realm = *p;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65295

---

backport of https://github.com/ceph/ceph/pull/55768
parent tracker: https://tracker.ceph.com/issues/53192

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh