### PR TITLE
squid: qa: increase debugging for snap_schedule

### DIFF
--- a/qa/suites/fs/workload/tasks/3-snaps/yes.yaml
+++ b/qa/suites/fs/workload/tasks/3-snaps/yes.yaml
@@ -3,8 +3,6 @@ mgrmodules:
     - exec:
         mon.a:
           - ceph mgr module enable snap_schedule
-          - ceph config set mgr mgr/snap_schedule/allow_m_granularity true
-          - ceph config set mgr mgr/snap_schedule/dump_on_update true
 overrides:
   ceph:
     conf:
@@ -19,6 +17,9 @@ overrides:
 tasks:
 - exec:
     mon.a:
+      - ceph config set mgr mgr/snap_schedule/log_level debug
+      - ceph config set mgr mgr/snap_schedule/allow_m_granularity true
+      - ceph config set mgr mgr/snap_schedule/dump_on_update true
       - ceph fs snap-schedule add --fs=cephfs --path=/ --snap_schedule=1m
       - ceph fs snap-schedule retention add --fs=cephfs --path=/ --retention-spec-or-period=6m3h
       - ceph fs snap-schedule status --fs=cephfs --path=/


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65706

---

backport of https://github.com/ceph/ceph/pull/57044
parent tracker: https://tracker.ceph.com/issues/65617

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh