### PR TITLE
quincy: rgw: fix ListOpenIDConnectProviders XML format

### DIFF
--- a/src/rgw/rgw_rest_oidc_provider.cc
+++ b/src/rgw/rgw_rest_oidc_provider.cc
@@ -219,7 +219,7 @@ void RGWListOIDCProviders::execute(optional_yield y)
     s->formatter->open_object_section("ListOpenIDConnectProvidersResult");
     s->formatter->open_array_section("OpenIDConnectProviderList");
     for (const auto& it : result) {
-      s->formatter->open_object_section("Arn");
+      s->formatter->open_object_section("member");
       auto& arn = it->get_arn();
       ldpp_dout(s, 0) << "ARN: " << arn << dendl;
       s->formatter->dump_string("Arn", arn);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58327

---

backport of https://github.com/ceph/ceph/pull/49426
parent tracker: https://tracker.ceph.com/issues/53171

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh