### PR TITLE
quincy: mgr/dashboard: fix duplicate grafana panels when on mgr failover

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
@@ -14,6 +14,10 @@ alerting:
 scrape_configs:
   - job_name: 'ceph'
     honor_labels: true
+    relabel_configs:
+    - source_labels: [instance]
+      target_label: instance
+      replacement: 'ceph_cluster'
     static_configs:
     - targets:
 {% for mgr in mgr_scrape_list %}

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -475,6 +475,10 @@ class TestMonitoring:
                 scrape_configs:
                   - job_name: 'ceph'
                     honor_labels: true
+                    relabel_configs:
+                    - source_labels: [instance]
+                      target_label: instance
+                      replacement: 'ceph_cluster'
                     static_configs:
                     - targets:
                       - '[::1]:9283'


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65513

---

backport of https://github.com/ceph/ceph/pull/56626
parent tracker: https://tracker.ceph.com/issues/64970

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh