### PR TITLE
rgw: don't print error when ldap isn't configured

### DIFF
--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -384,7 +384,6 @@ void rgw::AppMain::init_ldap()
   std::string ldap_bindpw = parse_rgw_ldap_bindpw(cct);
 
   if (ldap_uri.empty()) {
-    derr << "LDAP not started since no server URIs were provided in the configuration." << dendl;
     return;
   }
 


### PR DESCRIPTION
> LDAP not started since no server URIs were provided in the configuration.

lack of ldap configuration is not an error, it's the default

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
