### PR TITLE
osd: increase osd_max_pg_per_osd_hard_ratio from 3 to 10

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3083,7 +3083,7 @@ options:
     OSD refuses to create new PGs. An OSD stops creating new PGs if the number
     of PGs it serves exceeds
     ``osd_max_pg_per_osd_hard_ratio`` \* ``mon_max_pg_per_osd``.
-  default: 3
+  default: 10
   see_also:
   - mon_max_pg_per_osd
   min: 1


### PR DESCRIPTION
A hard ratio of 3 is hit too often during normal maintinance tasks such as adding a new host. In that case, OSDs prevent pg peering and many PGs are stuck in activating state. The OSDs log this warning:

    maybe_wait_for_max_pg withhold creation of pg

Increase the default hard_ratio to 10. This larger value has proven to work well in real life across many production clusters.

Fixes: https://tracker.ceph.com/issues/65749
