### PR TITLE
squid: mgr/dashboard: Support Description and AccountId in rgw roles 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -870,9 +870,12 @@ edit_role_form = Form(path='/edit',
         "MaxSessionDuration": {'cellTemplate': 'duration'},
         "RoleId": {'isHidden': True},
         "AssumeRolePolicyDocument": {'isHidden': True},
-        "PermissionPolicies": {'isHidden': True}
+        "PermissionPolicies": {'isHidden': True},
+        "Description": {'isHidden': True},
+        "AccountId": {'isHidden': True}
     },
-    detail_columns=['RoleId', 'AssumeRolePolicyDocument', 'PermissionPolicies'],
+    detail_columns=['RoleId', 'Description',
+                    'AssumeRolePolicyDocument', 'PermissionPolicies', 'AccountId'],
     meta=CRUDMeta()
 )
 class RgwUserRole(NamedTuple):
@@ -884,6 +887,8 @@ class RgwUserRole(NamedTuple):
     MaxSessionDuration: int
     AssumeRolePolicyDocument: str
     PermissionPolicies: List
+    Description: str
+    AccountId: str
 
 
 @APIRouter('/rgw/realm', Scope.RGW)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65542

---

backport of https://github.com/ceph/ceph/pull/56919
parent tracker: https://tracker.ceph.com/issues/65506

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh