### PR TITLE
qa/cephadm: teuthology test for deploying raw OSDs

### DIFF
--- a/qa/suites/orch/cephadm/osds/2-ops/deploy-raw.yaml
+++ b/qa/suites/orch/cephadm/osds/2-ops/deploy-raw.yaml
@@ -1,0 +1,30 @@
+overrides:
+  cephadm:
+    raw-osds: True
+tasks:
+- cephadm.shell:
+    host.a:
+      - |
+        set -e
+        set -x
+        ceph orch ps
+        ceph orch device ls
+        ceph osd tree
+        ORCH_PS=$(ceph orch ps)
+        if grep -q "No daemons" <<< "$ORCH_PS"; then
+          echo "No OSDs were deployed"
+          exit 1
+        fi
+        ceph orch ps | grep -q "running"
+        if grep -q "failed" <<< "$ORCH_PS"; then
+          echo "At least one raw OSD deployed is failed"
+          exit 1
+        fi
+        if grep -q "stopped" <<< "$ORCH_PS"; then
+          echo "At least one raw OSD deployed is stopped"
+          exit 1
+        fi
+        if ceph-volume lvm list; then
+          echo "ceph-volume lvm list was expected to give non-zero rc with all raw OSDs"
+          exit 1
+        fi


### PR DESCRIPTION
This was a hole in our testing coverage

The test relies on the fact that
'ceph-volume lvm list' returns a nonzero
rc when there are no lvm OSDs present

```
root@smithi156:/# ceph-volume lvm list
No valid Ceph lvm devices found
root@smithi156:/# echo $?
1
```

with lvm OSDs present, it will instead
reports on the lvs and give a zero rc

```
root@smithi097:/# ceph-volume lvm list

====== osd.0 =======

  [block]       /dev/ceph-ffeadaf4-...

...

root@smithi097:/# echo $?
0
```

Assuming the override this test has works
properly and all the OSDs we see are raw,
we can use the nonzero rc to confirm the
OSDs are raw


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
