### PR TITLE
reef: os/bluestore: fix crash caused by dividing by 0

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5808,7 +5808,7 @@ int BlueStore::_create_alloc()
       cct, cct->_conf->bluestore_allocator,
       bdev->get_conventional_region_size(),
       alloc_size,
-      0, 0,
+      zone_size, 0,
       "zoned_block");
     if (!a) {
       lderr(cct) << __func__ << " failed to create " << cct->_conf->bluestore_allocator


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63315

---

backport of https://github.com/ceph/ceph/pull/54155
parent tracker: https://tracker.ceph.com/issues/63308

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh