### PR TITLE
mgr/dashboard: Move features to advanced section and expand by default rbd config section

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.po.ts
@@ -44,7 +44,6 @@ export class PoolPageHelper extends PageHelper {
   edit_pool_configuration(name: string, bpsLimit: string) {
     this.navigateEdit(name);
 
-    cy.get('.collapsible').click();
     cy.get('cd-rbd-configuration-form')
       .get('input[name=rbd_qos_bps_limit]')
       .clear()
@@ -53,7 +52,6 @@ export class PoolPageHelper extends PageHelper {
 
     this.navigateEdit(name);
 
-    cy.get('.collapsible').click();
     cy.get('cd-rbd-configuration-form')
       .get('input[name=rbd_qos_bps_limit]')
       .should('have.value', bpsLimit);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-configuration-form/rbd-configuration-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-configuration-form/rbd-configuration-form.component.ts
@@ -69,7 +69,7 @@ export class RbdConfigurationFormComponent implements OnInit {
 
     this.rbdConfigurationService
       .getWritableSections()
-      .forEach((section) => (this.sectionVisibility[section.class] = false));
+      .forEach((section) => (this.sectionVisibility[section.class] = true));
   }
 
   getDirtyValues(includeLocalValues = false, localFieldType?: RbdConfigurationSourceField) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -219,29 +219,6 @@
           </div>
         </div>
 
-        <!-- Features -->
-        <div class="form-group row"
-             formGroupName="features">
-          <label i18n
-                 class="cd-col-form-label"
-                 for="features">Features</label>
-          <div class="cd-col-form-input">
-            <div class="custom-control custom-checkbox"
-                 *ngFor="let feature of featuresList">
-              <input type="checkbox"
-                     class="custom-control-input"
-                     id="{{ feature.key }}"
-                     name="{{ feature.key }}"
-                     formControlName="{{ feature.key }}">
-              <label class="custom-control-label"
-                     for="{{ feature.key }}">{{ feature.desc }}</label>
-              <cd-helper *ngIf="feature.helperHtml"
-                         html="{{ feature.helperHtml }}">
-              </cd-helper>
-            </div>
-          </div>
-        </div>
-
         <!-- Mirroring -->
         <div class="form-group row">
           <div class="cd-col-form-offset">
@@ -300,9 +277,31 @@
 
         <!-- Advanced -->
         <cd-form-advanced-fieldset>
+          <!-- Features -->
+          <div class="form-group row"
+               formGroupName="features">
+            <label i18n
+                   class="cd-col-form-label"
+                   for="features">Features</label>
+            <div class="cd-col-form-input">
+              <div class="custom-control custom-checkbox"
+                   *ngFor="let feature of featuresList">
+                <input type="checkbox"
+                       class="custom-control-input"
+                       id="{{ feature.key }}"
+                       name="{{ feature.key }}"
+                       formControlName="{{ feature.key }}">
+                <label class="custom-control-label"
+                       for="{{ feature.key }}">{{ feature.desc }}</label>
+                <cd-helper *ngIf="feature.helperHtml"
+                           html="{{ feature.helperHtml }}">
+                </cd-helper>
+              </div>
+            </div>
+          </div>
+
           <h4 class="cd-header"
               i18n>Striping</h4>
-
           <!-- Object Size -->
           <div class="form-group row">
             <label i18n


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/65207

- Moves "features" section in rbd image create form to "Advanced" section.
- makes rbd configuration section to be expanded by default rather than
  being collapsed as it has only single section. This will improve user experience as it will not
require two clicks.
- updates e2e test

[Screencast from 2024-04-05 17-31-30.webm](https://github.com/ceph/ceph/assets/25664409/1b93e39c-2611-4b85-929f-dc593aa4b1ba)



## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
