### PR TITLE
squid: install-deps: enable copr ceph/grpc

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -517,6 +517,11 @@ else
                 $SUDO rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$MAJOR_VERSION
                 $SUDO rm -f /etc/yum.repos.d/dl.fedoraproject.org*
                 if test $ID = centos -a $MAJOR_VERSION = 8 ; then
+                    # for grpc-devel
+                    # See https://copr.fedorainfracloud.org/coprs/ceph/grpc/
+                    # epel is enabled for all major versions couple of lines above
+                    $SUDO dnf copr enable -y ceph/grpc
+
                     # Enable 'powertools' or 'PowerTools' repo
                     $SUDO dnf config-manager --set-enabled $(dnf repolist --all 2>/dev/null|gawk 'tolower($0) ~ /^powertools\s/{print $1}')
                     dts_ver=11
@@ -532,6 +537,9 @@ else
                     $SUDO dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
                     $SUDO dnf config-manager --setopt=apt-mirror.front.sepia.ceph.com_lab-extras_8_.gpgcheck=0 --save
                     $SUDO dnf -y module enable javapackages-tools
+
+                    # Enable ceph/grpc from copr for el8, this is needed for nvmeof management.
+                    $SUDO dnf copr enable -y ceph/grpc
                 fi
                 ;;
         esac


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65368

---

backport of https://github.com/ceph/ceph/pull/56530
parent tracker: https://tracker.ceph.com/issues/65184

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh