### PR TITLE
qa: add expected warnings to ignorelist

### DIFF
--- a/qa/suites/rados/dashboard/tasks/e2e.yaml
+++ b/qa/suites/rados/dashboard/tasks/e2e.yaml
@@ -17,6 +17,8 @@ tasks:
     clients:
       client.1:
         - cephadm/create_iscsi_disks.sh
+      log-ignorelist:
+        - \(OSD_DOWN\)
 - workunit:
     clients:
       client.0:

--- a/qa/suites/upgrade/reef-x/parallel/workload/test_rbd_python.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/workload/test_rbd_python.yaml
@@ -6,6 +6,8 @@ overrides:
     ceph:
       extra_system_packages:
       - python3-pytest
+    log-ignorelist:
+      - \(OSD_DOWN\)
 workload:
   full_sequential:
     - print: "**** done start test_rbd_python.yaml"

--- a/qa/tasks/thrashosds-health.yaml
+++ b/qa/tasks/thrashosds-health.yaml
@@ -28,3 +28,6 @@ overrides:
       - mons down
       - mon down
       - out of quorum
+      - nodeep-scrub flag\(s\) set
+      - noscrub flag\(s\) set
+      - noscrub,nodeep-scrub flag\(s\) set


### PR DESCRIPTION
Based on the latest main baseline run (https://pulpito.ceph.com/teuthology-2024-04-28_20:00:15-rados-main-distro-default-smithi/) I analyzed some of the warnings, determined they were expected within the test scenario, and added them to the ignorelist.

Partially fixes: https://tracker.ceph.com/issues/65521
Signed-off-by: Laura Flores <lflores@ibm.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
