### PR TITLE
squid: qa/cephfs: fix root_squash check failure bug

### DIFF
--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -66,7 +66,7 @@ def gen_mds_cap_str(caps):
 
     caps = ((perm1, fsname1, cephfs_mntpt1), (perm2, fsname2, cephfs_mntpt2))
     """
-    def _gen_mds_cap_str(perm, fsname=None, cephfs_mntpt='/'):
+    def _gen_mds_cap_str(perm, fsname=None, cephfs_mntpt='/', root_squash=False):
         mds_cap = f'allow {perm}'
         if fsname:
             mds_cap += f' fsname={fsname}'
@@ -74,6 +74,8 @@ def gen_mds_cap_str(caps):
             if cephfs_mntpt[0] == '/':
                 cephfs_mntpt = cephfs_mntpt[1:]
             mds_cap += f' path={cephfs_mntpt}'
+        if root_squash:
+            mds_cap += ' root_squash'
         return mds_cap
 
     if len(caps) == 1:

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1688,7 +1688,7 @@ class TestFsAuthorizeUpdate(CephFSTestCase):
         keyring = self.fs.mon_manager.get_keyring(self.client_id)
         moncap = gen_mon_cap_str((('r', self.fs.name,),))
         osdcap = gen_osd_cap_str(((PERM, self.fs.name),))
-        mdscap = gen_mds_cap_str(((PERM, self.fs.name, PATH),))
+        mdscap = gen_mds_cap_str(((PERM, self.fs.name, PATH, True),))
         for cap in (moncap, osdcap, mdscap):
             self.assertIn(cap, keyring)
         self._remount(self.mount_a, self.fs.name, keyring, PATH)

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1691,8 +1691,6 @@ class TestFsAuthorizeUpdate(CephFSTestCase):
         mdscap = gen_mds_cap_str(((PERM, self.fs.name, PATH, True),))
         for cap in (moncap, osdcap, mdscap):
             self.assertIn(cap, keyring)
-        self._remount(self.mount_a, self.fs.name, keyring, PATH)
-        self.captester.run_cap_tests(self.fs, self.client_id, PERM, PATH)
 
     def _get_uid(self):
         return self.mount_a.client_remote.run(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65361

---

backport of https://github.com/ceph/ceph/pull/54778
parent tracker: https://tracker.ceph.com/issues/63141


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
