### PR TITLE
squid: osd/scrub: remove detection & handling of reservation timeouts from the code

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -520,16 +520,6 @@ options:
     stats (inc. scrub/block duration) every this many seconds.
   default: 120
   with_legacy: false
-- name: osd_scrub_reservation_timeout
-  type: millisecs
-  level: advanced
-  desc: Maximum wait (milliseconds) for replicas' response to scrub reservation requests
-  long_desc: Maximum wait (milliseconds) for all replicas to respond to
-    scrub reservation requests, before the scrub session is aborted. Disable by setting
-    to a very large value.
-  default: 300000
-  min: 2000
-  with_legacy: false
 - name: osd_scrub_disable_reservation_queuing
   type: bool
   level: advanced

--- a/src/osd/osd_perf_counters.cc
+++ b/src/osd/osd_perf_counters.cc
@@ -406,7 +406,6 @@ PerfCounters *build_scrub_labeled_perf(CephContext *cct, std::string label)
   scrub_perf.add_u64_counter(scrbcnt_resrv_success, "scrub_reservations_completed", "successfully completed reservation processes");
   scrub_perf.add_time_avg(scrbcnt_resrv_successful_elapsed, "successful_reservations_elapsed", "time to scrub reservation completion");
   scrub_perf.add_u64_counter(scrbcnt_resrv_aborted, "reservation_process_aborted", "scrub reservation was aborted");
-  scrub_perf.add_u64_counter(scrbcnt_resrv_timed_out, "reservation_process_timed_out", "scrub reservation timed out");
   scrub_perf.add_u64_counter(scrbcnt_resrv_rejected, "reservation_process_failure", "scrub reservation failed due to replica denial");
   scrub_perf.add_u64_counter(scrbcnt_resrv_skipped, "reservation_process_skipped", "scrub reservation skipped for high priority scrub");
   scrub_perf.add_time_avg(scrbcnt_resrv_failed_elapsed, "failed_reservations_elapsed", "time for scrub reservation to fail");

--- a/src/osd/osd_perf_counters.h
+++ b/src/osd/osd_perf_counters.h
@@ -218,8 +218,6 @@ enum {
   scrbcnt_resrv_successful_elapsed,
   /// # failed attempt to reserve replicas due to an abort
   scrbcnt_resrv_aborted,
-  /// # reservation process timed out
-  scrbcnt_resrv_timed_out,
   /// # reservation failed due to a 'rejected' response
   scrbcnt_resrv_rejected,
   /// # reservation skipped for high-priority scrubs

--- a/src/osd/scrubber/scrub_machine.cc
+++ b/src/osd/scrubber/scrub_machine.cc
@@ -234,18 +234,7 @@ ReservingReplicas::ReservingReplicas(my_context ctx)
       *scrbr, context<PrimaryActive>().last_request_sent_nonce,
       *session.m_perf_set);
 
-  if (session.m_reservations->get_last_sent()) {
-    // the 1'st reservation request was sent
-
-    auto timeout = scrbr->get_pg_cct()->_conf.get_val<milliseconds>(
-	"osd_scrub_reservation_timeout");
-    if (timeout.count() > 0) {
-      // Start a timer to handle case where the replicas take a long time to
-      // ack the reservation.  See ReservationTimeout handler below.
-      m_timeout_token =
-	  machine.schedule_timer_event_after<ReservationTimeout>(timeout);
-    }
-  } else {
+  if (!session.m_reservations->get_last_sent()) {
     // no replicas to reserve
     dout(10) << "no replicas to reserve" << dendl;
     // can't transit directly from here
@@ -301,24 +290,6 @@ sc::result ReservingReplicas::react(const ReplicaReject& ev)
   return transit<PrimaryIdle>();
 }
 
-sc::result ReservingReplicas::react(const ReservationTimeout&)
-{
-  DECLARE_LOCALS;  // 'scrbr' & 'pg_id' aliases
-  auto& session = context<Session>();
-  dout(10) << "ReservingReplicas::react(const ReservationTimeout&)" << dendl;
-  session.m_reservations->log_failure_and_duration(scrbcnt_resrv_timed_out);
-
-  const auto msg = fmt::format(
-      "osd.{} PgScrubber: {} timeout on reserving replicas (since {})",
-      scrbr->get_whoami(), scrbr->get_spgid(), entered_at);
-  dout(1) << msg << dendl;
-  scrbr->get_clog()->warn() << msg;
-
-  // cause the scrubber to stop the scrub session, marking 'reservation
-  // failure' as the cause (affecting future scheduling)
-  scrbr->flag_reservations_failure();
-  return transit<PrimaryIdle>();
-}
 
 // ----------------------- ActiveScrubbing -----------------------------------
 

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -156,9 +156,6 @@ VALUE_EVENT(ReserverGranted, AsyncScrubResData);
 /// all replicas have granted our reserve request
 MEV(RemotesReserved)
 
-/// reservations have timed out
-MEV(ReservationTimeout)
-
 /// initiate a new scrubbing session (relevant if we are a Primary)
 MEV(StartScrub)
 
@@ -565,25 +562,21 @@ struct Session : sc::state<Session, PrimaryActive, ReservingReplicas>,
   ScrubTimePoint m_session_started_at{ScrubClock::now()};
 };
 
-struct ReservingReplicas : sc::state<ReservingReplicas, Session>,
-			   NamedSimply {
+struct ReservingReplicas : sc::state<ReservingReplicas, Session>, NamedSimply {
   explicit ReservingReplicas(my_context ctx);
   ~ReservingReplicas();
-  using reactions = mpl::list<sc::custom_reaction<ReplicaGrant>,
-			      sc::custom_reaction<ReplicaReject>,
-			      sc::transition<RemotesReserved, ActiveScrubbing>,
-			      sc::custom_reaction<ReservationTimeout>>;
+  using reactions = mpl::list<
+      sc::custom_reaction<ReplicaGrant>,
+      sc::custom_reaction<ReplicaReject>,
+      sc::transition<RemotesReserved, ActiveScrubbing>>;
 
   ScrubTimePoint entered_at = ScrubClock::now();
-  ScrubMachine::timer_event_token_t m_timeout_token;
 
   /// a "raw" event carrying a peer's grant response
   sc::result react(const ReplicaGrant&);
 
   /// a "raw" event carrying a peer's denial response
   sc::result react(const ReplicaReject&);
-
-  sc::result react(const ReservationTimeout&);
 };
 
 


### PR DESCRIPTION
as no timeout can be set for reserver-based (queued) reservation requests.

Backport of https://github.com/ceph/ceph/pull/56389

Original tracker:  https://tracker.ceph.com/issues/65044
Backport tracker:  https://tracker.ceph.com/issues/65646