### PR TITLE
[rgw]: Fast path for resharding

### DIFF
--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -94,6 +94,19 @@ private:
                  std::ostream *os,
 		 Formatter *formatter,
                  const DoutPrefixProvider *dpp);
+  bool is_fast_reshard(int current_shards,
+                       int target_shards);
+  int do_reshard_fast(RGWBucketInfo& new_bucket_info,
+                      int current_shards,
+                      int target_shards,
+                      int max_entries, bool verbose, std::ostream *os,
+                      Formatter *formatter, const DoutPrefixProvider *dpp,
+                      optional_yield y);
+  int do_reshard_fast_process(RGWBucketInfo &new_bucket_info,
+                              int current_shards, int target_shards, int job_id,
+                              int growth_factor, int max_entries,
+                              const DoutPrefixProvider *dpp, optional_yield y);
+
 public:
 
   // pass nullptr for the final parameter if no outer reshard lock to


### PR DESCRIPTION
**This MR is an RFC and should not be merged.**

This RFC partially addresses [64805](https://tracker.ceph.com/issues/64805), [52776](https://tracker.ceph.com/issues/52776) and other similar issues. The main problem is that reshard process takes a lot of time even for relatively small buckets. In my tests it shows about 130 thousand objects per second.

Current reshard process:

1. block all shards
2. create new bucket-index objects
3. read old bucket-index objects one by one and for each key
    1. take hash of their key
    2. perform modulo operation by the new number of shards
    3. put the key into the new bucket-index with a specific number
4. unlock shards

This process can be done in parallel for each shard if the new number of shards is multiple of the old one. This way modulo operation is going to fall into exactly `n` new shards where `n` is growth factor. 

This solution does not fix this issue but makes it more manageable for us. I have not noticed any problems during testing but maybe I missed something.

Benchmarks:

|number of objects|old time|new time|
|---|---|---|
|100e6|1110s|120s(x9.25)|
|17e6|137s|28s (x4.8)|
|6e6|54s|9.7s(x5.6)|
|6e6 (1e6 multipart)| 64.1s|11.8s(x5.4)|

Additionally I can reimplement this in the current `main` if required.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
