### PR TITLE
quincy: mon: add created_at and ceph_version_when_created meta

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2379,6 +2379,19 @@ void Monitor::collect_metadata(Metadata *m)
   for (auto& i : errs) {
     dout(1) << __func__ << " " << i.first << ": " << i.second << dendl;
   }
+
+  string ceph_version_when_created;
+  int r = store->read_meta("ceph_version_when_created", &ceph_version_when_created);
+  if (r < 0 || ceph_version_when_created.empty()) {
+    ceph_version_when_created = "";
+  }
+  (*m)["ceph_version_when_created"] = ceph_version_when_created;
+  string created_at;
+  r = store->read_meta("created_at", &created_at);
+  if (r < 0 || created_at.empty()) {
+    created_at = "";
+  }
+  (*m)["created_at"] = created_at;
 }
 
 void Monitor::finish_election()

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -31,6 +31,7 @@
 #include "common/safe_io.h"
 #include "common/blkdev.h"
 #include "common/PriorityCache.h"
+#include "common/version.h"
 
 #define dout_context g_ceph_context
 
@@ -690,9 +691,20 @@ class MonitorDBStore
   }
 
   int create_and_open(std::ostream &out) {
+    int r = write_meta("ceph_version_when_created", pretty_version_to_str());
+    if (r < 0)
+      return r;
+
+    std::ostringstream created_at;
+    utime_t now = ceph_clock_now();
+    now.gmtime(created_at);
+    r = write_meta("created_at", created_at.str());
+    if (r < 0)
+      return r;
+
     // record the type before open
     std::string kv_type;
-    int r = read_meta("kv_backend", &kv_type);
+    r = read_meta("kv_backend", &kv_type);
     if (r < 0) {
       kv_type = g_conf()->mon_keyvaluedb;
       r = write_meta("kv_backend", kv_type);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65257

---

backport of https://github.com/ceph/ceph/pull/53858
parent tracker: https://tracker.ceph.com/issues/57515

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh