### PR TITLE
rgw: allow disabling mdsearch APIs

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2384,6 +2384,15 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_enable_mdsearch
+  type: bool
+  level: basic
+  desc: Enable elastic metadata search APIs
+  long_desc: This configurable controls whether RGW handles the elastic metadata search APIs.
+  default: true
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_user_unique_email
   type: bool
   level: basic

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4605,6 +4605,9 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_get()
   }
 
   if (s->info.args.exists("mdsearch")) {
+    if (!s->cct->_conf->rgw_enable_mdsearch) {
+      return NULL;
+    }
     return new RGWGetBucketMetaSearch_ObjStore_S3;
   }
 
@@ -4727,6 +4730,9 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_delete()
   }
 
   if (s->info.args.exists("mdsearch")) {
+    if (!s->cct->_conf->rgw_enable_mdsearch) {
+      return NULL;
+    }
     return new RGWDelBucketMetaSearch_ObjStore_S3;
   }
 
@@ -4740,6 +4746,9 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_post()
   }
 
   if (s->info.args.exists("mdsearch")) {
+    if (!s->cct->_conf->rgw_enable_mdsearch) {
+      return NULL;
+    }
     return new RGWConfigBucketMetaSearch_ObjStore_S3;
   }
 


### PR DESCRIPTION
Since this is visible to the bucket owners, it can be presumed to be a functional feature. Providing the ability to deactivate the feature could be beneficial in such scenarios.

Fixes: https://tracker.ceph.com/issues/65397