### PR TITLE
mgr/cephadm: make setting --cgroups=split configurable for adopted daemons

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -5035,6 +5035,11 @@ def _get_parser():
         action='store_true',
         default=CONTAINER_INIT,
         help=argparse.SUPPRESS)
+    parser_adopt.add_argument(
+        '--no-cgroups-split',
+        action='store_true',
+        default=False,
+        help='Do not run containers with --cgroups=split (currently only relevant when using podman)')
 
     parser_rm_daemon = subparsers.add_parser(
         'rm-daemon', help='remove daemon instance')


### PR DESCRIPTION
Support for making --cgroups=split configurable was added in the past.
Previous support did not include adoption of legacy daemons
This commit adds support for configuring --cgroups=split when running 'adopt' command

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
- Component impact
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket

Fixes: https://tracker.ceph.com/issues/65739

Signed-off-by: Gilad Sid <sid.gilad@gmail.com>