### PR TITLE
quincy: bluestore/bluestore_types: check 'it' valid before using

### DIFF
--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -1315,7 +1315,7 @@ struct sb_info_space_efficient_map_t {
 	  [](const sb_info_t& a, const uint64_t& b) {
 	    return a < b;
 	  });
-	if (it->get_sbid() == id) {
+        if (it != aux_items.end() && it->get_sbid() == id) {
 	  return it;
 	}
       }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65483

---

backport of https://github.com/ceph/ceph/pull/56854
parent tracker: https://tracker.ceph.com/issues/65482

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh