### PR TITLE
mon/ConfigMonitor: Config set better filters WHO daemons that can exist

### DIFF
--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -542,6 +542,14 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
     name = ConfFile::normalize_key_name(name);
     
     if (prefix == "config set" && !force) {
+
+      // Check if 'who' contains any special symbols
+      if (who.find_first_of("!@#$%^&*") != std::string::npos) {
+          ss << "Cannot contain special symbols '" << who << "'";
+          err = -EINVAL;
+          goto reply;
+      }
+
       const Option *opt = g_conf().find_option(name);
       if (!opt) {
 	opt = mon.mgrmon()->find_module_option(name);


### PR DESCRIPTION
Config set should better filter for WHO daemons that can exist

Fixes: https://tracker.ceph.com/issues/62588

The ceph config command would accept daemons with illegal name

**Before fix:**

```
suyash@suyash-Vivo-Ubuntu:~/ceph/build$ sudo ./bin/ceph config dump
*** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
2024-04-16T22:45:04.989+0530 7b33c2d1c640 -1 WARNING: all dangerous and experimental features are enabled.
2024-04-16T22:45:05.061+0530 7b33c2d1c640 -1 WARNING: all dangerous and experimental features are enabled.
WHO     MASK  LEVEL     OPTION                            VALUE        RO
global        advanced  osd_pool_default_min_size         1              
global        advanced  osd_pool_default_size             3              
mon           advanced  mon_allow_pool_delete             true           
mon           advanced  mon_allow_pool_size_one           true           
mon           advanced  mon_data_avail_crit               1              
mon           advanced  mon_data_avail_warn               2              
mon           advanced  mon_osd_reporter_subtree_level    osd            
mgr           advanced  mgr/dashboard/x/ssl_server_port   41247        * 
mgr           advanced  mgr/prometheus/x/server_port      9283           
mgr           advanced  mgr/restful/x/server_port         42247        * 
osd           advanced  osd_copyfrom_max_chunk            524288         
osd           dev       osd_debug_misdirected_ops         true           
osd           dev       osd_debug_op_order                true           
osd           advanced  osd_scrub_load_threshold          2000.000000    
osd.#         advanced  osd_max_backfills                 3              
osd.$         advanced  osd_max_backfills                 3              
osd.*         advanced  osd_max_backfills                 3              
osd.0         basic     osd_mclock_max_capacity_iops_ssd  2151.954446    
osd.1         basic     osd_mclock_max_capacity_iops_ssd  2099.170771    
osd.2         basic     osd_mclock_max_capacity_iops_ssd  2169.316098    
osd.4         advanced  osd_max_backfills                 3              
osd.^         advanced  osd_max_backfills                 3              
mds           dev       mds_debug_auth_pins               true           
mds           dev       mds_debug_frag                    true           
mds           dev       mds_debug_subtrees                true 
```
The fix now prevents accepting invalid names

**After fix:**

![Screenshot from 2024-04-17 17-20-04](https://github.com/ceph/ceph/assets/109069262/10823a38-1634-432a-9c0b-76316a5a55f7)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
