### PR TITLE
test/osd/types: free PriorSet::pcontdec memory

### DIFF
--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -1655,22 +1655,24 @@ struct PITest : ::testing::Test {
     RequiredPredicate rec_pred(min_to_peer);
     MapPredicate map_pred(osd_states);
 
+    auto correct_pcontdec = std::make_unique<RequiredPredicate>(rec_pred);
     PI::PriorSet correct(
       ec_pool,
       probe,
       down,
       blocked_by,
       pg_down,
-      new RequiredPredicate(rec_pred));
+      correct_pcontdec.get());
 
     PastIntervals compact;
     for (auto &&i: intervals) {
       compact.add_interval(ec_pool, i);
     }
+    auto compact_ps_pcontdec = std::make_unique<RequiredPredicate>(rec_pred);
     PI::PriorSet compact_ps = compact.get_prior_set(
       ec_pool,
       last_epoch_started,
-      new RequiredPredicate(rec_pred),
+      compact_ps_pcontdec.get(),
       map_pred,
       up,
       acting,


### PR DESCRIPTION
When sanitizer is enabled, result shows as following

```
=================================================================
==207167==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5148fcc in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1664:7
    #2 0xaaaac50ff7dc in PITest_past_intervals_ec_Test::TestBody() /root/ceph/src/test/osd/types.cc:1707:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5148fcc in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1664:7
    #2 0xaaaac510ac3c in PITest_past_intervals_ec_no_subsets_Test::TestBody() /root/ceph/src/test/osd/types.cc:1799:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5148fcc in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1664:7
    #2 0xaaaac50fce54 in PITest_past_intervals_rep_Test::TestBody() /root/ceph/src/test/osd/types.cc:1683:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5149264 in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1673:7
    #2 0xaaaac5107e3c in PITest_past_intervals_rep_no_subsets_Test::TestBody() /root/ceph/src/test/osd/types.cc:1776:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5148fcc in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1664:7
    #2 0xaaaac5107e3c in PITest_past_intervals_rep_no_subsets_Test::TestBody() /root/ceph/src/test/osd/types.cc:1776:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5149264 in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1673:7
    #2 0xaaaac51054d0 in PITest_past_intervals_ec_down_Test::TestBody() /root/ceph/src/test/osd/types.cc:1753:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5148fcc in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1664:7
    #2 0xaaaac51054d0 in PITest_past_intervals_ec_down_Test::TestBody() /root/ceph/src/test/osd/types.cc:1753:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5149264 in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1673:7
    #2 0xaaaac510248c in PITest_past_intervals_rep_down_Test::TestBody() /root/ceph/src/test/osd/types.cc:1729:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5149264 in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1673:7
    #2 0xaaaac51109b0 in PITest_past_intervals_rep_lost_Test::TestBody() /root/ceph/src/test/osd/types.cc:1846:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5148fcc in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1664:7
    #2 0xaaaac51109b0 in PITest_past_intervals_rep_lost_Test::TestBody() /root/ceph/src/test/osd/types.cc:1846:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5149264 in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1673:7
    #2 0xaaaac510dc88 in PITest_past_intervals_ec_no_subsets2_Test::TestBody() /root/ceph/src/test/osd/types.cc:1822:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5148fcc in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1664:7
    #2 0xaaaac510dc88 in PITest_past_intervals_ec_no_subsets2_Test::TestBody() /root/ceph/src/test/osd/types.cc:1822:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5149264 in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1673:7
    #2 0xaaaac510ac3c in PITest_past_intervals_ec_no_subsets_Test::TestBody() /root/ceph/src/test/osd/types.cc:1799:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5149264 in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1673:7
    #2 0xaaaac50fce54 in PITest_past_intervals_rep_Test::TestBody() /root/ceph/src/test/osd/types.cc:1683:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5149264 in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1673:7
    #2 0xaaaac5113760 in PITest_past_intervals_ec_lost_Test::TestBody() /root/ceph/src/test/osd/types.cc:1870:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5148fcc in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1664:7
    #2 0xaaaac5113760 in PITest_past_intervals_ec_lost_Test::TestBody() /root/ceph/src/test/osd/types.cc:1870:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5149264 in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1673:7
    #2 0xaaaac50ff7dc in PITest_past_intervals_ec_Test::TestBody() /root/ceph/src/test/osd/types.cc:1707:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac50a2c48 in operator new(unsigned long) (/root/ceph/build/bin/unittest_osd_types+0x242c48) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)
    #1 0xaaaac5148fcc in PITest::run(bool, std::__cxx11::list<PastIntervals::pg_interval_t, std::allocator<PastIntervals::pg_interval_t> >, unsigned int, unsigned int, std::vector<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> >, std::allocator<std::pair<int, std::pair<PastIntervals::osd_state_t, unsigned int> > > >, std::vector<int, std::allocator<int> >, std::vector<int, std::allocator<int> >, std::set<pg_shard_t, std::less<pg_shard_t>, std::allocator<pg_shard_t> >, std::set<int, std::less<int>, std::allocator<int> >, std::map<int, unsigned int, std::less<int>, std::allocator<std::pair<int const, unsigned int> > >, bool) /root/ceph/src/test/osd/types.cc:1664:7
    #2 0xaaaac510248c in PITest_past_intervals_rep_down_Test::TestBody() /root/ceph/src/test/osd/types.cc:1729:3
    #3 0xaaaac531ee18 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaac52d27bc in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaac5285848 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaac528778c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaac5288d8c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaac52a4b50 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaac5326548 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaac52d9500 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaac52a3fc8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaac5226f84 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaac5226f00 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #14 0xffff930273f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff930274c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaac4ff4b2c in _start (/root/ceph/build/bin/unittest_osd_types+0x194b2c) (BuildId: 54d356bd0f2daa8bb228f480da3ed4fd9ac8f632)

SUMMARY: AddressSanitizer: 288 byte(s) leaked in 18 allocation(s).
```

PriorSet::pcontdec should be freed





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
