### PR TITLE
[DNM] mgr/balancer: set upmap_max_deviation to 1

### DIFF
--- a/qa/standalone/mgr/balancer.sh
+++ b/qa/standalone/mgr/balancer.sh
@@ -141,7 +141,6 @@ function TEST_balancer2() {
     done
 
     ceph osd set-require-min-compat-client luminous
-    ceph config set mgr mgr/balancer/upmap_max_deviation 1
     ceph balancer mode upmap || return 1
     ceph balancer on || return 1
     ceph config set mgr mgr/balancer/sleep_interval 5

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -316,7 +316,7 @@ class Module(MgrModule):
                runtime=True),
         Option(name='upmap_max_deviation',
                type='int',
-               default=5,
+               default=1,
                min=1,
                desc='deviation below which no optimization is attempted',
                long_desc='If the number of PGs are within this count then no optimization is attempted',


### PR DESCRIPTION
Field experience shows that previous value 5 leads to skewed OSD utilization. Set it to 1 and update the relevant test.

Fixes: https://tracker.ceph.com/issues/65748
