### PR TITLE
.github: add core label to build/ops files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -105,6 +105,8 @@ bluestore:
   - src/os/bluestore/**
 
 core:
+  - "**/CMakeLists.txt"
+  - admin/**
   - doc/man/8/ceph-authtool.rst
   - doc/man/8/ceph-conf.rst
   - doc/man/8/ceph-create-keys.rst
@@ -117,6 +119,16 @@ core:
   - doc/man/8/monmaptool.rst
   - doc/man/8/rados.rst
   - doc/rados/**
+  - ceph.spec.in
+  - cmake/**
+  - debian/**
+  - do_cmake.sh
+  - do_freebsd.sh
+  - install-deps.sh
+  - keys/**
+  - make-debs.sh
+  - make-dist
+  - make-srpm.sh
   - qa/standalone/**
   - qa/suites/rados/**
   - qa/workunits/erasure-code/**
@@ -124,6 +136,7 @@ core:
   - qa/workunits/mon/**
   - qa/workunits/objectstore/**
   - qa/workunits/rados/**
+  - run-make-check.sh
   - src/ceph.in
   - src/ceph_osd.cc
   - src/ceph_mon.cc
@@ -148,6 +161,8 @@ core:
   - src/tools/rados/**
   - src/test/librados/**
   - src/test/osd/**
+  - win32_build.sh
+  - win32_deps_build.sh
 
 crimson:
   - doc/dev/crimson/**


### PR DESCRIPTION
PRs that only have the "build/ops" label are often left unreviewed and untested. Since we usually run these PRs through the rados suite anyway, adding the core label will ensure these PRs actually get tested.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
