### PR TITLE
reef: mgr/dashboard: exclude cloned-deleted RBD snaps

### DIFF
--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -359,6 +359,10 @@ class RbdService(object):
             # snapshots
             stat['snapshots'] = []
             for snap in img.list_snaps():
+                # Skip trash snapshots (cloned-and-then-deleted format v2 snapshots)
+                if snap['namespace'] == rbd.RBD_SNAP_NAMESPACE_TYPE_TRASH:
+                    continue
+
                 try:
                     snap['mirror_mode'] = MIRROR_IMAGE_MODE(img.mirror_image_get_mode()).name
                 except ValueError as ex:
@@ -368,7 +372,7 @@ class RbdService(object):
                     img.get_snap_timestamp(snap['id']).isoformat())
 
                 snap['is_protected'] = None
-                if mirror_mode != rbd.RBD_MIRROR_IMAGE_MODE_SNAPSHOT:
+                if snap['namespace'] == rbd.RBD_SNAP_NAMESPACE_TYPE_USER:
                     snap['is_protected'] = img.is_protected_snap(snap['name'])
                 snap['used_bytes'] = None
                 snap['children'] = []


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65756

---

backport of https://github.com/ceph/ceph/pull/57151
parent tracker: https://tracker.ceph.com/issues/65698

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh