### PR TITLE
quincy: doc/rados: remove dual-stack docs

### DIFF
--- a/doc/rados/configuration/msgr2.rst
+++ b/doc/rados/configuration/msgr2.rst
@@ -90,10 +90,6 @@ Similarly, two options control whether IPv4 and IPv6 addresses are used:
   * :confval:`ms_bind_ipv6` [default: false] controls whether a daemon binds
     to an IPv6 address
 
-.. note:: The ability to bind to multiple ports has paved the way for
-   dual-stack IPv4 and IPv6 support.  That said, dual-stack operation is
-   not yet supported as of Quincy v17.2.0.
-
 Connection modes
 ----------------
 

--- a/doc/rados/configuration/network-config-ref.rst
+++ b/doc/rados/configuration/network-config-ref.rst
@@ -214,28 +214,6 @@ following option to the ``[global]`` section of your Ceph configuration file.
 We prefer that the cluster network is **NOT** reachable from the public network
 or the Internet for added security.
 
-IPv4/IPv6 Dual Stack Mode
--------------------------
-
-If you want to run in an IPv4/IPv6 dual stack mode and want to define your public and/or
-cluster networks, then you need to specify both your IPv4 and IPv6 networks for each:
-
-.. code-block:: ini
-
-	[global]
-		# ... elided configuration
-		public_network = {IPv4 public-network/netmask}, {IPv6 public-network/netmask}
-
-This is so that Ceph can find a valid IP address for both address families.
-
-If you want just an IPv4 or an IPv6 stack environment, then make sure you set the `ms bind`
-options correctly.
-
-.. note::
-   Binding to IPv4 is enabled by default, so if you just add the option to bind to IPv6
-   you'll actually put yourself into dual stack mode. If you want just IPv6, then disable IPv4 and
-   enable IPv6. See `Bind`_ below.
-
 Ceph Daemons
 ============
 


### PR DESCRIPTION
Remove references to dual-stack mode in
doc/rados/configuration/network-config-ref.rst and doc/rados/configuration/msgr2.rst. This feature seems to have been planned but never to have been completely implemented.

See the tracker issue listed below for an email exchange detailing the confusion caused by the presence in the documentation of this now-removed information.

Fixes: https://tracker.ceph.com/issues/65631

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit c65d2056c27d75f91af44e004d8defe7ffbf5fc8)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
