### PR TITLE
[squid] rgw/lc: advance head if the current entry doesn't exist

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2284,13 +2284,28 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker,
       /* fetches the entry pointed to by head.bucket */
       ret = sal_lc->get_entry(lc_shard, head->get_marker(), &entry);
       if (ret == -ENOENT) {
-        ret = sal_lc->get_next_entry(lc_shard, head->get_marker(), &entry);
-        if (ret < 0) {
-          ldpp_dout(this, 0) << "RGWLC::process() sal_lc->get_next_entry(lc_shard, "
-                             << "head.marker, entry) returned error ret==" << ret
-                             << dendl;
-          goto exit;
-        }
+        /* skip to next entry */
+	std::unique_ptr<rgw::sal::Lifecycle::LCEntry> tmp_entry = sal_lc->get_entry();
+	tmp_entry->set_bucket(head->get_marker());
+	if (advance_head(lc_shard, *head.get(), *tmp_entry.get(), now) < 0) {
+	  goto exit;
+	}
+	/* done with this shard */
+	if (head->get_marker().empty()) {
+	  ldpp_dout(this, 5) <<
+	      "RGWLC::process() next_entry not found. cycle finished lc_shard="
+			       << lc_shard << " worker=" << worker->ix
+			       << dendl;
+          head->set_shard_rollover_date(ceph_clock_now());
+          ret = sal_lc->put_head(lc_shard, *head.get());
+          if (ret < 0) {
+	    ldpp_dout(this, 0) << "RGWLC::process() failed to put head "
+                               << lc_shard
+			       << dendl;
+	  }
+	  goto exit;
+	}
+	continue;
       }
       if (ret < 0) {
 	ldpp_dout(this, 0) << "RGWLC::process() sal_lc->get_entry(lc_shard, head.marker, entry) "

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2203,6 +2203,55 @@ exit:
   return ret;
 } /* advance head */
 
+inline int RGWLC::check_if_shard_done(const std::string& lc_shard,
+				rgw::sal::Lifecycle::LCHead& head, int worker_ix)
+{
+  int ret{0};
+
+  if (head.get_marker().empty()) {
+    /* done with this shard */
+    ldpp_dout(this, 5) <<
+      "RGWLC::process() next_entry not found. cycle finished lc_shard="
+       << lc_shard << " worker=" << worker_ix
+       << dendl;
+      head.set_shard_rollover_date(ceph_clock_now());
+      ret = sal_lc->put_head(lc_shard, head);
+      if (ret < 0) {
+        ldpp_dout(this, 0) << "RGWLC::process() failed to put head "
+                           << lc_shard
+	  	                     << dendl;
+      }
+      ret = 1; // to mark that shard is done
+  }
+  return ret;
+}
+
+inline int RGWLC::update_head(const std::string& lc_shard,
+			       rgw::sal::Lifecycle::LCHead& head,
+			       rgw::sal::Lifecycle::LCEntry& entry,
+			       time_t start_date, int worker_ix)
+{
+  int ret{0};
+
+	ret = advance_head(lc_shard, head, entry, start_date);
+    if (ret != 0) {
+      ldpp_dout(this, 0) << "RGWLC::update_head() failed to advance head "
+		         << lc_shard
+		         << dendl;
+	  goto exit;
+	}
+
+  ret = check_if_shard_done(lc_shard, head, worker_ix);
+  if (ret < 0) {
+      ldpp_dout(this, 0) << "RGWLC::update_head() failed to check if shard is done "
+		         << lc_shard
+		         << dendl;
+  }
+
+exit:
+  return ret;
+}
+
 int RGWLC::process(int index, int max_lock_secs, LCWorker* worker,
 		   bool once = false)
 {
@@ -2285,27 +2334,13 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker,
       ret = sal_lc->get_entry(lc_shard, head->get_marker(), &entry);
       if (ret == -ENOENT) {
         /* skip to next entry */
-	std::unique_ptr<rgw::sal::Lifecycle::LCEntry> tmp_entry = sal_lc->get_entry();
-	tmp_entry->set_bucket(head->get_marker());
-	if (advance_head(lc_shard, *head.get(), *tmp_entry.get(), now) < 0) {
-	  goto exit;
-	}
-	/* done with this shard */
-	if (head->get_marker().empty()) {
-	  ldpp_dout(this, 5) <<
-	      "RGWLC::process() next_entry not found. cycle finished lc_shard="
-			       << lc_shard << " worker=" << worker->ix
-			       << dendl;
-          head->set_shard_rollover_date(ceph_clock_now());
-          ret = sal_lc->put_head(lc_shard, *head.get());
-          if (ret < 0) {
-	    ldpp_dout(this, 0) << "RGWLC::process() failed to put head "
-                               << lc_shard
-			       << dendl;
-	  }
-	  goto exit;
-	}
-	continue;
+	      std::unique_ptr<rgw::sal::Lifecycle::LCEntry> tmp_entry = sal_lc->get_entry();
+      	tmp_entry->set_bucket(head->get_marker());
+
+	      if (update_head(lc_shard, *head.get(), *tmp_entry.get(), now, worker->ix) != 0) {
+	        goto exit;
+	      }
+        continue;
       }
       if (ret < 0) {
 	ldpp_dout(this, 0) << "RGWLC::process() sal_lc->get_entry(lc_shard, head.marker, entry) "
@@ -2326,51 +2361,21 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker,
               << "RGWLC::process(): ACTIVE entry: " << entry
               << " index: " << index << " worker ix: " << worker->ix << dendl;
 	  /* skip to next entry */
-	  if (advance_head(lc_shard, *head.get(), *entry.get(), now) < 0) {
-	    goto exit;
-	  }
-	  /* done with this shard */
-	  if (head->get_marker().empty()) {
-	    ldpp_dout(this, 5) <<
-	      "RGWLC::process() cycle finished lc_shard="
-			       << lc_shard << " worker=" << worker->ix
-			       << dendl;
-	    head->set_shard_rollover_date(ceph_clock_now());
-	    ret = sal_lc->put_head(lc_shard, *head.get());
-	    if (ret < 0) {
-	      ldpp_dout(this, 0) << "RGWLC::process() failed to put head "
-				 << lc_shard
-				 << dendl;
-	    }
-	    goto exit;
+	  if (update_head(lc_shard, *head.get(), *entry.get(), now, worker->ix) != 0) {
+	     goto exit;
 	  }
           continue;
         }
       } else {
 	if ((entry->get_status() == lc_complete) &&
 	    already_run_today(cct, entry->get_start_time())) {
-	  /* skip to next entry */
-	  if (advance_head(lc_shard, *head.get(), *entry.get(), now) < 0) {
-	    goto exit;
-	  }
 	  ldpp_dout(this, 5) << "RGWLC::process() worker ix: " << worker->ix
 			     << " SKIP processing for already-processed bucket " << entry->get_bucket()
 			     << dendl;
-	  /* done with this shard */
-	  if (head->get_marker().empty()) {
-	    ldpp_dout(this, 5) <<
-	      "RGWLC::process() cycle finished lc_shard="
-			       << lc_shard << " worker=" << worker->ix
-			       << dendl;
-	    head->set_shard_rollover_date(ceph_clock_now());
-	    ret = sal_lc->put_head(lc_shard, *head.get());
-	    if (ret < 0) {
-	      ldpp_dout(this, 0) << "RGWLC::process() failed to put head "
-				 << lc_shard
-				 << dendl;
-	    }
-	    goto exit;
-	  }
+	  /* skip to next entry */
+	      if (update_head(lc_shard, *head.get(), *entry.get(), now, worker->ix) != 0) {
+	        goto exit;
+	      }
 	  continue;
 	}
       }
@@ -2452,19 +2457,7 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker,
       }
     }
 
-    /* done with this shard */
-    if (head->get_marker().empty()) {
-      ldpp_dout(this, 5) <<
-	"RGWLC::process() cycle finished lc_shard="
-			 << lc_shard << " worker=" << worker->ix
-			 << dendl;
-      head->set_shard_rollover_date(ceph_clock_now());
-      ret = sal_lc->put_head(lc_shard,  *head.get());
-      if (ret < 0) {
-	ldpp_dout(this, 0) << "RGWLC::process() failed to put head "
-			   << lc_shard
-			   << dendl;
-      }
+    if (check_if_shard_done(lc_shard, *head.get(), worker->ix) != 0 ) {
       goto exit;
     }
   } while(1 && !once && !going_down());

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -631,6 +631,13 @@ public:
 		   rgw::sal::Lifecycle::LCHead& head,
 		   rgw::sal::Lifecycle::LCEntry& entry,
 		   time_t start_date);
+  int check_if_shard_done(const std::string& lc_shard,
+ 			 rgw::sal::Lifecycle::LCHead& head,
+       int worker_ix);
+  int update_head(const std::string& lc_shard,
+			 rgw::sal::Lifecycle::LCHead& head,
+			 rgw::sal::Lifecycle::LCEntry& entry,
+			 time_t start_date, int worker_ix);
   int process(int index, int max_lock_secs, LCWorker* worker, bool once);
   int process_bucket(int index, int max_lock_secs, LCWorker* worker,
 		     const std::string& bucket_entry_marker, bool once);


### PR DESCRIPTION
When skipping the non-exist LC entry, instead of get_next_entry(), use advance_head() to fetch the next entry. In case the cycle is finished for that shard, head should be reset to avoid lc process being stuck in indefinite loop.

This is backport of https://github.com/ceph/ceph/pull/56486

Fixes: https://tracker.ceph.com/issues/65666
Signed-off-by: Soumya Koduri [skoduri@redhat.com](mailto:skoduri@redhat.com)

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
