### PR TITLE
python: remove some vestigial tox basepython directives

### DIFF
--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -35,7 +35,6 @@ deps =
 commands=pytest {posargs}
 
 [testenv:mypy]
-basepython = python3
 deps =
     mypy
     types-PyYAML
@@ -44,7 +43,6 @@ deps =
 commands = mypy --config-file ../mypy.ini {posargs:cephadm.py cephadmlib}
 
 [testenv:flake8]
-basepython = python3
 allowlist_externals = bash
 deps =
     flake8 == 5.0.4

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -146,7 +146,6 @@ commands =
       {posargs:{[testenv:fix]modules}}
 
 [testenv:pylint]
-basepython = python3
 deps =
     pylint
 modules =
@@ -155,7 +154,6 @@ commands =
     pylint {[pylint]addopts} {posargs:{[testenv:pylint]modules}}
 
 [testenv:flake8]
-basepython = python3
 deps =
     flake8
 allowlist_externals = bash
@@ -182,7 +180,6 @@ commands =
     bash -c 'test $(git ls-files cephadm | grep ".py$" | grep -v tests | xargs grep "docker.io" | wc -l) == 13'
 
 [testenv:jinjalint]
-basepython = python3
 deps =
     jinjaninja
 commands =


### PR DESCRIPTION
Remove some instances of  what I think are vestigial configuration parameters setting
    `basepython` in tox.ini. These may have been useful during the change
    from python 2 to 3, but I don't see them serving any useful purpose
    at this current time. In fact they now interfere with the ability to
    globally override the basepython version of all testenv's at once.
    So let's just remove them. We can always add it back if we find
    an issue in the future (and document it!).


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s> nope
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
