### PR TITLE
crimson/os/seastore: misc cleanups and fixes

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -1162,7 +1162,7 @@ SegmentCleaner::clean_space_ret SegmentCleaner::clean_space()
   if (!reclaim_state) {
     segment_id_t seg_id = get_next_reclaim_segment();
     auto &segment_info = segments[seg_id];
-    INFO("reclaim {} {} start, usage={}, time_bound={}",
+    INFO("reclaim start... {} {}, usage={}, time_bound={}",
          seg_id, segment_info,
          space_tracker->calc_utilization(seg_id),
          sea_time_point_printer_t{segments.get_time_bound()});
@@ -1239,7 +1239,7 @@ SegmentCleaner::clean_space_ret SegmentCleaner::clean_space()
               d, pavail_ratio, runs);
         if (reclaim_state->is_complete()) {
           auto segment_to_release = reclaim_state->get_segment_id();
-          INFO("reclaim {} finish, reclaimed alive/total={}",
+          INFO("reclaim finish {}, reclaimed alive/total={}",
                segment_to_release,
                stats.reclaiming_bytes/(double)segments.get_segment_size());
           stats.reclaimed_bytes += stats.reclaiming_bytes;
@@ -1263,7 +1263,7 @@ SegmentCleaner::clean_space_ret SegmentCleaner::clean_space()
             segments.mark_empty(segment_to_release);
             auto new_usage = calc_utilization(segment_to_release);
             adjust_segment_util(old_usage, new_usage);
-            INFO("released {}, {}",
+            INFO("reclaim released {}, {}",
                  segment_to_release, stat_printer_t{*this, false});
             background_callback->maybe_wake_blocked_io();
           });

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1083,7 +1083,8 @@ record_t Cache::prepare_record(
   const journal_seq_t &journal_dirty_tail)
 {
   LOG_PREFIX(Cache::prepare_record);
-  SUBTRACET(seastore_t, "enter", t);
+  SUBTRACET(seastore_t, "enter, journal_head={}, dirty_tail={}",
+            t, journal_head, journal_dirty_tail);
 
   auto trans_src = t.get_src();
   assert(!t.is_weak());

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -218,7 +218,7 @@ public:
       ++next_id
     );
     SUBDEBUGT(seastore_t, "created name={}, source={}, is_weak={}",
-             *ret, name, src, is_weak);
+              *ret, name, src, is_weak);
     assert(!is_weak || src == Transaction::src_t::READ);
     return ret;
   }
