### PR TITLE
[WIP] containerized build tools

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Ignore everything
+*
+
+# Don't ignore files required for docker build
+!run-make-check.sh
+!install-deps.sh
+!do_cmake.sh
+!src/script/buildcontainer-setup.sh
+!src/script/run-make.sh
+!src/script/lib-build.sh
+!ceph.spec.in
+!debian

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,27 @@
+ARG DISTRO='quay.io/centos/centos:stream8'
+FROM $DISTRO
+
+ARG JENKINS_HOME
+
+ARG JENKINS_USER=jenkins
+ARG JENKINS_USER_ID=1110
+ARG JENKINS_USER_GID=100
+
+
+#SHELL ["bash", "-x", "-c"]
+RUN useradd --uid ${JENKINS_USER_ID} --gid ${JENKINS_USER_GID} --create-home ${JENKINS_USER}
+
+COPY ./ /src/ceph
+ENV FOR_MAKE_CHECK=1
+ARG DISTRO
+ARG CLEAN_DNF=yes
+ARG CEPH_BRANCH=main
+# Note that we do not use ENV for the following. This is because we do not
+# want them permamently stored in the container's layer.
+RUN DISTRO=$DISTRO \
+    CEPH_BRANCH=$CEPH_BRANCH \
+    CLEAN_DNF=$CLEAN_DNF \
+    /src/ceph/src/script/buildcontainer-setup.sh
+
+
+USER ${JENKINS_USER}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,66 @@
+pipeline {
+  agent {
+    dockerfile {
+      label 'docker'
+      filename 'Dockerfile.build'
+      additionalBuildArgs '--build-arg JENKINS_HOME=$JENKINS_HOME'
+      args '-v $HOME/.ccache:/home/jenkins/.ccache'
+    }
+  }
+
+  options {
+    timestamps()
+    disableConcurrentBuilds(abortPrevious: true)
+    timeout(time: 2, unit: 'HOURS')
+  }
+
+
+  stages {
+    stage('Configure') {
+      steps {
+        runMakeCheck 'configure'
+      }
+    }
+
+    stage('Build') {
+      steps {
+        sh '. ./run-make-check.sh && build vstart'
+      }
+    }
+
+    stage('Test') {
+      parallel {
+        stage('Unit Tests') {
+          steps {
+            sh '. ./run-make-check.sh && build tests'
+            sh '. ./run-make-check.sh && cd build && run'
+          }
+          post {
+            always{
+              xunit(
+                thresholds: [skipped(failureThreshold: '0'), failed(failureThreshold: '0')],
+                tools: [CTest(
+                  deleteOutputFiles: true,
+                  failIfNotNew: true,
+                  pattern: 'build/Testing/**/Test.xml',
+                  skipNoTestFiles: true,
+                  stopProcessingIfError: true)
+                ]
+              )
+            }
+          }
+        }
+      } // parallel
+    } // stage('Test')
+
+  } // stages
+} // pipeline
+
+def runMakeCheck(String command) {
+  sh """
+  #!/usr/bin/env bash
+  set -exo pipefail
+  source ./run-make-check.sh
+  ${command}
+  """
+}

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -466,7 +466,7 @@ else
         ;;
     almalinux|rocky|centos|fedora|rhel|ol|virtuozzo)
         builddepcmd="dnf -y builddep --allowerasing"
-        echo "Using dnf to install dependencies"
+        echo "Using dnf to install dependencies: ID=$ID"
         case "$ID" in
             fedora)
                 $SUDO dnf install -y dnf-utils

