### PR TITLE
Revert "doc: Use older mistune"

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -16,5 +16,4 @@ typed-ast
 sphinxcontrib-mermaid
 sphinxcontrib-openapi
 sphinxcontrib-seqdiag
-mistune < 2.0.0
 natsort


### PR DESCRIPTION
This reverts commit ed2ad24a4ba3ad3f8103926bfea2466b9eb61222.

Fixes: https://tracker.ceph.com/issues/65555

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
