### PR TITLE
squid: rgw/multisite: x-rgw-replicated-at uses dump_time_header()

### DIFF
--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -37,7 +37,7 @@ static inline int rgw_http_error_to_errno(int http_err)
     case 503:
         return -EBUSY;
     default:
-        return -EIO;
+        return -ERR_INTERNAL_ERROR;
   }
 
   return 0; /* unreachable */

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -469,7 +469,7 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs,
     try {
       ceph::real_time replicated_time;
       decode(replicated_time, i->second);
-      dump_time(s, "x-rgw-replicated-at", replicated_time);
+      dump_time_header(s, "x-rgw-replicated-at", replicated_time);
     } catch (const buffer::error&) {}
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65412

---

backport of https://github.com/ceph/ceph/pull/56765
parent tracker: https://tracker.ceph.com/issues/65373

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh