### PR TITLE
mgr/dashboard: Support Description and AccountId in rgw roles

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -858,9 +858,12 @@ edit_role_form = Form(path='/edit',
         "MaxSessionDuration": {'cellTemplate': 'duration'},
         "RoleId": {'isHidden': True},
         "AssumeRolePolicyDocument": {'isHidden': True},
-        "PermissionPolicies": {'isHidden': True}
+        "PermissionPolicies": {'isHidden': True},
+        "Description": {'isHidden': True},
+        "AccountId": {'isHidden': True}
     },
-    detail_columns=['RoleId', 'AssumeRolePolicyDocument', 'PermissionPolicies'],
+    detail_columns=['RoleId', 'Description',
+                    'AssumeRolePolicyDocument', 'PermissionPolicies', 'AccountId'],
     meta=CRUDMeta()
 )
 class RgwUserRole(NamedTuple):
@@ -872,6 +875,8 @@ class RgwUserRole(NamedTuple):
     MaxSessionDuration: int
     AssumeRolePolicyDocument: str
     PermissionPolicies: List
+    Description: str
+    AccountId: str
 
 
 @APIRouter('/rgw/realm', Scope.RGW)


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/65506

Rgw roles list page is crashing due to these new fields coming from api but not supported in dashboard frontend.
This will also fix failing CI tests.

![image](https://github.com/ceph/ceph/assets/25664409/2869889a-5a6b-4d82-b16d-d49b65a5a368)


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
