### PR TITLE
reef: qa: ignore human-friendly POOL_APP_NOT_ENABLED in clog

### DIFF
--- a/qa/cephfs/overrides/ignorelist_health.yaml
+++ b/qa/cephfs/overrides/ignorelist_health.yaml
@@ -11,5 +11,6 @@ overrides:
       - MDS_INSUFFICIENT_STANDBY
       - MDS_UP_LESS_THAN_MAX
       - POOL_APP_NOT_ENABLED
+      - do not have an application enabled
       - overall HEALTH_
       - Replacing daemon


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65520

---

backport of https://github.com/ceph/ceph/pull/56642
parent tracker: https://tracker.ceph.com/issues/65271

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh