### PR TITLE
squid: qa: ignore human-friendly POOL_APP_NOT_ENABLED in clog

### DIFF
--- a/qa/cephfs/overrides/ignorelist_health.yaml
+++ b/qa/cephfs/overrides/ignorelist_health.yaml
@@ -12,6 +12,7 @@ overrides:
       - MDS_UP_LESS_THAN_MAX
       - filesystem is online with fewer MDS than max_mds
       - POOL_APP_NOT_ENABLED
+      - do not have an application enabled
       - overall HEALTH_
       - Replacing daemon
       - deprecated feature inline_data


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65519

---

backport of https://github.com/ceph/ceph/pull/56642
parent tracker: https://tracker.ceph.com/issues/65271

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh