### PR TITLE
squid: mgr/dashboard: pin xmlsec to 1.3.13

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1393,7 +1393,7 @@ def exec_test():
         log.info('\nrunning vstart.sh now...')
         # usually, i get vstart.sh running completely in less than 100
         # seconds.
-        remote.run(args=args, env=vstart_env, timeout=(3 * 60))
+        remote.run(args=args, env=vstart_env, timeout=(10 * 60))
         log.info('\nvstart.sh finished running')
 
         # Wait for OSD to come up so that subsequent injectargs etc will

--- a/src/pybind/mgr/dashboard/requirements-test.txt
+++ b/src/pybind/mgr/dashboard/requirements-test.txt
@@ -3,3 +3,4 @@ pytest-instafail
 pyfakefs==4.5.0
 jsonschema~=4.0
 PyJWT~=2.0
+xmlsec==1.3.13 # Pinning because of https://github.com/xmlsec/python-xmlsec/issues/314


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65581

---

backport of https://github.com/ceph/ceph/pull/56974
parent tracker: https://tracker.ceph.com/issues/65571

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh