### PR TITLE
qa/rgw: barbican uses branch stable/2023.1

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/barbican.yaml
+++ b/qa/suites/rgw/crypt/2-kms/barbican.yaml
@@ -68,7 +68,7 @@ tasks:
           project: s3
 - barbican:
     client.0:
-      force-branch: stable/xena
+      force-branch: stable/2023.1
       use-keystone-role: client.0
       keystone_authtoken:
         auth_plugin: password


### PR DESCRIPTION
the stable/xena branch no longer exists. it was moved to unmaintained/xena. use the same stable/2023.1 branch as keystone

Fixes: https://tracker.ceph.com/issues/65334

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
