### PR TITLE
reef: client: clear resend_mds only after sending request

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1692,7 +1692,6 @@ mds_rank_t Client::choose_target_mds(MetaRequest *req, Inode** phash_diri)
 
   if (req->resend_mds >= 0) {
     mds = req->resend_mds;
-    req->resend_mds = -1;
     ldout(cct, 10) << __func__ << " resend_mds specified as mds." << mds << dendl;
     goto out;
   }
@@ -2048,6 +2047,7 @@ int Client::make_request(MetaRequest *request,
 
     // wait for signal
     ldout(cct, 20) << "awaiting reply|forward|kick on " << &caller_cond << dendl;
+    request->resend_mds = -1; /* reset for retries */
     request->kick = false;
     std::unique_lock l{client_lock, std::adopt_lock};
     caller_cond.wait(l, [request] {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65709

---

backport of https://github.com/ceph/ceph/pull/57043
parent tracker: https://tracker.ceph.com/issues/65614

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh