### PR TITLE
test/TestQuiesceAgent: free quiesce_requests Context

### DIFF
--- a/src/test/mds/TestQuiesceAgent.cc
+++ b/src/test/mds/TestQuiesceAgent.cc
@@ -139,12 +139,18 @@ class QuiesceAgentTest : public testing::Test {
     }
 
     void TearDown() override {
+      for (auto it = quiesce_requests.cbegin(); it != quiesce_requests.cend(); ) {
+        if (it->second.second) {
+          it->second.second->complete(-ECANCELED);
+        }
+        it = quiesce_requests.erase(it);
+      }
+
       if (agent) {
         agent->shutdown();
         agent.reset();
       }
     }
-
 
     using R = QuiesceMap::Roots::value_type;
     using RootInitList = std::initializer_list<R>;


### PR DESCRIPTION
When sanitizer is enabled, unittest_mds_quiesce_agent fails as following

```
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from QuiesceAgentTest
[ RUN      ] QuiesceAgentTest.ThreadManagement
[       OK ] QuiesceAgentTest.ThreadManagement (3 ms)
[ RUN      ] QuiesceAgentTest.DbUpdates
[       OK ] QuiesceAgentTest.DbUpdates (1 ms)
[ RUN      ] QuiesceAgentTest.QuiesceProtocol
[       OK ] QuiesceAgentTest.QuiesceProtocol (3 ms)
[ RUN      ] QuiesceAgentTest.DuplicateQuiesceRequest
[       OK ] QuiesceAgentTest.DuplicateQuiesceRequest (2 ms)
[ RUN      ] QuiesceAgentTest.TimeoutBeforeComplete
[       OK ] QuiesceAgentTest.TimeoutBeforeComplete (2 ms)
[----------] 5 tests from QuiesceAgentTest (11 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (11 ms total)
[  PASSED  ] 5 tests.

=================================================================
==3975692==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0xaaaadd81c7c8 in operator new(unsigned long) (/root/ceph/build/bin/unittest_mds_quiesce_agent+0x1fc7c8) (BuildId: 7d45344ba1e43661d9de484f0a5d129377c4d4ae)
    #1 0xaaaadd8878d8 in QuiesceAgent::agent_thread_main() /root/ceph/src/mds/QuiesceAgent.cc:136:68
    #2 0xaaaadd86de38 in QuiesceAgent::AgentThread::entry() /root/ceph/src/mds/QuiesceAgent.h:244:24
    #3 0xffff83d6b554 in Thread::entry_wrapper() /root/ceph/src/common/Thread.cc:87:10
    #4 0xffff83d6b314 in Thread::_entry_func(void*) /root/ceph/src/common/Thread.cc:74:29
    #5 0xffff8154d5c4 in start_thread nptl/./nptl/pthread_create.c:442:8
    #6 0xffff815b5ed8  misc/../sysdeps/unix/sysv/linux/aarch64/clone.S:79

Indirect leak of 120 byte(s) in 1 object(s) allocated from:
    #0 0xaaaadd81c7c8 in operator new(unsigned long) (/root/ceph/build/bin/unittest_mds_quiesce_agent+0x1fc7c8) (BuildId: 7d45344ba1e43661d9de484f0a5d129377c4d4ae)
    #1 0xaaaadd8af4f4 in __gnu_cxx::new_allocator<std::_Sp_counted_ptr_inplace<QuiesceAgent::TrackedRoot, std::allocator<QuiesceAgent::TrackedRoot>, (__gnu_cxx::_Lock_policy)2> >::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/ext/new_allocator.h:127:27
    #2 0xaaaadd8af3d8 in std::allocator<std::_Sp_counted_ptr_inplace<QuiesceAgent::TrackedRoot, std::allocator<QuiesceAgent::TrackedRoot>, (__gnu_cxx::_Lock_policy)2> >::allocate(unsigned long) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/allocator.h:185:32
    #3 0xaaaadd8af3d8 in std::allocator_traits<std::allocator<std::_Sp_counted_ptr_inplace<QuiesceAgent::TrackedRoot, std::allocator<QuiesceAgent::TrackedRoot>, (__gnu_cxx::_Lock_policy)2> > >::allocate(std::allocator<std::_Sp_counted_ptr_inplace<QuiesceAgent::TrackedRoot, std::allocator<QuiesceAgent::TrackedRoot>, (__gnu_cxx::_Lock_policy)2> >&, unsigned long) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:464:20
    #4 0xaaaadd8aef00 in std::__allocated_ptr<std::allocator<std::_Sp_counted_ptr_inplace<QuiesceAgent::TrackedRoot, std::allocator<QuiesceAgent::TrackedRoot>, (__gnu_cxx::_Lock_policy)2> > > std::__allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<QuiesceAgent::TrackedRoot, std::allocator<QuiesceAgent::TrackedRoot>, (__gnu_cxx::_Lock_policy)2> > >(std::allocator<std::_Sp_counted_ptr_inplace<QuiesceAgent::TrackedRoot, std::allocator<QuiesceAgent::TrackedRoot>, (__gnu_cxx::_Lock_policy)2> >&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/allocated_ptr.h:98:21
    #5 0xaaaadd8aec14 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<QuiesceAgent::TrackedRoot, std::allocator<QuiesceAgent::TrackedRoot>, QuiesceState&, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >&>(QuiesceAgent::TrackedRoot*&, std::_Sp_alloc_shared_tag<std::allocator<QuiesceAgent::TrackedRoot> >, QuiesceState&, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:648:19
    #6 0xaaaadd8ae988 in std::__shared_ptr<QuiesceAgent::TrackedRoot, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<QuiesceAgent::TrackedRoot>, QuiesceState&, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >&>(std::_Sp_alloc_shared_tag<std::allocator<QuiesceAgent::TrackedRoot> >, QuiesceState&, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1342:14
    #7 0xaaaadd8ae70c in std::shared_ptr<QuiesceAgent::TrackedRoot>::shared_ptr<std::allocator<QuiesceAgent::TrackedRoot>, QuiesceState&, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >&>(std::_Sp_alloc_shared_tag<std::allocator<QuiesceAgent::TrackedRoot> >, QuiesceState&, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:409:4
    #8 0xaaaadd8ae484 in std::shared_ptr<QuiesceAgent::TrackedRoot> std::allocate_shared<QuiesceAgent::TrackedRoot, std::allocator<QuiesceAgent::TrackedRoot>, QuiesceState&, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >&>(std::allocator<QuiesceAgent::TrackedRoot> const&, QuiesceState&, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:862:14
    #9 0xaaaadd88ff0c in std::shared_ptr<QuiesceAgent::TrackedRoot> std::make_shared<QuiesceAgent::TrackedRoot, QuiesceState&, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >&>(QuiesceState&, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:878:14
    #10 0xaaaadd884a6c in QuiesceAgent::db_update(QuiesceMap&) /root/ceph/src/mds/QuiesceAgent.cc:60:26
    #11 0xaaaadd84a840 in QuiesceAgentTest::update(QuiesceDbVersion, std::initializer_list<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, QuiesceMap::RootInfo> >) /root/ceph/src/test/mds/TestQuiesceAgent.cc:156:18
    #12 0xaaaadd84985c in QuiesceAgentTest::update(unsigned long, std::initializer_list<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, QuiesceMap::RootInfo> >) /root/ceph/src/test/mds/TestQuiesceAgent.cc:165:14
    #13 0xaaaadd8288a8 in QuiesceAgentTest_DbUpdates_Test::TestBody() /root/ceph/src/test/mds/TestQuiesceAgent.cc:213:16
    #14 0xaaaadd977230 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #15 0xaaaadd924590 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #16 0xaaaadd8d4a40 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #17 0xaaaadd8d6984 in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #18 0xaaaadd8d7f84 in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #19 0xaaaadd8f3d48 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #20 0xaaaadd981130 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #21 0xaaaadd92bb64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #22 0xaaaadd8f31c0 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #23 0xaaaadd820710 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #24 0xaaaadd81ed3c in main /root/ceph/src/test/unit.cc:45:10
    #25 0xffff814f73f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #26 0xffff814f74c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #27 0xaaaadd76e6ac in _start (/root/ceph/build/bin/unittest_mds_quiesce_agent+0x14e6ac) (BuildId: 7d45344ba1e43661d9de484f0a5d129377c4d4ae)

SUMMARY: AddressSanitizer: 184 byte(s) leaked in 2 allocation(s).
```

quiesce_requests Context should be freed.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
