### PR TITLE
os/bluestore: Blazingly fast new BlueFS WAL disk format :rocket: 

### DIFF
--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -30,6 +30,7 @@ Synopsis
 | **ceph-bluestore-tool** reshard --path *osd path* --sharding *new sharding* [ --sharding-ctrl *control string* ]
 | **ceph-bluestore-tool** show-sharding --path *osd path*
 | **ceph-bluestore-tool** trim --path *osd path*
+| **ceph-bluestore-tool** downgrade-wal-to-v1 --path *osd path*
 
 
 Description
@@ -138,6 +139,11 @@ Commands
    This operation uses TRIM / discard to free unused blocks from BlueStore and BlueFS block devices,
    and allows the drive to perform more efficient internal housekeeping.
    If BlueStore runs with discard enabled, this option may not be useful.
+   
+:command: `downgrade-wal-to-v1` --path *osd path*
+
+   Changes WAL disk format from the new version to the legacy one. Useful for downgrades, or if you
+   might want to disable this new feature (bluefs_wal_v2).
 
 Options
 =======

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6584,3 +6584,12 @@ options:
   desc: Enables exception throwing instead of process abort on transaction submission error.
   default: false
   with_legacy: false
+- name: bluefs_wal_v2
+  type: bool
+  level: advanced
+  desc: Enables a faster backend in BlueFS for WAL writes.
+  long_desc: Enabling this feature will reduce ~50% the amount of fdatasync syscalls issued by WAL writes. This happens because we embed metadata
+    with the data itself. Downgrading from a version that uses v2 to v1 will require running `ceph-bluestore-tool --command downgrade-wal-to-v1`
+    to move wal files to previous format.
+  default: true
+  with_legacy: false

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -1876,6 +1876,16 @@ inline std::enable_if_t<traits::supported && !traits::featured> decode_nohead(
   static_assert(CEPH_RELEASE >= (CEPH_RELEASE_SQUID /*19*/ + 2) || compat == 2);	\
   _denc_start(p, &struct_v, &struct_compat, &_denc_pchar, &_denc_u32);	\
   do {
+  
+// This variant is unsafe, because older versions will not even catch incompatibility.
+// The ability to decode must be verified by other means,
+#define DENC_START_UNSAFE(v, compat, p)				\
+  __u8 struct_v = v;							\
+  __u8 struct_compat = compat;						\
+  char *_denc_pchar;							\
+  uint32_t _denc_u32;							\
+  _denc_start(p, &struct_v, &struct_compat, &_denc_pchar, &_denc_u32);	\
+  do {
 
 // For osd_reqid_t which cannot be upgraded at all.
 // We used it to communicate with clients and now we cannot safely upgrade.

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -40,7 +40,8 @@ endif()
 add_library(os STATIC ${libos_srcs})
 target_link_libraries(os
   legacy-option-headers
-  blk)
+  blk
+  fmt::fmt)
 
 target_link_libraries(os heap_profiler kv)
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
+#include <asm-generic/errno-base.h>
 #include <chrono>
+#include <fmt/compile.h>
 #include "boost/algorithm/string.hpp" 
 #include "bluestore_common.h"
 #include "BlueFS.h"
@@ -9,8 +11,10 @@
 #include "common/errno.h"
 #include "common/perf_counters.h"
 #include "Allocator.h"
+#include "include/buffer_fwd.h"
 #include "include/ceph_assert.h"
 #include "common/admin_socket.h"
+#include "os/bluestore/bluefs_types.h"
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_bluefs
@@ -1177,9 +1181,15 @@ int BlueFS::fsck()
   return 0;
 }
 
-int BlueFS::_write_super(int dev)
+int BlueFS::_write_super(int dev, uint8_t wal_version)
 {
   ++super.version;
+  if (wal_version > 0) {
+    super.wal_version = wal_version;
+  } else {
+    bool use_wal_v2 = cct->_conf.get_val<bool>("bluefs_wal_v2");
+    super.wal_version = use_wal_v2 ? 2 : 1;
+  }
   // build superblock
   bufferlist bl;
   encode(super, bl);
@@ -1565,6 +1575,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
               vselector->get_hint_by_dir(dirname);
             vselector->add_usage(file->vselector_hint, file->fnode);
 
+
 	    q->second->file_map[filename] = file;
 	    ++file->refs;
 	  }
@@ -1590,8 +1601,10 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 	    ceph_assert(q != nodes.dir_map.end());
 	    map<string,FileRef>::iterator r = q->second->file_map.find(filename);
 	    ceph_assert(r != q->second->file_map.end());
-            ceph_assert(r->second->refs > 0); 
-	    --r->second->refs;
+
+      FileRef file = r->second;
+      ceph_assert(file->refs > 0); 
+	    --file->refs;
 	    q->second->file_map.erase(r);
 	  }
 	}
@@ -1640,6 +1653,7 @@ int BlueFS::_replay(bool noop, bool to_stdout)
         {
 	  bluefs_fnode_t fnode;
 	  decode(fnode, p);
+          ceph_assert(fnode.type == bluefs_node_type::REGULAR || fnode.type == bluefs_node_type::WAL_V2);
 	  dout(20) << __func__ << " 0x" << std::hex << pos << std::dec
                    << ":  op_file_update " << " " << fnode << " " << dendl;
           if (unlikely(to_stdout)) {
@@ -1710,8 +1724,10 @@ int BlueFS::_replay(bool noop, bool to_stdout)
 	    if (fnode.ino != 1) {
 	      vselector->sub_usage(f->vselector_hint, fnode);
 	    }
-	    fnode.size = delta.size;
 	    fnode.claim_extents(delta.extents);
+      fnode.size = delta.size;
+      fnode.wal_limit = delta.wal_limit;
+      fnode.wal_size = delta.wal_size;
 	    dout(20) << __func__ << " 0x" << std::hex << pos << std::dec
 		     << ":  op_file_update_inc produced " << " " << fnode << " " << dendl;
 
@@ -1787,7 +1803,18 @@ int BlueFS::_replay(bool noop, bool to_stdout)
     dirty.seq_live = log_seq + 1;
     log.t.seq = log.seq_live;
     dirty.seq_stable = log_seq;
+
+    for (const auto &[filename, file] : nodes.file_map) {
+      if (file->is_new_wal()) {
+          dout(5) << __func__ << " " << file << " " << file->refs << dendl;
+          if (file->refs == 0) {
+            continue;
+          }
+          _wal_update_size(file, file->fnode.size);
+      }
+    }
   }
+
 
   dout(10) << __func__ << " log file size was 0x"
            << std::hex << log_file->fnode.size << std::dec << dendl;
@@ -2113,6 +2140,7 @@ int BlueFS::device_migrate_to_new(
   return 0;
 }
 
+
 BlueFS::FileRef BlueFS::_get_file(uint64_t ino)
 {
   auto p = nodes.file_map.find(ino);
@@ -2273,6 +2301,185 @@ int64_t BlueFS::_read_random(
            << std::dec  << dendl;
   --h->file->num_reading;
   logger->tinc(l_bluefs_read_random_lat, mono_clock::now() - t0);
+  return ret;
+}
+
+void BlueFS::_wal_update_size(FileRef file, uint64_t increment) {
+  using WALLength = File::WALFlush::WALLength;
+  
+  file->is_wal_read_loaded = true;
+  file->wal_flushes.clear();
+  
+  uint64_t flush_offset = 0;
+  dout(20) 
+      << fmt::format(
+        "{} updating WAL file {} for range {:#x}~{:#x} limit is {:#x}", 
+        __func__, file->fnode.ino, flush_offset, increment, file->fnode.wal_limit) 
+      << dendl;
+  ceph_assert(file->wal_flushes.empty());
+
+  FileReader *h = new FileReader(file, cct->_conf->bluefs_max_prefetch, false, true);
+  
+  size_t header_size = File::WALFlush::header_size();
+
+  uint64_t flush_end = flush_offset + increment;
+  while (flush_offset < file->fnode.wal_limit) {
+    // read first part of wal flush
+    bufferlist bl;
+    bluefs_wal_header_t header;
+    
+    uint64_t read_result = (uint64_t)_read(h, flush_offset, header_size, &bl, nullptr);
+    if (read_result < header_size) {
+      dout(20) << fmt::format("{} cannot read wal header, most likely we are out of bounds. flush_offset={:#X}", __func__, flush_offset) << dendl;
+      break;
+    }
+    
+    dout(30) << __func__ << " result \n";
+    bl.hexdump(*_dout);
+    *_dout << dendl;
+    auto buffer_iterator = bl.cbegin();
+    try {
+      decode(header, buffer_iterator);
+    } catch(ceph::buffer::error& e) {
+      // EOF or corruption
+      dout(30) << fmt::format("couldn't decode wal flush header at offset {:#x}: {}", flush_offset, e.what()) << dendl;
+      break;
+    }
+    
+    WALLength flush_length = header.flush_length;
+    dout(20) << __func__ << " flush_length " << flush_length << dendl;
+    File::WALFlush new_flush(flush_offset, flush_length);
+
+    // read marker
+    bl.clear();
+    uint64_t marker_offset = new_flush.get_marker_offset();
+    read_result = _read(h, marker_offset, new_flush.tail_size(), &bl, nullptr);
+    if (read_result < new_flush.tail_size()) {
+      dout(20) << fmt::format("{} cannot read marker, most likely we are out of bounds. flush_offset={:#X}, marker_offset={:#X}", __func__, flush_offset, marker_offset) << dendl;
+      break;
+    }
+    uint64_t marker;
+    buffer_iterator = bl.cbegin();
+    decode(marker, buffer_iterator);
+    if (marker != File::WALFlush::generate_hashed_marker(super.osd_uuid, file->fnode.ino)) {
+      // EOF or corruption
+      dout(30) << fmt::format("reached eof or marker corruption {:#x}", flush_offset) << dendl;
+      break;
+    }
+
+    uint64_t increase = new_flush.end_offset() - new_flush.offset;
+    dout(20) << fmt::format("{} adding flush {:#x}~{:#x}", __func__, flush_offset, new_flush.length) << dendl;
+    file->wal_flushes.push_back(new_flush);
+    if (flush_offset >= flush_end) {
+      dout(20) << fmt::format("{} recovering flush {:#x}~{:#x}", __func__, flush_offset, new_flush.length) << dendl;
+      file->fnode.wal_size += new_flush.length;
+      file->fnode.size += increase;
+      vselector->add_usage(file->vselector_hint, increase);
+    }
+
+    flush_offset += increase;
+  }
+
+  // if we read less it might mean corruption
+  if (flush_offset < flush_end) {
+    dout(20) << fmt::format("{} read less than expected {:#x} bytes", __func__, flush_offset) << dendl;
+  }
+  ceph_assert(flush_offset >= flush_end);
+
+  delete h;
+}
+
+int64_t BlueFS::_read_wal(
+  FileReader *h,         ///< [in] read from here
+  uint64_t off,          ///< [in] offset
+  size_t len,            ///< [in] this many bytes
+  bufferlist *outbl,     ///< [out] optional: reference the result here
+  char *out)             ///< [out] optional: or copy it here
+{
+  ceph_assert(h->file->is_wal_read_loaded);
+  dout(20) << __func__ << " h " << h << " offset: 0x" 
+    << off << std::hex << "~" << len << std::hex << dendl;
+  if (outbl) {
+    outbl->clear();
+  }
+
+  int64_t ret = 0;
+
+  // WAL data is wrapped in an envelope that has a format of [length of flush, payload, file ino]
+  // wal_data_logical_offset points to the offset of the payload we are currently in.
+  uint64_t wal_data_logical_offset = 0;
+
+
+  // save previous position as buffer pos is treated difffernt on regular files
+  uint64_t previous_pos = h->buf.pos;
+
+  uint64_t remaining_len = len;
+  auto flush_iterator = h->file->wal_flushes.begin();
+  while (remaining_len > 0 && flush_iterator != h->file->wal_flushes.end()) {
+    uint64_t flush_offset = flush_iterator->offset;
+    uint64_t flush_length = flush_iterator->length;
+    dout(25) << fmt::format("{} flush_offset={:#x} flush_length={:#x}", __func__, flush_offset, flush_length) << dendl;
+
+    if (flush_length == 0) {
+      if (remaining_len > 0) {
+        dout(5) << __func__ << " flush_length 0: reading less then required "
+          << ret << "<" << len - ret << dendl;
+      }
+      break;
+    }
+    // if we won't find offset here, go ahead
+    bool in_range = wal_data_logical_offset < off + len && wal_data_logical_offset + flush_length > off;
+    ceph_assert(wal_data_logical_offset < off+len);
+    if (!in_range) {
+      if (off >= wal_data_logical_offset + flush_length) {
+        // move to next flush
+        // TODO(pere): do we check "ino" here too?
+        wal_data_logical_offset += flush_length;
+        flush_iterator++;
+        continue;
+      }
+    }
+
+    uint64_t payload_offset = flush_iterator->get_payload_offset();
+
+    uint64_t skip_front = 0;
+    if(wal_data_logical_offset < off) { 
+      // offset is in this flush chunk so if we are before we move forward
+      skip_front = off - wal_data_logical_offset;
+    }
+    payload_offset += skip_front;
+    wal_data_logical_offset += skip_front;
+
+    dout(20) << fmt::format("{} payload_offset is {:#X} after skipping {:#X} bytes", __func__, payload_offset, skip_front) << dendl;
+
+    uint64_t data_to_read_from_flush = std::min(flush_length-skip_front, remaining_len);
+    bufferlist payload;
+    dout(25) << fmt::format("{} data to read from flush = {:#X}", __func__, data_to_read_from_flush) << dendl;
+    _read(h, payload_offset, data_to_read_from_flush, &payload, nullptr);
+
+    if (out) {
+      auto p = payload.begin();
+      p.copy(data_to_read_from_flush, out);
+      out += data_to_read_from_flush;
+    }
+    if (outbl) {
+      outbl->claim_append(payload);
+    }
+    flush_iterator++;
+
+    remaining_len -= data_to_read_from_flush;
+    wal_data_logical_offset += data_to_read_from_flush;
+    ret += data_to_read_from_flush;
+  }
+  if (remaining_len > 0) {
+    dout(20) << __func__ << " reading less than required, missing: " << remaining_len <<  dendl;
+  }
+
+  dout(20) << __func__ << std::hex
+           << " got 0x" << ret
+           << std::dec  << dendl;
+  ceph_assert(!outbl || (int)outbl->length() == ret);
+  h->buf.pos = previous_pos + ret;
   return ret;
 }
 
@@ -3399,14 +3606,19 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
   if (partial) {
     tail_block.splice(0, tail_block.length(), &bl);
   }
+  dout(20) << __func__ << " tail is" << std::hex << bl.length() << dendl;
+  ceph_assert(length >= bl.length());
   const auto remaining_len = length - bl.length();
   buffer.splice(0, remaining_len, &bl);
   if (buffer.length()) {
     dout(20) << " leaving 0x" << std::hex << buffer.length() << std::dec
              << " unflushed" << dendl;
   }
-  if (const unsigned tail = bl.length() & ~super.block_mask(); tail) {
-    const auto padding_len = super.block_size - tail;
+  unsigned padding_len = 0;
+  // Append padding to fill block
+  const unsigned tail = bl.length() & ~super.block_mask();
+  if (tail) {
+    padding_len = super.block_size - tail;
     dout(20) << __func__ << " caching tail of 0x"
              << std::hex << tail
              << " and padding block with 0x" << padding_len
@@ -3417,6 +3629,7 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
     // Otherwise a costly rebuild could happen in e.g. `KernelDevice`.
     buffer_appender.append_zero(padding_len);
     buffer.splice(buffer.length() - padding_len, padding_len, &bl);
+    
     // Deep copy the tail here. This allows to avoid costlier copy on
     // bufferlist rebuild in e.g. `KernelDevice` and minimizes number
     // of memory allocations.
@@ -3428,6 +3641,7 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
   } else {
     tail_block.clear();
   }
+
   return bl;
 }
 
@@ -3479,6 +3693,13 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
   ceph_assert(h->file->num_readers.load() == 0);
   ceph_assert(h->file->fnode.ino > 1);
 
+  if (h->file->is_new_wal()) {
+    // WALFlush::WALLength is already appended at the start of first append_try_flush
+    // update length, offset is already updated with correct position
+    length += File::WALFlush::tail_size();
+  }
+  uint64_t end = offset + length;
+
   dout(10) << __func__ << " " << h << " pos 0x" << std::hex << h->pos
 	   << " 0x" << offset << "~" << length << std::dec
 	   << " to " << h->file->fnode
@@ -3491,9 +3712,11 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
 
   bool buffered = cct->_conf->bluefs_buffered_io;
 
-  if (offset + length <= h->pos)
+  if (end <= h->pos)
     return 0;
   if (offset < h->pos) {
+    // NOTE: let's assume that we do not overwrite wal
+    ceph_assert(!h->file->is_new_wal());
     length -= h->pos - offset;
     offset = h->pos;
     dout(10) << " still need 0x"
@@ -3506,11 +3729,11 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
   uint64_t allocated = h->file->fnode.get_allocated();
   // do not bother to dirty the file if we are overwriting
   // previously allocated extents.
-  if (allocated < offset + length) {
+  if (allocated < end) {
     // we should never run out of log space here; see the min runway check
     // in _flush_and_sync_log.
     int r = _allocate(vselector->select_prefer_bdev(h->file->vselector_hint),
-		      offset + length - allocated,
+		      end - allocated,
                       0,
 		      &h->file->fnode,
 		      [&](const bluefs_extent_t& e) {
@@ -3525,11 +3748,27 @@ int BlueFS::_flush_range_F(FileWriter *h, uint64_t offset, uint64_t length)
     }
     h->file->is_dirty = true;
   }
-  if (h->file->fnode.size < offset + length) {
-    vselector->add_usage(h->file->vselector_hint, offset + length - h->file->fnode.size);
-    h->file->fnode.size = offset + length;
-    h->file->is_dirty = true;
+  if (h->file->fnode.size < end) {
+    vselector->add_usage(h->file->vselector_hint, end - h->file->fnode.size);
+    h->file->fnode.size = end;
+    // Don't mark regular appends as dirty on WAL_V2. Note that allocations are marked as dirty.
+    if (!h->file->is_new_wal()) {
+      h->file->is_dirty = true;
+    }
   }
+
+  if (h->file->is_new_wal()) {
+    // create WAL flush envelope
+    uint64_t flush_size = length - File::WALFlush::extra_envelope_size_on_front_and_tail();
+    ceph_assert(h->get_wal_header_filler() != nullptr);
+    bluefs_wal_header_t(flush_size).encode(*h->get_wal_header_filler());
+    h->set_wal_header_filler(nullptr);
+
+    h->append(h->file->wal_marker);
+    h->file->fnode.wal_size += flush_size;
+    h->file->fnode.wal_limit = h->file->fnode.get_allocated();
+  }
+
   dout(20) << __func__ << " file now, unflushed " << h->file->fnode << dendl;
   int res = _flush_data(h, offset, length, buffered);
   logger->tinc(l_bluefs_flush_lat, mono_clock::now() - t0);
@@ -3619,6 +3858,7 @@ int BlueFS::_flush_data(FileWriter *h, uint64_t offset, uint64_t length, bool bu
       }
     }
   }
+
   dout(20) << __func__ << " h " << h << " pos now 0x"
            << std::hex << h->pos << std::dec << dendl;
   return 0;
@@ -3659,6 +3899,14 @@ void BlueFS::append_try_flush(FileWriter *h, const char* buf, size_t len)/*_WF_L
   bool flushed_sum = false;
   {
     std::unique_lock hl(h->lock);
+
+    if (h->file->is_new_wal() && h->get_buffer_length() == 0) {
+      size_t size = 0;
+      bluefs_wal_header_t().bound_encode(size);
+      bufferlist::contiguous_filler filler = h->append_hole(size);
+      h->set_wal_header_filler(std::make_unique<bufferlist::contiguous_filler>(bufferlist::contiguous_filler(filler)));
+    }
+
     size_t max_size = 1ull << 30; // cap to 1GB
     while (len > 0) {
       bool need_flush = true;
@@ -3791,12 +4039,22 @@ int BlueFS::truncate(FileWriter *h, uint64_t offset)/*_WF_L*/
   vselector->sub_usage(h->file->vselector_hint, h->file->fnode.size - offset);
   h->file->fnode.size = offset;
   h->file->is_dirty = true;
+  if (h->file->is_new_wal()) {
+    // This assumption comes from reading logs of rocksdb+bluefs where a WAL file follows this pattern:
+    // 1. create wal
+    // 2. open_for_write
+    // 3. close_writer
+    // 4. truncate -> fnode.size
+    // 5. unlink
+    ceph_assert(h->file->fnode.size == offset || offset == 0);
+    h->file->fnode.wal_limit = offset;
+  }
   log.t.op_file_update_inc(h->file->fnode);
   logger->tinc(l_bluefs_truncate_lat, mono_clock::now() - t0);
   return 0;
 }
 
-int BlueFS::fsync(FileWriter *h)/*_WF_WD_WLD_WLNF_WNF*/
+int BlueFS::fsync(FileWriter *h, bool force_dirty)/*_WF_WD_WLD_WLNF_WNF*/
 {
   auto t0 = mono_clock::now();
   _maybe_check_vselector_LNF();
@@ -3809,7 +4067,7 @@ int BlueFS::fsync(FileWriter *h)/*_WF_WD_WLD_WLNF_WNF*/
     if (r < 0)
       return r;
     _flush_bdev(h);
-    if (h->file->is_dirty) {
+    if (h->file->is_dirty || force_dirty) {
       _signal_dirty_to_log_D(h);
       h->file->is_dirty = false;
     }
@@ -4066,8 +4324,11 @@ int BlueFS::preallocate(FileRef f, uint64_t off, uint64_t len)/*_LF*/
       });
     if (r < 0)
       return r;
-
+    if (f->is_new_wal()) {
+      f->fnode.wal_limit = f->fnode.get_allocated();
+    }
     log.t.op_file_update_inc(f->fnode);
+    f->is_dirty = true;
   }
   return 0;
 }
@@ -4179,18 +4440,15 @@ int BlueFS::open_for_write(
 	   << " vsel_hint " << file->vselector_hint
 	   << dendl;
 
-  log.t.op_file_update(file->fnode);
-  if (create)
-    log.t.op_dir_link(dirname, filename, file->fnode.ino);
-
-  std::lock_guard dl(dirty.lock);
-  for (auto& p : pending_release_extents) {
-    dirty.pending_release[p.bdev].insert(p.offset, p.length);
-  }
-  }
-  *h = _create_writer(file);
-
-  if (boost::algorithm::ends_with(filename, ".log")) {
+	*h = _create_writer(file);
+	
+	if (boost::algorithm::ends_with(filename, ".log")) {
+	  bool use_wal_v2 = cct->_conf.get_val<bool>("bluefs_wal_v2");
+    if (use_wal_v2) {
+      file->fnode.type = WAL_V2;
+      file->is_wal_read_loaded = false;
+      file->wal_marker = File::WALFlush::generate_hashed_marker(super.osd_uuid, file->fnode.ino);
+    }
     (*h)->writer_type = BlueFS::WRITER_WAL;
     if (logger && !overwrite) {
       logger->inc(l_bluefs_files_written_wal);
@@ -4201,6 +4459,18 @@ int BlueFS::open_for_write(
       logger->inc(l_bluefs_files_written_sst);
     }
   }
+  
+  log.t.op_file_update(file->fnode);
+  if (create) {
+    log.t.op_dir_link(dirname, filename, file->fnode.ino);
+  }
+
+  std::lock_guard dl(dirty.lock);
+  for (auto& p : pending_release_extents) {
+    dirty.pending_release[p.bdev].insert(p.offset, p.length);
+  }
+  }
+
 
   dout(10) << __func__ << " h " << *h << " on " << file->fnode << dendl;
   return 0;
@@ -4242,6 +4512,11 @@ void BlueFS::_close_writer(FileWriter *h)
 }
 void BlueFS::close_writer(FileWriter *h)
 {
+  if (h->file->is_new_wal()) {
+    // we force fsync by forcing dirty flag
+    fsync(h, true);
+  }
+  
   {
     std::lock_guard l(h->lock);
     _drain_writer(h);
@@ -4417,8 +4692,15 @@ int BlueFS::stat(std::string_view dirname, std::string_view filename,
   File *file = q->second.get();
   dout(10) << __func__ << " " << dirname << "/" << filename
 	   << " " << file->fnode << dendl;
-  if (size)
-    *size = file->fnode.size;
+				
+  if (size) {
+    if (file->is_new_wal()) {
+      *size = file->fnode.wal_size;
+    } else {
+      *size = file->fnode.size;
+    }
+  }
+  
   if (mtime)
     *mtime = file->fnode.mtime;
   return 0;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -781,6 +781,7 @@ public:
     const std::set<int>& devs_source,
     int dev_target,
     const bluefs_layout_t& layout);
+  int downgrade_wal_to_v1();
 
   uint64_t get_used();
   uint64_t get_total(unsigned id);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3048,6 +3048,7 @@ public:
   int repair(bool deep) override {
     return _fsck(deep ? FSCK_DEEP : FSCK_REGULAR, true);
   }
+  int downgrade_wal_to_v1();
   int quick_fix() override {
     return _fsck(FSCK_SHALLOW, true);
   }

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -5,7 +5,9 @@
 #include "bluefs_types.h"
 #include "BlueFS.h"
 #include "common/Formatter.h"
+#include "include/byteorder.h"
 #include "include/denc.h"
+#include "include/encoding.h"
 #include "include/uuid.h"
 #include "include/stringify.h"
 
@@ -75,13 +77,19 @@ void bluefs_layout_t::generate_test_instances(list<bluefs_layout_t*>& ls)
 }
 
 // bluefs_super_t
-bluefs_super_t::bluefs_super_t() : version(0), block_size(4096) {
+bluefs_super_t::bluefs_super_t() : version(0), block_size(4096), wal_version(1) {
   bluefs_max_alloc_size.resize(BlueFS::MAX_BDEV, 0);
 }
 
 void bluefs_super_t::encode(bufferlist& bl) const
 {
-  ENCODE_START(3, 1, bl);
+  __u8 _version = 3;
+  __u8 _compat = 1;
+  if (wal_version >= 2) {
+    _version = 4;
+    _compat = 4;
+  }
+  ENCODE_START(_version, _compat, bl);
   encode(uuid, bl);
   encode(osd_uuid, bl);
   encode(version, bl);
@@ -89,12 +97,15 @@ void bluefs_super_t::encode(bufferlist& bl) const
   encode(log_fnode, bl);
   encode(memorized_layout, bl);
   encode(bluefs_max_alloc_size, bl);
+  if (_version >= 4) {
+    encode(wal_version, bl);
+  }
   ENCODE_FINISH(bl);
 }
 
 void bluefs_super_t::decode(bufferlist::const_iterator& p)
 {
-  DECODE_START(3, p);
+  DECODE_START(4, p);
   decode(uuid, p);
   decode(osd_uuid, p);
   decode(version, p);
@@ -107,6 +118,9 @@ void bluefs_super_t::decode(bufferlist::const_iterator& p)
     decode(bluefs_max_alloc_size, p);
   } else {
     std::fill(bluefs_max_alloc_size.begin(), bluefs_max_alloc_size.end(), 0);
+  }
+  if (struct_v >= 4) {
+    decode(wal_version, p);
   }
   DECODE_FINISH(p);
 }
@@ -177,6 +191,10 @@ bluefs_fnode_delta_t* bluefs_fnode_t::make_delta(bluefs_fnode_delta_t* delta) {
   delta->mtime = mtime;
   delta->offset = allocated_commited;
   delta->extents.clear();
+
+  delta->type = type;
+  delta->wal_limit = wal_limit;
+  delta->wal_size = wal_size;
   if (allocated_commited < allocated) {
     uint64_t x_off = 0;
     auto p = seek(allocated_commited, &x_off);
@@ -214,17 +232,24 @@ void bluefs_fnode_t::generate_test_instances(list<bluefs_fnode_t*>& ls)
   ls.back()->mtime = utime_t(123,45);
   ls.back()->extents.push_back(bluefs_extent_t(0, 1048576, 4096));
   ls.back()->__unused__ = 1;
+  ls.back()->type = 0;
 }
 
 ostream& operator<<(ostream& out, const bluefs_fnode_t& file)
 {
-  return out << "file(ino " << file.ino
+  out << "file(ino " << file.ino
 	     << " size 0x" << std::hex << file.size << std::dec
 	     << " mtime " << file.mtime
 	     << " allocated " << std::hex << file.allocated << std::dec
 	     << " alloc_commit " << std::hex << file.allocated_commited << std::dec
-	     << " extents " << file.extents
-	     << ")";
+	     << " extents " << file.extents;
+  if (file.type == WAL_V2) {
+    out << " wal_limit " << file.wal_limit << std::hex;
+    out << " wal_size " << file.wal_size << std::hex;
+    out << " type WAL_V2 " << std::dec;
+  }
+  out << ")";
+  return out;
 }
 
 // bluefs_fnode_delta_t
@@ -317,3 +342,29 @@ ostream& operator<<(ostream& out, const bluefs_transaction_t& t)
 	     << std::dec << ")";
 }
 
+void bluefs_wal_header_t::bound_encode(size_t &s) const {
+  s += 1; // version
+  s += 1; // compat
+  s += 4; // size
+  denc(flush_length, s);
+}
+
+void bluefs_wal_header_t::encode(bufferlist& bl) const {
+  ENCODE_START(1, 1, bl);
+  encode(flush_length, bl);
+  ENCODE_FINISH(bl);
+}
+
+void bluefs_wal_header_t::encode(bufferlist::contiguous_filler& filler_in) const {
+  ENCODE_START_FILLER(1, 1, filler_in);
+  ceph_le64 flush_length_le(flush_length);
+  filler_in.copy_in(sizeof(flush_length_le), (char*)&flush_length_le);
+  ENCODE_FINISH_FILLER();
+}
+
+void bluefs_wal_header_t::decode(bufferlist::const_iterator& p)
+{
+  DECODE_START(1, p);
+  decode(flush_length, p);
+  DECODE_FINISH(p);
+}

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -345,7 +345,8 @@ int main(int argc, char **argv)
         "bluefs-stats, "
         "reshard, "
         "show-sharding, "
-	"trim")
+       	"trim, "
+        "downgrade-wal-to-v1")
     ;
   po::options_description po_all("All options");
   po_all.add(po_options).add(po_positional);
@@ -458,7 +459,7 @@ int main(int argc, char **argv)
     }
   }
 
-  if (action == "fsck" || action == "repair" || action == "quick-fix" || action == "allocmap" || action == "qfsck" || action == "restore_cfb") {
+  if (action == "fsck" || action == "repair" || action == "quick-fix" || action == "allocmap" || action == "qfsck" || action == "restore_cfb" || action == "migrate-wal-to-v1") {
     if (path.empty()) {
       cerr << "must specify bluestore path" << std::endl;
       exit(EXIT_FAILURE);
@@ -654,7 +655,8 @@ int main(int argc, char **argv)
   }
   else if (action == "fsck" ||
       action == "repair" ||
-      action == "quick-fix") {
+      action == "quick-fix" ||
+      action == "downgrade-wal-to-v1") {
     validate_path(cct.get(), path, false);
     BlueStore bluestore(cct.get(), path);
     int r;
@@ -662,6 +664,8 @@ int main(int argc, char **argv)
       r = bluestore.fsck(fsck_deep);
     } else if (action == "repair") {
       r = bluestore.repair(fsck_deep);
+    } else if (action == "downgrade-wal-to-v1") {
+      r = bluestore.downgrade_wal_to_v1();
     } else {
       r = bluestore.quick_fix();
     }

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1416,6 +1416,61 @@ TEST(BlueFS, test_wal_write_multiple_recover_partial_reads) {
   }
 }
 
+TEST(BlueFS, test_wal_migrate) {
+  uint64_t size_wal = 1048576 * 64;
+  TempBdev bdev_wal{size_wal};
+  uint64_t size_db = 1048576 * 128;
+  TempBdev bdev_db{size_db};
+  uint64_t size_slow = 1048576 * 256;
+  TempBdev bdev_slow{size_slow};
+
+  ConfSaver conf(g_ceph_context->_conf);
+  conf.SetVal("bluefs_min_flush_size", "65536");
+  conf.ApplyChanges();
+
+  BlueFS fs(g_ceph_context);
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_WAL,  bdev_wal.path,  false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB,   bdev_db.path,   false));
+  ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_SLOW, bdev_slow.path, false));
+  uuid_d fsid;
+  ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, true, true }));
+  ASSERT_EQ(0, fs.mount());
+  ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, true, true }));
+
+  string dir_db = "db.wal";
+  ASSERT_EQ(0, fs.mkdir(dir_db));
+
+  string wal_file = "wal1.log";
+  BlueFS::FileWriter *writer;
+  ASSERT_EQ(0, fs.open_for_write(dir_db, wal_file, &writer, false));
+  ASSERT_NE(nullptr, writer);
+
+  bufferlist bl1;
+  auto gen_debugable = [](size_t amount, bufferlist& bl) {
+    for (size_t i = 0; i < amount; i++) {
+      bl.append('a');
+    }
+  };
+  gen_debugable(70000, bl1);
+  fs.append_try_flush(writer, bl1.c_str(), bl1.length());
+  fs.fsync(writer);
+
+  // WAL files don't update internal extents while writing to save memory, only on _replay
+  fs.umount();
+  fs.mount();
+  fs.downgrade_wal_to_v1();
+
+  BlueFS::FileReader *reader;
+  ASSERT_EQ(0, fs.open_for_read(dir_db, wal_file, &reader));
+  ASSERT_EQ(reader->file->fnode.type, bluefs_node_type::REGULAR);
+  ASSERT_EQ(reader->file->is_new_wal(), false);
+  
+  bufferlist read_bl;
+  fs.read(reader, 0, 70000, &read_bl, NULL);
+  ASSERT_TRUE(bl_eq(bl1, read_bl));
+  delete reader;
+  fs.umount();
+}
 
 TEST(BlueFS, test_wal_write_truncate) {
   uint64_t size_wal = 1048576 * 64;


### PR DESCRIPTION
## problem
BlueFS write are expensive due to every `BlueFS::fsync` invoking `disk->flush` twice, one for the file data and another one for BlueFS log metadata.  We can avoid this duality by joining merging metadata and data in the same envelope. This PR delievers on that front.

## New format
**Previous a bluefs log transaction** would hold a file_update_inc that includes the increase of file size, that way we now what is the length of data the file hold in its own extents. Therefore, every write would perform a `fnode->size += delta` and consequently **mark it as dirty**.

This new format is basically a envelope that holds both data and delta metadata plus some error detection stuff:

* `Flush length (u64)` -> the length of the data in the envelope
* `Payload (flush length)` -> data of the WAL write asked for (size is flush length)
* `Marker (u64)` -> id of the file used for error detection (this in talks to change to crc or something else)

With this new format, **for every fsync we do, create this envelope and flush it without marking the file as dirty**, therefore not generating the log disk flush. This inferred huge benefits in performance that will be looking at next.

### EOF tricks
A "huge" problem is: how do we know we cannot read more data from the file. Either we reach end of allocated extents or... in this case we append some 0s to the evenlope so that next flush_length is overwritten and therefore we can check if next flush is not yet flushed to disk. This basically works like a null terminated string.

## Preliminary results:
I ran multiple fio jobs including different workloads: randrw, random writes, random reads, etc... 

![image](https://github.com/ceph/ceph/assets/30913090/d5bfe033-9e55-4047-a9c3-96430a5f4753)

![image](https://github.com/ceph/ceph/assets/30913090/791d3f87-ffb3-405a-8999-6b68baa12629)

By counting number of flushes with a simple counter vs a vector of flush extents we saw a significat performance degradation that might be worth to use the vector only in replay and forget about storing flush extents during the run:
![image](https://github.com/ceph/ceph/assets/30913090/7345f5a5-1e05-4ca0-9a1c-d320f09caa94)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
