### PR TITLE
reef: cephfs-mirror: use monotonic clock

### DIFF
--- a/src/tools/cephfs_mirror/FSMirror.h
+++ b/src/tools/cephfs_mirror/FSMirror.h
@@ -52,7 +52,7 @@ public:
            m_mirror_watcher->is_failed();
   }
 
-  utime_t get_failed_ts() {
+  monotime get_failed_ts() {
     std::scoped_lock locker(m_lock);
     if (m_instance_watcher) {
       return m_instance_watcher->get_failed_ts();
@@ -61,7 +61,7 @@ public:
       return m_mirror_watcher->get_failed_ts();
     }
 
-    return utime_t();
+    return clock::now();
   }
 
   bool is_blocklisted() {
@@ -69,7 +69,7 @@ public:
     return is_blocklisted(locker);
   }
 
-  utime_t get_blocklisted_ts() {
+  monotime get_blocklisted_ts() {
     std::scoped_lock locker(m_lock);
     if (m_instance_watcher) {
       return m_instance_watcher->get_blocklisted_ts();
@@ -78,7 +78,7 @@ public:
       return m_mirror_watcher->get_blocklisted_ts();
     }
 
-    return utime_t();
+    return clock::now();
   }
 
   Peers get_peers() {

--- a/src/tools/cephfs_mirror/InstanceWatcher.cc
+++ b/src/tools/cephfs_mirror/InstanceWatcher.cc
@@ -116,15 +116,15 @@ void InstanceWatcher::handle_rewatch_complete(int r) {
     dout(0) << ": client blocklisted" <<dendl;
     std::scoped_lock locker(m_lock);
     m_blocklisted = true;
-    m_blocklisted_ts = ceph_clock_now();
+    m_blocklisted_ts = clock::now();
   } else if (r == -ENOENT) {
     derr << ": mirroring object deleted" << dendl;
     m_failed = true;
-    m_failed_ts = ceph_clock_now();
+    m_failed_ts = clock::now();
   } else if (r < 0) {
     derr << ": rewatch error: " << cpp_strerror(r) << dendl;
     m_failed = true;
-    m_failed_ts = ceph_clock_now();
+    m_failed_ts = clock::now();
   }
 }
 

--- a/src/tools/cephfs_mirror/InstanceWatcher.h
+++ b/src/tools/cephfs_mirror/InstanceWatcher.h
@@ -10,6 +10,7 @@
 #include "include/Context.h"
 #include "include/rados/librados.hpp"
 #include "Watcher.h"
+#include "Types.h"
 
 class ContextWQ;
 
@@ -49,7 +50,7 @@ public:
     return m_blocklisted;
   }
 
-  utime_t get_blocklisted_ts() {
+  monotime get_blocklisted_ts() {
     std::scoped_lock locker(m_lock);
     return m_blocklisted_ts;
   }
@@ -59,7 +60,7 @@ public:
     return m_failed;
   }
 
-  utime_t get_failed_ts() {
+  monotime get_failed_ts() {
     std::scoped_lock locker(m_lock);
     return m_failed_ts;
   }
@@ -76,8 +77,8 @@ private:
   bool m_blocklisted = false;
   bool m_failed = false;
 
-  utime_t m_blocklisted_ts;
-  utime_t m_failed_ts;
+  monotime m_blocklisted_ts;
+  monotime m_failed_ts;
 
   void create_instance();
   void handle_create_instance(int r);

--- a/src/tools/cephfs_mirror/Mirror.cc
+++ b/src/tools/cephfs_mirror/Mirror.cc
@@ -22,6 +22,8 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "cephfs::mirror::Mirror " << __func__
 
+using namespace std::chrono;
+
 // Performance Counters
 enum {
   l_cephfs_mirror_first = 4000,
@@ -247,7 +249,7 @@ int Mirror::init_mon_client() {
     return r;
   }
 
-  r = m_monc->authenticate(std::chrono::duration<double>(m_cct->_conf.get_val<std::chrono::seconds>("client_mount_timeout")).count());
+  r = m_monc->authenticate(duration<double>(m_cct->_conf.get_val<seconds>("client_mount_timeout")).count());
   if (r < 0) {
     derr << ": failed to authenticate to monitor: " << cpp_strerror(r) << dendl;
     return r;
@@ -537,19 +539,18 @@ void Mirror::peer_removed(const Filesystem &filesystem, const Peer &peer) {
 void Mirror::update_fs_mirrors() {
   dout(20) << dendl;
 
-  auto now = ceph_clock_now();
-  double blocklist_interval = g_ceph_context->_conf.get_val<std::chrono::seconds>
-    ("cephfs_mirror_restart_mirror_on_blocklist_interval").count();
-  double failed_interval = g_ceph_context->_conf.get_val<std::chrono::seconds>
-    ("cephfs_mirror_restart_mirror_on_failure_interval").count();
+  seconds blocklist_interval = g_ceph_context->_conf.get_val<seconds>
+    ("cephfs_mirror_restart_mirror_on_blocklist_interval");
+  seconds failed_interval = g_ceph_context->_conf.get_val<seconds>
+    ("cephfs_mirror_restart_mirror_on_failure_interval");
 
   {
     std::scoped_lock locker(m_lock);
     for (auto &[filesystem, mirror_action] : m_mirror_actions) {
       auto failed_restart = mirror_action.fs_mirror && mirror_action.fs_mirror->is_failed() &&
-	(failed_interval > 0 && (mirror_action.fs_mirror->get_failed_ts() - now) > failed_interval);
+	(failed_interval.count() > 0 && duration_cast<seconds>(mirror_action.fs_mirror->get_failed_ts() - clock::now()) > failed_interval);
       auto blocklisted_restart = mirror_action.fs_mirror && mirror_action.fs_mirror->is_blocklisted() &&
-	(blocklist_interval > 0 && (mirror_action.fs_mirror->get_blocklisted_ts() - now) > blocklist_interval);
+	(blocklist_interval.count() > 0 && duration_cast<seconds>(mirror_action.fs_mirror->get_blocklisted_ts() - clock::now()) > blocklist_interval);
 
       if (!mirror_action.action_in_progress && !_is_restarting(filesystem)) {
 	if (failed_restart || blocklisted_restart) {
@@ -582,7 +583,7 @@ void Mirror::schedule_mirror_update_task() {
                                      m_timer_task = nullptr;
                                      update_fs_mirrors();
                                    });
-  double after = g_ceph_context->_conf.get_val<std::chrono::seconds>
+  double after = g_ceph_context->_conf.get_val<seconds>
     ("cephfs_mirror_action_update_interval").count();
   dout(20) << ": scheduling fs mirror update (" << m_timer_task << ") after "
            << after << " seconds" << dendl;

--- a/src/tools/cephfs_mirror/MirrorWatcher.cc
+++ b/src/tools/cephfs_mirror/MirrorWatcher.cc
@@ -11,7 +11,6 @@
 #include "aio_utils.h"
 #include "MirrorWatcher.h"
 #include "FSMirror.h"
-#include "Types.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_cephfs_mirror
@@ -93,15 +92,15 @@ void MirrorWatcher::handle_rewatch_complete(int r) {
     dout(0) << ": client blocklisted" <<dendl;
     std::scoped_lock locker(m_lock);
     m_blocklisted = true;
-    m_blocklisted_ts = ceph_clock_now();
+    m_blocklisted_ts = clock::now();
   } else if (r == -ENOENT) {
     derr << ": mirroring object deleted" << dendl;
     m_failed = true;
-    m_failed_ts = ceph_clock_now();
+    m_failed_ts = clock::now();
   } else if (r < 0) {
     derr << ": rewatch error: " << cpp_strerror(r) << dendl;
     m_failed = true;
-    m_failed_ts = ceph_clock_now();
+    m_failed_ts = clock::now();
   }
 }
 

--- a/src/tools/cephfs_mirror/MirrorWatcher.h
+++ b/src/tools/cephfs_mirror/MirrorWatcher.h
@@ -10,6 +10,7 @@
 #include "include/Context.h"
 #include "include/rados/librados.hpp"
 #include "Watcher.h"
+#include "Types.h"
 
 class ContextWQ;
 class Messenger;
@@ -47,7 +48,7 @@ public:
     return m_blocklisted;
   }
 
-  utime_t get_blocklisted_ts() {
+  monotime get_blocklisted_ts() {
     std::scoped_lock locker(m_lock);
     return m_blocklisted_ts;
   }
@@ -57,7 +58,7 @@ public:
     return m_failed;
   }
 
-  utime_t get_failed_ts() {
+  monotime get_failed_ts() {
     std::scoped_lock locker(m_lock);
     return m_failed_ts;
   }
@@ -76,8 +77,8 @@ private:
   bool m_blocklisted = false;
   bool m_failed = false;
 
-  utime_t m_blocklisted_ts;
-  utime_t m_failed_ts;
+  monotime m_blocklisted_ts;
+  monotime m_failed_ts;
 
   void register_watcher();
   void handle_register_watcher(int r);

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1554,7 +1554,7 @@ void PeerReplayer::sync_snaps(const std::string &dir_root,
 void PeerReplayer::run(SnapshotReplayerThread *replayer) {
   dout(10) << ": snapshot replayer=" << replayer << dendl;
 
-  time last_directory_scan = clock::zero();
+  monotime last_directory_scan = clock::zero();
   auto scan_interval = g_ceph_context->_conf.get_val<uint64_t>(
     "cephfs_mirror_directory_scan_interval");
 

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -132,9 +132,6 @@ private:
     }
   };
 
-  using clock = ceph::coarse_mono_clock;
-  using time = ceph::coarse_mono_time;
-
   // stats sent to service daemon
   struct ServiceDaemonStats {
     uint64_t failed_dir_count = 0;
@@ -143,14 +140,14 @@ private:
 
   struct SnapSyncStat {
     uint64_t nr_failures = 0; // number of consecutive failures
-    boost::optional<time> last_failed; // lat failed timestamp
+    boost::optional<monotime> last_failed; // lat failed timestamp
     bool failed = false; // hit upper cap for consecutive failures
     boost::optional<std::pair<uint64_t, std::string>> last_synced_snap;
     boost::optional<std::pair<uint64_t, std::string>> current_syncing_snap;
     uint64_t synced_snap_count = 0;
     uint64_t deleted_snap_count = 0;
     uint64_t renamed_snap_count = 0;
-    time last_synced = clock::zero();
+    monotime last_synced = clock::zero();
     boost::optional<double> last_sync_duration;
   };
 

--- a/src/tools/cephfs_mirror/Types.h
+++ b/src/tools/cephfs_mirror/Types.h
@@ -81,6 +81,8 @@ typedef std::shared_ptr<librados::IoCtx> IoCtxRef;
 // not a shared_ptr since the type is incomplete
 typedef ceph_mount_info *MountRef;
 
+using clock = ceph::coarse_mono_clock;
+using monotime = ceph::coarse_mono_time;
 } // namespace mirror
 } // namespace cephfs
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/65319
Original-issue: https://tracker.ceph.com/issues/62265
Original-PR: https://github.com/ceph/ceph/pull/55701
(cherry picked from commit 7f0e7feea52c2917a6c234fffce1e5d9ff8ef791)


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>