--- a/src/script/build-in-container.sh
+++ b/src/script/build-in-container.sh
@@ -1,0 +1,287 @@
+#!/bin/bash
+#
+# Build ceph in a container, creating the container environment if necessary.
+# Use a build recipe (-r) to automatically perform a build step. Otherwise,
+# pass CLI args after -- terminator to run whatever command you want in
+# the build container.
+#
+
+set -e -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+CEPH_ROOT="$SCRIPT_DIR/../.."
+
+DISTRO=centos8
+TAG=
+CONTAINER_NAME="ceph-build"
+BUILD_CTR=yes
+BUILD=yes
+BUILD_DIR=build
+HOMEDIR=/build
+DNF_CACHE=
+ENABLE_CCACHE=volume
+EXTRA_ARGS=()
+BUILD_ARGS=()
+
+show_help() {
+    echo "build-in-container.sh:"
+    echo "    --help                Show help"
+    grep "###:" "${0}" | grep -v sed | sed 's,.*###: ,    ,'
+    echo ""
+}
+
+show_recipes() {
+    echo "build-in-container.sh recipes:"
+    echo "  You can execute one or more recipe on the same command line."
+    echo "  Each recipe will run in a new container instance."
+    echo ""
+    grep "###%" "${0}" | grep -v sed | sed 's,.*###% ,    ,'
+    echo ""
+}
+
+get_engine() {
+    if command -v podman >/dev/null 2>&1; then
+        echo podman
+        return 0
+    fi
+    if command -v docker >/dev/null 2>&1; then
+        echo docker
+        return 0
+    fi
+    echo "ERROR: no container engine found" >&2
+    return 2
+}
+
+build_container() {
+    engine="$(get_engine)"
+    cmd=("${engine}" build -t "${CONTAINER_NAME}:${TAG}" --build-arg JENKINS_HOME="$HOMEDIR")
+    if [ "$DISTRO" ]; then
+        cmd+=(--build-arg DISTRO="${DISTRO}")
+    fi
+    if [ "$DNF_CACHE" ]; then
+        mkdir -p "$DNF_CACHE/lib" "$DNF_CACHE/cache"
+        cmd+=(-v "$DNF_CACHE/lib:/var/lib/dnf:Z"
+              -v "$DNF_CACHE/cache:/var/cache/dnf:Z"
+              --build-arg CLEAN_DNF=no)
+    fi
+    cmd+=(-f Dockerfile.build .)
+
+    "${cmd[@]}"
+}
+
+# get_recipe extends BUILD_ARGS with commands to execute the named recipe.
+# Exits on an invalid recipe.
+get_recipe() {
+    RECIPE_BUILD_ARGS=()
+    case "$1" in
+        ###% configure
+        ###%     Runs the configure function with defaults for unit testing.
+        configure)
+            RECIPE_BUILD_ARGS=(bash -c 'cd /build && source ./src/script/run-make.sh && configure')
+        ;;
+        ###% configure-if-needed
+        ###%     Runs the configure recipe only when the build dir doesn't exist.
+        configure-if-needed)
+            RECIPE_BUILD_ARGS=(bash -c 'cd /build && source ./src/script/run-make.sh && has_build_dir || configure')
+        ;;
+        ###% build
+        ###%     Runs the build (without support for unit tests).
+        build)
+            RECIPE_BUILD_ARGS=(bash -c 'cd /build && source ./src/script/run-make.sh && enable_compiler_env && build vstart')
+        ;;
+        ###% build-tests
+        ###%     Runs the build with support for unit tests.
+        build-tests)
+            RECIPE_BUILD_ARGS=(bash -c 'cd /build && source ./src/script/run-make.sh && enable_compiler_env && build tests')
+        ;;
+        ###% run-tests
+        ###%     Runs the unit test suite.
+        run-tests)
+            # shellcheck disable=SC2016 # We want the bash-in-container to expand the var
+            RECIPE_BUILD_ARGS=(bash -c 'cd /build && source ./run-make-check.sh && enable_compiler_env && cd $BUILD_DIR && run')
+        ;;
+        ###% make-srpm
+        ###%     Generates a source rpm (assumes a CentOS/RH container).
+        make-srpm)
+            RECIPE_BUILD_ARGS=(bash -c 'cd /build && ./make-srpm.sh')
+        ;;
+        ###% rpmbuild
+        ###%     Builds binary rpms from source rpm (assumes a CentOS/RH container).
+        rpmbuild)
+            RECIPE_BUILD_ARGS=(bash -c 'rpmbuild --rebuild -D"_topdir /build/_rpm" /build/ceph-*.src.rpm')
+        ;;
+        *)
+            echo "invalid recipe: $1" >&2
+            exit 2
+        ;;
+    esac
+}
+
+build_ceph() {
+    engine="$(get_engine)"
+    cmd=("${engine}" run --name ceph_build --rm)
+    case "$engine" in
+        *podman)
+            cmd+=("--pids-limit=-1")
+        ;;
+    esac
+    local hname="${TAG:=ceph-build}"
+    cmd+=(--hostname="${hname//./-}")
+    cmd+=(-v "$PWD:$HOMEDIR:Z")
+    cmd+=(-e "HOMEDIR=$HOMEDIR")
+    cmd+=(-e "BUILD_DIR=$BUILD_DIR")
+
+    if [ "${ENABLE_CCACHE}" = "volume" ]; then
+        ccvol="ceph-ccache-${TAG:=default}"
+        if ! "${engine}" volume exists "${ccvol}" ; then
+            "${engine}" volume create "${ccvol}"
+        fi
+        cmd+=(-v "$ccvol:$HOMEDIR/.ccache:Z")
+        cmd+=(-e "CCACHE_DIR=$HOMEDIR/.ccache")
+        cmd+=(-e "CCACHE_BASEDIR=${HOMEDIR}")
+    fi
+    cmd+=("${EXTRA_ARGS[@]}")
+    cmd+=("$CONTAINER_NAME:$TAG")
+
+    "${cmd[@]}" "$@"
+}
+
+parse_cli() {
+    CLI="$(getopt -o hd:t:x:b:r: --long help,distro:,tag:,name:,no-build,no-container-build,dnf-cache:,build-dir:,recipe:,help-recipes -n "$0" -- "$@")"
+    eval set -- "${CLI}"
+    while true ; do
+        case "$1" in
+            ###: -d / --distro=<VALUE>
+            ###:     Specify a distro image or short name (eg. centos8)
+            -d|--distro)
+                DISTRO="$2"
+                shift
+                shift
+            ;;
+            ###: -t / --tag=<VALUE>
+            ###:     Specify a container tag (eg. main)
+            -t|--tag)
+                TAG="$2"
+                shift
+                shift
+            ;;
+            ###: --name=<VALUE>
+            ###:     Specify a container name (default: ceph-build)
+            --name)
+                CONTAINER_NAME="$2"
+                shift
+                shift
+            ;;
+            ###: --dnf-cache=<VALUE>
+            ###:     Enable dnf caching in given dir (build container)
+            --dnf-cache)
+                DNF_CACHE="$2"
+                shift
+                shift
+            ;;
+            ###: -b / --build-dir=<VALUE>
+            ###:     Specify (relative) build directory to use (ceph build)
+            -b|--build-dir)
+                BUILD_DIR="$2"
+                shift
+                shift
+            ;;
+            ###: -x<ARG>
+            ###:     Pass extra argument to container run command
+            -x)
+                EXTRA_ARGS+=("$2")
+                shift
+                shift
+            ;;
+            ###: -r / --recipe=<VALUE>
+            ###:     Ceph build recipe to use. If not provided, the remaining
+            ###:     arguments will be executed directly as a build commmand.
+            ###:     Can be specified more than once. Use --help-recipes for details.
+            -r|--recipe)
+                BUILD_RECIPES+=("$2")
+                shift
+                shift
+            ;;
+            ###: --no-build
+            ###:     Skip building Ceph
+            --no-build)
+                BUILD=no
+                shift
+            ;;
+            ###: --no-container-build
+            ###:     Skip constructing a build container
+            --no-container-build)
+                BUILD_CTR=no
+                shift
+            ;;
+            ###: --help-recipes
+            ###:     Show available build recipes.
+            --help-recipes)
+                show_recipes
+                exit 0
+            ;;
+            -h|--help)
+                show_help
+                exit 0
+            ;;
+            --)
+                shift
+                BUILD_ARGS+=("$@")
+                break
+            ;;
+            *)
+                echo "unknown option: $1" >&2
+                exit 2
+            ;;
+        esac
+    done
+}
+
+build_in_container() {
+    parse_cli "$@"
+    # We didn't want tracing before, it is all boring boilerplate and cli
+    # handling. We enable it now that we're beginning to run interesting
+    # stuff and want to know what we are actually executing.
+    set -x
+
+    case "$DISTRO" in
+        ubuntu22.04)
+            DISTRO_NAME="ubuntu22.04"
+            DISTRO="docker.io/ubuntu:22.04"
+        ;;
+        centos9|centos?stream9)
+            DISTRO_NAME="centos9"
+            DISTRO="quay.io/centos/centos:stream9"
+        ;;
+        centos8|centos?stream8)
+            DISTRO_NAME="centos8"
+            DISTRO="quay.io/centos/centos:stream8"
+        ;;
+        *)
+            DISTRO_NAME="custom"
+        ;;
+    esac
+
+    if [ -z "${TAG}" ]; then
+        GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+        TAG="${GIT_BRANCH}.${DISTRO_NAME}"
+    fi
+
+    cd "$CEPH_ROOT"
+    if [ "$BUILD_CTR" = yes ]; then
+        build_container
+    fi
+    if [ "$BUILD" = yes ]; then
+        for rec in "${BUILD_RECIPES[@]}"; do
+            get_recipe "${rec}"
+            build_ceph "${RECIPE_BUILD_ARGS[@]}"
+        done
+        if [ "${#BUILD_ARGS[@]}" -gt 0 ]; then
+            build_ceph "${BUILD_ARGS[@]}"
+        fi
+    fi
+}
+
+if [ "$0" = "${BASH_SOURCE[0]}" ]; then
+    build_in_container "$@"
+fi

