### PR TITLE
test/test_rgw_crypto: free allocated test_in

### DIFF
--- a/src/test/rgw/test_rgw_crypto.cc
+++ b/src/test/rgw/test_rgw_crypto.cc
@@ -806,6 +806,7 @@ TEST(TestRGWCrypto, verify_Encrypt_Decrypt)
     decrypt.flush();
     ASSERT_EQ(get_sink.get_sink().length(), test_size);
     ASSERT_EQ(get_sink.get_sink(), std::string_view((char*)test_in,test_size));
+    delete[] test_in;
   }
   while (test_size < 20000);
 }


### PR DESCRIPTION
When sanitizer is enabled, unittest__rgw_crypto shows

```
=================================================================
==136464==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 75023 byte(s) in 22 object(s) allocated from:
    #0 0xaaaabf7fb86c in operator new[](unsigned long) (/root/ceph/build/bin/unittest_rgw_crypto+0x48b86c) (BuildId: 8023dc30820215da92d6d4883620bedd8ac1190d)
    #1 0xaaaabf81db48 in TestRGWCrypto_verify_Encrypt_Decrypt_Test::TestBody() /root/ceph/src/test/rgw/test_rgw_crypto.cc:780:24
    #2 0xaaaabf9018ac in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #3 0xaaaabf8b08a4 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #4 0xaaaabf861f88 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #5 0xaaaabf863ecc in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #6 0xaaaabf8654cc in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #7 0xaaaabf881290 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #8 0xaaaabf90b7ac in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #9 0xaaaabf8b7ac0 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #10 0xaaaabf880708 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #11 0xaaaabf823d70 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #12 0xaaaabf81f390 in main /root/ceph/src/test/rgw/test_rgw_crypto.cc:822:10
    #13 0xffff878673f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #14 0xffff878674c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #15 0xaaaabf74d62c in _start (/root/ceph/build/bin/unittest_rgw_crypto+0x3dd62c) (BuildId: 8023dc30820215da92d6d4883620bedd8ac1190d)

SUMMARY: AddressSanitizer: 75023 byte(s) leaked in 22 allocation(s).
```

test_in should be freed to address the warning.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
