### PR TITLE
squid: qa/cephadm: use squid image as default for test_cephadm workunit

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -10,9 +10,10 @@ FSID='00000000-0000-0000-0000-0000deadbeef'
 
 # images that are used
 IMAGE_MAIN=${IMAGE_MAIN:-'quay.ceph.io/ceph-ci/ceph:main'}
-IMAGE_PACIFIC=${IMAGE_PACIFIC:-'quay.ceph.io/ceph-ci/ceph:pacific'}
-#IMAGE_OCTOPUS=${IMAGE_OCTOPUS:-'quay.ceph.io/ceph-ci/ceph:octopus'}
-IMAGE_DEFAULT=${IMAGE_MAIN}
+IMAGE_QUINCY=${IMAGE_QUINCY:-'quay.ceph.io/ceph-ci/ceph:quincy'}
+IMAGE_REEF=${IMAGE_REEF:-'quay.ceph.io/ceph-ci/ceph:reef'}
+IMAGE_SQUID=${IMAGE_SQUID:-'quay.ceph.io/ceph-ci/ceph:squid'}
+IMAGE_DEFAULT=${IMAGE_SQUID}
 
 OSD_IMAGE_NAME="${SCRIPT_NAME%.*}_osd.img"
 OSD_IMAGE_SIZE='6G'


### PR DESCRIPTION
This patch is intended directly for the squid branch. On squid, we should be running tests using the squid image. This should have been updated at some point after squid branched off from main. This hasn't started causing any actual test failures yet, but will as soon as the version on main goes from 19 -> 20

Fixes: https://tracker.ceph.com/issues/64208


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
