### PR TITLE
squid: doc/rgw: add release note for changes to rgw_realm init

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -73,6 +73,10 @@
   more. Existing users can be adopted into new accounts. This process is optional
   but irreversible. See https://docs.ceph.com/en/squid/radosgw/account and
   https://docs.ceph.com/en/squid/radosgw/iam for details.
+* rgw: On startup, radosgw and radosgw-admin now validate the ``rgw_realm``
+  config option. Previously, they would ignore invalid or missing realms and
+  go on to load a zone/zonegroup in a different realm. If startup fails with
+  a  "failed to load realm" error, fix or remove the ``rgw_realm`` option.
 * CephFS: Running the command "ceph fs authorize" for an existing entity now
   upgrades the entity's capabilities instead of printing an error. It can now
   also change read/write permissions in a capability that the entity already


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65636

---

backport of https://github.com/ceph/ceph/pull/56990
parent tracker: https://tracker.ceph.com/issues/65575

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh