### PR TITLE
github: update PR template for readability during review

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,37 @@
 
 
+<details>
+<summary>Show contribution guidelines</summary>
 
+  - To sign and title your commits, please refer to
+    [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).
+    - Please give your pull request a title like
 
-<!--
-  - Please give your pull request a title like
+          [component]: [short description]
 
-      [component]: [short description]
+    - Please use this format for each git commit message:
 
-  - Please use this format for each git commit message:
+          [component]: [short description]
 
-      [component]: [short description]
+          [A longer multiline description]
 
-      [A longer multiline description]
-
-      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
-      Signed-off-by: [Your Name] <[your email]>
+          Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
+          Signed-off-by: [Your Name] <[your email]>
 
     For examples, use "git log".
--->
 
-## Contribution Guidelines
-- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).
+  - If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to
+    [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.
 
-- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.
+  - When filling out the below checklist, you may click boxes directly in the GitHub web UI.
+    When entering or editing the entire PR message in the GitHub web UI editor,
+    you may also select a checklist item by adding an `x` between the brackets: `[x]`.
+    Spaces and capitalization matter when checking off items this way.
+</details>
 
-- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.
+<details>
+<summary>Show checklist</summary>
 
-## Checklist
 - Tracker (select at least one)
   - [ ] References tracker ticket
   - [ ] Very recent bug; references commit where it was introduced
@@ -45,6 +50,7 @@
   - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
   - [ ] Includes bug reproducer
   - [ ] No tests
+</details>
 
 <details>
 <summary>Show available Jenkins commands</summary>


### PR DESCRIPTION
Following a discussion in a [slack thread](https://ceph-storage.slack.com/archives/C1HFZTW81/p1712583039024809) on `#ceph-devel`, here is a suggestion to update the PR template.

The rationale is as follows:

* Contribution guidelines should be a comment, as they don't matter when rendering an existing PR. They will stay available in the comment for any PR unless removed by the editor.
* The checklist is unnecessarily verbose. If a single item from a section applies, there's no need to show the unchecked options when rendering a PR. Additionally, looking at the labels and the changes themselves could be sufficient to determine most of the information from the checklist. Finally, the checklist is rarely even filled in. To save the real estate for the PR description the checklist is put into a collapsed details section, just one click away for anyone who needs to review it.

Use `Edit` on this description to see what it will look like to PR authors if this change gets merged

This change will require an update to the checklist verifier, since there's no more a `##Checklist` header which is required by the current verification code.

<details>
<summary>Show contribution guidelines</summary>

  - To sign and title your commits, please refer to
    [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).
    - Please give your pull request a title like

          [component]: [short description]

    - Please use this format for each git commit message:

          [component]: [short description]

          [A longer multiline description]

          Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
          Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

  - If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to
    [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

  - When filling out the below checklist, you may click boxes directly in the GitHub web UI.
    When entering or editing the entire PR message in the GitHub web UI editor,
    you may also select a checklist item by adding an `x` between the brackets: `[x]`.
    Spaces and capitalization matter when checking off items this way.
</details>

<details>
<summary>Show checklist</summary>

- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
</details>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
