### PR TITLE
squid: mds: use mds_cache_quiesce_decay_rate to init quiesce_counter

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -132,7 +132,7 @@ MDCache::MDCache(MDSRank *m, PurgeQueue &purge_queue_) :
   stray_manager(m, purge_queue_),
   recovery_queue(m),
   trim_counter(g_conf().get_val<double>("mds_cache_trim_decay_rate")),
-  quiesce_counter(g_conf().get_val<double>("mds_cache_trim_decay_rate")),
+  quiesce_counter(g_conf().get_val<double>("mds_cache_quiesce_decay_rate")),
   quiesce_threshold(g_conf().get_val<Option::size_t>("mds_cache_quiesce_threshold")),
   quiesce_sleep(g_conf().get_val<std::chrono::milliseconds>("mds_cache_quiesce_sleep"))
 {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65619

---

backport of https://github.com/ceph/ceph/pull/56723
parent tracker: https://tracker.ceph.com/issues/65342

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh