### PR TITLE
crush: reject swap bucket if source == dest

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1302,6 +1302,8 @@ int CrushWrapper::swap_bucket(CephContext *cct, int src, int dst)
     return -EINVAL;
   if (!item_exists(src) || !item_exists(dst))
     return -EINVAL;
+  if (src == dst)
+    return -EINVAL;
   crush_bucket *a = get_bucket(src);
   crush_bucket *b = get_bucket(dst);
   if (is_parent_of(a->id, b->id) || is_parent_of(b->id, a->id)) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10839,6 +10839,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     }
     int sid = newcrush.get_item_id(source);
     int did = newcrush.get_item_id(dest);
+    if (sid == did) {
+        ss << "source " << source << "and dest " << dest << "are identical";
+        err = -EINVAL;
+        goto reply_no_propose;
+    }
     int sparent;
     if (newcrush.get_immediate_parent_id(sid, &sparent) == 0 && !force) {
       ss << "source item " << source << " is not an orphan bucket; pass --yes-i-really-mean-it to proceed anyway";


### PR DESCRIPTION
The mon will crash if a user mistakenly puts source == dest in a swap bucket command. Reject instead.

Fixes: https://tracker.ceph.com/issues/55461