### PR TITLE
reef: osd/SnapMapper: fix _lookup_purged_snap

### DIFF
--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -688,6 +688,10 @@ int SnapMapper::_lookup_purged_snap(
   decode(gotpool, p);
   decode(*begin, p);
   decode(*end, p);
+  if (gotpool != pool) {
+    dout(20) << __func__ << " got wrong pool " << gotpool << dendl;
+    return -ENOENT;
+  }
   if (snap < *begin || snap >= *end) {
     dout(20) << __func__ << " pool " << pool << " snap " << snap
 	     << " found [" << *begin << "," << *end << "), no overlap" << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65305

---

backport of https://github.com/ceph/ceph/pull/55562
parent tracker: https://tracker.ceph.com/issues/64347

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh