### PR TITLE
quincy: doc/rados: fix outdated value for ms_bind_port_max

### DIFF
--- a/doc/rados/configuration/network-config-ref.rst
+++ b/doc/rados/configuration/network-config-ref.rst
@@ -56,7 +56,7 @@ Recommendations - Networks`_ for additional details.
 IP Tables
 =========
 
-By default, daemons `bind`_ to ports within the ``6800:7300`` range. You may
+By default, daemons `bind`_ to ports within the ``6800:7568`` range. You may
 configure this range at your discretion. Before configuring your IP tables,
 check the default ``iptables`` configuration.
 
@@ -96,7 +96,7 @@ A :term:`Ceph Metadata Server` or :term:`Ceph Manager` listens on the first
 available port on the public network beginning at port 6800. Note that this 
 behavior is not deterministic, so if you are running more than one OSD or MDS
 on the same host, or if you restart the daemons within a short window of time,
-the daemons will bind to higher ports. You should open the entire 6800-7300
+the daemons will bind to higher ports. You should open the entire 6800-7568
 range by default.  When you add the rule using the example below, make sure
 you replace ``{iface}`` with the public network interface (e.g., ``eth0``,
 ``eth1``, etc.), ``{ip-address}`` with the IP address of the public network
@@ -106,7 +106,7 @@ For example:
 
 .. prompt:: bash $
 
-   sudo iptables -A INPUT -i {iface} -m multiport -p tcp -s {ip-address}/{netmask} --dports 6800:7300 -j ACCEPT
+   sudo iptables -A INPUT -i {iface} -m multiport -p tcp -s {ip-address}/{netmask} --dports 6800:7568 -j ACCEPT
 
 
 OSD IP Tables
@@ -136,7 +136,7 @@ Each Ceph OSD Daemon on a Ceph Node may use up to four ports:
               \---------------/
 
 When a daemon fails and restarts without letting go of the port, the restarted
-daemon will bind to a new port. You should open the entire 6800-7300 port range
+daemon will bind to a new port. You should open the entire 6800-7568 port range
 to handle this possibility.
 
 If you set up separate public and cluster networks, you must add rules for both
@@ -149,7 +149,7 @@ public or cluster network. For example:
 
 .. prompt:: bash $
 
-   sudo iptables -A INPUT -i {iface}  -m multiport -p tcp -s {ip-address}/{netmask} --dports 6800:7300 -j ACCEPT
+   sudo iptables -A INPUT -i {iface}  -m multiport -p tcp -s {ip-address}/{netmask} --dports 6800:7568 -j ACCEPT
 
 .. tip:: If you run Ceph Metadata Servers on the same Ceph Node as the 
    Ceph OSD Daemons, you can consolidate the public network configuration step. 
@@ -314,7 +314,7 @@ Bind
 ----
 
 Bind settings set the default port ranges Ceph OSD and MDS daemons use. The
-default range is ``6800:7300``. Ensure that your `IP Tables`_ configuration
+default range is ``6800:7568``. Ensure that your `IP Tables`_ configuration
 allows you to use the configured port range.
 
 You may also enable Ceph daemons to bind to IPv6 addresses instead of IPv4

--- a/doc/rados/troubleshooting/troubleshooting-mon.rst
+++ b/doc/rados/troubleshooting/troubleshooting-mon.rst
@@ -493,10 +493,10 @@ trying to connect to Ceph daemons. For example::
 
 It might also be necessary to add rules to iptables on your Ceph hosts to
 ensure that clients are able to access the TCP ports associated with your Ceph
-monitors (default: port 6789) and Ceph OSDs (default: 6800 through 7300). For
+monitors (default: port 6789) and Ceph OSDs (default: 6800 through 7568). For
 example::
 
-    iptables -A INPUT -m multiport -p tcp -s {ip-address}/{netmask} --dports 6789,6800:7300 -j ACCEPT
+    iptables -A INPUT -m multiport -p tcp -s {ip-address}/{netmask} --dports 6789,6800:7568 -j ACCEPT
 
 
 Monitor Store Failures


### PR DESCRIPTION
The highest port number used by OSD or MDS daemons was increased from 7300 to 7568 in [1] but the documentation still refers to 7300 in multiple locations.

[1] https://github.com/ceph/ceph/pull/42210

Fixes: https://tracker.ceph.com/issues/65609
Signed-off-by: Pierre Riteau <pierre@stackhpc.com>
(cherry picked from commit 23d2740241af2118652fef6e7d6a286f338a18f2)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

