### PR TITLE
test/osd/TestOSDScrub: free res_ninit/res_nquery  and MonClient resource

### DIFF
--- a/src/common/dns_resolve.cc
+++ b/src/common/dns_resolve.cc
@@ -56,6 +56,7 @@ DNSResolver::~DNSResolver()
 #ifdef HAVE_RES_NQUERY
   for (auto iter = states.begin(); iter != states.end(); ++iter) {
     struct __res_state *s = *iter;
+    res_nclose(s);
     delete s;
   }
 #endif

--- a/src/test/osd/TestOSDScrub.cc
+++ b/src/test/osd/TestOSDScrub.cc
@@ -196,6 +196,7 @@ TEST(TestOSDScrub, scrub_time_permit) {
   now = utime_t(mktime(&tm), 0);
   ret = osd->scrub_time_permit(now);
   ASSERT_FALSE(ret);
+  mc.shutdown();
 }
 
 // Local Variables:


### PR DESCRIPTION
When sanitizer is enabled, unittest_osdscrub shows

```
=================================================================
==1633952==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 28 byte(s) in 1 object(s) allocated from:
    #0 0xaaaab4e108e0 in malloc (/root/ceph/build/bin/unittest_osdscrub+0x1ed08e0) (BuildId: b3cfa2137be96d75535beecf0f2500cec10c7550)
    https://github.com/ceph/ceph/pull/1 0xffffa8cac2f8 in __res_context_send resolv/./resolv/res_send.c:334:9
    https://github.com/ceph/ceph/pull/2 0xffffa8ca9c54 in __res_context_query resolv/./resolv/res_query.c:216:6
    https://github.com/ceph/ceph/pull/3 0xffffa8caa4a8 in __res_context_querydomain resolv/./resolv/res_query.c:625:9
    https://github.com/ceph/ceph/pull/4 0xffffa8caa4a8 in __res_context_search resolv/./resolv/res_query.c:381:9
    https://github.com/ceph/ceph/pull/5 0xffffa8caaa20 in context_search_common resolv/./resolv/res_query.c:550:16
    https://github.com/ceph/ceph/pull/6 0xffffa8caaa20 in res_nsearch resolv/./resolv/res_query.c:563:10
    https://github.com/ceph/ceph/pull/7 0xffffabbf1f64 in ceph::ResolvHWrapper::res_nsearch(__res_state*, char const*, int, int, unsigned char*, int) /root/ceph/src/common/dns_resolve.cc:37:10
    https://github.com/ceph/ceph/pull/8 0xffffabbf6574 in ceph::DNSResolver::resolve_srv_hosts(ceph::common::CephContext*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, ceph::DNSResolver::SRV_Protocol, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ceph::DNSResolver::Record, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, ceph::DNSResolver::Record> > >*) /root/ceph/src/common/dns_resolve.cc:295:19
    https://github.com/ceph/ceph/pull/9 0xffffac8edaf0 in MonMap::init_with_dns_srv(ceph::common::CephContext*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, std::ostream&) /root/ceph/src/mon/MonMap.cc:935:36
    https://github.com/ceph/ceph/pull/10 0xffffac8eeec8 in MonMap::build_initial(ceph::common::CephContext*, bool, std::ostream&) /root/ceph/src/mon/MonMap.cc:1014:20
    https://github.com/ceph/ceph/pull/11 0xffffac85beb0 in MonClient::build_initial_monmap() /root/ceph/src/mon/MonClient.cc:93:18
    https://github.com/ceph/ceph/pull/12 0xaaaab4e50d98 in TestOSDScrub_scrub_time_permit_Test::TestBody() /root/ceph/src/test/osd/TestOSDScrub.cc:73:6
    https://github.com/ceph/ceph/pull/13 0xaaaab4f655b0 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    https://github.com/ceph/ceph/pull/14 0xaaaab4f16264 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    https://github.com/ceph/ceph/pull/15 0xaaaab4ec6ca8 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    https://github.com/ceph/ceph/pull/16 0xaaaab4ec8bec in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    https://github.com/ceph/ceph/pull/17 0xaaaab4eca1ec in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    https://github.com/ceph/ceph/pull/18 0xaaaab4ee5fb0 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    https://github.com/ceph/ceph/pull/19 0xaaaab4f6f4c4 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    https://github.com/ceph/ceph/pull/20 0xaaaab4f1d4bc in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    https://github.com/ceph/ceph/pull/21 0xaaaab4ee5428 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    https://github.com/ceph/ceph/pull/22 0xaaaab4e4b790 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    https://github.com/ceph/ceph/pull/23 0xaaaab4e49dbc in main /root/ceph/src/test/unit.cc:45:10
    https://github.com/ceph/ceph/pull/24 0xffffa8bc73f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    https://github.com/ceph/ceph/pull/25 0xffffa8bc74c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    https://github.com/ceph/ceph/pull/26 0xaaaab4d9972c in _start (/root/ceph/build/bin/unittest_osdscrub+0x1e5972c) (BuildId: b3cfa2137be96d75535beecf0f2500cec10c7550)

-----------------------------------------------------
Suppressions used:
  count      bytes template
      1         45 ^MallocExtension::Initialize
-----------------------------------------------------

SUMMARY: AddressSanitizer: 28 byte(s) leaked in 1 allocation(s).
```

1. 'res_ninit/res_nquery' memory should be freed.
2. free MonClient using Monclient::shutdown


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
