### PR TITLE
mds/cache: defer trim() until no MDS is rejoining

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -14082,13 +14082,6 @@ void MDCache::handle_mdsmap(const MDSMap &mdsmap, const MDSMap &oldmap) {
   }
 }
 
-bool MDCache::is_ready_to_trim_cache(void)
-{
-  // null rejoin_done means rejoin has finished and all the rejoin acks
-  // have been well received.
-  return is_open() && !rejoin_done;
-}
-
 void MDCache::upkeep_main(void)
 {
   std::unique_lock lock(upkeep_mutex);
@@ -14109,7 +14102,7 @@ void MDCache::upkeep_main(void)
         if (active_with_clients) {
           trim_client_leases();
         }
-        if (is_ready_to_trim_cache() || mds->is_standby_replay()) {
+        if (is_open() || mds->is_standby_replay()) {
           trim();
         }
         if (active_with_clients) {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6923,7 +6923,7 @@ std::pair<bool, uint64_t> MDCache::trim(uint64_t count)
 
       // don't trim subtree root if its auth MDS is recovering.
       // This simplify the cache rejoin code.
-      if (dir->is_subtree_root() && rejoin_ack_gather.count(dir->get_dir_auth().first))
+      if (dir->is_rejoining())
         continue;
       trim_dirfrag(dir, 0, expiremap);
       ++trimmed;

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1479,8 +1479,6 @@ private:
 
   void upkeep_main(void);
 
-  bool is_ready_to_trim_cache(void);
-
   uint64_t cache_memory_limit;
   double cache_reservation;
   double cache_health_threshold;


### PR DESCRIPTION

Just before the last cache_rejoin ack being received the entire subtree, together with the inode subtree root belongs to, were trimmed the isolated_inodes list couldn't be correctly erased. We should defer calling the trim() until the last cache_rejoin ack being received.

The "rejoin_done" will be set when the local MDS is rejoining, but "rejoin_ack_gather" will be always set when the other MDSs are rejoining.

Fixes: https://tracker.ceph.com/issues/50821

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
