### PR TITLE
quincy: librbd: make group and group snapshot IDs more random

### DIFF
--- a/src/librbd/Utils.cc
+++ b/src/librbd/Utils.cc
@@ -59,6 +59,7 @@ librados::AioCompletion *create_rados_callback(Context *on_finish) {
   return create_rados_callback<Context, &Context::complete>(on_finish);
 }
 
+// also used for group and group snapshot ids
 std::string generate_image_id(librados::IoCtx &ioctx) {
   librados::Rados rados(ioctx);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65588

---

backport of https://github.com/ceph/ceph/pull/56987
parent tracker: https://tracker.ceph.com/issues/65573