### PR TITLE
tests/scripts: use 'tell pg deep-scrub pgid' instead of 'tell pgid deep-scrub'

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1303,7 +1303,7 @@ def osd_scrub_pgs(ctx, config):
                     # request was missed.  do not do it every time because
                     # the scrub may be in progress or not reported yet and
                     # we will starve progress.
-                    manager.raw_cluster_cmd('tell', pgid, 'deep-scrub')
+                    manager.raw_cluster_cmd('pg', 'deep-scrub', pgid)
             if gap_cnt > retries:
                 raise RuntimeError('Exiting scrub checking -- not all pgs scrubbed.')
         if loop:


### PR DESCRIPTION

as older OSD versions do not support the former.

Fixes: https://tracker.ceph.com/issues/64972

