### PR TITLE
rgw/rgw_lua_utils: free std::string

### DIFF
--- a/src/rgw/rgw_lua_utils.h
+++ b/src/rgw/rgw_lua_utils.h
@@ -292,10 +292,9 @@ template<typename MapType>
 typename MapType::iterator* create_iterator_metadata(lua_State* L, const std::string_view name, 
     const typename MapType::iterator& start_it, const typename MapType::iterator& end_it) {
   using Iterator = typename MapType::iterator;
-  const std::string qualified_name = get_iterator_name(name);
   // create metatable for userdata
   // metatable is created before the userdata to save on allocation if the metatable already exists
-  const auto metatable_is_new = luaL_newmetatable(L, qualified_name.c_str());
+  const auto metatable_is_new = luaL_newmetatable(L, get_iterator_name(name).c_str());
   const auto metatable_pos = lua_gettop(L);
   int userdata_pos;
   Iterator* new_it = nullptr;


### PR DESCRIPTION
When sanitizer is ON, unittest_rgw_lua shows

```
=================================================================
==3738104==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 31 byte(s) in 1 object(s) allocated from:
    #0 0xaaaac100e848 in operator new(unsigned long) (/root/ceph/build/bin/unittest_rgw_lua+0x25fe848) (BuildId: 524cddb1d44130431ac70e09896af3ab7cecef82)
    #1 0xffff9356dec0 in __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/ext/new_allocator.h:127:27
    #2 0xffff9356de3c in std::allocator<char>::allocate(unsigned long) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/allocator.h:185:32
    #3 0xffff9356de3c in std::allocator_traits<std::allocator<char> >::allocate(std::allocator<char>&, unsigned long) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:464:20
    #4 0xffff9356db3c in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_create(unsigned long&, unsigned long) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.tcc:153:14
    #5 0xffff93570bb0 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.tcc:219:14
    #6 0xffff935e1bbc in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct_aux<char const*>(char const*, char const*, std::__false_type) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:255:11
    #7 0xffff935e197c in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:274:4
    #8 0xffff935da484 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, unsigned long, std::allocator<char> const&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:521:9
    #9 0xffff95b3d0ac in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > fmt::v9::to_string<char, 500ul>(fmt::v9::basic_memory_buffer<char, 500ul, std::allocator<char> > const&) /root/ceph/src/fmt/include/fmt/format.h:4050:10
    #10 0xffff95b39874 in fmt::v9::vformat[abi:cxx11](fmt::v9::basic_string_view<char>, fmt::v9::basic_format_args<fmt::v9::basic_format_context<fmt::v9::appender, char> >) /root/ceph/src/fmt/include/fmt/format-inl.h:1473:10
    #11 0xaaaac1264ab4 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > fmt::v9::format<std::basic_string_view<char, std::char_traits<char> > const&>(fmt::v9::basic_format_string<char, fmt::v9::type_identity<std::basic_string_view<char, std::char_traits<char> > const&>::type>, std::basic_string_view<char, std::char_traits<char> > const&) /root/ceph/src/fmt/include/fmt/core.h:3206:10
    #12 0xaaaac1264ab4 in rgw::lua::get_iterator_name[abi:cxx11](std::basic_string_view<char, std::char_traits<char> >) /root/ceph/src/rgw/rgw_lua_utils.h:276:10
    #13 0xaaaac1286864 in boost::container::flat_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, void>::iterator* rgw::lua::create_iterator_metadata<boost::container::flat_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, void> >(lua_State*, std::basic_string_view<char, std::char_traits<char> >, boost::container::flat_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, void>::iterator const&, boost::container::flat_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, void>::iterator const&) /root/ceph/src/rgw/rgw_lua_utils.h:295:38
    #14 0xaaaac128603c in int rgw::lua::next<boost::container::flat_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, void>, void>(lua_State*) /root/ceph/src/rgw/rgw_lua_utils.h:432:15
    #15 0xffff917d1e94  (/lib/aarch64-linux-gnu/liblua5.3.so.0+0x11e94) (BuildId: 3debb95525f7191c93f5ba6001de5c986b4cedfb)
    #16 0xffff917d20ec  (/lib/aarch64-linux-gnu/liblua5.3.so.0+0x120ec) (BuildId: 3debb95525f7191c93f5ba6001de5c986b4cedfb)
    #17 0xffff917dc32c  (/lib/aarch64-linux-gnu/liblua5.3.so.0+0x1c32c) (BuildId: 3debb95525f7191c93f5ba6001de5c986b4cedfb)
    #18 0xffff917d23b8  (/lib/aarch64-linux-gnu/liblua5.3.so.0+0x123b8) (BuildId: 3debb95525f7191c93f5ba6001de5c986b4cedfb)
    #19 0xffff917ca528  (/lib/aarch64-linux-gnu/liblua5.3.so.0+0xa528) (BuildId: 3debb95525f7191c93f5ba6001de5c986b4cedfb)
    #20 0xffff917ccf38  (/lib/aarch64-linux-gnu/liblua5.3.so.0+0xcf38) (BuildId: 3debb95525f7191c93f5ba6001de5c986b4cedfb)
    #21 0xffff917d226c in lua_pcallk (/lib/aarch64-linux-gnu/liblua5.3.so.0+0x1226c) (BuildId: 3debb95525f7191c93f5ba6001de5c986b4cedfb)
    #22 0xaaaac1232a8c in rgw::lua::request::execute(rgw::sal::Driver*, RGWREST*, OpsLogSink*, req_state*, RGWOp*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /root/ceph/src/rgw/rgw_lua_request.cc:823:9
    #23 0xaaaac1021934 in TestRGWLua_MetadataIterator_Test::TestBody() /root/ceph/src/test/rgw/test_rgw_lua.cc:628:8
    #24 0xaaaac121a40c in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #25 0xaaaac11cee0c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #26 0xaaaac1182268 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #27 0xaaaac11841ac in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #28 0xaaaac11857ac in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #29 0xaaaac11a1570 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #30 0xaaaac1224280 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #31 0xaaaac11d593c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14

SUMMARY: AddressSanitizer: 31 byte(s) leaked in 1 allocation(s).
```

Should avoid std::string does not be freed.
https://github.com/ceph/ceph/blob/08d35a8d8529783882dd092c73c0b27be41c4d86/src/rgw/rgw_lua_utils.h#L364, this way should be OK.

Reported issue: https://github.com/llvm/llvm-project/issues/60709
Fix:
https://github.com/llvm/llvm-project/commit/c6b12b7c3bc81266e8becbcccf0eaf4622db0cd0
(clang >= 17, but CI use clang 14)




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
