### PR TITLE
mds/cache: don't assume non-auth xlocks to be remote locks

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -711,7 +711,7 @@ void Locker::_drop_locks(MutationImpl *mut, set<CInode*> *pneed_issue,
     MDSCacheObject *obj = lock->get_parent();
 
     if (it->is_xlock()) {
-      if (obj->is_auth()) {
+      if (obj->is_auth() || lock->is_locallock()) {
 	bool ni = false;
 	xlock_finish(it++, mut, &ni);
 	if (ni)

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -4173,7 +4173,7 @@ void MDCache::rejoin_send_rejoins()
       for (const auto& q : mdr->locks) {
 	auto lock = q.lock;
 	auto obj = lock->get_parent();
-	if (q.is_xlock() && !obj->is_auth()) {
+	if (q.is_xlock() && !obj->is_auth() && !lock->is_locallock()) {
 	  mds_rank_t who = obj->authority().first;
 	  if (rejoins.count(who) == 0) continue;
 	  const auto& rejoin = rejoins[who];
@@ -9890,7 +9890,7 @@ void MDCache::request_drop_foreign_locks(const MDRequestRef& mdr)
 
   for (auto it = mdr->locks.begin(); it != mdr->locks.end(); ) {
     SimpleLock *lock = it->lock;
-    if (it->is_xlock() && !lock->get_parent()->is_auth()) {
+    if (!lock->is_locallock() && it->is_xlock() && !lock->get_parent()->is_auth()) {
       dout(10) << "request_drop_foreign_locks forgetting lock " << *lock
 	       << " on " << lock->get_parent() << dendl;
       lock->put_xlock();

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3048,6 +3048,9 @@ void Server::dispatch_peer_request(const MDRequestRef& mdr)
       SimpleLock *lock = mds->locker->get_lock(mdr->peer_request->get_lock_type(),
 					       mdr->peer_request->get_object_info());
 
+      // we shouldn't be getting peer requests about local locks
+      ceph_assert(!lock->is_locallock());
+
       if (!lock) {
 	dout(10) << "don't have object, dropping" << dendl;
 	ceph_abort_msg("don't have object"); // can this happen, if we auth pinned properly.


### PR DESCRIPTION
A few places in the code assumed that non-auth xlocks
must be remote, which prevented a proper drop lock procedure
when those locks turned out to be locallocks.

Fixes: https://tracker.ceph.com/issues/65606

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
