### PR TITLE
mds: remove the incorrect std::move for fsname and path 

### DIFF
--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -118,8 +118,8 @@ struct MDSCapMatch {
   MDSCapMatch(const std::string& fsname_, const std::string& path_,
 	      bool root_squash_, int64_t uid_=MDS_AUTH_UID_ANY,
 	      const std::vector<gid_t>& gids_={}) {
-    fs_name = std::move(fsname_);
-    path = std::move(path_);
+    fs_name = fsname_;
+    path = path_;
     root_squash = root_squash_;
     uid = (uid_ == 0) ? -1 : uid_;
     gids = gids_;


### PR DESCRIPTION
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
