### PR TITLE
osd/ECTransaction: Remove incorrect asserts in generate_transactions

### DIFF
--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -193,9 +193,6 @@ void ECTransaction::generate_transactions(
       xattr_rollback[ECUtil::get_hinfo_key()] = old_hinfo;
 
       if (op.is_none() && op.truncate && op.truncate->first == 0) {
-	ceph_assert(op.truncate->first == 0);
-	ceph_assert(op.truncate->first ==
-	       op.truncate->second);
 	ceph_assert(entry);
 	ceph_assert(obc);
 


### PR DESCRIPTION
Back in PR #11701 when EC Overwrites were added, there was significant churn in the ECTransaction code.  Several asserts were added in generate_transactions, but the code changed several times and it appears some of those asserts don't make sense in the final version of the PR.

This PR removes two of those asserts.  The first doesn't appear to be necessary given how the surrounding conditional block changed.   The second appears to be an incorrect assert that was left over from an earlier commit that no longer should be in place given the logic that was added to handle truncate (which roughly mirrors what we do in ReplicatedBackend).

It's possible the assert for entry and/or obc are also unnecessary, however I left those in place for now.

Fixes: https://tracker.ceph.com/issues/65509