### PR TITLE
reef: os/bluestore: fix the problem of l_bluefs_log_compactions double recording

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2700,7 +2700,6 @@ void BlueFS::_rewrite_log_and_layout_sync_LNF_LD(bool permit_dev_fallback,
 
   // we're mostly done
   dout(10) << __func__ << " log extents " << log_file->fnode.extents << dendl;
-  logger->inc(l_bluefs_log_compactions);
 
   // Part 4
   // Finalization. Release old space.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64590

---

backport of https://github.com/ceph/ceph/pull/55700
parent tracker: https://tracker.ceph.com/issues/64533

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh