### PR TITLE
squid: mgr/cephadm: cleanup service size logic block

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2239,8 +2239,9 @@ Then run the following:
             if service_name is not None and service_name != nm:
                 continue
 
-            if spec.service_type not in ['osd', 'node-proxy']:
-                size = spec.placement.get_target_count(self.cache.get_schedulable_hosts())
+            if spec.service_type == 'osd':
+                # osd counting is special
+                size = 0
             elif spec.service_type == 'node-proxy':
                 # we only deploy node-proxy daemons on hosts we have oob info for
                 # Let's make the expected daemon count `orch ls` displays reflect that
@@ -2248,8 +2249,7 @@ Then run the following:
                 oob_info_hosts = [h for h in schedulable_hosts if h.hostname in self.node_proxy_cache.oob.keys()]
                 size = spec.placement.get_target_count(oob_info_hosts)
             else:
-                # osd counting is special
-                size = 0
+                size = spec.placement.get_target_count(self.cache.get_schedulable_hosts())
 
             sm[nm] = orchestrator.ServiceDescription(
                 spec=spec,


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/56933

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
