### PR TITLE
qa/cephadm: ignore stray daemon warning during rados_api_tests

### DIFF
--- a/qa/suites/orch/cephadm/thrash/1-start.yaml
+++ b/qa/suites/orch/cephadm/thrash/1-start.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-ignorelist:
+    - \(CEPHADM_STRAY_DAEMON\)
     log-only-match:
       - CEPHADM_
 tasks:

--- a/qa/suites/rados/basic/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/basic/tasks/rados_api_tests.yaml
@@ -11,6 +11,7 @@ overrides:
     - \(POOL_APP_NOT_ENABLED\)
     - \(PG_AVAILABILITY\)
     - \(PG_DEGRADED\)
+    - \(CEPHADM_STRAY_DAEMON\)
     conf:
       client:
         debug ms: 1


### PR DESCRIPTION
The "stray daemon" that is getting logged about in this test is from "stray daemon laundry.pid70383 on host smithi027 not managed by cephadm". It seems the rados_api_tests is creating some additional "laundry" entity during these tests that gets reported as an actual daemon in the mgr, but cephadm is unaware of it, resulting in the warning. Originally we thought to maybe add "laundry" itself to the ignorelist, but without an additional patch that added extra logging for debug purposes (which can't be merged) the log statement found in the logs due to this problem will not say what daemon it found to be stray. There will just be a generic warning about a stray daemon. In a real cluster, a user would then check "ceph health detail" to find out what daemon is stray, but the log scraper can't do this and just fails the test due to the presence of the warning.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
