### PR TITLE
mon: implement mon backup mechanism

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -600,6 +600,84 @@ is far outweighed by the number of accidental pool (and thus data) deletions it 
 
 For more information about the pool flags see :ref:`Pool values <setpoolvalues>`.
 
+Monitor backup
+==============
+
+The Ceph Monitor can create consistent backups of its RocksDB to facilitate restoration in case the entire Monitor cluster fails. It uses the native RocksDB backup functionality to create consistent
+snapshots that can be backed up elsewhere without downtime.
+
+When :ref:`Backup Interval<mon_backup_interval>` is set, the backup is triggered the specified interval in minutes.
+
+When :ref:`Auto Backup <mon_auto_backup>` is enabled, creation of certain objects like auth
+permissions trigger a backup.
+
+In order to limit demands on the Ceph Monitor database, shared backups are the default. Every fifth backup, or any manually-triggered backup however will be a full backup.
+If :ref:`Always Full Backup <mon_backup_always_full>` is enabled, all backups are full copies. Full backups can be copied to an external
+location by copying the backup folder. Shared backups use a shared object tree and only store pointers.
+The cleanup mechanism will keep full backups over incremental to reduce the risk of corruption.
+
+
+The :ref:`Backup Cleanup<mon_backup_cleanup_interval>` specifies the interval for backup cleanup.
+The cleanup algorithm keeps the last ``mon_backup_keep_last`` backups. It then collects hourly ``mon_backup_keep_hourly``
+and daily ``mon_backup_keep_daily`` versions. It selects the largest of all variants in a time window.
+
+You can trigger `backup` and `backup_cleanup` through the admin socket of any mon.
+
+  .. prompt:: bash #
+     ceph --admin-daemon .../mon.asok backup
+
+  .. prompt:: bash #
+     ceph --admin-daemon .../mon.asok backup_cleanup
+
+Since all backup operations run in their own threads, monitoring should be done using performance metrics.
+Use Prometheus to monitor for `backup_failed` or missing `backup_started` counters.
+
+  .. prompt:: bash #
+     ./bin/ceph --admin-daemon .../mon.asok perf dump | jq '.["mon"] | with_entries(select(.key | startswith("backup_")))'
+
+  .. prompt:: json #
+     {
+        "backup_running": 0,
+        "backup_started": 2,
+        "backup_success": 2,
+        "backup_failed": 0,
+        "backup_duration": {
+          "avgcount": 2,
+          "sum": 0.149076498,
+          "avgtime": 0.074538249
+        },
+        "backup_last_success": 1722001989.849262,
+        "backup_last_success_id": 3,
+        "backup_last_failed": 0,
+        "backup_last_size": 3924677,
+        "backup_last_files": 6,
+        "backup_cleanup_started": 1,
+        "backup_cleanup_running": 0,
+        "backup_cleanup_success": 1,
+        "backup_cleanup_failed": 0,
+        "backup_cleanup_size": 86144,
+        "backup_cleanup_kept": 1,
+        "backup_cleanup_duration": {
+          "avgcount": 1,
+          "sum": 0.002031246,
+          "avgtime": 0.002031246
+        },
+        "backup_cleanup_freed": 0,
+        "backup_cleanup_deleted": 0
+     }
+
+
+.. confval:: mon_backup_path
+.. confval:: mon_auto_backup
+.. confval:: mon_backup_always_full
+.. confval:: mon_backup_min_avail
+.. confval:: mon_backup_keep_last
+.. confval:: mon_backup_keep_hourly
+.. confval:: mon_backup_keep_daily
+.. confval:: mon_backup_interval
+.. confval:: mon_backup_cleanup_interval
+
+
 Miscellaneous
 =============
 

--- a/doc/rados/troubleshooting/troubleshooting-mon.rst
+++ b/doc/rados/troubleshooting/troubleshooting-mon.rst
@@ -518,6 +518,27 @@ or::
 
   Corruption: 1 missing files; e.g.: /var/lib/ceph/mon/mon.foo/store.db/1234567.ldb
 
+Recovery using mon backup
+-------------------------
+
+If you enabled :term:`Monitor Backup` in the configuration file, you will find backups in the specified location.
+To list available backups run:
+
+.. code-block:: bash
+
+  ceph-mon -i [num] --list-backups /path/to/backups
+
+To restore a backup, run following command:
+
+.. code-block:: bash
+
+  ceph-mon -i [num] --restore-backup /path/to/backups --backup-version <version>
+
+If the `--backup-version` argument is omitted, the latest version will be restored.
+The cluster will recover from that point on by applying missing `osdmap` versions to each OSD.
+Auth accounts and other non-OSD-related entries are lost.
+
+
 Recovery Using Healthy Monitor(s)
 ---------------------------------
 

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -232,6 +232,8 @@ static void usage()
        << "        restore the backup from location and exit\n"
        << "  --backup-version <version>\n"
        << "        defaults to -1, which is the last valid backup\n"
+       << "  --list-backups <directory>\n"
+       << "        list available backups\n"
        << std::endl;
   generic_server_usage();
 }
@@ -270,7 +272,7 @@ int main(int argc, const char **argv)
   bool compact = false;
   bool force_sync = false;
   bool yes_really = false;
-  std::string osdmapfn, inject_monmap, extract_monmap, crush_loc, restore_backup_location;
+  std::string osdmapfn, inject_monmap, extract_monmap, crush_loc, restore_backup_location, list_backup_location;
   std::optional<uint32_t> restore_backup_version;
 
   auto args = argv_to_vec(argc, argv);
@@ -344,6 +346,8 @@ int main(int argc, const char **argv)
       extract_monmap = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--set-crush-location", (char*)NULL)) {
       crush_loc = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--list-backups", (char*)NULL)) {
+      list_backup_location = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--restore-backup", (char*)NULL)) {
       restore_backup_location = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--backup-version", (char*)NULL)) {
@@ -377,6 +381,20 @@ int main(int argc, const char **argv)
   if (g_conf()->name.get_id().empty()) {
     cerr << "must specify id (--id <id> or --name mon.<id>)" << std::endl;
     exit(1);
+  }
+
+  // -- list backups --
+  if (list_backup_location.length()) {
+    cerr << "list backup from location '" << list_backup_location << "'" << std::endl << std::endl;
+    std::vector<KeyValueDB::BackupStats> backup_infos = MonitorDBStore::list_backups(cct.get(), g_conf()->mon_data, list_backup_location);
+    cerr << "ID:\tTime:\t\t\t\tSize:" << std::endl;
+    for (const auto& bi : backup_infos)
+    {
+      cerr << bi.id
+           << "\t"; bi.timestamp.asctime(cerr)
+           << "\t" << bi.size << " bytes" << std::endl;
+    }
+    exit(0);
   }
 
   // -- restore backup --

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -19,6 +19,7 @@
 #include <fcntl.h>
 
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -36,6 +37,7 @@
 #include "include/CompatSet.h"
 
 #include "common/ceph_argparse.h"
+#include "common/strtol.h"
 #include "common/debug.h"
 #include "common/pick_address.h"
 #include "common/JSONFormatter.h"
@@ -225,7 +227,11 @@ static void usage()
        << "  --mon-data <directory>\n"
        << "        where the mon store and keyring are located\n"
        << "  --set-crush-location <bucket>=<foo>"
-       << "        sets monitor's crush bucket location (only for stretch mode)"
+       << "        sets monitor's crush bucket location (only for stretch mode)\n"
+       << "  --restore-backup <directory>\n"
+       << "        restore the backup from location and exit\n"
+       << "  --backup-version <version>\n"
+       << "        defaults to -1, which is the last valid backup\n"
        << std::endl;
   generic_server_usage();
 }
@@ -264,7 +270,8 @@ int main(int argc, const char **argv)
   bool compact = false;
   bool force_sync = false;
   bool yes_really = false;
-  std::string osdmapfn, inject_monmap, extract_monmap, crush_loc;
+  std::string osdmapfn, inject_monmap, extract_monmap, crush_loc, restore_backup_location;
+  std::optional<uint32_t> restore_backup_version;
 
   auto args = argv_to_vec(argc, argv);
   if (args.empty()) {
@@ -337,6 +344,16 @@ int main(int argc, const char **argv)
       extract_monmap = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--set-crush-location", (char*)NULL)) {
       crush_loc = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--restore-backup", (char*)NULL)) {
+      restore_backup_location = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--backup-version", (char*)NULL)) {
+      std::string parse_err;
+      long long v = strict_strtoll(val.c_str(), 10, &parse_err);
+      if (!parse_err.empty() || v < 0 || v > UINT32_MAX) {
+        cerr << "invalid --backup-version '" << val << "'" << std::endl;
+        exit(1);
+      }
+      restore_backup_version = static_cast<uint32_t>(v);
     } else {
       ++i;
     }
@@ -359,6 +376,18 @@ int main(int argc, const char **argv)
 
   if (g_conf()->name.get_id().empty()) {
     cerr << "must specify id (--id <id> or --name mon.<id>)" << std::endl;
+    exit(1);
+  }
+
+  // -- restore backup --
+  if (restore_backup_location.length()) {
+    cerr << "restoring backup from location '" << restore_backup_location << "' to '"
+         << g_conf()->mon_data << "'" << std::endl;
+    if (MonitorDBStore::restore_backup(cct.get(), g_conf()->mon_data, restore_backup_location, restore_backup_version)) {
+        cerr << "successfully restored backup. Start ceph-mon normally" << std::endl;
+        exit(0);
+    }
+    cerr << "restoring failed. Try an earlier version." << std::endl;
     exit(1);
   }
 
@@ -537,7 +566,7 @@ int main(int argc, const char **argv)
       exit(1);
     }
     store.close();
-    dout(0) << argv[0] << ": created monfs at " << g_conf()->mon_data 
+    dout(0) << argv[0] << ": created monfs at " << g_conf()->mon_data
 	    << " for " << g_conf()->name << dendl;
     return 0;
   }

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1169,6 +1169,40 @@ options:
   flags:
   - no_mon_update
   with_legacy: true
+- name: mon_backup_path
+  type: str
+  level: advanced
+  desc: path to mon database backups
+  fmt_desc: the monitor's backup location.
+  default: /var/backups/ceph/mon/$cluster-$id
+  services:
+  - mon
+  flags:
+  - no_mon_update
+- name: mon_backup_always_full
+  type: bool
+  level: advanced
+  desc: always create full backups, otherwise only externally triggered and every 5th backup is automatically full.
+  default: false
+  services:
+  - mon
+  flags:
+  - runtime
+- name: mon_backup_min_avail
+  type: int
+  level: advanced
+  desc: only start backups if available disk space is above percentage
+  default: 5
+  services:
+  - mon
+- name: mon_backup_interval
+  type: uint
+  level: advanced
+  desc: automatic backups every N minutes
+  services:
+  - mon
+  flags:
+  - no_mon_update
 - name: mon_rocksdb_options
   type: str
   level: advanced

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1205,10 +1205,47 @@ options:
   default: 5
   services:
   - mon
+- name: mon_backup_keep_last
+  type: uint
+  level: advanced
+  desc: keep last N backups
+  fmt_desc: keep the last backups of the monitor database
+  default: 6
+  services:
+  - mon
+  flags:
+  - no_mon_update
+- name: mon_backup_keep_hourly
+  type: uint
+  level: advanced
+  desc: number of hourly backups
+  default: 5
+  services:
+  - mon
+  flags:
+  - no_mon_update
+- name: mon_backup_keep_daily
+  type: uint
+  level: advanced
+  desc: number of daily backups
+  fmt_desc: Keep a one backup of every specified days
+  default: 7
+  services:
+  - mon
+  flags:
+  - no_mon_update
 - name: mon_backup_interval
   type: uint
   level: advanced
   desc: automatic backups every N minutes
+  services:
+  - mon
+  flags:
+  - no_mon_update
+- name: mon_backup_cleanup_interval
+  type: uint
+  level: advanced
+  desc: trigger backup cleanup every specified minutes
   services:
   - mon
   flags:

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1179,6 +1179,16 @@ options:
   - mon
   flags:
   - no_mon_update
+- name: mon_auto_backup
+  type: bool
+  level: advanced
+  desc: automatically trigger backups on important database changes
+  default: false
+  services:
+  - mon
+  flags:
+  - runtime
+  with_legacy: true
 - name: mon_backup_always_full
   type: bool
   level: advanced

--- a/src/kv/KeyValueDB.cc
+++ b/src/kv/KeyValueDB.cc
@@ -30,6 +30,15 @@ bool KeyValueDB::restore_backup(CephContext *cct,
   return false;
 }
 
+std::vector<KeyValueDB::BackupStats> KeyValueDB::list_backups(
+  CephContext *cct, const std::string &type, const std::string &backup_location)
+{
+  if (type == "rocksdb") {
+    return RocksDBStore::list_backups(cct, backup_location);
+  }
+  return std::vector<BackupStats>();
+}
+
 int KeyValueDB::test_init(const string& type, const string& dir)
 {
   if (type == "rocksdb") {

--- a/src/kv/KeyValueDB.cc
+++ b/src/kv/KeyValueDB.cc
@@ -18,6 +18,18 @@ KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
   return NULL;
 }
 
+bool KeyValueDB::restore_backup(CephContext *cct,
+                                const std::string &type,
+                                const std::string &path,
+                                const std::string &backup_location,
+                                std::optional<uint32_t> version)
+{
+  if (type == "rocksdb") {
+    return RocksDBStore::restore_backup(cct, path, backup_location, version);
+  }
+  return false;
+}
+
 int KeyValueDB::test_init(const string& type, const string& dir)
 {
   if (type == "rocksdb") {

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -426,6 +426,9 @@ public:
   /// look like a successful backup
   virtual BackupStats backup(const std::string& path, bool full) { return BackupStats{.error = true}; }
 
+  /// restore from backup the specified backup version
+  static bool restore_backup(CephContext *cct, const std::string &type, const std::string &path, const std::string &backup_location, std::optional<uint32_t> version);
+
   /// compact the underlying store
   virtual void compact() {}
 

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -13,6 +13,7 @@
 #include <string_view>
 #include <boost/scoped_ptr.hpp>
 #include "include/encoding.h"
+#include "include/utime.h"
 #include "common/Formatter.h"
 #include "common/perf_counters.h"
 #include "common/PriorityCache.h"
@@ -24,6 +25,15 @@
  */
 class KeyValueDB {
 public:
+  struct BackupStats {
+    bool error;
+    uint64_t id;
+    utime_t timestamp;
+    std::string msg;
+    uint64_t size;
+    uint64_t number_files;
+  };
+
   class TransactionImpl {
   public:
     // amount of ops included
@@ -112,8 +122,8 @@ public:
     }
 
     /// Remove Single Key which exists and was not overwritten.
-    /// This API is only related to performance optimization, and should only be 
-    /// re-implemented by log-insert-merge tree based keyvalue stores(such as RocksDB). 
+    /// This API is only related to performance optimization, and should only be
+    /// re-implemented by log-insert-merge tree based keyvalue stores(such as RocksDB).
     /// If a key is overwritten (by calling set multiple times), then the result
     /// of calling rm_single_key on this key is undefined.
     virtual void rm_single_key(
@@ -410,6 +420,11 @@ public:
 				       const std::string& key_prefix) {
     return 0;
   }
+
+  /// creates a kv database backup in directory path
+  /// the default reports failure: a backend without backup support must not
+  /// look like a successful backup
+  virtual BackupStats backup(const std::string& path, bool full) { return BackupStats{.error = true}; }
 
   /// compact the underlying store
   virtual void compact() {}

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -25,6 +25,16 @@
  */
 class KeyValueDB {
 public:
+  struct BackupCleanupStats {
+    bool error;
+    utime_t timestamp;
+    uint32_t corrupted;
+    uint32_t deleted;
+    uint32_t kept;
+    uint64_t size;
+    uint64_t freed;
+  };
+
   struct BackupStats {
     bool error;
     uint64_t id;
@@ -425,6 +435,9 @@ public:
   /// the default reports failure: a backend without backup support must not
   /// look like a successful backup
   virtual BackupStats backup(const std::string& path, bool full) { return BackupStats{.error = true}; }
+
+  /// cleanup old backups
+  virtual BackupCleanupStats backup_cleanup(const std::string& path, uint64_t keep_last, uint64_t keep_hourly, uint64_t keep_daily) { return BackupCleanupStats{.error = true}; }
 
   /// restore from backup the specified backup version
   static bool restore_backup(CephContext *cct, const std::string &type, const std::string &path, const std::string &backup_location, std::optional<uint32_t> version);

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -442,6 +442,8 @@ public:
   /// restore from backup the specified backup version
   static bool restore_backup(CephContext *cct, const std::string &type, const std::string &path, const std::string &backup_location, std::optional<uint32_t> version);
 
+  static std::vector<BackupStats> list_backups(CephContext *cct, const std::string &type, const std::string &backup_location);
+
   /// compact the underlying store
   virtual void compact() {}
 

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -2279,6 +2279,31 @@ KeyValueDB::BackupCleanupStats RocksDBStore::backup_cleanup(const std::string& p
   return rv;
 }
 
+std::vector<KeyValueDB::BackupStats> RocksDBStore::list_backups(CephContext *cct, const std::string& backup_location) {
+  std::vector<KeyValueDB::BackupStats> rv;
+  rocksdb::Status s;
+  auto backup_engine = open_backup_engine(rocksdb::BackupEngineOptions(backup_location), s);
+
+  if (!backup_engine || !s.ok()) {
+    // cleaning backups when folder is not available is minor problem
+    ldout(cct, 10) << __func__ << "can't list backups: " << s.ToString() << dendl;
+    return rv;
+  }
+
+  std::vector<rocksdb::BackupInfo> backup_infos;
+  backup_engine->GetBackupInfo(&backup_infos);
+  for (const auto& bi : backup_infos)
+  {
+    KeyValueDB::BackupStats br;
+    br.id = bi.backup_id;
+    br.timestamp = utime_t(bi.timestamp, 0);
+    br.size = bi.size;
+    br.number_files = bi.number_files;
+    rv.push_back(br);
+  }
+  return rv;
+}
+
 void RocksDBStore::compact()
 {
   dout(2) << __func__ << " starting" << dendl;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -18,6 +18,7 @@
 #include "rocksdb/slice.h"
 #include "rocksdb/cache.h"
 #include "rocksdb/filter_policy.h"
+#include "rocksdb/utilities/backup_engine.h"
 #include "rocksdb/utilities/convenience.h"
 #include "rocksdb/utilities/table_properties_collectors.h"
 #include "rocksdb/merge_operator.h"
@@ -26,6 +27,8 @@
 #include "common/perf_counters.h"
 #include "common/PriorityCache.h"
 #include "common/strtol.h"
+#include "common/safe_io.h"
+#include "common/errno.h"
 #include "include/common_fwd.h"
 #include "include/scope_guard.h"
 #include "include/str_list.h"
@@ -69,6 +72,7 @@ static const char* sharding_def_dir = "sharding";
 static const char* sharding_def_file = "sharding/def";
 static const char* sharding_recreate = "sharding/recreate_columns";
 static const char* resharding_column_lock = "reshardingXcommencingXlocked";
+
 
 static bufferlist to_bufferlist(rocksdb::Slice in) {
   bufferlist bl;
@@ -2046,6 +2050,77 @@ int RocksDBStore::split_key(rocksdb::Slice in, string_view *prefix, string_view 
   return 0;
 }
 
+static std::unique_ptr<rocksdb::BackupEngine> open_backup_engine(
+  const rocksdb::BackupEngineOptions& options, rocksdb::Status& s)
+{
+  rocksdb::BackupEngine* engine = nullptr;
+  s = rocksdb::BackupEngine::Open(options, rocksdb::Env::Default(), &engine);
+  return std::unique_ptr<rocksdb::BackupEngine>{engine};
+}
+
+KeyValueDB::BackupStats RocksDBStore::backup(const std::string& path, bool full)
+{
+  ldout(cct, 20) << __func__ << " start backup action" << dendl;
+  std::lock_guard backup_locker{backup_lock};
+  rocksdb::BackupEngineOptions engine_options = rocksdb::BackupEngineOptions(path);
+  engine_options.share_table_files = !full;
+  engine_options.sync = true;
+
+  rocksdb::Status s;
+  auto backup_engine = open_backup_engine(engine_options, s);
+
+  KeyValueDB::BackupStats rv;
+  if (!backup_engine || !s.ok()) {
+    ldout(cct, 0) << __func__ << "can't create backup_engine: " << s.ToString() << dendl;
+    rv.msg = s.ToString();
+    rv.error = true;
+    return rv;
+  }
+
+  rocksdb::BackupID new_backup;
+  rocksdb::BackupInfo new_backup_info;
+  rocksdb::CreateBackupOptions new_backup_options = rocksdb::CreateBackupOptions();
+  new_backup_options.flush_before_backup = true;
+
+  s = backup_engine->CreateNewBackupWithMetadata(new_backup_options, db, "", &new_backup);
+
+  rv.timestamp = ceph_clock_now();
+  rv.msg = s.ToString();
+
+  if (!s.ok()) {
+    ldout(cct, 0) << __func__ << "can't create backup: " << s.ToString() << dendl;
+    rv.error = true;
+    return rv;
+  } else {
+    ldout(cct, 10) << __func__ << "created backup successfully: " << s.ToString() << dendl;
+    rv.msg = s.ToString();
+  }
+  s = backup_engine->GetBackupInfo(new_backup, &new_backup_info);
+  if (!s.ok()) {
+    ldout(cct, 0) << __func__ << "can't get backup info: " << s.ToString() << dendl;
+    rv.error = true;
+    rv.msg = s.ToString();
+    return rv;
+  }
+  rv.id = new_backup_info.backup_id;
+  rv.size = new_backup_info.size;
+  rv.number_files = new_backup_info.number_files;
+
+  if (full) {
+    // record the id of the last full backup
+    std::string id_str = std::to_string(new_backup_info.backup_id);
+    int r = safe_write_file(path.c_str(), "last_full",
+                            id_str.c_str(), id_str.size(), 0644);
+    if (r < 0) {
+      ldout(cct, 1) << __func__ << " failed to write last_full marker: "
+                    << cpp_strerror(r) << dendl;
+    }
+  }
+
+  return rv;
+}
+
+
 void RocksDBStore::compact()
 {
   dout(2) << __func__ << " starting" << dendl;
@@ -3356,7 +3431,7 @@ int RocksDBStore::prepare_for_reshard(const std::string& new_sharding,
 	   << full_name << dendl;
       return -EINVAL;
     }
-    dout(10) << "created column " << full_name << " handle = " << (void*)cf << dendl; 
+    dout(10) << "created column " << full_name << " handle = " << (void*)cf << dendl;
     existing_columns.push_back(full_name);
     handles.push_back(cf);
   }

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -7,6 +7,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -2078,6 +2079,9 @@ KeyValueDB::BackupStats RocksDBStore::backup(const std::string& path, bool full)
     return rv;
   }
 
+  // we remove corrupted backups first to not link to broken ones
+  remove_corrupted_backups(backup_engine.get(), nullptr);
+
   rocksdb::BackupID new_backup;
   rocksdb::BackupInfo new_backup_info;
   rocksdb::CreateBackupOptions new_backup_options = rocksdb::CreateBackupOptions();
@@ -2091,6 +2095,7 @@ KeyValueDB::BackupStats RocksDBStore::backup(const std::string& path, bool full)
   if (!s.ok()) {
     ldout(cct, 0) << __func__ << "can't create backup: " << s.ToString() << dendl;
     rv.error = true;
+    remove_corrupted_backups(backup_engine.get(), nullptr);
     return rv;
   } else {
     ldout(cct, 10) << __func__ << "created backup successfully: " << s.ToString() << dendl;
@@ -2151,6 +2156,127 @@ bool RocksDBStore::restore_backup(CephContext *cct, const std::string& path, con
     derr << "Error when restoring backup: " << s.ToString() << dendl;
   }
   return s.ok();
+}
+
+static bool compare_backupinfo_by_timestamp(const rocksdb::BackupInfo& a, const rocksdb::BackupInfo& b)
+{
+  return a.timestamp >= b.timestamp;
+}
+
+struct TimeBucket {
+  utime_t start;
+  utime_t end;
+  rocksdb::BackupID backup_id = 0;
+  uint64_t backup_size = 0;
+
+  TimeBucket(utime_t start, utime_t end) :
+              start(start), end(end) {}
+};
+
+void RocksDBStore::remove_corrupted_backups(rocksdb::BackupEngine *backup_engine, KeyValueDB::BackupCleanupStats *rv) {
+  std::vector<rocksdb::BackupID> corrupt_backup_ids;
+  backup_engine->GetCorruptedBackups(&corrupt_backup_ids);
+  if (corrupt_backup_ids.size() > 0) {
+    for (rocksdb::BackupID backup_id : corrupt_backup_ids) {
+      ldout(cct, 1) << __func__ << "delete corrupted backup: " << backup_id << dendl;
+      backup_engine->DeleteBackup(backup_id);
+      if (rv) {
+        rv->corrupted++;
+      }
+    }
+  }
+}
+
+KeyValueDB::BackupCleanupStats RocksDBStore::backup_cleanup(const std::string& path, uint64_t keep_last, uint64_t keep_hourly, uint64_t keep_daily)
+{
+  ldout(cct, 20) << __func__ << " start backup action" << dendl;
+  std::lock_guard backup_locker{backup_lock};
+  BackupCleanupStats rv = {};
+  rocksdb::Status s;
+  auto backup_engine = open_backup_engine(rocksdb::BackupEngineOptions(path), s);
+  if (!backup_engine || !s.ok()) {
+    // cleaning backups when folder is not available is minor problem
+    ldout(cct, 10) << __func__ << "can't clean backups: " << s.ToString() << dendl;
+    rv.error = true;
+    return rv;
+  }
+  // remove corrupted backups first
+  std::unordered_set<rocksdb::BackupID> keep_backups;
+
+  remove_corrupted_backups(backup_engine.get(), &rv);
+  ldout(cct, 20) << __func__ << "collect garbage" << dendl;
+
+  std::vector<rocksdb::BackupInfo> backup_infos;
+  backup_engine->GetBackupInfo(&backup_infos);
+
+  if (backup_infos.empty()) {
+    ldout(cct, 15) << __func__ << "no backup infos " << dendl;
+    return rv;
+  }
+  // sort all backups with newest backup first
+  std::stable_sort(backup_infos.begin(), backup_infos.end(), compare_backupinfo_by_timestamp);
+  utime_t now = ceph_clock_now();
+
+  std::vector<TimeBucket> buckets;
+  // create a time bucket for each interval (hourly / daily)
+  utime_t start = now.round_to_hour();
+  for (uint64_t i = 0; i < keep_hourly; i++) {
+    buckets.push_back(TimeBucket(start, start + utime_t(3600.0 - 1.0, 0)));
+    start -= 3600.0;
+  }
+  start = now.round_to_day();
+  for (uint64_t i = 0; i < keep_daily; i++) {
+    buckets.push_back(TimeBucket(start, start + utime_t(86400.0 - 1.0, 0)));
+    start -= 86400.0;
+  }
+
+  for (size_t i = 0; i < backup_infos.size(); i++)
+  {
+    const rocksdb::BackupInfo& bi = backup_infos[i];
+    // keep last n backups
+    if (i < keep_last) {
+      keep_backups.insert(bi.backup_id);
+      continue;
+    }
+    // check for time window
+    utime_t ts = utime_t(bi.timestamp, 0);
+    for (TimeBucket& bucket : buckets)
+    {
+      if (ts >= bucket.start && ts <= bucket.end) {
+        // if there are multiple backups available for a timeslot, use the larger one which
+        // is more likely a full backup. rocksdb does not store if full backup was created
+        if (bucket.backup_id == 0 ||
+            (bi.size > bucket.backup_size)) {
+          bucket.backup_id = bi.backup_id;
+          bucket.backup_size = bi.size;
+        }
+      }
+    }
+  }
+  // push the winners into the list
+  for (TimeBucket& bucket : buckets)
+  {
+    if (bucket.backup_id) {
+      keep_backups.insert(bucket.backup_id);
+    }
+  }
+
+  rv.kept = keep_backups.size();
+
+  for (const auto& bi : backup_infos)
+  {
+    if (keep_backups.contains(bi.backup_id)) {
+      rv.size += bi.size;
+      continue;
+    } else {
+      ldout(cct, 10) << __func__ << "delete old backup: " << bi.backup_id << dendl;
+      backup_engine->DeleteBackup(bi.backup_id);
+      rv.freed += bi.size;
+      rv.deleted++;
+    }
+  }
+  rv.timestamp = ceph_clock_now();
+  return rv;
 }
 
 void RocksDBStore::compact()

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -22,6 +22,7 @@
 #include "rocksdb/utilities/convenience.h"
 #include "rocksdb/utilities/table_properties_collectors.h"
 #include "rocksdb/merge_operator.h"
+#include "rocksdb/util/stderr_logger.h"
 
 #include "common/Clock.h" // for ceph_clock_now()
 #include "common/perf_counters.h"
@@ -2120,6 +2121,37 @@ KeyValueDB::BackupStats RocksDBStore::backup(const std::string& path, bool full)
   return rv;
 }
 
+bool RocksDBStore::restore_backup(CephContext *cct, const std::string& path, const std::string& backup_path, std::optional<uint32_t> version)
+{
+  rocksdb::StderrLogger logger = rocksdb::StderrLogger();
+  rocksdb::BackupEngineOptions engine_options = rocksdb::BackupEngineOptions(backup_path);
+  engine_options.info_log = &logger;
+
+  rocksdb::BackupEngineReadOnly* backup_engine_raw = nullptr;
+  rocksdb::Status s = rocksdb::BackupEngineReadOnly::Open(
+    rocksdb::Env::Default(),
+    engine_options,
+    &backup_engine_raw);
+  std::unique_ptr<rocksdb::BackupEngineReadOnly> backup_engine{backup_engine_raw};
+  const rocksdb::RestoreOptions options = rocksdb::RestoreOptions();
+  if (!s.ok()) {
+    derr << __func__ << "can't open backup folder: " << s.ToString() << dendl;
+    return false;
+  }
+  if (!version) {
+    derr << "restore last valid backup" << dendl;
+    s = backup_engine->RestoreDBFromLatestBackup(
+        options,
+        path,
+        path);
+  } else {
+    s = backup_engine->RestoreDBFromBackup(options, *version, path, path);
+  }
+  if (!s.ok()) {
+    derr << "Error when restoring backup: " << s.ToString() << dendl;
+  }
+  return s.ok();
+}
 
 void RocksDBStore::compact()
 {

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -151,6 +151,7 @@ private:
   int do_open(std::ostream &out, bool create_if_missing, bool open_readonly,
 	      const std::string& cfs="");
   int load_rocksdb_options(bool create_if_missing, rocksdb::Options& opt);
+  void remove_corrupted_backups(rocksdb::BackupEngine *engine, KeyValueDB::BackupCleanupStats *result);
 public:
   static bool parse_sharding_def(const std::string_view text_def,
 				std::vector<ColumnFamily>& sharding_def,
@@ -217,6 +218,7 @@ public:
   }
 
   KeyValueDB::BackupStats backup(const std::string& path, bool full) override;
+  struct KeyValueDB::BackupCleanupStats backup_cleanup(const std::string& path, uint64_t keep_last, uint64_t keep_hourly, uint64_t keep_daily);
   static bool restore_backup(CephContext *cct, const std::string &path, const std::string &backup_location, std::optional<uint32_t> version);
 
   void compact() override;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -220,6 +220,7 @@ public:
   KeyValueDB::BackupStats backup(const std::string& path, bool full) override;
   struct KeyValueDB::BackupCleanupStats backup_cleanup(const std::string& path, uint64_t keep_last, uint64_t keep_hourly, uint64_t keep_daily);
   static bool restore_backup(CephContext *cct, const std::string &path, const std::string &backup_location, std::optional<uint32_t> version);
+  static std::vector<BackupStats> list_backups(CephContext *cct, const std::string& backup_location);
 
   void compact() override;
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -217,6 +217,7 @@ public:
   }
 
   KeyValueDB::BackupStats backup(const std::string& path, bool full) override;
+  static bool restore_backup(CephContext *cct, const std::string &path, const std::string &backup_location, std::optional<uint32_t> version);
 
   void compact() override;
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -21,6 +21,7 @@
 #include "rocksdb/statistics.h"
 #include "rocksdb/table.h"
 #include "rocksdb/db.h"
+#include "rocksdb/utilities/backup_engine.h"
 #include "kv/rocksdb_cache/BinnedLRUCache.h"
 #include <errno.h>
 #include "common/errno.h"
@@ -115,11 +116,14 @@ public:
 		 uint32_t hash_l, uint32_t hash_h)
       : name(name), shard_cnt(shard_cnt), options(options), hash_l(hash_l), hash_h(hash_h) {}
   };
+
 private:
   friend std::ostream& operator<<(std::ostream& out, const ColumnFamily& cf);
 
   bool must_close_default_cf = false;
   rocksdb::ColumnFamilyHandle *default_cf = nullptr;
+  // serialize backup_engine operations; concurrent ones are problematic
+  ceph::mutex backup_lock = ceph::make_mutex("RocksDBStore::Backup");
 
   /// column families in use, name->handles
   struct prefix_shards {
@@ -211,6 +215,8 @@ public:
   uint64_t get_delete_range_threshold() const {
     return cct->_conf.get_val<uint64_t>("rocksdb_delete_range_threshold");
   }
+
+  KeyValueDB::BackupStats backup(const std::string& path, bool full) override;
 
   void compact() override;
 

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -981,6 +981,7 @@ int AuthMonitor::import_keyring(KeyRing& keyring)
     int err = add_entity(p->first, p->second);
     ceph_assert(err == 0);
   }
+  mon.set_should_backup();
   return 0;
 }
 
@@ -1080,6 +1081,7 @@ int AuthMonitor::add_entity(
   dout(10) << " add auth entity " << auth_inc.name << dendl;
   dout(30) << "    " << auth_inc.auth << dendl;
   push_cephx_inc(auth_inc);
+  mon.set_should_backup();
   return 0;
 }
 
@@ -1445,6 +1447,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
     err = 0;
     wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
 					      get_last_committed() + 1));
+    mon.set_should_backup();
     return true;
   } else if (prefix == "auth add" && !entity_name.empty()) {
     /* expected behavior:
@@ -1819,6 +1822,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
 
       err = _update_caps(entity, newcaps, op, ss, ds, &rdata, f.get());
       if (err == 0) {
+        mon.set_should_backup();
 	return true;
       } else {
 	goto done;
@@ -1827,6 +1831,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
 
     err = _create_entity(entity, newcaps, op, ss, ds, &rdata, f.get());
     if (err == 0) {
+      mon.set_should_backup();
       return true;
     } else {
       goto done;
@@ -1851,6 +1856,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
 
     wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
 					      get_last_committed() + 1));
+    mon.set_should_backup();
     return true;
   } else if (prefix == "auth rotate") {
     if (entity_name.empty()) {

--- a/src/mon/CMakeLists.txt
+++ b/src/mon/CMakeLists.txt
@@ -10,6 +10,7 @@ set(lib_mon_srcs
   MgrMonitor.cc
   MgrStatMonitor.cc
   Monitor.cc
+  MonitorBackup.cc
   MonmapMonitor.cc
   LogMonitor.cc
   AuthMonitor.cc

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1588,3 +1588,7 @@ COMMAND_WITH_FLAG("backup",
             "backups mon database",
             "mon", "rwx",
             FLAG(TELL))
+COMMAND_WITH_FLAG("backup_cleanup",
+            "delete old backups",
+            "mon", "rwx",
+            FLAG(TELL))

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1584,3 +1584,7 @@ COMMAND_WITH_FLAG("dump_ops_in_flight",
             "show the ops currently in flight",
             "mon", "r",
             FLAG(TELL))
+COMMAND_WITH_FLAG("backup",
+            "backups mon database",
+            "mon", "rwx",
+            FLAG(TELL))

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -41,6 +41,7 @@
 #include "MonitorDBStore.h"
 #include "MonMap.h"
 #include "Paxos.h"
+#include "MonitorBackup.h"
 
 #include "messages/PaxosServiceMessage.h"
 #include "messages/MMonCommand.h"
@@ -549,7 +550,10 @@ will start to track new ops received afterwards.";
 	    << duration << " seconds" << dendl;
     out << "compacted " << g_conf().get_val<std::string>("mon_keyvaluedb")
 	<< " in " << duration << " seconds";
- } else {
+  } else if (command == "backup") {
+    // externally requested backups are always full ones
+    r = backup(true);
+  } else {
     ceph_abort_msg("bad AdminSocket command binding");
   }
   (read_only ? audit_clog->debug() : audit_clog->info())
@@ -566,6 +570,30 @@ abort:
     << "cmd=" << command << " "
     << "args=" << args << ": aborted";
   return r;
+}
+
+int Monitor::backup(bool full)
+{
+  if (!backup_manager) {
+    dout(1) << "backup manager not started" << dendl;
+    return -EIO;
+  }
+  std::string backup_path = g_conf().get_val<string>("mon_backup_path");
+  dout(1) << "triggering backup full=" << full << dendl;
+  if (backup_path.empty()) {
+    logger->inc(l_mon_backup_failed);
+    dout(1) << "backup failed: no backup_path configured" << dendl;
+    return -ENOTDIR;
+  }
+  uint64_t jobid = backup_manager->backup(full);
+  if (jobid > 0) {
+    dout(1) << "queues backup job id"
+              << jobid << dendl;
+    return 0;
+  } else {
+    dout(1) << "failed to queue job" << dendl;
+    return -EIO;
+  }
 }
 
 void Monitor::handle_signal(int signum)
@@ -825,6 +853,26 @@ int Monitor::preinit()
         "ewon", PerfCountersBuilder::PRIO_INTERESTING);
     pcb.add_u64_counter(l_mon_election_lose, "election_lose", "Elections lost",
         "elst", PerfCountersBuilder::PRIO_INTERESTING);
+    pcb.add_u64(l_mon_backup_running, "backup_running", "Mon backup process is running",
+        nullptr, PerfCountersBuilder::PRIO_USEFUL);
+    pcb.add_u64_counter(l_mon_backup_started, "backup_started", "Mon backups started",
+        nullptr, PerfCountersBuilder::PRIO_INTERESTING);
+    pcb.add_u64_counter(l_mon_backup_success, "backup_success", "Mon backups finished successfully",
+        nullptr, PerfCountersBuilder::PRIO_USEFUL);
+    pcb.add_u64_counter(l_mon_backup_failed, "backup_failed", "Mon backups failed",
+        nullptr, PerfCountersBuilder::PRIO_USEFUL);
+    pcb.add_time_avg(l_mon_backup_duration, "backup_duration", "Mon backup duration",
+        nullptr, PerfCountersBuilder::PRIO_USEFUL);
+    pcb.add_time(l_mon_backup_last_success, "backup_last_success", "Last successfull mon backup",
+        nullptr, PerfCountersBuilder::PRIO_USEFUL);
+    pcb.add_u64(l_mon_backup_last_success_id, "backup_last_success_id", "Last successfull mon backup id",
+        nullptr, PerfCountersBuilder::PRIO_INTERESTING);
+    pcb.add_time(l_mon_backup_last_failed, "backup_last_failed", "Last failed mon backup",
+        nullptr, PerfCountersBuilder::PRIO_USEFUL);
+    pcb.add_u64(l_mon_backup_last_size, "backup_last_size", "Last backup size",
+        nullptr, PerfCountersBuilder::PRIO_INTERESTING);
+    pcb.add_u64(l_mon_backup_last_files, "backup_last_files", "Last backup file numbers",
+        nullptr, PerfCountersBuilder::PRIO_INTERESTING);
     logger = pcb.create_perf_counters();
     cct->get_perfcounters_collection()->add(logger);
   }
@@ -1031,6 +1079,9 @@ int Monitor::init()
 
   // add features of myself into feature_map
   session_map.feature_map.add_mon(con_self->get_features());
+  
+  backup_manager = std::make_unique<MonitorBackupManager>(cct, this);
+
   return 0;
 }
 
@@ -1126,6 +1177,8 @@ void Monitor::shutdown()
     delete admin_hook;
     admin_hook = NULL;
   }
+  backup_manager->stop();
+  backup_manager.reset();
 
   elector.shutdown();
 
@@ -6118,6 +6171,7 @@ void Monitor::tick()
     prepare_new_fingerprint(t);
     paxos->trigger_propose();
   }
+  backup_manager->tick();
 
   mgr_client.update_daemon_health(get_health_metrics());
   new_tick();

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -553,6 +553,8 @@ will start to track new ops received afterwards.";
   } else if (command == "backup") {
     // externally requested backups are always full ones
     r = backup(true);
+  } else if (command == "backup_cleanup") {
+    r = backup_cleanup();
   } else {
     ceph_abort_msg("bad AdminSocket command binding");
   }
@@ -594,6 +596,26 @@ int Monitor::backup(bool full)
     dout(1) << "failed to queue job" << dendl;
     return -EIO;
   }
+}
+
+int Monitor::backup_cleanup()
+{
+  if (!backup_manager) {
+    dout(1) << "backup manager not started" << dendl;
+    return -EIO;
+  }
+  dout(1) << "triggering backup_cleanup" << dendl;
+  logger->inc(l_mon_backup_cleanup_started);
+  std::string backup_path = g_conf().get_val<string>("mon_backup_path");
+  if (backup_path.empty()) {
+    dout(1) << "backup_cleanup failed: no backup_path configured" << dendl;
+    logger->inc(l_mon_backup_cleanup_failed);
+    return -ENOTDIR;
+  }
+  uint32_t jobid = backup_manager->cleanup();
+  dout(1) << "queues backup cleanup job "
+            << jobid << dendl;
+  return jobid > 0 ? 0 : -EIO;
 }
 
 void Monitor::handle_signal(int signum)
@@ -872,6 +894,24 @@ int Monitor::preinit()
     pcb.add_u64(l_mon_backup_last_size, "backup_last_size", "Last backup size",
         nullptr, PerfCountersBuilder::PRIO_INTERESTING);
     pcb.add_u64(l_mon_backup_last_files, "backup_last_files", "Last backup file numbers",
+        nullptr, PerfCountersBuilder::PRIO_INTERESTING);
+    pcb.add_u64_counter(l_mon_backup_cleanup_started, "backup_cleanup_started", "Mon backup cleanup started",
+        nullptr, PerfCountersBuilder::PRIO_INTERESTING);
+    pcb.add_u64(l_mon_backup_cleanup_running, "backup_cleanup_running", "Mon backup cleanup is running",
+        nullptr, PerfCountersBuilder::PRIO_INTERESTING);
+    pcb.add_u64_counter(l_mon_backup_cleanup_success, "backup_cleanup_success", "Mon backup cleanup finished successfully",
+        nullptr, PerfCountersBuilder::PRIO_USEFUL);
+    pcb.add_u64_counter(l_mon_backup_cleanup_failed, "backup_cleanup_failed", "Mon backup cleanup failed",
+        nullptr, PerfCountersBuilder::PRIO_USEFUL);
+    pcb.add_u64(l_mon_backup_cleanup_size, "backup_cleanup_size", "Size of backups removed",
+        nullptr, PerfCountersBuilder::PRIO_INTERESTING);
+    pcb.add_u64(l_mon_backup_cleanup_kept, "backup_cleanup_kept", "Number of backups kept after cleanup",
+        nullptr, PerfCountersBuilder::PRIO_INTERESTING);
+    pcb.add_time_avg(l_mon_backup_cleanup_duration, "backup_cleanup_duration", "Mon backup cleanup duration",
+        nullptr, PerfCountersBuilder::PRIO_INTERESTING);
+    pcb.add_u64(l_mon_backup_cleanup_freed, "backup_cleanup_freed", "Mon backup cleanup freed size in bytes",
+        nullptr, PerfCountersBuilder::PRIO_INTERESTING);
+    pcb.add_u64(l_mon_backup_cleanup_deleted, "backup_cleanup_deleted", "Mon backup cleanup deleted backups",
         nullptr, PerfCountersBuilder::PRIO_INTERESTING);
     logger = pcb.create_perf_counters();
     cct->get_perfcounters_collection()->add(logger);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -6171,6 +6171,11 @@ void Monitor::tick()
     prepare_new_fingerprint(t);
     paxos->trigger_propose();
   }
+  // trigger backup if required
+  if (mon_backup_requested && g_conf()->mon_auto_backup) {
+      backup();
+      mon_backup_requested = false;
+  }
   backup_manager->tick();
 
   mgr_client.update_daemon_health(get_health_metrics());

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -111,6 +111,15 @@ enum {
   l_mon_backup_last_failed,
   l_mon_backup_last_size,
   l_mon_backup_last_files,
+  l_mon_backup_cleanup_started,
+  l_mon_backup_cleanup_running,
+  l_mon_backup_cleanup_success,
+  l_mon_backup_cleanup_failed,
+  l_mon_backup_cleanup_size,
+  l_mon_backup_cleanup_kept,
+  l_mon_backup_cleanup_duration,
+  l_mon_backup_cleanup_freed,
+  l_mon_backup_cleanup_deleted,
   l_mon_last,
 };
 
@@ -1067,6 +1076,7 @@ private:
   }
   // Execute mon database backup
   int backup(bool full = false);
+  int backup_cleanup();
 
 private:
   // don't allow copying

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -50,6 +50,7 @@
 #include "include/CompatSet.h"
 #include "mon/MonitorDBStore.h"
 #include "mon/mon_types.h" // for Metadata, PAXOS_*, ScrubResult
+#include "mon/MonitorBackup.h"
 #include "mgr/MgrClient.h"
 #include <boost/smart_ptr/atomic_shared_ptr.hpp>
 #include <boost/smart_ptr/shared_ptr.hpp>
@@ -100,6 +101,16 @@ enum {
   l_mon_election_call,
   l_mon_election_win,
   l_mon_election_lose,
+  l_mon_backup_running,
+  l_mon_backup_started,
+  l_mon_backup_success,
+  l_mon_backup_failed,
+  l_mon_backup_duration,
+  l_mon_backup_last_success,
+  l_mon_backup_last_success_id,
+  l_mon_backup_last_failed,
+  l_mon_backup_last_size,
+  l_mon_backup_last_files,
   l_mon_last,
 };
 
@@ -107,6 +118,7 @@ class Paxos;
 class PaxosService;
 
 class AdminSocketHook;
+class MonitorBackupManager;
 
 #define COMPAT_SET_LOC "feature_set"
 
@@ -1001,6 +1013,8 @@ private:
 
   OpTracker op_tracker;
 
+  std::unique_ptr<MonitorBackupManager> backup_manager;
+
  public:
   Monitor(CephContext *cct_, std::string nm, MonitorDBStore *s,
 	  Messenger *m, Messenger *mgr_m, MonMap *map);
@@ -1045,6 +1059,9 @@ private:
 		       ceph::Formatter *f,
 		       std::ostream& err,
 		       std::ostream& out);
+
+  // Execute mon database backup
+  int backup(bool full = false);
 
 private:
   // don't allow copying

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -1014,6 +1014,7 @@ private:
   OpTracker op_tracker;
 
   std::unique_ptr<MonitorBackupManager> backup_manager;
+  bool mon_backup_requested = false;
 
  public:
   Monitor(CephContext *cct_, std::string nm, MonitorDBStore *s,
@@ -1060,6 +1061,10 @@ private:
 		       std::ostream& err,
 		       std::ostream& out);
 
+  // Notify monitor that it should create a new database backup
+  void set_should_backup() {
+    mon_backup_requested = true;
+  }
   // Execute mon database backup
   int backup(bool full = false);
 

--- a/src/mon/MonitorBackup.cc
+++ b/src/mon/MonitorBackup.cc
@@ -28,8 +28,10 @@ void *MonitorBackupManager::entry() {
         }
 
         KeyValueDB::BackupStats *stats = m_last_backup.get();
+        KeyValueDB::BackupCleanupStats *cleanup_stats = m_last_cleanup.get();
         auto now = ceph_clock_now();
         uint64_t interval = m_cct->_conf.get_val<uint64_t>("mon_backup_interval");
+        uint64_t cleanup_interval = m_cct->_conf.get_val<uint64_t>("mon_backup_cleanup_interval");
         bool start_backup = false;
         bool start_backup_full = false;
 
@@ -44,12 +46,28 @@ void *MonitorBackupManager::entry() {
         }
 
         m_lock.lock();
+
+        bool start_cleanup = m_do_cleanup;
+        if (!cleanup_stats && cleanup_interval > 0) {
+            start_cleanup = true;
+        } else if (cleanup_stats && cleanup_interval > 0) {
+            if ((now - cleanup_stats->timestamp) > (cleanup_interval * 60)) {
+                dout(10) << " trigger timed backup cleanup " << dendl;
+                start_cleanup = true;
+            }
+        }
+
         start_backup |= m_do_backup;
         start_backup_full |= m_do_backup_full;
+
+        m_do_cleanup = false;
         m_do_backup = false;
         m_do_backup_full = false;
         m_lock.unlock();
 
+        if (start_cleanup) {
+            do_cleanup();
+        }
         if (start_backup) {
             do_backup(start_backup_full);
         }
@@ -60,6 +78,31 @@ void MonitorBackupManager::stop() {
     m_manager_stop = true;
     m_wakeup.Put();
     join();
+}
+
+void MonitorBackupManager::do_cleanup() {
+    if (!mon || !mon->store || !mon->logger) {
+        return;
+    }
+    dout(5) << "start backup cleanup" << dendl;
+    auto start = ceph_clock_now();
+    mon->logger->set(l_mon_backup_cleanup_running, 1);
+    KeyValueDB::BackupCleanupStats stats = mon->store->backup_cleanup();
+    mon->logger->set(l_mon_backup_cleanup_size, stats.size);
+    mon->logger->set(l_mon_backup_cleanup_kept, stats.kept);
+    mon->logger->set(l_mon_backup_cleanup_freed, stats.freed);
+    mon->logger->set(l_mon_backup_cleanup_deleted, stats.deleted);
+    if (stats.error) {
+        mon->logger->inc(l_mon_backup_cleanup_failed);
+    } else {
+        mon->logger->inc(l_mon_backup_cleanup_success);
+    }
+    shared_ptr<KeyValueDB::BackupCleanupStats> ptr = std::make_shared<KeyValueDB::BackupCleanupStats>(stats);
+    m_last_cleanup.swap(ptr);
+    auto end = ceph_clock_now();
+    utime_t duration = end - start;
+    mon->logger->tinc(l_mon_backup_cleanup_duration, duration);
+    mon->logger->set(l_mon_backup_cleanup_running, 0);
 }
 
 /***

--- a/src/mon/MonitorBackup.cc
+++ b/src/mon/MonitorBackup.cc
@@ -1,0 +1,129 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+* Ceph - scalable distributed file system
+*
+* Copyright (C) 2021 B1-Systems GmbH
+*
+* This is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License version 2.1, as published by the Free Software
+* Foundation. See file COPYING.
+*/
+
+#include "mon/MonitorBackup.h"
+#include "mon/Monitor.h"
+
+#define dout_subsys ceph_subsys_mon
+
+/***
+ * Thread which runs monitor backup operations
+ */
+void *MonitorBackupManager::entry() {
+    while (true) {
+        m_wakeup.Get();
+
+        if (m_manager_stop) {
+            return nullptr;
+        }
+
+        KeyValueDB::BackupStats *stats = m_last_backup.get();
+        auto now = ceph_clock_now();
+        uint64_t interval = m_cct->_conf.get_val<uint64_t>("mon_backup_interval");
+        bool start_backup = false;
+        bool start_backup_full = false;
+
+        if (!stats && interval > 0) {
+            start_backup = true;
+            start_backup_full = true;
+        } else if (stats && interval > 0) {
+            if ((now - stats->timestamp) > (interval * 60)) {
+                dout(10) << " trigger timed backup " << dendl;
+                start_backup = true;
+            }
+        }
+
+        m_lock.lock();
+        start_backup |= m_do_backup;
+        start_backup_full |= m_do_backup_full;
+        m_do_backup = false;
+        m_do_backup_full = false;
+        m_lock.unlock();
+
+        if (start_backup) {
+            do_backup(start_backup_full);
+        }
+    }
+}
+
+void MonitorBackupManager::stop() {
+    m_manager_stop = true;
+    m_wakeup.Put();
+    join();
+}
+
+/***
+ * Checks for enough free space to do backup.
+ * Returns true if there is enough free space
+*/
+bool MonitorBackupManager::check_free_space() {
+    ceph_data_stats_t stats;
+    int err = get_fs_stats(stats, m_cct->_conf.get_val<std::string>("mon_backup_path").c_str());
+    if (err < 0) {
+      dout(1) << "error checking monitor backup directory: " << cpp_strerror(err)
+           << dendl;
+      return false;
+    }
+
+    if (stats.avail_percent <= m_cct->_conf.get_val<int64_t>("mon_backup_min_avail")) {
+      dout(1) << "ERROR: not enough disk space to start backup: " << "(available: "
+           << stats.avail_percent << "% " << byte_u_t(stats.byte_avail) << ")\n"
+           << "run backup_cleanup regularly or decrease mon_backup_min_avail" << dendl;
+      return false;
+    }
+    return true;
+}
+
+void MonitorBackupManager::do_backup(bool full) {
+    dout(1) << "start backup" << dendl;
+    if (!mon || !mon->store || !mon->logger) {
+        return;
+    }
+    mon->logger->inc(l_mon_backup_started);
+    auto start = ceph_clock_now();
+
+    if (!check_free_space()) {
+        mon->logger->inc(l_mon_backup_failed);
+        mon->logger->tset(l_mon_backup_last_failed, start);
+        return;
+    }
+
+    full |= m_cct->_conf.get_val<bool>("mon_backup_always_full");
+
+    // we do full backups when it is the first of every 5th backup
+    if (!full && (!m_last_backup || m_last_backup.get()->id % 5 == 0)) {
+        full = true;
+    }
+
+    KeyValueDB::BackupStats stats = mon->store->backup(full);
+
+    auto end = ceph_clock_now();
+    utime_t duration = end - start;
+    mon->logger->tinc(l_mon_backup_duration, duration);
+    mon->logger->set(l_mon_backup_last_size, stats.size);
+    mon->logger->set(l_mon_backup_last_files, stats.number_files);
+    if (stats.error) {
+        mon->logger->inc(l_mon_backup_failed);
+        mon->logger->tset(l_mon_backup_last_failed, stats.timestamp);
+        dout(1) << "failed backup in "
+                  << utimespan_str(duration) << " seconds" << dendl;
+    } else {
+        mon->logger->inc(l_mon_backup_success);
+        mon->logger->tset(l_mon_backup_last_success, stats.timestamp);
+        mon->logger->set(l_mon_backup_last_success_id, stats.id);
+        dout(1) << "finished backup in "
+                << utimespan_str(duration) << " seconds" << dendl;
+    }
+    std::shared_ptr<KeyValueDB::BackupStats> ptr = std::make_shared<KeyValueDB::BackupStats>(stats);
+    m_last_backup.swap(ptr);
+}

--- a/src/mon/MonitorBackup.h
+++ b/src/mon/MonitorBackup.h
@@ -1,0 +1,88 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+* Ceph - scalable distributed file system
+*
+* Copyright (C) 2021 B1-Systems GmbH
+*
+* This is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License version 2.1, as published by the Free Software
+* Foundation. See file COPYING.
+*/
+
+#ifndef CEPH_MONITOR_BACKUP_H
+#define CEPH_MONITOR_BACKUP_H
+
+#include <list>
+#include <set>
+#include <string>
+
+#include "common/Semaphore.h"
+#include "common/Thread.h"
+#include "common/ceph_context.h"
+#include "kv/KeyValueDB.h"
+#include "mon/MonitorDBStore.h"
+
+using std::shared_ptr;
+class Monitor;
+
+using ceph::common::CephContext;
+
+class MonitorBackupManager : public Thread {
+  CephContext *m_cct;
+  Monitor *mon;
+  ceph::mutex m_lock;
+  Semaphore m_wakeup{};
+  bool m_manager_stop{false};
+
+  bool m_do_backup{false};
+  bool m_do_backup_full{false};
+  uint64_t m_last_job_id{0};
+  shared_ptr<KeyValueDB::BackupStats> m_last_backup;
+
+  void do_backup(bool full);
+  bool check_free_space();
+protected:
+  void *entry() override;
+
+public:
+  explicit MonitorBackupManager(CephContext *cct, Monitor *monitor) :
+    m_cct(cct),
+    mon(monitor),
+    m_lock(ceph::make_mutex("mon::BackupManager::m_lock")) {
+      create("mon::backups");
+  }
+
+  void tick() {
+    // wake up timers etc
+    m_wakeup.Put();
+  }
+
+  /**
+   * Stop the backup manager thread.
+   **/
+  void stop();
+  /**
+   * Start a new backup.
+   * @returns {uint64_t} new job id
+   **/
+  uint64_t backup(bool full) {
+    m_lock.lock();
+    // requesting a full backup has higher priority
+    m_do_backup = true;
+    if (full) {
+      m_do_backup_full = true;
+    }
+    uint64_t rv = ++m_last_job_id;
+    m_lock.unlock();
+    m_wakeup.Put();
+    return rv;
+  }
+
+  shared_ptr<KeyValueDB::BackupStats> last_backup_info() {
+    return m_last_backup;
+  }
+};
+
+#endif

--- a/src/mon/MonitorBackup.h
+++ b/src/mon/MonitorBackup.h
@@ -38,10 +38,13 @@ class MonitorBackupManager : public Thread {
 
   bool m_do_backup{false};
   bool m_do_backup_full{false};
+  bool m_do_cleanup{false};
   uint64_t m_last_job_id{0};
+  shared_ptr<KeyValueDB::BackupCleanupStats> m_last_cleanup;
   shared_ptr<KeyValueDB::BackupStats> m_last_backup;
 
   void do_backup(bool full);
+  void do_cleanup();
   bool check_free_space();
 protected:
   void *entry() override;
@@ -80,8 +83,22 @@ public:
     return rv;
   }
 
+  /// Start a new backup cleanup
+  uint64_t cleanup() {
+    m_lock.lock();
+    m_do_cleanup = true;
+    uint64_t rv = ++m_last_job_id;
+    m_lock.unlock();
+    m_wakeup.Put();
+    return rv;
+  }
+
   shared_ptr<KeyValueDB::BackupStats> last_backup_info() {
     return m_last_backup;
+  }
+
+  shared_ptr<KeyValueDB::BackupCleanupStats> last_cleanup_info() {
+    return m_last_cleanup;
   }
 };
 

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -757,6 +757,16 @@ class MonitorDBStore
     return db->backup(g_conf().get_val<std::string>("mon_backup_path"), full);
   }
 
+  /// @brief Cleanup old backups
+  /// @return backup cleanup statistics
+  KeyValueDB::BackupCleanupStats backup_cleanup() {
+    return db->backup_cleanup(
+      g_conf().get_val<std::string>("mon_backup_path"),
+      g_conf().get_val<uint64_t>("mon_backup_keep_last"),
+      g_conf().get_val<uint64_t>("mon_backup_keep_hourly"),
+      g_conf().get_val<uint64_t>("mon_backup_keep_daily"));
+  }
+
   /// @brief Restores a backup with given version from backup_path
   /// @param cct ceph context
   /// @param path path to database location

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -46,7 +46,7 @@ class MonitorDBStore
   int dump_fd_binary;
   std::ofstream dump_fd_json;
   ceph::JSONFormatter dump_fmt;
-  
+
 
   Finisher io_work;
 
@@ -691,7 +691,7 @@ class MonitorDBStore
     if (r < 0)
       return r;
 
-    // Monitors are few in number, so the resource cost of exposing 
+    // Monitors are few in number, so the resource cost of exposing
     // very detailed stats is low: ramp up the priority of all the
     // KV store's perf counters.  Do this after open, because backend may
     // not have constructed PerfCounters earlier.
@@ -798,8 +798,29 @@ class MonitorDBStore
    */
   int read_meta(const std::string& key,
 		std::string *value) const {
+
+  return read_meta_path(key,
+                value,
+                &path);
+  }
+
+  /**
+   * read_meta_path - read a simple configuration key out-of-band
+   *
+   * Read a simple key value to an specified path store.
+   *
+   * Trailing whitespace is stripped off.
+   *
+   * @param key key name
+   * @param value pointer to value string
+   * @param path path to directory
+   * @returns 0 for success, or an error code
+   */
+  static int read_meta_path(const std::string& key,
+		std::string *value,
+                const std::string *path) {
     char buf[4096];
-    int r = safe_read_file(path.c_str(), key.c_str(),
+    int r = safe_read_file(path->c_str(), key.c_str(),
 			   buf, sizeof(buf));
     if (r <= 0)
       return r;

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -757,6 +757,24 @@ class MonitorDBStore
     return db->backup(g_conf().get_val<std::string>("mon_backup_path"), full);
   }
 
+  /// @brief Restores a backup with given version from backup_path
+  /// @param cct ceph context
+  /// @param path path to database location
+  /// @param backup_path path to backup location
+  /// @param version version of the backup to restore
+  /// @return true on success
+  static bool restore_backup(CephContext *cct, const std::string &path, const std::string &backup_path, std::optional<uint32_t> version) {
+    std::string kv_type;
+    int r = read_meta_path("kv_backend", &kv_type, &path);
+    if (r < 0) {
+        // Some proper error reporting would be nice
+        return false;
+    }
+    std::string store_path = get_store_path(path);
+
+    return KeyValueDB::restore_backup(cct, kv_type, store_path, backup_path, version);
+  }
+
   void compact() {
     db->compact();
   }

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -65,6 +65,20 @@ class MonitorDBStore
     return path;
   }
 
+  // returns the database store path
+  static std::string get_store_path(std::string path) {
+    int pos = 0;
+    for (auto rit = path.rbegin(); rit != path.rend(); ++rit, ++pos) {
+      if (*rit != '/') {
+	      break;
+      }
+    }
+    std::ostringstream os;
+    os << path.substr(0, path.size() - pos) << "/store.db";
+    std::string full_path = os.str();
+    return full_path;
+  }
+
   std::shared_ptr<PriorityCache::PriCache> get_priority_cache() const {
     return db->get_priority_cache();
   }
@@ -631,14 +645,7 @@ class MonitorDBStore
   }
 
   void _open(const std::string& kv_type) {
-    int pos = 0;
-    for (auto rit = path.rbegin(); rit != path.rend(); ++rit, ++pos) {
-      if (*rit != '/')
-	break;
-    }
-    std::ostringstream os;
-    os << path.substr(0, path.size() - pos) << "/store.db";
-    std::string full_path = os.str();
+    std::string full_path = get_store_path(path);
 
     KeyValueDB *db_ptr = KeyValueDB::create(g_ceph_context,
 					    kv_type,
@@ -741,6 +748,13 @@ class MonitorDBStore
     io_work.stop();
     is_open = false;
     db.reset(NULL);
+  }
+
+  /// @brief Creates a backup of the database
+  /// @param full whether to force a full backup
+  /// @return backup statistics
+  KeyValueDB::BackupStats backup(bool full = false) {
+    return db->backup(g_conf().get_val<std::string>("mon_backup_path"), full);
   }
 
   void compact() {

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -767,6 +767,22 @@ class MonitorDBStore
       g_conf().get_val<uint64_t>("mon_backup_keep_daily"));
   }
 
+  /// @brief List all backup versions
+  /// @param cct ceph context
+  /// @param path path to database location
+  /// @param backup_path path to backup location
+  /// @return vector of BackupStats
+  static std::vector<KeyValueDB::BackupStats> list_backups(CephContext *cct, const std::string &path, const std::string &backup_path) {
+    std::string kv_type;
+    int r = read_meta_path("kv_backend", &kv_type, &path);
+    if (r < 0) {
+        // Some proper error reporting would be nice
+        return std::vector<KeyValueDB::BackupStats>();
+    }
+
+    return KeyValueDB::list_backups(cct, kv_type, backup_path);
+  }
+
   /// @brief Restores a backup with given version from backup_path
   /// @param cct ceph context
   /// @param path path to database location

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10191,6 +10191,7 @@ int OSDMonitor::prepare_command_osd_new(
     if (has_lockbox) {
       ceph_assert(nullptr != svc);
       svc->do_osd_new(uuid, dmcrypt_key);
+      mon.set_should_backup();
     }
   }
 

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1157,6 +1157,7 @@ start_mon() {
 [mon.$f]
         host = $HOSTNAME
         mon data = $CEPH_DEV_DIR/mon.$f
+        mon backup path = $CEPH_DEV_DIR/mon.$f-backup
 EOF
             count=$(($count + 2))
         done


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/63801

This patchset implements ceph mon backup functionality using the rocksdb BackupEngine feature.

Manual backups can be triggered via the admin socket using the "backup" command.

If the new setting `mon.auto_backup` is enabled, the backup is triggered when:

- new OSD with encryption keys are added - OSD with encryption are note recoverable when mon is corrupted
- important auth permission changes - auth keys are not stored in OSDs


Backups can be restored with the `--restore-backup` and `--backup-version` arguments.
ceph-mon exits with 0 after successful restoration so the monitor can be started normally afterwards.
If no backup-version is specified, the last valid backup is restored.

Open questions: should the backup() called from the tick() function be run in the `ThreadPool cpu_tp` ?

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
