### PR TITLE
rgw/multisite: x-rgw-replicated-at uses dump_time_header()

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -469,7 +469,7 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs,
     try {
       ceph::real_time replicated_time;
       decode(replicated_time, i->second);
-      dump_time(s, "x-rgw-replicated-at", replicated_time);
+      dump_time_header(s, "x-rgw-replicated-at", replicated_time);
     } catch (const buffer::error&) {}
   }
 


### PR DESCRIPTION
dump_time() encodes this timestamp as json/xml. use dump_time_header() instead

Fixes: https://tracker.ceph.com/issues/65373

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
