### PR TITLE
squid: qa: fix krbd_msgr_segments and krbd_rxbounce failing on 8.stream

### DIFF
--- a/qa/rbd/krbd_msgr_segments.t
+++ b/qa/rbd/krbd_msgr_segments.t
@@ -76,9 +76,9 @@ Cloned bios (dm-snapshot.ko, based on generic/081):
   $ sudo xfs_io -f -c 'pwrite 0 5M' /mnt/file1 >/dev/null
   $ sudo umount /mnt
   $ sudo vgremove -f vg_img
-    Logical volume "lv_snap" successfully removed
-    Logical volume "lv_img" successfully removed
-    Volume group "vg_img" successfully removed
+    Logical volume "lv_snap" successfully removed* (glob)
+    Logical volume "lv_img" successfully removed* (glob)
+    Volume group "vg_img" successfully removed* (glob)
   $ sudo pvremove $DEV
     Labels on physical volume "/dev/rbd?" successfully wiped* (glob)
   $ sudo rbd unmap $DEV

--- a/qa/suites/krbd/ms_modeless/tasks/krbd_rxbounce.yaml
+++ b/qa/suites/krbd/ms_modeless/tasks/krbd_rxbounce.yaml
@@ -1,4 +1,10 @@
 tasks:
+- install:
+    extra_system_packages:
+      rpm:
+      - gcc-c++
+      deb:
+      - g++
 - workunit:
     clients:
       all:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65550

---

backport of https://github.com/ceph/ceph/pull/56908
parent tracker: https://tracker.ceph.com/issues/65481