### PR TITLE
rgw: false assumption on vault bucket key deletion

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/vault_kv.yaml
+++ b/qa/suites/rgw/crypt/2-kms/vault_kv.yaml
@@ -13,8 +13,8 @@ overrides:
 tasks:
 - vault:
     client.0:
-      install_url: https://releases.hashicorp.com/vault/1.2.2/vault_1.2.2_linux_amd64.zip
-      install_sha256: 7725b35d9ca8be3668abe63481f0731ca4730509419b4eb29fa0b0baa4798458
+      install_url: https://releases.hashicorp.com/vault/1.19.0/vault_1.19.0_linux_amd64.zip
+      install_sha256: 9df904271319452bbb37825cfe50726383037550cc04b7c2d0ab09e2f08f82a1
       root_token: test_root_token
       engine: kv
       prefix: /v1/kv/data/

--- a/qa/suites/rgw/crypt/2-kms/vault_old.yaml
+++ b/qa/suites/rgw/crypt/2-kms/vault_old.yaml
@@ -13,8 +13,8 @@ overrides:
 tasks:
 - vault:
     client.0:
-      install_url: https://releases.hashicorp.com/vault/1.2.2/vault_1.2.2_linux_amd64.zip
-      install_sha256: 7725b35d9ca8be3668abe63481f0731ca4730509419b4eb29fa0b0baa4798458
+      install_url: https://releases.hashicorp.com/vault/1.19.0/vault_1.19.0_linux_amd64.zip
+      install_sha256: 9df904271319452bbb37825cfe50726383037550cc04b7c2d0ab09e2f08f82a1
       root_token: test_root_token
       engine: transit
       flavor: old

--- a/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
+++ b/qa/suites/rgw/crypt/2-kms/vault_transit.yaml
@@ -19,8 +19,8 @@ overrides:
 tasks:
 - vault:
     client.0:
-      install_url: https://releases.hashicorp.com/vault/1.2.2/vault_1.2.2_linux_amd64.zip
-      install_sha256: 7725b35d9ca8be3668abe63481f0731ca4730509419b4eb29fa0b0baa4798458
+      install_url: https://releases.hashicorp.com/vault/1.19.0/vault_1.19.0_linux_amd64.zip
+      install_sha256: 9df904271319452bbb37825cfe50726383037550cc04b7c2d0ab09e2f08f82a1
       root_token: test_root_token
       engine: transit
       prefix: /v1/transit/keys/

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -651,8 +651,8 @@ public:
     }
     if (dummy_bl.length() != 0) {
       ldpp_dout(dpp, 0) << "ERROR: unexpected response from Vault making a key: "
-	<< dummy_bl
-	<< dendl;
+        << std::string_view(dummy_bl.c_str(), dummy_bl.length())
+        << dendl;
     }
     return 0;
   }
@@ -688,25 +688,21 @@ public:
     int res = send_request(dpp, "POST", "", config_path,
                            post_data, y, dummy_bl);
     if (res < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: unexpected response from Vault marking key to delete, ret: "
+        << res << " response: "
+        << std::string_view(dummy_bl.c_str(), dummy_bl.length())
+        << dendl;
       return res;
-    }
-    if (dummy_bl.length() != 0) {
-      ldpp_dout(dpp, 0) << "ERROR: unexpected response from Vault marking key to delete: "
-	<< dummy_bl
-	<< dendl;
-      return -EINVAL;
     }
 
     res = send_request(dpp, "DELETE", "", delete_path,
                        string{}, y, dummy_bl);
     if (res < 0) {
+      ldpp_dout(dpp, 0) << "ERROR: unexpected response from Vault deleting key, ret: "
+        << res << " response: "
+        << std::string_view(dummy_bl.c_str(), dummy_bl.length())
+        << dendl;
       return res;
-    }
-    if (dummy_bl.length() != 0) {
-      ldpp_dout(dpp, 0) << "ERROR: unexpected response from Vault deleting key: "
-	<< dummy_bl
-	<< dendl;
-      return -EINVAL;
     }
     return 0;
   }


### PR DESCRIPTION
On bucket key deletion when the request to change the property of the key for deletion_allowed to true is made, it is expected that the response body be empty. But this assumption is false and there would be a dump of the new config in the response. this condition would prevent the key deletion from being done.

Fixes: https://tracker.ceph.com/issues/65626