### PR TITLE
erasure-code/shec: replace 0 with nullptr when appropriate

### DIFF
--- a/src/erasure-code/shec/ErasureCodeShecTableCache.cc
+++ b/src/erasure-code/shec/ErasureCodeShecTableCache.cc
@@ -130,7 +130,7 @@ ErasureCodeShecTableCache::getEncodingTableNoLock(int technique, int k, int m, i
   // create a pointer to store an encoding table address
   if (!encoding_table[technique][k][m][c][w]) {
     encoding_table[technique][k][m][c][w] = new (int*);
-    *encoding_table[technique][k][m][c][w] = 0;
+    *encoding_table[technique][k][m][c][w] = nullptr;
   }
   return encoding_table[technique][k][m][c][w];
 }

--- a/src/erasure-code/shec/ErasureCodeShecTableCache.h
+++ b/src/erasure-code/shec/ErasureCodeShecTableCache.h
@@ -42,10 +42,10 @@ class ErasureCodeShecTableCache {
     int* dm_column;  // size: k
     int* minimum;  // size: k+m
     DecodingCacheParameter() {
-      decoding_matrix = 0;
-      dm_row = 0;
-      dm_column = 0;
-      minimum = 0;
+      decoding_matrix = nullptr;
+      dm_row = nullptr;
+      dm_column = nullptr;
+      minimum = nullptr;
     }
     ~DecodingCacheParameter() {
       if (decoding_matrix) {


### PR DESCRIPTION
0 fails to send the message to human readers that the variable is a pointer, but nullptr does. for improving the readability, let's use nullptr when the variable in question is a pointer.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
