### PR TITLE
os/BlueStore: NCB fix for leaked space when bdev_async_discard is ena…

### DIFF
--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -285,8 +285,8 @@ public:
     int write_hint = WRITE_LIFE_NOT_SET) = 0;
   virtual int flush() = 0;
   virtual bool try_discard(interval_set<uint64_t> &to_release, bool async=true) { return false; }
-  virtual int discard_drain(uint32_t timeout_msec = 0) { return 0; }
-
+  virtual void discard_drain() { return; }
+  virtual const interval_set<uint64_t>* get_discard_queued() { return nullptr;}
   // for managing buffered readers/writers
   virtual int invalidate_cache(uint64_t off, uint64_t len) = 0;
   virtual int open(const std::string& path) = 0;

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -286,7 +286,7 @@ public:
   virtual int flush() = 0;
   virtual bool try_discard(interval_set<uint64_t> &to_release, bool async=true) { return false; }
   virtual void discard_drain() { return; }
-  virtual const interval_set<uint64_t>* get_discard_queued() { return nullptr;}
+  virtual void swap_discard_queued(interval_set<uint64_t>& other)  { other.clear(); }
   // for managing buffered readers/writers
   virtual int invalidate_cache(uint64_t off, uint64_t len) = 0;
   virtual int open(const std::string& path) = 0;

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -285,7 +285,7 @@ public:
     int write_hint = WRITE_LIFE_NOT_SET) = 0;
   virtual int flush() = 0;
   virtual bool try_discard(interval_set<uint64_t> &to_release, bool async=true) { return false; }
-  virtual void discard_drain() { return; }
+  virtual int discard_drain(uint32_t timeout_msec = 0) { return 0; }
 
   // for managing buffered readers/writers
   virtual int invalidate_cache(uint64_t off, uint64_t len) = 0;

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -587,13 +587,35 @@ bool KernelDevice::_discard_started()
   return !discard_threads.empty();
 }
 
-void KernelDevice::discard_drain()
+int KernelDevice::discard_drain(uint32_t timeout_msec = 0)
 {
   dout(10) << __func__ << dendl;
+  bool check_timeout = false;
+  utime_t end_time;
+  if (timeout_msec) {
+    check_timeout = true;
+    uint32_t timeout_sec = 0;
+    if (timeout_msec >= 1000) {
+      timeout_sec = (timeout_msec / 1000);
+      timeout_msec = (timeout_msec % 1000);
+    }
+    end_time = ceph_clock_now();
+    // add the timeout after converting from msec to nsec
+    end_time.tv.tv_nsec += (timeout_msec * (1000*1000));
+    if (end_time.tv.tv_nsec > (1000*1000*1000)) {
+      end_time.tv.tv_nsec -= (1000*1000*1000);
+      end_time.tv.tv_sec += 1;
+    }
+    end_time.tv.tv_sec += timeout_sec;
+  }
   std::unique_lock l(discard_lock);
   while (!discard_queued.empty() || discard_running) {
     discard_cond.wait(l);
+    if (check_timeout && ceph_clock_now() > end_time) {
+      return -1;
+    }
   }
+  return 0;
 }
 
 static bool is_expected_ioerr(const int r)

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -591,7 +591,7 @@ void KernelDevice::discard_drain()
 {
   dout(10) << __func__ << dendl;
   std::unique_lock l(discard_lock);
-  while (!discard_queued.empty() || discard_running) {
+  while (!discard_queued.empty() || (discard_running > 0)) {
     discard_cond.wait(l);
   }
 }
@@ -731,6 +731,12 @@ void KernelDevice::_aio_thread()
   dout(10) << __func__ << " end" << dendl;
 }
 