@@ -227,7 +227,7 @@ public:
   void reset_transaction_preserve_handle(Transaction &t) {
     LOG_PREFIX(Cache::reset_transaction_preserve_handle);
     if (t.did_reset()) {
-      SUBTRACET(seastore_t, "reset", t);
+      SUBDEBUGT(seastore_t, "reset", t);
       ++(get_by_src(stats.trans_created_by_src, t.get_src()));
     }
     t.reset_preserve_handle(last_commit);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1251,8 +1251,10 @@ seastar::future<> SeaStore::Shard::do_transaction_no_callbacks(
     op_type_t::TRANSACTION,
     [this](auto &ctx) {
       return with_trans_intr(*ctx.transaction, [&, this](auto &t) {
+        LOG_PREFIX(SeaStore::Shard::do_transaction_no_callbacks);
+        SUBDEBUGT(seastore_t, "start with {} objects",
+                  t, ctx.iter.objects.size());
 #ifndef NDEBUG
-	LOG_PREFIX(SeaStore::Shard::do_transaction_no_callbacks);
 	TRACET(" transaction dump:\n", t);
 	JSONFormatter f(true);
 	f.open_object_section("transaction");
@@ -1311,7 +1313,9 @@ SeaStore::Shard::_do_transaction_step(
   std::vector<OnodeRef> &d_onodes,
   ceph::os::Transaction::iterator &i)
 {
+  LOG_PREFIX(SeaStore::Shard::_do_transaction_step);
   auto op = i.decode_op();
+  SUBTRACET(seastore_t, "got op {}", *ctx.transaction, op->op);
 
   using ceph::os::Transaction;
   if (op->op == Transaction::OP_NOP)

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -255,7 +255,6 @@ public:
 	    ctx.reset_preserve_handle(*transaction_manager);
 	    return std::invoke(f, ctx);
 	  }).handle_error(
-	    crimson::ct_error::eagain::pass_further{},
 	    crimson::ct_error::all_same_way([&ctx](auto e) {
 	      on_error(ctx.ext_transaction);
 	    })

--- a/src/test/crimson/gtest_seastar.h
+++ b/src/test/crimson/gtest_seastar.h
@@ -13,12 +13,12 @@ struct seastar_test_suite_t : public ::testing::Test {
 
   template <typename Func>
   void run(Func &&func) {
-    return seastar_env.run(std::forward<Func>(func));
+    seastar_env.run(std::forward<Func>(func));
   }
 
   template <typename Func>
   void run_ertr(Func &&func) {
-    return run(
+    run(
       [func=std::forward<Func>(func)]() mutable {
 	return std::invoke(std::move(func)).handle_error(
 	  crimson::ct_error::assert_all("error"));
@@ -40,23 +40,23 @@ struct seastar_test_suite_t : public ::testing::Test {
     };
   }
 
-  auto run_scl(auto &&f) {
-    return run([this, f=std::forward<decltype(f)>(f)]() mutable {
+  void run_scl(auto &&f) {
+    run([this, f=std::forward<decltype(f)>(f)]() mutable {
       return std::invoke(scl(std::move(f)));
     });
   }
 
-  auto run_ertr_scl(auto &&f) {
-    return run_ertr(scl(std::forward<decltype(f)>(f)));
+  void run_ertr_scl(auto &&f) {
+    run_ertr(scl(std::forward<decltype(f)>(f)));
   }
 
   virtual seastar::future<> set_up_fut() { return seastar::now(); }
   void SetUp() final {
-    return run([this] { return set_up_fut(); });
+    run([this] { return set_up_fut(); });
   }
 
   virtual seastar::future<> tear_down_fut() { return seastar::now(); }
   void TearDown() final {
-    return run([this] { return tear_down_fut(); });
+    run([this] { return tear_down_fut(); });
   }
 };

--- a/src/test/crimson/gtest_seastar.h
+++ b/src/test/crimson/gtest_seastar.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "crimson/common/errorator.h"
+#include "crimson/common/log.h"
 #include "gtest/gtest.h"
 
 #include "seastar_runner.h"
@@ -12,25 +13,38 @@ struct seastar_test_suite_t : public ::testing::Test {
   static SeastarRunner seastar_env;
 
   template <typename Func>
+  void do_run(Func &&func, const char *name) {
+    seastar_env.run([func=std::forward<Func>(func), name]() mutable {
+      crimson::get_logger(ceph_subsys_test).info(
+        "{} started...", name);
+      return std::invoke(std::move(func)
+      ).finally([name] {
+        crimson::get_logger(ceph_subsys_test).info(
+          "{} finished", name);
+      });
+    });
+  }
+
+  template <typename Func>
   void run(Func &&func) {
-    seastar_env.run(std::forward<Func>(func));
+    do_run(std::forward<Func>(func), "run");
   }
 
   template <typename Func>
   void run_ertr(Func &&func) {
-    run(
+    do_run(
       [func=std::forward<Func>(func)]() mutable {
 	return std::invoke(std::move(func)).handle_error(
 	  crimson::ct_error::assert_all("error"));
-      });
+      }, "run_ertr");
   }
 
   template <typename Func>
   void run_async(Func &&func) {
-    run(
+    do_run(
       [func=std::forward<Func>(func)]() mutable {
 	return seastar::async(std::forward<Func>(func));
-      });
+      }, "run_async");
   }
 
   template <typename F>
@@ -41,9 +55,9 @@ struct seastar_test_suite_t : public ::testing::Test {
   }
 
   void run_scl(auto &&f) {
-    run([this, f=std::forward<decltype(f)>(f)]() mutable {
+    do_run([this, f=std::forward<decltype(f)>(f)]() mutable {
       return std::invoke(scl(std::move(f)));
-    });
+    }, "run_scl");
   }
 
   void run_ertr_scl(auto &&f) {
@@ -52,11 +66,11 @@ struct seastar_test_suite_t : public ::testing::Test {
 
   virtual seastar::future<> set_up_fut() { return seastar::now(); }
   void SetUp() final {
-    run([this] { return set_up_fut(); });
+    do_run([this] { return set_up_fut(); }, "setup");
   }
 
   virtual seastar::future<> tear_down_fut() { return seastar::now(); }
   void TearDown() final {
-    run([this] { return tear_down_fut(); });
+    do_run([this] { return tear_down_fut(); }, "teardown");
   }
 };


### PR DESCRIPTION
This is the misc cleanups and fixes during debugging.

Still trying to fix https://tracker.ceph.com/issues/65585.

~~Seem to me the blocking issue of test-seastore reveals a deadlock from background cleaning -- the IO transaction didn't proceed after a conflict. But I'm not able to root cause it yet, because adding more logs seem to make it unreproducible.~~

Update: cannot reproduce after https://github.com/ceph/ceph/pull/57129.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
