### PR TITLE
blk/bluestore: remove BlockDevice::supported_bdev_label()

### DIFF
--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -209,7 +209,6 @@ public:
   static BlockDevice *create(
     CephContext* cct, const std::string& path, aio_callback_t cb, void *cbpriv, aio_callback_t d_cb,
     void *d_cbpriv, const char* dev_name = "");
-  virtual bool supported_bdev_label() { return true; }
   virtual bool is_rotational() { return rotational; }
 
   // HM-SMR-specific calls

--- a/src/blk/pmem/PMEMDevice.h
+++ b/src/blk/pmem/PMEMDevice.h
@@ -41,7 +41,6 @@ class PMEMDevice : public BlockDevice {
 public:
   PMEMDevice(CephContext *cct, aio_callback_t cb, void *cbpriv);
 
-  bool supported_bdev_label() override { return !devdax_device; }
   void aio_submit(IOContext *ioc) override;
 
   int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const override;

--- a/src/blk/spdk/NVMEDevice.h
+++ b/src/blk/spdk/NVMEDevice.h
@@ -52,8 +52,6 @@ class NVMEDevice : public BlockDevice {
 
   NVMEDevice(CephContext* cct, aio_callback_t cb, void *cbpriv);
 
-  bool supported_bdev_label() override { return false; }
-
   static bool support(const std::string& path);
 
   void aio_submit(IOContext *ioc) override;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -550,13 +550,6 @@ int BlueFS::add_block_device(unsigned id, const string& path, bool trim,
   return 0;
 }
 
-bool BlueFS::bdev_support_label(unsigned id)
-{
-  ceph_assert(id < bdev.size());
-  ceph_assert(bdev[id]);
-  return bdev[id]->supported_bdev_label();
-}
-
 uint64_t BlueFS::get_block_device_size(unsigned id) const
 {
   if (id < bdev.size() && bdev[id])

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -737,8 +737,7 @@ public:
   }
 
   int add_block_device(unsigned bdev, const std::string& path, bool trim,
-                       bluefs_shared_alloc_context_t* _shared_alloc = nullptr);
-  bool bdev_support_label(unsigned id);
+		       bluefs_shared_alloc_context_t* _shared_alloc = nullptr);
   uint64_t get_block_device_size(unsigned bdev) const;
   BlockDevice* get_block_device(unsigned bdev) const;
 


### PR DESCRIPTION
Block device got this interface function with https://github.com/ceph/ceph/pull/7145. 
In bluestore, bdev label just means "first disk block, located at #0". 
For other devices, there is deeper meaning: https://docs.pmem.io/ndctl-user-guide/managing-label-storage-areas-lsa

It is most likely that two distinct features were joined by name.
It is obvious that any block device will be able to write to its first block.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
