### PR TITLE
quincy: rgw/multisite: avoid writing multipart parts to the bucket index log

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4201,11 +4201,15 @@ void RGWPutObj::execute(optional_yield y)
     emplace_attr(RGW_ATTR_OBJECT_RETENTION, std::move(obj_retention_bl));
   }
 
+  // don't track the individual parts of multipart uploads. they replicate in
+  // full after CompleteMultipart
+  const uint32_t complete_flags = multipart ? 0 : rgw::sal::FLAG_LOG_OP;
+
   tracepoint(rgw_op, processor_complete_enter, s->req_id.c_str());
   op_ret = processor->complete(s->obj_size, etag, &mtime, real_time(), attrs,
                                (delete_at ? *delete_at : real_time()), if_match, if_nomatch,
                                (user_data.empty() ? nullptr : &user_data), nullptr, nullptr,
-                               s->yield);
+                               s->yield, complete_flags);
   tracepoint(rgw_op, processor_complete_exit, s->req_id.c_str());
 
   /* produce torrent */

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -2230,7 +2230,7 @@ int RadosMultipartUpload::init(const DoutPrefixProvider *dpp, optional_yield y, 
     encode(upload_info, bl);
     obj_op.meta.data = &bl;
 
-    ret = obj_op.write_meta(dpp, bl.length(), 0, attrs, y);
+    ret = obj_op.write_meta(dpp, bl.length(), 0, attrs, y, false);
   } while (ret == -EEXIST);
 
   return ret;
@@ -2815,7 +2815,7 @@ int RadosMultipartWriter::complete(size_t accounted_size, const std::string& eta
                        optional_yield y)
 {
   return processor.complete(accounted_size, etag, mtime, set_mtime, attrs, delete_at,
-			    if_match, if_nomatch, user_data, zones_trace, canceled, y);
+			    if_match, if_nomatch, user_data, zones_trace, canceled, y, flags);
 }
 
 const RGWZoneGroup& RadosZone::get_zonegroup()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64324

---

backport of https://github.com/ceph/ceph/pull/55252
parent tracker: https://tracker.ceph.com/issues/21800

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh