### PR TITLE
qa/cephadm: only fail on CEPHADM_ error in logs

### DIFF
--- a/qa/suites/orch/cephadm/mgr-nfs-upgrade/1-bootstrap/17.2.0.yaml
+++ b/qa/suites/orch/cephadm/mgr-nfs-upgrade/1-bootstrap/17.2.0.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm:
     roleless: true

--- a/qa/suites/orch/cephadm/no-agent-workunits/task/test_cephadm_timeout.yaml
+++ b/qa/suites/orch/cephadm/no-agent-workunits/task/test_cephadm_timeout.yaml
@@ -4,6 +4,10 @@ roles:
   - mgr.a
   - osd.0
   - client.0
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/no-agent-workunits/task/test_orch_cli.yaml
+++ b/qa/suites/orch/cephadm/no-agent-workunits/task/test_orch_cli.yaml
@@ -6,6 +6,10 @@ roles:
   - mon.a
   - mgr.a
   - client.0
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/no-agent-workunits/task/test_orch_cli_mon.yaml
+++ b/qa/suites/orch/cephadm/no-agent-workunits/task/test_orch_cli_mon.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     log-ignorelist:
       - MON_DOWN
+    log-only-match:
+      - CEPHADM_
 roles:
 - - host.a
   - osd.0

--- a/qa/suites/orch/cephadm/osds/1-start.yaml
+++ b/qa/suites/orch/cephadm/osds/1-start.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm:
     roleless: true

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_basic.yaml
@@ -10,6 +10,10 @@ roles:
   # Reserve a host for acting as a test client
   - - host.b
     - cephadm.exclude
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
   # TODO: (jjm) I don't think `install` is necessary for this file. Remove?
   - install:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_domain.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_domain.yaml
@@ -9,6 +9,10 @@ roles:
 # Reserve a host for acting as a domain controller
 - - host.b
   - cephadm.exclude
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm.deploy_samba_ad_dc:
     role: host.b

--- a/qa/suites/orch/cephadm/smoke-roleless/1-start.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/1-start.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm:
     roleless: true

--- a/qa/suites/orch/cephadm/smoke-singlehost/1-start.yaml
+++ b/qa/suites/orch/cephadm/smoke-singlehost/1-start.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm:
     roleless: true

--- a/qa/suites/orch/cephadm/smoke-small/start.yaml
+++ b/qa/suites/orch/cephadm/smoke-small/start.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm:
     conf:

--- a/qa/suites/orch/cephadm/smoke/start.yaml
+++ b/qa/suites/orch/cephadm/smoke/start.yaml
@@ -5,6 +5,8 @@ overrides:
       - mons down
       - mon down
       - out of quorum
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm:
     conf:

--- a/qa/suites/orch/cephadm/thrash/1-start.yaml
+++ b/qa/suites/orch/cephadm/thrash/1-start.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/simple.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/simple.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm.shell:
     env: [sha1]

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm.shell:
     env: [sha1]

--- a/qa/suites/orch/cephadm/with-work/start.yaml
+++ b/qa/suites/orch/cephadm/with-work/start.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/workunits/task/test_ca_signed_key.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_ca_signed_key.yaml
@@ -12,6 +12,9 @@ roles:
 overrides:
   cephadm:
     use-ca-signed-key: True
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/workunits/task/test_extra_daemon_features.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_extra_daemon_features.yaml
@@ -7,6 +7,10 @@ roles:
   - mon.b
   - mgr.b
   - osd.1
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/workunits/task/test_host_drain.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_host_drain.yaml
@@ -5,6 +5,8 @@ overrides:
       - mons down
       - mon down
       - out of quorum
+    log-only-match:
+      - CEPHADM_
 roles:
 - - host.a
   - mon.a

--- a/qa/suites/orch/cephadm/workunits/task/test_iscsi_container/test_iscsi_container.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_iscsi_container/test_iscsi_container.yaml
@@ -6,6 +6,10 @@ roles:
   - mon.a
   - mgr.a
   - client.0
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/workunits/task/test_monitoring_stack_basic.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_monitoring_stack_basic.yaml
@@ -5,6 +5,8 @@ overrides:
       - mons down
       - mon down
       - out of quorum
+    log-only-match:
+      - CEPHADM_
 roles:
 - - host.a
   - mon.a

--- a/qa/suites/orch/cephadm/workunits/task/test_rgw_multisite.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_rgw_multisite.yaml
@@ -5,6 +5,8 @@ overrides:
       - mons down
       - mon down
       - out of quorum
+    log-only-match:
+      - CEPHADM_
 roles:
 - - host.a
   - mon.a

--- a/qa/suites/orch/cephadm/workunits/task/test_set_mon_crush_locations.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_set_mon_crush_locations.yaml
@@ -6,6 +6,8 @@ overrides:
       - mon down
       - mons down
       - out of quorum
+    log-only-match:
+      - CEPHADM_
 roles:
 - - host.a
   - osd.0

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -430,7 +430,7 @@ def ceph_log(ctx, config):
 
     finally:
         log.info('Checking cluster log for badness...')
-        def first_in_ceph_log(pattern, excludes):
+        def first_in_ceph_log(pattern, excludes, only_match):
             """
             Find the first occurrence of the pattern specified in the Ceph log,
             Returns None if none found.
@@ -445,6 +445,8 @@ def ceph_log(ctx, config):
                 '/var/log/ceph/{fsid}/ceph.log'.format(
                     fsid=fsid),
             ]
+            if only_match:
+                args.extend([run.Raw('|'), 'egrep', '|'.join(only_match)])
             if excludes:
                 for exclude in excludes:
                     args.extend([run.Raw('|'), 'egrep', '-v', exclude])
@@ -460,14 +462,22 @@ def ceph_log(ctx, config):
                 return stdout
             return None
 
+        # NOTE: technically the first and third arg to first_in_ceph_log
+        # are serving a similar purpose here of being something we
+        # look for in the logs. The reason they are separate args is that
+        # we want '\[ERR\]|\[WRN\]|\[SEC\]' to always have to be in the thing
+        # we match even if the test yaml specifies nothing else, and then the
+        # log-only-match options are for when a test only wants to fail on
+        # a specific subset of log lines that '\[ERR\]|\[WRN\]|\[SEC\]' matches
         if first_in_ceph_log('\[ERR\]|\[WRN\]|\[SEC\]',
-                             config.get('log-ignorelist')) is not None:
+                             config.get('log-ignorelist'),
+                             config.get('log-only-match')) is not None:
             log.warning('Found errors (ERR|WRN|SEC) in cluster log')
             ctx.summary['success'] = False
             # use the most severe problem as the failure reason
             if 'failure_reason' not in ctx.summary:
                 for pattern in ['\[SEC\]', '\[ERR\]', '\[WRN\]']:
-                    match = first_in_ceph_log(pattern, config['log-ignorelist'])
+                    match = first_in_ceph_log(pattern, config['log-ignorelist'], config.get('log-only-match'))
                     if match is not None:
                         ctx.summary['failure_reason'] = \
                             '"{match}" in cluster log'.format(


### PR DESCRIPTION
Rather than failing for any instance of
[ERR], [WRN], or [SEC]. The orch/cephadm suite
does a lot of stuff that can cause these various
warnings to breifly appear. Trying to catch all
cases has been difficult and the suite has been
red for some time. This patch makes it so it
instead only matches log messages that
include CEPHADM_ on top of having [ERR], [WRN],
or [SEC] as those warnings have been the ones
that have actually lead us to cephadm bugs, while
the others are pretty much always just noise in
these tests. This patch does not apply this
to the mds_upgrade_sequence, nfs, or rbd-iscsi
sections as those are symlinked from other suites
and I didn't want to affect those suites tests
directly with this change.
    
Signed-off-by: Adam King <adking@redhat.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
