### PR TITLE
quincy: Do not duplicate query-string in ops-log

### DIFF
--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -601,13 +601,9 @@ int rgw_log_op(RGWREST* const rest, struct req_state *s, const RGWOp* op, OpsLog
     uri.append(s->info.env->get("REQUEST_URI"));
   }
 
-  if (s->info.env->exists("QUERY_STRING")) {
-    const char* qs = s->info.env->get("QUERY_STRING");
-    if(qs && (*qs != '\0')) {
-      uri.append("?");
-      uri.append(qs);
-    }
-  }
+  /* Formerly, we appended QUERY_STRING to uri, but in RGW, QUERY_STRING is a
+   * substring of REQUEST_URI--appending qs to uri here duplicates qs to the
+   * ops log */
 
   if (s->info.env->exists("HTTP_VERSION")) {
     uri.append(" ");


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/59144

---

backport of https://github.com/ceph/ceph/pull/50486
parent tracker: https://tracker.ceph.com/issues/59059

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh