### PR TITLE
ceph.spec.in: ceph-mgr-dashboard does not require werkzeug

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -680,7 +680,6 @@ Requires:       python%{python3_pkgversion}-grpcio-tools
 %if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
 Requires:       python%{python3_pkgversion}-cherrypy
 Requires:       python%{python3_pkgversion}-routes
-Requires:       python%{python3_pkgversion}-werkzeug
 %if 0%{?weak_deps}
 Recommends:     python%{python3_pkgversion}-saml
 %if 0%{?fedora} || 0%{?rhel} <= 8


### PR DESCRIPTION
Nothing in the dashboard codebase imports `werkzeug`. It appears this was leftover from the time when the dashboard was packaged with the rest of the mgr modules.

Fixes: https://tracker.ceph.com/issues/65693