### PR TITLE
squid: mgr/dashboard: start using alertmanager v2

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/prometheus.py
+++ b/src/pybind/mgr/dashboard/controllers/prometheus.py
@@ -46,9 +46,9 @@ class PrometheusRESTController(RESTController):
         # type (str, str, dict, dict)
         user, password, cert_file = self.get_access_info('alertmanager')
         verify = cert_file.name if cert_file else Settings.ALERTMANAGER_API_SSL_VERIFY
-        response = self._proxy(self._get_api_url(Settings.ALERTMANAGER_API_HOST),
+        response = self._proxy(self._get_api_url(Settings.ALERTMANAGER_API_HOST, version='v2'),
                                method, path, 'Alertmanager', params, payload,
-                               user=user, password=password, verify=verify)
+                               user=user, password=password, verify=verify, is_alertmanager=True)
         if cert_file:
             cert_file.close()
             os.unlink(cert_file.name)
@@ -81,15 +81,16 @@ class PrometheusRESTController(RESTController):
 
         return user, password, cert_file
 
-    def _get_api_url(self, host):
-        return host.rstrip('/') + '/api/v1'
+    def _get_api_url(self, host, version='v1'):
+        return f'{host.rstrip("/")}/api/{version}'
 
     def balancer_status(self):
         return ceph_service.CephService.send_command('mon', 'balancer status')
 
     def _proxy(self, base_url, method, path, api_name, params=None, payload=None, verify=True,
-               user=None, password=None):
+               user=None, password=None, is_alertmanager=False):
         # type (str, str, str, str, dict, dict, bool)
+        content = None
         try:
             from requests.auth import HTTPBasicAuth
             auth = HTTPBasicAuth(user, password) if user and password else None
@@ -102,11 +103,14 @@ class PrometheusRESTController(RESTController):
                 http_status_code=404,
                 component='prometheus')
         try:
-            content = json.loads(response.content, strict=False)
+            if response.content:
+                content = json.loads(response.content, strict=False)
         except json.JSONDecodeError as e:
             raise DashboardException(
                 "Error parsing Prometheus Alertmanager response: {}".format(e.msg),
                 component='prometheus')
+        if is_alertmanager:
+            return content
         balancer_status = self.balancer_status()
         if content['status'] == 'success':  # pylint: disable=R1702
             alerts_info = []
@@ -145,6 +149,10 @@ class Prometheus(PrometheusRESTController):
     @RESTController.Collection(method='DELETE', path='/silence/{s_id}', status=204)
     def delete_silence(self, s_id):
         return self.alert_proxy('DELETE', '/silence/' + s_id) if s_id else None
+
+    @RESTController.Collection(method='GET', path='/alertgroup')
+    def get_alertgroup(self, **params):
+        return self.alert_proxy('GET', '/alerts/groups', params)
 
 
 @APIRouter('/prometheus/notifications', Scope.PROMETHEUS)

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -9951,6 +9951,28 @@ paths:
       - jwt: []
       tags:
       - Prometheus
+  /api/prometheus/alertgroup:
+    get:
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - Prometheus
   /api/prometheus/data:
     get:
       parameters: []

--- a/src/pybind/mgr/dashboard/tests/test_prometheus.py
+++ b/src/pybind/mgr/dashboard/tests/test_prometheus.py
@@ -12,7 +12,7 @@ from ..tests import ControllerTestCase
 
 class PrometheusControllerTest(ControllerTestCase):
     alert_host = 'http://alertmanager:9093/mock'
-    alert_host_api = alert_host + '/api/v1'
+    alert_host_api = alert_host + '/api/v2'
 
     prometheus_host = 'http://prometheus:9090/mock'
     prometheus_host_api = prometheus_host + '/api/v1'


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65255

---

backport of https://github.com/ceph/ceph/pull/53679
parent tracker: https://tracker.ceph.com/issues/65070

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh