### PR TITLE
reef: install-deps: save and restore user's XDG_CACHE_HOME

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -565,6 +565,9 @@ function preload_wheels_for_tox() {
 if $for_make_check; then
     mkdir -p install-deps-cache
     top_srcdir=$(pwd)
+    if [ -n "$XDG_CACHE_HOME" ]; then
+        ORIGINAL_XDG_CACHE_HOME=$XDG_CACHE_HOME
+    fi
     export XDG_CACHE_HOME=$top_srcdir/install-deps-cache
     wip_wheelhouse=wheelhouse-wip
     #
@@ -575,6 +578,11 @@ if $for_make_check; then
     done
     rm -rf $top_srcdir/install-deps-python3
     rm -rf $XDG_CACHE_HOME
+    if [ -n "$ORIGINAL_XDG_CACHE_HOME" ]; then
+        XDG_CACHE_HOME=$ORIGINAL_XDG_CACHE_HOME
+    else
+        unset XDG_CACHE_HOME
+    fi
     type git > /dev/null || (echo "Dashboard uses git to pull dependencies." ; false)
 fi
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65578

---

backport of https://github.com/ceph/ceph/pull/56513
parent tracker: https://tracker.ceph.com/issues/65175

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh