### PR TITLE
squid: suites/rados/cephadm: adding OSD_DOWN to the log-ignorelist

### DIFF
--- a/qa/suites/orch/cephadm/osds/1-start.yaml
+++ b/qa/suites/orch/cephadm/osds/1-start.yaml
@@ -20,6 +20,8 @@ openstack:
     size: 10 # GB
 overrides:
   ceph:
+    log-ignorelist:
+      - OSD_DOWN
     conf:
       osd:
         osd shutdown pgref assert: true

--- a/qa/suites/orch/cephadm/smoke-singlehost/1-start.yaml
+++ b/qa/suites/orch/cephadm/smoke-singlehost/1-start.yaml
@@ -22,6 +22,8 @@ openstack:
     size: 10 # GB
 overrides:
   ceph:
+    log-ignorelist:
+      - OSD_DOWN
     conf:
       osd:
         osd shutdown pgref assert: true


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65414

---

backport of https://github.com/ceph/ceph/pull/56613
parent tracker: https://tracker.ceph.com/issues/64865

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh