### PR TITLE
mgr/dashboard: use $__rate_interval everywhere

### DIFF
--- a/monitoring/ceph-mixin/dashboards/ceph-cluster.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/ceph-cluster.libsonnet
@@ -162,7 +162,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         { color: 'green' },
       ])
       .addTarget($.addTargetSchema(
-        expr='sum(irate(ceph_osd_op_w_in_bytes{%(matchers)s}[5m]))' % $.matchers(),
+        expr='sum(irate(ceph_osd_op_w_in_bytes{%(matchers)s}[$__rate_interval]))' % $.matchers(),
         instant=true,
         interval='$interval',
         datasource='$datasource',
@@ -185,7 +185,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         { color: '#9ac48a', value: 0 },
       ])
       .addTarget($.addTargetSchema(
-        expr='sum(irate(ceph_osd_op_r_out_bytes{%(matchers)s}[5m]))' % $.matchers(),
+        expr='sum(irate(ceph_osd_op_r_out_bytes{%(matchers)s}[$__rate_interval]))' % $.matchers(),
         instant=true,
         interval='$interval',
         datasource='$datasource',
@@ -482,7 +482,7 @@ local g = import 'grafonnet/grafana.libsonnet';
       ])
       .addTargets([
         $.addTargetSchema(
-          expr='sum(irate(ceph_osd_op_w{%(matchers)s}[1m]))' % $.matchers(),
+          expr='sum(irate(ceph_osd_op_w{%(matchers)s}[$__rate_interval]))' % $.matchers(),
           legendFormat='',
           datasource='$datasource',
           instant=true,
@@ -513,7 +513,7 @@ local g = import 'grafonnet/grafana.libsonnet';
       ])
       .addTargets([
         $.addTargetSchema(
-          expr='sum(irate(ceph_osd_op_r{%(matchers)s}[1m]))' % $.matchers(),
+          expr='sum(irate(ceph_osd_op_r{%(matchers)s}[$__rate_interval]))' % $.matchers(),
           legendFormat='',
           datasource='$datasource',
           instant=true,
@@ -716,7 +716,7 @@ local g = import 'grafonnet/grafana.libsonnet';
       .addTargets(
         [
           $.addTargetSchema(
-            expr='sum(irate(ceph_osd_op_w_in_bytes{%(matchers)s}[5m]))' % $.matchers(),
+            expr='sum(irate(ceph_osd_op_w_in_bytes{%(matchers)s}[$__rate_interval]))' % $.matchers(),
             datasource='$datasource',
             interval='$interval',
             legendFormat='Write',
@@ -724,7 +724,7 @@ local g = import 'grafonnet/grafana.libsonnet';
             range=true,
           ),
           $.addTargetSchema(
-            expr='sum(irate(ceph_osd_op_r_out_bytes{%(matchers)s}[5m]))' % $.matchers(),
+            expr='sum(irate(ceph_osd_op_r_out_bytes{%(matchers)s}[$__rate_interval]))' % $.matchers(),
             datasource='$datasource',
             interval='$interval',
             legendFormat='Read',
@@ -759,7 +759,7 @@ local g = import 'grafonnet/grafana.libsonnet';
       .addTargets(
         [
           $.addTargetSchema(
-            expr='sum(irate(ceph_osd_op_w{%(matchers)s}[1m]))' % $.matchers(),
+            expr='sum(irate(ceph_osd_op_w{%(matchers)s}[$__rate_interval]))' % $.matchers(),
             datasource='$datasource',
             interval='$interval',
             legendFormat='Write',
@@ -767,7 +767,7 @@ local g = import 'grafonnet/grafana.libsonnet';
             range=true,
           ),
           $.addTargetSchema(
-            expr='sum(irate(ceph_osd_op_r{%(matchers)s}[1m]))' % $.matchers(),
+            expr='sum(irate(ceph_osd_op_r{%(matchers)s}[$__rate_interval]))' % $.matchers(),
             datasource='$datasource',
             interval='$interval',
             legendFormat='Read',
@@ -1430,7 +1430,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           yBucketSize=null,
           pluginVersion='9.4.7',
         ).addTarget($.addTargetSchema(
-          expr='rate(ceph_osd_op_r_latency_sum{%(matchers)s}[5m]) / rate(ceph_osd_op_r_latency_count{%(matchers)s}[5m]) >= 0' % $.matchers(),
+          expr='rate(ceph_osd_op_r_latency_sum{%(matchers)s}[$__rate_interval]) / rate(ceph_osd_op_r_latency_count{%(matchers)s}[$__rate_interval]) >= 0' % $.matchers(),
           datasource='$datasource',
           interval='$interval',
           instant=false,
@@ -1481,7 +1481,7 @@ local g = import 'grafonnet/grafana.libsonnet';
           yBucketSize=null,
           pluginVersion='9.4.7',
         ).addTarget($.addTargetSchema(
-          expr='rate(ceph_osd_op_w_latency_sum{%(matchers)s}[5m]) / rate(ceph_osd_op_w_latency_count{%(matchers)s}[5m]) >= 0' % $.matchers(),
+          expr='rate(ceph_osd_op_w_latency_sum{%(matchers)s}[$__rate_interval]) / rate(ceph_osd_op_w_latency_count{%(matchers)s}[$__rate_interval]) >= 0' % $.matchers(),
           datasource='$datasource',
           interval='$interval',
           legendFormat='',
@@ -1512,12 +1512,12 @@ local g = import 'grafonnet/grafana.libsonnet';
         ])
         .addTargets([
           $.addTargetSchema(
-            expr='avg(rate(ceph_osd_op_r_latency_sum{%(matchers)s}[5m]) / rate(ceph_osd_op_r_latency_count{%(matchers)s}[5m]) >= 0)' % $.matchers(),
+            expr='avg(rate(ceph_osd_op_r_latency_sum{%(matchers)s}[$__rate_interval]) / rate(ceph_osd_op_r_latency_count{%(matchers)s}[$__rate_interval]) >= 0)' % $.matchers(),
             datasource='$datasource',
             legendFormat='Read',
           ),
           $.addTargetSchema(
-            expr='avg(rate(ceph_osd_op_w_latency_sum{%(matchers)s}[5m]) / rate(ceph_osd_op_w_latency_count{%(matchers)s}[5m]) >= 0)' % $.matchers(),
+            expr='avg(rate(ceph_osd_op_w_latency_sum{%(matchers)s}[$__rate_interval]) / rate(ceph_osd_op_w_latency_count{%(matchers)s}[$__rate_interval]) >= 0)' % $.matchers(),
             datasource='$datasource',
             legendFormat='Write',
           ),

--- a/monitoring/ceph-mixin/dashboards/pool.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/pool.libsonnet
@@ -682,7 +682,7 @@ local g = import 'grafonnet/grafana.libsonnet';
         'Objects out(-) / in(+) ',
         null,
         |||
-          deriv(ceph_pool_objects{%(matchers)s}[1m]) *
+          deriv(ceph_pool_objects{%(matchers)s}[$__rate_interval]) *
             on(pool_id) group_left(instance, name) ceph_pool_metadata{name=~"$pool_name", %(matchers)s}
         ||| % $.matchers(),
         'Objects per second',

--- a/monitoring/ceph-mixin/dashboards_out/ceph-cluster-advanced.json
+++ b/monitoring/ceph-mixin/dashboards_out/ceph-cluster-advanced.json
@@ -378,7 +378,7 @@
          "targets": [
             {
                "datasource": "$datasource",
-               "expr": "sum(irate(ceph_osd_op_w_in_bytes{cluster=~\"$cluster\", }[5m]))",
+               "expr": "sum(irate(ceph_osd_op_w_in_bytes{cluster=~\"$cluster\", }[$__rate_interval]))",
                "format": "time_series",
                "instant": true,
                "interval": "$interval",
@@ -456,7 +456,7 @@
          "targets": [
             {
                "datasource": "$datasource",
-               "expr": "sum(irate(ceph_osd_op_r_out_bytes{cluster=~\"$cluster\", }[5m]))",
+               "expr": "sum(irate(ceph_osd_op_r_out_bytes{cluster=~\"$cluster\", }[$__rate_interval]))",
                "format": "time_series",
                "instant": true,
                "interval": "$interval",
@@ -1001,7 +1001,7 @@
          "targets": [
             {
                "datasource": "$datasource",
-               "expr": "sum(irate(ceph_osd_op_w{cluster=~\"$cluster\", }[1m]))",
+               "expr": "sum(irate(ceph_osd_op_w{cluster=~\"$cluster\", }[$__rate_interval]))",
                "format": "time_series",
                "instant": true,
                "intervalFactor": 1,
@@ -1080,7 +1080,7 @@
          "targets": [
             {
                "datasource": "$datasource",
-               "expr": "sum(irate(ceph_osd_op_r{cluster=~\"$cluster\", }[1m]))",
+               "expr": "sum(irate(ceph_osd_op_r{cluster=~\"$cluster\", }[$__rate_interval]))",
                "format": "time_series",
                "instant": true,
                "intervalFactor": 1,
@@ -1503,7 +1503,7 @@
          "targets": [
             {
                "datasource": "$datasource",
-               "expr": "sum(irate(ceph_osd_op_w_in_bytes{cluster=~\"$cluster\", }[5m]))",
+               "expr": "sum(irate(ceph_osd_op_w_in_bytes{cluster=~\"$cluster\", }[$__rate_interval]))",
                "format": "time_series",
                "interval": "$interval",
                "intervalFactor": 1,
@@ -1514,7 +1514,7 @@
             },
             {
                "datasource": "$datasource",
-               "expr": "sum(irate(ceph_osd_op_r_out_bytes{cluster=~\"$cluster\", }[5m]))",
+               "expr": "sum(irate(ceph_osd_op_r_out_bytes{cluster=~\"$cluster\", }[$__rate_interval]))",
                "format": "time_series",
                "interval": "$interval",
                "intervalFactor": 1,
@@ -1610,7 +1610,7 @@
          "targets": [
             {
                "datasource": "$datasource",
-               "expr": "sum(irate(ceph_osd_op_w{cluster=~\"$cluster\", }[1m]))",
+               "expr": "sum(irate(ceph_osd_op_w{cluster=~\"$cluster\", }[$__rate_interval]))",
                "format": "time_series",
                "interval": "$interval",
                "intervalFactor": 1,
@@ -1621,7 +1621,7 @@
             },
             {
                "datasource": "$datasource",
-               "expr": "sum(irate(ceph_osd_op_r{cluster=~\"$cluster\", }[1m]))",
+               "expr": "sum(irate(ceph_osd_op_r{cluster=~\"$cluster\", }[$__rate_interval]))",
                "format": "time_series",
                "interval": "$interval",
                "intervalFactor": 1,
@@ -3105,7 +3105,7 @@
                "targets": [
                   {
                      "datasource": "$datasource",
-                     "expr": "rate(ceph_osd_op_r_latency_sum{cluster=~\"$cluster\", }[5m]) / rate(ceph_osd_op_r_latency_count{cluster=~\"$cluster\", }[5m]) >= 0",
+                     "expr": "rate(ceph_osd_op_r_latency_sum{cluster=~\"$cluster\", }[$__rate_interval]) / rate(ceph_osd_op_r_latency_count{cluster=~\"$cluster\", }[$__rate_interval]) >= 0",
                      "format": "time_series",
                      "instant": false,
                      "interval": "$interval",
@@ -3230,7 +3230,7 @@
                "targets": [
                   {
                      "datasource": "$datasource",
-                     "expr": "rate(ceph_osd_op_w_latency_sum{cluster=~\"$cluster\", }[5m]) / rate(ceph_osd_op_w_latency_count{cluster=~\"$cluster\", }[5m]) >= 0",
+                     "expr": "rate(ceph_osd_op_w_latency_sum{cluster=~\"$cluster\", }[$__rate_interval]) / rate(ceph_osd_op_w_latency_count{cluster=~\"$cluster\", }[$__rate_interval]) >= 0",
                      "format": "time_series",
                      "instant": false,
                      "interval": "$interval",
@@ -3340,7 +3340,7 @@
                "targets": [
                   {
                      "datasource": "$datasource",
-                     "expr": "avg(rate(ceph_osd_op_r_latency_sum{cluster=~\"$cluster\", }[5m]) / rate(ceph_osd_op_r_latency_count{cluster=~\"$cluster\", }[5m]) >= 0)",
+                     "expr": "avg(rate(ceph_osd_op_r_latency_sum{cluster=~\"$cluster\", }[$__rate_interval]) / rate(ceph_osd_op_r_latency_count{cluster=~\"$cluster\", }[$__rate_interval]) >= 0)",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "Read",
@@ -3348,7 +3348,7 @@
                   },
                   {
                      "datasource": "$datasource",
-                     "expr": "avg(rate(ceph_osd_op_w_latency_sum{cluster=~\"$cluster\", }[5m]) / rate(ceph_osd_op_w_latency_count{cluster=~\"$cluster\", }[5m]) >= 0)",
+                     "expr": "avg(rate(ceph_osd_op_w_latency_sum{cluster=~\"$cluster\", }[$__rate_interval]) / rate(ceph_osd_op_w_latency_count{cluster=~\"$cluster\", }[$__rate_interval]) >= 0)",
                      "format": "time_series",
                      "intervalFactor": 1,
                      "legendFormat": "Write",

--- a/monitoring/ceph-mixin/dashboards_out/pool-detail.json
+++ b/monitoring/ceph-mixin/dashboards_out/pool-detail.json
@@ -261,7 +261,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "deriv(ceph_pool_objects{cluster=~\"$cluster\", }[1m]) *\n  on(pool_id) group_left(instance, name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\", }\n",
+               "expr": "deriv(ceph_pool_objects{cluster=~\"$cluster\", }[$__rate_interval]) *\n  on(pool_id) group_left(instance, name) ceph_pool_metadata{name=~\"$pool_name\", cluster=~\"$cluster\", }\n",
                "format": "time_series",
                "intervalFactor": 1,
                "legendFormat": "Objects per second",


### PR DESCRIPTION
Follow-up of faeea8d165342245929ea26441ee0cbb8957e3a7

Most of the dashboards uses `$__rate_interval` appropriately but there are some hardcoded intervals left. Let's use `$__rate_interval` everywhere so the graphs do not disappear as "No data" when a custom scrape interval other than 15s is used.

ref:
- https://docs.ceph.com/en/latest/mgr/prometheus/#confval-mgr-prometheus-scrape_interval
- https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/

> $ dashboard-linter lint ceph-cluster.json | grep __rate_interval
> 
> Checks that each target uses $__rate_interval.
> [❌] Dashboard 'Ceph - Cluster', panel 'Cluster I/O', target idx '0' invalid PromQL query 'sum(irate(ceph_osd_op_w_in_bytes[1m]))': should use $__rate_interval
> [❌] Dashboard 'Ceph - Cluster', panel 'Cluster I/O', target idx '1' invalid PromQL query 'sum(irate(ceph_osd_op_r_out_bytes[1m]))': should use $__rate_interval
> [❌] Dashboard 'Ceph - Cluster', panel 'Recovery Rate', target idx '0' invalid PromQL query 'sum(irate(ceph_osd_recovery_ops[1m]))': should use $__rate_interval



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
