### PR TITLE
reef: mgr/dashboard: fix duplicate grafana panels when on mgr failover

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
@@ -41,6 +41,10 @@ scrape_configs:
     tls_config:
       ca_file: mgr_prometheus_cert.pem
     honor_labels: true
+    relabel_configs:
+    - source_labels: [instance]
+      target_label: instance
+      replacement: 'ceph_cluster'
     http_sd_configs:
     - url: {{ mgr_prometheus_sd_url }}
       basic_auth:
@@ -54,6 +58,9 @@ scrape_configs:
     - source_labels: [__address__]
       target_label: cluster
       replacement: {{ cluster_fsid }}
+    - source_labels: [instance]
+      target_label: instance
+      replacement: 'ceph_cluster'
     http_sd_configs:
     - url: {{ mgr_prometheus_sd_url }}
 {% endif %}

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -696,6 +696,9 @@ class TestMonitoring:
                     - source_labels: [__address__]
                       target_label: cluster
                       replacement: fsid
+                    - source_labels: [instance]
+                      target_label: instance
+                      replacement: 'ceph_cluster'
                     http_sd_configs:
                     - url: http://[::1]:8765/sd/prometheus/sd-config?service=mgr-prometheus
 
@@ -855,6 +858,10 @@ class TestMonitoring:
                     tls_config:
                       ca_file: mgr_prometheus_cert.pem
                     honor_labels: true
+                    relabel_configs:
+                    - source_labels: [instance]
+                      target_label: instance
+                      replacement: 'ceph_cluster'
                     http_sd_configs:
                     - url: https://[::1]:8765/sd/prometheus/sd-config?service=mgr-prometheus
                       basic_auth:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65512

---

backport of https://github.com/ceph/ceph/pull/56626
parent tracker: https://tracker.ceph.com/issues/64970

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh