### PR TITLE
quincy: rgw: update options yaml file so LDAP uri isn't an invalid example

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -883,8 +883,8 @@ options:
 - name: rgw_ldap_uri
   type: str
   level: advanced
-  desc: Space-separated list of LDAP servers in URI format.
-  default: ldaps://<ldap.your.domain>
+  desc: Space-separated list of LDAP servers in URI format, e.g., "ldaps://<ldap.your.domain>".
+  default:
   services:
   - rgw
   with_legacy: true

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -579,10 +579,12 @@ namespace rgw {
       store->ctx()->_conf->rgw_ldap_dnattr;
     std::string ldap_bindpw = parse_rgw_ldap_bindpw(store->ctx());
 
-    ldh = new rgw::LDAPHelper(ldap_uri, ldap_binddn, ldap_bindpw.c_str(),
-			      ldap_searchdn, ldap_searchfilter, ldap_dnattr);
-    ldh->init();
-    ldh->bind();
+    if (! ldap_uri.empty()) {
+      ldh = new rgw::LDAPHelper(ldap_uri, ldap_binddn, ldap_bindpw.c_str(),
+				ldap_searchdn, ldap_searchfilter, ldap_dnattr);
+      ldh->init();
+      ldh->bind();
+    }
 
     rgw_log_usage_init(g_ceph_context, store);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65341

---

backport of https://github.com/ceph/ceph/pull/56645
parent tracker: https://tracker.ceph.com/issues/65277

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh