### PR TITLE
doc/rgw: add release note for changes to rgw_realm init

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -73,6 +73,10 @@
   more. Existing users can be adopted into new accounts. This process is optional
   but irreversible. See https://docs.ceph.com/en/squid/radosgw/account and
   https://docs.ceph.com/en/squid/radosgw/iam for details.
+* rgw: On startup, radosgw and radosgw-admin now validate the ``rgw_realm``
+  config option. Previously, they would ignore invalid or missing realms and
+  go on to load a zone/zonegroup in a different realm. If startup fails with
+  a  "failed to load realm" error, fix or remove the ``rgw_realm`` option.
 * CephFS: Running the command "ceph fs authorize" for an existing entity now
   upgrades the entity's capabilities instead of printing an error. It can now
   also change read/write permissions in a capability that the entity already


### PR DESCRIPTION
in https://github.com/ceph/ceph/pull/48482, i removed some strange fallback behavior when the configured `rgw_realm` doesn't exist. if a user requests a specific realm, we shouldn't silently load a configuration from a different realm. that's an easy way to cause data loss by applying writes/deletes to the wrong realm/zone

add a release note to warn users in case they've already misconfigured `rgw_realm`, because radosgws may not start up after upgrade

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
