### PR TITLE
examples/rgw: teach boto about the BLAKE3 checksum algorithm

### DIFF
--- a/examples/rgw/boto3/blake3_checksum.py
+++ b/examples/rgw/boto3/blake3_checksum.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+
+import boto3
+import sys
+
+if len(sys.argv) != 3:
+    print('Usage: ' + sys.argv[0] + ' <bucket> <object>')
+    sys.exit(1)
+
+# bucket name as first argument
+bucketname = sys.argv[1]
+objectname = sys.argv[2]
+
+# endpoint and keys from vstart
+endpoint = 'http://127.0.0.1:8000'
+access_key='0555b35654ad1656d804'
+secret_key='h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=='
+
+client = boto3.client('s3',
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key)
+
+client.put_object(Bucket=bucketname, Key=objectname, Body='contents',
+                  ChecksumAlgorithm='BLAKE3', ChecksumBLAKE3='contents')

--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -235,22 +235,22 @@
         "UsageStatsSummary": {
             "type": "structure",
             "members": {
-		        "QuotaMaxBytes":{"shape":"QuotaMaxBytes"},
-		        "QuotaMaxBuckets":{"shape": "QuotaMaxBuckets"},
-		        "QuotaMaxObjCount":{"shape":"QuotaMaxObjCount"},
-		        "QuotaMaxBytesPerBucket":{"shape":"QuotaMaxBytesPerBucket"},
+                "QuotaMaxBytes":{"shape":"QuotaMaxBytes"},
+                "QuotaMaxBuckets":{"shape": "QuotaMaxBuckets"},
+                "QuotaMaxObjCount":{"shape":"QuotaMaxObjCount"},
+                "QuotaMaxBytesPerBucket":{"shape":"QuotaMaxBytesPerBucket"},
                 "QuotaMaxObjCountPerBucket":{"shape":"QuotaMaxObjCountPerBucket"},
-		        "TotalBytes":{"shape":"TotalBytes"},
+                "TotalBytes":{"shape":"TotalBytes"},
                 "TotalBytesRounded":{"shape":"TotalBytesRounded"},
                 "TotalEntries":{"shape":"TotalEntries"}
             }
         },
         "QuotaMaxBytes":{"type":"integer"},
-	    "QuotaMaxBuckets":{"type": "integer"},
-	    "QuotaMaxObjCount":{"type":"integer"},
-	    "QuotaMaxBytesPerBucket":{"type":"integer"},
-	    "QuotaMaxObjCountPerBucket":{"type":"integer"},
-	    "TotalBytesRounded":{"type":"integer"},
+        "QuotaMaxBuckets":{"type": "integer"},
+        "QuotaMaxObjCount":{"type":"integer"},
+        "QuotaMaxBytesPerBucket":{"type":"integer"},
+        "QuotaMaxObjCountPerBucket":{"type":"integer"},
+        "TotalBytesRounded":{"type":"integer"},
         "TotalBytes":{"type":"integer"},
         "TotalEntries":{"type":"integer"}
     },

--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -23,6 +23,17 @@
             "output": {"shape": "GetUsageStatsOutput"},
             "documentationUrl":"https://docs.ceph.com/docs/master/radosgw/s3/serviceops#get-usage-stats",
             "documentation":"<p>Get usage stats for the user</p>"
+        },
+        "GetObject":{
+            "httpChecksum":{
+                "responseAlgorithms":[
+                    "CRC32",
+                    "CRC32C",
+                    "SHA256",
+                    "SHA1",
+                    "BLAKE3"
+                ]
+            }
         }
     },
     "shapes": {
@@ -252,7 +263,144 @@
         "QuotaMaxObjCountPerBucket":{"type":"integer"},
         "TotalBytesRounded":{"type":"integer"},
         "TotalBytes":{"type":"integer"},
-        "TotalEntries":{"type":"integer"}
+        "TotalEntries":{"type":"integer"},
+        "Checksum":{
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>The base64-encoded, 256-bit BLAKE3 checksum of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension.</p>"
+                }
+            }
+        },
+        "ChecksumAlgorithm":{
+            "enum":[
+                "CRC32",
+                "CRC32C",
+                "SHA1",
+                "SHA256",
+                "BLAKE3"
+            ]
+        },
+        "ChecksumBLAKE3":{"type":"string"},
+        "CompleteMultipartUploadOutput":{
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>The base64-encoded, 256-bit BLAKE3 checksum of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension.</p>"
+                }
+            }
+        },
+        "CompleteMultipartUploadRequest":{
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32 checksum of the object. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension.</p>",
+                    "location":"header",
+                    "locationName":"x-amz-checksum-blake3"
+                }
+            }
+        },
+        "CompletedPart":{
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>The base64-encoded, 256-bit BLAKE3 checksum of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension.</p>"
+                }
+            }
+        },
+        "CopyObjectResult":{
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>The base64-encoded, 256-bit BLAKE3 checksum of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension.</p>"
+                }
+            }
+        },
+        "CopyPartResult":{
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>The base64-encoded, 256-bit BLAKE3 checksum of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension.</p>"
+                }
+            }
+        },
+        "GetObjectOutput":{
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>The base64-encoded, 256-bit BLAKE3 checksum of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension.</p>",
+                    "location":"header",
+                    "locationName":"x-amz-checksum-blake3"
+                }
+            }
+        },
+        "HeadObjectOutput":{
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>The base64-encoded, 256-bit BLAKE3 checksum of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension.</p>",
+                    "location":"header",
+                    "locationName":"x-amz-checksum-blake3"
+                }
+            }
+        },
+        "ObjectPart":{
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>The base64-encoded, 256-bit BLAKE3 checksum of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension.</p>"
+                }
+            }
+        },
+        "Part":{
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>The base64-encoded, 256-bit BLAKE3 checksum of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension.</p>"
+                }
+            }
+        },
+        "PutObjectOutput":{
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>The base64-encoded, 256-bit BLAKE3 checksum of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension.</p>",
+                    "location":"header",
+                    "locationName":"x-amz-checksum-blake3"
+                }
+            }
+        },
+        "PutObjectRequest":{
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 256-bit BLAKE3 checksum of the object. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension.</p>",
+                    "location":"header",
+                    "locationName":"x-amz-checksum-blake3"
+                }
+            }
+        },
+        "UploadPartOutput":{
+            "type":"structure",
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>The base64-encoded, 256-bit BLAKE3 checksum of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension.</p>",
+                    "location":"header",
+                    "locationName":"x-amz-checksum-blake3"
+                }
+            }
+        },
+        "UploadPartRequest":{
+            "members":{
+                "ChecksumBLAKE3":{
+                    "shape":"ChecksumBLAKE3",
+                    "documentation":"<p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 256-bit BLAKE3 checksum of the object. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>. This checksum algorithm is a Ceph RGW extension..</p>",
+                    "location":"header",
+                    "locationName":"x-amz-checksum-blake3"
+                }
+            }
+        }
     },
     "documentation":"<p/>"
 }


### PR DESCRIPTION
allow boto clients like awscli to use BLAKE3 as a checksum algorithm

```
$ aws s3api put-object help
...
       --checksum-algorithm (string)
          Indicates  the  algorithm used to create the checksum for the object
          when you use the SDK. This header will not  provide  any  additional
          functionality  if  you don't use the SDK. When you send this header,
          there must  be  a  corresponding  x-amz-checksum-*algorithm*  ``  or
          ``x-amz-trailer  header sent. Otherwise, Amazon S3 fails the request
          with the HTTP status code 400 Bad Request .
...
          Possible values:
          o CRC32
          o CRC32C
          o SHA1
          o SHA256
          o BLAKE3
...
       --checksum-blake3 (string)
          This header can be used as a data integrity check to verify that the
          data received is the same data that was originally sent. This header
          specifies the base64-encoded, 256-bit BLAKE3 checksum of the object.
          For more information, see Checking object integrity in the Amazon S3
          User Guide . This checksum algorithm is a Ceph RGW extension.
...
OUTPUT
...
       ChecksumBLAKE3 -> (string)
          The base64-encoded, 256-bit BLAKE3 checksum of the object. This will
          only be present if it was uploaded with the object.  With  multipart
          uploads,  this  may  not be a checksum value of the object. For more
          information about how checksums are calculated  with  multipart  up-
          loads,  see  Checking object integrity in the Amazon S3 User Guide .
          This checksum algorithm is a Ceph RGW extension.
```
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
