### PR TITLE
squid: ceph-volume: osd objectstore refactor

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -1,216 +1,20 @@
 from __future__ import print_function
 import argparse
 import logging
-import os
 from textwrap import dedent
-from ceph_volume import process, conf, decorators, terminal, configuration
-from ceph_volume.util import system, disk
-from ceph_volume.util import prepare as prepare_utils
-from ceph_volume.util import encryption as encryption_utils
-from ceph_volume.systemd import systemctl
-from ceph_volume.api import lvm as api
-from .listing import direct_report
+from ceph_volume import objectstore
 
 
 logger = logging.getLogger(__name__)
 
 
-
-def get_osd_device_path(osd_lvs, device_type, dmcrypt_secret=None):
-    """
-    ``device_type`` can be one of ``db``, ``wal`` or ``block`` so that we can
-     query LVs on system and fallback to querying the uuid if that is not
-     present.
-
-    Return a path if possible, failing to do that a ``None``, since some of
-    these devices are optional.
-    """
-    osd_block_lv = None
-    for lv in osd_lvs:
-        if lv.tags.get('ceph.type') == 'block':
-            osd_block_lv = lv
-            break
-    if osd_block_lv:
-        is_encrypted = osd_block_lv.tags.get('ceph.encrypted', '0') == '1'
-        logger.debug('Found block device (%s) with encryption: %s', osd_block_lv.name, is_encrypted)
-        uuid_tag = 'ceph.%s_uuid' % device_type
-        device_uuid = osd_block_lv.tags.get(uuid_tag)
-        if not device_uuid:
-            return None
-
-    device_lv = None
-    for lv in osd_lvs:
-        if lv.tags.get('ceph.type') == device_type:
-            device_lv = lv
-            break
-    if device_lv:
-        if is_encrypted:
-            encryption_utils.luks_open(dmcrypt_secret, device_lv.lv_path, device_uuid)
-            return '/dev/mapper/%s' % device_uuid
-        return device_lv.lv_path
-
-    # this could be a regular device, so query it with blkid
-    physical_device = disk.get_device_from_partuuid(device_uuid)
-    if physical_device:
-        if is_encrypted:
-            encryption_utils.luks_open(dmcrypt_secret, physical_device, device_uuid)
-            return '/dev/mapper/%s' % device_uuid
-        return physical_device
-
-    raise RuntimeError('could not find %s with uuid %s' % (device_type, device_uuid))
-
-
-def activate_bluestore(osd_lvs, no_systemd=False, no_tmpfs=False):
-    for lv in osd_lvs:
-        if lv.tags.get('ceph.type') == 'block':
-            osd_block_lv = lv
-            break
-    else:
-        raise RuntimeError('could not find a bluestore OSD to activate')
-
-    is_encrypted = osd_block_lv.tags.get('ceph.encrypted', '0') == '1'
-    if is_encrypted and conf.dmcrypt_no_workqueue is None:
-        encryption_utils.set_dmcrypt_no_workqueue()
-    dmcrypt_secret = None
-    osd_id = osd_block_lv.tags['ceph.osd_id']
-    conf.cluster = osd_block_lv.tags['ceph.cluster_name']
-    osd_fsid = osd_block_lv.tags['ceph.osd_fsid']
-    configuration.load_ceph_conf_path(osd_block_lv.tags['ceph.cluster_name'])
-    configuration.load()
-
-    # mount on tmpfs the osd directory
-    osd_path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
-    if not system.path_is_mounted(osd_path):
-        # mkdir -p and mount as tmpfs
-        prepare_utils.create_osd_path(osd_id, tmpfs=not no_tmpfs)
-    # XXX This needs to be removed once ceph-bluestore-tool can deal with
-    # symlinks that exist in the osd dir
-    for link_name in ['block', 'block.db', 'block.wal']:
-        link_path = os.path.join(osd_path, link_name)
-        if os.path.exists(link_path):
-            os.unlink(os.path.join(osd_path, link_name))
-    # encryption is handled here, before priming the OSD dir
-    if is_encrypted:
-        osd_lv_path = '/dev/mapper/%s' % osd_block_lv.lv_uuid
-        lockbox_secret = osd_block_lv.tags['ceph.cephx_lockbox_secret']
-        encryption_utils.write_lockbox_keyring(osd_id, osd_fsid, lockbox_secret)
-        dmcrypt_secret = encryption_utils.get_dmcrypt_key(osd_id, osd_fsid)
-        encryption_utils.luks_open(dmcrypt_secret, osd_block_lv.lv_path, osd_block_lv.lv_uuid)
-    else:
-        osd_lv_path = osd_block_lv.lv_path
-
-    db_device_path = get_osd_device_path(osd_lvs, 'db', dmcrypt_secret=dmcrypt_secret)
-    wal_device_path = get_osd_device_path(osd_lvs, 'wal', dmcrypt_secret=dmcrypt_secret)
-
-    # Once symlinks are removed, the osd dir can be 'primed again. chown first,
-    # regardless of what currently exists so that ``prime-osd-dir`` can succeed
-    # even if permissions are somehow messed up
-    system.chown(osd_path)
-    prime_command = [
-        'ceph-bluestore-tool', '--cluster=%s' % conf.cluster,
-        'prime-osd-dir', '--dev', osd_lv_path,
-        '--path', osd_path, '--no-mon-config']
-
-    process.run(prime_command)
-    # always re-do the symlink regardless if it exists, so that the block,
-    # block.wal, and block.db devices that may have changed can be mapped
-    # correctly every time
-    process.run(['ln', '-snf', osd_lv_path, os.path.join(osd_path, 'block')])
-    system.chown(os.path.join(osd_path, 'block'))
-    system.chown(osd_path)
-    if db_device_path:
-        destination = os.path.join(osd_path, 'block.db')
-        process.run(['ln', '-snf', db_device_path, destination])
-        system.chown(db_device_path)
-        system.chown(destination)
-    if wal_device_path:
-        destination = os.path.join(osd_path, 'block.wal')
-        process.run(['ln', '-snf', wal_device_path, destination])
-        system.chown(wal_device_path)
-        system.chown(destination)
-
-    if no_systemd is False:
-        # enable the ceph-volume unit for this OSD
-        systemctl.enable_volume(osd_id, osd_fsid, 'lvm')
-
-        # enable the OSD
-        systemctl.enable_osd(osd_id)
-
-        # start the OSD
-        systemctl.start_osd(osd_id)
-    terminal.success("ceph-volume lvm activate successful for osd ID: %s" % osd_id)
-
-
 class Activate(object):
-
     help = 'Discover and mount the LVM device associated with an OSD ID and start the Ceph OSD'
 
-    def __init__(self, argv):
+    def __init__(self, argv, args=None):
+        self.objectstore = None
         self.argv = argv
-
-    @decorators.needs_root
-    def activate_all(self, args):
-        listed_osds = direct_report()
-        osds = {}
-        for osd_id, devices in listed_osds.items():
-            # the metadata for all devices in each OSD will contain
-            # the FSID which is required for activation
-            for device in devices:
-                fsid = device.get('tags', {}).get('ceph.osd_fsid')
-                if fsid:
-                    osds[fsid] = osd_id
-                    break
-        if not osds:
-            terminal.warning('Was unable to find any OSDs to activate')
-            terminal.warning('Verify OSDs are present with "ceph-volume lvm list"')
-            return
-        for osd_fsid, osd_id in osds.items():
-            if not args.no_systemd and systemctl.osd_is_active(osd_id):
-                terminal.warning(
-                    'OSD ID %s FSID %s process is active. Skipping activation' % (osd_id, osd_fsid)
-                )
-            else:
-                terminal.info('Activating OSD ID %s FSID %s' % (osd_id, osd_fsid))
-                self.activate(args, osd_id=osd_id, osd_fsid=osd_fsid)
-
-    @decorators.needs_root
-    def activate(self, args, osd_id=None, osd_fsid=None):
-        """
-        :param args: The parsed arguments coming from the CLI
-        :param osd_id: When activating all, this gets populated with an
-                       existing OSD ID
-        :param osd_fsid: When activating all, this gets populated with an
-                         existing OSD FSID
-        """
-        osd_id = osd_id if osd_id else args.osd_id
-        osd_fsid = osd_fsid if osd_fsid else args.osd_fsid
-
-        if osd_id and osd_fsid:
-            tags = {'ceph.osd_id': osd_id, 'ceph.osd_fsid': osd_fsid}
-        elif not osd_id and osd_fsid:
-            tags = {'ceph.osd_fsid': osd_fsid}
-        elif osd_id and not osd_fsid:
-            raise RuntimeError('could not activate osd.{}, please provide the '
-                               'osd_fsid too'.format(osd_id))
-        else:
-            raise RuntimeError('Please provide both osd_id and osd_fsid')
-        lvs = api.get_lvs(tags=tags)
-        if not lvs:
-            raise RuntimeError('could not find osd.%s with osd_fsid %s' %
-                               (osd_id, osd_fsid))
-
-        # This argument is only available when passed in directly or via
-        # systemd, not when ``create`` is being used
-        # placeholder when a new objectstore support will be added
-        if getattr(args, 'auto_detect_objectstore', False):
-            logger.info('auto detecting objectstore')
-            return activate_bluestore(lvs, args.no_systemd)
-
-        # explicit 'objectstore' flags take precedence
-        if getattr(args, 'bluestore', False):
-            activate_bluestore(lvs, args.no_systemd, getattr(args, 'no_tmpfs', False))
-        elif any('ceph.block_device' in lv.tags for lv in lvs):
-            activate_bluestore(lvs, args.no_systemd, getattr(args, 'no_tmpfs', False))
+        self.args = args
 
     def main(self):
         sub_command_help = dedent("""
@@ -257,6 +61,14 @@ class Activate(object):
             help='force bluestore objectstore activation',
         )
         parser.add_argument(
+            '--objectstore',
+            dest='objectstore',
+            help='The OSD objectstore.',
+            default='bluestore',
+            choices=['bluestore', 'seastore'],
+            type=str,
+        )
+        parser.add_argument(
             '--all',
             dest='activate_all',
             action='store_true',
@@ -273,11 +85,15 @@ class Activate(object):
             action='store_true',
             help='Do not use a tmpfs mount for OSD data dir'
         )
-        if len(self.argv) == 0:
+        if len(self.argv) == 0 and self.args is None:
             print(sub_command_help)
             return
-        args = parser.parse_args(self.argv)
-        if args.activate_all:
-            self.activate_all(args)
+        if self.args is None:
+            self.args = parser.parse_args(self.argv)
+        if self.args.bluestore:
+            self.args.objectstore = 'bluestore'
+        self.objectstore = objectstore.mapping['LVM'][self.args.objectstore](args=self.args)
+        if self.args.activate_all:
+            self.objectstore.activate_all()
         else:
-            self.activate(args)
+            self.objectstore.activate()

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -36,6 +36,13 @@ def rollback_osd(args, osd_id=None):
 
 
 common_args = {
+    '--objectstore': {
+        'dest': 'objectstore',
+        'help': 'The OSD objectstore.',
+        'default': 'bluestore',
+        'choices': ['bluestore', 'seastore'],
+        'type': str,
+    },
     '--data': {
         'help': 'OSD data path. A physical device or logical volume',
         'required': True,
@@ -86,7 +93,7 @@ common_args = {
 bluestore_args = {
     '--bluestore': {
         'action': 'store_true',
-        'help': 'Use the bluestore objectstore',
+        'help': 'Use the bluestore objectstore. (DEPRECATED: use --objectstore instead)',
     },
     '--block.db': {
         'dest': 'block_db',

--- a/src/ceph-volume/ceph_volume/devices/lvm/create.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/create.py
@@ -3,10 +3,8 @@ from textwrap import dedent
 import logging
 from ceph_volume.util import system
 from ceph_volume.util.arg_validators import exclude_group_options
-from ceph_volume import decorators, terminal
+from ceph_volume import decorators, terminal, objectstore
 from .common import create_parser, rollback_osd
-from .prepare import Prepare
-from .activate import Activate
 
 logger = logging.getLogger(__name__)
 
@@ -15,27 +13,29 @@ class Create(object):
 
     help = 'Create a new OSD from an LVM device'
 
-    def __init__(self, argv):
+    def __init__(self, argv, args=None):
+        self.objectstore = None
         self.argv = argv
+        self.args = args
 
     @decorators.needs_root
-    def create(self, args):
-        if not args.osd_fsid:
-            args.osd_fsid = system.generate_uuid()
-        prepare_step = Prepare([])
-        prepare_step.safe_prepare(args)
-        osd_id = prepare_step.osd_id
+    def create(self):
+        if not self.args.osd_fsid:
+            self.args.osd_fsid = system.generate_uuid()
+        self.objectstore = objectstore.mapping['LVM'][self.args.objectstore](args=self.args)
+        self.objectstore.safe_prepare()
+        osd_id = self.objectstore.osd_id
         try:
             # we try this for activate only when 'creating' an OSD, because a rollback should not
             # happen when doing normal activation. For example when starting an OSD, systemd will call
             # activate, which would never need to be rolled back.
-            Activate([]).activate(args)
+            self.objectstore.activate()
         except Exception:
             logger.exception('lvm activate was unable to complete, while creating the OSD')
             logger.info('will rollback OSD ID creation')
-            rollback_osd(args, osd_id)
+            rollback_osd(self.args, osd_id)
             raise
-        terminal.success("ceph-volume lvm create successful for: %s" % args.data)
+        terminal.success("ceph-volume lvm create successful for: %s" % self.args.data)
 
     def main(self):
         sub_command_help = dedent("""
@@ -69,9 +69,9 @@ class Create(object):
             print(sub_command_help)
             return
         exclude_group_options(parser, groups=['bluestore'], argv=self.argv)
-        args = parser.parse_args(self.argv)
-        # Default to bluestore here since defaulting it in add_argument may
-        # cause both to be True
-        if not args.bluestore:
-            args.bluestore = True
-        self.create(args)
+        if self.args is None:
+            self.args = parser.parse_args(self.argv)
+        if self.args.bluestore:
+            self.args.objectstore = 'bluestore'
+        self.objectstore = objectstore.mapping['LVM'][self.args.objectstore]
+        self.create()

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -1,289 +1,22 @@
 from __future__ import print_function
-import json
 import logging
 from textwrap import dedent
-from ceph_volume.util import prepare as prepare_utils
-from ceph_volume.util import encryption as encryption_utils
-from ceph_volume.util import system, disk
-from ceph_volume.util.arg_validators import exclude_group_options
-from ceph_volume import conf, decorators, terminal
-from ceph_volume.api import lvm as api
-from .common import prepare_parser, rollback_osd
+from ceph_volume import objectstore
+from .common import prepare_parser
 
 
 logger = logging.getLogger(__name__)
-
-
-def prepare_dmcrypt(key, device, device_type, tags):
-    """
-    Helper for devices that are encrypted. The operations needed for
-    block, db, wal devices are all the same
-    """
-    if not device:
-        return ''
-    tag_name = 'ceph.%s_uuid' % device_type
-    uuid = tags[tag_name]
-    return encryption_utils.prepare_dmcrypt(key, device, uuid)
-
-def prepare_bluestore(block, wal, db, secrets, tags, osd_id, fsid):
-    """
-    :param block: The name of the logical volume for the bluestore data
-    :param wal: a regular/plain disk or logical volume, to be used for block.wal
-    :param db: a regular/plain disk or logical volume, to be used for block.db
-    :param secrets: A dict with the secrets needed to create the osd (e.g. cephx)
-    :param id_: The OSD id
-    :param fsid: The OSD fsid, also known as the OSD UUID
-    """
-    cephx_secret = secrets.get('cephx_secret', prepare_utils.create_key())
-    # encryption-only operations
-    if secrets.get('dmcrypt_key'):
-        # If encrypted, there is no need to create the lockbox keyring file because
-        # bluestore re-creates the files and does not have support for other files
-        # like the custom lockbox one. This will need to be done on activation.
-        # format and open ('decrypt' devices) and re-assign the device and journal
-        # variables so that the rest of the process can use the mapper paths
-        key = secrets['dmcrypt_key']
-        block = prepare_dmcrypt(key, block, 'block', tags)
-        wal = prepare_dmcrypt(key, wal, 'wal', tags)
-        db = prepare_dmcrypt(key, db, 'db', tags)
-
-    # create the directory
-    prepare_utils.create_osd_path(osd_id, tmpfs=True)
-    # symlink the block
-    prepare_utils.link_block(block, osd_id)
-    # get the latest monmap
-    prepare_utils.get_monmap(osd_id)
-    # write the OSD keyring if it doesn't exist already
-    prepare_utils.write_keyring(osd_id, cephx_secret)
-    # prepare the osd filesystem
-    prepare_utils.osd_mkfs_bluestore(
-        osd_id, fsid,
-        keyring=cephx_secret,
-        wal=wal,
-        db=db
-    )
 
 
 class Prepare(object):
 
     help = 'Format an LVM device and associate it with an OSD'
 
-    def __init__(self, argv):
+    def __init__(self, argv, args=None):
+        self.objectstore = None
         self.argv = argv
+        self.args = args
         self.osd_id = None
-
-    def get_ptuuid(self, argument):
-        uuid = disk.get_partuuid(argument)
-        if not uuid:
-            terminal.error('blkid could not detect a PARTUUID for device: %s' % argument)
-            raise RuntimeError('unable to use device')
-        return uuid
-
-    def setup_device(self, device_type, device_name, tags, size, slots):
-        """
-        Check if ``device`` is an lv, if so, set the tags, making sure to
-        update the tags with the lv_uuid and lv_path which the incoming tags
-        will not have.
-
-        If the device is not a logical volume, then retrieve the partition UUID
-        by querying ``blkid``
-        """
-        if device_name is None:
-            return '', '', tags
-        tags['ceph.type'] = device_type
-        tags['ceph.vdo'] = api.is_vdo(device_name)
-
-        try:
-            vg_name, lv_name = device_name.split('/')
-            lv = api.get_single_lv(filters={'lv_name': lv_name,
-                                            'vg_name': vg_name})
-        except ValueError:
-            lv = None
-
-        if lv:
-            lv_uuid = lv.lv_uuid
-            path = lv.lv_path
-            tags['ceph.%s_uuid' % device_type] = lv_uuid
-            tags['ceph.%s_device' % device_type] = path
-            lv.set_tags(tags)
-        elif disk.is_device(device_name):
-            # We got a disk, create an lv
-            lv_type = "osd-{}".format(device_type)
-            name_uuid = system.generate_uuid()
-            kwargs = {
-                'device': device_name,
-                'tags': tags,
-                'slots': slots
-            }
-            #TODO use get_block_db_size and co here to get configured size in
-            #conf file
-            if size != 0:
-                kwargs['size'] = size
-            lv = api.create_lv(
-                lv_type,
-                name_uuid,
-                **kwargs)
-            path = lv.lv_path
-            tags['ceph.{}_device'.format(device_type)] = path
-            tags['ceph.{}_uuid'.format(device_type)] = lv.lv_uuid
-            lv_uuid = lv.lv_uuid
-            lv.set_tags(tags)
-        else:
-            # otherwise assume this is a regular disk partition
-            name_uuid = self.get_ptuuid(device_name)
-            path = device_name
-            tags['ceph.%s_uuid' % device_type] = name_uuid
-            tags['ceph.%s_device' % device_type] = path
-            lv_uuid = name_uuid
-        return path, lv_uuid, tags
-
-    def prepare_data_device(self, device_type, osd_uuid):
-        """
-        Check if ``arg`` is a device or partition to create an LV out of it
-        with a distinct volume group name, assigning LV tags on it and
-        ultimately, returning the logical volume object.  Failing to detect
-        a device or partition will result in error.
-
-        :param arg: The value of ``--data`` when parsing args
-        :param device_type: Usually ``block``
-        :param osd_uuid: The OSD uuid
-        """
-        device = self.args.data
-        if disk.is_partition(device) or disk.is_device(device):
-            # we must create a vg, and then a single lv
-            lv_name_prefix = "osd-{}".format(device_type)
-            kwargs = {'device': device,
-                      'tags': {'ceph.type': device_type},
-                      'slots': self.args.data_slots,
-                     }
-            logger.debug('data device size: {}'.format(self.args.data_size))
-            if self.args.data_size != 0:
-                kwargs['size'] = self.args.data_size
-            return api.create_lv(
-                lv_name_prefix,
-                osd_uuid,
-                **kwargs)
-        else:
-            error = [
-                'Cannot use device ({}).'.format(device),
-                'A vg/lv path or an existing device is needed']
-            raise RuntimeError(' '.join(error))
-
-        raise RuntimeError('no data logical volume found with: {}'.format(device))
-
-    def safe_prepare(self, args=None):
-        """
-        An intermediate step between `main()` and `prepare()` so that we can
-        capture the `self.osd_id` in case we need to rollback
-
-        :param args: Injected args, usually from `lvm create` which compounds
-                     both `prepare` and `create`
-        """
-        if args is not None:
-            self.args = args
-
-        try:
-            vgname, lvname = self.args.data.split('/')
-            lv = api.get_single_lv(filters={'lv_name': lvname,
-                                            'vg_name': vgname})
-        except ValueError:
-            lv = None
-
-        if api.is_ceph_device(lv):
-            logger.info("device {} is already used".format(self.args.data))
-            raise RuntimeError("skipping {}, it is already prepared".format(self.args.data))
-        try:
-            self.prepare()
-        except Exception:
-            logger.exception('lvm prepare was unable to complete')
-            logger.info('will rollback OSD ID creation')
-            rollback_osd(self.args, self.osd_id)
-            raise
-        terminal.success("ceph-volume lvm prepare successful for: %s" % self.args.data)
-
-    def get_cluster_fsid(self):
-        """
-        Allows using --cluster-fsid as an argument, but can fallback to reading
-        from ceph.conf if that is unset (the default behavior).
-        """
-        if self.args.cluster_fsid:
-            return self.args.cluster_fsid
-        else:
-            return conf.ceph.get('global', 'fsid')
-
-    @decorators.needs_root
-    def prepare(self):
-        # FIXME we don't allow re-using a keyring, we always generate one for the
-        # OSD, this needs to be fixed. This could either be a file (!) or a string
-        # (!!) or some flags that we would need to compound into a dict so that we
-        # can convert to JSON (!!!)
-        secrets = {'cephx_secret': prepare_utils.create_key()}
-        cephx_lockbox_secret = ''
-        encrypted = 1 if self.args.dmcrypt else 0
-        cephx_lockbox_secret = '' if not encrypted else prepare_utils.create_key()
-
-        if encrypted:
-            secrets['dmcrypt_key'] = encryption_utils.create_dmcrypt_key()
-            secrets['cephx_lockbox_secret'] = cephx_lockbox_secret
-
-        cluster_fsid = self.get_cluster_fsid()
-
-        osd_fsid = self.args.osd_fsid or system.generate_uuid()
-        crush_device_class = self.args.crush_device_class
-        if crush_device_class:
-            secrets['crush_device_class'] = crush_device_class
-        # reuse a given ID if it exists, otherwise create a new ID
-        self.osd_id = prepare_utils.create_id(osd_fsid, json.dumps(secrets), osd_id=self.args.osd_id)
-        tags = {
-            'ceph.osd_fsid': osd_fsid,
-            'ceph.osd_id': self.osd_id,
-            'ceph.cluster_fsid': cluster_fsid,
-            'ceph.cluster_name': conf.cluster,
-            'ceph.crush_device_class': crush_device_class,
-            'ceph.osdspec_affinity': prepare_utils.get_osdspec_affinity()
-        }
-        if self.args.bluestore:
-            try:
-                vg_name, lv_name = self.args.data.split('/')
-                block_lv = api.get_single_lv(filters={'lv_name': lv_name,
-                                                      'vg_name': vg_name})
-            except ValueError:
-                block_lv = None
-
-            if not block_lv:
-                block_lv = self.prepare_data_device('block', osd_fsid)
-
-            tags['ceph.block_device'] = block_lv.lv_path
-            tags['ceph.block_uuid'] = block_lv.lv_uuid
-            tags['ceph.cephx_lockbox_secret'] = cephx_lockbox_secret
-            tags['ceph.encrypted'] = encrypted
-            tags['ceph.vdo'] = api.is_vdo(block_lv.lv_path)
-
-            wal_device, wal_uuid, tags = self.setup_device(
-                'wal',
-                self.args.block_wal,
-                tags,
-                self.args.block_wal_size,
-                self.args.block_wal_slots)
-            db_device, db_uuid, tags = self.setup_device(
-                'db',
-                self.args.block_db,
-                tags,
-                self.args.block_db_size,
-                self.args.block_db_slots)
-
-            tags['ceph.type'] = 'block'
-            block_lv.set_tags(tags)
-
-            prepare_bluestore(
-                block_lv.lv_path,
-                wal_device,
-                db_device,
-                secrets,
-                tags,
-                self.osd_id,
-                osd_fsid,
-            )
 
     def main(self):
         sub_command_help = dedent("""
@@ -315,13 +48,12 @@ class Prepare(object):
             prog='ceph-volume lvm prepare',
             description=sub_command_help,
         )
-        if len(self.argv) == 0:
+        if len(self.argv) == 0 and self.args is None:
             print(sub_command_help)
             return
-        exclude_group_options(parser, argv=self.argv, groups=['bluestore'])
-        self.args = parser.parse_args(self.argv)
-        # Default to bluestore here since defaulting it in add_argument may
-        # cause both to be True
-        if not self.args.bluestore:
-            self.args.bluestore = True
-        self.safe_prepare()
+        if self.args is None:
+            self.args = parser.parse_args(self.argv)
+        if self.args.bluestore:
+            self.args.objectstore = 'bluestore'
+        self.objectstore = objectstore.mapping['LVM'][self.args.objectstore](args=self.args)
+        self.objectstore.safe_prepare()

--- a/src/ceph-volume/ceph_volume/devices/raw/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/activate.py
@@ -82,7 +82,9 @@ class Activate(object):
             return
         self.args = parser.parse_args(self.argv)
 
-        devs = [self.args.device]
+        devs = []
+        if self.args.device:
+            devs = [self.args.device]
         if self.args.block_wal:
             devs.append(self.args.block_wal)
         if self.args.block_db:

--- a/src/ceph-volume/ceph_volume/devices/raw/common.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/common.py
@@ -12,6 +12,14 @@ def create_parser(prog, description):
         description=description,
     )
     parser.add_argument(
+        '--objectstore',
+        dest='objectstore',
+        help='The OSD objectstore.',
+        default='bluestore',
+        choices=['bluestore', 'seastore'],
+        type=str,
+    ),
+    parser.add_argument(
         '--data',
         required=True,
         type=arg_validators.ValidRawDevice(as_string=True),
@@ -20,7 +28,8 @@ def create_parser(prog, description):
     parser.add_argument(
         '--bluestore',
         action='store_true',
-        help='Use BlueStore backend')
+        help='Use BlueStore backend. (DEPRECATED: use --objectstore instead)'
+    )
     parser.add_argument(
         '--crush-device-class',
         dest='crush_device_class',

--- a/src/ceph-volume/ceph_volume/devices/raw/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/prepare.py
@@ -1,61 +1,11 @@
 from __future__ import print_function
-import json
 import logging
 import os
 from textwrap import dedent
-from ceph_volume.util import prepare as prepare_utils
-from ceph_volume.util import encryption as encryption_utils
-from ceph_volume.util import disk
-from ceph_volume.util import system
-from ceph_volume import decorators, terminal
-from ceph_volume.devices.lvm.common import rollback_osd
+from ceph_volume import terminal, objectstore
 from .common import create_parser
 
 logger = logging.getLogger(__name__)
-
-def prepare_dmcrypt(key, device, device_type, fsid):
-    """
-    Helper for devices that are encrypted. The operations needed for
-    block, db, wal, devices are all the same
-    """
-    if not device:
-        return ''
-    kname = disk.lsblk(device)['KNAME']
-    mapping = 'ceph-{}-{}-{}-dmcrypt'.format(fsid, kname, device_type)
-    return encryption_utils.prepare_dmcrypt(key, device, mapping)
-
-def prepare_bluestore(block, wal, db, secrets, osd_id, fsid, tmpfs):
-    """
-    :param block: The name of the logical volume for the bluestore data
-    :param wal: a regular/plain disk or logical volume, to be used for block.wal
-    :param db: a regular/plain disk or logical volume, to be used for block.db
-    :param secrets: A dict with the secrets needed to create the osd (e.g. cephx)
-    :param id_: The OSD id
-    :param fsid: The OSD fsid, also known as the OSD UUID
-    """
-    cephx_secret = secrets.get('cephx_secret', prepare_utils.create_key())
-
-    if secrets.get('dmcrypt_key'):
-        key = secrets['dmcrypt_key']
-        block = prepare_dmcrypt(key, block, 'block', fsid)
-        wal = prepare_dmcrypt(key, wal, 'wal', fsid)
-        db = prepare_dmcrypt(key, db, 'db', fsid)
-
-    # create the directory
-    prepare_utils.create_osd_path(osd_id, tmpfs=tmpfs)
-    # symlink the block
-    prepare_utils.link_block(block, osd_id)
-    # get the latest monmap
-    prepare_utils.get_monmap(osd_id)
-    # write the OSD keyring if it doesn't exist already
-    prepare_utils.write_keyring(osd_id, cephx_secret)
-    # prepare the osd filesystem
-    prepare_utils.osd_mkfs_bluestore(
-        osd_id, fsid,
-        keyring=cephx_secret,
-        wal=wal,
-        db=db
-    )
 
 
 class Prepare(object):
@@ -65,65 +15,7 @@ class Prepare(object):
     def __init__(self, argv):
         self.argv = argv
         self.osd_id = None
-
-    def safe_prepare(self, args=None):
-        """
-        An intermediate step between `main()` and `prepare()` so that we can
-        capture the `self.osd_id` in case we need to rollback
-
-        :param args: Injected args, usually from `raw create` which compounds
-                     both `prepare` and `create`
-        """
-        if args is not None:
-            self.args = args
-        try:
-            self.prepare()
-        except Exception:
-            logger.exception('raw prepare was unable to complete')
-            logger.info('will rollback OSD ID creation')
-            rollback_osd(self.args, self.osd_id)
-            raise
-        dmcrypt_log = 'dmcrypt' if args.dmcrypt else 'clear'
-        terminal.success("ceph-volume raw {} prepare successful for: {}".format(dmcrypt_log, self.args.data))
-
-
-    @decorators.needs_root
-    def prepare(self):
-        secrets = {'cephx_secret': prepare_utils.create_key()}
-        encrypted = 1 if self.args.dmcrypt else 0
-        cephx_lockbox_secret = '' if not encrypted else prepare_utils.create_key()
-
-        if encrypted:
-            secrets['dmcrypt_key'] = os.getenv('CEPH_VOLUME_DMCRYPT_SECRET')
-            secrets['cephx_lockbox_secret'] = cephx_lockbox_secret # dummy value to make `ceph osd new` not complaining
-
-        osd_fsid = system.generate_uuid()
-        crush_device_class = self.args.crush_device_class
-        if crush_device_class:
-            secrets['crush_device_class'] = crush_device_class
-        tmpfs = not self.args.no_tmpfs
-        wal = ""
-        db = ""
-        if self.args.block_wal:
-            wal = self.args.block_wal
-        if self.args.block_db:
-            db = self.args.block_db
-
-        # reuse a given ID if it exists, otherwise create a new ID
-        self.osd_id = prepare_utils.create_id(
-            osd_fsid,
-            json.dumps(secrets),
-            osd_id=self.args.osd_id)
-
-        prepare_bluestore(
-            self.args.data,
-            wal,
-            db,
-            secrets,
-            self.osd_id,
-            osd_fsid,
-            tmpfs,
-        )
+        self.objectstore = None
 
     def main(self):
         sub_command_help = dedent("""
@@ -148,13 +40,13 @@ class Prepare(object):
             print(sub_command_help)
             return
         self.args = parser.parse_args(self.argv)
-        if not self.args.bluestore:
-            terminal.error('must specify --bluestore (currently the only supported backend)')
-            raise SystemExit(1)
+        if self.args.bluestore:
+            self.args.objectstore = 'bluestore'
         if self.args.dmcrypt and not os.getenv('CEPH_VOLUME_DMCRYPT_SECRET'):
             terminal.error('encryption was requested (--dmcrypt) but environment variable ' \
                            'CEPH_VOLUME_DMCRYPT_SECRET is not set, you must set ' \
                            'this variable to provide a dmcrypt secret.')
             raise SystemExit(1)
 
-        self.safe_prepare(self.args)
+        self.objectstore = objectstore.mapping['RAW'][self.args.objectstore](args=self.args)
+        self.objectstore.safe_prepare(self.args)

--- a/src/ceph-volume/ceph_volume/objectstore/__init__.py
+++ b/src/ceph-volume/ceph_volume/objectstore/__init__.py
@@ -1,0 +1,11 @@
+from . import lvmbluestore
+from . import rawbluestore
+
+mapping = {
+    'LVM': {
+        'bluestore': lvmbluestore.LvmBlueStore
+    },
+    'RAW': {
+        'bluestore': rawbluestore.RawBlueStore
+    }
+}

--- a/src/ceph-volume/ceph_volume/objectstore/baseobjectstore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/baseobjectstore.py
@@ -1,0 +1,154 @@
+import logging
+import os
+import errno
+import time
+from ceph_volume import conf, terminal, process
+from ceph_volume.util import prepare as prepare_utils
+from ceph_volume.util import system, disk
+from typing import Dict, Any, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+    from ceph_volume.api.lvm import Volume
+
+
+logger = logging.getLogger(__name__)
+
+
+class BaseObjectStore:
+    def __init__(self, args: "argparse.Namespace") -> None:
+        self.args: "argparse.Namespace" = args
+        # FIXME we don't allow re-using a keyring, we always generate one
+        # for the OSD, this needs to be fixed. This could either be a file (!)
+        # or a string (!!) or some flags that we would need to compound
+        # into a dict so that we can convert to JSON (!!!)
+        self.secrets = {'cephx_secret': prepare_utils.create_key()}
+        self.cephx_secret = self.secrets.get('cephx_secret',
+                                             prepare_utils.create_key())
+        self.encrypted = 0
+        self.tags: Dict[str, Any] = {}
+        self.osd_id: str = ''
+        self.osd_fsid = ''
+        self.block_lv: Optional["Volume"] = None
+        self.cephx_lockbox_secret = ''
+        self.objectstore: str = ''
+        self.osd_mkfs_cmd: List[str] = []
+        self.block_device_path = ''
+        if hasattr(self.args, 'dmcrypt'):
+            if self.args.dmcrypt:
+                self.encrypted = 1
+                self.cephx_lockbox_secret = prepare_utils.create_key()
+                self.secrets['cephx_lockbox_secret'] = \
+                    self.cephx_lockbox_secret
+
+    def get_ptuuid(self, argument: str) -> str:
+        uuid = disk.get_partuuid(argument)
+        if not uuid:
+            terminal.error('blkid could not detect a PARTUUID for device: %s' %
+                           argument)
+            raise RuntimeError('unable to use device')
+        return uuid
+
+    def get_osdspec_affinity(self) -> str:
+        return os.environ.get('CEPH_VOLUME_OSDSPEC_AFFINITY', '')
+
+    def pre_prepare(self) -> None:
+        raise NotImplementedError()
+
+    def prepare_data_device(self,
+                            device_type: str,
+                            osd_uuid: str) -> Optional["Volume"]:
+        raise NotImplementedError()
+
+    def safe_prepare(self, args: "argparse.Namespace") -> None:
+        raise NotImplementedError()
+
+    def add_objectstore_opts(self) -> None:
+        raise NotImplementedError()
+
+    def prepare_osd_req(self, tmpfs: bool = True) -> None:
+        # create the directory
+        prepare_utils.create_osd_path(self.osd_id, tmpfs=tmpfs)
+        # symlink the block
+        prepare_utils.link_block(self.block_device_path, self.osd_id)
+        # get the latest monmap
+        prepare_utils.get_monmap(self.osd_id)
+        # write the OSD keyring if it doesn't exist already
+        prepare_utils.write_keyring(self.osd_id, self.cephx_secret)
+
+    def prepare(self) -> None:
+        raise NotImplementedError()
+
+    def prepare_dmcrypt(self) -> None:
+        raise NotImplementedError()
+
+    def get_cluster_fsid(self) -> str:
+        """
+        Allows using --cluster-fsid as an argument, but can fallback to reading
+        from ceph.conf if that is unset (the default behavior).
+        """
+        if self.args.cluster_fsid:
+            return self.args.cluster_fsid
+        else:
+            return conf.ceph.get('global', 'fsid')
+
+    def get_osd_path(self) -> str:
+        return '/var/lib/ceph/osd/%s-%s/' % (conf.cluster, self.osd_id)
+
+    def build_osd_mkfs_cmd(self) -> List[str]:
+        self.supplementary_command = [
+            '--osd-data', self.osd_path,
+            '--osd-uuid', self.osd_fsid,
+            '--setuser', 'ceph',
+            '--setgroup', 'ceph'
+        ]
+        self.osd_mkfs_cmd = [
+            'ceph-osd',
+            '--cluster', conf.cluster,
+            '--osd-objectstore', self.objectstore,
+            '--mkfs',
+            '-i', self.osd_id,
+            '--monmap', self.monmap,
+        ]
+        if self.cephx_secret is not None:
+            self.osd_mkfs_cmd.extend(['--keyfile', '-'])
+        try:
+            self.add_objectstore_opts()
+        except NotImplementedError:
+            logger.info("No specific objectstore options to add.")
+
+        self.osd_mkfs_cmd.extend(self.supplementary_command)
+        return self.osd_mkfs_cmd
+
+    def osd_mkfs(self) -> None:
+        self.osd_path = self.get_osd_path()
+        self.monmap = os.path.join(self.osd_path, 'activate.monmap')
+        cmd = self.build_osd_mkfs_cmd()
+
+        system.chown(self.osd_path)
+        """
+        When running in containers the --mkfs on raw device sometimes fails
+        to acquire a lock through flock() on the device because systemd-udevd holds one temporarily.
+        See KernelDevice.cc and _lock() to understand how ceph-osd acquires the lock.
+        Because this is really transient, we retry up to 5 times and wait for 1 sec in-between
+        """
+        for retry in range(5):
+            _, _, returncode = process.call(cmd,
+                                            stdin=self.cephx_secret,
+                                            terminal_verbose=True,
+                                            show_command=True)
+            if returncode == 0:
+                break
+            else:
+                if returncode == errno.EWOULDBLOCK:
+                    time.sleep(1)
+                    logger.info('disk is held by another process, '
+                                'trying to mkfs again... (%s/5 attempt)' %
+                                retry)
+                    continue
+                else:
+                    raise RuntimeError('Command failed with exit code %s: %s' %
+                                       (returncode, ' '.join(cmd)))
+
+    def activate(self) -> None:
+        raise NotImplementedError()

--- a/src/ceph-volume/ceph_volume/objectstore/bluestore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/bluestore.py
@@ -1,0 +1,61 @@
+import logging
+import os
+from .baseobjectstore import BaseObjectStore
+from ceph_volume.util import system
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+logger = logging.getLogger(__name__)
+
+
+class BlueStore(BaseObjectStore):
+    def __init__(self, args: "argparse.Namespace") -> None:
+        super().__init__(args)
+        self.args: "argparse.Namespace" = args
+        self.objectstore = 'bluestore'
+        self.osd_id: str = ''
+        self.osd_fsid: str = ''
+        self.osd_path: str = ''
+        self.key: Optional[str] = None
+        self.block_device_path: str = ''
+        self.wal_device_path: str = ''
+        self.db_device_path: str = ''
+
+    def add_objectstore_opts(self) -> None:
+        """
+        Create the files for the OSD to function. A normal call will look like:
+
+            ceph-osd --cluster ceph --mkfs --mkkey -i 0 \
+                    --monmap /var/lib/ceph/osd/ceph-0/activate.monmap \
+                    --osd-data /var/lib/ceph/osd/ceph-0 \
+                    --osd-uuid 8d208665-89ae-4733-8888-5d3bfbeeec6c \
+                    --keyring /var/lib/ceph/osd/ceph-0/keyring \
+                    --setuser ceph --setgroup ceph
+
+        In some cases it is required to use the keyring, when it is passed
+        in as a keyword argument it is used as part of the ceph-osd command
+        """
+
+        if self.wal_device_path:
+            self.osd_mkfs_cmd.extend(
+                ['--bluestore-block-wal-path', self.wal_device_path]
+            )
+            system.chown(self.wal_device_path)
+
+        if self.db_device_path:
+            self.osd_mkfs_cmd.extend(
+                ['--bluestore-block-db-path', self.db_device_path]
+            )
+            system.chown(self.db_device_path)
+
+        if self.get_osdspec_affinity():
+            self.osd_mkfs_cmd.extend(['--osdspec-affinity',
+                                      self.get_osdspec_affinity()])
+
+    def unlink_bs_symlinks(self) -> None:
+        for link_name in ['block', 'block.db', 'block.wal']:
+            link_path = os.path.join(self.osd_path, link_name)
+            if os.path.exists(link_path):
+                os.unlink(os.path.join(self.osd_path, link_name))

--- a/src/ceph-volume/ceph_volume/objectstore/lvmbluestore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/lvmbluestore.py
@@ -293,6 +293,7 @@ class LvmBlueStore(BlueStore):
         Return a path if possible, failing to do that a ``None``, since some of
         these devices are optional.
         """
+        # TODO(guits): this should be moved in a new function get_device_uuid_from_lv()
         osd_block_lv = None
         for lv in osd_lvs:
             if lv.tags.get('ceph.type') == 'block':

--- a/src/ceph-volume/ceph_volume/objectstore/lvmbluestore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/lvmbluestore.py
@@ -1,0 +1,490 @@
+import json
+import logging
+import os
+from ceph_volume import conf, terminal, decorators, configuration, process
+from ceph_volume.api import lvm as api
+from ceph_volume.util import prepare as prepare_utils
+from ceph_volume.util import encryption as encryption_utils
+from ceph_volume.util import system, disk
+from ceph_volume.systemd import systemctl
+from ceph_volume.devices.lvm.common import rollback_osd
+from ceph_volume.devices.lvm.listing import direct_report
+from .bluestore import BlueStore
+from typing import Dict, Any, Optional, List, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+    from ceph_volume.api.lvm import Volume
+
+logger = logging.getLogger(__name__)
+
+
+class LvmBlueStore(BlueStore):
+    def __init__(self, args: "argparse.Namespace") -> None:
+        super().__init__(args)
+        self.tags: Dict[str, Any] = {}
+        self.block_lv: Optional["Volume"] = None
+
+    def pre_prepare(self) -> None:
+        if self.encrypted:
+            self.secrets['dmcrypt_key'] = encryption_utils.create_dmcrypt_key()
+
+        cluster_fsid = self.get_cluster_fsid()
+
+        self.osd_fsid = self.args.osd_fsid or system.generate_uuid()
+        crush_device_class = self.args.crush_device_class
+        if crush_device_class:
+            self.secrets['crush_device_class'] = crush_device_class
+        # reuse a given ID if it exists, otherwise create a new ID
+        self.osd_id = prepare_utils.create_id(self.osd_fsid,
+                                              json.dumps(self.secrets),
+                                              osd_id=self.args.osd_id)
+        self.tags = {
+            'ceph.osd_fsid': self.osd_fsid,
+            'ceph.osd_id': self.osd_id,
+            'ceph.cluster_fsid': cluster_fsid,
+            'ceph.cluster_name': conf.cluster,
+            'ceph.crush_device_class': crush_device_class,
+            'ceph.osdspec_affinity': self.get_osdspec_affinity()
+        }
+
+        try:
+            vg_name, lv_name = self.args.data.split('/')
+            self.block_lv = api.get_single_lv(filters={'lv_name': lv_name,
+                                                       'vg_name': vg_name})
+        except ValueError:
+            self.block_lv = None
+
+        if not self.block_lv:
+            self.block_lv = self.prepare_data_device('block', self.osd_fsid)
+        self.block_device_path = self.block_lv.__dict__['lv_path']
+
+        self.tags['ceph.block_device'] = self.block_lv.__dict__['lv_path']
+        self.tags['ceph.block_uuid'] = self.block_lv.__dict__['lv_uuid']
+        self.tags['ceph.cephx_lockbox_secret'] = self.cephx_lockbox_secret
+        self.tags['ceph.encrypted'] = self.encrypted
+        self.tags['ceph.vdo'] = api.is_vdo(self.block_lv.__dict__['lv_path'])
+
+    def prepare_data_device(self,
+                            device_type: str,
+                            osd_uuid: str) -> Optional["Volume"]:
+        """
+        Check if ``arg`` is a device or partition to create an LV out of it
+        with a distinct volume group name, assigning LV tags on it and
+        ultimately, returning the logical volume object.  Failing to detect
+        a device or partition will result in error.
+
+        :param arg: The value of ``--data`` when parsing args
+        :param device_type: Usually ``block``
+        :param osd_uuid: The OSD uuid
+        """
+
+        device = self.args.data
+        if disk.is_partition(device) or disk.is_device(device):
+            # we must create a vg, and then a single lv
+            lv_name_prefix = "osd-{}".format(device_type)
+            kwargs = {
+                'device': device,
+                'tags': {'ceph.type': device_type},
+                'slots': self.args.data_slots,
+                }
+            logger.debug('data device size: {}'.format(self.args.data_size))
+            if self.args.data_size != 0:
+                kwargs['size'] = self.args.data_size
+            return api.create_lv(
+                lv_name_prefix,
+                osd_uuid,
+                **kwargs)
+        else:
+            error = [
+                'Cannot use device ({}).'.format(device),
+                'A vg/lv path or an existing device is needed']
+            raise RuntimeError(' '.join(error))
+
+    def safe_prepare(self,
+                     args: Optional["argparse.Namespace"] = None) -> None:
+        """
+        An intermediate step between `main()` and `prepare()` so that we can
+        capture the `self.osd_id` in case we need to rollback
+
+        :param args: Injected args, usually from `lvm create` which compounds
+                     both `prepare` and `create`
+        """
+        if args is not None:
+            self.args = args
+
+        try:
+            vgname, lvname = self.args.data.split('/')
+            lv = api.get_single_lv(filters={'lv_name': lvname,
+                                            'vg_name': vgname})
+        except ValueError:
+            lv = None
+
+        if api.is_ceph_device(lv):
+            logger.info("device {} is already used".format(self.args.data))
+            raise RuntimeError("skipping {}, it is already prepared".format(
+                self.args.data))
+        try:
+            self.prepare()
+        except Exception:
+            logger.exception('lvm prepare was unable to complete')
+            logger.info('will rollback OSD ID creation')
+            rollback_osd(self.args, self.osd_id)
+            raise
+        terminal.success("ceph-volume lvm prepare successful for: %s" %
+                         self.args.data)
+
+    @decorators.needs_root
+    def prepare(self) -> None:
+        # 1/
+        # Need to be reworked (move it to the parent class + call super()? )
+        self.pre_prepare()
+
+        # 2/
+        self.wal_device_path, wal_uuid, tags = self.setup_device(
+            'wal',
+            self.args.block_wal,
+            self.tags,
+            self.args.block_wal_size,
+            self.args.block_wal_slots)
+        self.db_device_path, db_uuid, tags = self.setup_device(
+            'db',
+            self.args.block_db,
+            self.tags,
+            self.args.block_db_size,
+            self.args.block_db_slots)
+
+        self.tags['ceph.type'] = 'block'
+        self.block_lv.set_tags(self.tags)  # type: ignore
+
+        # 3/ encryption-only operations
+        if self.secrets.get('dmcrypt_key'):
+            self.prepare_dmcrypt()
+
+        # 4/ osd_prepare req
+        self.prepare_osd_req()
+
+        # 5/ bluestore mkfs
+        # prepare the osd filesystem
+        self.osd_mkfs()
+
+    def prepare_dmcrypt(self) -> None:
+        # If encrypted, there is no need to create the lockbox keyring file
+        # because bluestore re-creates the files and does not have support
+        # for other files like the custom lockbox one. This will need to be
+        # done on activation. Format and open ('decrypt' devices) and
+        # re-assign the device and journal variables so that the rest of the
+        # process can use the mapper paths
+        key = self.secrets['dmcrypt_key']
+
+        self.block_device_path = \
+            self.luks_format_and_open(key,
+                                      self.block_device_path,
+                                      'block',
+                                      self.tags)
+        self.wal_device_path = self.luks_format_and_open(key,
+                                                         self.wal_device_path,
+                                                         'wal',
+                                                         self.tags)
+        self.db_device_path = self.luks_format_and_open(key,
+                                                        self.db_device_path,
+                                                        'db',
+                                                        self.tags)
+
+    def luks_format_and_open(self,
+                             key: Optional[str],
+                             device: str,
+                             device_type: str,
+                             tags: Dict[str, Any]) -> str:
+        """
+        Helper for devices that are encrypted. The operations needed for
+        block, db, wal devices are all the same
+        """
+        if not device:
+            return ''
+        tag_name = 'ceph.%s_uuid' % device_type
+        uuid = tags[tag_name]
+        # format data device
+        encryption_utils.luks_format(
+            key,
+            device
+        )
+        encryption_utils.luks_open(
+            key,
+            device,
+            uuid
+        )
+
+        return '/dev/mapper/%s' % uuid
+
+    def setup_device(self,
+                     device_type: str,
+                     device_name: str,
+                     tags: Dict[str, Any],
+                     size: int,
+                     slots: int) -> Tuple[str, str, Dict[str, Any]]:
+        """
+        Check if ``device`` is an lv, if so, set the tags, making sure to
+        update the tags with the lv_uuid and lv_path which the incoming tags
+        will not have.
+
+        If the device is not a logical volume, then retrieve the partition UUID
+        by querying ``blkid``
+        """
+        if device_name is None:
+            return '', '', tags
+        tags['ceph.type'] = device_type
+        tags['ceph.vdo'] = api.is_vdo(device_name)
+
+        try:
+            vg_name, lv_name = device_name.split('/')
+            lv = api.get_single_lv(filters={'lv_name': lv_name,
+                                            'vg_name': vg_name})
+        except ValueError:
+            lv = None
+
+        if lv:
+            lv_uuid = lv.lv_uuid
+            path = lv.lv_path
+            tags['ceph.%s_uuid' % device_type] = lv_uuid
+            tags['ceph.%s_device' % device_type] = path
+            lv.set_tags(tags)
+        elif disk.is_device(device_name):
+            # We got a disk, create an lv
+            lv_type = "osd-{}".format(device_type)
+            name_uuid = system.generate_uuid()
+            kwargs = {
+                'device': device_name,
+                'tags': tags,
+                'slots': slots
+            }
+            # TODO use get_block_db_size and co here to get configured size in
+            # conf file
+            if size != 0:
+                kwargs['size'] = size
+            lv = api.create_lv(
+                lv_type,
+                name_uuid,
+                **kwargs)
+            path = lv.lv_path
+            tags['ceph.{}_device'.format(device_type)] = path
+            tags['ceph.{}_uuid'.format(device_type)] = lv.lv_uuid
+            lv_uuid = lv.lv_uuid
+            lv.set_tags(tags)
+        else:
+            # otherwise assume this is a regular disk partition
+            name_uuid = self.get_ptuuid(device_name)
+            path = device_name
+            tags['ceph.%s_uuid' % device_type] = name_uuid
+            tags['ceph.%s_device' % device_type] = path
+            lv_uuid = name_uuid
+        return path, lv_uuid, tags
+
+    def get_osd_device_path(self,
+                            osd_lvs: List["Volume"],
+                            device_type: str,
+                            dmcrypt_secret: Optional[str] =
+                            None) -> Optional[str]:
+        """
+        ``device_type`` can be one of ``db``, ``wal`` or ``block`` so that we
+        can query LVs on system and fallback to querying the uuid if that is
+        not present.
+
+        Return a path if possible, failing to do that a ``None``, since some of
+        these devices are optional.
+        """
+        osd_block_lv = None
+        for lv in osd_lvs:
+            if lv.tags.get('ceph.type') == 'block':
+                osd_block_lv = lv
+                break
+        if osd_block_lv:
+            is_encrypted = osd_block_lv.tags.get('ceph.encrypted', '0') == '1'
+            logger.debug('Found block device (%s) with encryption: %s',
+                         osd_block_lv.name, is_encrypted)
+            uuid_tag = 'ceph.%s_uuid' % device_type
+            device_uuid = osd_block_lv.tags.get(uuid_tag)
+            if not device_uuid:
+                return None
+
+        device_lv: Optional["Volume"] = None
+        for lv in osd_lvs:
+            if lv.tags.get('ceph.type') == device_type:
+                device_lv = lv
+                break
+        if device_lv:
+            if is_encrypted:
+                encryption_utils.luks_open(dmcrypt_secret,
+                                           device_lv.__dict__['lv_path'],
+                                           device_uuid)
+                return '/dev/mapper/%s' % device_uuid
+            return device_lv.__dict__['lv_path']
+
+        # this could be a regular device, so query it with blkid
+        physical_device = disk.get_device_from_partuuid(device_uuid)
+        if physical_device:
+            if is_encrypted:
+                encryption_utils.luks_open(dmcrypt_secret,
+                                           physical_device,
+                                           device_uuid)
+                return '/dev/mapper/%s' % device_uuid
+            return physical_device
+
+        raise RuntimeError('could not find %s with uuid %s' % (device_type,
+                                                               device_uuid))
+
+    def _activate(self,
+                  osd_lvs: List["Volume"],
+                  no_systemd: bool = False,
+                  no_tmpfs: bool = False) -> None:
+        for lv in osd_lvs:
+            if lv.tags.get('ceph.type') == 'block':
+                osd_block_lv = lv
+                break
+        else:
+            raise RuntimeError('could not find a bluestore OSD to activate')
+
+        is_encrypted = osd_block_lv.tags.get('ceph.encrypted', '0') == '1'
+        dmcrypt_secret = None
+        osd_id = osd_block_lv.tags['ceph.osd_id']
+        conf.cluster = osd_block_lv.tags['ceph.cluster_name']
+        osd_fsid = osd_block_lv.tags['ceph.osd_fsid']
+        configuration.load_ceph_conf_path(
+            osd_block_lv.tags['ceph.cluster_name'])
+        configuration.load()
+
+        # mount on tmpfs the osd directory
+        self.osd_path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
+        if not system.path_is_mounted(self.osd_path):
+            # mkdir -p and mount as tmpfs
+            prepare_utils.create_osd_path(osd_id, tmpfs=not no_tmpfs)
+
+        # XXX This needs to be removed once ceph-bluestore-tool can deal with
+        # symlinks that exist in the osd dir
+        self.unlink_bs_symlinks()
+
+        # encryption is handled here, before priming the OSD dir
+        if is_encrypted:
+            osd_lv_path = '/dev/mapper/%s' % osd_block_lv.__dict__['lv_uuid']
+            lockbox_secret = osd_block_lv.tags['ceph.cephx_lockbox_secret']
+            encryption_utils.write_lockbox_keyring(osd_id,
+                                                   osd_fsid,
+                                                   lockbox_secret)
+            dmcrypt_secret = encryption_utils.get_dmcrypt_key(osd_id, osd_fsid)
+            encryption_utils.luks_open(dmcrypt_secret,
+                                       osd_block_lv.__dict__['lv_path'],
+                                       osd_block_lv.__dict__['lv_uuid'])
+        else:
+            osd_lv_path = osd_block_lv.__dict__['lv_path']
+
+        db_device_path = \
+            self.get_osd_device_path(osd_lvs, 'db',
+                                     dmcrypt_secret=dmcrypt_secret)
+        wal_device_path = \
+            self.get_osd_device_path(osd_lvs,
+                                     'wal',
+                                     dmcrypt_secret=dmcrypt_secret)
+
+        # Once symlinks are removed, the osd dir can be 'primed again.
+        # chown first, regardless of what currently exists so that
+        # ``prime-osd-dir`` can succeed even if permissions are
+        # somehow messed up.
+        system.chown(self.osd_path)
+        prime_command = [
+            'ceph-bluestore-tool', '--cluster=%s' % conf.cluster,
+            'prime-osd-dir', '--dev', osd_lv_path,
+            '--path', self.osd_path, '--no-mon-config']
+
+        process.run(prime_command)
+        # always re-do the symlink regardless if it exists, so that the block,
+        # block.wal, and block.db devices that may have changed can be mapped
+        # correctly every time
+        process.run(['ln',
+                     '-snf',
+                     osd_lv_path,
+                     os.path.join(self.osd_path, 'block')])
+        system.chown(os.path.join(self.osd_path, 'block'))
+        system.chown(self.osd_path)
+        if db_device_path:
+            destination = os.path.join(self.osd_path, 'block.db')
+            process.run(['ln', '-snf', db_device_path, destination])
+            system.chown(db_device_path)
+            system.chown(destination)
+        if wal_device_path:
+            destination = os.path.join(self.osd_path, 'block.wal')
+            process.run(['ln', '-snf', wal_device_path, destination])
+            system.chown(wal_device_path)
+            system.chown(destination)
+
+        if no_systemd is False:
+            # enable the ceph-volume unit for this OSD
+            systemctl.enable_volume(osd_id, osd_fsid, 'lvm')
+
+            # enable the OSD
+            systemctl.enable_osd(osd_id)
+
+            # start the OSD
+            systemctl.start_osd(osd_id)
+        terminal.success("ceph-volume lvm activate successful for osd ID: %s" %
+                         osd_id)
+
+    @decorators.needs_root
+    def activate_all(self) -> None:
+        listed_osds = direct_report()
+        osds = {}
+        for osd_id, devices in listed_osds.items():
+            # the metadata for all devices in each OSD will contain
+            # the FSID which is required for activation
+            for device in devices:
+                fsid = device.get('tags', {}).get('ceph.osd_fsid')
+                if fsid:
+                    osds[fsid] = osd_id
+                    break
+        if not osds:
+            terminal.warning('Was unable to find any OSDs to activate')
+            terminal.warning('Verify OSDs are present with '
+                             '"ceph-volume lvm list"')
+            return
+        for osd_fsid, osd_id in osds.items():
+            if not self.args.no_systemd and systemctl.osd_is_active(osd_id):
+                terminal.warning(
+                    'OSD ID %s FSID %s process is active. '
+                    'Skipping activation' % (osd_id, osd_fsid)
+                )
+            else:
+                terminal.info('Activating OSD ID %s FSID %s' % (osd_id,
+                                                                osd_fsid))
+                self.activate(self.args, osd_id=osd_id, osd_fsid=osd_fsid)
+
+    @decorators.needs_root
+    def activate(self,
+                 args: Optional["argparse.Namespace"] = None,
+                 osd_id: Optional[str] = None,
+                 osd_fsid: Optional[str] = None) -> None:
+        """
+        :param args: The parsed arguments coming from the CLI
+        :param osd_id: When activating all, this gets populated with an
+                       existing OSD ID
+        :param osd_fsid: When activating all, this gets populated with an
+                         existing OSD FSID
+        """
+        osd_id = osd_id if osd_id else self.args.osd_id
+        osd_fsid = osd_fsid if osd_fsid else self.args.osd_fsid
+
+        if osd_id and osd_fsid:
+            tags = {'ceph.osd_id': osd_id, 'ceph.osd_fsid': osd_fsid}
+        elif not osd_id and osd_fsid:
+            tags = {'ceph.osd_fsid': osd_fsid}
+        elif osd_id and not osd_fsid:
+            raise RuntimeError('could not activate osd.{}, please provide the '
+                               'osd_fsid too'.format(osd_id))
+        else:
+            raise RuntimeError('Please provide both osd_id and osd_fsid')
+        lvs = api.get_lvs(tags=tags)
+        if not lvs:
+            raise RuntimeError('could not find osd.%s with osd_fsid %s' %
+                               (osd_id, osd_fsid))
+
+        self._activate(lvs, self.args.no_systemd, getattr(self.args,
+                                                          'no_tmpfs',
+                                                          False))

--- a/src/ceph-volume/ceph_volume/objectstore/rawbluestore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/rawbluestore.py
@@ -1,0 +1,181 @@
+import logging
+import json
+import os
+from .bluestore import BlueStore
+from ceph_volume import terminal, decorators, conf, process
+from ceph_volume.util import system, disk
+from ceph_volume.util import prepare as prepare_utils
+from ceph_volume.util import encryption as encryption_utils
+from ceph_volume.devices.lvm.common import rollback_osd
+from ceph_volume.devices.raw.list import direct_report
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+logger = logging.getLogger(__name__)
+
+
+class RawBlueStore(BlueStore):
+    def __init__(self, args: "argparse.Namespace") -> None:
+        super().__init__(args)
+        if hasattr(self.args, 'data'):
+            self.block_device_path = self.args.data
+        if hasattr(self.args, 'block_db'):
+            self.db_device_path = self.args.block_db
+        if hasattr(self.args, 'block_wal'):
+            self.wal_device_path = self.args.block_wal
+
+    def prepare_dmcrypt(self) -> None:
+        """
+        Helper for devices that are encrypted. The operations needed for
+        block, db, wal, devices are all the same
+        """
+        key = self.secrets['dmcrypt_key']
+
+        for device, device_type in [(self.block_device_path, 'block'),
+                                    (self.db_device_path, 'db'),
+                                    (self.wal_device_path, 'wal')]:
+
+            if device:
+                kname = disk.lsblk(device)['KNAME']
+                mapping = 'ceph-{}-{}-{}-dmcrypt'.format(self.osd_fsid,
+                                                         kname,
+                                                         device_type)
+                # format data device
+                encryption_utils.luks_format(
+                    key,
+                    device
+                )
+                encryption_utils.luks_open(
+                    key,
+                    device,
+                    mapping
+                )
+                self.__dict__[f'{device_type}_device_path'] = \
+                    '/dev/mapper/{}'.format(mapping)
+
+    def safe_prepare(self,
+                     args: Optional["argparse.Namespace"] = None) -> None:
+        """
+        An intermediate step between `main()` and `prepare()` so that we can
+        capture the `self.osd_id` in case we need to rollback
+
+        :param args: Injected args, usually from `raw create` which compounds
+                     both `prepare` and `create`
+        """
+        if args is not None:
+            self.args = args  # This should be moved (to __init__ ?)
+        try:
+            self.prepare()
+        except Exception:
+            logger.exception('raw prepare was unable to complete')
+            logger.info('will rollback OSD ID creation')
+            rollback_osd(self.args, self.osd_id)
+            raise
+        dmcrypt_log = 'dmcrypt' if hasattr(args, 'dmcrypt') else 'clear'
+        terminal.success("ceph-volume raw {} prepare "
+                         "successful for: {}".format(dmcrypt_log,
+                                                     self.args.data))
+
+    @decorators.needs_root
+    def prepare(self) -> None:
+        if self.encrypted:
+            self.secrets['dmcrypt_key'] = \
+                os.getenv('CEPH_VOLUME_DMCRYPT_SECRET')
+        self.osd_fsid = system.generate_uuid()
+        crush_device_class = self.args.crush_device_class
+        if crush_device_class:
+            self.secrets['crush_device_class'] = crush_device_class
+
+        tmpfs = not self.args.no_tmpfs
+        if self.args.block_wal:
+            self.wal = self.args.block_wal
+        if self.args.block_db:
+            self.db = self.args.block_db
+
+        # reuse a given ID if it exists, otherwise create a new ID
+        self.osd_id = prepare_utils.create_id(
+            self.osd_fsid, json.dumps(self.secrets))
+
+        if self.secrets.get('dmcrypt_key'):
+            self.prepare_dmcrypt()
+
+        self.prepare_osd_req(tmpfs=tmpfs)
+
+        # prepare the osd filesystem
+        self.osd_mkfs()
+
+    def _activate(self,
+                  meta: Dict[str, Any],
+                  tmpfs: bool) -> None:
+        # find the osd
+        osd_id = meta['osd_id']
+        osd_uuid = meta['osd_uuid']
+
+        # mount on tmpfs the osd directory
+        self.osd_path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
+        if not system.path_is_mounted(self.osd_path):
+            # mkdir -p and mount as tmpfs
+            prepare_utils.create_osd_path(osd_id, tmpfs=tmpfs)
+
+        # XXX This needs to be removed once ceph-bluestore-tool can deal with
+        # symlinks that exist in the osd dir
+
+        self.unlink_bs_symlinks()
+
+        # Once symlinks are removed, the osd dir can be 'primed again. chown
+        # first, regardless of what currently exists so that ``prime-osd-dir``
+        # can succeed even if permissions are somehow messed up
+        system.chown(self.osd_path)
+        prime_command = [
+            'ceph-bluestore-tool',
+            'prime-osd-dir',
+            '--path', self.osd_path,
+            '--no-mon-config',
+            '--dev', meta['device'],
+        ]
+        process.run(prime_command)
+
+        # always re-do the symlink regardless if it exists, so that the block,
+        # block.wal, and block.db devices that may have changed can be mapped
+        # correctly every time
+        prepare_utils.link_block(meta['device'], osd_id)
+
+        if 'device_db' in meta:
+            prepare_utils.link_db(meta['device_db'], osd_id, osd_uuid)
+
+        if 'device_wal' in meta:
+            prepare_utils.link_wal(meta['device_wal'], osd_id, osd_uuid)
+
+        system.chown(self.osd_path)
+        terminal.success("ceph-volume raw activate "
+                         "successful for osd ID: %s" % osd_id)
+
+    @decorators.needs_root
+    def activate(self,
+                 devs: List[str],
+                 start_osd_id: str,
+                 start_osd_uuid: str,
+                 tmpfs: bool) -> None:
+        """
+        :param args: The parsed arguments coming from the CLI
+        """
+        assert devs or start_osd_id or start_osd_uuid
+        found = direct_report(devs)
+
+        activated_any = False
+        for osd_uuid, meta in found.items():
+            osd_id = meta['osd_id']
+            if start_osd_id is not None and str(osd_id) != str(start_osd_id):
+                continue
+            if start_osd_uuid is not None and osd_uuid != start_osd_uuid:
+                continue
+            logger.info('Activating osd.%s uuid %s cluster %s' % (
+                osd_id, osd_uuid, meta['ceph_fsid']))
+            self._activate(meta,
+                           tmpfs=tmpfs)
+            activated_any = True
+
+        if not activated_any:
+            raise RuntimeError('did not find any matching OSD to activate')

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -782,7 +782,7 @@ class TestGetLVs(object):
 
 class TestGetSinglePV(object):
 
-    @patch('ceph_volume.devices.lvm.prepare.api.get_pvs')
+    @patch('ceph_volume.api.lvm.get_pvs')
     def test_get_single_pv_multiple_matches_raises_runtimeerror(self, m_get_pvs):
         fake_pvs = []
         fake_pvs.append(api.PVolume(pv_name='/dev/sda', pv_tags={}))
@@ -794,14 +794,14 @@ class TestGetSinglePV(object):
             api.get_single_pv()
         assert "matched more than 1 PV present on this host." in str(e.value)
 
-    @patch('ceph_volume.devices.lvm.prepare.api.get_pvs')
+    @patch('ceph_volume.api.lvm.get_pvs')
     def test_get_single_pv_no_match_returns_none(self, m_get_pvs):
         m_get_pvs.return_value = []
 
         pv = api.get_single_pv()
         assert pv == None
 
-    @patch('ceph_volume.devices.lvm.prepare.api.get_pvs')
+    @patch('ceph_volume.api.lvm.get_pvs')
     def test_get_single_pv_one_match(self, m_get_pvs):
         fake_pvs = []
         fake_pvs.append(api.PVolume(pv_name='/dev/sda', pv_tags={}))
@@ -815,7 +815,7 @@ class TestGetSinglePV(object):
 
 class TestGetSingleVG(object):
 
-    @patch('ceph_volume.devices.lvm.prepare.api.get_vgs')
+    @patch('ceph_volume.api.lvm.get_vgs')
     def test_get_single_vg_multiple_matches_raises_runtimeerror(self, m_get_vgs):
         fake_vgs = []
         fake_vgs.append(api.VolumeGroup(vg_name='vg1'))
@@ -827,14 +827,14 @@ class TestGetSingleVG(object):
             api.get_single_vg()
         assert "matched more than 1 VG present on this host." in str(e.value)
 
-    @patch('ceph_volume.devices.lvm.prepare.api.get_vgs')
+    @patch('ceph_volume.api.lvm.get_vgs')
     def test_get_single_vg_no_match_returns_none(self, m_get_vgs):
         m_get_vgs.return_value = []
 
         vg = api.get_single_vg()
         assert vg == None
 
-    @patch('ceph_volume.devices.lvm.prepare.api.get_vgs')
+    @patch('ceph_volume.api.lvm.get_vgs')
     def test_get_single_vg_one_match(self, m_get_vgs):
         fake_vgs = []
         fake_vgs.append(api.VolumeGroup(vg_name='vg1'))
@@ -847,7 +847,7 @@ class TestGetSingleVG(object):
 
 class TestGetSingleLV(object):
 
-    @patch('ceph_volume.devices.lvm.prepare.api.get_lvs')
+    @patch('ceph_volume.api.lvm.get_lvs')
     def test_get_single_lv_multiple_matches_raises_runtimeerror(self, m_get_lvs):
         fake_lvs = []
         fake_lvs.append(api.Volume(lv_name='lv1',
@@ -866,14 +866,14 @@ class TestGetSingleLV(object):
             api.get_single_lv()
         assert "matched more than 1 LV present on this host" in str(e.value)
 
-    @patch('ceph_volume.devices.lvm.prepare.api.get_lvs')
+    @patch('ceph_volume.api.lvm.get_lvs')
     def test_get_single_lv_no_match_returns_none(self, m_get_lvs):
         m_get_lvs.return_value = []
 
         lv = api.get_single_lv()
         assert lv == None
 
-    @patch('ceph_volume.devices.lvm.prepare.api.get_lvs')
+    @patch('ceph_volume.api.lvm.get_lvs')
     def test_get_single_lv_one_match(self, m_get_lvs):
         fake_lvs = []
         fake_lvs.append(api.Volume(lv_name='lv1', lv_path='/dev/vg1/lv1', vg_name='vg1', lv_tags='', lv_uuid='fake-uuid'))

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -256,6 +256,13 @@ def is_root(monkeypatch):
     """
     monkeypatch.setattr('os.getuid', lambda: 0)
 
+@pytest.fixture
+def is_non_root(monkeypatch):
+    """
+    Patch ``os.getuid()`` so that ceph-volume's decorators that ensure a user
+    is not root.
+    """
+    monkeypatch.setattr('os.getuid', lambda: 100)
 
 @pytest.fixture
 def tmpfile(tmpdir):
@@ -380,6 +387,8 @@ def fake_filesystem(fs):
     fs.create_dir('/sys/block/sda/slaves')
     fs.create_dir('/sys/block/sda/queue')
     fs.create_dir('/sys/block/rbd0')
+    fs.create_dir('/var/log/ceph')
+    fs.create_dir('/tmp/osdpath')
     yield fs
 
 @pytest.fixture

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
@@ -63,7 +63,7 @@ class TestActivate(object):
             a.objectstore.activate()
         assert result.value.args[0] == 'Please provide both osd_id and osd_fsid'
 
-    def test_bluestore_no_systemd(self, is_root, monkeypatch, capture):
+    def test_bluestore_no_systemd(self, m_create_key, is_root, monkeypatch, capture):
         monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         fake_enable = Capture()
         fake_start_osd = Capture()
@@ -88,7 +88,7 @@ class TestActivate(object):
         assert fake_enable.calls == []
         assert fake_start_osd.calls == []
 
-    def test_bluestore_systemd(self, is_root, monkeypatch, capture):
+    def test_bluestore_systemd(self, m_create_key, is_root, monkeypatch, capture):
         monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         fake_enable = Capture()
         fake_start_osd = Capture()
@@ -114,7 +114,7 @@ class TestActivate(object):
         assert fake_enable.calls != []
         assert fake_start_osd.calls != []
 
-    def test_bluestore_no_systemd_autodetect(self, is_root, monkeypatch, capture):
+    def test_bluestore_no_systemd_autodetect(self, m_create_key, is_root, monkeypatch, capture):
         monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         fake_enable = Capture()
         fake_start_osd = Capture()
@@ -140,7 +140,7 @@ class TestActivate(object):
         assert fake_enable.calls == []
         assert fake_start_osd.calls == []
 
-    def test_bluestore_systemd_autodetect(self, is_root, monkeypatch, capture):
+    def test_bluestore_systemd_autodetect(self, m_create_key, is_root, monkeypatch, capture):
         monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         fake_enable = Capture()
         fake_start_osd = Capture()
@@ -242,7 +242,7 @@ class TestActivateAll(object):
         m_activate.assert_has_calls(calls)
 
     @patch('ceph_volume.objectstore.lvmbluestore.LvmBlueStore.activate')
-    def test_detects_osds_to_activate_no_systemd(self, m_activate, is_root, monkeypatch):
+    def test_detects_osds_to_activate_no_systemd(self, m_activate, m_create_key, is_root, monkeypatch):
         monkeypatch.setattr('ceph_volume.objectstore.lvmbluestore.direct_report', lambda: direct_report)
         args = ['--all', '--no-systemd', '--bluestore']
         a = activate.Activate(args)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
@@ -3,7 +3,10 @@ from copy import deepcopy
 from ceph_volume.devices.lvm import activate
 from ceph_volume.api import lvm as api
 from ceph_volume.tests.conftest import Capture
-
+from ceph_volume import objectstore
+#from ceph_volume.util.prepare import create_key
+from mock import patch, call
+from argparse import Namespace
 
 class Args(object):
 
@@ -16,33 +19,48 @@ class Args(object):
             setattr(self, k, v)
 
 
+@patch('ceph_volume.util.prepare.create_key', return_value='fake-secret')
 class TestActivate(object):
 
     # these tests are very functional, hence the heavy patching, it is hard to
     # test the negative side effect with an actual functional run, so we must
     # setup a perfect scenario for this test to check it can really work
     # with/without osd_id
-    def test_no_osd_id_matches_fsid_bluestore(self, is_root, monkeypatch, capture):
-        FooVolume = api.Volume(lv_name='foo', lv_path='/dev/vg/foo',
-                               lv_tags="ceph.osd_fsid=1234")
+    def test_no_osd_id_matches_fsid_bluestore(self,
+                                              m_create_key,
+                                              is_root,
+                                              monkeypatch,
+                                              capture):
+        FooVolume = api.Volume(lv_name='foo',
+                            lv_path='/dev/vg/foo',
+                            lv_tags="ceph.osd_fsid=1234")
         volumes = []
         volumes.append(FooVolume)
         monkeypatch.setattr(api, 'get_lvs', lambda **kwargs: volumes)
-        monkeypatch.setattr(activate, 'activate_bluestore', capture)
+        monkeypatch.setattr(objectstore.lvmbluestore.LvmBlueStore,
+                            '_activate',
+                            capture)
+
         args = Args(osd_id=None, osd_fsid='1234', bluestore=True)
-        activate.Activate([]).activate(args)
+        a = activate.Activate([])
+        a.objectstore = objectstore.lvmbluestore.LvmBlueStore(args=args)
+        a.objectstore.activate()
         assert capture.calls[0]['args'][0] == [FooVolume]
 
-    def test_osd_id_no_osd_fsid(self, is_root):
+    def test_osd_id_no_osd_fsid(self, m_create_key, is_root):
         args = Args(osd_id=42, osd_fsid=None)
+        a = activate.Activate([])
+        a.objectstore = objectstore.lvmbluestore.LvmBlueStore(args=args)
         with pytest.raises(RuntimeError) as result:
-            activate.Activate([]).activate(args)
+            a.objectstore.activate()
         assert result.value.args[0] == 'could not activate osd.42, please provide the osd_fsid too'
 
-    def test_no_osd_id_no_osd_fsid(self, is_root):
+    def test_no_osd_id_no_osd_fsid(self, m_create_key, is_root):
         args = Args(osd_id=None, osd_fsid=None)
+        a = activate.Activate([])
+        a.objectstore = objectstore.lvmbluestore.LvmBlueStore(args=args)
         with pytest.raises(RuntimeError) as result:
-            activate.Activate([]).activate(args)
+            a.objectstore.activate()
         assert result.value.args[0] == 'Please provide both osd_id and osd_fsid'
 
     def test_bluestore_no_systemd(self, is_root, monkeypatch, capture):
@@ -52,8 +70,8 @@ class TestActivate(object):
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda *a, **kw: True)
         monkeypatch.setattr('ceph_volume.util.system.chown', lambda *a, **kw: True)
         monkeypatch.setattr('ceph_volume.process.run', lambda *a, **kw: True)
-        monkeypatch.setattr(activate.systemctl, 'enable_volume', fake_enable)
-        monkeypatch.setattr(activate.systemctl, 'start_osd', fake_start_osd)
+        monkeypatch.setattr(objectstore.lvmbluestore.systemctl, 'enable_volume', fake_enable)
+        monkeypatch.setattr(objectstore.lvmbluestore.systemctl, 'start_osd', fake_start_osd)
         DataVolume = api.Volume(
             lv_name='data',
             lv_path='/dev/vg/data',
@@ -64,7 +82,9 @@ class TestActivate(object):
         monkeypatch.setattr(api, 'get_lvs', lambda **kwargs: deepcopy(volumes))
 
         args = Args(osd_id=None, osd_fsid='1234', no_systemd=True, bluestore=True)
-        activate.Activate([]).activate(args)
+        a = activate.Activate([])
+        a.objectstore = objectstore.lvmbluestore.LvmBlueStore(args=args)
+        a.objectstore.activate()
         assert fake_enable.calls == []
         assert fake_start_osd.calls == []
 
@@ -75,8 +95,8 @@ class TestActivate(object):
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda *a, **kw: True)
         monkeypatch.setattr('ceph_volume.util.system.chown', lambda *a, **kw: True)
         monkeypatch.setattr('ceph_volume.process.run', lambda *a, **kw: True)
-        monkeypatch.setattr(activate.systemctl, 'enable_volume', fake_enable)
-        monkeypatch.setattr(activate.systemctl, 'start_osd', fake_start_osd)
+        monkeypatch.setattr(objectstore.lvmbluestore.systemctl, 'enable_volume', fake_enable)
+        monkeypatch.setattr(objectstore.lvmbluestore.systemctl, 'start_osd', fake_start_osd)
         DataVolume = api.Volume(
             lv_name='data',
             lv_path='/dev/vg/data',
@@ -88,7 +108,9 @@ class TestActivate(object):
 
         args = Args(osd_id=None, osd_fsid='1234', no_systemd=False,
                     bluestore=True)
-        activate.Activate([]).activate(args)
+        a = activate.Activate([])
+        a.objectstore = objectstore.lvmbluestore.LvmBlueStore(args=args)
+        a.objectstore.activate()
         assert fake_enable.calls != []
         assert fake_start_osd.calls != []
 
@@ -99,8 +121,8 @@ class TestActivate(object):
         monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda *a, **kw: True)
         monkeypatch.setattr('ceph_volume.util.system.chown', lambda *a, **kw: True)
         monkeypatch.setattr('ceph_volume.process.run', lambda *a, **kw: True)
-        monkeypatch.setattr(activate.systemctl, 'enable_volume', fake_enable)
-        monkeypatch.setattr(activate.systemctl, 'start_osd', fake_start_osd)
+        monkeypatch.setattr(objectstore.lvmbluestore.systemctl, 'enable_volume', fake_enable)
+        monkeypatch.setattr(objectstore.lvmbluestore.systemctl, 'start_osd', fake_start_osd)
         DataVolume = api.Volume(
             lv_name='data',
             lv_path='/dev/vg/data',
@@ -112,7 +134,9 @@ class TestActivate(object):
 
         args = Args(osd_id=None, osd_fsid='1234', no_systemd=True,
                     bluestore=True, auto_detect_objectstore=True)
-        activate.Activate([]).activate(args)
+        a = activate.Activate([])
+        a.objectstore = objectstore.lvmbluestore.LvmBlueStore(args=args)
+        a.objectstore.activate()
         assert fake_enable.calls == []
         assert fake_start_osd.calls == []
 
@@ -125,8 +149,8 @@ class TestActivate(object):
         monkeypatch.setattr('ceph_volume.util.system.chown', lambda *a, **kw:
                             True)
         monkeypatch.setattr('ceph_volume.process.run', lambda *a, **kw: True)
-        monkeypatch.setattr(activate.systemctl, 'enable_volume', fake_enable)
-        monkeypatch.setattr(activate.systemctl, 'start_osd', fake_start_osd)
+        monkeypatch.setattr(objectstore.lvmbluestore.systemctl, 'enable_volume', fake_enable)
+        monkeypatch.setattr(objectstore.lvmbluestore.systemctl, 'start_osd', fake_start_osd)
         DataVolume = api.Volume(
             lv_name='data',
             lv_path='/dev/vg/data',
@@ -138,33 +162,37 @@ class TestActivate(object):
 
         args = Args(osd_id=None, osd_fsid='1234', no_systemd=False,
                     bluestore=True, auto_detect_objectstore=False)
-        activate.Activate([]).activate(args)
+        a = activate.Activate([])
+        a.objectstore = objectstore.lvmbluestore.LvmBlueStore(args=args)
+        a.objectstore.activate()
         assert fake_enable.calls != []
         assert fake_start_osd.calls != []
 
+
+@patch('ceph_volume.util.prepare.create_key', return_value='fake-secret')
+@patch('ceph_volume.objectstore.lvmbluestore.LvmBlueStore.activate_all')
+@patch('ceph_volume.objectstore.lvmbluestore.LvmBlueStore.activate')
 class TestActivateFlags(object):
 
-    def test_default_objectstore(self, capture):
+    def test_default_objectstore(self, m_activate, m_activate_all, m_create_key, capture):
         args = ['0', 'asdf-ljh-asdf']
-        activation = activate.Activate(args)
-        activation.activate = capture
-        activation.main()
-        parsed_args = capture.calls[0]['args'][0]
-        assert parsed_args.bluestore is False
 
-    def test_uses_bluestore(self, capture):
+        a = activate.Activate(args)
+        a.main()
+        assert a.args.objectstore == 'bluestore'
+
+    def test_bluestore_backward_compatibility(self, m_activate, m_activate_all, m_create_key, capture):
         args = ['--bluestore', '0', 'asdf-ljh-asdf']
-        activation = activate.Activate(args)
-        activation.activate = capture
-        activation.main()
-        parsed_args = capture.calls[0]['args'][0]
-        assert parsed_args.bluestore is True
+        a = activate.Activate(args)
+        a.main()
+        assert a.args.objectstore == 'bluestore'
 
 
+@patch('ceph_volume.util.prepare.create_key', return_value='fake-secret')
 class TestActivateAll(object):
 
-    def test_does_not_detect_osds(self, capsys, is_root, capture, monkeypatch):
-        monkeypatch.setattr('ceph_volume.devices.lvm.activate.direct_report', lambda: {})
+    def test_does_not_detect_osds(self, m_create_key, capsys, is_root, monkeypatch):
+        monkeypatch.setattr('ceph_volume.objectstore.lvmbluestore.direct_report', lambda: {})
         args = ['--all']
         activation = activate.Activate(args)
         activation.main()
@@ -172,9 +200,9 @@ class TestActivateAll(object):
         assert 'Was unable to find any OSDs to activate' in err
         assert 'Verify OSDs are present with ' in err
 
-    def test_detects_running_osds(self, capsys, is_root, capture, monkeypatch):
-        monkeypatch.setattr('ceph_volume.devices.lvm.activate.direct_report', lambda: direct_report)
-        monkeypatch.setattr('ceph_volume.devices.lvm.activate.systemctl.osd_is_active', lambda x: True)
+    def test_detects_running_osds(self, m_create_key, capsys, is_root, capture, monkeypatch):
+        monkeypatch.setattr('ceph_volume.objectstore.lvmbluestore.direct_report', lambda: direct_report)
+        monkeypatch.setattr('ceph_volume.objectstore.lvmbluestore.systemctl.osd_is_active', lambda x: True)
         args = ['--all']
         activation = activate.Activate(args)
         activation.main()
@@ -182,30 +210,66 @@ class TestActivateAll(object):
         assert 'a8789a96ce8b process is active. Skipping activation' in err
         assert 'b8218eaa1634 process is active. Skipping activation' in err
 
-    def test_detects_osds_to_activate_systemd(self, is_root, capture, monkeypatch):
-        monkeypatch.setattr('ceph_volume.devices.lvm.activate.direct_report', lambda: direct_report)
-        monkeypatch.setattr('ceph_volume.devices.lvm.activate.systemctl.osd_is_active', lambda x: False)
-        args = ['--all']
-        activation = activate.Activate(args)
-        activation.activate = capture
-        activation.main()
-        calls = sorted(capture.calls, key=lambda x: x['kwargs']['osd_id'])
-        assert calls[0]['kwargs']['osd_id'] == '0'
-        assert calls[0]['kwargs']['osd_fsid'] == '957d22b7-24ce-466a-9883-b8218eaa1634'
-        assert calls[1]['kwargs']['osd_id'] == '1'
-        assert calls[1]['kwargs']['osd_fsid'] == 'd0f3e4ad-e52a-4520-afc0-a8789a96ce8b'
+    @patch('ceph_volume.objectstore.lvmbluestore.LvmBlueStore.activate')
+    def test_detects_osds_to_activate_systemd(self, m_activate, m_create_key, is_root, monkeypatch):
+        monkeypatch.setattr('ceph_volume.objectstore.lvmbluestore.direct_report', lambda: direct_report)
+        monkeypatch.setattr('ceph_volume.objectstore.lvmbluestore.systemctl.osd_is_active', lambda x: False)
+        args = ['--all', '--bluestore']
+        a = activate.Activate(args)
+        a.main()
+        calls = [
+            call(Namespace(activate_all=True,
+                           auto_detect_objectstore=False,
+                           bluestore=True,
+                           no_systemd=False,
+                           no_tmpfs=False,
+                           objectstore='bluestore',
+                           osd_fsid=None,
+                           osd_id=None),
+                           osd_id='0',
+                           osd_fsid='957d22b7-24ce-466a-9883-b8218eaa1634'),
+            call(Namespace(activate_all=True,
+                           auto_detect_objectstore=False,
+                           bluestore=True,
+                           no_systemd=False,
+                           no_tmpfs=False,
+                           objectstore='bluestore',
+                           osd_fsid=None,
+                           osd_id=None),
+                           osd_id='1',
+                           osd_fsid='d0f3e4ad-e52a-4520-afc0-a8789a96ce8b')
+        ]
+        m_activate.assert_has_calls(calls)
 
-    def test_detects_osds_to_activate_no_systemd(self, is_root, capture, monkeypatch):
-        monkeypatch.setattr('ceph_volume.devices.lvm.activate.direct_report', lambda: direct_report)
-        args = ['--all', '--no-systemd']
-        activation = activate.Activate(args)
-        activation.activate = capture
-        activation.main()
-        calls = sorted(capture.calls, key=lambda x: x['kwargs']['osd_id'])
-        assert calls[0]['kwargs']['osd_id'] == '0'
-        assert calls[0]['kwargs']['osd_fsid'] == '957d22b7-24ce-466a-9883-b8218eaa1634'
-        assert calls[1]['kwargs']['osd_id'] == '1'
-        assert calls[1]['kwargs']['osd_fsid'] == 'd0f3e4ad-e52a-4520-afc0-a8789a96ce8b'
+    @patch('ceph_volume.objectstore.lvmbluestore.LvmBlueStore.activate')
+    def test_detects_osds_to_activate_no_systemd(self, m_activate, is_root, monkeypatch):
+        monkeypatch.setattr('ceph_volume.objectstore.lvmbluestore.direct_report', lambda: direct_report)
+        args = ['--all', '--no-systemd', '--bluestore']
+        a = activate.Activate(args)
+        a.main()
+        calls = [
+            call(Namespace(activate_all=True,
+                           auto_detect_objectstore=False,
+                           bluestore=True,
+                           no_systemd=True,
+                           no_tmpfs=False,
+                           objectstore='bluestore',
+                           osd_fsid=None,
+                           osd_id=None),
+                           osd_id='0',
+                           osd_fsid='957d22b7-24ce-466a-9883-b8218eaa1634'),
+            call(Namespace(activate_all=True,
+                           auto_detect_objectstore=False,
+                           bluestore=True,
+                           no_systemd=True,
+                           no_tmpfs=False,
+                           objectstore='bluestore',
+                           osd_fsid=None,
+                           osd_id=None),
+                           osd_id='1',
+                           osd_fsid='d0f3e4ad-e52a-4520-afc0-a8789a96ce8b')
+        ]
+        m_activate.assert_has_calls(calls)
 
 #
 # Activate All fixture

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -54,14 +54,14 @@ class TestBatch(object):
                        devices=devs,
                        db_devices=[],
                        wal_devices=[],
-                       bluestore=True,
+                       objectstore='bluestore',
                        block_db_size="1G",
                        dmcrypt=True,
                        data_allocate_fraction=1.0,
                       )
         b = batch.Batch([])
-        plan = b.get_plan(args)
         b.args = args
+        plan = b.get_deployment_layout()
         b.report(plan)
 
     @pytest.mark.parametrize('format_', ['json', 'json-pretty'])

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_migrate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_migrate.py
@@ -524,7 +524,8 @@ class TestNew(object):
     def mock_prepare_dmcrypt(self, *args, **kwargs):
         return '/dev/mapper/' + kwargs['mapping']
 
-    def test_newdb_non_root(self):
+    @patch('os.getuid', return_value=1)
+    def test_newdb_non_root(self, m_getuid):
         with pytest.raises(Exception) as error:
             migrate.NewDB(argv=[
                 '--osd-id', '1',

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -39,7 +39,7 @@ class TestPrepareDevice(object):
 
 @patch('ceph_volume.util.prepare.create_key', return_value='fake-secret')
 class TestGetClusterFsid(object):
-    def setup(self):
+    def setup_method(self):
         self.p = lvm.prepare.Prepare([])
 
     def test_fsid_is_passed_in(self, m_create_key, factory):
@@ -57,7 +57,7 @@ class TestGetClusterFsid(object):
 @patch('ceph_volume.util.prepare.create_key', return_value='fake-secret')
 class TestPrepare(object):
 
-    def setup(self):
+    def setup_method(self):
         self.p = lvm.prepare.Prepare([])
 
     def test_main_spits_help_with_no_arguments(self, m_create_key, capsys):

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -2,6 +2,7 @@ import pytest
 from ceph_volume.devices import lvm
 from ceph_volume.api import lvm as api
 from mock.mock import patch, Mock
+from ceph_volume import objectstore
 
 
 class TestLVM(object):
@@ -24,102 +25,116 @@ class TestLVM(object):
         assert 'Format an LVM device' in stdout
 
 
+@patch('ceph_volume.util.prepare.create_key', return_value='fake-secret')
 class TestPrepareDevice(object):
 
-    def test_cannot_use_device(self, factory):
+    def test_cannot_use_device(self, m_create_key, factory):
         args = factory(data='/dev/var/foo')
         with pytest.raises(RuntimeError) as error:
             p = lvm.prepare.Prepare([])
-            p.args = args
-            p.prepare_data_device( 'data', '0')
+            p.objectstore = objectstore.lvmbluestore.LvmBlueStore(args=args)
+            p.objectstore.prepare_data_device( 'data', '0')
         assert 'Cannot use device (/dev/var/foo)' in str(error.value)
         assert 'A vg/lv path or an existing device is needed' in str(error.value)
 
-
+@patch('ceph_volume.util.prepare.create_key', return_value='fake-secret')
 class TestGetClusterFsid(object):
+    def setup(self):
+        self.p = lvm.prepare.Prepare([])
 
-    def test_fsid_is_passed_in(self, factory):
+    def test_fsid_is_passed_in(self, m_create_key, factory):
         args = factory(cluster_fsid='aaaa-1111')
-        prepare_obj = lvm.prepare.Prepare([])
-        prepare_obj.args = args
-        assert prepare_obj.get_cluster_fsid() == 'aaaa-1111'
+        self.p.objectstore = objectstore.lvmbluestore.LvmBlueStore(args)
+        assert self.p.objectstore.get_cluster_fsid() == 'aaaa-1111'
 
-    def test_fsid_is_read_from_ceph_conf(self, factory, conf_ceph_stub):
+    def test_fsid_is_read_from_ceph_conf(self, m_create_key, factory, conf_ceph_stub):
         conf_ceph_stub('[global]\nfsid = bbbb-2222')
-        prepare_obj = lvm.prepare.Prepare([])
-        prepare_obj.args = factory(cluster_fsid=None)
-        assert prepare_obj.get_cluster_fsid() == 'bbbb-2222'
+        args = factory(cluster_fsid='')
+        self.p.objectstore = objectstore.lvmbluestore.LvmBlueStore(args)
+        assert self.p.objectstore.get_cluster_fsid() == 'bbbb-2222'
 
 
+@patch('ceph_volume.util.prepare.create_key', return_value='fake-secret')
 class TestPrepare(object):
 
-    def test_main_spits_help_with_no_arguments(self, capsys):
+    def setup(self):
+        self.p = lvm.prepare.Prepare([])
+
+    def test_main_spits_help_with_no_arguments(self, m_create_key, capsys):
         lvm.prepare.Prepare([]).main()
         stdout, stderr = capsys.readouterr()
         assert 'Prepare an OSD by assigning an ID and FSID' in stdout
 
-    def test_main_shows_full_help(self, capsys):
+    def test_main_shows_full_help(self, m_create_key, capsys):
         with pytest.raises(SystemExit):
             lvm.prepare.Prepare(argv=['--help']).main()
         stdout, stderr = capsys.readouterr()
         assert 'Use the bluestore objectstore' in stdout
         assert 'A physical device or logical' in stdout
 
-    @patch('ceph_volume.devices.lvm.prepare.api.is_ceph_device')
-    def test_safe_prepare_osd_already_created(self, m_is_ceph_device):
+    @patch('ceph_volume.api.lvm.is_ceph_device')
+    def test_safe_prepare_osd_already_created(self, m_create_key, m_is_ceph_device):
         m_is_ceph_device.return_value = True
         with pytest.raises(RuntimeError) as error:
-            prepare = lvm.prepare.Prepare(argv=[])
-            prepare.args = Mock()
-            prepare.args.data = '/dev/sdfoo'
-            prepare.get_lv = Mock()
-            prepare.safe_prepare()
+            self.p.args = Mock()
+            self.p.args.data = '/dev/sdfoo'
+            self.p.get_lv = Mock()
+            self.p.objectstore = objectstore.lvmbluestore.LvmBlueStore(args=self.p.args)
+            self.p.objectstore.safe_prepare()
             expected = 'skipping {}, it is already prepared'.format('/dev/sdfoo')
             assert expected in str(error.value)
 
-    def test_setup_device_device_name_is_none(self):
-        result = lvm.prepare.Prepare([]).setup_device(device_type='data', device_name=None, tags={'ceph.type': 'data'}, size=0, slots=None)
+    def test_setup_device_device_name_is_none(self, m_create_key):
+        self.p.objectstore = objectstore.lvmbluestore.LvmBlueStore(args=[])
+        result = self.p.objectstore.setup_device(device_type='data',
+                                            device_name=None,
+                                            tags={'ceph.type': 'data'},
+                                            size=0,
+                                            slots=None)
         assert result == ('', '', {'ceph.type': 'data'})
 
     @patch('ceph_volume.api.lvm.Volume.set_tags')
-    @patch('ceph_volume.devices.lvm.prepare.api.get_single_lv')
-    def test_setup_device_lv_passed(self, m_get_single_lv, m_set_tags):
+    @patch('ceph_volume.api.lvm.get_single_lv')
+    def test_setup_device_lv_passed(self, m_get_single_lv, m_set_tags, m_create_key):
         fake_volume = api.Volume(lv_name='lv_foo', lv_path='/fake-path', vg_name='vg_foo', lv_tags='', lv_uuid='fake-uuid')
         m_get_single_lv.return_value = fake_volume
-        result = lvm.prepare.Prepare([]).setup_device(device_type='data', device_name='vg_foo/lv_foo', tags={'ceph.type': 'data'}, size=0, slots=None)
+        self.p.objectstore = objectstore.lvmbluestore.LvmBlueStore(args=[])
+        result = self.p.objectstore.setup_device(device_type='data', device_name='vg_foo/lv_foo', tags={'ceph.type': 'data'}, size=0, slots=None)
 
         assert result == ('/fake-path', 'fake-uuid', {'ceph.type': 'data',
                                                     'ceph.vdo': '0',
                                                     'ceph.data_uuid': 'fake-uuid',
                                                     'ceph.data_device': '/fake-path'})
 
-    @patch('ceph_volume.devices.lvm.prepare.api.create_lv')
+    @patch('ceph_volume.api.lvm.create_lv')
     @patch('ceph_volume.api.lvm.Volume.set_tags')
     @patch('ceph_volume.util.disk.is_device')
-    def test_setup_device_device_passed(self, m_is_device, m_set_tags, m_create_lv):
+    def test_setup_device_device_passed(self, m_is_device, m_set_tags, m_create_lv, m_create_key):
         fake_volume = api.Volume(lv_name='lv_foo', lv_path='/fake-path', vg_name='vg_foo', lv_tags='', lv_uuid='fake-uuid')
         m_is_device.return_value = True
         m_create_lv.return_value = fake_volume
-        result = lvm.prepare.Prepare([]).setup_device(device_type='data', device_name='/dev/sdx', tags={'ceph.type': 'data'}, size=0, slots=None)
+        self.p.objectstore = objectstore.lvmbluestore.LvmBlueStore(args=[])
+        result = self.p.objectstore.setup_device(device_type='data', device_name='/dev/sdx', tags={'ceph.type': 'data'}, size=0, slots=None)
 
         assert result == ('/fake-path', 'fake-uuid', {'ceph.type': 'data',
                                                     'ceph.vdo': '0',
                                                     'ceph.data_uuid': 'fake-uuid',
                                                     'ceph.data_device': '/fake-path'})
 
-    @patch('ceph_volume.devices.lvm.prepare.Prepare.get_ptuuid')
-    @patch('ceph_volume.devices.lvm.prepare.api.get_single_lv')
-    def test_setup_device_partition_passed(self, m_get_single_lv, m_get_ptuuid):
+    @patch('ceph_volume.objectstore.baseobjectstore.BaseObjectStore.get_ptuuid')
+    @patch('ceph_volume.api.lvm.get_single_lv')
+    def test_setup_device_partition_passed(self, m_get_single_lv, m_get_ptuuid, m_create_key):
         m_get_single_lv.side_effect = ValueError()
         m_get_ptuuid.return_value = 'fake-uuid'
-        result = lvm.prepare.Prepare([]).setup_device(device_type='data', device_name='/dev/sdx', tags={'ceph.type': 'data'}, size=0, slots=None)
+        self.p.objectstore = objectstore.lvmbluestore.LvmBlueStore(args=[])
+        result = self.p.objectstore.setup_device(device_type='data', device_name='/dev/sdx', tags={'ceph.type': 'data'}, size=0, slots=None)
 
         assert result == ('/dev/sdx', 'fake-uuid', {'ceph.type': 'data',
                                                     'ceph.vdo': '0',
                                                     'ceph.data_uuid': 'fake-uuid',
                                                     'ceph.data_device': '/dev/sdx'})
 
-    def test_invalid_osd_id_passed(self):
+    def test_invalid_osd_id_passed(self, m_create_key):
         with pytest.raises(SystemExit):
             lvm.prepare.Prepare(argv=['--osd-id', 'foo']).main()
 

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_zap.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_zap.py
@@ -139,17 +139,6 @@ class TestEnsureAssociatedLVs(object):
         out, err = capsys.readouterr()
         assert "Zapping successful for OSD: 1" in err
 
-    def test_block_and_partition_are_found(self, monkeypatch):
-        monkeypatch.setattr(zap.disk, 'get_device_from_partuuid', lambda x: '/dev/sdb1')
-        tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,ceph.type=block'
-        osd = api.Volume(
-            lv_name='volume1', lv_uuid='y', vg_name='', lv_path='/dev/VolGroup/block', lv_tags=tags)
-        volumes = []
-        volumes.append(osd)
-        result = zap.ensure_associated_lvs(volumes)
-        assert '/dev/sdb1' in result
-        assert '/dev/VolGroup/block' in result
-
     def test_journal_is_found(self, fake_call):
         tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,ceph.type=journal'
         osd = api.Volume(
@@ -211,7 +200,6 @@ class TestEnsureAssociatedLVs(object):
     def test_ensure_associated_lvs(self, m_get_lvs):
         zap.ensure_associated_lvs([], lv_tags={'ceph.osd_id': '1'})
         calls = [
-            call(tags={'ceph.type': 'journal', 'ceph.osd_id': '1'}),
             call(tags={'ceph.type': 'db', 'ceph.osd_id': '1'}),
             call(tags={'ceph.type': 'wal', 'ceph.osd_id': '1'})
         ]

--- a/src/ceph-volume/ceph_volume/tests/devices/raw/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/raw/test_prepare.py
@@ -1,6 +1,6 @@
 import pytest
 from ceph_volume.devices import raw
-from mock.mock import patch
+from mock.mock import patch, MagicMock
 from ceph_volume import objectstore
 
 class TestRaw(object):
@@ -47,8 +47,13 @@ class TestPrepare(object):
         assert 'Path to bluestore block.wal block device' in stdout
         assert 'Enable device encryption via dm-crypt' in stdout
 
+    @patch('ceph_volume.util.arg_validators.set_dmcrypt_no_workqueue', return_value=MagicMock())
     @patch('ceph_volume.util.arg_validators.ValidRawDevice.__call__')
-    def test_prepare_dmcrypt_no_secret_passed(self, m_valid_device, m_create_key, capsys):
+    def test_prepare_dmcrypt_no_secret_passed(self,
+                                              m_valid_device,
+                                              m_set_dmcrypt_no_workqueue,
+                                              m_create_key,
+                                              capsys):
         m_valid_device.return_value = '/dev/foo'
         with pytest.raises(SystemExit):
             raw.prepare.Prepare(argv=['--bluestore', '--data', '/dev/foo', '--dmcrypt']).main()

--- a/src/ceph-volume/ceph_volume/tests/devices/raw/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/raw/test_prepare.py
@@ -1,7 +1,7 @@
 import pytest
 from ceph_volume.devices import raw
 from mock.mock import patch
-
+from ceph_volume import objectstore
 
 class TestRaw(object):
 
@@ -22,15 +22,21 @@ class TestRaw(object):
         assert 'prepare ' in stdout
         assert 'Format a raw device' in stdout
 
-
+@patch('ceph_volume.util.prepare.create_key', return_value='fake-secret')
 class TestPrepare(object):
+    def _setup(self, **kw):
+        args = kw.get('args', [])
+        self.p = raw.prepare.Prepare([])
+        self.p.objectstore = objectstore.rawbluestore.RawBlueStore(args=args)
+        for k, v in kw.items():
+            setattr(self.p.objectstore, k, v)
 
-    def test_main_spits_help_with_no_arguments(self, capsys):
+    def test_main_spits_help_with_no_arguments(self, m_create_key, capsys):
         raw.prepare.Prepare([]).main()
         stdout, stderr = capsys.readouterr()
         assert 'Prepare an OSD by assigning an ID and FSID' in stdout
 
-    def test_main_shows_full_help(self, capsys):
+    def test_main_shows_full_help(self, m_create_key, capsys):
         with pytest.raises(SystemExit):
             raw.prepare.Prepare(argv=['--help']).main()
         stdout, stderr = capsys.readouterr()
@@ -42,7 +48,7 @@ class TestPrepare(object):
         assert 'Enable device encryption via dm-crypt' in stdout
 
     @patch('ceph_volume.util.arg_validators.ValidRawDevice.__call__')
-    def test_prepare_dmcrypt_no_secret_passed(self, m_valid_device, capsys):
+    def test_prepare_dmcrypt_no_secret_passed(self, m_valid_device, m_create_key, capsys):
         m_valid_device.return_value = '/dev/foo'
         with pytest.raises(SystemExit):
             raw.prepare.Prepare(argv=['--bluestore', '--data', '/dev/foo', '--dmcrypt']).main()
@@ -52,43 +58,52 @@ class TestPrepare(object):
     @patch('ceph_volume.util.encryption.luks_open')
     @patch('ceph_volume.util.encryption.luks_format')
     @patch('ceph_volume.util.disk.lsblk')
-    def test_prepare_dmcrypt_block(self, m_lsblk, m_luks_format, m_luks_open):
+    def test_prepare_dmcrypt_block(self, m_lsblk, m_luks_format, m_luks_open, m_create_key, factory):
         m_lsblk.return_value = {'KNAME': 'foo'}
         m_luks_format.return_value = True
         m_luks_open.return_value = True
-        result = raw.prepare.prepare_dmcrypt('foo', '/dev/foo', 'block', '123')
+        self._setup(block_device_path='/dev/foo',
+                    osd_fsid='123',
+                    secrets=dict(dmcrypt_key='foo'))
+        self.p.objectstore.prepare_dmcrypt()
         m_luks_open.assert_called_with('foo', '/dev/foo', 'ceph-123-foo-block-dmcrypt')
         m_luks_format.assert_called_with('foo', '/dev/foo')
-        assert result == '/dev/mapper/ceph-123-foo-block-dmcrypt'
+        assert self.p.objectstore.__dict__['block_device_path'] == '/dev/mapper/ceph-123-foo-block-dmcrypt'
 
     @patch('ceph_volume.util.encryption.luks_open')
     @patch('ceph_volume.util.encryption.luks_format')
     @patch('ceph_volume.util.disk.lsblk')
-    def test_prepare_dmcrypt_db(self, m_lsblk, m_luks_format, m_luks_open):
+    def test_prepare_dmcrypt_db(self, m_lsblk, m_luks_format, m_luks_open, m_create_key):
         m_lsblk.return_value = {'KNAME': 'foo'}
         m_luks_format.return_value = True
         m_luks_open.return_value = True
-        result = raw.prepare.prepare_dmcrypt('foo', '/dev/foo', 'db', '123')
-        m_luks_open.assert_called_with('foo', '/dev/foo', 'ceph-123-foo-db-dmcrypt')
-        m_luks_format.assert_called_with('foo', '/dev/foo')
-        assert result == '/dev/mapper/ceph-123-foo-db-dmcrypt'
+        self._setup(db_device_path='/dev/db-foo',
+                    osd_fsid='456',
+                    secrets=dict(dmcrypt_key='foo'))
+        self.p.objectstore.prepare_dmcrypt()
+        m_luks_open.assert_called_with('foo', '/dev/db-foo', 'ceph-456-foo-db-dmcrypt')
+        m_luks_format.assert_called_with('foo', '/dev/db-foo')
+        assert self.p.objectstore.__dict__['db_device_path'] == '/dev/mapper/ceph-456-foo-db-dmcrypt'
 
     @patch('ceph_volume.util.encryption.luks_open')
     @patch('ceph_volume.util.encryption.luks_format')
     @patch('ceph_volume.util.disk.lsblk')
-    def test_prepare_dmcrypt_wal(self, m_lsblk, m_luks_format, m_luks_open):
+    def test_prepare_dmcrypt_wal(self, m_lsblk, m_luks_format, m_luks_open, m_create_key):
         m_lsblk.return_value = {'KNAME': 'foo'}
         m_luks_format.return_value = True
         m_luks_open.return_value = True
-        result = raw.prepare.prepare_dmcrypt('foo', '/dev/foo', 'wal', '123')
-        m_luks_open.assert_called_with('foo', '/dev/foo', 'ceph-123-foo-wal-dmcrypt')
-        m_luks_format.assert_called_with('foo', '/dev/foo')
-        assert result == '/dev/mapper/ceph-123-foo-wal-dmcrypt'
+        self._setup(wal_device_path='/dev/wal-foo',
+                    osd_fsid='789',
+                    secrets=dict(dmcrypt_key='foo'))
+        self.p.objectstore.prepare_dmcrypt()
+        m_luks_open.assert_called_with('foo', '/dev/wal-foo', 'ceph-789-foo-wal-dmcrypt')
+        m_luks_format.assert_called_with('foo', '/dev/wal-foo')
+        assert self.p.objectstore.__dict__['wal_device_path'] == '/dev/mapper/ceph-789-foo-wal-dmcrypt'
 
-    @patch('ceph_volume.devices.raw.prepare.rollback_osd')
-    @patch('ceph_volume.devices.raw.prepare.Prepare.prepare')
+    @patch('ceph_volume.objectstore.rawbluestore.rollback_osd')
+    @patch('ceph_volume.objectstore.rawbluestore.RawBlueStore.prepare')
     @patch('ceph_volume.util.arg_validators.ValidRawDevice.__call__')
-    def test_safe_prepare_exception_raised(self, m_valid_device, m_prepare, m_rollback_osd):
+    def test_safe_prepare_exception_raised(self, m_valid_device, m_prepare, m_rollback_osd, m_create_key):
         m_valid_device.return_value = '/dev/foo'
         m_prepare.side_effect=Exception('foo')
         m_rollback_osd.return_value = 'foobar'

--- a/src/ceph-volume/ceph_volume/tests/devices/simple/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/simple/test_activate.py
@@ -1,11 +1,13 @@
 import os
 import pytest
 from ceph_volume.devices.simple import activate
+from mock.mock import patch
 
 
 class TestActivate(object):
 
-    def test_no_data_uuid(self, factory, is_root, monkeypatch, capture, fake_filesystem):
+    @patch('ceph_volume.decorators.os.getuid', return_value=0)
+    def test_no_data_uuid(self, m_getuid, factory, capture, fake_filesystem):
         fake_filesystem.create_file('/tmp/json-config', contents='{}')
         args = factory(osd_id='0', osd_fsid='1234', json_config='/tmp/json-config')
         with pytest.raises(RuntimeError):
@@ -22,7 +24,7 @@ class TestActivate(object):
         stdout, stderr = capsys.readouterr()
         assert 'Activate OSDs by mounting devices previously configured' in stdout
 
-    def test_activate_all(self, is_root, monkeypatch):
+    def test_activate_all(self, monkeypatch):
         '''
         make sure Activate calls activate for each file returned by glob
         '''

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_baseobjectstore.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_baseobjectstore.py
@@ -1,0 +1,162 @@
+import pytest
+from mock.mock import patch, Mock, call
+from ceph_volume.objectstore.baseobjectstore import BaseObjectStore
+from ceph_volume.util import system
+
+
+@patch('ceph_volume.objectstore.baseobjectstore.prepare_utils.create_key', Mock(return_value=['AQCee6ZkzhOrJRAAZWSvNC3KdXOpC2w8ly4AZQ==']))
+class TestBaseObjectStore:
+    def test_init_dmcrypt(self, factory):
+        args = factory(dmcrypt=True)
+        bo = BaseObjectStore(args)
+        assert bo.encrypted == 1
+        assert bo.cephx_lockbox_secret == ['AQCee6ZkzhOrJRAAZWSvNC3KdXOpC2w8ly4AZQ==']
+        assert bo.secrets['cephx_lockbox_secret'] == ['AQCee6ZkzhOrJRAAZWSvNC3KdXOpC2w8ly4AZQ==']
+
+    @patch('ceph_volume.process.call', Mock(return_value=(['c6798f59-01'], '', 0)))
+    def test_get_ptuuid_ok(self):
+        """
+        Test that the ptuuid is returned
+        """
+        assert BaseObjectStore([]).get_ptuuid('/dev/sda') == 'c6798f59-01'
+
+    @patch('ceph_volume.process.call', Mock(return_value=('', '', 0)))
+    def test_get_ptuuid_raises_runtime_error(self, capsys):
+        """
+        Test that the ptuuid is returned
+        """
+        with pytest.raises(RuntimeError) as error:
+            bo = BaseObjectStore([])
+            bo.get_ptuuid('/dev/sda')
+        stdout, stderr = capsys.readouterr()
+        assert 'blkid could not detect a PARTUUID for device: /dev/sda' in stderr
+        assert str(error.value) == 'unable to use device'
+
+    @patch.dict('os.environ', {'CEPH_VOLUME_OSDSPEC_AFFINITY': 'foo'})
+    def test_get_osdspec_affinity(self):
+        assert BaseObjectStore([]).get_osdspec_affinity() == 'foo'
+
+    def test_pre_prepare(self):
+        with pytest.raises(NotImplementedError):
+            BaseObjectStore([]).pre_prepare()
+
+    def test_prepare_data_device(self):
+        with pytest.raises(NotImplementedError):
+            BaseObjectStore([]).prepare_data_device('foo', 'bar')
+
+    def test_safe_prepare(self):
+        with pytest.raises(NotImplementedError):
+            BaseObjectStore([]).safe_prepare(args=None)
+
+    def test_add_objectstore_opts(self):
+        with pytest.raises(NotImplementedError):
+            BaseObjectStore([]).add_objectstore_opts()
+
+    @patch('ceph_volume.util.prepare.create_osd_path')
+    @patch('ceph_volume.util.prepare.link_block')
+    @patch('ceph_volume.util.prepare.get_monmap')
+    @patch('ceph_volume.util.prepare.write_keyring')
+    def test_prepare_osd_req(self, m_write_keyring, m_get_monmap, m_link_block, m_create_osd_path):
+        bo = BaseObjectStore([])
+        bo.osd_id = '123'
+        bo.block_device_path = '/dev/foo'
+        bo.prepare_osd_req()
+        assert m_create_osd_path.mock_calls == [call('123', tmpfs=True)]
+        assert m_link_block.mock_calls == [call('/dev/foo', '123')]
+        assert m_get_monmap.mock_calls == [call('123')]
+        assert m_write_keyring.mock_calls == [call('123', ['AQCee6ZkzhOrJRAAZWSvNC3KdXOpC2w8ly4AZQ=='])]
+
+    def test_prepare(self):
+        with pytest.raises(NotImplementedError):
+            BaseObjectStore([]).prepare()
+
+    def test_prepare_dmcrypt(self):
+        with pytest.raises(NotImplementedError):
+            BaseObjectStore([]).prepare_dmcrypt()
+
+    def test_cluster_fsid_from_args(self, factory):
+        args = factory(cluster_fsid='abcd')
+        bo = BaseObjectStore(args)
+        assert bo.get_cluster_fsid() == 'abcd'
+
+    def test_cluster_fsid_from_conf(self, conf_ceph_stub, factory):
+        args = factory(cluster_fsid=None)
+        conf_ceph_stub('[global]\nfsid = abcd-123')
+        bo = BaseObjectStore([])
+        bo.args = args
+        assert bo.get_cluster_fsid() == 'abcd-123'
+
+    @patch('ceph_volume.conf.cluster', 'ceph')
+    def test_get_osd_path(self):
+        bo = BaseObjectStore([])
+        bo.osd_id = '123'
+        assert bo.get_osd_path() == '/var/lib/ceph/osd/ceph-123/'
+
+    @patch('ceph_volume.conf.cluster', 'ceph')
+    def test_build_osd_mkfs_cmd_base(self):
+        bo = BaseObjectStore([])
+        bo.osd_path = '/var/lib/ceph/osd/ceph-123/'
+        bo.osd_fsid = 'abcd-1234'
+        bo.objectstore = 'my-fake-objectstore'
+        bo.osd_id = '123'
+        bo.monmap = '/etc/ceph/ceph.monmap'
+        result = bo.build_osd_mkfs_cmd()
+
+        assert result == ['ceph-osd',
+                          '--cluster',
+                          'ceph',
+                          '--osd-objectstore',
+                          'my-fake-objectstore',
+                          '--mkfs', '-i', '123',
+                          '--monmap',
+                          '/etc/ceph/ceph.monmap',
+                          '--keyfile', '-',
+                          '--osd-data',
+                          '/var/lib/ceph/osd/ceph-123/',
+                          '--osd-uuid', 'abcd-1234',
+                          '--setuser', 'ceph',
+                          '--setgroup', 'ceph']
+
+    def test_osd_mkfs_ok(self, monkeypatch, fake_call):
+        bo = BaseObjectStore([])
+        bo.get_osd_path = lambda: '/var/lib/ceph/osd/ceph-123/'
+        bo.build_osd_mkfs_cmd = lambda: ['ceph-osd', '--mkfs', 'some', 'fake', 'args']
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        bo.osd_mkfs()
+        assert fake_call.calls == [
+            {
+                'args': (['ceph-osd',
+                          '--mkfs',
+                          'some',
+                          'fake',
+                          'args'],),
+                'kwargs': {
+                    'stdin': ['AQCee6ZkzhOrJRAAZWSvNC3KdXOpC2w8ly4AZQ=='],
+                    'terminal_verbose': True,
+                    'show_command': True}
+                }
+            ]
+
+    @patch('ceph_volume.process.call', Mock(return_value=([], [], 999)))
+    def test_osd_mkfs_fails(self, monkeypatch):
+        bo = BaseObjectStore([])
+        bo.get_osd_path = lambda: '/var/lib/ceph/osd/ceph-123/'
+        bo.build_osd_mkfs_cmd = lambda: ['ceph-osd', '--mkfs', 'some', 'fake', 'args']
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        with pytest.raises(RuntimeError) as error:
+            bo.osd_mkfs()
+        assert str(error.value) == 'Command failed with exit code 999: ceph-osd --mkfs some fake args'
+
+    @patch('time.sleep', Mock())
+    @patch('ceph_volume.process.call', return_value=([], [], 11))
+    def test_osd_mkfs_fails_EWOULDBLOCK(self, m_call, monkeypatch):
+        bo = BaseObjectStore([])
+        bo.get_osd_path = lambda: '/var/lib/ceph/osd/ceph-123/'
+        bo.build_osd_mkfs_cmd = lambda: ['ceph-osd', '--mkfs', 'some', 'fake', 'args']
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        bo.osd_mkfs()
+        assert m_call.call_count == 5
+
+    def test_activate(self):
+        with pytest.raises(NotImplementedError):
+            BaseObjectStore([]).activate()

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_bluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_bluestore.py
@@ -1,0 +1,27 @@
+from mock import patch, Mock
+from ceph_volume.objectstore.bluestore import BlueStore
+
+
+class TestBlueStore:
+    @patch('ceph_volume.objectstore.baseobjectstore.prepare_utils.create_key', Mock(return_value=['AQCee6ZkzhOrJRAAZWSvNC3KdXOpC2w8ly4AZQ==']))
+    def setup_method(self, m_create_key):
+        self.b = BlueStore([])
+        self.b.osd_mkfs_cmd = ['binary', 'arg1']
+
+    def test_add_objectstore_opts_wal_device_path(self, monkeypatch):
+        monkeypatch.setattr('ceph_volume.util.system.chown', lambda path: 0)
+        self.b.wal_device_path = '/dev/nvme0n1'
+        self.b.add_objectstore_opts()
+        assert self.b.osd_mkfs_cmd == ['binary', 'arg1', '--bluestore-block-wal-path', '/dev/nvme0n1']
+
+    def test_add_objectstore_opts_db_device_path(self, monkeypatch):
+        monkeypatch.setattr('ceph_volume.util.system.chown', lambda path: 0)
+        self.b.db_device_path = '/dev/ssd1'
+        self.b.add_objectstore_opts()
+        assert self.b.osd_mkfs_cmd == ['binary', 'arg1', '--bluestore-block-db-path', '/dev/ssd1']
+
+    def test_add_objectstore_opts_osdspec_affinity(self, monkeypatch):
+        monkeypatch.setattr('ceph_volume.util.system.chown', lambda path: 0)
+        self.b.get_osdspec_affinity = lambda: 'foo'
+        self.b.add_objectstore_opts()
+        assert self.b.osd_mkfs_cmd == ['binary', 'arg1', '--osdspec-affinity', 'foo']

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_lvmbluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_lvmbluestore.py
@@ -1,0 +1,561 @@
+import pytest
+from mock import patch, Mock, MagicMock, call
+from ceph_volume.objectstore.lvmbluestore import LvmBlueStore
+from ceph_volume.api.lvm import Volume
+from ceph_volume.util import system
+
+
+class TestLvmBlueStore:
+    @patch('ceph_volume.objectstore.lvmbluestore.prepare_utils.create_key', Mock(return_value=['AQCee6ZkzhOrJRAAZWSvNC3KdXOpC2w8ly4AZQ==']))
+    def setup_method(self, m_create_key):
+        self.lvm_bs = LvmBlueStore([])
+
+    @patch('ceph_volume.conf.cluster', 'ceph')
+    @patch('ceph_volume.api.lvm.get_single_lv')
+    @patch('ceph_volume.objectstore.lvmbluestore.prepare_utils.create_id', Mock(return_value='111'))
+    @patch('ceph_volume.objectstore.lvmbluestore.encryption_utils.create_dmcrypt_key', Mock(return_value='fake-dmcrypt-key'))
+    def test_pre_prepare_lv(self, m_get_single_lv, factory):
+        args = factory(cluster_fsid='abcd',
+                       osd_fsid='abc123',
+                       crush_device_class='ssd',
+                       osd_id='111',
+                       data='vg_foo/lv_foo')
+        m_get_single_lv.return_value = Volume(lv_name='lv_foo',
+                                              lv_path='/fake-path',
+                                              vg_name='vg_foo',
+                                              lv_tags='',
+                                              lv_uuid='fake-uuid')
+        self.lvm_bs.encrypted = True
+        self.lvm_bs.args = args
+        self.lvm_bs.pre_prepare()
+        assert self.lvm_bs.secrets['dmcrypt_key'] == 'fake-dmcrypt-key'
+        assert self.lvm_bs.secrets['crush_device_class'] == 'ssd'
+        assert self.lvm_bs.osd_id == '111'
+        assert self.lvm_bs.block_device_path == '/fake-path'
+        assert self.lvm_bs.tags == {'ceph.osd_fsid': 'abc123',
+                                    'ceph.osd_id': '111',
+                                    'ceph.cluster_fsid': 'abcd',
+                                    'ceph.cluster_name': 'ceph',
+                                    'ceph.crush_device_class': 'ssd',
+                                    'ceph.osdspec_affinity': '',
+                                    'ceph.block_device': '/fake-path',
+                                    'ceph.block_uuid': 'fake-uuid',
+                                    'ceph.cephx_lockbox_secret': '',
+                                    'ceph.encrypted': True,
+                                    'ceph.vdo': '0'}
+
+    @patch('ceph_volume.objectstore.lvmbluestore.prepare_utils.create_id', Mock(return_value='111'))
+    @patch('ceph_volume.objectstore.lvmbluestore.encryption_utils.create_dmcrypt_key', Mock(return_value='fake-dmcrypt-key'))
+    def test_pre_prepare_no_lv(self, factory):
+        args = factory(cluster_fsid='abcd',
+                       osd_fsid='abc123',
+                       crush_device_class='ssd',
+                       osd_id='111',
+                       data='/dev/foo')
+        self.lvm_bs.prepare_data_device = lambda x, y: Volume(lv_name='lv_foo',
+                                                              lv_path='/fake-path',
+                                                              vg_name='vg_foo',
+                                                              lv_tags='',
+                                                              lv_uuid='fake-uuid')
+        self.lvm_bs.encrypted = True
+        self.lvm_bs.args = args
+        self.lvm_bs.pre_prepare()
+        assert self.lvm_bs.secrets['dmcrypt_key'] == 'fake-dmcrypt-key'
+        assert self.lvm_bs.secrets['crush_device_class'] == 'ssd'
+        assert self.lvm_bs.osd_id == '111'
+        assert self.lvm_bs.block_device_path == '/fake-path'
+        assert self.lvm_bs.tags == {'ceph.osd_fsid': 'abc123',
+                                    'ceph.osd_id': '111',
+                                    'ceph.cluster_fsid': 'abcd',
+                                    'ceph.cluster_name': None,
+                                    'ceph.crush_device_class': 'ssd',
+                                    'ceph.osdspec_affinity': '',
+                                    'ceph.block_device': '/fake-path',
+                                    'ceph.block_uuid': 'fake-uuid',
+                                    'ceph.cephx_lockbox_secret': '',
+                                    'ceph.encrypted': True,
+                                    'ceph.vdo': '0'}
+
+    @patch('ceph_volume.util.disk.is_partition', Mock(return_value=True))
+    @patch('ceph_volume.api.lvm.create_lv')
+    def test_prepare_data_device(self, m_create_lv, factory):
+        args = factory(data='/dev/foo',
+                       data_slots=1,
+                       data_size=102400)
+        self.lvm_bs.args = args
+        m_create_lv.return_value = Volume(lv_name='lv_foo',
+                                          lv_path='/fake-path',
+                                          vg_name='vg_foo',
+                                          lv_tags='',
+                                          lv_uuid='abcd')
+        assert self.lvm_bs.prepare_data_device('block', 'abcd') == m_create_lv.return_value
+        assert self.lvm_bs.args.data_size == 102400
+
+    @patch('ceph_volume.util.disk.is_device', Mock(return_value=False))
+    @patch('ceph_volume.util.disk.is_partition', Mock(return_value=False))
+    def test_prepare_data_device_fails(self, factory):
+        args = factory(data='/dev/foo')
+        self.lvm_bs.args = args
+        with pytest.raises(RuntimeError) as error:
+            self.lvm_bs.prepare_data_device('block', 'abcd')
+        assert ('Cannot use device (/dev/foo). '
+        'A vg/lv path or an existing device is needed') == str(error.value)
+
+    @patch('ceph_volume.api.lvm.is_ceph_device', Mock(return_value=True))
+    @patch('ceph_volume.api.lvm.get_single_lv')
+    def test_safe_prepare_is_ceph_device(self, m_get_single_lv, factory):
+        args = factory(data='/dev/foo')
+        self.lvm_bs.args = args
+        m_get_single_lv.return_value = Volume(lv_name='lv_foo',
+                                              lv_path='/fake-path',
+                                              vg_name='vg_foo',
+                                              lv_tags='',
+                                              lv_uuid='fake-uuid')
+        self.lvm_bs.prepare = MagicMock()
+        with pytest.raises(RuntimeError) as error:
+            self.lvm_bs.safe_prepare(args)
+        assert str(error.value) == 'skipping /dev/foo, it is already prepared'
+
+    @patch('ceph_volume.api.lvm.is_ceph_device', Mock(return_value=False))
+    @patch('ceph_volume.api.lvm.get_single_lv')
+    def test_safe_prepare(self, m_get_single_lv, factory):
+        args = factory(data='vg_foo/lv_foo')
+        self.lvm_bs.args = args
+        m_get_single_lv.return_value = Volume(lv_name='lv_foo',
+                                              lv_path='/fake-path',
+                                              vg_name='vg_foo',
+                                              lv_tags='',
+                                              lv_uuid='fake-uuid')
+        self.lvm_bs.prepare = MagicMock()
+        self.lvm_bs.safe_prepare()
+        assert self.lvm_bs.prepare.called
+
+    @patch('ceph_volume.objectstore.lvmbluestore.LvmBlueStore.prepare', Mock(side_effect=Exception))
+    @patch('ceph_volume.api.lvm.is_ceph_device', Mock(return_value=False))
+    # @patch('ceph_volume.devices.lvm.common.rollback_osd')
+    @patch('ceph_volume.objectstore.lvmbluestore.rollback_osd')
+    @patch('ceph_volume.api.lvm.get_single_lv')
+    def test_safe_prepare_raises_exception(self, m_get_single_lv, m_rollback_osd, factory):
+        args = factory(data='/dev/foo')
+        self.lvm_bs.args = args
+        self.lvm_bs.osd_id = '111'
+        m_get_single_lv.return_value = Volume(lv_name='lv_foo',
+                                              lv_path='/fake-path',
+                                              vg_name='vg_foo',
+                                              lv_tags='',
+                                              lv_uuid='fake-uuid')
+        m_rollback_osd.return_value = MagicMock()
+        with pytest.raises(Exception):
+            self.lvm_bs.safe_prepare()
+        assert m_rollback_osd.mock_calls == [call(self.lvm_bs.args, '111')]
+
+    @patch('ceph_volume.objectstore.baseobjectstore.BaseObjectStore.get_ptuuid', Mock(return_value='c6798f59-01'))
+    @patch('ceph_volume.api.lvm.Volume.set_tags', MagicMock())
+    @patch('ceph_volume.api.lvm.get_single_lv')
+    def test_prepare(self, m_get_single_lv, factory):
+        m_get_single_lv.return_value = Volume(lv_name='lv_foo',
+                                              lv_path='/fake-path',
+                                              vg_name='vg_foo',
+                                              lv_tags='',
+                                              lv_uuid='fake-uuid')
+        args = factory(data='vg_foo/lv_foo',
+                       block_wal='/dev/foo1',
+                       block_db='/dev/foo2',
+                       block_wal_size=123,
+                       block_db_size=123,
+                       block_wal_slots=1,
+                       block_db_slots=1,
+                       )
+        self.lvm_bs.args = args
+        self.lvm_bs.pre_prepare = lambda: None
+        self.lvm_bs.block_lv = MagicMock()
+        self.lvm_bs.prepare_osd_req = MagicMock()
+        self.lvm_bs.osd_mkfs = MagicMock()
+        self.lvm_bs.prepare_dmcrypt = MagicMock()
+        self.lvm_bs.secrets['dmcrypt_key'] = 'fake-secret'
+        self.lvm_bs.prepare()
+        assert self.lvm_bs.wal_device_path == '/dev/foo1'
+        assert self.lvm_bs.db_device_path == '/dev/foo2'
+        assert self.lvm_bs.block_lv.set_tags.mock_calls == [call({'ceph.type': 'block', 'ceph.vdo': '0', 'ceph.wal_uuid': 'c6798f59-01', 'ceph.wal_device': '/dev/foo1', 'ceph.db_uuid': 'c6798f59-01', 'ceph.db_device': '/dev/foo2'})]
+        assert self.lvm_bs.prepare_dmcrypt.called
+        assert self.lvm_bs.osd_mkfs.called
+        assert self.lvm_bs.prepare_osd_req.called
+
+    def test_prepare_dmcrypt(self):
+        self.lvm_bs.secrets = {'dmcrypt_key': 'fake-secret'}
+        self.lvm_bs.tags = {'ceph.block_uuid': 'block-uuid1',
+                            'ceph.db_uuid': 'db-uuid2',
+                            'ceph.wal_uuid': 'wal-uuid3'}
+        self.lvm_bs.luks_format_and_open = lambda *a: f'/dev/mapper/{a[3]["ceph."+a[2]+"_uuid"]}'
+        self.lvm_bs.prepare_dmcrypt()
+        assert self.lvm_bs.block_device_path == '/dev/mapper/block-uuid1'
+        assert self.lvm_bs.db_device_path == '/dev/mapper/db-uuid2'
+        assert self.lvm_bs.wal_device_path == '/dev/mapper/wal-uuid3'
+
+    @patch('ceph_volume.objectstore.lvmbluestore.encryption_utils.luks_open')
+    @patch('ceph_volume.objectstore.lvmbluestore.encryption_utils.luks_format')
+    def test_luks_format_and_open(self, m_luks_format, m_luks_open):
+        result = self.lvm_bs.luks_format_and_open('key',
+                                                  '/dev/foo',
+                                                  'block',
+                                                  {'ceph.block_uuid': 'block-uuid1'})
+        assert result == '/dev/mapper/block-uuid1'
+
+    def test_luks_format_and_open_not_device(self):
+        result = self.lvm_bs.luks_format_and_open('key',
+                                                  '',
+                                                  'block',
+                                                  {})
+        assert result == ''
+
+    def test_setup_device_is_none(self):
+        result = self.lvm_bs.setup_device('block',
+                                          None,
+                                          {},
+                                          1,
+                                          1)
+        assert result == ('', '', {})
+
+    @patch('ceph_volume.api.lvm.Volume.set_tags', return_value=MagicMock())
+    @patch('ceph_volume.util.system.generate_uuid',
+           Mock(return_value='d83fa1ca-bd68-4c75-bdc2-464da58e8abd'))
+    @patch('ceph_volume.api.lvm.create_lv')
+    @patch('ceph_volume.util.disk.is_device', Mock(return_value=True))
+    def test_setup_device_is_device(self, m_create_lv, m_set_tags):
+        m_create_lv.return_value = Volume(lv_name='lv_foo',
+                                          lv_path='/fake-path',
+                                          vg_name='vg_foo',
+                                          lv_tags='',
+                                          lv_uuid='fake-uuid')
+        result = self.lvm_bs.setup_device('block',
+                                          '/dev/foo',
+                                          {},
+                                          1,
+                                          1)
+        assert m_create_lv.mock_calls == [call('osd-block',
+                                               'd83fa1ca-bd68-4c75-bdc2-464da58e8abd',
+                                               device='/dev/foo',
+                                               tags={'ceph.type': 'block',
+                                                     'ceph.vdo': '0',
+                                                     'ceph.block_device': '/fake-path',
+                                                     'ceph.block_uuid': 'fake-uuid'},
+                                               slots=1,
+                                               size=1)]
+        assert result == ('/fake-path',
+                         'fake-uuid',
+                         {'ceph.type': 'block',
+                          'ceph.vdo': '0',
+                          'ceph.block_device': '/fake-path',
+                          'ceph.block_uuid': 'fake-uuid'
+                          })
+
+    @patch('ceph_volume.api.lvm.get_single_lv')
+    @patch('ceph_volume.api.lvm.Volume.set_tags', return_value=MagicMock())
+    def test_setup_device_is_lv(self, m_set_tags, m_get_single_lv):
+        m_get_single_lv.return_value = Volume(lv_name='lv_foo',
+                                              lv_path='/fake-path',
+                                              vg_name='vg_foo',
+                                              lv_tags='',
+                                              lv_uuid='fake-uuid')
+        result = self.lvm_bs.setup_device('block',
+                                          'vg_foo/lv_foo',
+                                          {},
+                                          1,
+                                          1)
+        assert result == ('/fake-path',
+                         'fake-uuid',
+                         {'ceph.type': 'block',
+                          'ceph.vdo': '0',
+                          'ceph.block_device': '/fake-path',
+                          'ceph.block_uuid': 'fake-uuid'
+                          })
+
+    @patch('ceph_volume.api.lvm.Volume.set_tags', return_value=MagicMock())
+    def test_setup_device_partition(self, m_set_tags):
+        self.lvm_bs.get_ptuuid = lambda x: 'c6798f59-01'
+        result = self.lvm_bs.setup_device('block',
+                                          '/dev/foo1',
+                                          {},
+                                          1,
+                                          1)
+        assert result == ('/dev/foo1',
+                         'c6798f59-01',
+                         {'ceph.type': 'block',
+                          'ceph.vdo': '0',
+                          'ceph.block_uuid': 'c6798f59-01',
+                          'ceph.block_device': '/dev/foo1'})
+
+    def test_get_osd_device_path_lv_block(self):
+        lvs = [Volume(lv_name='lv_foo',
+                      lv_path='/fake-path',
+                      vg_name='vg_foo',
+                      lv_tags='ceph.type=block,ceph.block_uuid=fake-block-uuid',
+                      lv_uuid='fake-block-uuid')]
+        assert self.lvm_bs.get_osd_device_path(lvs, 'block') == '/fake-path'
+
+    @patch('ceph_volume.objectstore.lvmbluestore.encryption_utils.luks_open', MagicMock())
+    def test_get_osd_device_path_lv_block_encrypted(self):
+        lvs = [Volume(lv_name='lv_foo',
+                      lv_path='/fake-path',
+                      vg_name='vg_foo',
+                      lv_tags='ceph.type=block,ceph.block_uuid=fake-block-uuid,ceph.encrypted=1',
+                      lv_uuid='fake-block-uuid')]
+        assert self.lvm_bs.get_osd_device_path(lvs, 'block') == '/dev/mapper/fake-block-uuid'
+
+    def test_get_osd_device_path_lv_db(self):
+        lvs = [Volume(lv_name='lv_foo-block',
+                      lv_path='/fake-block-path',
+                      vg_name='vg_foo',
+                      lv_tags='ceph.type=block,ceph.block_uuid=fake-block-uuid,ceph.db_uuid=fake-db-uuid',
+                      lv_uuid='fake-block-uuid'),
+               Volume(lv_name='lv_foo-db',
+                      lv_path='/fake-db-path',
+                      vg_name='vg_foo_db',
+                      lv_tags='ceph.type=db,ceph.block_uuid=fake-block-uuid,ceph.db_uuid=fake-db-uuid',
+                      lv_uuid='fake-db-uuid')]
+        assert self.lvm_bs.get_osd_device_path(lvs, 'db') == '/fake-db-path'
+
+    def test_get_osd_device_path_no_device_uuid(self):
+        lvs = [Volume(lv_name='lv_foo-block',
+                      lv_path='/fake-block-path',
+                      vg_name='vg_foo',
+                      lv_tags='ceph.type=block,ceph.block_uuid=fake-block-uuid',
+                      lv_uuid='fake-block-uuid'),
+               Volume(lv_name='lv_foo-db',
+                      lv_path='/fake-db-path',
+                      vg_name='vg_foo_db',
+                      lv_tags='ceph.type=db,ceph.block_uuid=fake-block-uuid',
+                      lv_uuid='fake-db-uuid')]
+        assert not self.lvm_bs.get_osd_device_path(lvs, 'db')
+
+    @patch('ceph_volume.util.disk.get_device_from_partuuid')
+    @patch('ceph_volume.objectstore.lvmbluestore.encryption_utils.luks_open', MagicMock())
+    def test_get_osd_device_path_phys_encrypted(self, m_get_device_from_partuuid):
+        m_get_device_from_partuuid.return_value = '/dev/sda1'
+        lvs = [Volume(lv_name='lv_foo-block',
+                     lv_path='/fake-block-path',
+                     vg_name='vg_foo',
+                     lv_tags='ceph.type=block,ceph.block_uuid=fake-block-uuid,ceph.db_uuid=fake-db-uuid,ceph.osd_id=0,ceph.osd_fsid=abcd,ceph.cluster_name=ceph,ceph.encrypted=1',
+                     lv_uuid='fake-block-uuid')]
+        assert self.lvm_bs.get_osd_device_path(lvs, 'db') == '/dev/mapper/fake-db-uuid'
+
+    @patch('ceph_volume.util.disk.get_device_from_partuuid')
+    def test_get_osd_device_path_phys(self, m_get_device_from_partuuid):
+        m_get_device_from_partuuid.return_value = '/dev/sda1'
+        lvs = [Volume(lv_name='lv_foo-block',
+                     lv_path='/fake-block-path',
+                     vg_name='vg_foo',
+                     lv_tags='ceph.type=block,ceph.block_uuid=fake-block-uuid,ceph.db_uuid=fake-db-uuid,ceph.osd_id=0,ceph.osd_fsid=abcd,ceph.cluster_name=ceph',
+                     lv_uuid='fake-block-uuid')]
+        self.lvm_bs.get_osd_device_path(lvs, 'db')
+
+    @patch('ceph_volume.util.disk.get_device_from_partuuid')
+    def test_get_osd_device_path_phys_raises_exception(self, m_get_device_from_partuuid):
+        m_get_device_from_partuuid.return_value = ''
+        lvs = [Volume(lv_name='lv_foo-block',
+                     lv_path='/fake-block-path',
+                     vg_name='vg_foo',
+                     lv_tags='ceph.type=block,ceph.block_uuid=fake-block-uuid,ceph.db_uuid=fake-db-uuid,ceph.osd_id=0,ceph.osd_fsid=abcd,ceph.cluster_name=ceph',
+                     lv_uuid='fake-block-uuid')]
+        with pytest.raises(RuntimeError):
+            self.lvm_bs.get_osd_device_path(lvs, 'db')
+
+    def test__activate_raises_exception(self):
+        lvs = [Volume(lv_name='lv_foo-db',
+                      lv_path='/fake-path',
+                      vg_name='vg_foo',
+                      lv_tags='ceph.type=db,ceph.db_uuid=fake-db-uuid',
+                      lv_uuid='fake-db-uuid')]
+        with pytest.raises(RuntimeError) as error:
+            self.lvm_bs._activate(lvs)
+        assert str(error.value) == 'could not find a bluestore OSD to activate'
+
+    @patch('ceph_volume.objectstore.lvmbluestore.encryption_utils.write_lockbox_keyring', MagicMock())
+    @patch('ceph_volume.objectstore.lvmbluestore.encryption_utils.get_dmcrypt_key', MagicMock())
+    @patch('ceph_volume.objectstore.lvmbluestore.prepare_utils.create_osd_path')
+    @patch('ceph_volume.terminal.success')
+    @pytest.mark.parametrize("encrypted", ["ceph.encrypted=0", "ceph.encrypted=1"])
+    def test__activate(self,
+                       m_success, m_create_osd_path,
+                       monkeypatch, fake_run, fake_call, encrypted, conf_ceph_stub):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
+        monkeypatch.setattr('ceph_volume.util.system.path_is_mounted', lambda path: False)
+        m_create_osd_path.return_value = MagicMock()
+        m_success.return_value = MagicMock()
+        lvs = [Volume(lv_name='lv_foo-block',
+                      lv_path='/fake-block-path',
+                      vg_name='vg_foo',
+                      lv_tags=f'ceph.type=block,ceph.db_uuid=fake-db-uuid,ceph.block_uuid=fake-block-uuid,ceph.wal_uuid=fake-wal-uuid,ceph.osd_id=0,ceph.osd_fsid=abcd,ceph.cluster_name=ceph,{encrypted},ceph.cephx_lockbox_secret=abcd',
+                      lv_uuid='fake-block-uuid'),
+               Volume(lv_name='lv_foo-db',
+                      lv_path='/fake-db-path',
+                      vg_name='vg_foo_db',
+                      lv_tags=f'ceph.type=db,ceph.db_uuid=fake-db-uuid,ceph.block_uuid=fake-block-uuid,ceph.wal_uuid=fake-wal-uuid,ceph.osd_id=0,ceph.osd_fsid=abcd,ceph.cluster_name=ceph,{encrypted},ceph.cephx_lockbox_secret=abcd',
+                      lv_uuid='fake-db-uuid'),
+               Volume(lv_name='lv_foo-db',
+                      lv_path='/fake-db-path',
+                      vg_name='vg_foo_db',
+                      lv_tags=f'ceph.type=wal,ceph.block_uuid=fake-block-uuid,ceph.wal_uuid=fake-wal-uuid,ceph.db_uuid=fake-db-uuid,ceph.osd_id=0,ceph.osd_fsid=abcd,ceph.cluster_name=ceph,{encrypted},ceph.cephx_lockbox_secret=abcd',
+                      lv_uuid='fake-wal-uuid')]
+        self.lvm_bs._activate(lvs)
+        if encrypted == "ceph.encrypted=0":
+            assert fake_run.calls == [{'args': (['ceph-bluestore-tool', '--cluster=ceph',
+                                                 'prime-osd-dir', '--dev', '/fake-block-path',
+                                                 '--path', '/var/lib/ceph/osd/ceph-0', '--no-mon-config'],),
+                                       'kwargs': {}},
+                                      {'args': (['ln', '-snf', '/fake-block-path',
+                                                 '/var/lib/ceph/osd/ceph-0/block'],),
+                                       'kwargs': {}},
+                                      {'args': (['ln', '-snf', '/fake-db-path',
+                                                 '/var/lib/ceph/osd/ceph-0/block.db'],),
+                                       'kwargs': {}},
+                                      {'args': (['ln', '-snf', '/fake-db-path',
+                                                 '/var/lib/ceph/osd/ceph-0/block.wal'],),
+                                       'kwargs': {}},
+                                      {'args': (['systemctl', 'enable',
+                                                 'ceph-volume@lvm-0-abcd'],),
+                                       'kwargs': {}},
+                                      {'args': (['systemctl', 'enable', '--runtime', 'ceph-osd@0'],),
+                                       'kwargs': {}},
+                                      {'args': (['systemctl', 'start', 'ceph-osd@0'],),
+                                       'kwargs': {}}]
+        else:
+            assert fake_run.calls == [{'args': (['ceph-bluestore-tool', '--cluster=ceph',
+                                                'prime-osd-dir', '--dev', '/dev/mapper/fake-block-uuid',
+                                                '--path', '/var/lib/ceph/osd/ceph-0', '--no-mon-config'],),
+                                      'kwargs': {}},
+                                      {'args': (['ln', '-snf', '/dev/mapper/fake-block-uuid',
+                                                  '/var/lib/ceph/osd/ceph-0/block'],),
+                                      'kwargs': {}},
+                                      {'args': (['ln', '-snf', '/dev/mapper/fake-db-uuid',
+                                                  '/var/lib/ceph/osd/ceph-0/block.db'],),
+                                      'kwargs': {}},
+                                      {'args': (['ln', '-snf', '/dev/mapper/fake-wal-uuid',
+                                                  '/var/lib/ceph/osd/ceph-0/block.wal'],),
+                                      'kwargs': {}},
+                                      {'args': (['systemctl', 'enable', 'ceph-volume@lvm-0-abcd'],),
+                                      'kwargs': {}},
+                                      {'args': (['systemctl', 'enable', '--runtime', 'ceph-osd@0'],),
+                                      'kwargs': {}},
+                                      {'args': (['systemctl', 'start', 'ceph-osd@0'],),
+                                      'kwargs': {}}]
+        assert m_success.mock_calls == [call('ceph-volume lvm activate successful for osd ID: 0')]
+
+    @patch('ceph_volume.systemd.systemctl.osd_is_active', return_value=False)
+    def test_activate_all(self,
+                          mock_lvm_direct_report,
+                          factory,
+                          fake_run):
+        args = factory(no_systemd=True)
+        self.lvm_bs.args = args
+        self.lvm_bs.activate = MagicMock()
+        self.lvm_bs.activate_all()
+        assert self.lvm_bs.activate.mock_calls == [call(args,
+                                                        osd_id='1',
+                                                        osd_fsid='824f7edf-371f-4b75-9231-4ab62a32d5c0'),
+                                                   call(args,
+                                                        osd_id='0',
+                                                        osd_fsid='a0e07c5b-bee1-4ea2-ae07-cb89deda9b27')]
+
+    @patch('ceph_volume.systemd.systemctl.osd_is_active', return_value=False)
+    def test_activate_all_no_osd_found(self,
+                                       factory,
+                                       fake_run,
+                                       monkeypatch,
+                                       capsys):
+        monkeypatch.setattr('ceph_volume.objectstore.lvmbluestore.direct_report', lambda: {})
+        args = factory(no_systemd=True)
+        self.lvm_bs.args = args
+        self.lvm_bs.activate_all()
+        stdout, stderr = capsys.readouterr()
+        assert "Was unable to find any OSDs to activate" in stderr
+        assert "Verify OSDs are present with" in stderr
+
+    @patch('ceph_volume.systemd.systemctl.osd_is_active', return_value=True)
+    def test_activate_all_osd_is_active(self,
+                                        mock_lvm_direct_report,
+                                        factory,
+                                        fake_run):
+        args = factory(no_systemd=False)
+        self.lvm_bs.args = args
+        self.lvm_bs.activate = MagicMock()
+        self.lvm_bs.activate_all()
+        assert self.lvm_bs.activate.mock_calls == []
+
+    @patch('ceph_volume.api.lvm.get_lvs')
+    def test_activate_osd_id_and_fsid(self,
+                                      m_get_lvs,
+                                      factory):
+        args = factory(osd_id='1',
+                       osd_fsid='824f7edf',
+                       no_systemd=True)
+        lvs = [Volume(lv_name='lv_foo',
+                      lv_path='/fake-path',
+                      vg_name='vg_foo',
+                      lv_tags=f'ceph.osd_id={args.osd_id},ceph.osd_fsid={args.osd_fsid}',
+                      lv_uuid='fake-uuid')]
+        m_get_lvs.return_value = lvs
+        self.lvm_bs.args = args
+        self.lvm_bs._activate = MagicMock()
+        self.lvm_bs.activate()
+        assert self.lvm_bs._activate.mock_calls == [call(lvs, True, False)]
+        assert m_get_lvs.mock_calls == [call(tags={'ceph.osd_id': '1',
+                                                   'ceph.osd_fsid': '824f7edf'})]
+
+    @patch('ceph_volume.api.lvm.get_lvs')
+    def test_activate_not_osd_id_and_fsid(self,
+                                          m_get_lvs,
+                                          factory):
+        args = factory(no_systemd=True,
+                       osd_id=None,
+                       osd_fsid='824f7edf')
+        lvs = [Volume(lv_name='lv_foo',
+                      lv_path='/fake-path',
+                      vg_name='vg_foo',
+                      lv_tags='',
+                      lv_uuid='fake-uuid')]
+        m_get_lvs.return_value = lvs
+        self.lvm_bs.args = args
+        self.lvm_bs._activate = MagicMock()
+        self.lvm_bs.activate()
+        assert self.lvm_bs._activate.mock_calls == [call(lvs, True, False)]
+        assert m_get_lvs.mock_calls == [call(tags={'ceph.osd_fsid': '824f7edf'})]
+
+    def test_activate_osd_id_and_not_fsid(self,
+                                          factory):
+        args = factory(no_systemd=True,
+                       osd_id='1',
+                       osd_fsid=None)
+        self.lvm_bs.args = args
+        self.lvm_bs._activate = MagicMock()
+        with pytest.raises(RuntimeError) as error:
+            self.lvm_bs.activate()
+        assert str(error.value) == 'could not activate osd.1, please provide the osd_fsid too'
+
+    def test_activate_not_osd_id_and_not_fsid(self,
+                                              factory):
+        args = factory(no_systemd=True,
+                       osd_id=None,
+                       osd_fsid=None)
+        self.lvm_bs.args = args
+        self.lvm_bs._activate = MagicMock()
+        with pytest.raises(RuntimeError) as error:
+            self.lvm_bs.activate()
+        assert str(error.value) == 'Please provide both osd_id and osd_fsid'
+
+    @patch('ceph_volume.api.lvm.get_lvs')
+    def test_activate_couldnt_find_osd(self,
+                                       m_get_lvs,
+                                       factory):
+        args = factory(osd_id='1',
+                       osd_fsid='824f7edf',
+                       no_systemd=True)
+        lvs = []
+        m_get_lvs.return_value = lvs
+        self.lvm_bs.args = args
+        self.lvm_bs._activate = MagicMock()
+        with pytest.raises(RuntimeError) as error:
+            self.lvm_bs.activate()
+        assert str(error.value) == 'could not find osd.1 with osd_fsid 824f7edf'

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_lvmbluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_lvmbluestore.py
@@ -152,7 +152,7 @@ class TestLvmBlueStore:
     @patch('ceph_volume.objectstore.baseobjectstore.BaseObjectStore.get_ptuuid', Mock(return_value='c6798f59-01'))
     @patch('ceph_volume.api.lvm.Volume.set_tags', MagicMock())
     @patch('ceph_volume.api.lvm.get_single_lv')
-    def test_prepare(self, m_get_single_lv, factory):
+    def test_prepare(self, m_get_single_lv, is_root, factory):
         m_get_single_lv.return_value = Volume(lv_name='lv_foo',
                                               lv_path='/fake-path',
                                               vg_name='vg_foo',
@@ -445,7 +445,9 @@ class TestLvmBlueStore:
 
     @patch('ceph_volume.systemd.systemctl.osd_is_active', return_value=False)
     def test_activate_all(self,
+                          m_create_key,
                           mock_lvm_direct_report,
+                          is_root,
                           factory,
                           fake_run):
         args = factory(no_systemd=True)
@@ -461,6 +463,8 @@ class TestLvmBlueStore:
 
     @patch('ceph_volume.systemd.systemctl.osd_is_active', return_value=False)
     def test_activate_all_no_osd_found(self,
+                                       m_create_key,
+                                       is_root,
                                        factory,
                                        fake_run,
                                        monkeypatch,
@@ -476,6 +480,7 @@ class TestLvmBlueStore:
     @patch('ceph_volume.systemd.systemctl.osd_is_active', return_value=True)
     def test_activate_all_osd_is_active(self,
                                         mock_lvm_direct_report,
+                                        is_root,
                                         factory,
                                         fake_run):
         args = factory(no_systemd=False)
@@ -487,6 +492,7 @@ class TestLvmBlueStore:
     @patch('ceph_volume.api.lvm.get_lvs')
     def test_activate_osd_id_and_fsid(self,
                                       m_get_lvs,
+                                      is_root,
                                       factory):
         args = factory(osd_id='1',
                        osd_fsid='824f7edf',
@@ -507,6 +513,7 @@ class TestLvmBlueStore:
     @patch('ceph_volume.api.lvm.get_lvs')
     def test_activate_not_osd_id_and_fsid(self,
                                           m_get_lvs,
+                                          is_root,
                                           factory):
         args = factory(no_systemd=True,
                        osd_id=None,
@@ -524,6 +531,7 @@ class TestLvmBlueStore:
         assert m_get_lvs.mock_calls == [call(tags={'ceph.osd_fsid': '824f7edf'})]
 
     def test_activate_osd_id_and_not_fsid(self,
+                                          is_root,
                                           factory):
         args = factory(no_systemd=True,
                        osd_id='1',
@@ -535,6 +543,7 @@ class TestLvmBlueStore:
         assert str(error.value) == 'could not activate osd.1, please provide the osd_fsid too'
 
     def test_activate_not_osd_id_and_not_fsid(self,
+                                              is_root,
                                               factory):
         args = factory(no_systemd=True,
                        osd_id=None,
@@ -548,6 +557,7 @@ class TestLvmBlueStore:
     @patch('ceph_volume.api.lvm.get_lvs')
     def test_activate_couldnt_find_osd(self,
                                        m_get_lvs,
+                                       is_root,
                                        factory):
         args = factory(osd_id='1',
                        osd_fsid='824f7edf',

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_rawbluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_rawbluestore.py
@@ -1,0 +1,156 @@
+import pytest
+from mock import patch, Mock, MagicMock, call
+from ceph_volume.objectstore.rawbluestore import RawBlueStore
+from ceph_volume.util import system
+
+
+class TestRawBlueStore:
+    @patch('ceph_volume.objectstore.rawbluestore.prepare_utils.create_key', Mock(return_value=['AQCee6ZkzhOrJRAAZWSvNC3KdXOpC2w8ly4AZQ==']))
+    def setup_method(self, m_create_key):
+        self.raw_bs = RawBlueStore([])
+
+    def test_prepare_dmcrypt(self,
+                             device_info,
+                             fake_call,
+                             key_size):
+        self.raw_bs.secrets = {'dmcrypt_key': 'foo'}
+        self.raw_bs.block_device_path = '/dev/foo0'
+        self.raw_bs.db_device_path = '/dev/foo1'
+        self.raw_bs.wal_device_path = '/dev/foo2'
+        lsblk = {"TYPE": "disk",
+                 "NAME": "foo0",
+                 'KNAME': 'foo0'}
+        device_info(lsblk=lsblk)
+        self.raw_bs.prepare_dmcrypt()
+        assert self.raw_bs.block_device_path == "/dev/mapper/ceph--foo0-block-dmcrypt"
+        assert self.raw_bs.db_device_path == "/dev/mapper/ceph--foo0-db-dmcrypt"
+        assert self.raw_bs.wal_device_path == "/dev/mapper/ceph--foo0-wal-dmcrypt"
+
+    @patch('ceph_volume.objectstore.rawbluestore.rollback_osd')
+    @patch('ceph_volume.objectstore.rawbluestore.RawBlueStore.prepare')
+    def test_safe_prepare_raises_exception(self,
+                                           m_prepare,
+                                           m_rollback_osd,
+                                           factory,
+                                           capsys):
+        m_prepare.side_effect = Exception
+        m_rollback_osd.return_value = MagicMock()
+        args = factory(osd_id='1')
+        self.raw_bs.args = args
+        self.raw_bs.osd_id = self.raw_bs.args.osd_id
+        with pytest.raises(Exception):
+            self.raw_bs.safe_prepare()
+        assert m_rollback_osd.mock_calls == [call(self.raw_bs.args, '1')]
+
+    @patch('ceph_volume.objectstore.rawbluestore.RawBlueStore.prepare', MagicMock())
+    def test_safe_prepare(self,
+                          factory,
+                          capsys):
+        args = factory(dmcrypt=True,
+                       data='/dev/foo')
+        # self.raw_bs.args = args
+        self.raw_bs.safe_prepare(args)
+        stdout, stderr = capsys.readouterr()
+        assert "prepare successful for: /dev/foo" in stderr
+
+    # @patch('ceph_volume.objectstore.rawbluestore.prepare_utils.create_id')
+    # @patch('ceph_volume.objectstore.rawbluestore.system.generate_uuid', return_value='fake-uuid')
+    @patch.dict('os.environ', {'CEPH_VOLUME_DMCRYPT_SECRET': 'dmcrypt-key'})
+    @patch('ceph_volume.objectstore.rawbluestore.prepare_utils.create_id')
+    @patch('ceph_volume.objectstore.rawbluestore.system.generate_uuid')
+    def test_prepare(self, m_generate_uuid, m_create_id, factory):
+        m_generate_uuid.return_value = 'fake-uuid'
+        m_create_id.return_value = MagicMock()
+        self.raw_bs.prepare_dmcrypt = MagicMock()
+        self.raw_bs.prepare_osd_req = MagicMock()
+        self.raw_bs.osd_mkfs = MagicMock()
+        args = factory(crush_device_class='foo',
+                       no_tmpfs=False,
+                       block_wal='/dev/foo1',
+                       block_db='/dev/foo2',)
+        self.raw_bs.args = args
+        self.raw_bs.secrets = dict()
+        self.raw_bs.encrypted = True
+        self.raw_bs.prepare()
+        assert self.raw_bs.prepare_osd_req.mock_calls == [call(tmpfs=True)]
+        assert self.raw_bs.osd_mkfs.called
+        assert self.raw_bs.prepare_dmcrypt.called
+
+    @patch('ceph_volume.conf.cluster', 'ceph')
+    @patch('ceph_volume.objectstore.rawbluestore.prepare_utils.link_wal')
+    @patch('ceph_volume.objectstore.rawbluestore.prepare_utils.link_db')
+    @patch('ceph_volume.objectstore.rawbluestore.prepare_utils.link_block')
+    @patch('os.path.exists')
+    @patch('os.unlink')
+    @patch('ceph_volume.objectstore.rawbluestore.prepare_utils.create_osd_path')
+    @patch('ceph_volume.objectstore.rawbluestore.process.run')
+    def test__activate(self,
+                       m_run,
+                       m_create_osd_path,
+                       m_unlink,
+                       m_exists,
+                       m_link_block,
+                       m_link_db,
+                       m_link_wal,
+                       monkeypatch):
+        meta = dict(osd_id='1',
+                    osd_uuid='fake-uuid',
+                    device='/dev/foo',
+                    device_db='/dev/foo1',
+                    device_wal='/dev/foo2')
+        m_run.return_value = MagicMock()
+        m_exists.side_effect = lambda path: True
+        m_create_osd_path.return_value = MagicMock()
+        m_unlink.return_value = MagicMock()
+        monkeypatch.setattr(system, 'chown', lambda path: 0)
+        monkeypatch.setattr(system, 'path_is_mounted', lambda path: 0)
+        self.raw_bs._activate(meta, True)
+        calls = [call('/var/lib/ceph/osd/ceph-1/block'),
+                 call('/var/lib/ceph/osd/ceph-1/block.db'),
+                 call('/var/lib/ceph/osd/ceph-1/block.wal')]
+        assert m_run.mock_calls == [call(['ceph-bluestore-tool',
+                                         'prime-osd-dir',
+                                         '--path', '/var/lib/ceph/osd/ceph-1',
+                                         '--no-mon-config', '--dev', '/dev/foo'])]
+        assert m_unlink.mock_calls == calls
+        assert m_exists.mock_calls == calls
+        assert m_create_osd_path.mock_calls == [call('1', tmpfs=True)]
+
+    def test_activate_raises_exception(self,
+                                       mock_raw_direct_report):
+        with pytest.raises(RuntimeError) as error:
+            self.raw_bs.activate([],
+                                '123',
+                                'fake-uuid',
+                                True)
+        assert str(error.value) == 'did not find any matching OSD to activate'
+
+    def test_activate_osd_id(self,
+                             mock_raw_direct_report):
+        self.raw_bs._activate = MagicMock()
+        self.raw_bs.activate([],
+                            '8',
+                            '824f7edf-371f-4b75-9231-4ab62a32d5c0',
+                            True)
+        self.raw_bs._activate.mock_calls == [call({'ceph_fsid': '7dccab18-14cf-11ee-837b-5254008f8ca5',
+                                                   'device': '/dev/mapper/ceph--40bc7bd7--4aee--483e--ba95--89a64bc8a4fd-osd--block--824f7edf--371f--4b75--9231--4ab62a32d5c0',
+                                                   'device_db': '/dev/mapper/ceph--73d6d4db--6528--48f2--a4e2--1c82bc87a9ac-osd--db--b82d920d--be3c--4e4d--ba64--18f7e8445892',
+                                                   'osd_id': 8,
+                                                   'osd_uuid': '824f7edf-371f-4b75-9231-4ab62a32d5c0',
+                                                   'type': 'bluestore'},
+                                                  tmpfs=True)]
+
+    def test_activate_osd_fsid(self,
+                               mock_raw_direct_report):
+        self.raw_bs._activate = MagicMock()
+        with pytest.raises(RuntimeError):
+            self.raw_bs.activate([],
+                                '8',
+                                'a0e07c5b-bee1-4ea2-ae07-cb89deda9b27',
+                                True)
+        self.raw_bs._activate.mock_calls == [call({'ceph_fsid': '7dccab18-14cf-11ee-837b-5254008f8ca5',
+                                                   'device': '/dev/mapper/ceph--e34cc3f5--a70d--49df--82b3--46bcbd63d4b0-osd--block--a0e07c5b--bee1--4ea2--ae07--cb89deda9b27',
+                                                   'osd_id': 9,
+                                                   'osd_uuid': 'a0e07c5b-bee1-4ea2-ae07-cb89deda9b27',
+                                                   'type': 'bluestore'},
+                                                  tmpfs=True)]

--- a/src/ceph-volume/ceph_volume/tests/objectstore/test_rawbluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/objectstore/test_rawbluestore.py
@@ -58,7 +58,7 @@ class TestRawBlueStore:
     @patch.dict('os.environ', {'CEPH_VOLUME_DMCRYPT_SECRET': 'dmcrypt-key'})
     @patch('ceph_volume.objectstore.rawbluestore.prepare_utils.create_id')
     @patch('ceph_volume.objectstore.rawbluestore.system.generate_uuid')
-    def test_prepare(self, m_generate_uuid, m_create_id, factory):
+    def test_prepare(self, m_generate_uuid, m_create_id, is_root, factory):
         m_generate_uuid.return_value = 'fake-uuid'
         m_create_id.return_value = MagicMock()
         self.raw_bs.prepare_dmcrypt = MagicMock()
@@ -117,6 +117,7 @@ class TestRawBlueStore:
         assert m_create_osd_path.mock_calls == [call('1', tmpfs=True)]
 
     def test_activate_raises_exception(self,
+                                       is_root,
                                        mock_raw_direct_report):
         with pytest.raises(RuntimeError) as error:
             self.raw_bs.activate([],
@@ -126,6 +127,7 @@ class TestRawBlueStore:
         assert str(error.value) == 'did not find any matching OSD to activate'
 
     def test_activate_osd_id(self,
+                             is_root,
                              mock_raw_direct_report):
         self.raw_bs._activate = MagicMock()
         self.raw_bs.activate([],
@@ -141,6 +143,7 @@ class TestRawBlueStore:
                                                   tmpfs=True)]
 
     def test_activate_osd_fsid(self,
+                               is_root,
                                mock_raw_direct_report):
         self.raw_bs._activate = MagicMock()
         with pytest.raises(RuntimeError):

--- a/src/ceph-volume/ceph_volume/tests/systemd/test_main.py
+++ b/src/ceph-volume/ceph_volume/tests/systemd/test_main.py
@@ -31,15 +31,15 @@ class TestMain(object):
     def setup_method(self):
         conf.log_path = '/tmp/'
 
-    def test_no_arguments_parsing_error(self):
+    def test_no_arguments_parsing_error(self, fake_filesystem):
         with pytest.raises(RuntimeError):
             main(args=[])
 
-    def test_parsing_suffix_error(self):
+    def test_parsing_suffix_error(self, fake_filesystem):
         with pytest.raises(exceptions.SuffixParsingError):
             main(args=['asdf'])
 
-    def test_correct_command(self, monkeypatch):
+    def test_correct_command(self, monkeypatch, fake_filesystem):
         run = Capture()
         monkeypatch.setattr(process, 'run', run)
         main(args=['ceph-volume-systemd', 'lvm-8715BEB4-15C5-49DE-BA6F-401086EC7B41-0' ])

--- a/src/ceph-volume/ceph_volume/tests/test_main.py
+++ b/src/ceph-volume/ceph_volume/tests/test_main.py
@@ -32,7 +32,7 @@ class TestVolume(object):
         assert '--cluster' in stdout
         assert '--log-path' in stdout
 
-    def test_log_ignoring_missing_ceph_conf(self, caplog):
+    def test_log_ignoring_missing_ceph_conf(self, caplog, fake_filesystem):
         with pytest.raises(SystemExit) as error:
             main.Volume(argv=['ceph-volume', '--cluster', 'barnacle', 'lvm', '--help'])
         # make sure we aren't causing an actual error
@@ -41,7 +41,7 @@ class TestVolume(object):
         assert log.message == 'ignoring inability to load ceph.conf'
         assert log.levelname == 'WARNING'
 
-    def test_logs_current_command(self, caplog):
+    def test_logs_current_command(self, caplog, fake_filesystem):
         with pytest.raises(SystemExit) as error:
             main.Volume(argv=['ceph-volume', '--cluster', 'barnacle', 'lvm', '--help'])
         # make sure we aren't causing an actual error
@@ -50,7 +50,7 @@ class TestVolume(object):
         assert log.message == 'Running command: ceph-volume --cluster barnacle lvm --help'
         assert log.levelname == 'INFO'
 
-    def test_logs_set_level_warning(self, caplog):
+    def test_logs_set_level_warning(self, caplog, fake_filesystem):
         with pytest.raises(SystemExit) as error:
             main.Volume(argv=['ceph-volume', '--log-level', 'warning', '--cluster', 'barnacle', 'lvm', '--help'])
         # make sure we aren't causing an actual error

--- a/src/ceph-volume/ceph_volume/tests/test_terminal.py
+++ b/src/ceph-volume/ceph_volume/tests/test_terminal.py
@@ -131,13 +131,3 @@ class TestWriteUnicode(object):
         writer.seek(0)
         val = buffer.getvalue()
         assert self.octpus_and_squid_en.encode(encoding) in val
-
-    def test_writer_uses_log_on_unicodeerror(self, stream, monkeypatch, capture):
-
-        if sys.version_info > (3,):
-            pytest.skip("Something breaks inside of pytest's capsys")
-        monkeypatch.setattr(terminal.terminal_logger, 'info', capture)
-        buffer = io.BytesIO()
-        writer = stream(buffer, 'ascii')
-        terminal._Write(_writer=writer).raw(self.message)
-        assert self.octpus_and_squid_en in capture.calls[0]['args'][0]

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -544,7 +544,14 @@ class TestSizeSpecificFormatting(object):
 
 
 class TestAllowLoopDevsWarning(object):
+    def setup(self):
+        disk.AllowLoopDevices.allow = False
+        disk.AllowLoopDevices.warned = False
+        if os.environ.get('CEPH_VOLUME_ALLOW_LOOP_DEVICES'):
+            os.environ.pop('CEPH_VOLUME_ALLOW_LOOP_DEVICES')
+
     def test_loop_dev_warning(self, fake_call, caplog):
+        disk.AllowLoopDevices.warned = False
         assert disk.allow_loop_devices() is False
         assert not caplog.records
         os.environ['CEPH_VOLUME_ALLOW_LOOP_DEVICES'] = "y"

--- a/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
@@ -103,8 +103,9 @@ class TestLuksFormat(object):
 
 
 class TestLuksOpen(object):
+    @patch('ceph_volume.util.encryption.bypass_workqueue', return_value=False)
     @patch('ceph_volume.util.encryption.process.call')
-    def test_luks_open_command_with_default_size(self, m_call, conf_ceph_stub):
+    def test_luks_open_command_with_default_size(self, m_call, m_bypass_workqueue, conf_ceph_stub):
         conf_ceph_stub('[global]\nfsid=abcd')
         expected = [
             'cryptsetup',
@@ -120,8 +121,9 @@ class TestLuksOpen(object):
         encryption.luks_open('abcd', '/dev/foo', '/dev/bar')
         assert m_call.call_args[0][0] == expected
 
+    @patch('ceph_volume.util.encryption.bypass_workqueue', return_value=False)
     @patch('ceph_volume.util.encryption.process.call')
-    def test_luks_open_command_with_custom_size(self, m_call, conf_ceph_stub):
+    def test_luks_open_command_with_custom_size(self, m_call, m_bypass_workqueue, conf_ceph_stub):
         conf_ceph_stub('[global]\nfsid=abcd\n[osd]\nosd_dmcrypt_key_size=256')
         expected = [
             'cryptsetup',

--- a/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
@@ -119,7 +119,7 @@ class TestFormatDevice(object):
 
 
 class TestOsdMkfsBluestore(object):
-    def setup(self):
+    def setup_method(self):
         conf.cluster = 'ceph'
 
     def test_keyring_is_added(self, fake_call, monkeypatch):

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -5,7 +5,7 @@ from ceph_volume import terminal, decorators, process
 from ceph_volume.util.device import Device
 from ceph_volume.util import disk
 from ceph_volume.util.encryption import set_dmcrypt_no_workqueue
-from ceph_volume import process, conf
+
 
 def valid_osd_id(val):
     return str(int(val))

--- a/src/ceph-volume/tox.ini
+++ b/src/ceph-volume/tox.ini
@@ -11,7 +11,7 @@ deps=
 allowlist_externals=
   ./tox_install_command.sh
 install_command=./tox_install_command.sh {opts} {packages}
-commands=py.test --numprocesses=auto -vv {posargs:ceph_volume/tests} --ignore=ceph_volume/tests/functional
+commands=py.test -vv {posargs:ceph_volume/tests} --ignore=ceph_volume/tests/functional
 
 [testenv:py3-flake8]
 deps=flake8


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65480

---

backport of https://github.com/ceph/ceph/pull/52650
parent tracker: https://tracker.ceph.com/issues/61827

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh