### PR TITLE
squid: qa/cephadm: ignore stray daemon warning during rados_api_tests

### DIFF
--- a/qa/suites/orch/cephadm/thrash/1-start.yaml
+++ b/qa/suites/orch/cephadm/thrash/1-start.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-ignorelist:
+    - \(CEPHADM_STRAY_DAEMON\)
     log-only-match:
       - CEPHADM_
 tasks:

--- a/qa/suites/rados/basic/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/basic/tasks/rados_api_tests.yaml
@@ -11,6 +11,7 @@ overrides:
     - \(POOL_APP_NOT_ENABLED\)
     - \(PG_AVAILABILITY\)
     - \(PG_DEGRADED\)
+    - \(CEPHADM_STRAY_DAEMON\)
     conf:
       client:
         debug ms: 1


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/57144

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
