### PR TITLE
reef: mgr/cephadm: set OSD cap for NVMEoF daemon to "profile rbd"

### DIFF
--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -31,7 +31,7 @@ class NvmeofService(CephService):
 
         keyring = self.get_keyring_with_caps(self.get_auth_entity(nvmeof_gw_id),
                                              ['mon', 'profile rbd',
-                                              'osd', 'allow all tag rbd *=*'])
+                                              'osd', 'profile rbd'])
 
         # TODO: check if we can force jinja2 to generate dicts with double quotes instead of using json.dumps
         transport_tcp_options = json.dumps(spec.transport_tcp_options) if spec.transport_tcp_options else None


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65763

---

backport of https://github.com/ceph/ceph/pull/57143
parent tracker: https://tracker.ceph.com/issues/65691

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh