### PR TITLE
PGMap: remove pool max_avail scale factor

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -882,10 +882,6 @@ void PGMapDigest::dump_object_stat_sum(
   const object_stat_sum_t &sum = pool_stat.stats.sum;
   const store_statfs_t statfs = pool_stat.store_stats;
 
-  if (sum.num_object_copies > 0) {
-    raw_used_rate *= (float)(sum.num_object_copies - sum.num_objects_degraded) / sum.num_object_copies;
-  }
-
   uint64_t used_data_bytes = pool_stat.get_allocated_data_bytes(per_pool);
   uint64_t used_omap_bytes = pool_stat.get_allocated_omap_bytes(per_pool_omap);
   uint64_t used_bytes = used_data_bytes + used_omap_bytes;

--- a/src/test/mon/PGMap.cc
+++ b/src/test/mon/PGMap.cc
@@ -83,23 +83,20 @@ TEST(pgmap, dump_object_stat_sum_0)
   pool.tier_of = 0;
   PGMap::dump_object_stat_sum(tbl, nullptr, pool_stat, avail,
 			      pool.get_size(), verbose, true, true, &pool);
-  float copies_rate =
-    (static_cast<float>(sum.num_object_copies - sum.num_objects_degraded) /
-      sum.num_object_copies) * pool.get_size();
+
   float used_percent = (float)statfs.allocated /
     (statfs.allocated + avail) * 100;
-  uint64_t stored = statfs.data_stored / copies_rate;
 
   unsigned col = 0;
-  ASSERT_EQ(stringify(byte_u_t(stored)), tbl.get(0, col++));
-  ASSERT_EQ(stringify(byte_u_t(stored)), tbl.get(0, col++));
+  ASSERT_EQ(stringify(byte_u_t(statfs.data_stored/pool.get_size())), tbl.get(0, col++));
+  ASSERT_EQ(stringify(byte_u_t(statfs.data_stored/pool.get_size())), tbl.get(0, col++));
   ASSERT_EQ(stringify(byte_u_t(0)), tbl.get(0, col++));
   ASSERT_EQ(stringify(si_u_t(sum.num_objects)), tbl.get(0, col++));
   ASSERT_EQ(stringify(byte_u_t(statfs.allocated)), tbl.get(0, col++));
   ASSERT_EQ(stringify(byte_u_t(statfs.allocated)), tbl.get(0, col++));
   ASSERT_EQ(stringify(byte_u_t(0)), tbl.get(0, col++));
   ASSERT_EQ(percentify(used_percent), tbl.get(0, col++));
-  ASSERT_EQ(stringify(byte_u_t(avail/copies_rate)), tbl.get(0, col++));
+  ASSERT_EQ(stringify(byte_u_t(avail/pool.get_size())), tbl.get(0, col++));
   ASSERT_EQ(stringify(si_u_t(pool.quota_max_objects)), tbl.get(0, col++));
   ASSERT_EQ(stringify(byte_u_t(pool.quota_max_bytes)), tbl.get(0, col++));
   ASSERT_EQ(stringify(si_u_t(sum.num_objects_dirty)), tbl.get(0, col++));


### PR DESCRIPTION
The scaling of max_avail by the ratio of non-degraded to total objects count results in the reported max_avail increasing proportionally to the number of OSDs marked `down` but not `out`.  This is counter intuitive since OSDs going `down` should never result in more space being available.

Removing the scale factor allows max_avail to remain unchanged until the OSDs are marked `out`.

Example:
- Cluster with 4 OSD nodes, 10 OSDs each
- 3x replicated pool
- `max_avail` from `ceph df detail --format=json` output with all OSDs `up+in`: 72158076207104
- `max_avail` with 1 OSD node (10 OSDs) `down+in`: 96042674552832

Fixes: https://tracker.ceph.com/issues/65591

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
