### PR TITLE
squid: doc/cephadm: Squid default images procedure

### DIFF
--- a/doc/cephadm/services/monitoring.rst
+++ b/doc/cephadm/services/monitoring.rst
@@ -184,9 +184,79 @@ To see the default container images, run a command of the following form:
    DEFAULT_ALERT_MANAGER_IMAGE = 'quay.io/prometheus/alertmanager:v0.27.0'   
    DEFAULT_GRAFANA_IMAGE = 'quay.io/ceph/grafana:10.4.0'
 
+``cephadm`` stores a local copy of the ``cephadm`` binary in
+``var/lib/ceph/{FSID}/cephadm.{DIGEST}``, where ``{DIGEST}`` is an alphanumeric
+string representing the currently-running version of Ceph. In the Squid and
+Reef releases of Ceph, this ``cephadm`` file is stored as a zip file and must
+be unzipped before its contents can be examined.
+
+This procedure explains how to generate a list of the default container images
+used by ``cephadm``.
+
+.. note:: This procedure applies only to the Reef and Squid releases of Ceph.
+   If you are using a different version of Ceph, you cannot use this procedure
+   to examine the list of default containers used by cephadm. Make sure that
+   you are reading the documentation for the release of Ceph that you have
+   installed.
+
+#. To create a directory called ``cephadm_dir``, run the following command:
+
+   .. prompt:: bash #
+
+      mkdir cephadm_dir
+
+#. To unzip ``/var/lib/ceph/{FSID}/cephadm.{DIGEST}`` in the directory
+   ``cephadm_dir``, run a command of the following form:
+
+   .. prompt:: bash #
+
+      unzip /var/lib/ceph/{FSID}/cephadm.{DIGEST} -d cephadm_dir > /dev/null
+
+   ::
+
+      warning [/var/lib/ceph/{FSID}/cephadm.{DIGEST}]:  14 extra bytes at
+      beginning or within zipfile
+      (attempting to process anyway)
+
+
+#. To use ``egrep`` to search for the string ``_IMAGE`` in the file
+   ``cephadm_dir_cephadmlib/constants.py``, run the following command: 
+
+   .. prompt:: bash #
+
+      egrep "_IMAGE" cephadm_dir/cephadmlib/constants.py
+
+   ::
+
+      DEFAULT_IMAGE = 'quay.ceph.io/ceph-ci/ceph:main'
+      DEFAULT_IMAGE_IS_MAIN = True
+      DEFAULT_IMAGE_RELEASE = 'squid'
+      DEFAULT_PROMETHEUS_IMAGE = 'quay.io/prometheus/prometheus:v2.43.0'
+      DEFAULT_LOKI_IMAGE = 'docker.io/grafana/loki:2.4.0'
+      DEFAULT_PROMTAIL_IMAGE = 'docker.io/grafana/promtail:2.4.0'
+      DEFAULT_NODE_EXPORTER_IMAGE = 'quay.io/prometheus/node-exporter:v1.5.0'
+      DEFAULT_ALERT_MANAGER_IMAGE = 'quay.io/prometheus/alertmanager:v0.25.0'
+      DEFAULT_GRAFANA_IMAGE = 'quay.io/ceph/grafana:9.4.12'
+      DEFAULT_HAPROXY_IMAGE = 'quay.io/ceph/haproxy:2.3'
+      DEFAULT_KEEPALIVED_IMAGE = 'quay.io/ceph/keepalived:2.2.4'
+      DEFAULT_NVMEOF_IMAGE = 'quay.io/ceph/nvmeof:1.2.1'
+      DEFAULT_SNMP_GATEWAY_IMAGE = 'docker.io/maxwo/snmp-notifier:v1.2.1'
+      DEFAULT_ELASTICSEARCH_IMAGE = 'quay.io/omrizeneva/elasticsearch:6.8.23'
+      DEFAULT_JAEGER_COLLECTOR_IMAGE = 'quay.io/jaegertracing/jaeger-collector:1.29'
+      DEFAULT_JAEGER_AGENT_IMAGE = 'quay.io/jaegertracing/jaeger-agent:1.29'
+      DEFAULT_JAEGER_QUERY_IMAGE = 'quay.io/jaegertracing/jaeger-query:1.29'
+      DEFAULT_SMB_IMAGE = 'quay.io/samba.org/samba-server:devbuilds-centos-amd64'
+
 Default monitoring images are specified in
 ``/src/cephadm/cephadmlib/constants.py`` and in
 ``/src/pybind/mgr/cephadm/module.py``.
+
+*The information in the "Default Images" section was developed by Eugen Block
+in a thread on the [ceph-users] mailing list in April of 2024 and updated for
+Squid and Reef by Adam King in a thread on GitHub here:*
+`Default Images Squid GitHub discussion <https://github.com/ceph/ceph/pull/57208#discussion_r1586614140>`_.
+*The [ceph-users] thread can be viewed here:*
+`Default Images [ceph-users] mailing list thread <https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/thread/QGC66QIFBKRTPZAQMQEYFXOGZJ7RLWBN/>`_.
 
 Using custom images
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Address Adam King's request for version-specific
cephadm-container-image-retrieval procedures, which he requested here: https://github.com/ceph/ceph/pull/57208#discussion_r1586614140





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
