### PR TITLE
ceph-volume: create LVs when using partitions

### DIFF
--- a/src/ceph-volume/ceph_volume/objectstore/lvmbluestore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/lvmbluestore.py
@@ -249,8 +249,8 @@ class LvmBlueStore(BlueStore):
             tags['ceph.%s_uuid' % device_type] = lv_uuid
             tags['ceph.%s_device' % device_type] = path
             lv.set_tags(tags)
-        elif disk.is_device(device_name):
-            # We got a disk, create an lv
+        elif disk.is_partition(device_name) or disk.is_device(device_name):
+            # We got a disk or a partition, create an lv
             lv_type = "osd-{}".format(device_type)
             name_uuid = system.generate_uuid()
             kwargs = {


### PR DESCRIPTION
commit [1] introduced a behavior change.
`ceph-volume lvm prepare` used to create VGs/LVs when it was passed partitions for db and/or wal devices. Since commit [1] has been introduced, it made ceph-volume consume the partition directly, it doesn't create LV anymore. Although this doesn't prevent from creating OSDs, this is a behavior change.

Fixes: https://tracker.ceph.com/issues/65477

[1] 1e7223281fa044c9653633e305c0b344e4c9b3a4