### PR TITLE
mgr/dashboard: pin xmlsec to 1.3.13

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1399,7 +1399,7 @@ def exec_test():
         log.info('\nrunning vstart.sh now...')
         # usually, i get vstart.sh running completely in less than 100
         # seconds.
-        remote.run(args=args, env=vstart_env, timeout=(5 * 60))
+        remote.run(args=args, env=vstart_env, timeout=(10 * 60))
         log.info('\nvstart.sh finished running')
 
         # Wait for OSD to come up so that subsequent injectargs etc will

--- a/src/pybind/mgr/dashboard/requirements-test.txt
+++ b/src/pybind/mgr/dashboard/requirements-test.txt
@@ -3,3 +3,4 @@ pytest-instafail
 pyfakefs==4.5.0
 jsonschema~=4.0
 PyJWT~=2.0
+xmlsec==1.3.13 # Pinning because of https://github.com/xmlsec/python-xmlsec/issues/314


### PR DESCRIPTION
Also has: [qa/vstart_runner: increase timeout for vstart.sh command](https://github.com/ceph/ceph/pull/56974/commits/5a8a9df401663ca48b0031104d00ea0e4b636165) which fixes Fixes: https://tracker.ceph.com/issues/65565



xmlsec is an inner dependency used by python3-saml. A [newer release ](https://pypi.org/project/xmlsec/#history)of it broke the import.
https://github.com/xmlsec/python-xmlsec/issues/314

Fixes the `run-tox-mgr-dashboard-py3` failure in [make check](https://jenkins.ceph.com/job/ceph-pull-requests/133500/consoleFull#-1011227698e840cee4-f4a4-4183-81dd-42855615f2c1)
```
__init__.py:60: in <module>
    from .module import Module, StandbyModule  # noqa: F401
module.py:36: in <module>
    from .services.sso import SSO_COMMANDS, handle_sso_command
services/sso.py:20: in <module>
    from onelogin.saml2.settings import OneLogin_Saml2_Settings as Saml2Settings
.tox/py3/lib/python3.10/site-packages/onelogin/saml2/settings.py:18: in <module>
    from onelogin.saml2.metadata import OneLogin_Saml2_Metadata
.tox/py3/lib/python3.10/site-packages/onelogin/saml2/metadata.py:15: in <module>
    from onelogin.saml2.utils import OneLogin_Saml2_Utils
.tox/py3/lib/python3.10/site-packages/onelogin/saml2/utils.py:23: in <module>
    import xmlsec
E   xmlsec.Error: (100, 'lxml & xmlsec libxml2 library version mismatch')
```

Fixes: https://tracker.ceph.com/issues/65571


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
