### PR TITLE
reef: mgr/cephadm: fix node-proxy service size

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2194,8 +2194,14 @@ Then run the following:
             if service_name is not None and service_name != nm:
                 continue
 
-            if spec.service_type != 'osd':
+            if spec.service_type not in ['osd', 'node-proxy']:
                 size = spec.placement.get_target_count(self.cache.get_schedulable_hosts())
+            elif spec.service_type == 'node-proxy':
+                # we only deploy node-proxy daemons on hosts we have oob info for
+                # Let's make the expected daemon count `orch ls` displays reflect that
+                schedulable_hosts = self.cache.get_schedulable_hosts()
+                oob_info_hosts = [h for h in schedulable_hosts if h.hostname in self.node_proxy_cache.oob.keys()]
+                size = spec.placement.get_target_count(oob_info_hosts)
             else:
                 # osd counting is special
                 size = 0


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/56637

We only actually deploy node-proxy on hosts that
we were given oob info for. without this patch,
with no oob info and 10 hosts, the service would
report 0/10 daemons running. This gives the impression the daemons are failing to be placed in some way.
This change makes it so the size of the service
match the actual number of hosts cephadm is
planning to deploy the daemons on.

Signed-off-by: Adam King <adking@redhat.com>
(cherry picked from commit 7ce1f790f375dfcbda73a6ec8d7db18f35484e2f)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
