### PR TITLE
reef: qa: add support/qa for cephfs-shell on CentOS 9 / RHEL9

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -14,6 +14,8 @@
 
 >=19.0.0
 
+* The cephfs-shell utility is now packaged for RHEL 9 / CentOS 9 as required
+  python dependencies are now available in EPEL9.
 * RGW: S3 multipart uploads using Server-Side Encryption now replicate correctly in
   multi-site. Previously, the replicas of such objects were corrupted on decryption.
   A new tool, ``radosgw-admin bucket resync encrypted multipart``, can be used to

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -98,7 +98,7 @@
 %else
 %bcond_without jaeger
 %endif
-%if 0%{?fedora} || 0%{?suse_version} >= 1500
+%if 0%{?fedora} || 0%{?suse_version} >= 1500 || 0%{?rhel} >= 9
 # distros that ship cmd2 and/or colorama
 %bcond_without cephfs_shell
 %else

--- a/qa/cephfs/begin/0-install.yaml
+++ b/qa/cephfs/begin/0-install.yaml
@@ -3,7 +3,6 @@ tasks:
       extra_packages:
         rpm:
         - python3-cephfs
-        - cephfs-shell
         - cephfs-top
         - cephfs-mirror
         deb:

--- a/qa/cephfs/begin/0-install.yaml
+++ b/qa/cephfs/begin/0-install.yaml
@@ -3,6 +3,7 @@ tasks:
       extra_packages:
         rpm:
         - python3-cephfs
+        - cephfs-shell
         - cephfs-top
         - cephfs-mirror
         deb:

--- a/qa/suites/fs/shell/distro
+++ b/qa/suites/fs/shell/distro
@@ -1,1 +1,1 @@
-.qa/distros/supported-random-distro$
+.qa/distros/supported

--- a/qa/suites/fs/shell/tasks/cephfs-shell.yaml
+++ b/qa/suites/fs/shell/tasks/cephfs-shell.yaml
@@ -1,7 +1,3 @@
-# Right now, cephfs-shell is only available as a package on Ubuntu
-# This overrides the random distribution that's chosen in the other yaml fragments.
-os_type: ubuntu
-os_version: "20.04"
 tasks:
   - cephfs_test_runner:
       modules:

--- a/qa/suites/fs/shell/tasks/cephfs-shell.yaml
+++ b/qa/suites/fs/shell/tasks/cephfs-shell.yaml
@@ -1,3 +1,6 @@
+teuthology:
+  postmerge:
+    - if not (yaml.os_type == "ubuntu" or yaml.os_type == "centos"  and yaml.os_version == "9.stream") then reject() end
 tasks:
   - cephfs_test_runner:
       modules:

--- a/qa/suites/fs/shell/tasks/cephfs-shell.yaml
+++ b/qa/suites/fs/shell/tasks/cephfs-shell.yaml
@@ -2,6 +2,10 @@ teuthology:
   postmerge:
     - if not (yaml.os_type == "ubuntu" or yaml.os_type == "centos"  and yaml.os_version == "9.stream") then reject() end
 tasks:
+  - install:
+      extra_packages:
+        rpm:
+          - cephfs-shell
   - cephfs_test_runner:
       modules:
         - tasks.cephfs.test_cephfs_shell


### PR DESCRIPTION
Supersedes https://github.com/ceph/ceph/pull/54865

Fixes: https://tracker.ceph.com/issues/63782
Original-issue: https://tracker.ceph.com/issues/43393
Original-PR: https://github.com/ceph/ceph/pull/54726