### PR TITLE
squid: mds: abort fragment/export when quiesced

### DIFF
--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -81,6 +81,13 @@ class CephFSTestCase(CephTestCase):
 
     LOAD_SETTINGS = [] # type: ignore
 
+    def _reqid_tostr(self, reqid):
+        """
+        Change a json reqid to a string representation.
+        """
+
+        return f"{reqid['entity']['type']}.{reqid['entity']['num']}:{reqid['tid']}"
+
     def _save_mount_details(self):
         """
         XXX: Tests may change details of mount objects, so let's stash them so

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -1317,6 +1317,9 @@ class Filesystem(MDSCluster):
         kwargs.pop('status', None) # not useful
         try:
             out = self.get_ceph_cmd_stdout("tell", f"mds.{mds_id}", *args, **kwargs)
+            out = out.strip()
+            if len(out) == 0:
+                return {}
             return json.loads(out)
         except json.decoder.JSONDecodeError:
             log.error("could not decode: {}".format(out))

--- a/qa/tasks/cephfs/test_quiesce.py
+++ b/qa/tasks/cephfs/test_quiesce.py
@@ -325,9 +325,6 @@ class QuiesceTestCase(CephFSTestCase):
         # check request/cap count is stopped
         # count inodes under /usr and count subops!
 
-    def reqid_tostr(self, reqid):
-        return f"{reqid['entity']['type']}.{reqid['entity']['num']}:{reqid['tid']}"
-
 class TestQuiesce(QuiesceTestCase):
     """
     Single rank functional tests.
@@ -344,7 +341,7 @@ class TestQuiesce(QuiesceTestCase):
         sleep(secrets.randbelow(30)+10)
 
         J = self.fs.rank_tell(["quiesce", "path", self.subvolume])
-        reqid = self.reqid_tostr(J['op']['reqid'])
+        reqid = self._reqid_tostr(J['op']['reqid'])
         self._wait_for_quiesce_complete(reqid)
 
         self._verify_quiesce()
@@ -360,7 +357,7 @@ class TestQuiesce(QuiesceTestCase):
         sleep(secrets.randbelow(30)+10)
 
         J = self.fs.rank_tell(["quiesce", "path", self.subvolume])
-        reqid = self.reqid_tostr(J['op']['reqid'])
+        reqid = self._reqid_tostr(J['op']['reqid'])
         self._wait_for_quiesce_complete(reqid)
 
         #path = os.path.normpath(os.path.join(self.mntpnt, ".."))
@@ -376,7 +373,7 @@ class TestQuiesce(QuiesceTestCase):
         """
 
         J = self.fs.rank_tell(["quiesce", "path", self.subvolume])
-        reqid = self.reqid_tostr(J['op']['reqid'])
+        reqid = self._reqid_tostr(J['op']['reqid'])
         self._wait_for_quiesce_complete(reqid)
         self._verify_quiesce()
 
@@ -387,7 +384,7 @@ class TestQuiesce(QuiesceTestCase):
         """
 
         J = self.fs.rank_tell(["quiesce", "path", self.subvolume])
-        reqid = self.reqid_tostr(J['op']['reqid'])
+        reqid = self._reqid_tostr(J['op']['reqid'])
         self._wait_for_quiesce_complete(reqid)
         self._verify_quiesce()
         ops = self.fs.get_ops()
@@ -418,7 +415,7 @@ class TestQuiesce(QuiesceTestCase):
         log.debug(f"{P}")
 
         J = self.fs.rank_tell(["quiesce", "path", self.subvolume])
-        reqid = self.reqid_tostr(J['op']['reqid'])
+        reqid = self._reqid_tostr(J['op']['reqid'])
         self._wait_for_quiesce_complete(reqid)
 
         P = self.fs.rank_tell(["ops"])
@@ -488,7 +485,7 @@ class TestQuiesce(QuiesceTestCase):
         path = self.mount_a.cephfs_mntpt + "/dir"
 
         J = self.fs.rank_tell(["quiesce", "path", path, '--wait'])
-        reqid = self.reqid_tostr(J['op']['reqid'])
+        reqid = self._reqid_tostr(J['op']['reqid'])
         self._wait_for_quiesce_complete(reqid, path=path)
         self._verify_quiesce(root=path)
 
@@ -515,7 +512,7 @@ class TestQuiesce(QuiesceTestCase):
         self._configure_subvolume()
 
         op1 = self.fs.rank_tell(["quiesce", "path", self.subvolume])['op']
-        op1_reqid = self.reqid_tostr(op1['reqid'])
+        op1_reqid = self._reqid_tostr(op1['reqid'])
         op2 = self.fs.rank_tell(["quiesce", "path", self.subvolume, '--wait'])['op']
         op1 = self.fs.get_op(op1_reqid)['type_data'] # for possible dup result
         log.debug(f"op1 = {op1}")
@@ -551,7 +548,7 @@ class TestQuiesce(QuiesceTestCase):
 
         J = self.fs.rank_tell(["quiesce", "path", self.subvolume])
         log.debug(f"{J}")
-        reqid = self.reqid_tostr(J['op']['reqid'])
+        reqid = self._reqid_tostr(J['op']['reqid'])
         self._wait_for_quiesce_complete(reqid)
         self._verify_quiesce(root=self.subvolume)
 
@@ -573,7 +570,7 @@ class TestQuiesce(QuiesceTestCase):
 
         J = self.fs.rank_tell(["quiesce", "path", self.subvolume])
         log.debug(f"{J}")
-        reqid = self.reqid_tostr(J['op']['reqid'])
+        reqid = self._reqid_tostr(J['op']['reqid'])
         self._wait_for_quiesce_complete(reqid)
         self._verify_quiesce(root=self.subvolume)
 
@@ -660,7 +657,7 @@ class TestQuiesceMultiRank(QuiesceTestCase):
         for d in dirs:
             path = os.path.join(self.mntpnt, d)
             op = self.fs.rank_tell("quiesce", "path", path, rank=0)['op']
-            reqid = self.reqid_tostr(op['reqid'])
+            reqid = self._reqid_tostr(op['reqid'])
             log.info(f"created {reqid}")
             qops.append(reqid)
 
@@ -723,11 +720,11 @@ class TestQuiesceMultiRank(QuiesceTestCase):
             path = os.path.join(self.mntpnt, d)
             for r in self.ranks:
                 op = self.fs.rank_tell(["quiesce", "path", path], rank=r)['op']
-                reqid = self.reqid_tostr(op['reqid'])
+                reqid = self._reqid_tostr(op['reqid'])
                 log.info(f"created {reqid}")
                 ops.append((r, op, path))
         for rank, op, path in ops:
-            reqid = self.reqid_tostr(op['reqid'])
+            reqid = self._reqid_tostr(op['reqid'])
             log.debug(f"waiting for ({rank}, {reqid})")
             op = self._wait_for_quiesce_complete(reqid, rank=rank, path=path, status=status)
         for rank, op, path in ops:
@@ -780,8 +777,8 @@ class TestQuiesceSplitAuth(QuiesceTestCase):
 
         op0 = self.fs.rank_tell(["quiesce", "path", self.subvolume], rank=0)['op']
         op1 = self.fs.rank_tell(["quiesce", "path", self.subvolume], rank=1)['op']
-        reqid0 = self.reqid_tostr(op0['reqid'])
-        reqid1 = self.reqid_tostr(op1['reqid'])
+        reqid0 = self._reqid_tostr(op0['reqid'])
+        reqid1 = self._reqid_tostr(op1['reqid'])
         op0 = self._wait_for_quiesce_complete(reqid0, rank=0, timeout=300)
         op1 = self._wait_for_quiesce_complete(reqid1, rank=1, timeout=300)
         log.debug(f"op0 = {op0}")

--- a/qa/tasks/cephfs/test_quiesce.py
+++ b/qa/tasks/cephfs/test_quiesce.py
@@ -5,6 +5,7 @@ import os
 import re
 import secrets
 import tempfile
+import time
 import unittest
 from io import StringIO
 import os.path
@@ -584,6 +585,26 @@ class TestQuiesce(QuiesceTestCase):
         dfc2 = p['mds']['dir_fetch_complete']
         self.assertGreater(dfc2, dfc1)
 
+        self._wait_for_quiesce_complete(reqid)
+        self._verify_quiesce(root=self.subvolume)
+
+    def test_quiesce_dir_fragment(self):
+        """
+        That quiesce completes with fragmentation in the background.
+        """
+
+        self.config_set('mds', 'mds_bal_split_size', '10')
+        self.config_set('mds', 'mds_bal_merge_size', '1') # do not merge
+        self.config_set('mds', 'mds_bal_split_bits', '1')
+        self._configure_subvolume()
+        self._client_background_workload()
+
+        # time for the workload to get busy
+        time.sleep(5)
+
+        J = self.fs.rank_tell("quiesce", "path", self.subvolume)
+        log.debug(f"{J}")
+        reqid = self._reqid_tostr(J['op']['reqid'])
         self._wait_for_quiesce_complete(reqid)
         self._verify_quiesce(root=self.subvolume)
 

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2978,7 +2978,7 @@ bool CInode::can_auth_pin(int *err_ret, bool bypassfreezing) const {
     err = ERR_EXPORTING_INODE;
   } else {
     if (parent)
-      return parent->can_auth_pin(err_ret);
+      return parent->can_auth_pin(err_ret, bypassfreezing);
     err = 0;
   }
   if (err && err_ret)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65738

---

backport of https://github.com/ceph/ceph/pull/57059
parent tracker: https://tracker.ceph.com/issues/65603

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh