### PR TITLE
Revert "RGW: a subuser with no permission can still list buckets and create buckets"

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1184,14 +1184,13 @@ bool verify_user_permission_no_policy(const DoutPrefixProvider* dpp,
   if (s->identity->get_identity_type() == TYPE_ROLE)
     return false;
 
-  /* S3 doesn't have a subuser, it takes user permissions  */
-  if ((perm & (int)s->perm_mask) != perm)
-    return false;
-
   /* S3 doesn't support account ACLs, so user_acl will be uninitialized. */
   if (user_acl.get_owner().id.empty())
     return true;
-  
+
+  if ((perm & (int)s->perm_mask) != perm)
+    return false;
+
   return user_acl.verify_permission(dpp, *s->identity, perm, perm);
 }
 


### PR DESCRIPTION
This reverts commit 3cc27f0676c7ba2677f92969339b18b665c53c02.

this broke topic permissions in https://github.com/ceph/ceph/pull/54333. these perm_mask flags are only valid for s3 actions. for other apis like sns/sts/iam, perm_mask is RGW_PERM_INVALID which causes valid requests to be rejected

we can revisit this later, but the account support in https://github.com/ceph/ceph/pull/54333 is a higher priority than an obscure fix for subuser permissions

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
