### PR TITLE
dev: add devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:jammy
+ARG USERNAME=user
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME -s /usr/bin/bash \
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+RUN export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC \
+    && apt-get -y install tzdata wget git openjdk-11-jdk
+
+USER $USERNAME
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+
+{
+    "name": "Ceph Developer Environment",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "containerUser": "user",
+    "postCreateCommand": ".devcontainer/post_create.sh",
+    "shutdownAction": "stopContainer",
+    "customizations": {
+        "vscode": {
+          "extensions": [
+            "streetsidesoftware.code-spell-checker",
+            "ms-vscode.cpptools-extension-pack",
+            "mwinters-stuff.ninjabuild",
+            "ms-vscode.cmake-tools",
+            "josetr.cmake-language-support-vscode",
+            "vscjava.vscode-java-pack"
+           ]
+        }
+    }
+}

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+./install-deps.sh

--- a/doc/dev/quick_guide.rst
+++ b/doc/dev/quick_guide.rst
@@ -40,6 +40,17 @@ Finally, build ceph:
 
 Omit ``--target...`` if you want to do a full build.
 
+Devcontainer
+------------
+
+Ceph ships a working devcontainer that can be used with IDEs that support it, like ``vscode`` with the ``Dev Containers`` plugin.
+This is a good choice for systems that are not directly supported.
+Once the container finished bootstrapping, the commands like ``do_cmake.sh`` will run successfully inside the docker environment.
+
+.. note::
+   devcontainers do not work well with git worktree setup, as the parent git repository will not be reachable.
+   You will need to do a regular checkout for each environment you want to use in parallel.
+
 
 Running a development deployment
 --------------------------------


### PR DESCRIPTION
Adds fully functional development container based on ubuntu.
It installs all the requirements on startup, so running do_cmake.sh will create a correctly configured build.

vscode will also have most popular c++/cmake/ninja plugins installed. I tested that typical functions like jump to definition work.

This reduces the setup time for new developers a lot.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test docs`
</details>
