### PR TITLE
squid: rgw: ignore SIGXFSZ, which apparently can triggered by heavy ops-log …

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -134,6 +134,7 @@ int main(int argc, char *argv[])
   register_async_signal_handler(SIGTERM, rgw::signal::handle_sigterm);
   register_async_signal_handler(SIGINT, rgw::signal::handle_sigterm);
   register_async_signal_handler(SIGUSR1, rgw::signal::handle_sigterm);
+  register_async_signal_handler(SIGXFSZ, rgw::signal::sig_handler_noop);
   sighandler_alrm = signal(SIGALRM, godown_alarm);
 
   main.init_perfcounters();
@@ -184,6 +185,7 @@ int main(int argc, char *argv[])
     unregister_async_signal_handler(SIGTERM, rgw::signal::handle_sigterm);
     unregister_async_signal_handler(SIGINT, rgw::signal::handle_sigterm);
     unregister_async_signal_handler(SIGUSR1, rgw::signal::handle_sigterm);
+    unregister_async_signal_handler(SIGXFSZ, rgw::signal::sig_handler_noop);
     shutdown_async_signal_handler();
   };
 

--- a/src/rgw/rgw_signal.cc
+++ b/src/rgw/rgw_signal.cc
@@ -33,6 +33,10 @@ static int signal_fd[2] = {0, 0};
 namespace rgw {
 namespace signal {
 
+void sig_handler_noop(int signum) {
+  /* NOP */
+} /* sig_handler_noop */
+
 void sighup_handler(int signum) {
     if (rgw::AppMain::ops_log_file != nullptr) {
         rgw::AppMain::ops_log_file->reopen();

--- a/src/rgw/rgw_signal.h
+++ b/src/rgw/rgw_signal.h
@@ -19,6 +19,7 @@
 namespace rgw {
 namespace signal {
 
+void sig_handler_noop(int signum);
 void signal_shutdown();
 void wait_shutdown();
 int signal_fd_init();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65427

---

backport of https://github.com/ceph/ceph/pull/55381
parent tracker: https://tracker.ceph.com/issues/64244

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh