### PR TITLE
squid: qa: fixing tests in test_cephfs_shell.TestShellOpts

### DIFF
--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -1108,7 +1108,9 @@ class TestShellOpts(TestCephFSShell):
         # output of following command -
         # editor - was: 'vim'
         # now: '?'
-        # editor: '?'
+        # Name    Value                           Description
+        # ====================================================================================================
+        # editor  ?                               Program used by 'edit'
         self.editor_val = self.get_cephfs_shell_cmd_output(
             'set editor ?, set editor').split('\n')[4]
         self.editor_val = self.editor_val.split()[1].strip(). \
@@ -1125,7 +1127,9 @@ class TestShellOpts(TestCephFSShell):
 
         # output of following command -
         # CephFS:~/>>> set editor
-        # editor: 'vim'
+        # Name    Value                           Description
+        # ====================================================================================================
+        # editor  ???                             Program used by 'edit'
         final_editor_val = self.get_cephfs_shell_cmd_output(
             cmd='set editor', shell_conf_path=self.tempconfpath)
         final_editor_val = final_editor_val.split('\n')[2]
@@ -1136,14 +1140,16 @@ class TestShellOpts(TestCephFSShell):
 
     def test_reading_conf_with_dup_opt(self):
         """
-        Read conf without duplicate sections/options.
+        Read conf with duplicate sections/options.
         """
         self.write_tempconf("[cephfs-shell]\neditor = ???\neditor = " +
                             self.editor_val)
 
         # output of following command -
         # CephFS:~/>>> set editor
-        # editor: 'vim'
+        # Name    Value                           Description
+        # ====================================================================================================
+        # editor  ?                               Program used by 'edit'
         final_editor_val = self.get_cephfs_shell_cmd_output(
             cmd='set editor', shell_conf_path=self.tempconfpath)
         final_editor_val = final_editor_val.split('\n')[2]
@@ -1156,9 +1162,11 @@ class TestShellOpts(TestCephFSShell):
         self.write_tempconf("[cephfs-shell]\neditor = ???")
 
         # output of following command -
-        # editor - was: vim
-        # now: vim
-        # editor: vim
+        # editor - was: ???
+        # now: ?
+        # Name    Value                           Description
+        # ====================================================================================================
+        # editor  ?                               Program used by 'edit'
         final_editor_val = self.get_cephfs_shell_cmd_output(
             cmd='set editor %s, set editor' % self.editor_val,
             shell_conf_path=self.tempconfpath)

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -1110,9 +1110,9 @@ class TestShellOpts(TestCephFSShell):
         # now: '?'
         # editor: '?'
         self.editor_val = self.get_cephfs_shell_cmd_output(
-            'set editor ?, set editor').split('\n')[2]
-        self.editor_val = self.editor_val.split(':')[1]. \
-            replace("'", "", 2).strip()
+            'set editor ?, set editor').split('\n')[4]
+        self.editor_val = self.editor_val.split()[1].strip(). \
+            replace("'", "", 2)
 
     def write_tempconf(self, confcontents):
         self.tempconfpath = self.mount_a.client_remote.mktemp(
@@ -1128,8 +1128,9 @@ class TestShellOpts(TestCephFSShell):
         # editor: 'vim'
         final_editor_val = self.get_cephfs_shell_cmd_output(
             cmd='set editor', shell_conf_path=self.tempconfpath)
-        final_editor_val = final_editor_val.split(': ')[1]
-        final_editor_val = final_editor_val.replace("'", "", 2)
+        final_editor_val = final_editor_val.split('\n')[2]
+        final_editor_val = final_editor_val.split()[1].strip(). \
+            replace("'", "", 2)
 
         self.assertNotEqual(self.editor_val, final_editor_val)
 
@@ -1145,8 +1146,9 @@ class TestShellOpts(TestCephFSShell):
         # editor: 'vim'
         final_editor_val = self.get_cephfs_shell_cmd_output(
             cmd='set editor', shell_conf_path=self.tempconfpath)
-        final_editor_val = final_editor_val.split(': ')[1]
-        final_editor_val = final_editor_val.replace("'", "", 2)
+        final_editor_val = final_editor_val.split('\n')[2]
+        final_editor_val = final_editor_val.split()[1].strip(). \
+            replace("'", "", 2)
 
         self.assertEqual(self.editor_val, final_editor_val)
 
@@ -1160,8 +1162,8 @@ class TestShellOpts(TestCephFSShell):
         final_editor_val = self.get_cephfs_shell_cmd_output(
             cmd='set editor %s, set editor' % self.editor_val,
             shell_conf_path=self.tempconfpath)
-        final_editor_val = final_editor_val.split('\n')[2]
-        final_editor_val = final_editor_val.split(': ')[1]
-        final_editor_val = final_editor_val.replace("'", "", 2)
+        final_editor_val = final_editor_val.split('\n')[4]
+        final_editor_val = final_editor_val.split()[1].strip(). \
+            replace("'", "", 2)
 
         self.assertEqual(self.editor_val, final_editor_val)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65347

---

backport of https://github.com/ceph/ceph/pull/55725
parent tracker: https://tracker.ceph.com/issues/63699

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh