### PR TITLE
doc/radosgw: use 'confval' directive for reshard config options

### DIFF
--- a/doc/radosgw/dynamicresharding.rst
+++ b/doc/radosgw/dynamicresharding.rst
@@ -45,21 +45,12 @@ multisite environment. For information on dynamic resharding, see
 Configuration
 =============
 
-Enable/Disable dynamic bucket index resharding:
-
-- ``rgw_dynamic_resharding``:  true/false, default: true
-
-Configuration options that control the resharding process:
-
-- ``rgw_max_objs_per_shard``: maximum number of objects per bucket index shard before resharding is triggered, default: 100000
-
-- ``rgw_max_dynamic_shards``: maximum number of bucket index shards that dynamic resharding can increase to, default: 1999
-
-- ``rgw_reshard_bucket_lock_duration``: duration, in seconds, that writes to the bucket are locked during resharding, default: 360 (i.e., 6 minutes)
-
-- ``rgw_reshard_thread_interval``: maximum time, in seconds, between rounds of resharding queue processing, default: 600 seconds (i.e., 10 minutes)
-
-- ``rgw_reshard_num_logs``: number of shards for the resharding queue, default: 16
+.. confval:: rgw_dynamic_resharding
+.. confval:: rgw_max_objs_per_shard
+.. confval:: rgw_max_dynamic_shards
+.. confval:: rgw_reshard_bucket_lock_duration
+.. confval:: rgw_reshard_thread_interval
+.. confval:: rgw_reshard_num_logs
 
 Admin commands
 ==============


### PR DESCRIPTION
this will render the config options with their descriptions/defaults taken directly from common/options/rgw.yaml.in

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
