### PR TITLE
librbd: make librbd::Image moveable

### DIFF
--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -532,6 +532,14 @@ public:
   Image();
   ~Image();
 
+  // non-copyable
+  Image(const Image& rhs) = delete;
+  Image& operator=(const Image& rhs) = delete;
+
+  // moveable
+  Image(Image&& rhs) noexcept;
+  Image& operator=(Image&& rhs) noexcept;
+
   int close();
   int aio_close(RBD::AioCompletion *c);
 
@@ -853,9 +861,6 @@ public:
 
 private:
   friend class RBD;
-
-  Image(const Image& rhs);
-  const Image& operator=(const Image& rhs);
 
   image_ctx_t ctx;
 };

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -51,6 +51,7 @@
 #include "librbd/io/ReadResult.h"
 #include <algorithm>
 #include <string>
+#include <utility>
 #include <vector>
 
 #ifdef WITH_LTTNG
@@ -1607,6 +1608,17 @@ namespace librbd {
   Image::~Image()
   {
     close();
+  }
+
+  Image::Image(Image&& rhs) noexcept : ctx{std::exchange(rhs.ctx, nullptr)}
+  {
+  }
+
+  Image& Image::operator=(Image&& rhs) noexcept
+  {
+    Image tmp(std::move(rhs));
+    std::swap(ctx, tmp.ctx);
+    return *this;
   }
 
   int Image::close()


### PR DESCRIPTION
This PR adds move constructor and move assignment operator to the librbd::Image.
Also marks copy ctor/assign op as deleted, and makes them public for better compiler diagnostics.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
