### PR TITLE
squid: mds/quiesce-db: always clear the db if a membership is lost

### DIFF
--- a/src/mds/QuiesceDbManager.h
+++ b/src/mds/QuiesceDbManager.h
@@ -204,6 +204,7 @@ class QuiesceDbManager {
     std::queue<QuiesceDbPeerAck> pending_acks;
     std::deque<RequestContext*> pending_requests;
     bool db_thread_should_exit = false;
+    bool db_thread_should_clear_db = true;
 
     class QuiesceDbThread : public Thread {
       public:

--- a/src/test/mds/TestQuiesceDb.cc
+++ b/src/test/mds/TestQuiesceDb.cc
@@ -1571,7 +1571,7 @@ TEST_F(QuiesceDbTest, MultiRankRecovery)
   ASSERT_NO_FATAL_FAILURE(configure_cluster({ mds_gid_t(1), mds_gid_t(2), mds_gid_t(3) }));
 
   // we expect the db to be populated since the new leader must have discovered newer versions
-  // we expect the sets to become quiescing since there's at least one member that's not acking (the new one)
+  // we expect the sets to become quiesced since all members are now acking
   EXPECT_EQ(OK(), run_request([](auto& r) {
     r.set_id = "set1";
     r.await = sec(1);
@@ -1598,15 +1598,9 @@ TEST_F(QuiesceDbTest, MultiRankRecovery)
   });
 
   // add back a quiescing peer
-  ASSERT_NO_FATAL_FAILURE(configure_cluster({ mds_gid_t(1), mds_gid_t(2), mds_gid_t(3)}));
-
-  EXPECT_EQ(OK(), run_request([](auto& r) {}));
-  ASSERT_EQ(2, last_request->response.sets.size());
-  EXPECT_EQ(QS_QUIESCED, last_request->response.sets.at("set1").rstate.state);
-  EXPECT_EQ(QS_QUIESCED, last_request->response.sets.at("set2").rstate.state);
+  ASSERT_NO_FATAL_FAILURE(configure_cluster({ mds_gid_t(1), mds_gid_t(2), mds_gid_t(3) }));
 
   EXPECT_EQ(std::future_status::ready, did_ack3.wait_for(std::chrono::milliseconds(2000)));
-
   EXPECT_EQ(OK(), run_request([](auto& r) {}));
   ASSERT_EQ(2, last_request->response.sets.size());
   EXPECT_EQ(QS_QUIESCED, last_request->response.sets.at("set1").rstate.state);


### PR DESCRIPTION
Fixes-Backport: https://tracker.ceph.com/issues/65066

Fixes-Original: https://tracker.ceph.com/issues/64912
(cherry picked from commit e1c8e08961e8199f1da74dc9d1eb2a940e2908d5)
Original-PR: https://github.com/ceph/ceph/pull/56245


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
