### PR TITLE
ceph-volume: use os.makedirs for mkdir_p

### DIFF
--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -134,7 +134,7 @@ def mkdir_p(path, chown=True):
     A `mkdir -p` that defaults to chown the path to the ceph user
     """
     try:
-        os.mkdir(path)
+        os.makedirs(path)
     except OSError as e:
         if e.errno == errno.EEXIST:
             pass


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/65584
