### PR TITLE
reef: mds: Add fragment to scrub

### DIFF
--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -199,6 +199,8 @@ class TestScrubChecks(CephFSTestCase):
 
     MDSS_REQUIRED = 1
     CLIENTS_REQUIRED = 1
+    def get_dsplits(self, dir_ino):
+        return self.fs.rank_asok(['dump', 'inode', str(dir_ino)])['dirfragtree']['splits']
 
     def test_scrub_checks(self):
         self._checks(0)
@@ -361,6 +363,86 @@ class TestScrubChecks(CephFSTestCase):
 
         # fragstat should be fixed
         self.mount_a.run_shell(["rmdir", test_dir])
+
+    def test_scrub_merge_dirfrags(self):
+        """
+        That a directory is merged during scrub.
+        """
+
+        test_path = "testdir"
+        abs_test_path = f"/{test_path}"
+        split_size = 20
+        merge_size = 5
+        split_bits = 1
+        self.config_set('mds', 'mds_bal_split_size', split_size)
+        self.config_set('mds', 'mds_bal_merge_size', merge_size)
+        self.config_set('mds', 'mds_bal_split_bits', split_bits)
+
+        self.mount_a.run_shell(["mkdir", test_path])
+        dir_ino=self.mount_a.path_to_ino(test_path)
+
+        self.assertEqual(len(self.get_dsplits(dir_ino)), 0)
+        self.mount_a.create_n_files(f"{test_path}/file", split_size * 2)
+
+        self.mount_a.umount_wait()
+
+        self.fs.flush()
+        self.fs.mds_fail_restart()
+        self.fs.wait_for_daemons()
+
+        split_size = 100
+        merge_size = 30
+        self.config_set('mds', 'mds_bal_split_size', split_size)
+        self.config_set('mds', 'mds_bal_merge_size', merge_size)
+
+        #Assert to ensure split is present
+        self.assertGreater(len(self.get_dsplits(dir_ino)), 0)
+        out_json = self.fs.run_scrub(["start", abs_test_path, "recursive"])
+        self.assertNotEqual(out_json, None)
+
+        #Wait until no splits to confirm merge by scrub
+        self.wait_until_true(
+            lambda: len(self.get_dsplits(dir_ino)) == 0,
+            timeout=30
+        )
+
+    def test_scrub_split_dirfrags(self):
+        """
+        That a directory is split during scrub.
+        """
+
+        test_path = "testdir"
+        abs_test_path = f"/{test_path}"
+        split_size = 20
+        merge_size = 5
+        split_bits = 1
+
+        self.mount_a.run_shell(["mkdir", test_path])
+        dir_ino=self.mount_a.path_to_ino(test_path)
+
+        self.assertEqual(len(self.get_dsplits(dir_ino)), 0)
+        self.mount_a.create_n_files(f"{test_path}/file", split_size + 1)
+
+        self.mount_a.umount_wait()
+
+        self.fs.flush()
+        self.fs.mds_fail_restart()
+        self.fs.wait_for_daemons()
+
+        self.config_set('mds', 'mds_bal_split_size', split_size)
+        self.config_set('mds', 'mds_bal_merge_size', merge_size)
+        self.config_set('mds', 'mds_bal_split_bits', split_bits)
+
+        #Assert to ensure no splits are present
+        self.assertEqual(len(self.get_dsplits(dir_ino)), 0)
+        out_json = self.fs.run_scrub(["start", abs_test_path, "recursive"])
+        self.assertNotEqual(out_json, None)
+
+        #Wait until split is present to confirm split by scrub
+        self.wait_until_true(
+            lambda: len(self.get_dsplits(dir_ino)) > 0,
+            timeout=30
+        )
 
     def test_stray_evaluation_with_scrub(self):
         """

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -12514,6 +12514,9 @@ void MDCache::force_readonly()
   mds->mdlog->flush();
 }
 
+void MDCache::maybe_fragment(CDir *dir) {
+  mds->balancer->maybe_fragment(dir, false);
+}
 
 // ==============================================================
 // debug crap

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -269,6 +269,8 @@ class MDCache {
   bool is_readonly() { return readonly; }
   void force_readonly();
 
+  void maybe_fragment(CDir* dir);
+
   static file_layout_t gen_default_file_layout(const MDSMap &mdsmap);
   static file_layout_t gen_default_log_layout(const MDSMap &mdsmap);
 

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -470,6 +470,7 @@ void ScrubStack::scrub_dirfrag(CDir *dir, bool *done)
                  << " log and `damage ls` output for details";
   }
 
+  mdcache->maybe_fragment(dir);
   dir->scrub_finished();
   dir->auth_unpin(this);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65488

---

backport of https://github.com/ceph/ceph/pull/53564
parent tracker: https://tracker.ceph.com/issues/57481

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh