### PR TITLE
squid: rgw: update options yaml file so LDAP uri isn't an invalid example

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -913,8 +913,8 @@ options:
 - name: rgw_ldap_uri
   type: str
   level: advanced
-  desc: Space-separated list of LDAP servers in URI format.
-  default: ldaps://<ldap.your.domain>
+  desc: Space-separated list of LDAP servers in URI format, e.g., "ldaps://<ldap.your.domain>".
+  default:
   services:
   - rgw
   with_legacy: true

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -381,6 +381,11 @@ void rgw::AppMain::init_ldap()
   const string &ldap_dnattr = cct->_conf->rgw_ldap_dnattr;
   std::string ldap_bindpw = parse_rgw_ldap_bindpw(cct);
 
+  if (ldap_uri.empty()) {
+    derr << "LDAP not started since no server URIs were provided in the configuration." << dendl;
+    return;
+  }
+
   ldh.reset(new rgw::LDAPHelper(ldap_uri, ldap_binddn,
             ldap_bindpw.c_str(), ldap_searchdn, ldap_searchfilter, ldap_dnattr));
   ldh->init();
@@ -603,7 +608,7 @@ void rgw::AppMain::shutdown(std::function<void(void)> finalize_async_signals)
     fe->stop();
   }
 
-  ldh.reset(nullptr); // deletes
+  ldh.reset(nullptr); // deletes ldap helper if it was created
   rgw_log_usage_finalize();
 
   delete olog;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65339

---

backport of https://github.com/ceph/ceph/pull/56645
parent tracker: https://tracker.ceph.com/issues/65277

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh