### PR TITLE
osd/PrimaryLogPG: Reuse clone overlaps when rolling back

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8567,8 +8567,12 @@ void PrimaryLogPG::_do_rollback_to(OpContext *ctx, ObjectContextRef rollback_to,
     snapset.clone_overlap.lower_bound(snapid);
   ceph_assert(rollback_target_iter != snapset.clone_overlap.end());
   interval_set<uint64_t> new_last_clone_overlap = rollback_target_iter->second;
+
+  // Let's reuse what we already have, bring forward the overlaps
+  // between the rollback target to the newest clone we have
+  auto last_clone_overlap_iter = --snapset.clone_overlap.end();
   for (auto iter = rollback_target_iter;
-       iter != snapset.clone_overlap.end();
+       iter != last_clone_overlap_iter;
        ++iter) {
     new_last_clone_overlap.intersection_of(iter->second);
   }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8590,10 +8590,11 @@ void PrimaryLogPG::_do_rollback_to(OpContext *ctx, ObjectContextRef rollback_to,
     last_clone_overlap_iter->second = new_last_clone_overlap;
   }
 
-  if (obs.oi.size > 0) {
+  // Calculate what is modified (not used by the last clone overlap)
+  // between the rollback target and the last clone overlap
+  if (rollback_to->obs.oi.size > 0) {
     interval_set<uint64_t> modified;
-    modified.insert(0, obs.oi.size);
-    last_clone_overlap_iter->second.intersection_of(modified);
+    modified.insert(0, rollback_to->obs.oi.size);
     modified.subtract(last_clone_overlap_iter->second);
     ctx->modified_ranges.union_of(modified);
   }


### PR DESCRIPTION
See the following example:
```
rbd du --exact <>
NAME               PROVISIONED USED
test_rollback@snap       4 MiB 4 MiB
test_rollback            4 MiB 4 MiB
<TOTAL>                  4 MiB 8 MiB
```
When rolling back to  `snap`, both head and the clone each take 4MB. 
```
rbd du --exact c<>
NAME               PROVISIONED USED
test_rollback@snap       4 MiB 4 MiB
test_rollback            4 MiB 4 MiB       <--- should be zero 
<TOTAL>                  4 MiB 8 MiB
```
With this fix,the head will use 0 MB due to perfect usage of the previous (last) clone:
```
rbd du --exact c<>
NAME               PROVISIONED USED
test_rollback@snap       4 MiB 4 MiB
test_rollback            4 MiB 0 MiB      
<TOTAL>                  4 MiB 4 MiB
```

Fixes: https://tracker.ceph.com/issues/64735

Originated from: #55991
CC: @yanggogo

Docs added: https://github.com/ceph/ceph/pull/56173


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
