### PR TITLE
rgw/account: add bucket_quota to RGWAccountInfo

### DIFF
--- a/doc/radosgw/account.rst
+++ b/doc/radosgw/account.rst
@@ -153,8 +153,13 @@ To view account stats::
 
 To enable an account quota::
 
-	radosgw-admin quota set --account-id={accountid} --max-size=10G
-	radosgw-admin quota enable --account-id={accountid}
+	radosgw-admin quota set --quota-scope=account --account-id={accountid} --max-size=10G
+	radosgw-admin quota enable --quota-scope=account --account-id={accountid}
+
+To enable a bucket quota for the account::
+
+	radosgw-admin quota set --quota-scope=bucket --account-id={accountid} --max-objects=1000000
+	radosgw-admin quota enable --quota-scope=bucket --account-id={accountid}
 
 Migrate an existing User into an Account
 ----------------------------------------

--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -538,8 +538,9 @@ users.** If a default quota is set in the Ceph Object Gateway Config, then that
 quota is set for all subsequently-created users, and that quota is enabled. See
 ``rgw_bucket_default_quota_max_objects``,
 ``rgw_bucket_default_quota_max_size``, ``rgw_user_default_quota_max_objects``,
-and ``rgw_user_default_quota_max_size`` in `Ceph Object Gateway Config
-Reference`_
+``rgw_user_default_quota_max_size``, ``rgw_account_default_quota_max_objects``,
+and ``rgw_account_default_quota_max_size`` in `Ceph Object Gateway Config
+Reference`_.
 
 Quota Cache
 -----------

--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -53,6 +53,8 @@ instances or all radosgw-admin options can be put into the ``[global]`` or the
 .. confval:: rgw_bucket_default_quota_max_size
 .. confval:: rgw_user_default_quota_max_objects
 .. confval:: rgw_user_default_quota_max_size
+.. confval:: rgw_account_default_quota_max_objects
+.. confval:: rgw_account_default_quota_max_size
 .. confval:: rgw_verify_ssl
 .. confval:: rgw_max_chunk_size
 

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2300,6 +2300,31 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_account_default_quota_max_objects
+  type: int
+  level: basic
+  desc: Account quota max objects
+  long_desc: The default quota configuration for total number of objects for a single
+    account. A negative number means 'unlimited'.
+  fmt_desc: Default max number of objects for a account. This includes all
+    objects in all buckets owned by the account. Set on new accounts
+    if no other quota is specified. Has no effect on existing accounts.
+  default: -1
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_account_default_quota_max_size
+  type: int
+  level: basic
+  desc: Account quota max size
+  long_desc: The default quota configuration for total size of objects for a single
+    account. A negative number means 'unlimited'.
+  fmt_desc: The value for account max size quota in bytes set on new accounts,
+    if no other quota is specified.  Has no effect on existing accounts.
+  default: -1
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_multipart_min_part_size
   type: size
   level: advanced

--- a/src/rgw/rgw_account.cc
+++ b/src/rgw/rgw_account.cc
@@ -227,14 +227,22 @@ int modify(const DoutPrefixProvider* dpp,
     info.max_buckets = *op_state.max_buckets;
   }
 
-  if (op_state.quota_max_size) {
-    info.quota.max_size = *op_state.quota_max_size;
+  RGWQuotaInfo* pquota = nullptr;
+  if (op_state.quota_scope == "account") {
+    pquota = &info.quota;
+  } else if (op_state.quota_scope == "bucket") {
+    pquota = &info.bucket_quota;
   }
-  if (op_state.quota_max_objects) {
-    info.quota.max_objects = *op_state.quota_max_objects;
-  }
-  if (op_state.quota_enabled) {
-    info.quota.enabled = *op_state.quota_enabled;
+  if (pquota) {
+    if (op_state.quota_max_size) {
+      pquota->max_size = *op_state.quota_max_size;
+    }
+    if (op_state.quota_max_objects) {
+      pquota->max_objects = *op_state.quota_max_objects;
+    }
+    if (op_state.quota_enabled) {
+      pquota->enabled = *op_state.quota_enabled;
+    }
   }
 
   constexpr bool exclusive = false;

--- a/src/rgw/rgw_account.cc
+++ b/src/rgw/rgw_account.cc
@@ -22,6 +22,7 @@
 #include "common/utf8.h"
 
 #include "rgw_oidc_provider.h"
+#include "rgw_quota.h"
 #include "rgw_role.h"
 #include "rgw_sal.h"
 
@@ -135,6 +136,10 @@ int create(const DoutPrefixProvider* dpp,
   if (op_state.max_buckets) {
     info.max_buckets = *op_state.max_buckets;
   }
+
+  const ConfigProxy& conf = dpp->get_cct()->_conf;
+  rgw_apply_default_account_quota(info.quota, conf);
+  rgw_apply_default_bucket_quota(info.bucket_quota, conf);
 
   // account id is optional, but must be valid
   if (op_state.account_id.empty()) {

--- a/src/rgw/rgw_account.h
+++ b/src/rgw/rgw_account.h
@@ -49,6 +49,7 @@ struct AdminOpState {
   std::optional<int32_t> max_groups;
   std::optional<int32_t> max_access_keys;
   std::optional<int32_t> max_buckets;
+  std::string quota_scope;
   std::optional<int64_t> quota_max_size;
   std::optional<int64_t> quota_max_objects;
   std::optional<bool> quota_enabled;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -468,7 +468,7 @@ void usage()
   cout << "\nQuota options:\n";
   cout << "   --max-objects                 specify max objects (negative value to disable)\n";
   cout << "   --max-size                    specify max size (in B/K/M/G/T, negative value to disable)\n";
-  cout << "   --quota-scope                 scope of quota (bucket, user)\n";
+  cout << "   --quota-scope                 scope of quota (bucket, user, account)\n";
   cout << "\nRate limiting options:\n";
   cout << "   --max-read-ops                specify max requests per minute for READ ops per RGW (GET and HEAD request methods), 0 means unlimited\n";
   cout << "   --max-read-bytes              specify max bytes per minute for READ ops per RGW (GET and HEAD request methods), 0 means unlimited\n";
@@ -10672,6 +10672,13 @@ next:
       op_state.account_id = account_id;
       op_state.tenant = tenant;
       op_state.account_name = account_name;
+
+      if (quota_scope != "bucket" && quota_scope != "account") {
+        cerr << "ERROR: invalid quota scope specification. Please specify "
+            "either --quota-scope=bucket or --quota-scope=account" << std::endl;
+        return EINVAL;
+      }
+      op_state.quota_scope = quota_scope;
 
       if (opt_cmd == OPT::QUOTA_ENABLE) {
         op_state.quota_enabled = true;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -3018,6 +3018,7 @@ void RGWAccountInfo::dump(Formatter * const f) const
   encode_json("name", name, f);
   encode_json("email", email, f);
   encode_json("quota", quota, f);
+  encode_json("bucket_quota", bucket_quota, f);
   encode_json("max_users", max_users, f);
   encode_json("max_roles", max_roles, f);
   encode_json("max_groups", max_groups, f);
@@ -3032,6 +3033,7 @@ void RGWAccountInfo::decode_json(JSONObj* obj)
   JSONDecoder::decode_json("name", name, obj);
   JSONDecoder::decode_json("email", email, obj);
   JSONDecoder::decode_json("quota", quota, obj);
+  JSONDecoder::decode_json("bucket_quota", bucket_quota, obj);
   JSONDecoder::decode_json("max_users", max_users, obj);
   JSONDecoder::decode_json("max_roles", max_roles, obj);
   JSONDecoder::decode_json("max_groups", max_groups, obj);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -787,6 +787,7 @@ struct RGWAccountInfo {
   std::string name;
   std::string email;
   RGWQuotaInfo quota;
+  RGWQuotaInfo bucket_quota;
 
   static constexpr int32_t DEFAULT_USER_LIMIT = 1000;
   int32_t max_users = DEFAULT_USER_LIMIT;
@@ -804,7 +805,7 @@ struct RGWAccountInfo {
   int32_t max_access_keys = DEFAULT_ACCESS_KEY_LIMIT;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(id, bl);
     encode(tenant, bl);
     encode(name, bl);
@@ -815,11 +816,12 @@ struct RGWAccountInfo {
     encode(max_groups, bl);
     encode(max_buckets, bl);
     encode(max_access_keys, bl);
+    encode(bucket_quota, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(id, bl);
     decode(tenant, bl);
     decode(name, bl);
@@ -830,6 +832,9 @@ struct RGWAccountInfo {
     decode(max_groups, bl);
     decode(max_buckets, bl);
     decode(max_access_keys, bl);
+    if (struct_v >= 2) {
+      decode(bucket_quota, bl);
+    }
     DECODE_FINISH(bl);
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1408,8 +1408,8 @@ static int get_owner_quota_info(DoutPrefixProvider* dpp,
         RGWObjVersionTracker objv; // ignored
         int r = driver->load_account_by_id(dpp, y, account_id, info, attrs, objv);
         if (r >= 0) {
-          // no bucket quota
           quotas.user_quota = info.quota;
+          quotas.bucket_quota = info.bucket_quota;
         }
         return r;
       }), owner);

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -1019,6 +1019,18 @@ void rgw_apply_default_user_quota(RGWQuotaInfo& quota, const ConfigProxy& conf)
   }
 }
 
+void rgw_apply_default_account_quota(RGWQuotaInfo& quota, const ConfigProxy& conf)
+{
+  if (conf->rgw_account_default_quota_max_objects >= 0) {
+    quota.max_objects = conf->rgw_account_default_quota_max_objects;
+    quota.enabled = true;
+  }
+  if (conf->rgw_account_default_quota_max_size >= 0) {
+    quota.max_size = conf->rgw_account_default_quota_max_size;
+    quota.enabled = true;
+  }
+}
+
 void RGWQuotaInfo::dump(Formatter *f) const
 {
   f->dump_bool("enabled", enabled);

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -20,6 +20,7 @@
 #include "common/lru_map.h"
 
 #include "rgw/rgw_quota_types.h"
+#include "rgw/rgw_user_types.h"
 #include "common/async/yield_context.h"
 #include "rgw_sal_fwd.h"
 
@@ -47,3 +48,4 @@ public:
 // apply default quotas from configuration
 void rgw_apply_default_bucket_quota(RGWQuotaInfo& quota, const ConfigProxy& conf);
 void rgw_apply_default_user_quota(RGWQuotaInfo& quota, const ConfigProxy& conf);
+void rgw_apply_default_account_quota(RGWQuotaInfo& quota, const ConfigProxy& conf);

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -336,7 +336,7 @@
   Quota options:
      --max-objects                 specify max objects (negative value to disable)
      --max-size                    specify max size (in B/K/M/G/T, negative value to disable)
-     --quota-scope                 scope of quota (bucket, user)
+     --quota-scope                 scope of quota (bucket, user, account)
   
   Rate limiting options:
      --max-read-ops                specify max requests per minute for READ ops per RGW (GET and HEAD request methods), 0 means unlimited


### PR DESCRIPTION
support bucket quotas per account the same way as for user

Fixes: https://tracker.ceph.com/issues/65551

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
