### PR TITLE
squid: rgw/notification: Fix the notification FilterRule to emit unique key name in json & Log successful delivery of notification event.

### DIFF
--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -23,20 +23,24 @@ void set_event_id(std::string& id, const std::string& hash, const utime_t& ts) {
 }
 
 void rgw_s3_key_filter::dump(Formatter *f) const {
+  if (!has_content()) {
+    return;
+  }
+  f->open_array_section("FilterRules");
   if (!prefix_rule.empty()) {
-    f->open_object_section("FilterRule");
+    f->open_object_section("");
     ::encode_json("Name", "prefix", f);
     ::encode_json("Value", prefix_rule, f);
     f->close_section();
   }
   if (!suffix_rule.empty()) {
-    f->open_object_section("FilterRule");
+    f->open_object_section("");
     ::encode_json("Name", "suffix", f);
     ::encode_json("Value", suffix_rule, f);
     f->close_section();
   }
   if (!regex_rule.empty()) {
-    f->open_object_section("FilterRule");
+    f->open_object_section("");
     ::encode_json("Name", "regex", f);
     ::encode_json("Value", regex_rule, f);
     f->close_section();
@@ -97,8 +101,12 @@ bool rgw_s3_key_filter::has_content() const {
 }
 
 void rgw_s3_key_value_filter::dump(Formatter *f) const {
+  if (!has_content()) {
+    return;
+  }
+  f->open_array_section("FilterRules");
   for (const auto& key_value : kv) {
-    f->open_object_section("FilterRule");
+    f->open_object_section("");
     ::encode_json("Name", key_value.first, f);
     ::encode_json("Value", key_value.second, f);
     f->close_section();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64954

---

backport of https://github.com/ceph/ceph/pull/55796
parent tracker: https://tracker.ceph.com/issues/64653

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh