### PR TITLE
quincy: client: log debug message when requesting unmount

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6783,11 +6783,13 @@ void Client::_unmount(bool abort)
 
 void Client::unmount()
 {
+  ldout(cct, 2) << __func__ << dendl;
   _unmount(false);
 }
 
 void Client::abort_conn()
 {
+  ldout(cct, 2) << __func__ << dendl;
   _unmount(true);
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66630

---

backport of https://github.com/ceph/ceph/pull/55659
parent tracker: https://tracker.ceph.com/issues/64503

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh