### PR TITLE
squid:osd/scrub: disable scrub reservation queuing

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -551,7 +551,7 @@ options:
     either success or failure (the pre-Squid version behaviour). This configuration
     option is introduced to support mixed-version clusters and debugging, and will
     be removed in the next release.
-  default: false
+  default: true
   with_legacy: false
 # where rados plugins are stored
 - name: osd_class_dir


### PR DESCRIPTION
as a temporary measure for Squid RC0. There are known problems in the existing code, with patch PRs being tested. This change disables the Reserver functionality, until such time as the patches are merged.