--- a/src/script/buildcontainer-setup.sh
+++ b/src/script/buildcontainer-setup.sh
@@ -26,7 +26,7 @@ case "${CEPH_BRANCH}~${DISTRO}" in
         fi
     ;;
     *~*centos*stream9)
-        #dnf install -y java-1.8.0-openjdk-headless /usr/bin/rpmbuild wget
+        dnf install -y /usr/bin/rpmbuild wget
         source ./src/script/run-make.sh
         prepare
         if [ "${CLEAN_DNF}" != no ]; then

--- a/src/script/buildcontainer-setup.sh
+++ b/src/script/buildcontainer-setup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This script expects to be run during the construction of a container The
+# resulting container has all the dependencies and tools installed needed to
+# build ceph. It DOES NOT and is not expected to build ceph during the
+# container build.
+
+# The script assumes the following environment variables are present during
+# the container build:
+# CEPH_BRANCH
+# DISTRO
+# CLEAN_DNF (for dnf based distros, ignored on others)
+
+set -e
+export LOCALE=C
+cd /src/ceph
+
+case "${CEPH_BRANCH}~${DISTRO}" in
+    *~*centos*stream8)
+        dnf install -y java-1.8.0-openjdk-headless /usr/bin/rpmbuild wget
+        source ./src/script/run-make.sh
+        prepare
+        if [ "${CLEAN_DNF}" != no ]; then
+            dnf clean all
+            rm -rf /var/cache/dnf/*
+        fi
+    ;;
+    *~*centos*stream9)
+        #dnf install -y java-1.8.0-openjdk-headless /usr/bin/rpmbuild wget
+        source ./src/script/run-make.sh
+        prepare
+        if [ "${CLEAN_DNF}" != no ]; then
+            dnf clean all
+            rm -rf /var/cache/dnf/*
+        fi
+    ;;
+    *~*ubuntu*22.04)
+        apt-get update
+        source ./src/script/run-make.sh
+        prepare
+    ;;
+    *)
+        echo "Unknown branch or build: ${CEPH_BRANCH}~${DISTRO}" >&2
+        exit 2
+    ;;
+esac
+
+
+

--- a/src/script/lib-build.sh
+++ b/src/script/lib-build.sh
@@ -92,6 +92,7 @@ function discover_compiler() {
     local cxx_compiler=g++
     local c_compiler=gcc
     # ubuntu/debian ci builds prefer clang
+    if [ "$NO_CLANG" != true ]; then
     for i in {17..12}; do
         if type -t "clang-$i" > /dev/null; then
             cxx_compiler="clang++-$i"
@@ -99,6 +100,7 @@ function discover_compiler() {
             break
         fi
     done
+    fi
     # but if this is {centos,rhel} we need gcc-toolset
     if [ -f "/opt/rh/gcc-toolset-11/enable" ]; then
         ci_debug "Detected SCL gcc-toolset-11 environment file"

--- a/src/script/lib-build.sh
+++ b/src/script/lib-build.sh
@@ -49,6 +49,34 @@ function get_processors() {
     fi
 }
 
+# has_build_dir returns true if a build directory exists and can be used
+# for builds. has_build_dir is designed to interoperate with do_cmake.sh
+# and uses the same BUILD_DIR environment variable. It checks for the
+# directory relative to the current working directory.
+function has_build_dir() {
+    ( cd "${BUILD_DIR:=build}" && [[ -f build.ninja || -f Makefile ]] )
+}
+
+# csudo (conditional sudo) checks if the script is root, or needs root,
+# and conditionally executes the command with sudo.
+# Set NEVER_SUDO=1 to disable sudo commands even if running as a non-root
+# user.
+function csudo() {
+    if [ "${EUID}" -eq 0 ]; then
+        # already root
+        ci_debug "PRIV COMMAND (already root): $*"
+        "$@"
+        return
+    fi
+    if [ "${NEVER_SUDO}" = 1 ]; then
+        ci_debug "PRIV COMMAND (NEVER_SUDO=1): $*"
+        "$@"
+        return
+    fi
+    ci_debug "SUDO COMMAND: $*"
+    sudo --non-interactive "$@"
+}
+
 # discover_compiler takes one argument, purpose, which may be used
 # to adjust the results for a specific need. It sets three environment
 # variables `discovered_c_compiler`, `discovered_cxx_compiler` and
@@ -85,4 +113,18 @@ function discover_compiler() {
     export discovered_cxx_compiler="${cxx_compiler}"
     export discovered_compiler_env="${compiler_env}"
     return 0
+}
+
+# enable_compiler_env sources a compiler environment if the detected compiler
+# needs such an environment. It takes an optional argument to pass to
+# `discover_compiler` otherwise it passes "default".
+function enable_compiler_env() {
+    local purpose="$1"
+    pupose="${purpose:=default}"
+    discover_compiler "${purpose}"
+    if [ "${discovered_compiler_env}" ]; then
+        ci_debug "Enabling compiler environment from: ${discovered_compiler_env}"
+        # shellcheck disable=SC1090
+        source "${discovered_compiler_env}"
+    fi
 }

--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -99,7 +99,7 @@ EOM
     local c_compiler="${discovered_c_compiler}"
     local cmake_opts
     cmake_opts+=" -DCMAKE_CXX_COMPILER=$cxx_compiler -DCMAKE_C_COMPILER=$c_compiler"
-    cmake_opts+=" -DCMAKE_CXX_FLAGS_DEBUG=-Werror"
+    #cmake_opts+=" -DCMAKE_CXX_FLAGS_DEBUG=-Werror"
     cmake_opts+=" -DENABLE_GIT_VERSION=OFF"
     cmake_opts+=" -DWITH_GTEST_PARALLEL=ON"
     cmake_opts+=" -DWITH_FIO=ON"

--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -55,7 +55,7 @@ function prepare() {
 
     if test -f ./install-deps.sh ; then
         ci_debug "Running install-deps.sh"
-        INSTALL_EXTRA_PACKAGES="ccache git $which_pkg clang lvm2"
+        INSTALL_EXTRA_PACKAGES="ccache git $which_pkg clang lvm2 jsonnet"
         $DRY_RUN source ./install-deps.sh || return 1
         trap clean_up_after_myself EXIT
     fi

--- a/src/test/run-cli-tests
+++ b/src/test/run-cli-tests
@@ -20,7 +20,7 @@ esac
 
 VENV="$BUILDDIR/virtualenv"
 CRAM_BIN="$VENV/bin/cram"
-if [ ! -e "$CRAM_BIN" ]; then
+if [ ! -e "$CRAM_BIN" ] || ! "${CRAM_BIN}" --version &> /dev/null ; then
     # With "make distcheck", the source directory must be read-only. I
     # patched cram to support that. See upstream ticket at
     # https://bitbucket.org/brodie/cram/issue/9/allow-read-only-directories-for-t


### PR DESCRIPTION
This is a messy work-in-progress branch that provides tools for building ceph and running the tests within containers. This is _NOT_ a tool to build container images for ceph. It either spits out binaries, packaged binaries, or executes test code.

Ideally, this has two use cases:
1. Use on build nodes, isolating the build environment from the real host os. This allows builders to be homogeneous with the containers provding the build dependencies.
2. Use on indvidual developer machines. Running Fedora and want to build ubuntu binaries, or centos packages? The included build script should help you do it.

The initial effort, started by Ernesto, was focused on use case 1. This was difficult for me to iterate on since I lack experience and access to Jenkins, so I mainly worked on use case 2.

The current state of the branch is a bit of a mess. I have a number of "hacks" and workarounds that have accumulated over time. Due to lack of time and focus on this task I have not been able to properly get real fixes into the project. But it's not a huge, insurmountable amount of changes either.

Finally, a quick mini-tutorial for the script:
```
./src/script/build-in-container.sh   -d centos8  -b _build_20240401  -x--user=0  -r configure-if-needed -r build
```

Breaking this example command down:
* -d / --distro  - what base distro to use. Supported values: centos8, centos9, ubuntu22.04
* -b / --build-dir - a directory for build artifacts (bind mounted into container)
* -x--user=0 - override container user, needed for bind mount
* -r / --recipe - build task to perform, Examples include: configure-if-needed, build, build-tests, run-tests, make-srpm, rpmbuild


I last tested it on 2024-04-01 using the above command successfully, but it's very raw so YMMV.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
