### PR TITLE
 reef: mds: defer trim() until after the last cache_rejoin ack being received

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -13483,6 +13483,13 @@ void MDCache::handle_mdsmap(const MDSMap &mdsmap, const MDSMap &oldmap) {
   }
 }
 
+bool MDCache::is_ready_to_trim_cache(void)
+{
+  // null rejoin_done means rejoin has finished and all the rejoin acks
+  // have been well received.
+  return is_open() && !rejoin_done;
+}
+
 void MDCache::upkeep_main(void)
 {
   std::unique_lock lock(upkeep_mutex);
@@ -13503,7 +13510,7 @@ void MDCache::upkeep_main(void)
         if (active_with_clients) {
           trim_client_leases();
         }
-        if (is_open() || mds->is_standby_replay()) {
+        if (is_ready_to_trim_cache() || mds->is_standby_replay()) {
           trim();
         }
         if (active_with_clients) {

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1351,6 +1351,8 @@ class MDCache {
 
   void upkeep_main(void);
 
+  bool is_ready_to_trim_cache(void);
+
   uint64_t cache_memory_limit;
   double cache_reservation;
   double cache_health_threshold;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65321

---

backport of https://github.com/ceph/ceph/pull/52648
parent tracker: https://tracker.ceph.com/issues/62036


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
