### PR TITLE
rgw: set correct requestId and hostId on s3select error

### DIFF
--- a/src/rgw/rgw_s3select_private.h
+++ b/src/rgw/rgw_s3select_private.h
@@ -153,8 +153,7 @@ public:
   void init_stats_response();
 
   void send_error_response(const char* error_code,
-                           const char* error_message,
-                           const char* resource_id);
+                           const char* error_message);
 
   void send_success_response();
 
@@ -163,8 +162,7 @@ public:
   void send_stats_response();
 
   void send_error_response_rgw_formatter(const char* error_code,
-                           const char* error_message,
-                           const char* resource_id);
+                           const char* error_message);
 
   std::string* get_buffer()
   {
@@ -238,10 +236,9 @@ private:
   std::function<void(void)> fp_chunked_transfer_encoding;
   int m_header_size;
 
-  const char* s3select_processTime_error = "s3select-ProcessingTime-Error";
-  const char* s3select_syntax_error = "s3select-Syntax-Error";
-  const char* s3select_resource_id = "resourcse-id";
-  const char* s3select_json_error = "json-Format-Error";
+  const char* s3select_processTime_error = "ProcessingTimeError";
+  const char* s3select_syntax_error = "UnsupportedSyntax";
+  const char* s3select_json_error = "InvalidJsonType";
 
 public:
   unsigned int chunk_number;


### PR DESCRIPTION
Previously, these fields remained constant despite the possibility of populating them with appropriate values.

Fixes: https://tracker.ceph.com/issues/65468