### PR TITLE
doc/rados: improve t-shooting pg

### DIFF
--- a/doc/rados/troubleshooting/troubleshooting-pg.rst
+++ b/doc/rados/troubleshooting/troubleshooting-pg.rst
@@ -573,11 +573,11 @@ and Ceph :ref:`Clock Settings <mon-config-ref-clock>` for more information.
 More Information on PG Repair
 -----------------------------
 Ceph stores and updates the checksums of objects stored in the cluster. When a
-scrub is performed on a PG, the OSD attempts to choose an authoritative copy
-from among its replicas. Only one of the possible cases is consistent. After
-performing a deep scrub, Ceph calculates the checksum of an object that is read
-from disk and compares it to the checksum that was previously recorded. If the
-current checksum and the previously recorded checksum do not match, that
+scrub is performed on a PG, the lead OSD attempts to choose an authoritative
+copy from among its replicas. Only one of the possible cases is consistent.
+After performing a deep scrub, Ceph calculates the checksum of each object that
+is read from disk and compares it to the checksum that was previously recorded.
+If the current checksum and the previously recorded checksum do not match, that
 mismatch is considered to be an inconsistency. In the case of replicated pools,
 any mismatch between the checksum of any replica of an object and the checksum
 of the authoritative copy means that there is an inconsistency. The discovery
@@ -585,10 +585,10 @@ of these inconsistencies cause a PG's state to be set to ``inconsistent``.
 
 The ``pg repair`` command attempts to fix inconsistencies of various kinds. If
 ``pg repair`` finds an inconsistent PG, it attempts to overwrite the digest of
-the inconsistent copy with the digest of the authoritative copy. If ``pg
-repair`` finds an inconsistent replicated pool, it marks the inconsistent copy
-as missing. In the case of replicated pools, recovery is beyond the scope of
-``pg repair``.
+the inconsistent copy with the digest of the authoritative copy. When ``pg
+repair`` finds an inconsistent copy in a replicated pool, it marks the
+inconsistent copy as missing. In the case of replicated pools, recovery is
+beyond the scope of ``pg repair``.
 
 In the case of erasure-coded and BlueStore pools, Ceph will automatically
 perform repairs if ``osd_scrub_auto_repair`` (default ``false``) is set to


### PR DESCRIPTION
Incorporate Anthony D'Atri's suggestions from
https://github.com/ceph/ceph/pull/57022 into the text in doc/rados/troubleshooting/troubleshooting-pg.rst.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
