### PR TITLE
reef: mgr/cephadm: try to avoid pull when getting container image info only if use_repo_digest is not set

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1658,12 +1658,13 @@ class CephadmServe:
             await self._registry_login(host, json.loads(str(self.mgr.get_store('registry_credentials'))))
 
         j = None
-        try:
-            j = await self._run_cephadm_json(host, '', 'inspect-image', [],
-                                             image=image_name, no_fsid=True,
-                                             error_ok=True)
-        except OrchestratorError:
-            pass
+        if not self.mgr.use_repo_digest:
+            try:
+                j = await self._run_cephadm_json(host, '', 'inspect-image', [],
+                                                 image=image_name, no_fsid=True,
+                                                 error_ok=True)
+            except OrchestratorError:
+                pass
 
         if not j:
             pullargs: List[str] = []


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/50311

The commit ac88200 introduced this possibility to skip pulling, but doing this unconditionally broke a use case when one was able to have a ceph image on a floating tag, and was able to upgrade to a new image pushed to that tag. As using a floating tag is possible only when use_repo_digest is enabled (the default), now skipping the pull if use_repo_digest is disabled will not break it anymore.

Signed-off-by: Mykola Golub <mykola.golub@clyso.com>
(cherry picked from commit 4d049880a0effa78b69179694430d8a274829342)


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
