### PR TITLE
Fix dependencies, so headers are built first

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,11 @@
 include(GetGitRevisionDescription)
 include(CheckCXXCompilerFlag)
 
+# Pre build targets
+# We make sure dependencies of this target run before everything else, or at
+# least those who requires them.
+add_custom_target(prebuild-targets)
+
 # for erasure and compressor plugins
 set(CEPH_INSTALL_PKGLIBDIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME})
 set(CEPH_INSTALL_FULL_PKGLIBDIR ${CMAKE_INSTALL_FULL_LIBDIR}/${PROJECT_NAME})
@@ -445,7 +450,7 @@ set_source_files_properties(ceph_ver.c
 add_library(common-objs OBJECT ${libcommon_files})
 target_compile_definitions(common-objs PRIVATE
   $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
-add_dependencies(common-objs legacy-option-headers)
+add_dependencies(common-objs prebuild-targets)
 
 if(WITH_JAEGER)
   add_dependencies(common-objs jaeger_base)
@@ -543,7 +548,7 @@ endif()
 
 add_library(common STATIC ${ceph_common_objs})
 target_link_libraries(common ${ceph_common_deps})
-add_dependencies(common legacy-option-headers)
+add_dependencies(common prebuild-targets)
 if(WITH_JAEGER)
 add_dependencies(common jaeger_base)
 endif()
@@ -561,7 +566,7 @@ if(ENABLE_COVERAGE)
   target_link_libraries(ceph-common gcov)
 endif(ENABLE_COVERAGE)
 
-add_dependencies(ceph-common legacy-option-headers)
+add_dependencies(ceph-common prebuild-targets)
 
 if(WITH_JAEGER)
 add_dependencies(ceph-common jaeger_base)
@@ -620,6 +625,7 @@ add_subdirectory(osdc)
 add_subdirectory(perfglue)
 
 add_library(rados_snap_set_diff_obj OBJECT librados/snap_set_diff.cc)
+add_dependencies(rados_snap_set_diff_obj prebuild-targets)
 
 option(WITH_LIBRADOSSTRIPER "build with libradosstriper support" ON)
 
@@ -670,7 +676,7 @@ set(ceph_mon_srcs
   ceph_mon.cc)
 add_executable(ceph-mon ${ceph_mon_srcs}
   $<TARGET_OBJECTS:common_texttable_obj>)
-add_dependencies(ceph-mon erasure_code_plugins)
+add_dependencies(ceph-mon prebuild-targets erasure_code_plugins)
 target_link_libraries(ceph-mon mon os global-static ceph-common
   ${ALLOC_LIBS}
   ${EXTRALIBS}
@@ -701,7 +707,7 @@ set(ceph_osd_srcs
   ceph_osd.cc)
 
 add_executable(ceph-osd ${ceph_osd_srcs})
-add_dependencies(ceph-osd erasure_code_plugins extblkdev_plugins)
+add_dependencies(ceph-osd prebuild-targets erasure_code_plugins extblkdev_plugins)
 target_link_libraries(ceph-osd osd os global-static common
   ${ALLOC_LIBS}
   ${BLKID_LIBRARIES})
@@ -720,6 +726,7 @@ if (WITH_CEPHFS)
   set(ceph_mds_srcs
     ceph_mds.cc)
   add_executable(ceph-mds ${ceph_mds_srcs})
+  add_dependencies(ceph-mds prebuild-targets)
   target_link_libraries(ceph-mds mds ${CMAKE_DL_LIBS} global-static ceph-common
     Boost::thread
     ${ALLOC_LIBS})
@@ -809,6 +816,7 @@ add_subdirectory(client)
 if(WITH_LIBCEPHFS)
   set(libcephfs_srcs libcephfs.cc)
   add_library(cephfs ${CEPH_SHARED} ${libcephfs_srcs})
+  add_dependencies(cephfs prebuild-targets)
   target_link_libraries(cephfs PRIVATE client ceph-common
     ${CRYPTO_LIBS} ${EXTRALIBS})
   if(ENABLE_SHARED)
@@ -832,6 +840,7 @@ if(WITH_LIBCEPHFS)
     ceph_syn.cc
     client/SyntheticClient.cc)
   add_executable(ceph-syn ${ceph_syn_srcs})
+  add_dependencies(ceph-syn prebuild-targets)
   target_link_libraries(ceph-syn client global-static ceph-common)
   install(TARGETS ceph-syn DESTINATION bin)
   if(LINUX)
@@ -842,6 +851,7 @@ endif(WITH_LIBCEPHFS)
 if(WITH_LIBCEPHSQLITE)
   set(cephsqlite_srcs libcephsqlite.cc SimpleRADOSStriper.cc)
   add_library(cephsqlite ${CEPH_SHARED} ${cephsqlite_srcs})
+  add_dependencies(cephsqlite prebuild-targets)
   target_link_libraries(cephsqlite PRIVATE cls_lock_client librados ceph-common SQLite3::SQLite3 ${EXTRALIBS})
   set_target_properties(cephsqlite PROPERTIES
     CXX_VISIBILITY_PRESET hidden
@@ -858,6 +868,7 @@ if(WITH_FUSE)
     ceph_fuse.cc
     client/fuse_ll.cc)
   add_executable(ceph-fuse ${ceph_fuse_srcs})
+  add_dependencies(ceph-fuse prebuild-targets)
   target_link_libraries(ceph-fuse FUSE::FUSE
     ${GSSAPI_LIBRARIES} client ceph-common global-static ${EXTRALIBS})
   set_target_properties(ceph-fuse PROPERTIES
@@ -877,6 +888,7 @@ if(WITH_RBD)
     add_library(krbd STATIC krbd.cc
       $<TARGET_OBJECTS:parse_secret_objs>)
     target_link_libraries(krbd keyutils::keyutils)
+    add_dependencies(krbd prebuild-targets)
   endif()
   add_subdirectory(librbd)
   if(WITH_FUSE)

--- a/src/arch/CMakeLists.txt
+++ b/src/arch/CMakeLists.txt
@@ -10,3 +10,4 @@ elseif(HAVE_PPC64LE OR HAVE_PPC64 OR HAVE_PPC)
 endif()
 
 add_library(arch OBJECT ${arch_srcs})
+add_dependencies(arch prebuild-targets)

--- a/src/auth/CMakeLists.txt
+++ b/src/auth/CMakeLists.txt
@@ -22,4 +22,4 @@ endif()
 
 add_library(common-auth-objs OBJECT ${auth_srcs})
 target_include_directories(common-auth-objs PRIVATE ${OPENSSL_INCLUDE_DIR})
-add_dependencies(common-auth-objs legacy-option-headers)
+add_dependencies(common-auth-objs prebuild-targets)

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -10,4 +10,5 @@ set(libclient_srcs
   posix_acl.cc
   Delegation.cc)
 add_library(client STATIC ${libclient_srcs})
+add_dependencies(client prebuild-targets)
 target_link_libraries(client osdc)

--- a/src/cls/CMakeLists.txt
+++ b/src/cls/CMakeLists.txt
@@ -4,6 +4,7 @@ set(cls_dir ${CMAKE_INSTALL_LIBDIR}/rados-classes)
 
 # cls_sdk
 add_library(cls_sdk SHARED sdk/cls_sdk.cc)
+add_dependencies(cls_sdk prebuild-targets)
 set_target_properties(cls_sdk PROPERTIES
   VERSION "1.0.0"
   SOVERSION "1"
@@ -14,6 +15,7 @@ install(TARGETS cls_sdk DESTINATION ${cls_dir})
 # cls_hello
 set(cls_hello_srcs hello/cls_hello.cc)
 add_library(cls_hello SHARED ${cls_hello_srcs})
+add_dependencies(cls_hello prebuild-targets)
 set_target_properties(cls_hello PROPERTIES
   VERSION "1.0.0"
   SOVERSION "1"
@@ -24,6 +26,7 @@ install(TARGETS cls_hello DESTINATION ${cls_dir})
 # cls_numops
 set(cls_numops_srcs numops/cls_numops.cc)
 add_library(cls_numops SHARED ${cls_numops_srcs})
+add_dependencies(cls_numops prebuild-targets)
 set_target_properties(cls_numops PROPERTIES
   VERSION "1.0.0"
   SOVERSION "1"
@@ -39,6 +42,7 @@ add_library(cls_numops_client STATIC ${cls_numops_client_srcs})
 if (WITH_RBD)
   set(cls_rbd_srcs rbd/cls_rbd.cc rbd/cls_rbd_types.cc)
   add_library(cls_rbd SHARED ${cls_rbd_srcs})
+  add_dependencies(cls_rbd prebuild-targets)
   set_target_properties(cls_rbd PROPERTIES
     VERSION "1.0.0"
     SOVERSION "1"
@@ -55,6 +59,7 @@ endif (WITH_RBD)
 # cls_lock
 set(cls_lock_srcs lock/cls_lock.cc)
 add_library(cls_lock SHARED ${cls_lock_srcs})
+add_dependencies(cls_lock prebuild-targets)
 set_target_properties(cls_lock PROPERTIES
   VERSION "1.0.0"
   SOVERSION "1"
@@ -67,12 +72,13 @@ set(cls_lock_client_srcs
   lock/cls_lock_types.cc
   lock/cls_lock_ops.cc)
 add_library(cls_lock_client STATIC ${cls_lock_client_srcs})
-
+add_dependencies(cls_lock_client prebuild-targets)
 
 # cls_otp
 if (WITH_RADOSGW)
   set(cls_otp_srcs otp/cls_otp.cc)
   add_library(cls_otp SHARED ${cls_otp_srcs})
+  add_dependencies(cls_otp prebuild-targets)
   target_link_libraries(cls_otp OATH::OATH)
   target_include_directories(cls_otp
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
@@ -90,6 +96,7 @@ if (WITH_RADOSGW)
     otp/cls_otp_types.cc
     )
   add_library(cls_otp_client STATIC ${cls_otp_client_srcs})
+  add_dependencies(cls_otp_client prebuild-targets)
 endif (WITH_RADOSGW)
 
 # cls_refcount
@@ -98,6 +105,7 @@ set(cls_refcount_srcs
   refcount/cls_refcount_ops.cc
   ${CMAKE_SOURCE_DIR}/src/common/ceph_json.cc)
 add_library(cls_refcount SHARED ${cls_refcount_srcs})
+add_dependencies(cls_refcount prebuild-targets)
 target_link_libraries(cls_refcount json_spirit)
 set_target_properties(cls_refcount PROPERTIES
   VERSION "1.0.0"
@@ -115,6 +123,7 @@ add_library(cls_refcount_client STATIC ${cls_refcount_client_srcs})
 # cls_version
 set(cls_version_srcs version/cls_version.cc)
 add_library(cls_version SHARED ${cls_version_srcs})
+add_dependencies(cls_version prebuild-targets)
 set_target_properties(cls_version PROPERTIES
   VERSION "1.0.0"
   SOVERSION "1"
@@ -126,11 +135,13 @@ set(cls_version_client_srcs
   version/cls_version_client.cc
   version/cls_version_types.cc)
 add_library(cls_version_client STATIC ${cls_version_client_srcs})
+add_dependencies(cls_version_client prebuild-targets)
 
 
 # cls_log
 set(cls_log_srcs log/cls_log.cc)
 add_library(cls_log SHARED ${cls_log_srcs})
+add_dependencies(cls_log prebuild-targets)
 set_target_properties(cls_log PROPERTIES
   VERSION "1.0.0"
   SOVERSION "1"
@@ -145,6 +156,7 @@ add_library(cls_log_client STATIC ${cls_log_client_srcs})
 # cls_timeindex
 set(cls_timeindex_srcs timeindex/cls_timeindex.cc)
 add_library(cls_timeindex SHARED ${cls_timeindex_srcs})
+add_dependencies(cls_timeindex prebuild-targets)
 set_target_properties(cls_timeindex PROPERTIES
   VERSION "1.0.0"
   SOVERSION "1"
@@ -156,11 +168,13 @@ set(cls_timeindex_client_srcs
   timeindex/cls_timeindex_types.cc
   timeindex/cls_timeindex_client.cc)
 add_library(cls_timeindex_client STATIC ${cls_timeindex_client_srcs})
+add_dependencies(cls_timeindex_client prebuild-targets)
 
 
 # cls_user
 set(cls_user_srcs user/cls_user.cc)
 add_library(cls_user SHARED ${cls_user_srcs})
+add_dependencies(cls_user prebuild-targets)
 set_target_properties(cls_user PROPERTIES
   VERSION "1.0.0"
   SOVERSION "1"
@@ -173,6 +187,7 @@ set(cls_user_client_srcs
   user/cls_user_types.cc
   user/cls_user_ops.cc)
 add_library(cls_user_client STATIC ${cls_user_client_srcs})
+add_dependencies(cls_user_client prebuild-targets)
 
 
 # cls_journal
@@ -180,6 +195,7 @@ set(cls_journal_srcs
   journal/cls_journal.cc
   journal/cls_journal_types.cc)
 add_library(cls_journal SHARED ${cls_journal_srcs})
+add_dependencies(cls_journal prebuild-targets)
 set_target_properties(cls_journal PROPERTIES
   VERSION "1.0.0"
   SOVERSION "1"
@@ -191,6 +207,7 @@ set(cls_journal_client_srcs
   journal/cls_journal_client.cc
   journal/cls_journal_types.cc)
 add_library(cls_journal_client STATIC ${cls_journal_client_srcs})
+add_dependencies(cls_journal_client prebuild-targets)
 
 
 # cls_rgw
@@ -201,6 +218,7 @@ if (WITH_RADOSGW)
     rgw/cls_rgw_types.cc
     ${CMAKE_SOURCE_DIR}/src/common/ceph_json.cc)
   add_library(cls_rgw SHARED ${cls_rgw_srcs})
+  add_dependencies(cls_rgw prebuild-targets)
   target_link_libraries(cls_rgw ${FMT_LIB} json_spirit)
   target_include_directories(cls_rgw
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
@@ -218,6 +236,7 @@ if (WITH_RADOSGW)
     rgw/cls_rgw_types.cc
     rgw/cls_rgw_ops.cc)
   add_library(cls_rgw_client STATIC ${cls_rgw_client_srcs})
+  add_dependencies(cls_rgw_client prebuild-targets)
   target_include_directories(cls_rgw_client
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
@@ -230,6 +249,7 @@ if (WITH_CEPHFS)
   set(cls_cephfs_srcs
     cephfs/cls_cephfs.cc)
   add_library(cls_cephfs SHARED ${cls_cephfs_srcs})
+  add_dependencies(cls_cephfs prebuild-targets)
   set_target_properties(cls_cephfs PROPERTIES
     VERSION "1.0.0"
     SOVERSION "1"
@@ -240,6 +260,7 @@ if (WITH_CEPHFS)
   set(cls_cephfs_client_srcs
     cephfs/cls_cephfs_client.cc)
   add_library(cls_cephfs_client STATIC ${cls_cephfs_client_srcs})
+  add_dependencies(cls_cephfs_client prebuild-targets)
 
 endif (WITH_CEPHFS)
 
@@ -249,6 +270,7 @@ if (NOT WIN32)
       lua/cls_lua.cc
       lua/lua_bufferlist.cc)
   add_library(cls_lua SHARED ${cls_lua_srcs})
+  add_dependencies(cls_lua prebuild-targets)
   set_target_properties(cls_lua PROPERTIES
     VERSION "1.0.0"
     SOVERSION "1"
@@ -264,19 +286,23 @@ endif (NOT WIN32)
 set(cls_lua_client_srcs
     lua/cls_lua_client.cc)
 add_library(cls_lua_client STATIC ${cls_lua_client_srcs})
+add_dependencies(cls_lua_client prebuild-targets)
 
 # cls_cas
 set(cls_cas_client_srcs
   cas/cls_cas_client.cc)
 add_library(cls_cas_client STATIC ${cls_cas_client_srcs})
+add_dependencies(cls_cas_client prebuild-targets)
 
 set(cls_cas_internal_srcs
   cas/cls_cas_internal.cc)
 add_library(cls_cas_internal STATIC ${cls_cas_internal_srcs})
+add_dependencies(cls_cas_internal prebuild-targets)
 
 set(cls_cas_srcs 
   cas/cls_cas.cc)
 add_library(cls_cas SHARED ${cls_cas_srcs})
+add_dependencies(cls_cas prebuild-targets)
 target_link_libraries(cls_cas cls_cas_internal)
 set_target_properties(cls_cas PROPERTIES
   VERSION "1.0.0"
@@ -293,6 +319,7 @@ set(cls_queue_srcs
   queue/cls_queue_src.cc
   ${CMAKE_SOURCE_DIR}/src/common/ceph_json.cc)
 add_library(cls_queue SHARED ${cls_queue_srcs})
+add_dependencies(cls_queue prebuild-targets)
 set_target_properties(cls_queue PROPERTIES
   VERSION "1.0.0"
   SOVERSION "1"
@@ -303,6 +330,7 @@ install(TARGETS cls_queue DESTINATION ${cls_dir})
 set(cls_queue_client_srcs
   queue/cls_queue_client.cc)
 add_library(cls_queue_client STATIC ${cls_queue_client_srcs})
+add_dependencies(cls_queue_client prebuild-targets)
 
 # cls_rgw_gc
 if (WITH_RADOSGW)
@@ -311,6 +339,7 @@ if (WITH_RADOSGW)
     queue/cls_queue_src.cc
     ${CMAKE_SOURCE_DIR}/src/common/ceph_json.cc)
   add_library(cls_rgw_gc SHARED ${cls_rgw_gc_srcs})
+  add_dependencies(cls_rgw_gc prebuild-targets)
   target_include_directories(cls_rgw_gc
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
@@ -326,6 +355,7 @@ if (WITH_RADOSGW)
     rgw_gc/cls_rgw_gc_client.cc
     rgw/cls_rgw_types.cc)
   add_library(cls_rgw_gc_client STATIC ${cls_rgw_gc_client_srcs})
+  add_dependencies(cls_rgw_gc_client prebuild-targets)
   target_include_directories(cls_rgw_gc_client
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/driver/rados"
 	  PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
@@ -339,6 +369,7 @@ set(cls_2pc_queue_srcs
   queue/cls_queue_src.cc
   ${CMAKE_SOURCE_DIR}/src/common/ceph_json.cc)
 add_library(cls_2pc_queue SHARED ${cls_2pc_queue_srcs})
+add_dependencies(cls_2pc_queue prebuild-targets)
 set_target_properties(cls_2pc_queue PROPERTIES
   VERSION "1.0.0"
   SOVERSION "1"
@@ -348,6 +379,7 @@ install(TARGETS cls_2pc_queue DESTINATION ${cls_dir})
 set(cls_2pc_queue_client_srcs
   2pc_queue/cls_2pc_queue_client.cc)
 add_library(cls_2pc_queue_client STATIC ${cls_2pc_queue_client_srcs})
+add_dependencies(cls_2pc_queue_client prebuild-targets)
 
 
 add_subdirectory(cmpomap)
@@ -355,6 +387,7 @@ add_subdirectory(cmpomap)
 # cls_fifo
 set(cls_fifo_srcs fifo/cls_fifo.cc)
 add_library(cls_fifo SHARED ${cls_fifo_srcs})
+add_dependencies(cls_fifo prebuild-targets)
 set_target_properties(cls_fifo PROPERTIES
   VERSION "1.0.0"
   SOVERSION "1"
@@ -366,6 +399,7 @@ install(TARGETS cls_fifo DESTINATION ${cls_dir})
 # cls_test_remote_reads
 set(cls_test_remote_reads_srcs test_remote_reads/cls_test_remote_reads.cc)
 add_library(cls_test_remote_reads SHARED ${cls_test_remote_reads_srcs})
+add_dependencies(cls_test_remote_reads prebuild-targets)
 set_target_properties(cls_test_remote_reads PROPERTIES
   VERSION "1.0.0"
   SOVERSION "1"

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,12 +1,14 @@
 add_library(common_buffer_obj OBJECT
   buffer.cc)
+add_dependencies(common_buffer_obj prebuild-targets)
 
 add_library(common_texttable_obj OBJECT
   TextTable.cc)
+add_dependencies(common_texttable_obj prebuild-targets)
 
 add_library(common_prioritycache_obj OBJECT
   PriorityCache.cc)
-add_dependencies(common_prioritycache_obj legacy-option-headers)
+add_dependencies(common_prioritycache_obj prebuild-targets)
 
 if(WIN32)
   add_library(dlfcn_win32 STATIC win32/dlfcn.cc win32/errno.cc)
@@ -183,6 +185,7 @@ endif()
 
 add_library(common-common-objs OBJECT
   ${common_srcs})
+add_dependencies(common-common-objs prebuild-targets)
 # Let's not rely on the default system headers and point Cmake to the
 # retrieved OpenSSL location. This is especially important when cross
 # compiling (e.g. targeting Windows).
@@ -193,7 +196,7 @@ target_compile_definitions(common-common-objs PRIVATE
   "CEPH_INSTALL_FULL_PKGLIBDIR=\"${CEPH_INSTALL_FULL_PKGLIBDIR}\""
   "CEPH_INSTALL_DATADIR=\"${CEPH_INSTALL_DATADIR}\""
   $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
-add_dependencies(common-common-objs legacy-option-headers)
+add_dependencies(common_prioritycache_obj prebuild-targets)
 
 set(common_mountcephfs_srcs
   armor.c
@@ -202,6 +205,7 @@ set(common_mountcephfs_srcs
   addr_parsing.c)
 add_library(common_mountcephfs_objs OBJECT
   ${common_mountcephfs_srcs})
+add_dependencies(common_mountcephfs_objs prebuild-targets)
 
 
 set(crc32_srcs
@@ -231,6 +235,7 @@ elseif(HAVE_ARMV8_CRC)
 endif(HAVE_INTEL)
 
 add_library(crc32 OBJECT ${crc32_srcs})
+add_dependencies(crc32 prebuild-targets)
 
 if(HAVE_ARMV8_CRC)
   set_target_properties(crc32 PROPERTIES
@@ -240,9 +245,11 @@ target_link_libraries(crc32
   arch)
 
 add_library(common_utf8 STATIC utf8.c)
+add_dependencies(common_utf8 prebuild-targets)
 
 if(HAVE_KEYUTILS)
   set(parse_secret_srcs
     secret.c)
   add_library(parse_secret_objs OBJECT ${parse_secret_srcs})
+  add_dependencies(parse_secret_objs prebuild-targets)
 endif()

--- a/src/common/options/CMakeLists.txt
+++ b/src/common/options/CMakeLists.txt
@@ -1,5 +1,7 @@
+# A custom target using comon_options_srcs will generate YAML files and its
+# corresponding source files and header files. Remove the headers target to
+# prevent headers from generating twice.
 set(common_options_srcs build_options.cc)
-set(legacy_options_headers)
 set(options_yamls)
 
 # to mimic the behavior of file(CONFIGURE ...)
@@ -31,8 +33,7 @@ function(add_options name)
   set(options_yamls ${options_yamls} PARENT_SCOPE)
   set(cc_file "${name}_options.cc")
   set(h_file "${PROJECT_BINARY_DIR}/include/${name}_legacy_options.h")
-  add_custom_command(PRE_BUILD
-    OUTPUT ${cc_file} ${h_file}
+  add_custom_command(OUTPUT ${cc_file} ${h_file}
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/y2c.py
       --input ${yaml_file}
       --output ${cc_file}
@@ -41,8 +42,6 @@ function(add_options name)
       DEPENDS ${yaml_file})
   list(APPEND common_options_srcs ${cc_file})
   set(common_options_srcs ${common_options_srcs} PARENT_SCOPE)
-  list(APPEND legacy_options_headers ${h_file})
-  set(legacy_options_headers ${legacy_options_headers} PARENT_SCOPE)
 endfunction()
 
 set(osd_erasure_code_plugins "jerasure" "lrc")
@@ -104,8 +103,9 @@ add_options(rgw)
 
 add_library(common-options-objs OBJECT
   ${common_options_srcs})
-add_custom_target(legacy-option-headers
-  DEPENDS ${legacy_options_headers})
+
+# Make common-options-objs as a pre-build requirement.
+add_dependencies(prebuild-targets common-options-objs)
 
 include(AddCephTest)
 add_ceph_test(validate-options

--- a/src/compressor/CMakeLists.txt
+++ b/src/compressor/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(compressor_objs OBJECT Compressor.cc)
 add_dependencies(compressor_objs common-objs)
-add_dependencies(compressor_objs legacy-option-headers)
+add_dependencies(compressor_objs prebuild-targets)
 
 if(HAVE_QATZIP AND HAVE_QAT)
   add_library(qat_compressor OBJECT QatAccel.cc)
@@ -10,6 +10,7 @@ if(HAVE_QATZIP AND HAVE_QAT)
                         QAT::zip
                        )
 endif()
+add_dependencies(compressor_objs prebuild-targets)
 
 ## compressor plugins
 

--- a/src/compressor/lz4/CMakeLists.txt
+++ b/src/compressor/lz4/CMakeLists.txt
@@ -6,6 +6,7 @@ set(lz4_sources
 )
 
 add_library(ceph_lz4 SHARED ${lz4_sources})
+add_dependencies(ceph_lz4 prebuild-targets)
 target_link_libraries(ceph_lz4
   PRIVATE LZ4::LZ4 compressor $<$<PLATFORM_ID:Windows>:ceph-common>)
 if(HAVE_QATZIP AND HAVE_QAT)

--- a/src/compressor/snappy/CMakeLists.txt
+++ b/src/compressor/snappy/CMakeLists.txt
@@ -5,6 +5,7 @@ set(snappy_sources
 )
 
 add_library(ceph_snappy SHARED ${snappy_sources})
+add_dependencies(ceph_snappy prebuild-targets)
 target_link_libraries(ceph_snappy
   PRIVATE snappy::snappy compressor $<$<PLATFORM_ID:Windows>:ceph-common>)
 set_target_properties(ceph_snappy PROPERTIES

--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -90,6 +90,7 @@ else()
 endif()
 
 add_library(ceph_zlib SHARED ${zlib_sources})
+add_dependencies(ceph_zlib prebuild-targets)
 target_link_libraries(ceph_zlib ZLIB::ZLIB compressor $<$<PLATFORM_ID:Windows>:ceph-common>)
 if(HAVE_QATZIP AND HAVE_QAT)
   target_link_libraries(ceph_zlib qat_compressor)

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -127,6 +127,8 @@ add_library(crimson-common STATIC
   $<TARGET_OBJECTS:common_mountcephfs_objs>
   $<TARGET_OBJECTS:common-options-objs>)
 
+add_dependencies(crimson-common prebuild-targets)
+
 target_compile_definitions(crimson-common PRIVATE
   "CMAKE_INSTALL_LIBDIR=\"${CMAKE_INSTALL_LIBDIR}\""
   "CEPH_INSTALL_FULL_PKGLIBDIR=\"${CEPH_INSTALL_FULL_PKGLIBDIR}\""
@@ -199,6 +201,7 @@ target_link_libraries(crimson
   PUBLIC
     crimson-common
     crimson::cflags)
+add_dependencies(crimson prebuild-targets)
 add_subdirectory(admin)
 add_subdirectory(os)
 add_subdirectory(osd)

--- a/src/crimson/admin/CMakeLists.txt
+++ b/src/crimson/admin/CMakeLists.txt
@@ -6,4 +6,4 @@ target_link_libraries(crimson-admin
   crimson::cflags
   Boost::MPL)
 add_dependencies(crimson-admin
-  legacy-option-headers)
+  prebuild-targets)

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -62,6 +62,7 @@ if(HAS_VTA)
   set_source_files_properties(main.cc
     PROPERTIES COMPILE_FLAGS -fno-var-tracking-assignments)
 endif()
+add_dependencies(crimson-osd prebuild-targets)
 target_link_libraries(crimson-osd
   crimson-admin
   crimson-common

--- a/src/crush/CMakeLists.txt
+++ b/src/crush/CMakeLists.txt
@@ -9,3 +9,4 @@ set(crush_srcs
   CrushLocation.cc)
 
 add_library(crush_objs OBJECT ${crush_srcs})
+add_dependencies(crush_objs prebuild-targets)

--- a/src/crypto/openssl/CMakeLists.txt
+++ b/src/crypto/openssl/CMakeLists.txt
@@ -5,6 +5,7 @@ set(openssl_crypto_plugin_srcs
   openssl_crypto_plugin.cc)
 
 add_library(ceph_crypto_openssl SHARED ${openssl_crypto_plugin_srcs})
+add_dependencies(ceph_crypto_openssl prebuild-targets)
 target_link_libraries(ceph_crypto_openssl
     PRIVATE OpenSSL::Crypto
     $<$<PLATFORM_ID:Windows>:ceph-common>

--- a/src/dokan/CMakeLists.txt
+++ b/src/dokan/CMakeLists.txt
@@ -5,6 +5,7 @@ set(ceph_dokan_srcs
   options.cc
   ../common/win32/code_page.rc)
 add_executable(ceph-dokan ${ceph_dokan_srcs})
+add_dependencies(ceph-dokan prebuild-targets)
 target_link_libraries(ceph-dokan ${DOKAN_LIBRARIES}
   ${GSSAPI_LIBRARIES}
   cephfs ceph-common global ${EXTRALIBS})

--- a/src/erasure-code/CMakeLists.txt
+++ b/src/erasure-code/CMakeLists.txt
@@ -32,10 +32,13 @@ if(WITH_EC_ISA_PLUGIN)
 endif()
 
 add_library(erasure_code STATIC ErasureCodePlugin.cc)
+add_dependencies(erasure_code prebuild-targets)
+
 target_link_libraries(erasure_code $<$<PLATFORM_ID:Windows>:dlfcn_win32>
                       ${CMAKE_DL_LIBS})
 
 add_library(erasure_code_objs OBJECT ErasureCode.cc)
+add_dependencies(erasure_code_objs prebuild-targets)
 
 add_custom_target(erasure_code_plugins DEPENDS
     ${EC_ISA_LIB}

--- a/src/erasure-code/jerasure/CMakeLists.txt
+++ b/src/erasure-code/jerasure/CMakeLists.txt
@@ -5,6 +5,7 @@ set(jerasure_utils_src
   ErasureCodeJerasure.cc)
 
 add_library(jerasure_utils OBJECT ${jerasure_utils_src})
+add_dependencies(jerasure_utils prebuild-targets)
 
 # Set the CFLAGS correctly for gf-complete based on SIMD compiler support
 set(GF_COMPILE_FLAGS)
@@ -66,6 +67,7 @@ if(HAVE_ARM_NEON OR HAVE_ARMV8_SIMD)
 endif()
 
 add_library(gf-complete_objs OBJECT ${gf-complete_srcs})
+add_dependencies(gf-complete_objs prebuild-targets)
 set_target_properties(gf-complete_objs PROPERTIES 
   COMPILE_FLAGS "${SIMD_COMPILE_FLAGS}")
 set_target_properties(gf-complete_objs PROPERTIES 
@@ -79,6 +81,7 @@ set(jerasure_srcs
   jerasure/src/reed_sol.c
   jerasure_init.cc)
 add_library(jerasure_objs OBJECT ${jerasure_srcs}) 
+add_dependencies(jerasure_objs prebuild-targets)
 
 set(ec_jerasure_objs
   $<TARGET_OBJECTS:gf-complete_objs>
@@ -87,6 +90,7 @@ set(ec_jerasure_objs
   $<TARGET_OBJECTS:erasure_code_objs>)
 
 add_library(ec_jerasure SHARED ${ec_jerasure_objs})
+add_dependencies(ec_jerasure prebuild-targets)
 set_target_properties(ec_jerasure PROPERTIES
   INSTALL_RPATH "")
 target_link_libraries(ec_jerasure ${EXTRALIBS})
@@ -96,6 +100,7 @@ install(TARGETS ec_jerasure DESTINATION ${erasure_plugin_dir})
 foreach(flavor ${jerasure_legacy_flavors})
   set(plugin_name "ec_jerasure_${flavor}")
   add_library(${plugin_name} SHARED ${ec_jerasure_objs})
+  add_dependencies(${plugin_name} prebuild-targets)
   set_target_properties(${plugin_name} PROPERTIES
     INSTALL_RPATH "")
   install(TARGETS ${plugin_name} DESTINATION ${erasure_plugin_dir})

--- a/src/erasure-code/shec/CMakeLists.txt
+++ b/src/erasure-code/shec/CMakeLists.txt
@@ -10,6 +10,7 @@ set(shec_utils_srcs
   determinant.c)
 
 add_library(shec_utils OBJECT ${shec_utils_srcs})
+add_dependencies(shec_utils prebuild-targets)
 
 set(ec_shec_objs
   $<TARGET_OBJECTS:gf-complete_objs>
@@ -17,6 +18,7 @@ set(ec_shec_objs
   $<TARGET_OBJECTS:shec_utils>)
 
 add_library(ec_shec SHARED ${ec_shec_objs})
+add_dependencies(ec_shec prebuild-targets)
 set_target_properties(ec_shec PROPERTIES
   INSTALL_RPATH "")
 target_link_libraries(ec_shec ${EXTRALIBS})
@@ -30,4 +32,5 @@ foreach(flavor ${jerasure_legacy_flavors})
     INSTALL_RPATH "")
   install(TARGETS ${plugin_name} DESTINATION ${erasure_plugin_dir})
   add_dependencies(ec_shec ${plugin_name})
+  add_dependencies(${plugin_name} prebuild-targets)
 endforeach()

--- a/src/exporter/CMakeLists.txt
+++ b/src/exporter/CMakeLists.txt
@@ -5,6 +5,7 @@ set(exporter_srcs
   util.cc
   )
 add_executable(ceph-exporter ${exporter_srcs})
+add_dependencies(ceph-exporter prebuild-targets)
 target_link_libraries(ceph-exporter
   global-static ceph-common)
 install(TARGETS ceph-exporter DESTINATION bin)

--- a/src/extblkdev/CMakeLists.txt
+++ b/src/extblkdev/CMakeLists.txt
@@ -5,6 +5,7 @@ set(extblkdev_plugin_dir ${CEPH_INSTALL_PKGLIBDIR}/extblkdev)
 add_subdirectory(vdo)
 
 add_library(extblkdev STATIC ExtBlkDevPlugin.cc)
+add_dependencies(extblkdev prebuild-targets)
 
 if(NOT WIN32)
 find_package(cap)

--- a/src/extblkdev/vdo/CMakeLists.txt
+++ b/src/extblkdev/vdo/CMakeLists.txt
@@ -6,4 +6,5 @@ set(vdo_srcs
 )
 
 add_library(ceph_ebd_vdo SHARED ${vdo_srcs})
+add_dependencies(ceph_ebd_vdo prebuild-targets)
 install(TARGETS ceph_ebd_vdo DESTINATION ${extblkdev_plugin_dir})

--- a/src/global/CMakeLists.txt
+++ b/src/global/CMakeLists.txt
@@ -8,12 +8,14 @@ else()
 endif()
 
 add_library(libglobal_objs OBJECT ${libglobal_srcs})
-add_dependencies(libglobal_objs legacy-option-headers)
+add_dependencies(libglobal_objs prebuild-targets)
 
 add_library(global-static STATIC
   $<TARGET_OBJECTS:libglobal_objs>)
+add_dependencies(global-static prebuild-targets)
 target_link_libraries(global-static common)
 
 add_library(global STATIC
   $<TARGET_OBJECTS:libglobal_objs>)
+add_dependencies(global prebuild-targets)
 target_link_libraries(global ceph-common ${EXTRALIBS})

--- a/src/librados/CMakeLists.txt
+++ b/src/librados/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(librados ${CEPH_SHARED}
   librados_c.cc
   librados_cxx.cc
   $<TARGET_OBJECTS:common_buffer_obj>)
+add_dependencies(librados_impl prebuild-targets)
+add_dependencies(librados prebuild-targets)
 if(ENABLE_SHARED)
   set_target_properties(librados PROPERTIES
     OUTPUT_NAME rados

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(rbd_types STATIC
 if (WITH_RBD_RWL)
   target_link_libraries(rbd_types
     PUBLIC pmdk::pmemobj)
+  add_dependencies(rbd_types prebuild-targets)
 endif()
 
 set(librbd_internal_srcs
@@ -220,9 +221,11 @@ if(LINUX AND HAVE_LIBCRYPTSETUP)
 endif()
 
 add_library(rbd_api STATIC librbd.cc)
+add_dependencies(rbd_api prebuild-targets)
 add_library(rbd_internal STATIC
   ${librbd_internal_srcs}
   $<TARGET_OBJECTS:rados_snap_set_diff_obj>)
+add_dependencies(rbd_internal prebuild-targets)
 if(WITH_LTTNG)
   # librbd.cc includes tracing/librbd.h
   add_dependencies(rbd_api librbd-tp)
@@ -249,6 +252,7 @@ set(rbd_plugin_parent_cache_srcs
   plugin/ParentCache.cc)
 add_library(librbd_plugin_parent_cache SHARED
   ${rbd_plugin_parent_cache_srcs})
+add_dependencies(librbd_plugin_parent_cache prebuild-targets)
 target_link_libraries(librbd_plugin_parent_cache PRIVATE
   ceph_immutable_object_cache_lib ceph-common librbd
   libneorados
@@ -297,6 +301,7 @@ if(WITH_RBD_RWL OR WITH_RBD_SSD_CACHE)
 
   add_library(librbd_plugin_pwl_cache SHARED
     ${rbd_plugin_pwl_srcs})
+  add_dependencies(librbd_plugin_pwl_cache prebuild-targets)
   target_link_libraries(librbd_plugin_pwl_cache PRIVATE
     blk
     ceph-common
@@ -309,6 +314,7 @@ if(WITH_RBD_RWL OR WITH_RBD_SSD_CACHE)
     target_link_libraries(librbd_plugin_pwl_cache
       PUBLIC pmdk::pmemobj
       PRIVATE pmdk::pmem)
+    add_dependencies(librbd_plugin_pwl_cache prebuild-targets)
   endif()
 
   set_target_properties(librbd_plugin_pwl_cache PROPERTIES
@@ -321,6 +327,7 @@ endif()
 
 add_library(librbd ${CEPH_SHARED}
   librbd.cc)
+add_dependencies(librbd prebuild-targets)
 if(WITH_LTTNG)
   add_dependencies(librbd librbd-tp)
 endif()

--- a/src/mgr/CMakeLists.txt
+++ b/src/mgr/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(mgr_cap_obj OBJECT
   MgrCap.cc)
+add_dependencies(mgr_cap_obj prebuild-targets)
 
 if(WITH_MGR)
   set(mgr_srcs
@@ -34,6 +35,7 @@ if(WITH_MGR)
     mgr_commands.cc
     $<TARGET_OBJECTS:mgr_cap_obj>)
   add_executable(ceph-mgr ${mgr_srcs})
+  add_dependencies(ceph-mgr prebuild-targets)
   target_compile_definitions(ceph-mgr PRIVATE PY_SSIZE_T_CLEAN)
   if(WITH_LIBCEPHSQLITE)
     target_link_libraries(ceph-mgr cephsqlite SQLite3::SQLite3)

--- a/src/mon/CMakeLists.txt
+++ b/src/mon/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(mon
   kv
   heap_profiler
   ${FMT_LIB})
+add_dependencies(mon prebuild-targets)
 if(WITH_JAEGER)
   target_link_libraries(mon jaeger_base)
 endif()

--- a/src/mount/CMakeLists.txt
+++ b/src/mount/CMakeLists.txt
@@ -6,5 +6,6 @@ set(mount_ceph_srcs
 add_executable(mount.ceph ${mount_ceph_srcs}
   $<TARGET_OBJECTS:parse_secret_objs>
   $<TARGET_OBJECTS:common_mountcephfs_objs>)
+add_dependencies(mount.ceph prebuild-targets)
 target_link_libraries(mount.ceph keyutils::keyutils ${CAPNG_LIBRARIES} global ceph-common)
 install(TARGETS mount.ceph DESTINATION ${CMAKE_INSTALL_SBINDIR})

--- a/src/msg/CMakeLists.txt
+++ b/src/msg/CMakeLists.txt
@@ -45,6 +45,7 @@ if(HAVE_RDMA)
 endif()
 
 add_library(common-msg-objs OBJECT ${msg_srcs})
+add_dependencies(common-msg-objs prebuild-targets)
 target_compile_definitions(common-msg-objs PRIVATE
   $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
 target_include_directories(common-msg-objs PRIVATE ${OPENSSL_INCLUDE_DIR})

--- a/src/neorados/CMakeLists.txt
+++ b/src/neorados/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_library(neorados_objs OBJECT
   RADOSImpl.cc)
+add_dependencies(neorados_objs prebuild-targets)
 target_compile_definitions(neorados_objs PRIVATE
   $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
 add_library(neorados_api_obj OBJECT
   RADOS.cc)
+add_dependencies(neorados_api_obj prebuild-targets)
 target_compile_definitions(neorados_api_obj PRIVATE
   $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
 

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -47,6 +47,7 @@ if(HAVE_LIBZFS)
 endif()
 
 add_library(os STATIC ${libos_srcs})
+add_dependencies(os prebuild-targets)
 target_link_libraries(os blk)
 
 target_link_libraries(os heap_profiler kv)

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -56,6 +56,7 @@ if(HAS_VTA)
     PROPERTIES COMPILE_FLAGS -fno-var-tracking-assignments)
 endif()
 add_library(osd STATIC ${osd_srcs})
+add_dependencies(osd prebuild-targets)
 target_link_libraries(osd
   PUBLIC dmclock::dmclock Boost::MPL
   PRIVATE os heap_profiler cpu_profiler ${FMT_LIB} ${CMAKE_DL_LIBS})

--- a/src/osdc/CMakeLists.txt
+++ b/src/osdc/CMakeLists.txt
@@ -5,6 +5,7 @@ set(osdc_files
   error_code.cc
   Striper.cc)
 add_library(osdc STATIC ${osdc_files})
+add_dependencies(osdc prebuild-targets)
 target_link_libraries(osdc ceph-common)
 if(WITH_EVENTTRACE)
   add_dependencies(osdc eventtrace_tp)

--- a/src/perfglue/CMakeLists.txt
+++ b/src/perfglue/CMakeLists.txt
@@ -1,6 +1,7 @@
 if(ALLOCATOR STREQUAL "tcmalloc")
   add_library(heap_profiler STATIC
     heap_profiler.cc)
+  add_dependencies(heap_profiler prebuild-targets)
   target_link_libraries(heap_profiler
     gperftools::tcmalloc)
 else()
@@ -14,9 +15,11 @@ if(WITH_PROFILER)
   find_package(gperftools 2.6.2 REQUIRED profiler)
   add_library(cpu_profiler STATIC
     cpu_profiler.cc)
+  add_dependencies(cpu_profiler prebuild-targets)
   target_link_libraries(cpu_profiler
     gperftools::profiler)
 else()
   add_library(cpu_profiler STATIC
     disabled_stubs.cc)
+  add_dependencies(cpu_profiler prebuild-targets)
 endif()

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -264,6 +264,7 @@ if(WITH_RADOSGW_D4N)
 endif()
 
 add_library(rgw_common STATIC ${librgw_common_srcs})
+add_dependencies(rgw_common prebuild-targets)
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-Wimplicit-const-int-float-conversion"
@@ -408,7 +409,7 @@ set_source_files_properties(rgw_iam_policy.cc PROPERTIES
 
 add_library(rgw_a STATIC
     ${rgw_a_srcs})
-
+add_dependencies(rgw_a prebuild-targets)
 target_compile_definitions(rgw_a PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 
 target_include_directories(rgw_a
@@ -448,6 +449,7 @@ set(rgw_schedulers_srcs
   rgw_dmclock_async_scheduler.cc)
 
 add_library(rgw_schedulers STATIC ${rgw_schedulers_srcs})
+add_dependencies(rgw_schedulers prebuild-targets)
 target_link_libraries(rgw_schedulers
   PUBLIC dmclock::dmclock spawn)
 
@@ -455,6 +457,7 @@ set(radosgw_srcs
   rgw_main.cc)
 
 add_executable(radosgw ${radosgw_srcs})
+add_dependencies(radosgw prebuild-targets)
 
 if(WITH_RADOSGW_ARROW_FLIGHT)
   # target_compile_definitions(radosgw PUBLIC WITH_ARROW_FLIGHT)
@@ -493,6 +496,7 @@ if(WITH_RADOSGW_ARROW_FLIGHT)
 endif(WITH_RADOSGW_ARROW_FLIGHT)
 
 add_executable(radosgw-admin ${radosgw_admin_srcs})
+add_dependencies(radosgw-admin prebuild-targets)
 target_link_libraries(radosgw-admin ${rgw_libs} librados
   cls_rgw_client cls_otp_client cls_lock_client cls_refcount_client
   cls_log_client cls_timeindex_client
@@ -523,6 +527,7 @@ install(TARGETS radosgw-es DESTINATION bin)
 set(radosgw_token_srcs
   rgw_token.cc)
 add_executable(radosgw-token ${radosgw_token_srcs})
+add_dependencies(radosgw-token prebuild-targets)
 target_link_libraries(radosgw-token librados
   global)
 install(TARGETS radosgw-token DESTINATION bin)
@@ -530,6 +535,7 @@ install(TARGETS radosgw-token DESTINATION bin)
 set(radosgw_object_expirer_srcs
   rgw_object_expirer.cc)
 add_executable(radosgw-object-expirer ${radosgw_object_expirer_srcs})
+add_dependencies(radosgw-object-expirer prebuild-targets)
 target_link_libraries(radosgw-object-expirer ${rgw_libs} librados
   cls_rgw_client cls_otp_client cls_lock_client cls_refcount_client
   cls_log_client cls_timeindex_client

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -9,6 +9,7 @@ if(WIN32)
 endif()
 
 add_library(unit-main OBJECT unit.cc)
+add_dependencies(unit-main prebuild-targets)
 target_include_directories(unit-main PRIVATE
   $<TARGET_PROPERTY:GTest::GTest,INTERFACE_INCLUDE_DIRECTORIES>)
 

--- a/src/test/librados_test_stub/CMakeLists.txt
+++ b/src/test/librados_test_stub/CMakeLists.txt
@@ -9,4 +9,4 @@ set(librados_test_stub_srcs
   TestRadosClient.cc
   TestWatchNotify.cc)
 add_library(rados_test_stub STATIC ${librados_test_stub_srcs})
-
+add_dependencies(rados_test_stub prebuild-targets)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -10,6 +10,7 @@ if(WIN32)
   list(APPEND rados_srcs ../common/win32/code_page.rc)
 endif()
 add_executable(rados ${rados_srcs})
+add_dependencies(rados prebuild-targets)
 
 target_link_libraries(rados librados global ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
 if(WITH_LIBRADOSSTRIPER)
@@ -30,14 +31,17 @@ endif()
 
 if(WITH_TESTS)
 add_executable(ceph_scratchtool scratchtool.c)
+add_dependencies(ceph_scratchtool prebuild-targets)
 target_link_libraries(ceph_scratchtool librados global)
 install(TARGETS ceph_scratchtool DESTINATION bin)
 
 add_executable(ceph_scratchtoolpp scratchtoolpp.cc)
+add_dependencies(ceph_scratchtoolpp prebuild-targets)
 target_link_libraries(ceph_scratchtoolpp librados global)
 install(TARGETS ceph_scratchtoolpp DESTINATION bin)
 
 add_executable(ceph_radosacl radosacl.cc)
+add_dependencies(ceph_radosacl prebuild-targets)
 target_link_libraries(ceph_radosacl librados global)
 install(TARGETS ceph_radosacl DESTINATION bin)
 
@@ -47,6 +51,7 @@ install(PROGRAMS
 endif(WITH_TESTS)
 
 add_executable(ceph-osdomap-tool ceph_osdomap_tool.cc)
+add_dependencies(ceph-osdomap-tool prebuild-targets)
 target_link_libraries(ceph-osdomap-tool os global Boost::program_options)
 install(TARGETS ceph-osdomap-tool DESTINATION bin)
 
@@ -54,6 +59,7 @@ add_executable(ceph-monstore-tool
   ceph_monstore_tool.cc
   ../auth/cephx/CephxKeyServer.cc
   ../mgr/mgr_commands.cc)
+add_dependencies(ceph-monstore-tool prebuild-targets)
 target_link_libraries(ceph-monstore-tool os global Boost::program_options)
 install(TARGETS ceph-monstore-tool DESTINATION bin)
 
@@ -61,6 +67,7 @@ add_executable(ceph-objectstore-tool
   ceph_objectstore_tool.cc
   rebuild_mondb.cc
   RadosDump.cc)
+add_dependencies(ceph-objectstore-tool prebuild-targets)
 target_link_libraries(ceph-objectstore-tool osd os global Boost::program_options ${CMAKE_DL_LIBS})
 if(WITH_FUSE)
   target_link_libraries(ceph-objectstore-tool FUSE::FUSE)
@@ -70,6 +77,7 @@ install(TARGETS ceph-objectstore-tool DESTINATION bin)
 if(WITH_LIBCEPHFS)
 if(WITH_TESTS)
   add_executable(ceph-client-debug ceph-client-debug.cc)
+  add_dependencies(ceph-client-debug prebuild-targets)
   target_link_libraries(ceph-client-debug cephfs global client)
   install(TARGETS ceph-client-debug DESTINATION bin)
 endif(WITH_TESTS)
@@ -78,26 +86,31 @@ endif(WITH_LIBCEPHFS)
 add_executable(ceph-kvstore-tool
   kvstore_tool.cc
   ceph_kvstore_tool.cc)
+add_dependencies(ceph-kvstore-tool prebuild-targets)
 target_link_libraries(ceph-kvstore-tool os global)
 install(TARGETS ceph-kvstore-tool DESTINATION bin)
 
 set(ceph_conf_srcs ceph_conf.cc)
 add_executable(ceph-conf ${ceph_conf_srcs})
+add_dependencies(ceph-conf prebuild-targets)
 target_link_libraries(ceph-conf global)
 install(TARGETS ceph-conf DESTINATION bin)
 
 set(crushtool_srcs crushtool.cc)
 add_executable(crushtool ${crushtool_srcs})
+add_dependencies(crushtool prebuild-targets)
 target_link_libraries(crushtool global)
 install(TARGETS crushtool DESTINATION bin)
 
 set(monmaptool_srcs monmaptool.cc)
 add_executable(monmaptool ${monmaptool_srcs})
+add_dependencies(monmaptool prebuild-targets)
 target_link_libraries(monmaptool global)
 install(TARGETS monmaptool DESTINATION bin)
 
 set(osdomaptool_srcs osdmaptool.cc)
 add_executable(osdmaptool ${osdomaptool_srcs})
+add_dependencies(osdmaptool prebuild-targets)
 target_link_libraries(osdmaptool global)
 install(TARGETS osdmaptool DESTINATION bin)
 
@@ -105,6 +118,7 @@ install(PROGRAMS crushdiff DESTINATION bin)
 
 set(ceph-diff-sorted_srcs ceph-diff-sorted.cc)
 add_executable(ceph-diff-sorted ${ceph-diff-sorted_srcs})
+add_dependencies(ceph-diff-sorted prebuild-targets)
 set_target_properties(ceph-diff-sorted PROPERTIES
   SKIP_RPATH TRUE
   INSTALL_RPATH "")
@@ -113,18 +127,21 @@ install(TARGETS ceph-diff-sorted DESTINATION bin)
 if(WITH_TESTS)
 set(ceph_psim_srcs psim.cc)
 add_executable(ceph_psim ${ceph_psim_srcs})
+add_dependencies(ceph_psim prebuild-targets)
 target_link_libraries(ceph_psim global)
 install(TARGETS ceph_psim DESTINATION bin)
 endif(WITH_TESTS)
 
 set(ceph_authtool_srcs ceph_authtool.cc)
 add_executable(ceph-authtool ${ceph_authtool_srcs})
+add_dependencies(ceph-authtool prebuild-targets)
 target_link_libraries(ceph-authtool global ${EXTRALIBS} ${CRYPTO_LIBS})
 install(TARGETS ceph-authtool DESTINATION bin)
 
 if(WITH_TESTS)
 set(ceph_dedup_tool_srcs ceph_dedup_tool.cc)
 add_executable(ceph-dedup-tool ${ceph_dedup_tool_srcs})
+add_dependencies(ceph-dedup-tool prebuild-targets)
 target_link_libraries(ceph-dedup-tool
   librados
   global

--- a/src/tools/cephfs/CMakeLists.txt
+++ b/src/tools/cephfs/CMakeLists.txt
@@ -9,6 +9,7 @@ set(cephfs_journal_tool_srcs
   RoleSelector.cc
   MDSUtility.cc)
 add_executable(cephfs-journal-tool ${cephfs_journal_tool_srcs})
+add_dependencies(cephfs-journal-tool prebuild-targets)
 target_link_libraries(cephfs-journal-tool librados mds osdc global
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
 
@@ -18,6 +19,7 @@ set(cephfs-meta-injection_srcs
   RoleSelector.cc
   MDSUtility.cc)
 add_executable(cephfs-meta-injection ${cephfs-meta-injection_srcs})
+add_dependencies(cephfs-meta-injection prebuild-targets)
 target_link_libraries(cephfs-meta-injection librados mds osdc global
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
 
@@ -27,6 +29,7 @@ set(cephfs_table_tool_srcs
   RoleSelector.cc
   MDSUtility.cc)
 add_executable(cephfs-table-tool ${cephfs_table_tool_srcs})
+add_dependencies(cephfs-table-tool prebuild-targets)
 target_link_libraries(cephfs-table-tool librados mds osdc global
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
 
@@ -37,6 +40,7 @@ set(cephfs_data_scan_srcs
   PgFiles.cc
   MDSUtility.cc)
 add_executable(cephfs-data-scan ${cephfs_data_scan_srcs})
+add_dependencies(cephfs-data-scan prebuild-targets)
 target_link_libraries(cephfs-data-scan librados cephfs mds osdc global
   cls_cephfs_client
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})

--- a/src/tools/cephfs_mirror/CMakeLists.txt
+++ b/src/tools/cephfs_mirror/CMakeLists.txt
@@ -13,9 +13,11 @@ set(cephfs_mirror_internal
 
 add_executable(cephfs-mirror
   main.cc)
+add_dependencies(cephfs-mirror prebuild-targets)
 
 add_library(cephfs_mirror_internal STATIC
   ${cephfs_mirror_internal})
+add_dependencies(cephfs_mirror_internal prebuild-targets)
 
 target_link_libraries(cephfs-mirror
   cephfs_mirror_internal

--- a/src/tools/erasure-code/CMakeLists.txt
+++ b/src/tools/erasure-code/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(ceph-erasure-code-tool
   ${PROJECT_SOURCE_DIR}/src/osd/ECUtil.cc
   ceph-erasure-code-tool.cc)
+add_dependencies(ceph-erasure-code-tool prebuild-targets)
 target_link_libraries(ceph-erasure-code-tool global ceph-common)
 install(TARGETS ceph-erasure-code-tool DESTINATION bin)

--- a/src/tools/immutable_object_cache/CMakeLists.txt
+++ b/src/tools/immutable_object_cache/CMakeLists.txt
@@ -8,6 +8,7 @@ set(ceph_immutable_object_cache_files
   Types.cc
   )
 add_library(ceph_immutable_object_cache_lib STATIC ${ceph_immutable_object_cache_files})
+add_dependencies(ceph_immutable_object_cache_lib prebuild-targets)
 
 add_executable(ceph-immutable-object-cache
   main.cc)

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -61,6 +61,7 @@ endif()
 
 add_executable(rbd ${rbd_srcs}
   $<TARGET_OBJECTS:common_texttable_obj>)
+add_dependencies(rbd prebuild-targets)
 set_target_properties(rbd PROPERTIES OUTPUT_NAME rbd)
 target_link_libraries(rbd
   cls_journal_client

--- a/src/tools/rbd_ggate/CMakeLists.txt
+++ b/src/tools/rbd_ggate/CMakeLists.txt
@@ -5,5 +5,6 @@ add_executable(rbd-ggate
   debug.cc
   ggate_drv.c
   main.cc)
+add_dependencies(rbd-ggate prebuild-targets)
 target_link_libraries(rbd-ggate geom librbd librados global)
 install(TARGETS rbd-ggate DESTINATION bin)

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(rbd_mirror_types STATIC
   image_map/Types.cc
   instance_watcher/Types.cc
   leader_watcher/Types.cc)
+add_dependencies(rbd_mirror_types prebuild-targets)
 
 set(rbd_mirror_internal
   ClusterWatcher.cc
@@ -67,9 +68,11 @@ set(rbd_mirror_internal
 add_library(rbd_mirror_internal STATIC
   ${rbd_mirror_internal}
   $<TARGET_OBJECTS:common_prioritycache_obj>)
+add_dependencies(rbd_mirror_internal prebuild-targets)
 
 add_executable(rbd-mirror
   main.cc)
+add_dependencies(rbd-mirror prebuild-targets)
 target_link_libraries(rbd-mirror
   rbd_mirror_internal
   rbd_mirror_types

--- a/src/tools/rbd_nbd/CMakeLists.txt
+++ b/src/tools/rbd_nbd/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(nl REQUIRED genl)
 add_executable(rbd-nbd rbd-nbd.cc)
+add_dependencies(rbd-nbd prebuild-targets)
 target_link_libraries(rbd-nbd librbd librados global nl::genl)
 install(TARGETS rbd-nbd DESTINATION bin)

--- a/src/tools/rbd_wnbd/CMakeLists.txt
+++ b/src/tools/rbd_wnbd/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(
     rbd_mapping.cc rbd_mapping_config.cc
     rbd_wnbd.cc wnbd_handler.cc wnbd_wmi.cc
     ../../common/win32/code_page.rc)
+add_dependencies(rbd-wnbd prebuild-targets)
 set_target_properties(
     rbd-wnbd PROPERTIES COMPILE_FLAGS
     "-fpermissive -I${WNBD_INCLUDE_DIRS}")


### PR DESCRIPTION
There's a race condition where on slow hosts, headers aren't generated before starting the build process. The way to fix this in a Debian package is to do:

override_dh_auto_build:
        dh_auto_build --buildsystem=cmake -- legacy-option-headers
        dh_auto_build --buildsystem=cmake

but this is a hack, and best is to get these dependencies fixed in the build process directly. This is what this patch is attempting to do.


Co-Author: Xinhui Yang <cyan@cyano.uk>