### PR TITLE
squid: doc/cephadm: remove downgrade reference from upgrade docs

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -56,13 +56,13 @@ Before you use cephadm to upgrade Ceph, verify that all hosts are currently onli
 
    ceph -s
 
-To upgrade (or downgrade) to a specific release, run the following command:
+To upgrade to a specific release, run a command of the following form:
 
 .. prompt:: bash #
 
   ceph orch upgrade start --ceph-version <version>
 
-For example, to upgrade to v16.2.6, run the following command:
+For example, to upgrade to v16.2.6, run a command of the following form:
 
 .. prompt:: bash #
 


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/57057

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
