### PR TITLE
common/StackStringStream: update pointer to newly allocated memory in overflow()

### DIFF
--- a/src/common/StackStringStream.h
+++ b/src/common/StackStringStream.h
@@ -77,6 +77,8 @@ protected:
     if (traits_type::not_eof(c)) {
       char str = traits_type::to_char_type(c);
       vec.push_back(str);
+      setp(vec.data(), vec.data() + vec.size());
+      pbump(vec.size());
       return c;
     } else {
       return traits_type::eof();


### PR DESCRIPTION
When sanitizer is enabled, unittest_log fails as following

```
[ RUN      ] Log.StderrPipeBig
=================================================================
==3302372==ERROR: AddressSanitizer: heap-use-after-free on address 0xffff96e01d00 at pc 0xaaaadd3db754 bp 0xffffd9ebffa0 sp 0xffffd9ebf790
READ of size 4096 at 0xffff96e01d00 thread T0
    #0 0xaaaadd3db750 in __asan_memmove (/root/ceph-19.0.0/build/bin/unittest_log+0x3fb750) (BuildId: 6fd965435d12fd345de38dddc8723053b9877409)
    https://github.com/Svelar/ceph/pull/1 0xffffafc23734 in char const* boost::container::dtl::memmove_n_source<char const*, char*>(char const*, unsigned long, char*) /root/ceph-19.0.0/build/boost/include/boost/container/detail/copy_move_algo.hpp:261:10
    https://github.com/Svelar/ceph/pull/2 0xffffafc23734 in boost::container::dtl::enable_if_memtransfer_copy_constructible<char const*, char*, char const*>::type boost::container::uninitialized_copy_alloc_n_source<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const*, char*>(boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>&, char const*, unsigned long, char*) /root/ceph-19.0.0/build/boost/include/boost/container/detail/copy_move_algo.hpp:600:11
    https://github.com/Svelar/ceph/pull/3 0xffffafc23734 in void boost::container::dtl::insert_range_proxy<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const*>::uninitialized_copy_n_and_update<char*>(boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>&, char*, unsigned long) /root/ceph-19.0.0/build/boost/include/boost/container/detail/advanced_insert_int.hpp:85:22
    https://github.com/Svelar/ceph/pull/4 0xffffafc23734 in void boost::container::expand_forward_and_insert_alloc<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char*, boost::container::dtl::insert_range_proxy<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const*> >(boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>&, char*, char*, unsigned long, boost::container::dtl::insert_range_proxy<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const*>) /root/ceph-19.0.0/build/boost/include/boost/container/detail/copy_move_algo.hpp:1469:23
    https://github.com/Svelar/ceph/pull/5 0xffffafc23734 in void boost::container::vector<char, boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, void>::priv_insert_forward_range_expand_forward<boost::container::dtl::insert_range_proxy<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const*> >(char*, unsigned long, boost::container::dtl::insert_range_proxy<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const*>, boost::move_detail::integral_constant<bool, false>) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:3058:7
    https://github.com/Svelar/ceph/pull/6 0xffffafc23734 in boost::container::vec_iterator<char*, false> boost::container::vector<char, boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, void>::priv_insert_forward_range<boost::container::dtl::insert_range_proxy<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const*> >(char* const&, unsigned long, boost::container::dtl::insert_range_proxy<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const*>) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:2890:16
    https://github.com/ceph/ceph/pull/7 0xffffafc23734 in boost::container::vec_iterator<char*, false> boost::container::vector<char, boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, void>::insert<char const*>(boost::container::vec_iterator<char*, true>, char const*, char const*, boost::move_detail::disable_if_or<void, boost::move_detail::is_convertible<char const*, unsigned long>, boost::container::dtl::is_input_iterator<char const*, has_iterator_category<char const*>::value>, boost::move_detail::bool_<false>, boost::move_detail::bool_<false> >::type*) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:2088:20
    https://github.com/ceph/ceph/pull/8 0xffffafc23734 in ceph::logging::ConcreteEntry::ConcreteEntry(ceph::logging::Entry const&) /root/ceph-19.0.0/src/log/Entry.h:84:9
    https://github.com/ceph/ceph/pull/9 0xffffafc21a88 in decltype(new ((void*)(0))ceph::logging::ConcreteEntry(std::declval<ceph::logging::Entry>())) std::construct_at<ceph::logging::ConcreteEntry, ceph::logging::Entry>(ceph::logging::ConcreteEntry*, ceph::logging::Entry&&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:97:39
    https://github.com/ceph/ceph/pull/10 0xffffafc21198 in void std::allocator_traits<std::allocator<ceph::logging::ConcreteEntry> >::construct<ceph::logging::ConcreteEntry, ceph::logging::Entry>(std::allocator<ceph::logging::ConcreteEntry>&, ceph::logging::ConcreteEntry*, ceph::logging::Entry&&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:518:4
    https://github.com/ceph/ceph/pull/11 0xffffafc16464 in ceph::logging::ConcreteEntry& std::vector<ceph::logging::ConcreteEntry, std::allocator<ceph::logging::ConcreteEntry> >::emplace_back<ceph::logging::Entry>(ceph::logging::Entry&&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/vector.tcc:115:6
    https://github.com/ceph/ceph/pull/12 0xffffafc0dcbc in ceph::logging::Log::submit_entry(ceph::logging::Entry&&) /root/ceph-19.0.0/src/log/Log.cc:265:9
    https://github.com/ceph/ceph/pull/13 0xaaaadd41a404 in Log_StderrPipeBig_Test::TestBody() /root/ceph-19.0.0/src/log/test.cc:280:9
    https://github.com/ceph/ceph/pull/14 0xaaaade0b4338 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2605:10
    https://github.com/ceph/ceph/pull/15 0xaaaade061244 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2641:14
    https://github.com/ceph/ceph/pull/16 0xaaaade012680 in testing::Test::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2680:5
    https://github.com/ceph/ceph/pull/17 0xaaaade0145c4 in testing::TestInfo::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2858:11
    https://github.com/ceph/ceph/pull/18 0xaaaade015bc4 in testing::TestSuite::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:3012:28
    https://github.com/ceph/ceph/pull/19 0xaaaade031988 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:5723:44
    https://github.com/ceph/ceph/pull/20 0xaaaade0be24c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2605:10
    https://github.com/ceph/ceph/pull/21 0xaaaade0687dc in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2641:14
    https://github.com/ceph/ceph/pull/22 0xaaaade030e00 in testing::UnitTest::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:5306:10
    https://github.com/ceph/ceph/pull/23 0xaaaadd425c48 in RUN_ALL_TESTS() /root/ceph-19.0.0/src/googletest/googletest/include/gtest/gtest.h:2486:46
    https://github.com/ceph/ceph/pull/24 0xaaaadd4207a0 in main /root/ceph-19.0.0/src/log/test.cc:503:10
    https://github.com/ceph/ceph/pull/25 0xffffac3473f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    https://github.com/ceph/ceph/pull/26 0xffffac3474c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    https://github.com/ceph/ceph/pull/27 0xaaaadd364d6c in _start (/root/ceph-19.0.0/build/bin/unittest_log+0x384d6c) (BuildId: 6fd965435d12fd345de38dddc8723053b9877409)

0xffff96e01d00 is located 0 bytes inside of 6553-byte region [0xffff96e01d00,0xffff96e03699)
freed by thread T0 here:
    #0 0xaaaadd4136f0 in operator delete(void*) (/root/ceph-19.0.0/build/bin/unittest_log+0x4336f0) (BuildId: 6fd965435d12fd345de38dddc8723053b9877409)
    https://github.com/Svelar/ceph/pull/1 0xaaaadd434968 in boost::container::new_allocator<char>::deallocate(char*, unsigned long) /root/ceph-19.0.0/build/boost/include/boost/container/new_allocator.hpp:171:7
    https://github.com/Svelar/ceph/pull/2 0xaaaadd434934 in boost::container::allocator_traits<boost::container::new_allocator<char> >::deallocate(boost::container::new_allocator<char>&, char*, unsigned long) /root/ceph-19.0.0/build/boost/include/boost/container/allocator_traits.hpp:308:9
    https://github.com/Svelar/ceph/pull/3 0xaaaadd434934 in boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>::deallocate(char*, unsigned long) /root/ceph-19.0.0/build/boost/include/boost/container/small_vector.hpp:255:10
    https://github.com/Svelar/ceph/pull/4 0xaaaadd43911c in boost::container::allocator_traits<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void> >::deallocate(boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>&, char*, unsigned long) /root/ceph-19.0.0/build/boost/include/boost/container/allocator_traits.hpp:308:9
    https://github.com/Svelar/ceph/pull/5 0xaaaadd43911c in boost::container::vector_alloc_holder<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, unsigned long, boost::move_detail::integral_constant<unsigned int, 1u> >::deallocate(char* const&, unsigned long) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:487:7
    https://github.com/Svelar/ceph/pull/6 0xaaaadd43911c in void boost::container::vector<char, boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, void>::priv_insert_forward_range_new_allocation<boost::container::dtl::insert_emplace_proxy<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const&> >(char*, unsigned long, char*, unsigned long, boost::container::dtl::insert_emplace_proxy<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const&>) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:3080:25
    https://github.com/ceph/ceph/pull/7 0xaaaadd438aec in boost::container::vec_iterator<char*, false> boost::container::vector<char, boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, void>::priv_insert_forward_range_no_capacity<boost::container::dtl::insert_emplace_proxy<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const&> >(char*, unsigned long, boost::container::dtl::insert_emplace_proxy<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const&>, boost::move_detail::integral_constant<unsigned int, 1u>) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:2830:13
    https://github.com/ceph/ceph/pull/8 0xaaaadd4328bc in char& boost::container::vector<char, boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, void>::emplace_back<char const&>(char const&) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:1888:24
    https://github.com/ceph/ceph/pull/9 0xaaaadd4328bc in void boost::container::vector<char, boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, void>::priv_push_back<char const&>(char const&) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:2746:13
    https://github.com/ceph/ceph/pull/10 0xaaaadd4328bc in boost::container::vector<char, boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, void>::push_back(char const&) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:1996:4
    https://github.com/ceph/ceph/pull/11 0xaaaadd4328bc in StackStringBuf<4096ul>::overflow(int) /root/ceph-19.0.0/src/common/StackStringStream.h:79:11
    https://github.com/ceph/ceph/pull/12 0xffffac6d3dac in std::ostream::put(char) (/lib/aarch64-linux-gnu/libstdc++.so.6+0x133dac) (BuildId: a012b2bb77110e84b266cd7425b50e57427abb02)
    https://github.com/ceph/ceph/pull/13 0xffffac6d4aac in std::basic_ostream<char, std::char_traits<char> >& std::operator<<<std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char) (/lib/aarch64-linux-gnu/libstdc++.so.6+0x134aac) (BuildId: a012b2bb77110e84b266cd7425b50e57427abb02)
    https://github.com/ceph/ceph/pull/14 0xaaaadd41a3c8 in Log_StderrPipeBig_Test::TestBody() /root/ceph-19.0.0/src/log/test.cc:278:9
    https://github.com/ceph/ceph/pull/15 0xaaaade0b4338 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2605:10
    https://github.com/ceph/ceph/pull/16 0xaaaade061244 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2641:14
    https://github.com/ceph/ceph/pull/17 0xaaaade012680 in testing::Test::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2680:5
    https://github.com/ceph/ceph/pull/18 0xaaaade0145c4 in testing::TestInfo::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2858:11
    https://github.com/ceph/ceph/pull/19 0xaaaade015bc4 in testing::TestSuite::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:3012:28
    https://github.com/ceph/ceph/pull/20 0xaaaade031988 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:5723:44
    https://github.com/ceph/ceph/pull/21 0xaaaade0be24c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2605:10
    https://github.com/ceph/ceph/pull/22 0xaaaade0687dc in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2641:14
    https://github.com/ceph/ceph/pull/23 0xaaaade030e00 in testing::UnitTest::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:5306:10
    https://github.com/ceph/ceph/pull/24 0xaaaadd425c48 in RUN_ALL_TESTS() /root/ceph-19.0.0/src/googletest/googletest/include/gtest/gtest.h:2486:46
    https://github.com/ceph/ceph/pull/25 0xaaaadd4207a0 in main /root/ceph-19.0.0/src/log/test.cc:503:10
    https://github.com/ceph/ceph/pull/26 0xffffac3473f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    https://github.com/ceph/ceph/pull/27 0xffffac3474c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    https://github.com/ceph/ceph/pull/28 0xaaaadd364d6c in _start (/root/ceph-19.0.0/build/bin/unittest_log+0x384d6c) (BuildId: 6fd965435d12fd345de38dddc8723053b9877409)

previously allocated by thread T0 here:
    #0 0xaaaadd412e88 in operator new(unsigned long) (/root/ceph-19.0.0/build/bin/unittest_log+0x432e88) (BuildId: 6fd965435d12fd345de38dddc8723053b9877409)
    https://github.com/Svelar/ceph/pull/1 0xaaaadd433ec0 in boost::container::new_allocator<char>::allocate(unsigned long) /root/ceph-19.0.0/build/boost/include/boost/container/new_allocator.hpp:160:30
    https://github.com/Svelar/ceph/pull/2 0xaaaadd438a68 in boost::container::allocator_traits<boost::container::new_allocator<char> >::priv_allocate(boost::move_detail::integral_constant<bool, false>, boost::container::new_allocator<char>&, unsigned long, void const*) /root/ceph-19.0.0/build/boost/include/boost/container/allocator_traits.hpp:395:16
    https://github.com/Svelar/ceph/pull/3 0xaaaadd438a68 in boost::container::allocator_traits<boost::container::new_allocator<char> >::allocate(boost::container::new_allocator<char>&, unsigned long, void const*) /root/ceph-19.0.0/build/boost/include/boost/container/allocator_traits.hpp:318:14
    https://github.com/Svelar/ceph/pull/4 0xaaaadd438a68 in boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>::allocate(unsigned long, void const*) /root/ceph-19.0.0/build/boost/include/boost/container/small_vector.hpp:248:14
    https://github.com/Svelar/ceph/pull/5 0xaaaadd438a68 in boost::container::allocator_traits<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void> >::allocate(boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>&, unsigned long) /root/ceph-19.0.0/build/boost/include/boost/container/allocator_traits.hpp:302:16
    https://github.com/Svelar/ceph/pull/6 0xaaaadd438a68 in boost::container::vector_alloc_holder<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, unsigned long, boost::move_detail::integral_constant<unsigned int, 1u> >::allocate(unsigned long) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:482:14
    https://github.com/ceph/ceph/pull/7 0xaaaadd438a68 in boost::container::vec_iterator<char*, false> boost::container::vector<char, boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, void>::priv_insert_forward_range_no_capacity<boost::container::dtl::insert_emplace_proxy<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const&> >(char*, unsigned long, boost::container::dtl::insert_emplace_proxy<boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, char const&>, boost::move_detail::integral_constant<unsigned int, 1u>) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:2826:73
    https://github.com/ceph/ceph/pull/8 0xaaaadd4328bc in char& boost::container::vector<char, boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, void>::emplace_back<char const&>(char const&) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:1888:24
    https://github.com/ceph/ceph/pull/9 0xaaaadd4328bc in void boost::container::vector<char, boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, void>::priv_push_back<char const&>(char const&) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:2746:13
    https://github.com/ceph/ceph/pull/10 0xaaaadd4328bc in boost::container::vector<char, boost::container::small_vector_allocator<char, boost::container::new_allocator<void>, void>, void>::push_back(char const&) /root/ceph-19.0.0/build/boost/include/boost/container/vector.hpp:1996:4
    https://github.com/ceph/ceph/pull/11 0xaaaadd4328bc in StackStringBuf<4096ul>::overflow(int) /root/ceph-19.0.0/src/common/StackStringStream.h:79:11
    https://github.com/ceph/ceph/pull/12 0xffffac6d3dac in std::ostream::put(char) (/lib/aarch64-linux-gnu/libstdc++.so.6+0x133dac) (BuildId: a012b2bb77110e84b266cd7425b50e57427abb02)
    https://github.com/ceph/ceph/pull/13 0xffffac6d4aac in std::basic_ostream<char, std::char_traits<char> >& std::operator<<<std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char) (/lib/aarch64-linux-gnu/libstdc++.so.6+0x134aac) (BuildId: a012b2bb77110e84b266cd7425b50e57427abb02)
    https://github.com/ceph/ceph/pull/14 0xaaaadd41a3c8 in Log_StderrPipeBig_Test::TestBody() /root/ceph-19.0.0/src/log/test.cc:278:9
    https://github.com/ceph/ceph/pull/15 0xaaaade0b4338 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2605:10
    https://github.com/ceph/ceph/pull/16 0xaaaade061244 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2641:14
    https://github.com/ceph/ceph/pull/17 0xaaaade012680 in testing::Test::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2680:5
    https://github.com/ceph/ceph/pull/18 0xaaaade0145c4 in testing::TestInfo::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2858:11
    https://github.com/ceph/ceph/pull/19 0xaaaade015bc4 in testing::TestSuite::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:3012:28
    https://github.com/ceph/ceph/pull/20 0xaaaade031988 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:5723:44
    https://github.com/ceph/ceph/pull/21 0xaaaade0be24c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2605:10
    https://github.com/ceph/ceph/pull/22 0xaaaade0687dc in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2641:14
    https://github.com/ceph/ceph/pull/23 0xaaaade030e00 in testing::UnitTest::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:5306:10
    https://github.com/ceph/ceph/pull/24 0xaaaadd425c48 in RUN_ALL_TESTS() /root/ceph-19.0.0/src/googletest/googletest/include/gtest/gtest.h:2486:46
    https://github.com/ceph/ceph/pull/25 0xaaaadd4207a0 in main /root/ceph-19.0.0/src/log/test.cc:503:10
    https://github.com/ceph/ceph/pull/26 0xffffac3473f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    https://github.com/ceph/ceph/pull/27 0xffffac3474c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    https://github.com/ceph/ceph/pull/28 0xaaaadd364d6c in _start (/root/ceph-19.0.0/build/bin/unittest_log+0x384d6c) (BuildId: 6fd965435d12fd345de38dddc8723053b9877409)

SUMMARY: AddressSanitizer: heap-use-after-free (/root/ceph-19.0.0/build/bin/unittest_log+0x3fb750) (BuildId: 6fd965435d12fd345de38dddc8723053b9877409) in __asan_memmove
Shadow bytes around the buggy address:
  0x200ff2dc0350: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x200ff2dc0360: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x200ff2dc0370: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x200ff2dc0380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x200ff2dc0390: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x200ff2dc03a0:[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x200ff2dc03b0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x200ff2dc03c0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x200ff2dc03d0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x200ff2dc03e0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x200ff2dc03f0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==3302372==ABORTING
```

vec.push_back(str) will allocate memory and release the old one once there is insufficient memory which causing the old one to be invalid. So streambuf's data pointer and insertion position should be updated to newly allocated memory's address in vec.

Fixes: https://tracker.ceph.com/issues/65805
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
