### PR TITLE
mds: add missing policylock to test F_QUIESCE_BLOCK

### DIFF
--- a/qa/tasks/cephfs/test_quiesce.py
+++ b/qa/tasks/cephfs/test_quiesce.py
@@ -228,6 +228,7 @@ class QuiesceTestCase(CephFSTestCase):
         visited = set()
         locks_expected = set([
           "iquiesce",
+          "ipolicy",
         ])
         if not splitauth:
             locks_expected.add('iauth')
@@ -263,6 +264,9 @@ class QuiesceTestCase(CephFSTestCase):
                             self.assertEqual(lock['flags'], 4)
                             self.assertEqual(lock['lock']['state'], 'lock')
                             self.assertEqual(lock['lock']['num_xlocks'], 1)
+                        elif lock_type == "ipolicy":
+                            self.assertEqual(lock['flags'], 1)
+                            self.assertEqual(lock['lock']['state'][:4], 'sync')
                         elif lock_type in ("ifile", "iauth", "ilink", "ixattr"):
                             self.assertFalse(splitauth)
                             self.assertEqual(lock['flags'], 1)

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -13625,6 +13625,7 @@ void MDCache::dispatch_quiesce_inode(const MDRequestRef& mdr)
     MutationImpl::LockOpVec lov;
 
     lov.add_xlock(&in->quiescelock); /* !! */
+    lov.add_rdlock(&in->policylock); /* for F_QUIESCE_BLOCK test */
 
     if (in->is_auth()) {
       if (splitauth) {


### PR DESCRIPTION
In order to check an inode's F_QUIESCE_BLOCK, the quiesce_inode op must acquire the policylock. Furthermore, to ensure the F_QUIESCE_BLOCK is not changed during quiesce, the lock must be held for the duration of the op's lifetime.

Fixes: https://tracker.ceph.com/issues/65595





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