+void KernelDevice::swap_discard_queued(interval_set<uint64_t>& other)
+{
+  std::unique_lock l(discard_lock);
+  discard_queued.swap(other);
+}
+
 void KernelDevice::_discard_thread(uint64_t tid)
 {
   dout(10) << __func__ << " thread " << tid << " start" << dendl;
@@ -755,13 +761,21 @@ void KernelDevice::_discard_thread(uint64_t tid)
       discard_cond.wait(l);
       dout(20) << __func__ << " wake" << dendl;
     } else {
-      // Swap the queued discards for a local list we'll process here
-      // without caring about thread fairness.  This allows the current
-      // thread to wait on the discard running while other threads pick
-      // up the next-in-queue, and do the same, ultimately issuing more
-      // discards in parallel, which is the goal.
-      discard_processing.swap(discard_queued);
-      discard_running = true;
+      // Limit local processing to MAX_LOCAL_DISCARD items.
+      // This will allow threads to work in parallel
+      //      instead of a single thread taking over the whole discard_queued.
+      // It will also allow threads to finish in a timely manner.
+      constexpr unsigned MAX_LOCAL_DISCARD = 10;
+      unsigned count = 0;
+      for (auto p = discard_queued.begin();
+	   p != discard_queued.end() && count < MAX_LOCAL_DISCARD;
+	   ++p, ++count) {
+	discard_processing.insert(p.get_start(), p.get_len());
+	discard_queued.erase(p);
+      }
+
+      // there are multiple active threads -> must use a counter instead of a flag
+      discard_running ++;
       l.unlock();
       dout(20) << __func__ << " finishing" << dendl;
       for (auto p = discard_processing.begin(); p != discard_processing.end(); ++p) {
@@ -771,7 +785,8 @@ void KernelDevice::_discard_thread(uint64_t tid)
       discard_callback(discard_callback_priv, static_cast<void*>(&discard_processing));
       discard_processing.clear();
       l.lock();
-      discard_running = false;
+      discard_running --;
+      ceph_assert(discard_running >= 0);
     }
   }
 

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -765,7 +765,7 @@ void KernelDevice::_discard_thread(uint64_t tid)
       // This will allow threads to work in parallel
       //      instead of a single thread taking over the whole discard_queued.
       // It will also allow threads to finish in a timely manner.
