### PR TITLE
crimson/osd/object_context_loader: Simplify interface

### DIFF
--- a/src/crimson/osd/object_context.cc
+++ b/src/crimson/osd/object_context.cc
@@ -53,6 +53,7 @@ std::optional<hobject_t> resolve_oid(
   if (oid.snap > ss.seq) {
     // Because oid.snap > ss.seq, we are trying to read from a snapshot
     // taken after the most recent write to this object. Read from head.
+    logger().debug("{} returning head", __func__);
     return oid.get_head();
   } else {
     // which clone would it be?

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -103,6 +103,11 @@ public:
     fully_loaded = true;
   }
 
+  void set_clone_ssc(SnapSetContextRef head_ssc) {
+    ceph_assert(!is_head());
+    ssc = head_ssc;
+  }
+
   /// pass the provided exception to any waiting consumers of this ObjectContext
   template<typename Exception>
   void interrupt(Exception ex) {

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -41,7 +41,7 @@ using crimson::common::local_conf;
   {
     LOG_PREFIX(ObjectContextLoader::with_clone_obc);
     assert(!oid.is_head());
-    return with_obc<RWState::RWREAD>(
+    return with_head_obc<RWState::RWREAD>(
       oid.get_head(),
       [FNAME, oid, func=std::move(func), this](auto head, auto) mutable
       -> load_obc_iertr::future<> {

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -75,6 +75,7 @@ using crimson::common::local_conf;
       auto loaded = get_or_load_obc<State>(clone, existed);
       return loaded.safe_then_interruptible(
         [func = std::move(func), head=std::move(head)](auto clone) mutable {
+        clone->set_clone_ssc(head->ssc);
         return std::move(func)(std::move(head), std::move(clone));
       });
     });
@@ -112,6 +113,7 @@ using crimson::common::local_conf;
         auto loaded = get_or_load_obc<State>(clone, existed);
         return loaded.safe_then_interruptible(
           [func = std::move(func), head=std::move(head)](auto clone) {
+          clone->set_clone_ssc(head->ssc);
           return std::move(func)(std::move(head), std::move(clone));
         });
       });
@@ -152,6 +154,9 @@ using crimson::common::local_conf;
         obc->set_head_state(std::move(md->os),
                             std::move(md->ssc));
       } else {
+        // we load and set the ssc only for head obc.
+        // For clones, the head's ssc will be referenced later.
+        // See set_clone_ssc
         obc->set_clone_state(std::move(md->os));
       }
       DEBUGDPP("returning obc {} for {}", dpp, obc->obs.oi, obc->obs.oi.soid);

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -47,8 +47,19 @@ using crimson::common::local_conf;
           crimson::ct_error::enoent::make()
         };
       }
+      auto resolved_oid = resolve_oid(head->get_head_ss(), oid);
+      if (!resolved_oid) {
+        ERRORDPP("clone {} not found", dpp, oid);
+        return load_obc_iertr::future<>{
+          crimson::ct_error::enoent::make()
+        };
+      }
+      if (resolved_oid->is_head()) {
+        // See resolve_oid
+        return std::move(func)(head, head);
+      }
       return this->with_clone_obc_only<State>(std::move(head),
-                                              oid,
+                                              *resolved_oid,
                                               std::move(func));
     });
   }
@@ -56,18 +67,12 @@ using crimson::common::local_conf;
   template<RWState::State State>
   ObjectContextLoader::load_obc_iertr::future<>
   ObjectContextLoader::with_clone_obc_only(ObjectContextRef head,
-                                           hobject_t oid,
+                                           hobject_t clone_oid,
                                            with_obc_func_t&& func)
   {
     LOG_PREFIX(ObjectContextLoader::with_clone_obc_only);
-    auto coid = resolve_oid(head->get_head_ss(), oid);
-    if (!coid) {
-      ERRORDPP("clone {} not found", dpp, oid);
-      return load_obc_iertr::future<>{
-        crimson::ct_error::enoent::make()
-      };
-    }
-    auto [clone, existed] = obc_registry.get_cached_obc(*coid);
+    DEBUGDPP("{}", clone_oid);
+    auto [clone, existed] = obc_registry.get_cached_obc(clone_oid);
     return clone->template with_lock<State, IOInterruptCondition>(
       [existed=existed, clone=std::move(clone),
        func=std::move(func), head=std::move(head), this]() mutable

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -22,6 +22,10 @@ using crimson::common::local_conf;
       return get_or_load_obc<State>(obc, existed)
       .safe_then_interruptible(
         [func = std::move(func)](auto obc) {
+        // The templat with_obc_func_t wrapper supports two obcs (head and clone).
+        // In the 'with_head_obc' case, however, only the head is in use.
+        // Pass the same head obc twice in order to
+        // to support the generic with_obc sturcture.
         return std::move(func)(obc, obc);
       });
     }).finally([FNAME, this, obc=std::move(obc)] {

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -9,11 +9,11 @@ using crimson::common::local_conf;
 
   template<RWState::State State>
   ObjectContextLoader::load_obc_iertr::future<>
-  ObjectContextLoader::with_head_obc(ObjectContextRef obc,
-                                     bool existed,
+  ObjectContextLoader::with_head_obc(const hobject_t& oid,
                                      with_obc_func_t&& func)
   {
     LOG_PREFIX(ObjectContextLoader::with_head_obc);
+    auto [obc, existed] = obc_registry.get_cached_obc(oid);
     DEBUGDPP("object {}", dpp, obc->get_oid());
     assert(obc->is_head());
     obc->append_to(obc_set_accessing);
@@ -36,7 +36,7 @@ using crimson::common::local_conf;
 
   template<RWState::State State>
   ObjectContextLoader::load_obc_iertr::future<>
-  ObjectContextLoader::with_clone_obc(hobject_t oid,
+  ObjectContextLoader::with_clone_obc(const hobject_t& oid,
                                       with_obc_func_t&& func)
   {
     LOG_PREFIX(ObjectContextLoader::with_clone_obc);
@@ -96,11 +96,7 @@ using crimson::common::local_conf;
                                 with_obc_func_t&& func)
   {
     if (oid.is_head()) {
-      auto [obc, existed] =
-        obc_registry.get_cached_obc(std::move(oid));
-      return with_head_obc<State>(std::move(obc),
-                                  existed,
-                                  std::move(func));
+      return with_head_obc<State>(oid, std::move(func));
     } else {
       return with_clone_obc<State>(oid, std::move(func));
     }

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -92,45 +92,6 @@ using crimson::common::local_conf;
 
   template<RWState::State State>
   ObjectContextLoader::load_obc_iertr::future<>
-  ObjectContextLoader::with_clone_obc_direct(
-    hobject_t oid,
-    with_obc_func_t&& func)
-  {
-    LOG_PREFIX(ObjectContextLoader::with_clone_obc_direct);
-    assert(!oid.is_head());
-    return with_obc<RWState::RWREAD>(
-      oid.get_head(),
-      [FNAME, oid, func=std::move(func), this](auto head, auto) mutable
-      -> load_obc_iertr::future<> {
-      if (!head->obs.exists) {
-        ERRORDPP("head doesn't exist for object {}", dpp, head->obs.oi.soid);
-        return load_obc_iertr::future<>{
-          crimson::ct_error::enoent::make()
-        };
-      }
-#ifndef NDEBUG
-      auto &ss = head->get_head_ss();
-      auto cit = std::find(
-	std::begin(ss.clones), std::end(ss.clones), oid.snap);
-      assert(cit != std::end(ss.clones));
-#endif
-      auto [clone, existed] = obc_registry.get_cached_obc(oid);
-      return clone->template with_lock<State, IOInterruptCondition>(
-        [existed=existed, clone=std::move(clone),
-         func=std::move(func), head=std::move(head), this]()
-        -> load_obc_iertr::future<> {
-        auto loaded = get_or_load_obc<State>(clone, existed);
-        return loaded.safe_then_interruptible(
-          [func = std::move(func), head=std::move(head)](auto clone) {
-          clone->set_clone_ssc(head->ssc);
-          return std::move(func)(std::move(head), std::move(clone));
-        });
-      });
-    });
-  }
-
-  template<RWState::State State>
-  ObjectContextLoader::load_obc_iertr::future<>
   ObjectContextLoader::with_obc(hobject_t oid,
                                 with_obc_func_t&& func)
   {
@@ -247,9 +208,4 @@ using crimson::common::local_conf;
   template ObjectContextLoader::load_obc_iertr::future<>
   ObjectContextLoader::with_obc<RWState::RWEXCL>(hobject_t,
                                                  with_obc_func_t&&);
-
-  template ObjectContextLoader::load_obc_iertr::future<>
-  ObjectContextLoader::with_clone_obc_direct<RWState::RWWRITE>(
-    hobject_t,
-    with_obc_func_t&&);
 }

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -33,6 +33,8 @@ public:
     std::function<load_obc_iertr::future<> (ObjectContextRef, ObjectContextRef)>;
 
   // Use this variant by default
+  // If oid is a clone object, the clone obc *and* it's
+  // matching head obc will be locked and can be used in func.
   template<RWState::State State>
   load_obc_iertr::future<> with_obc(hobject_t oid,
                                     with_obc_func_t&& func);
@@ -45,14 +47,6 @@ public:
   load_obc_iertr::future<> with_clone_obc_only(ObjectContextRef head,
                                                hobject_t clone_oid,
                                                with_obc_func_t&& func);
-
-  // Use this variant in the case where both the head
-  // object *and* the matching clone object are being used
-  // in func.
-  template<RWState::State State>
-  load_obc_iertr::future<> with_clone_obc_direct(
-    hobject_t oid,
-    with_obc_func_t&& func);
 
   load_obc_iertr::future<> reload_obc(ObjectContext& obc) const;
 

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -59,12 +59,11 @@ private:
   obc_accessing_list_t obc_set_accessing;
 
   template<RWState::State State>
-  load_obc_iertr::future<> with_clone_obc(hobject_t oid,
+  load_obc_iertr::future<> with_clone_obc(const hobject_t& oid,
                                           with_obc_func_t&& func);
 
   template<RWState::State State>
-  load_obc_iertr::future<> with_head_obc(ObjectContextRef obc,
-                                         bool existed,
+  load_obc_iertr::future<> with_head_obc(const hobject_t& oid,
                                          with_obc_func_t&& func);
 
   template<RWState::State State>

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -43,7 +43,7 @@ public:
   // with an already locked head.
   template<RWState::State State>
   load_obc_iertr::future<> with_clone_obc_only(ObjectContextRef head,
-                                               hobject_t oid,
+                                               hobject_t clone_oid,
                                                with_obc_func_t&& func);
 
   // Use this variant in the case where both the head

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -35,9 +35,13 @@ public:
   // Use this variant by default
   // If oid is a clone object, the clone obc *and* it's
   // matching head obc will be locked and can be used in func.
+  // resolve_clone: For SnapTrim, it may be possible that it
+  //                won't be possible to resolve the clone.
+  // See SnapTrimObjSubEvent::remove_or_update - in_removed_snaps_queue usage.
   template<RWState::State State>
   load_obc_iertr::future<> with_obc(hobject_t oid,
-                                    with_obc_func_t&& func);
+                                    with_obc_func_t&& func,
+                                    bool resolve_clone = true);
 
   // Use this variant in the case where the head object
   // obc is already locked and only the clone obc is needed.
@@ -60,7 +64,8 @@ private:
 
   template<RWState::State State>
   load_obc_iertr::future<> with_clone_obc(const hobject_t& oid,
-                                          with_obc_func_t&& func);
+                                          with_obc_func_t&& func,
+                                          bool resolve_clone);
 
   template<RWState::State State>
   load_obc_iertr::future<> with_head_obc(const hobject_t& oid,

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -441,8 +441,8 @@ SnapTrimObjSubEvent::start()
   }).then_interruptible([this] {
     logger().debug("{}: getting obc for {}", *this, coid);
     // end of commonality
-    // with_clone_obc_direct lock both clone's and head's obcs
-    return pg->obc_loader.with_clone_obc_direct<RWState::RWWRITE>(
+    // lock both clone's and head's obcs
+    return pg->obc_loader.with_obc<RWState::RWWRITE>(
       coid,
       [this](auto head_obc, auto clone_obc) {
       logger().debug("{}: got clone_obc={}", *this, clone_obc->get_oid());

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -469,7 +469,8 @@ SnapTrimObjSubEvent::start()
           });
         });
       });
-    }).si_then([this] {
+    },
+    false).si_then([this] {
       logger().debug("{}: completed", *this);
       return handle.complete();
     }).handle_error_interruptible(


### PR DESCRIPTION
Originated and blocked by: #56610 
This PR includes comments, cleanups and improved readability to object_context_loader.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
