### PR TITLE
qa: add a YAML to ignore MGR_DOWN warning

### DIFF
--- a/qa/suites/fs/nfs/overrides/ignore_mgr_down.yaml
+++ b/qa/suites/fs/nfs/overrides/ignore_mgr_down.yaml
@@ -1,0 +1,9 @@
+# When the NFS test class is constructed, the `MgrTestCase.setup_mgrs` invokes
+# `mgr fail` to restart the MGR which sometimes crashes the daemon and the
+# warning `MGR_DOWN` is generated. This is an intermittent failure which is
+# irrelevant to the NFS suite, and therefore should be ignored.
+
+overrides:
+  ceph:
+    log-ignorelist:
+      - MGR_DOWN


### PR DESCRIPTION
RCA showed that it is not the NFS code that lead to the warning since the warning occurred before the test cases started to execute, later on after some discussion with the venky and greg, it was found that there were some clog changes made recently which leads to this warning being added to the clog.

Digging more further, it was found that the warning is generated when `mgr fail` is run when there is no mgr available. The reason for unavailability is when `setup_mgrs()` in class `MgrTestCase` stops the mgr daemons, sometimes the mgr just crashes - `mgr handle_mgr_signal  *** Got signal Terminated *** ` and after which `mgr fail` (again part of `setup_mgrs()`) is run and the `MGR_DOWN` warning is generated. 

This warning is only evident in nfs is because this is the only fs suite that makes use of class `MgrTestCase`. To support my analysis, I had ran about 8 jobs in teuthology and I could not reproduce this warning. Since this is not harming the NFS test cases execution and the logs do mention that the mgr daemon did get restarted (`INFO:tasks.cephadm.mgr.x:Restarting mgr.x (starting--it wasn't running)...`), it is good to conclude that ignoring this warning is the simplest solution.

Fixes: https://tracker.ceph.com/issues/65265
Signed-off-by: Dhairya Parmar <dparmar@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
