### PR TITLE
mds: regular file inode flags are not replicated by the policylock

### DIFF
--- a/qa/tasks/cephfs/test_quiesce.py
+++ b/qa/tasks/cephfs/test_quiesce.py
@@ -706,6 +706,34 @@ class TestQuiesceMultiRank(QuiesceTestCase):
                 if not find_quiesce(False):
                     break
 
+    def test_quiesce_block_file_replicated(self):
+        """
+        That a file inode with quiesce.block is replicated.
+        """
+
+        self._configure_subvolume()
+
+        self.mount_a.run_shell_payload("mkdir -p dir1/dir2/dir3/dir4")
+
+        self.fs.set_max_mds(2)
+        status = self.fs.wait_for_daemons()
+
+        self.mount_a.setfattr("dir1", "ceph.dir.pin", "1")
+        self.mount_a.setfattr("dir1/dir2/dir3", "ceph.dir.pin", "0") # force dir2 to be replicated
+        status = self._wait_subtrees([(self.mntpnt+"/dir1", 1), (self.mntpnt+"/dir1/dir2/dir3", 0)], status=status, rank=1)
+
+        self.mount_a.setfattr("dir1/dir2", "ceph.quiesce.block", "1")
+
+        ino1 = self.fs.read_cache(self.mntpnt+"/dir1/dir2", depth=0, rank=1)[0]
+        self.assertTrue(ino1['quiesce_block'])
+        self.assertTrue(ino1['is_auth'])
+        replicas = ino1['auth_state']['replicas']
+        self.assertIn("0", replicas)
+
+        ino0 = self.fs.read_cache(self.mntpnt+"/dir1/dir2", depth=0, rank=0)[0]
+        self.assertFalse(ino0['is_auth'])
+        self.assertTrue(ino0['quiesce_block'])
+
     def test_quiesce_path_multirank(self):
         """
         That quiesce may complete with two ranks and a basic workload.

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2144,7 +2144,7 @@ void CInode::decode_lock_iflock(bufferlist::const_iterator& p)
 
 void CInode::encode_lock_ipolicy(bufferlist& bl)
 {
-  ENCODE_START(2, 1, bl);
+  ENCODE_START(3, 1, bl);
   if (is_dir()) {
     encode(get_inode()->version, bl);
     encode(get_inode()->ctime, bl);
@@ -2153,6 +2153,8 @@ void CInode::encode_lock_ipolicy(bufferlist& bl)
     encode(get_inode()->export_pin, bl);
     encode(get_inode()->flags, bl);
     encode(get_inode()->export_ephemeral_random_pin, bl);
+  } else {
+    encode(get_inode()->flags, bl);
   }
   ENCODE_FINISH(bl);
 }
@@ -2161,7 +2163,7 @@ void CInode::decode_lock_ipolicy(bufferlist::const_iterator& p)
 {
   ceph_assert(!is_auth());
   auto _inode = allocate_inode(*get_inode());
-  DECODE_START(1, p);
+  DECODE_START(3, p);
   if (is_dir()) {
     decode(_inode->version, p);
     utime_t tm;
@@ -2174,6 +2176,10 @@ void CInode::decode_lock_ipolicy(bufferlist::const_iterator& p)
     if (struct_v >= 2) {
       decode(_inode->flags, p);
       decode(_inode->export_ephemeral_random_pin, p);
+    }
+  } else {
+    if (struct_v >= 3) {
+      decode(_inode->flags, p);
     }
   }
   DECODE_FINISH(p);


### PR DESCRIPTION
## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
