### PR TITLE
test/test_back_trace: fix failed Basic UT because of different call stacks

### DIFF
--- a/src/test/common/test_back_trace.cc
+++ b/src/test/common/test_back_trace.cc
@@ -37,7 +37,7 @@ TEST(BackTrace, Basic) {
 		 "<foo.*>\\s"
 		 "at\\s.*$"};
 #else
-		 "\\(foo.*\\)\\s"
+		 "\\((foo|ceph::ClibBackTrace::ClibBackTrace).*\\)\\s"
 		 "\\[0x[[:xdigit:]]+\\]$"};
 #endif
   EXPECT_TRUE(std::regex_match(lines[lineno], e));


### PR DESCRIPTION
Run test on Kunpeng arm machine:
[ RUN      ] BackTrace.Basic
bt:
 ceph version Development (no_version) squid (dev)
 1: (ceph::ClibBackTrace::ClibBackTrace(int)+0x128) [0xaaaac54ff77c]
 2: (foo[abi:cxx11]()+0x1fc) [0xaaaac54fe5a4]
 3: (BackTrace_Basic_Test::TestBody()+0x284) [0xaaaac54fea80]
 4: (void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)+0x1e0) [0xaaaac56a52f4]
 5: (void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)+0x25c) [0xaaaac565d274]
 6: (testing::Test::Run()+0x310) [0xaaaac56101cc]
 7: (testing::TestInfo::Run()+0x338) [0xaaaac5612110]
 8: (testing::TestSuite::Run()+0x3e4) [0xaaaac5613710]
 9: (testing::internal::UnitTestImpl::RunAllTests()+0xa30) [0xaaaac562f4d4]
 10: (bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)+0x1e0) [0xaaaac56af17c]
 11: (bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)+0x25c) [0xaaaac56636e8]
 12: (testing::UnitTest::Run()+0x274) [0xaaaac562e94c]
 13: (RUN_ALL_TESTS()+0x10) [0xaaaac55b36e8]
 14: main()
 15: /lib/aarch64-linux-gnu/libc.so.6(+0x273fc) [0xffffa01973fc]
 16: __libc_start_main()
 17: _start()

src/test/common/test_back_trace.cc:44: Failure
Value of: std::regex_match(lines[lineno], e)
  Actual: false
Expected: true
[  FAILED  ] BackTrace.Basic (5 ms)
[----------] 1 test from BackTrace (5 ms total)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
