### PR TITLE
squid: qa/cephadm: only fail on CEPHADM_ error in logs

### DIFF
--- a/qa/suites/orch/cephadm/mgr-nfs-upgrade/1-bootstrap/17.2.0.yaml
+++ b/qa/suites/orch/cephadm/mgr-nfs-upgrade/1-bootstrap/17.2.0.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm:
     roleless: true

--- a/qa/suites/orch/cephadm/no-agent-workunits/task/test_cephadm_timeout.yaml
+++ b/qa/suites/orch/cephadm/no-agent-workunits/task/test_cephadm_timeout.yaml
@@ -4,6 +4,10 @@ roles:
   - mgr.a
   - osd.0
   - client.0
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/no-agent-workunits/task/test_orch_cli.yaml
+++ b/qa/suites/orch/cephadm/no-agent-workunits/task/test_orch_cli.yaml
@@ -6,6 +6,10 @@ roles:
   - mon.a
   - mgr.a
   - client.0
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/no-agent-workunits/task/test_orch_cli_mon.yaml
+++ b/qa/suites/orch/cephadm/no-agent-workunits/task/test_orch_cli_mon.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     log-ignorelist:
       - MON_DOWN
+    log-only-match:
+      - CEPHADM_
 roles:
 - - host.a
   - osd.0

--- a/qa/suites/orch/cephadm/osds/1-start.yaml
+++ b/qa/suites/orch/cephadm/osds/1-start.yaml
@@ -23,3 +23,5 @@ overrides:
     conf:
       osd:
         osd shutdown pgref assert: true
+    log-only-match:
+      - CEPHADM_

--- a/qa/suites/orch/cephadm/smoke-roleless/1-start.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/1-start.yaml
@@ -22,3 +22,5 @@ overrides:
     conf:
       osd:
         osd shutdown pgref assert: true
+    log-only-match:
+      - CEPHADM_

--- a/qa/suites/orch/cephadm/smoke-singlehost/1-start.yaml
+++ b/qa/suites/orch/cephadm/smoke-singlehost/1-start.yaml
@@ -25,3 +25,5 @@ overrides:
     conf:
       osd:
         osd shutdown pgref assert: true
+    log-only-match:
+      - CEPHADM_

--- a/qa/suites/orch/cephadm/smoke-small/start.yaml
+++ b/qa/suites/orch/cephadm/smoke-small/start.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm:
     conf:

--- a/qa/suites/orch/cephadm/smoke/start.yaml
+++ b/qa/suites/orch/cephadm/smoke/start.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     log-ignorelist:
       - MON_DOWN
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm:
     conf:

--- a/qa/suites/orch/cephadm/thrash/1-start.yaml
+++ b/qa/suites/orch/cephadm/thrash/1-start.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/simple.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/simple.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm.shell:
     env: [sha1]

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm.shell:
     env: [sha1]

--- a/qa/suites/orch/cephadm/with-work/start.yaml
+++ b/qa/suites/orch/cephadm/with-work/start.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/workunits/task/test_ca_signed_key.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_ca_signed_key.yaml
@@ -12,6 +12,9 @@ roles:
 overrides:
   cephadm:
     use-ca-signed-key: True
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/workunits/task/test_extra_daemon_features.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_extra_daemon_features.yaml
@@ -7,6 +7,10 @@ roles:
   - mon.b
   - mgr.b
   - osd.1
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/workunits/task/test_host_drain.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_host_drain.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     log-ignorelist:
       - MON_DOWN
+    log-only-match:
+      - CEPHADM_
 roles:
 - - host.a
   - mon.a

--- a/qa/suites/orch/cephadm/workunits/task/test_iscsi_container/test_iscsi_container.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_iscsi_container/test_iscsi_container.yaml
@@ -6,6 +6,10 @@ roles:
   - mon.a
   - mgr.a
   - client.0
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/workunits/task/test_monitoring_stack_basic.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_monitoring_stack_basic.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     log-ignorelist:
       - MON_DOWN
+    log-only-match:
+      - CEPHADM_
 roles:
 - - host.a
   - mon.a

--- a/qa/suites/orch/cephadm/workunits/task/test_rgw_multisite.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_rgw_multisite.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     log-ignorelist:
       - MON_DOWN
+    log-only-match:
+      - CEPHADM_
 roles:
 - - host.a
   - mon.a

--- a/qa/suites/orch/cephadm/workunits/task/test_set_mon_crush_locations.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_set_mon_crush_locations.yaml
@@ -3,6 +3,8 @@ overrides:
     log-ignorelist:
       - MON_DOWN
       - POOL_APP_NOT_ENABLED
+    log-only-match:
+      - CEPHADM_
 roles:
 - - host.a
   - osd.0


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/56767

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