-      constexpr unsigned MAX_LOCAL_DISCARD = 10;
+      constexpr unsigned MAX_LOCAL_DISCARD = 32;
       unsigned count = 0;
       for (auto p = discard_queued.begin();
 	   p != discard_queued.end() && count < MAX_LOCAL_DISCARD;

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -123,7 +123,7 @@ public:
   ~KernelDevice();
 
   void aio_submit(IOContext *ioc) override;
-  void discard_drain() override;
+  int discard_drain(uint32_t timeout_msec) override;
 
   int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const override;
   int get_devname(std::string *s) const override {

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -55,7 +55,7 @@ private:
 
   ceph::mutex discard_lock = ceph::make_mutex("KernelDevice::discard_lock");
   ceph::condition_variable discard_cond;
-  bool discard_running = false;
+  int discard_running = 0;
   interval_set<uint64_t> discard_queued;
 
   struct AioCompletionThread : public Thread {
@@ -124,7 +124,7 @@ public:
 
   void aio_submit(IOContext *ioc) override;
   void discard_drain() override;
-  const interval_set<uint64_t>* get_discard_queued() override { return &discard_queued;}
+  void swap_discard_queued(interval_set<uint64_t>& other) override;
   int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const override;
   int get_devname(std::string *s) const override {
     if (devname.empty()) {

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -123,8 +123,8 @@ public:
   ~KernelDevice();
 
   void aio_submit(IOContext *ioc) override;
-  int discard_drain(uint32_t timeout_msec) override;
-
+  void discard_drain() override;
+  const interval_set<uint64_t>* get_discard_queued() override { return &discard_queued;}
   int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const override;
   int get_devname(std::string *s) const override {
     if (devname.empty()) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7762,17 +7762,24 @@ void BlueStore::_close_db()
   db = nullptr;
 
   if (do_destage && fm && fm->is_null_manager()) {
-    // force all backgrounds discards to be committed before storing allocator
-    // set timeout to 500msec
-    int ret = bdev->discard_drain(500);
-    if (ret == 0) {
-      ret = store_allocator(alloc);
-      if (unlikely(ret != 0)) {
-	derr << __func__ << "::NCB::store_allocator() failed (we will need to rebuild it on startup)" << dendl;
+    if (cct->_conf->osd_fast_shutdown == false) {
+      // graceful shutdown -> commit backgrounds discards before storing allocator
+      bdev->discard_drain();
+    }
+
+    auto discard_queued = bdev->get_discard_queued();
+    if (discard_queued && (discard_queued->num_intervals() > 0)) {
+      dout(10) << __func__ << "::discard_drain: size=" << discard_queued->size()
+	       << " num_intervals=" << discard_queued->num_intervals() << dendl;
+      // copy discard_queued to the allocator before storing it
+      for (auto p = discard_queued->begin(); p != discard_queued->end(); ++p) {
+	dout(20) << __func__ << "::discarded-extent=[" << p.get_start() << ", " << p.get_len() << "]" << dendl;
+	alloc->init_add_free(p.get_start(), p.get_len());
       }
     }
-    else {
-      derr << __func__ << "::NCB::discard_drain() exceeded timeout (abort!)" << dendl;
+    int ret = store_allocator(alloc);
+    if (unlikely(ret != 0)) {
+      derr << __func__ << "::NCB::store_allocator() failed (we will need to rebuild it on startup)" << dendl;
     }
   }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7762,24 +7762,22 @@ void BlueStore::_close_db()
   db = nullptr;
 
   if (do_destage && fm && fm->is_null_manager()) {
-    if (cct->_conf->osd_fast_shutdown == false) {
-      // graceful shutdown -> commit backgrounds discards before storing allocator
-      bdev->discard_drain();
-    }
-
-    interval_set<uint64_t> discard_queued;
-    bdev->swap_discard_queued(discard_queued);
-    if (discard_queued.num_intervals() > 0) {
+    if (cct->_conf->osd_fast_shutdown) {
+      interval_set<uint64_t> discard_queued;
+      bdev->swap_discard_queued(discard_queued);
       dout(10) << __func__ << "::discard_drain: size=" << discard_queued.size()
 	       << " num_intervals=" << discard_queued.num_intervals() << dendl;
       // copy discard_queued to the allocator before storing it
       for (auto p = discard_queued.begin(); p != discard_queued.end(); ++p) {
-	dout(20) << __func__ << "::discarded-extent=[" << p.get_start() << ", " << p.get_len() << "]" << dendl;
+	dout(20) << __func__ << "::discarded-extent=[" << p.get_start()
+		 << ", " << p.get_len() << "]" << dendl;
 	alloc->init_add_free(p.get_start(), p.get_len());
       }
     }
-    // drain the items in the threads local discard_processing queues
-    // There are only a few items in those queues so it is fine to do so in fast shutdown
+
+    // When we reach here it is either a graceful shutdown (so can drain the full discards-queue)
+    //   or it was a fast shutdown, but we already moved the main discards-queue to the allocator
+    //   and only need to wait for the threads local discard_processing queues to drain
     bdev->discard_drain();
     int ret = store_allocator(alloc);
     if (unlikely(ret != 0)) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7767,16 +7767,20 @@ void BlueStore::_close_db()
       bdev->discard_drain();
     }
 
-    auto discard_queued = bdev->get_discard_queued();
-    if (discard_queued && (discard_queued->num_intervals() > 0)) {
-      dout(10) << __func__ << "::discard_drain: size=" << discard_queued->size()
-	       << " num_intervals=" << discard_queued->num_intervals() << dendl;
+    interval_set<uint64_t> discard_queued;
+    bdev->swap_discard_queued(discard_queued);
+    if (discard_queued.num_intervals() > 0) {
+      dout(10) << __func__ << "::discard_drain: size=" << discard_queued.size()
+	       << " num_intervals=" << discard_queued.num_intervals() << dendl;
       // copy discard_queued to the allocator before storing it
-      for (auto p = discard_queued->begin(); p != discard_queued->end(); ++p) {
+      for (auto p = discard_queued.begin(); p != discard_queued.end(); ++p) {
 	dout(20) << __func__ << "::discarded-extent=[" << p.get_start() << ", " << p.get_len() << "]" << dendl;
 	alloc->init_add_free(p.get_start(), p.get_len());
       }
     }
+    // drain the items in the threads local discard_processing queues
+    // There are only a few items in those queues so it is fine to do so in fast shutdown
+    bdev->discard_drain();
     int ret = store_allocator(alloc);
     if (unlikely(ret != 0)) {
       derr << __func__ << "::NCB::store_allocator() failed (we will need to rebuild it on startup)" << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7762,9 +7762,17 @@ void BlueStore::_close_db()
   db = nullptr;
 
   if (do_destage && fm && fm->is_null_manager()) {
-    int ret = store_allocator(alloc);
-    if (ret != 0) {
-      derr << __func__ << "::NCB::store_allocator() failed (continue with bitmapFreelistManager)" << dendl;
+    // force all backgrounds discards to be committed before storing allocator
+    // set timeout to 500msec
+    int ret = bdev->discard_drain(500);
+    if (ret == 0) {
+      ret = store_allocator(alloc);
+      if (unlikely(ret != 0)) {
+	derr << __func__ << "::NCB::store_allocator() failed (we will need to rebuild it on startup)" << dendl;
+      }
+    }
+    else {
+      derr << __func__ << "::NCB::discard_drain() exceeded timeout (abort!)" << dendl;
     }
   }
 


### PR DESCRIPTION
…bled

On graceful shutdown we call bdev->discard_drain() before calling store_allocator() to make sure all freed space is reflected in the allocator before destaging it.
On fast shutdown we remove the discarded queue and copy all its entries into the allocator before calling store_allocator().
This is logically identical to the behavior before NCB when the freed space was reflected in column-B entry in RocksDB which was used to construct the allocator after shutdown even if the free operation didn't complete.
The PR adds a drain wait for all discarded entries in the worker-threads private space to be committed.
We had to limit the private space entries to only 10 entries to guarantee that the drain will finish in timely manner  

Fixes: https://tracker.ceph.com/issues/65298
Signed-off-by: Gabriel BenHanokh <gbenhano@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
