### PR TITLE
squid: mgr/dashboard: remove minutely from retention 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/retention-frequency.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/retention-frequency.enum.ts
@@ -1,5 +1,4 @@
 export enum RetentionFrequency {
-  Minutely = 'm',
   Hourly = 'h',
   Daily = 'd',
   Weekly = 'w',


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65501

---

backport of https://github.com/ceph/ceph/pull/56907
parent tracker: https://tracker.ceph.com/issues/65493

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh