### PR TITLE
rgw/notify: fix crashes in lc due to reload of bucket.

### DIFF
--- a/src/rgw/driver/rados/rgw_cr_rados.cc
+++ b/src/rgw/driver/rados/rgw_cr_rados.cc
@@ -741,6 +741,15 @@ int send_sync_notification(const DoutPrefixProvider* dpp,
       return -EIO;
     }
   }
+  // bucket attrs are required for notification and since its not loaded,
+  // reload the bucket
+  int r = bucket->load_bucket(dpp, null_yield);
+  if (r < 0) {
+    ldpp_dout(dpp, 1) << "ERROR: failed to load bucket attrs for bucket:"
+                      << bucket->get_name() << " with error ret= " << r
+                      << " . Not sending notification" << dendl;
+    return r;
+  }
   rgw::notify::reservation_t notify_res(dpp, store, obj, nullptr, bucket,
                                         user_id, bucket->get_tenant(), req_id,
                                         null_yield);

--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
 #include "rgw_notify.h"
@@ -1011,21 +1011,7 @@ int publish_reserve(const DoutPrefixProvider* dpp,
   rgw_pubsub_bucket_topics bucket_topics;
   if (all_zonegroups_support(site, zone_features::notification_v2) &&
       res.store->stat_topics_v1(res.user_tenant, res.yield, res.dpp) == -ENOENT) {
-    auto ret = 0;
-    if (!res.s) {
-      //  for non S3-request caller (e.g., lifecycle, ObjectSync), bucket attrs
-      //  are not loaded, so force to reload the bucket, that reloads the attr.
-      // for non S3-request caller, res.s is nullptr
-      ret = res.bucket->load_bucket(dpp, res.yield);
-      if (ret < 0) {
-        ldpp_dout(dpp, 1)
-            << "ERROR: failed to reload bucket: '" << res.bucket->get_name()
-            << "' to get bucket notification attrs with error ret= " << ret
-            << dendl;
-        return ret;
-      }
-    }
-    ret = get_bucket_notifications(dpp, res.bucket, bucket_topics);
+    auto ret = get_bucket_notifications(dpp, res.bucket, bucket_topics);
     if (ret < 0) {
       return ret;
     }


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/64571

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
