### PR TITLE
qa/rgw/multisite: enable notification_v2 feature

### DIFF
--- a/qa/suites/rgw/multisite/realms/three-zones.yaml
+++ b/qa/suites/rgw/multisite/realms/three-zones.yaml
@@ -8,7 +8,7 @@ overrides:
         is_master: true
         is_default: true
         endpoints: [c1.client.0]
-        enabled_features: ['resharding']
+        enabled_features: ['resharding', 'notification_v2']
         zones:
           - name: test-zone1
             is_master: true

--- a/qa/suites/rgw/multisite/realms/two-zonegroup.yaml
+++ b/qa/suites/rgw/multisite/realms/two-zonegroup.yaml
@@ -8,7 +8,7 @@ overrides:
         is_master: true
         is_default: true
         endpoints: [c1.client.0]
-        enabled_features: ['resharding']
+        enabled_features: ['resharding', 'notification_v2']
         zones:
           - name: a1
             is_master: true
@@ -19,7 +19,7 @@ overrides:
       - name: b
         is_default: true
         endpoints: [c2.client.0]
-        enabled_features: ['resharding']
+        enabled_features: ['resharding', 'notification_v2']
         zones:
           - name: b1
             is_master: true


### PR DESCRIPTION
without this feature enabled, `test_topic_notification_sync()` fails with:

> An error occurred (InvalidArgument) when calling the CreateTopic operation: The 'notification_v2' zone feature must be enabled to create topics in an account

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
