### PR TITLE
squid: rgwlc: check for no-bucket at bucket_lc_process() preamble

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2104,7 +2104,7 @@ int RGWLC::process_bucket(int index, int max_lock_secs, LCWorker* worker,
   }
 
   /* do nothing if no bucket */
-  if (entry->get_bucket().empty()) {
+  if ((! entry) || entry->get_bucket().empty()) {
     return ret;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65353

---

backport of https://github.com/ceph/ceph/pull/56535
parent tracker: https://tracker.ceph.com/issues/65188

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh