### PR TITLE
cmake: link against legacy-option-headers instead of depending on it

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -443,9 +443,9 @@ set(libcommon_files
 set_source_files_properties(ceph_ver.c
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_BINARY_DIR}/src/include/ceph_ver.h)
 add_library(common-objs OBJECT ${libcommon_files})
+target_link_libraries(common-objs legacy-option-headers)
 target_compile_definitions(common-objs PRIVATE
   $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
-add_dependencies(common-objs legacy-option-headers)
 
 if(WITH_JAEGER)
   add_dependencies(common-objs jaeger_base)
@@ -542,8 +542,9 @@ if(WITH_BLUESTORE_PMEM OR WITH_RBD_RWL)
 endif()
 
 add_library(common STATIC ${ceph_common_objs})
-target_link_libraries(common ${ceph_common_deps})
-add_dependencies(common legacy-option-headers)
+target_link_libraries(common
+  ${ceph_common_deps}
+  legacy-option-headers)
 if(WITH_JAEGER)
 add_dependencies(common jaeger_base)
 endif()
@@ -561,7 +562,7 @@ if(ENABLE_COVERAGE)
   target_link_libraries(ceph-common gcov)
 endif(ENABLE_COVERAGE)
 
-add_dependencies(ceph-common legacy-option-headers)
+target_link_libraries(ceph-common legacy-option-headers)
 
 if(WITH_JAEGER)
 add_dependencies(ceph-common jaeger_base)

--- a/src/auth/CMakeLists.txt
+++ b/src/auth/CMakeLists.txt
@@ -22,4 +22,4 @@ endif()
 
 add_library(common-auth-objs OBJECT ${auth_srcs})
 target_include_directories(common-auth-objs PRIVATE ${OPENSSL_INCLUDE_DIR})
-add_dependencies(common-auth-objs legacy-option-headers)
+target_link_libraries(common-auth-objs legacy-option-headers)

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -10,4 +10,6 @@ set(libclient_srcs
   posix_acl.cc
   Delegation.cc)
 add_library(client STATIC ${libclient_srcs})
-target_link_libraries(client osdc)
+target_link_libraries(client
+  legacy-option-headers
+  osdc)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(common_texttable_obj OBJECT
 
 add_library(common_prioritycache_obj OBJECT
   PriorityCache.cc)
-add_dependencies(common_prioritycache_obj legacy-option-headers)
+target_link_libraries(common_prioritycache_obj legacy-option-headers)
 
 if(WIN32)
   add_library(dlfcn_win32 STATIC win32/dlfcn.cc win32/errno.cc)
@@ -193,7 +193,7 @@ target_compile_definitions(common-common-objs PRIVATE
   "CEPH_INSTALL_FULL_PKGLIBDIR=\"${CEPH_INSTALL_FULL_PKGLIBDIR}\""
   "CEPH_INSTALL_DATADIR=\"${CEPH_INSTALL_DATADIR}\""
   $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
-add_dependencies(common-common-objs legacy-option-headers)
+target_link_libraries(common-common-objs legacy-option-headers)
 
 set(common_mountcephfs_srcs
   armor.c

--- a/src/common/options/CMakeLists.txt
+++ b/src/common/options/CMakeLists.txt
@@ -104,8 +104,10 @@ add_options(rgw)
 
 add_library(common-options-objs OBJECT
   ${common_options_srcs})
-add_custom_target(legacy-option-headers
-  DEPENDS ${legacy_options_headers})
+add_library(legacy-option-headers INTERFACE)
+target_sources(legacy-option-headers
+  PRIVATE
+    ${legacy_options_headers})
 
 include(AddCephTest)
 add_ceph_test(validate-options

--- a/src/compressor/CMakeLists.txt
+++ b/src/compressor/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(compressor_objs OBJECT Compressor.cc)
 add_dependencies(compressor_objs common-objs)
-add_dependencies(compressor_objs legacy-option-headers)
+target_link_libraries(compressor_objs legacy-option-headers)
 
 if(HAVE_QATZIP AND HAVE_QAT)
   add_library(qat_compressor OBJECT QatAccel.cc)

--- a/src/compressor/lz4/CMakeLists.txt
+++ b/src/compressor/lz4/CMakeLists.txt
@@ -7,7 +7,9 @@ set(lz4_sources
 
 add_library(ceph_lz4 SHARED ${lz4_sources})
 target_link_libraries(ceph_lz4
-  PRIVATE LZ4::LZ4 compressor $<$<PLATFORM_ID:Windows>:ceph-common>)
+  PRIVATE
+  legacy-option-headers
+  LZ4::LZ4 compressor $<$<PLATFORM_ID:Windows>:ceph-common>)
 if(HAVE_QATZIP AND HAVE_QAT)
   target_link_libraries(ceph_lz4 PRIVATE qat_compressor)
 endif()

--- a/src/compressor/snappy/CMakeLists.txt
+++ b/src/compressor/snappy/CMakeLists.txt
@@ -6,7 +6,9 @@ set(snappy_sources
 
 add_library(ceph_snappy SHARED ${snappy_sources})
 target_link_libraries(ceph_snappy
-  PRIVATE snappy::snappy compressor $<$<PLATFORM_ID:Windows>:ceph-common>)
+  PRIVATE
+    legacy-option-headers
+    snappy::snappy compressor $<$<PLATFORM_ID:Windows>:ceph-common>)
 set_target_properties(ceph_snappy PROPERTIES
   VERSION 2.0.0
   SOVERSION 2

--- a/src/crimson/admin/CMakeLists.txt
+++ b/src/crimson/admin/CMakeLists.txt
@@ -3,7 +3,6 @@ add_library(crimson-admin STATIC
   osd_admin.cc
   pg_commands.cc)
 target_link_libraries(crimson-admin
+  legacy-option-headers
   crimson::cflags
   Boost::MPL)
-add_dependencies(crimson-admin
-  legacy-option-headers)

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -63,6 +63,7 @@ if(HAS_VTA)
     PROPERTIES COMPILE_FLAGS -fno-var-tracking-assignments)
 endif()
 target_link_libraries(crimson-osd
+  legacy-option-headers
   crimson-admin
   crimson-common
   crimson-os

--- a/src/dokan/CMakeLists.txt
+++ b/src/dokan/CMakeLists.txt
@@ -7,6 +7,7 @@ set(ceph_dokan_srcs
 add_executable(ceph-dokan ${ceph_dokan_srcs})
 target_link_libraries(ceph-dokan ${DOKAN_LIBRARIES}
   ${GSSAPI_LIBRARIES}
+  legacy-option-headers
   cephfs ceph-common global ${EXTRALIBS})
 set_target_properties(ceph-dokan PROPERTIES
   COMPILE_FLAGS "-I${DOKAN_INCLUDE_DIRS}")

--- a/src/global/CMakeLists.txt
+++ b/src/global/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 endif()
 
 add_library(libglobal_objs OBJECT ${libglobal_srcs})
-add_dependencies(libglobal_objs legacy-option-headers)
+target_link_libraries(libglobal_objs legacy-option-headers)
 
 add_library(global-static STATIC
   $<TARGET_OBJECTS:libglobal_objs>)

--- a/src/librados/CMakeLists.txt
+++ b/src/librados/CMakeLists.txt
@@ -4,7 +4,8 @@ add_library(librados_impl STATIC
   RadosClient.cc
   librados_util.cc
   librados_tp.cc)
-
+target_link_libraries(librados_impl
+  PRIVATE legacy-option-headers)
 # C/C++ API
 add_library(librados ${CEPH_SHARED}
   librados_c.cc

--- a/src/mds/CMakeLists.txt
+++ b/src/mds/CMakeLists.txt
@@ -52,5 +52,6 @@ set(mds_srcs
   ${CMAKE_SOURCE_DIR}/src/mgr/MDSPerfMetricTypes.cc)
 add_library(mds STATIC ${mds_srcs})
 target_link_libraries(mds PRIVATE
+  legacy-option-headers
   heap_profiler cpu_profiler osdc ${LUA_LIBRARIES})
 target_include_directories(mds PRIVATE "${LUA_INCLUDE_DIR}")

--- a/src/mon/CMakeLists.txt
+++ b/src/mon/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 add_library(mon STATIC
   ${lib_mon_srcs})
 target_link_libraries(mon
+  legacy-option-headers
   kv
   heap_profiler
   ${FMT_LIB})

--- a/src/msg/CMakeLists.txt
+++ b/src/msg/CMakeLists.txt
@@ -48,6 +48,9 @@ add_library(common-msg-objs OBJECT ${msg_srcs})
 target_compile_definitions(common-msg-objs PRIVATE
   $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
 target_include_directories(common-msg-objs PRIVATE ${OPENSSL_INCLUDE_DIR})
+target_link_libraries(common-msg-objs
+  PUBLIC
+    legacy-option-headers)
 
 if(WITH_DPDK)
   set(async_dpdk_srcs

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -47,7 +47,9 @@ if(HAVE_LIBZFS)
 endif()
 
 add_library(os STATIC ${libos_srcs})
-target_link_libraries(os blk)
+target_link_libraries(os
+  legacy-option-headers
+  blk)
 
 target_link_libraries(os heap_profiler kv)
 

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -58,7 +58,9 @@ endif()
 add_library(osd STATIC ${osd_srcs})
 target_link_libraries(osd
   PUBLIC dmclock::dmclock Boost::MPL
-  PRIVATE os heap_profiler cpu_profiler ${FMT_LIB} ${CMAKE_DL_LIBS})
+  PRIVATE
+    legacy-option-headers
+    os heap_profiler cpu_profiler ${FMT_LIB} ${CMAKE_DL_LIBS})
 if(WITH_LTTNG)
   add_dependencies(osd osd-tp pg-tp)
 endif()

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -275,6 +275,7 @@ endif()
 
 target_link_libraries(rgw_common
   PRIVATE
+    legacy-option-headers
     global
     cls_2pc_queue_client
     cls_cmpomap_client
@@ -426,6 +427,7 @@ endif()
 
 target_link_libraries(rgw_a
   PRIVATE
+    legacy-option-headers
     common_utf8 global
     ${CRYPTO_LIBS}
     ${ARROW_LIBRARIES}
@@ -474,6 +476,7 @@ target_include_directories(radosgw
 target_include_directories(radosgw SYSTEM PUBLIC "../rapidjson/include")
 
 target_link_libraries(radosgw PRIVATE
+  legacy-option-headers
   ${rgw_libs}
   rgw_schedulers
   kmip
@@ -493,7 +496,9 @@ if(WITH_RADOSGW_ARROW_FLIGHT)
 endif(WITH_RADOSGW_ARROW_FLIGHT)
 
 add_executable(radosgw-admin ${radosgw_admin_srcs})
-target_link_libraries(radosgw-admin ${rgw_libs} librados
+target_link_libraries(radosgw-admin
+  legacy-option-headers
+  ${rgw_libs} librados
   cls_rgw_client cls_otp_client cls_lock_client cls_refcount_client
   cls_log_client cls_timeindex_client
   cls_version_client cls_user_client
@@ -523,7 +528,9 @@ install(TARGETS radosgw-es DESTINATION bin)
 set(radosgw_token_srcs
   rgw_token.cc)
 add_executable(radosgw-token ${radosgw_token_srcs})
-target_link_libraries(radosgw-token librados
+target_link_libraries(radosgw-token
+  legacy-option-headers
+  librados
   global)
 install(TARGETS radosgw-token DESTINATION bin)
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -78,7 +78,9 @@ endif(WITH_LIBCEPHFS)
 add_executable(ceph-kvstore-tool
   kvstore_tool.cc
   ceph_kvstore_tool.cc)
-target_link_libraries(ceph-kvstore-tool os global)
+target_link_libraries(ceph-kvstore-tool
+  legacy-option-headers
+  os global)
 install(TARGETS ceph-kvstore-tool DESTINATION bin)
 
 set(ceph_conf_srcs ceph_conf.cc)
@@ -88,7 +90,9 @@ install(TARGETS ceph-conf DESTINATION bin)
 
 set(crushtool_srcs crushtool.cc)
 add_executable(crushtool ${crushtool_srcs})
-target_link_libraries(crushtool global)
+target_link_libraries(crushtool
+  legacy-option-headers
+  global)
 install(TARGETS crushtool DESTINATION bin)
 
 set(monmaptool_srcs monmaptool.cc)

--- a/src/tools/cephfs/CMakeLists.txt
+++ b/src/tools/cephfs/CMakeLists.txt
@@ -9,7 +9,9 @@ set(cephfs_journal_tool_srcs
   RoleSelector.cc
   MDSUtility.cc)
 add_executable(cephfs-journal-tool ${cephfs_journal_tool_srcs})
-target_link_libraries(cephfs-journal-tool librados mds osdc global
+target_link_libraries(cephfs-journal-tool
+  legacy-option-headers
+  librados mds osdc global
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
 
 set(cephfs-meta-injection_srcs
@@ -18,7 +20,9 @@ set(cephfs-meta-injection_srcs
   RoleSelector.cc
   MDSUtility.cc)
 add_executable(cephfs-meta-injection ${cephfs-meta-injection_srcs})
-target_link_libraries(cephfs-meta-injection librados mds osdc global
+target_link_libraries(cephfs-meta-injection
+  legacy-option-headers
+  librados mds osdc global
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
 
 set(cephfs_table_tool_srcs

--- a/src/tools/immutable_object_cache/CMakeLists.txt
+++ b/src/tools/immutable_object_cache/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(ceph_immutable_object_cache_lib STATIC ${ceph_immutable_object_cache
 add_executable(ceph-immutable-object-cache
   main.cc)
 target_link_libraries(ceph-immutable-object-cache
+  legacy-option-headers
   ceph_immutable_object_cache_lib
   librados
   StdFilesystem::filesystem

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(rbd_mirror_internal STATIC
 add_executable(rbd-mirror
   main.cc)
 target_link_libraries(rbd-mirror
+  legacy-option-headers
   rbd_mirror_internal
   rbd_mirror_types
   rbd_api

--- a/src/tools/rbd_wnbd/CMakeLists.txt
+++ b/src/tools/rbd_wnbd/CMakeLists.txt
@@ -8,7 +8,9 @@ set_target_properties(
     rbd-wnbd PROPERTIES COMPILE_FLAGS
     "-fpermissive -I${WNBD_INCLUDE_DIRS}")
 target_link_libraries(
-    rbd-wnbd setupapi rpcrt4
+    rbd-wnbd
+    legacy-option-headers
+    setupapi rpcrt4
     wbemuuid oleaut32
     ${WNBD_LIBRARIES}
     ${Boost_FILESYSTEM_LIBRARY}


### PR DESCRIPTION
in this changset, we change legacy-option-headers to an interface library target. and since legacy-option-headers is now an interface library, we are now able to link against it instead of depending on it. this allows us to populate the dependency from the targets linked against legacy-option-headers to the option headers files better.
