### PR TITLE
mgr/smb: disable JSON/YAML key sorting in favor of ordered dicts

### DIFF
--- a/src/pybind/mgr/smb/results.py
+++ b/src/pybind/mgr/smb/results.py
@@ -26,11 +26,13 @@ class Result:
         self.status = status
 
     def to_simplified(self) -> Simplified:
-        ds: Simplified = dict(self.status or {})
+        ds: Simplified = {}
         ds['resource'] = self.src.to_simplified()
-        ds['success'] = self.success
+        if self.status:
+            ds.update(self.status)
         if self.msg:
             ds['msg'] = self.msg
+        ds['success'] = self.success
         return ds
 
     def mgr_return_value(self) -> int:
@@ -77,8 +79,8 @@ class ResultGroup:
 
     def to_simplified(self) -> Simplified:
         return {
-            'success': self.success,
             'results': [r.to_simplified() for r in self._contents],
+            'success': self.success,
         }
 
     def mgr_return_value(self) -> int:

--- a/src/pybind/mgr/smb/tests/test_smb.py
+++ b/src/pybind/mgr/smb/tests/test_smb.py
@@ -600,3 +600,58 @@ def test_dump_service_spec(tmodule):
     assert cfg['spec']['features'] == ['domain']
     assert cfg['spec']['config_uri'] == 'mem:foo/config.smb'
     assert len(cfg['spec']['join_sources']) == 2
+
+
+def test_cmd_show_resource_json(tmodule):
+    _example_cfg_1(tmodule)
+
+    res, body, status = tmodule.show.command(['ceph.smb.cluster.foo'])
+    assert res == 0
+    assert (
+        body.strip()
+        == """
+{
+  "resource_type": "ceph.smb.cluster",
+  "cluster_id": "foo",
+  "auth_mode": "active-directory",
+  "intent": "present",
+  "domain_settings": {
+    "realm": "dom1.example.com",
+    "join_sources": [
+      {
+        "source_type": "password",
+        "auth": {
+          "username": "testadmin",
+          "password": "Passw0rd"
+        }
+      }
+    ]
+  }
+}
+    """.strip()
+    )
+
+
+def test_cmd_show_resource_yaml(tmodule):
+    _example_cfg_1(tmodule)
+
+    res, body, status = tmodule.show.command(
+        ['ceph.smb.cluster.foo'], format='yaml'
+    )
+    assert res == 0
+    assert (
+        body.strip()
+        == """
+resource_type: ceph.smb.cluster
+cluster_id: foo
+auth_mode: active-directory
+intent: present
+domain_settings:
+  realm: dom1.example.com
+  join_sources:
+  - source_type: password
+    auth:
+      username: testadmin
+      password: Passw0rd
+""".strip()
+    )


### PR DESCRIPTION
Depends on #56350 

This is the first follow up PR to the new smb mgr module. Instead of trying to fix everything in one giant PR I plan on iterating the smb work over more, smaller, easier to digest, PRs.

This change alters the output of the smb commands so that the JSON/YAML outputs are ordered by the code in a way that should make sense to human readers rather than sorted by the key names.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s>
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
