### PR TITLE
node-proxy: fix util.get_logger()

### DIFF
--- a/src/ceph-node-proxy/ceph_node_proxy/util.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/util.py
@@ -31,7 +31,8 @@ CONFIG: Dict[str, Any] = {
 
 
 def get_logger(name: str, level: Union[int, str] = logging.NOTSET) -> logging.Logger:
-    if level == logging.NOTSET:
+    log_level: Union[int, str] = level
+    if log_level == logging.NOTSET:
         log_level = CONFIG['logging']['level']
     logger = logging.getLogger(name)
     logger.setLevel(log_level)


### PR DESCRIPTION
when get_logger() is passed `level` variable, it fails with `UnboundLocalError` error:

```
Traceback (most recent call last):
  File "/usr/sbin/ceph-node-proxy", line 11, in <module>
    load_entry_point('ceph-node-proxy==1.0.0', 'console_scripts', 'ceph-node-proxy')()
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 476, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2700, in load_entry_point
    return ep.load()
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2318, in load
    return self.resolve()
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2324, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/lib/python3.6/site-packages/ceph_node_proxy/main.py", line 1, in <module>
    from ceph_node_proxy.redfishdellsystem import RedfishDellSystem
  File "/usr/lib/python3.6/site-packages/ceph_node_proxy/redfishdellsystem.py", line 1, in <module>
    from ceph_node_proxy.baseredfishsystem import BaseRedfishSystem
  File "/usr/lib/python3.6/site-packages/ceph_node_proxy/baseredfishsystem.py", line 3, in <module>
    from ceph_node_proxy.basesystem import BaseSystem
  File "/usr/lib/python3.6/site-packages/ceph_node_proxy/basesystem.py", line 3, in <module>
    from ceph_node_proxy.util import Config, get_logger, BaseThread
  File "/usr/lib/python3.6/site-packages/ceph_node_proxy/util.py", line 49, in <module>
    logger = get_logger(__name__)
  File "/usr/lib/python3.6/site-packages/ceph_node_proxy/util.py", line 37, in get_logger
    logger.setLevel(log_level)
UnboundLocalError: local variable 'log_level' referenced before assignment
```

Fixes: https://tracker.ceph.com/issues/65392

