### PR TITLE
squid: mds: regular file inode flags are not replicated by the policylock

### DIFF
--- a/qa/tasks/cephfs/test_quiesce.py
+++ b/qa/tasks/cephfs/test_quiesce.py
@@ -702,6 +702,34 @@ class TestQuiesceMultiRank(QuiesceTestCase):
                 if not find_quiesce(False):
                     break
 
+    def test_quiesce_block_file_replicated(self):
+        """
+        That a file inode with quiesce.block is replicated.
+        """
+
+        self._configure_subvolume()
+
+        self.mount_a.run_shell_payload("mkdir -p dir1/dir2/dir3/dir4")
+
+        self.fs.set_max_mds(2)
+        status = self.fs.wait_for_daemons()
+
+        self.mount_a.setfattr("dir1", "ceph.dir.pin", "1")
+        self.mount_a.setfattr("dir1/dir2/dir3", "ceph.dir.pin", "0") # force dir2 to be replicated
+        status = self._wait_subtrees([(self.mntpnt+"/dir1", 1), (self.mntpnt+"/dir1/dir2/dir3", 0)], status=status, rank=1)
+
+        self.mount_a.setfattr("dir1/dir2", "ceph.quiesce.block", "1")
+
+        ino1 = self.fs.read_cache(self.mntpnt+"/dir1/dir2", depth=0, rank=1)[0]
+        self.assertTrue(ino1['quiesce_block'])
+        self.assertTrue(ino1['is_auth'])
+        replicas = ino1['auth_state']['replicas']
+        self.assertIn("0", replicas)
+
+        ino0 = self.fs.read_cache(self.mntpnt+"/dir1/dir2", depth=0, rank=0)[0]
+        self.assertFalse(ino0['is_auth'])
+        self.assertTrue(ino0['quiesce_block'])
+
     def test_quiesce_path_multirank(self):
         """
         That quiesce may complete with two ranks and a basic workload.

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2143,7 +2143,7 @@ void CInode::decode_lock_iflock(bufferlist::const_iterator& p)
 
 void CInode::encode_lock_ipolicy(bufferlist& bl)
 {
-  ENCODE_START(2, 1, bl);
+  ENCODE_START(3, 1, bl);
   if (is_dir()) {
     encode(get_inode()->version, bl);
     encode(get_inode()->ctime, bl);
@@ -2152,6 +2152,8 @@ void CInode::encode_lock_ipolicy(bufferlist& bl)
     encode(get_inode()->export_pin, bl);
     encode(get_inode()->flags, bl);
     encode(get_inode()->export_ephemeral_random_pin, bl);
+  } else {
+    encode(get_inode()->flags, bl);
   }
   ENCODE_FINISH(bl);
 }
@@ -2160,7 +2162,7 @@ void CInode::decode_lock_ipolicy(bufferlist::const_iterator& p)
 {
   ceph_assert(!is_auth());
   auto _inode = allocate_inode(*get_inode());
-  DECODE_START(1, p);
+  DECODE_START(3, p);
   if (is_dir()) {
     decode(_inode->version, p);
     utime_t tm;
@@ -2173,6 +2175,10 @@ void CInode::decode_lock_ipolicy(bufferlist::const_iterator& p)
     if (struct_v >= 2) {
       decode(_inode->flags, p);
       decode(_inode->export_ephemeral_random_pin, p);
+    }
+  } else {
+    if (struct_v >= 3) {
+      decode(_inode->flags, p);
     }
   }
   DECODE_FINISH(p);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65711

---

backport of https://github.com/ceph/ceph/pull/56935
parent tracker: https://tracker.ceph.com/issues/65518

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh