### PR TITLE
mgr/smb: cluster linked  join auth and users/groups resource types

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -364,14 +364,7 @@ placement
 A join source object supports the following fields:
 
 source_type
-    One of ``password`` or ``resource``
-auth
-    Object. Required for ``source_type: password``. Fields:
-
-    username:
-        Required string. User with ability to join a system to AD.
-    password:
-        Required string. The AD user's password
+    Optional. Must be ``resource`` if specified.
 ref
     String. Required for ``source_type: resource``. Must refer to the ID of a
     ``ceph.smb.join.auth`` resource
@@ -381,25 +374,14 @@ ref
 A user group source object supports the following fields:
 
 source_type
-    One of ``inline`` or ``resource``
-values
-    Object. Required for ``source_type: inline``. Fields:
-
-    users
-        List of objects. Fields:
-
-        username
-            A user name
-        password
-            A password
-    groups
-        List of objects. Fields:
-
-        name
-            The name of the group
+    Optional. One of ``resource`` (the default) or ``empty``
 ref
     String. Required for ``source_type: resource``. Must refer to the ID of a
     ``ceph.smb.join.auth`` resource
+
+.. note::
+   The ``source_type`` ``empty`` is generally only for debugging and testing
+   the module and should not be needed in production deployments.
 
 The following is an example of a cluster configured for AD membership:
 
@@ -427,14 +409,8 @@ The following is an example of a cluster configured for standalone operation:
     cluster_id: rhumba
     auth_mode: user
     user_group_settings:
-      - source_type: inline
-        values:
-          users:
-            - name: chuckx
-              password: 3xample101
-            - name: steves
-              password: F00Bar123
-          groups: []
+      - source_type: resource
+        ref: ug1
     placement:
       hosts:
         - node6.mycluster.sink.test
@@ -534,6 +510,10 @@ auth
         Required string. User with ability to join a system to AD
     password
         Required string. The AD user's password
+linked_to_cluster:
+    Optional. A string containing a cluster id. If set, the resource may only
+    be used with the linked cluster and will automatically be removed when the
+    linked cluster is removed.
 
 Example:
 
@@ -564,7 +544,7 @@ values
     users
         List of objects. Fields:
 
-        username
+        name
             A user name
         password
             A password
@@ -573,6 +553,10 @@ values
 
         name
             The name of the group
+linked_to_cluster:
+    Optional. A string containing a cluster id. If set, the resource may only
+    be used with the linked cluster and will automatically be removed when the
+    linked cluster is removed.
 
 
 Example:

--- a/src/pybind/mgr/smb/enums.py
+++ b/src/pybind/mgr/smb/enums.py
@@ -41,15 +41,12 @@ class AuthMode(_StrEnum):
 
 
 class JoinSourceType(_StrEnum):
-    PASSWORD = 'password'
-    HTTP_URI = 'http_uri'
     RESOURCE = 'resource'
 
 
 class UserGroupSourceType(_StrEnum):
-    INLINE = 'inline'
-    HTTP_URI = 'http_uri'
     RESOURCE = 'resource'
+    EMPTY = 'empty'
 
 
 class ConfigNS(_StrEnum):

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -247,7 +247,7 @@ class ClusterConfigHandler:
     def apply(self, inputs: Iterable[SMBResource]) -> ResultGroup:
         log.debug('applying changes to internal data store')
         results = ResultGroup()
-        for resource in self._order_inputs(inputs):
+        for resource in order_resources(inputs):
             try:
                 result = self._update_resource(resource)
             except ErrorResult as err:
@@ -323,26 +323,6 @@ class ClusterConfigHandler:
                     )
         log.debug("search found %d resources", len(out))
         return out
-
-    def _order_inputs(
-        self, inputs: Iterable[SMBResource]
-    ) -> List[SMBResource]:
-        """Sort resource objects by type so that the user can largely input
-        objects freely but that references map out cleanly.
-        """
-
-        def _keyfunc(r: SMBResource) -> int:
-            if isinstance(r, resources.RemovedShare):
-                return -2
-            if isinstance(r, resources.RemovedCluster):
-                return -1
-            if isinstance(r, resources.Share):
-                return 2
-            if isinstance(r, resources.Cluster):
-                return 1
-            return 0
-
-        return sorted(inputs, key=_keyfunc)
 
     def _update_resource(self, resource: SMBResource) -> Result:
         """Update the internal store with a new resource object."""
@@ -714,6 +694,27 @@ class ClusterConfigHandler:
             join_source_entries=join_source_entries,
             user_source_entries=user_source_entries,
         )
+
+
+def order_resources(
+    resource_objs: Iterable[SMBResource],
+) -> List[SMBResource]:
+    """Sort resource objects by type so that the user can largely input
+    objects freely but that references map out cleanly.
+    """
+
+    def _keyfunc(r: SMBResource) -> int:
+        if isinstance(r, resources.RemovedShare):
+            return -2
+        if isinstance(r, resources.RemovedCluster):
+            return -1
+        if isinstance(r, resources.Share):
+            return 2
+        if isinstance(r, resources.Cluster):
+            return 1
+        return 0
+
+    return sorted(resource_objs, key=_keyfunc)
 
 
 def _auth_refs(cluster: resources.Cluster) -> Collection[str]:

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -1173,3 +1173,11 @@ def _cephx_data_entity(cluster_id: str) -> str:
     use for data access.
     """
     return f'client.smb.fs.cluster.{cluster_id}'
+
+
+def rand_name(prefix: str, max_len: int = 18, suffix_len: int = 8) -> str:
+    trunc = prefix[: (max_len - suffix_len)]
+    suffix = ''.join(
+        random.choice(string.ascii_lowercase) for _ in range(suffix_len)
+    )
+    return f'{trunc}{suffix}'

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -1099,8 +1099,6 @@ def _save_pending_join_auths(
     for idx, src in enumerate(checked(cluster.domain_settings).join_sources):
         if src.source_type == JoinSourceType.RESOURCE:
             javalues = checked(arefs[src.ref].auth)
-        elif src.source_type == JoinSourceType.PASSWORD:
-            javalues = checked(src.auth)
         else:
             raise ValueError(
                 f'unsupported join source type: {src.source_type}'
@@ -1124,9 +1122,8 @@ def _save_pending_users_and_groups(
         if ugsv.source_type == UserGroupSourceType.RESOURCE:
             ugvalues = augs[ugsv.ref].values
             assert ugvalues
-        elif ugsv.source_type == UserGroupSourceType.INLINE:
-            ugvalues = ugsv.values
-            assert ugvalues
+        elif ugsv.source_type == UserGroupSourceType.EMPTY:
+            continue
         else:
             raise ValueError(
                 f'unsupported users/groups source type: {ugsv.source_type}'

--- a/src/pybind/mgr/smb/proto.py
+++ b/src/pybind/mgr/smb/proto.py
@@ -18,7 +18,7 @@ from ceph.deployment.service_spec import SMBSpec
 
 # this uses a version check as opposed to a try/except because this
 # form makes mypy happy and try/except doesn't.
-if sys.version_info >= (3, 8):
+if sys.version_info >= (3, 8):  # pragma: no cover
     from typing import Protocol
 elif TYPE_CHECKING:  # pragma: no cover
     # typing_extensions will not be available for the real mgr server
@@ -29,7 +29,7 @@ else:  # pragma: no cover
         pass
 
 
-if sys.version_info >= (3, 11):
+if sys.version_info >= (3, 11):  # pragma: no cover
     from typing import Self
 elif TYPE_CHECKING:  # pragma: no cover
     # typing_extensions will not be available for the real mgr server

--- a/src/pybind/mgr/smb/proto.py
+++ b/src/pybind/mgr/smb/proto.py
@@ -78,13 +78,8 @@ class ConfigEntry(Protocol):
         ...  # pragma: no cover
 
 
-class ConfigStore(Protocol):
-    """A protocol for describing a configuration data store capable of
-    retaining and tracking configuration entry objects.
-    """
-
-    def __getitem__(self, key: EntryKey) -> ConfigEntry:
-        ...  # pragma: no cover
+class ConfigStoreListing(Protocol):
+    """A protocol for describing the content-listing methods of a config store."""
 
     def namespaces(self) -> Collection[str]:
         ...  # pragma: no cover
@@ -93,6 +88,15 @@ class ConfigStore(Protocol):
         ...  # pragma: no cover
 
     def __iter__(self) -> Iterator[EntryKey]:
+        ...  # pragma: no cover
+
+
+class ConfigStore(ConfigStoreListing, Protocol):
+    """A protocol for describing a configuration data store capable of
+    retaining and tracking configuration entry objects.
+    """
+
+    def __getitem__(self, key: EntryKey) -> ConfigEntry:
         ...  # pragma: no cover
 
     def remove(self, ns: EntryKey) -> bool:

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -338,11 +338,21 @@ class JoinAuth(_RBase):
     auth_id: str
     intent: Intent = Intent.PRESENT
     auth: Optional[JoinAuthValues] = None
+    # linked resources can only be used by the resource they are linked to
+    # and are automatically removed when the "parent" resource is removed
+    linked_to_cluster: Optional[str] = None
 
     def validate(self) -> None:
         if not self.auth_id:
             raise ValueError('auth_id requires a value')
         validation.check_id(self.auth_id)
+        if self.linked_to_cluster is not None:
+            validation.check_id(self.linked_to_cluster)
+
+    @resourcelib.customize
+    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+        rc.linked_to_cluster.quiet = True
+        return rc
 
 
 @resourcelib.resource('ceph.smb.usersgroups')
@@ -352,11 +362,21 @@ class UsersAndGroups(_RBase):
     users_groups_id: str
     intent: Intent = Intent.PRESENT
     values: Optional[UserGroupSettings] = None
+    # linked resources can only be used by the resource they are linked to
+    # and are automatically removed when the "parent" resource is removed
+    linked_to_cluster: Optional[str] = None
 
     def validate(self) -> None:
         if not self.users_groups_id:
             raise ValueError('users_groups_id requires a value')
         validation.check_id(self.users_groups_id)
+        if self.linked_to_cluster is not None:
+            validation.check_id(self.linked_to_cluster)
+
+    @resourcelib.customize
+    def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
+        rc.linked_to_cluster.quiet = True
+        return rc
 
 
 # SMBResource is a union of all valid top-level smb resource types.

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -162,18 +162,17 @@ class JoinAuthValues(_RBase):
 class JoinSource(_RBase):
     """Represents data that can be used to join a system to Active Directory."""
 
-    source_type: JoinSourceType
-    auth: Optional[JoinAuthValues] = None
-    uri: str = ''
+    source_type: JoinSourceType = JoinSourceType.RESOURCE
     ref: str = ''
 
     def validate(self) -> None:
-        if self.ref:
+        if not self.ref:
+            raise ValueError('reference value must be specified')
+        else:
             validation.check_id(self.ref)
 
     @resourcelib.customize
     def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
-        rc.uri.quiet = True
         rc.ref.quiet = True
         return rc
 
@@ -190,40 +189,21 @@ class UserGroupSettings(_RBase):
 class UserGroupSource(_RBase):
     """Represents data used to set up user/group settings for an instance."""
 
-    source_type: UserGroupSourceType
-    values: Optional[UserGroupSettings] = None
-    uri: str = ''
+    source_type: UserGroupSourceType = UserGroupSourceType.RESOURCE
     ref: str = ''
 
     def validate(self) -> None:
-        if self.source_type == UserGroupSourceType.INLINE:
-            pfx = 'inline User/Group configuration'
-            if self.values is None:
-                raise ValueError(pfx + ' requires values')
-            if self.uri:
-                raise ValueError(pfx + ' does not take a uri')
-            if self.ref:
-                raise ValueError(pfx + ' does not take a ref value')
-        if self.source_type == UserGroupSourceType.HTTP_URI:
-            pfx = 'http User/Group configuration'
-            if not self.uri:
-                raise ValueError(pfx + ' requires a uri')
-            if self.values:
-                raise ValueError(pfx + ' does not take inline values')
-            if self.ref:
-                raise ValueError(pfx + ' does not take a ref value')
         if self.source_type == UserGroupSourceType.RESOURCE:
-            pfx = 'resource reference User/Group configuration'
             if not self.ref:
-                raise ValueError(pfx + ' requires a ref value')
-            if self.uri:
-                raise ValueError(pfx + ' does not take a uri')
-            if self.values:
-                raise ValueError(pfx + ' does not take inline values')
+                raise ValueError('reference value must be specified')
+            else:
+                validation.check_id(self.ref)
+        else:
+            if self.ref:
+                raise ValueError('ref may not be specified')
 
     @resourcelib.customize
     def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
-        rc.uri.quiet = True
         rc.ref.quiet = True
         return rc
 

--- a/src/pybind/mgr/smb/results.py
+++ b/src/pybind/mgr/smb/results.py
@@ -68,6 +68,23 @@ class ResultGroup:
     def one(self) -> Result:
         return one(self._contents)
 
+    def squash(self, target: SMBResource) -> Result:
+        match: Optional[Result] = None
+        others: List[Result] = []
+        for result in self._contents:
+            if result.src == target:
+                match = result
+            else:
+                others.append(result)
+        if match:
+            match.success = self.success
+            match.status = {} if match.status is None else match.status
+            match.status['additional_results'] = [
+                r.to_simplified() for r in others
+            ]
+            return match
+        raise ValueError('no matching result for resource found')
+
     def __iter__(self) -> Iterator[Result]:
         return iter(self._contents)
 

--- a/src/pybind/mgr/smb/tests/test_enums.py
+++ b/src/pybind/mgr/smb/tests/test_enums.py
@@ -18,8 +18,6 @@ import smb.enums
         (smb.enums.State.UPDATED, "updated"),
         (smb.enums.AuthMode.USER, "user"),
         (smb.enums.AuthMode.ACTIVE_DIRECTORY, "active-directory"),
-        (smb.enums.JoinSourceType.PASSWORD, "password"),
-        (smb.enums.UserGroupSourceType.INLINE, "inline"),
     ],
 )
 def test_stringified(value, strval):

--- a/src/pybind/mgr/smb/tests/test_resources.py
+++ b/src/pybind/mgr/smb/tests/test_resources.py
@@ -117,10 +117,6 @@ domain_settings:
   join_sources:
     - source_type: resource
       ref: bob
-    - source_type: password
-      auth:
-        username: Administrator
-        password: fallb4kP4ssw0rd
 ---
 resource_type: ceph.smb.share
 cluster_id: chacha
@@ -168,13 +164,10 @@ def test_load_yaml_resource_yaml1():
     assert cluster.intent == enums.Intent.PRESENT
     assert cluster.auth_mode == enums.AuthMode.ACTIVE_DIRECTORY
     assert cluster.domain_settings.realm == 'CEPH.SINK.TEST'
-    assert len(cluster.domain_settings.join_sources) == 2
+    assert len(cluster.domain_settings.join_sources) == 1
     jsrc = cluster.domain_settings.join_sources
     assert jsrc[0].source_type == enums.JoinSourceType.RESOURCE
     assert jsrc[0].ref == 'bob'
-    assert jsrc[1].source_type == enums.JoinSourceType.PASSWORD
-    assert jsrc[1].auth.username == 'Administrator'
-    assert jsrc[1].auth.password == 'fallb4kP4ssw0rd'
 
     assert isinstance(loaded[1], smb.resources.Share)
     assert isinstance(loaded[2], smb.resources.Share)
@@ -427,7 +420,7 @@ domain_settings:
             "exc_type": ValueError,
             "error": "not supported",
         },
-        # u/g inline missing
+        # u/g empty with extra ref
         {
             "yaml": """
 resource_type: ceph.smb.cluster
@@ -435,89 +428,11 @@ cluster_id: randolph
 intent: present
 auth_mode: user
 user_group_settings:
-  - source_type: inline
-""",
-            "exc_type": ValueError,
-            "error": "requires values",
-        },
-        # u/g inline extra uri
-        {
-            "yaml": """
-resource_type: ceph.smb.cluster
-cluster_id: randolph
-intent: present
-auth_mode: user
-user_group_settings:
-  - source_type: inline
-    values:
-      users: []
-      groups: []
-    uri: http://foo.bar.example.com/baz.txt
-""",
-            "exc_type": ValueError,
-            "error": "does not take",
-        },
-        # u/g inline extra ref
-        {
-            "yaml": """
-resource_type: ceph.smb.cluster
-cluster_id: randolph
-intent: present
-auth_mode: user
-user_group_settings:
-  - source_type: inline
-    values:
-      users: []
-      groups: []
+  - source_type: empty
     ref: xyz
 """,
             "exc_type": ValueError,
-            "error": "does not take",
-        },
-        # u/g uri missing
-        {
-            "yaml": """
-resource_type: ceph.smb.cluster
-cluster_id: randolph
-intent: present
-auth_mode: user
-user_group_settings:
-  - source_type: http_uri
-""",
-            "exc_type": ValueError,
-            "error": "requires",
-        },
-        # u/g uri extra values
-        {
-            "yaml": """
-resource_type: ceph.smb.cluster
-cluster_id: randolph
-intent: present
-auth_mode: user
-user_group_settings:
-  - source_type: http_uri
-    values:
-      users: []
-      groups: []
-    uri: http://foo.bar.example.com/baz.txt
-""",
-            "exc_type": ValueError,
-            "error": "does not take",
-        },
-        # u/g uri extra ref
-        {
-            "yaml": """
-resource_type: ceph.smb.cluster
-cluster_id: randolph
-intent: present
-auth_mode: user
-user_group_settings:
-  - source_type: http_uri
-    uri: http://boop.example.net
-    ref: xyz
-""",
-            "exc_type": ValueError,
-            "error": "does not take",
+            "error": "ref may not be",
         },
         # u/g resource missing
         {
@@ -530,39 +445,7 @@ user_group_settings:
   - source_type: resource
 """,
             "exc_type": ValueError,
-            "error": "requires",
-        },
-        # u/g resource extra values
-        {
-            "yaml": """
-resource_type: ceph.smb.cluster
-cluster_id: randolph
-intent: present
-auth_mode: user
-user_group_settings:
-  - source_type: resource
-    ref: xyz
-    uri: http://example.net/foo
-""",
-            "exc_type": ValueError,
-            "error": "does not take",
-        },
-        # u/g resource extra resource
-        {
-            "yaml": """
-resource_type: ceph.smb.cluster
-cluster_id: randolph
-intent: present
-auth_mode: user
-user_group_settings:
-  - source_type: resource
-    ref: xyz
-    values:
-      users: []
-      groups: []
-""",
-            "exc_type": ValueError,
-            "error": "does not take",
+            "error": "reference value must be",
         },
     ],
 )

--- a/src/pybind/mgr/smb/tests/test_smb.py
+++ b/src/pybind/mgr/smb/tests/test_smb.py
@@ -39,11 +39,7 @@ def test_internal_apply_cluster(tmodule):
         auth_mode=smb.enums.AuthMode.USER,
         user_group_settings=[
             smb.resources.UserGroupSource(
-                source_type=smb.resources.UserGroupSourceType.INLINE,
-                values=smb.resources.UserGroupSettings(
-                    users=[],
-                    groups=[],
-                ),
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
             ),
         ],
     )
@@ -58,11 +54,7 @@ def test_cluster_add_cluster_ls(tmodule):
         auth_mode=smb.enums.AuthMode.USER,
         user_group_settings=[
             smb.resources.UserGroupSource(
-                source_type=smb.resources.UserGroupSourceType.INLINE,
-                values=smb.resources.UserGroupSettings(
-                    users=[],
-                    groups=[],
-                ),
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
             ),
         ],
     )
@@ -80,11 +72,7 @@ def test_internal_apply_cluster_and_share(tmodule):
         auth_mode=smb.enums.AuthMode.USER,
         user_group_settings=[
             smb.resources.UserGroupSource(
-                source_type=smb.resources.UserGroupSourceType.INLINE,
-                values=smb.resources.UserGroupSettings(
-                    users=[],
-                    groups=[],
-                ),
+                source_type=smb.resources.UserGroupSourceType.EMPTY,
             ),
         ],
     )
@@ -117,8 +105,7 @@ def test_internal_apply_remove_cluster(tmodule):
                 'intent': 'present',
                 'user_group_settings': [
                     {
-                        'source_type': 'inline',
-                        'values': {'users': [], 'groups': []},
+                        'source_type': 'empty',
                     }
                 ],
             }
@@ -149,8 +136,7 @@ def test_internal_apply_remove_shares(tmodule):
                 'intent': 'present',
                 'user_group_settings': [
                     {
-                        'source_type': 'inline',
-                        'values': {'users': [], 'groups': []},
+                        'source_type': 'empty',
                     }
                 ],
             },
@@ -230,8 +216,7 @@ def test_internal_apply_add_joinauth(tmodule):
                 'intent': 'present',
                 'user_group_settings': [
                     {
-                        'source_type': 'inline',
-                        'values': {'users': [], 'groups': []},
+                        'source_type': 'empty',
                     }
                 ],
             }
@@ -262,8 +247,7 @@ def test_internal_apply_add_usergroups(tmodule):
                 'intent': 'present',
                 'user_group_settings': [
                     {
-                        'source_type': 'inline',
-                        'values': {'users': [], 'groups': []},
+                        'source_type': 'empty',
                     }
                 ],
             }
@@ -296,13 +280,19 @@ def _example_cfg_1(tmodule):
                     'realm': 'dom1.example.com',
                     'join_sources': [
                         {
-                            'source_type': 'password',
-                            'auth': {
-                                'username': 'testadmin',
-                                'password': 'Passw0rd',
-                            },
+                            'source_type': 'resource',
+                            'ref': 'foo',
                         }
                     ],
+                },
+            },
+            'join_auths.foo': {
+                'resource_type': 'ceph.smb.join.auth',
+                'auth_id': 'foo',
+                'intent': 'present',
+                'auth': {
+                    'username': 'testadmin',
+                    'password': 'Passw0rd',
                 },
             },
             'shares.foo.s1': {

--- a/src/pybind/mgr/smb/tests/test_smb.py
+++ b/src/pybind/mgr/smb/tests/test_smb.py
@@ -490,15 +490,24 @@ def test_cluster_create_ad1(tmodule):
     assert len(result.src.domain_settings.join_sources) == 1
     assert (
         result.src.domain_settings.join_sources[0].source_type
-        == smb.enums.JoinSourceType.PASSWORD
+        == smb.enums.JoinSourceType.RESOURCE
+    )
+    assert result.src.domain_settings.join_sources[0].ref.startswith('fizzle')
+    assert 'additional_results' in result.status
+    assert len(result.status['additional_results']) == 1
+    assert (
+        result.status['additional_results'][0]['resource']['resource_type']
+        == 'ceph.smb.join.auth'
     )
     assert (
-        result.src.domain_settings.join_sources[0].auth.username
-        == 'Administrator'
+        result.status['additional_results'][0]['resource'][
+            'linked_to_cluster'
+        ]
+        == 'fizzle'
     )
-    assert (
-        result.src.domain_settings.join_sources[0].auth.password == 'Passw0rd'
-    )
+    assert result.status['additional_results'][0]['resource'][
+        'auth_id'
+    ].startswith('fizzle')
 
 
 def test_cluster_create_ad2(tmodule):


### PR DESCRIPTION
Depends on #56350 

Drop the embedded versions of the join source and users and groups     configs from the cluster resource type. This means that potentially     sensitive information is *always* stored in a separate resource     from the less-sensitive general cluster config. Future changes can     then make security related choices about those specific resource types     without worrying about having embedded variants inside the cluster resources.
    
The embedded values are moved to 'linked resources'. The JoinAuth and UsersAndGroups resource types gain a new optional field `linked_to_cluster` that binds the resource to a single cluster resource instance, making it exclusive to that cluster and automatically removed if the cluster resource is removed. Making it a suitable replacement for the embedded resources when used from the CLI command `smb cluster create ...`.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
