### PR TITLE
test/rgw_iam_policy: do not increase reference counting when boost::intrusive_ptr get

### DIFF
--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -785,7 +785,9 @@ class ManagedPolicyTest : public ::testing::Test {
 protected:
   intrusive_ptr<CephContext> cct;
 public:
-  ManagedPolicyTest() : cct(new CephContext(CEPH_ENTITY_TYPE_CLIENT)) {}
+  ManagedPolicyTest() {
+    cct.reset(new CephContext(CEPH_ENTITY_TYPE_CLIENT), false);
+  }
 };
 
 TEST_F(ManagedPolicyTest, IAMFullAccess)


### PR DESCRIPTION
When sanitizer is on, unittest_rgw_iam_policy shows

```
=================================================================
==2957634==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 9936 byte(s) in 1 object(s) allocated from:
    #0 0xaaaae4496248 in operator new(unsigned long) (/root/ceph-19.0.0/build/bin/unittest_bluestore_types+0xef6248) (BuildId: f63b15ff165fbd81074275a31e37535a1938809e)
    #1 0xaaaae46b8624 in BlueStore::OnodeCacheShard::create(ceph::common::CephContext*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ceph::common::PerfCounters*) /root/ceph-19.0.0/src/os/bluestore/BlueStore.cc:1187:7
    #2 0xaaaae44fa8a0 in Blob_put_ref_Test::TestBody() /root/ceph-19.0.0/src/test/objectstore/test_bluestore_types.cc:883:38
    #3 0xaaaae4699aa8 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaae46470a8 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaae45f890c in testing::Test::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaae45fa850 in testing::TestInfo::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaae45fbe50 in testing::TestSuite::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaae4617c14 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaae46a39a8 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaae464e640 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaae461708c in testing::UnitTest::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaae4564dd4 in RUN_ALL_TESTS() /root/ceph-19.0.0/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaae4551080 in main /root/ceph-19.0.0/src/test/objectstore/test_bluestore_types.cc:2847:10
    #14 0xffff998b73f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff998b74c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaae43e812c in _start (/root/ceph-19.0.0/build/bin/unittest_bluestore_types+0xe4812c) (BuildId: f63b15ff165fbd81074275a31e37535a1938809e)

Direct leak of 9936 byte(s) in 1 object(s) allocated from:
    #0 0xaaaae4496248 in operator new(unsigned long) (/root/ceph-19.0.0/build/bin/unittest_bluestore_types+0xef6248) (BuildId: f63b15ff165fbd81074275a31e37535a1938809e)
    #1 0xaaaae46b8624 in BlueStore::OnodeCacheShard::create(ceph::common::CephContext*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ceph::common::PerfCounters*) /root/ceph-19.0.0/src/os/bluestore/BlueStore.cc:1187:7
    #2 0xaaaae458ad68 in ExtentMapFixture::ExtentMapFixture() /root/ceph-19.0.0/src/test/objectstore/test_bluestore_types.cc:1307:10
    #3 0xaaaae4595414 in ExtentMapFixture_pollock_Test::ExtentMapFixture_pollock_Test() /root/ceph-19.0.0/src/test/objectstore/test_bluestore_types.cc:1572:1
    #4 0xaaaae4595304 in testing::internal::TestFactoryImpl<ExtentMapFixture_pollock_Test>::CreateTest() /root/ceph-19.0.0/src/googletest/googletest/include/gtest/internal/gtest-internal.h:472:44
    #5 0xaaaae469a054 in testing::Test* testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2605:10
    #6 0xaaaae4647fcc in testing::Test* testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2641:14
    #7 0xaaaae45fa82c in testing::TestInfo::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2848:22
    #8 0xaaaae45fbe50 in testing::TestSuite::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:3012:28
    #9 0xaaaae4617c14 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:5723:44
    #10 0xaaaae46a39a8 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2605:10
    #11 0xaaaae464e640 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2641:14
    #12 0xaaaae461708c in testing::UnitTest::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:5306:10
    #13 0xaaaae4564dd4 in RUN_ALL_TESTS() /root/ceph-19.0.0/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #14 0xaaaae4551080 in main /root/ceph-19.0.0/src/test/objectstore/test_bluestore_types.cc:2847:10
    #15 0xffff998b73f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #16 0xffff998b74c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #17 0xaaaae43e812c in _start (/root/ceph-19.0.0/build/bin/unittest_bluestore_types+0xe4812c) (BuildId: f63b15ff165fbd81074275a31e37535a1938809e)

Direct leak of 9936 byte(s) in 1 object(s) allocated from:
    #0 0xaaaae4496248 in operator new(unsigned long) (/root/ceph-19.0.0/build/bin/unittest_bluestore_types+0xef6248) (BuildId: f63b15ff165fbd81074275a31e37535a1938809e)
    #1 0xaaaae46b8624 in BlueStore::OnodeCacheShard::create(ceph::common::CephContext*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ceph::common::PerfCounters*) /root/ceph-19.0.0/src/os/bluestore/BlueStore.cc:1187:7
    #2 0xaaaae45102ac in ExtentMap_has_any_lextents_Test::TestBody() /root/ceph-19.0.0/src/test/objectstore/test_bluestore_types.cc:1154:36
    #3 0xaaaae4699aa8 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2605:10
    #4 0xaaaae46470a8 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2641:14
    #5 0xaaaae45f890c in testing::Test::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2680:5
    #6 0xaaaae45fa850 in testing::TestInfo::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2858:11
    #7 0xaaaae45fbe50 in testing::TestSuite::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:3012:28
    #8 0xaaaae4617c14 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:5723:44
    #9 0xaaaae46a39a8 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2605:10
    #10 0xaaaae464e640 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:2641:14
    #11 0xaaaae461708c in testing::UnitTest::Run() /root/ceph-19.0.0/src/googletest/googletest/src/gtest.cc:5306:10
    #12 0xaaaae4564dd4 in RUN_ALL_TESTS() /root/ceph-19.0.0/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #13 0xaaaae4551080 in main /root/ceph-19.0.0/src/test/objectstore/test_bluestore_types.cc:2847:10
    #14 0xffff998b73f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0xffff998b74c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #16 0xaaaae43e812c in _start (/root/ceph-19.0.0/build/bin/unittest_bluestore_types+0xe4812c) (BuildId: f63b15ff165fbd81074275a31e37535a1938809e)

...
...
...
Indirect leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0xaaaacf905688 in operator new(unsigned long) (/root/ceph/build/bin/unittest_rgw_iam_policy+0x25f5688) (BuildId: c8dd019430a8d0162485760a78979347f29d225f)
    #1 0xffff7f0b7ca8 in ceph::common::CephContext::CephContext(unsigned int, ceph::common::CephContext::create_options const&) /root/ceph/src/common/ceph_context.cc:781:24
    #2 0xffff7f0b514c in ceph::common::CephContext::CephContext(unsigned int, code_environment_t, int) /root/ceph/src/common/ceph_context.cc:697:5
    #3 0xaaaacf997dcc in ManagedPolicyTest::ManagedPolicyTest() /root/ceph/src/test/rgw/test_rgw_iam_policy.cc:788:33
    #4 0xaaaacf998294 in ManagedPolicyTest_IAMReadOnlyAccess_Test::ManagedPolicyTest_IAMReadOnlyAccess_Test() /root/ceph/src/test/rgw/test_rgw_iam_policy.cc:802:1
    #5 0xaaaacf998230 in testing::internal::TestFactoryImpl<ManagedPolicyTest_IAMReadOnlyAccess_Test>::CreateTest() /root/ceph/src/googletest/googletest/include/gtest/internal/gtest-internal.h:472:44
    #6 0xaaaacfb1a2d4 in testing::Test* testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #7 0xaaaacfaced5c in testing::Test* testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #8 0xaaaacfa83274 in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2848:22
    #9 0xaaaacfa84898 in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #10 0xaaaacfaa065c in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #11 0xaaaacfb23b9c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #12 0xaaaacfad4968 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #13 0xaaaacfa9fad4 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #14 0xaaaacfa23588 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #15 0xaaaacfa23504 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #16 0xffff7c5a73f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #17 0xffff7c5a74c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #18 0xaaaacf85756c in _start (/root/ceph/build/bin/unittest_rgw_iam_policy+0x254756c) (BuildId: c8dd019430a8d0162485760a78979347f29d225f)

Indirect leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0xaaaacf905688 in operator new(unsigned long) (/root/ceph/build/bin/unittest_rgw_iam_policy+0x25f5688) (BuildId: c8dd019430a8d0162485760a78979347f29d225f)
    #1 0xffff7f0b7ca8 in ceph::common::CephContext::CephContext(unsigned int, ceph::common::CephContext::create_options const&) /root/ceph/src/common/ceph_context.cc:781:24
    #2 0xffff7f0b514c in ceph::common::CephContext::CephContext(unsigned int, code_environment_t, int) /root/ceph/src/common/ceph_context.cc:697:5
    #3 0xaaaacf997dcc in ManagedPolicyTest::ManagedPolicyTest() /root/ceph/src/test/rgw/test_rgw_iam_policy.cc:788:33
    #4 0xaaaacf997d08 in ManagedPolicyTest_IAMFullAccess_Test::ManagedPolicyTest_IAMFullAccess_Test() /root/ceph/src/test/rgw/test_rgw_iam_policy.cc:791:1
    #5 0xaaaacf997ca4 in testing::internal::TestFactoryImpl<ManagedPolicyTest_IAMFullAccess_Test>::CreateTest() /root/ceph/src/googletest/googletest/include/gtest/internal/gtest-internal.h:472:44
    #6 0xaaaacfb1a2d4 in testing::Test* testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #7 0xaaaacfaced5c in testing::Test* testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #8 0xaaaacfa83274 in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2848:22
    #9 0xaaaacfa84898 in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #10 0xaaaacfaa065c in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #11 0xaaaacfb23b9c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #12 0xaaaacfad4968 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #13 0xaaaacfa9fad4 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #14 0xaaaacfa23588 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #15 0xaaaacfa23504 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #16 0xffff7c5a73f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #17 0xffff7c5a74c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #18 0xaaaacf85756c in _start (/root/ceph/build/bin/unittest_rgw_iam_policy+0x254756c) (BuildId: c8dd019430a8d0162485760a78979347f29d225f)

SUMMARY: AddressSanitizer: 67625436 byte(s) leaked in 21960 allocation(s).
```

To avoid memory not free, use reset for not increasing RC and keep code uniformity as above codes.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
