### PR TITLE
mds: adjust the locks order

### DIFF
--- a/qa/cephfs/conf/mds.yaml
+++ b/qa/cephfs/conf/mds.yaml
@@ -9,6 +9,7 @@ overrides:
         mds debug scatterstat: true
         mds op complaint time: 180
         mds verify scatter: true
+        mds detect deadlocks: true
         osd op complaint time: 180
         rados mon op timeout: 900
         rados osd op timeout: 900

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -457,6 +457,16 @@ options:
   - mds
   flags:
   - runtime
+- name: mds_detect_deadlocks
+  type: bool
+  level: advanced
+  desc: flag to detect deadlocks between requests.
+  fmt_desc: To enable it to detect deadlocks between requests.
+  default: false
+  services:
+  - mds
+  flags:
+  - runtime
 - name: mds_tick_interval
   type: float
   level: advanced

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -234,6 +234,10 @@ void Locker::detect_dead_locks(const MDRequestRef& mdr, int lock_type)
   bool any_waiter = false;
   bool order_messy = false;
 
+  if (!g_conf().get_val<bool>("mds_detect_deadlocks")) {
+    return;
+  }
+
   dout(15) << "detect_dead_locks " << *mdr << dendl;
   for (auto it = mdr->locks.begin(); it != mdr->locks.end(); ) {
     SimpleLock *lock = it->lock;

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -51,6 +51,8 @@ public:
 
   void nudge_log(SimpleLock *lock);
 
+  void detect_dead_locks(const MDRequestRef& mdr, int lock_type);
+
   bool acquire_locks(const MDRequestRef& mdr,
 		     MutationImpl::LockOpVec& lov,
 		     CInode *auth_pin_freeze=NULL,


### PR DESCRIPTION
This will just make the locks order as:

  1,  filelock
  2,  netstlock
  3,  authlock
  4,  linklock
  5,  snaplock
  6,  xattrlock
  7,  policylock
  8,  versionlock
  9,  flocklock
  10, dirfragtreelock

Fixes: https://tracker.ceph.com/issues/62123





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
