### PR TITLE
rgw: don't map to EIO in rgw_http_error_to_errno()

### DIFF
--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -37,7 +37,7 @@ static inline int rgw_http_error_to_errno(int http_err)
     case 503:
         return -EBUSY;
     default:
-        return -EIO;
+        return -ERR_INTERNAL_ERROR;
   }
 
   return 0; /* unreachable */


### PR DESCRIPTION
the http client uses EIO to detect connection errors specifically. if we map normal http errors to EIO, we incorrectly mark their endpoint as failed and route requests to other endpoints (if any exist)

default to ERR_INTERNAL_ERROR (500 InternalError) instead

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
