### PR TITLE
squid: qa/rgw: barbican uses branch stable/2023.1

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/barbican.yaml
+++ b/qa/suites/rgw/crypt/2-kms/barbican.yaml
@@ -68,7 +68,7 @@ tasks:
           project: s3
 - barbican:
     client.0:
-      force-branch: stable/xena
+      force-branch: stable/2023.1
       use-keystone-role: client.0
       keystone_authtoken:
         auth_plugin: password


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65411

---

backport of https://github.com/ceph/ceph/pull/56789
parent tracker: https://tracker.ceph.com/issues/65334

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh