### PR TITLE
mds: find a new head for the batch ops when the head is dead

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -9811,7 +9811,25 @@ void MDCache::request_forward(const MDRequestRef& mdr, mds_rank_t who, int port)
 void MDCache::dispatch_request(const MDRequestRef& mdr)
 {
   if (mdr->dead) {
-    dout(20) << __func__ << ": dead " << *mdr << dendl;
+    dout(10) << __func__ << ": dead " << *mdr << dendl;
+    //if the mdr is a "batch_op" and it has followers, pick a follower as
+    //the new "head of the batch ops" and go on processing the new one.
+    if (mdr->client_request && mdr->is_batch_head()) {
+      int mask = mdr->client_request->head.args.getattr.mask;
+      auto it = mdr->batch_op_map->find(mask);
+      auto new_batch_head = it->second->find_new_head();
+      if (!new_batch_head) {
+        mdr->batch_op_map->erase(it);
+        dout(10) << __func__ << ": mask '" << mask
+                 << "' batch head is dead and there is no follower" << dendl;
+        return;
+      }
+      dout(10) << __func__ << ": mask '" << mask
+               << "' batch head is dead and queue a new one "
+               << *new_batch_head << dendl;
+      mds->finisher->queue(new C_MDS_RetryRequest(this, new_batch_head));
+      return;
+    }
     return;
   }
   if (mdr->client_request) {

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -2647,9 +2647,14 @@ void Server::dispatch_client_request(const MDRequestRef& mdr)
       auto it = mdr->batch_op_map->find(mask);
       auto new_batch_head = it->second->find_new_head();
       if (!new_batch_head) {
-	mdr->batch_op_map->erase(it);
-	return;
+        mdr->batch_op_map->erase(it);
+        dout(10) << __func__ << ": mask '" << mask
+                 << "' batch head is killed and there is no follower" << dendl;
+        return;
       }
+      dout(10) << __func__ << ": mask '" << mask
+               << "' batch head is killed and queue a new one "
+               << *new_batch_head << dendl;
       mds->finisher->queue(new C_MDS_RetryRequest(mdcache, new_batch_head));
       return;
     } else {


### PR DESCRIPTION
If the batch head request is already dead and then we need to choose a new batch head anyways and release the reference for the current batch head request. Else it will be reported as slow request.

Fixes: https://tracker.ceph.com/issues/65536





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
