### PR TITLE
Test: osd-recovery-space.sh extends the wait time for "recovery toofull"

### DIFF
--- a/qa/standalone/osd/osd-recovery-space.sh
+++ b/qa/standalone/osd/osd-recovery-space.sh
@@ -76,6 +76,10 @@ function wait_for_state() {
 function wait_for_recovery_toofull() {
     local timeout=$1
     wait_for_state recovery_toofull $timeout
+    if [ $ret -ne 0 ]; then
+      echo "Error: Recovery toofull timeout"
+      return 1
+    fi
 }
 
 
@@ -131,7 +135,11 @@ function TEST_recovery_test_simple() {
     done
 
     # If this times out, we'll detected errors below
-    wait_for_recovery_toofull 30
+    wait_for_recovery_toofull 120
+    if [ $? -ne 0 ]; then
+      echo "Error: Recovery toofull timeout"
+      return 1
+    fi
 
     ERRORS=0
     if [ "$(ceph pg dump pgs | grep +recovery_toofull | wc -l)" != "1" ];


### PR DESCRIPTION


The osd-recovery-space test involves writing objects and expecting to receive the "toofull" flag.
If we don't wait long enough, we might check the "toofull" flag before all objects have completed writing, and the "toofull" status hasn't been activated yet.

The change will extend the waiting time and will also incorporate additional checks for the return code from the status wait.

Fixes: https://tracker.ceph.com/issues/44510





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
