### PR TITLE
qa/workunits/erasure-code: add bench data tables and graph support for additional jerasure techniques

### DIFF
--- a/qa/workunits/erasure-code/bench.html
+++ b/qa/workunits/erasure-code/bench.html
@@ -9,6 +9,7 @@
     <script language="javascript" type="text/javascript" src="jquery.flot.categories.js"></script>
     <script language="javascript" type="text/javascript" src="bench.js"></script>
     <script language="javascript" type="text/javascript" src="plot.js"></script>
+    <script language="javascript" type="text/javascript" src="tables.js"></script>
   </head>
   <body>
 
@@ -21,12 +22,45 @@
       <div class="demo-container">
 	<div id="encode" class="demo-placeholder"></div>
       </div>
-      <p>encode: Y = GB/s, X = K/M</p>
+      <h2>Encode:</h2>
+      <p>Y = GB/s, X = K/M</p>
+      <details>
+        <summary>Bench Data</summary>
+        <table id="encode-table">
+          <tr>
+            <th>Plugin</th>
+            <th>Technique</th>
+            <th>Time</th>
+            <th>Total Size</th>
+            <th>k</th>
+            <th>m</th>
+            <th>Iteration</th>
+            <th>Packet Size</th>
+          </tr>
+        </table>
+      </details>
 
       <div class="demo-container">
 	<div id="decode" class="demo-placeholder"></div>
       </div>
-      <p>decode: Y = GB/s, X = K/M/erasures</p>
+      <h2>Decode:</h2>
+      <p>Y = GB/s, X = K/M/erasures</p>
+      <details>
+        <summary>Bench Data</summary>
+        <table id="decode-table">
+          <tr>
+            <th>Plugin</th>
+            <th>Technique</th>
+            <th>Time</th>
+            <th>Total Size</th>
+            <th>k</th>
+            <th>m</th>
+            <th>Iteration</th>
+            <th>Packet Size</th>
+            <th>Erasures</th>
+          </tr>
+        </table>
+      </details>
 
     </div>
 

--- a/qa/workunits/erasure-code/bench.sh
+++ b/qa/workunits/erasure-code/bench.sh
@@ -50,10 +50,24 @@ export PATH=/sbin:$PATH
 : ${CEPH_ERASURE_CODE_BENCHMARK:=ceph_erasure_code_benchmark}
 : ${PLUGIN_DIRECTORY:=/usr/lib/ceph/erasure-code}
 : ${PLUGINS:=isa jerasure}
-: ${TECHNIQUES:=vandermonde cauchy}
+: ${TECHNIQUES:=vandermonde cauchy liberation reed_sol_r6_op blaum_roth liber8tion}
 : ${TOTAL_SIZE:=$((1024 * 1024))}
 : ${SIZE:=4096}
 : ${PARAMETERS:=--parameter jerasure-per-chunk-alignment=true}
+
+declare -rA isa_techniques=(
+    [vandermonde]="reed_sol_van"
+    [cauchy]="cauchy"
+)
+
+declare -rA jerasure_techniques=(
+    [vandermonde]="reed_sol_van"
+    [cauchy]="cauchy_good"
+    [reed_sol_r6_op]="reed_sol_r6_op"
+    [blaum_roth]="blaum_roth"
+    [liberation]="liberation"
+    [liber8tion]="liber8tion"
+)
 
 function bench_header() {
     echo -e "seconds\tKB\tplugin\tk\tm\twork.\titer.\tsize\teras.\tcommand."
@@ -100,6 +114,25 @@ function packetsize() {
     echo $p
 }
 
+function get_technique_name()
+{
+    local plugin=$1
+    local technique=$2
+
+    declare -n techniques="${plugin}_techniques"
+    echo ${techniques["$technique"]}
+}
+
+function technique_is_raid6() {
+    local technique=$1
+    local r6_techniques="liberation reed_sol_r6_op blaum_roth liber8tion"
+
+    if [[ $r6_techniques =~ $technique ]]; then
+        return 0
+    fi
+    return 1
+}
+
 function bench_run() {
     local plugin=jerasure
     local w=8
@@ -111,31 +144,31 @@ function bench_run() {
     k2ms[4]="2 3"
     k2ms[6]="2 3 4"
     k2ms[10]="3 4"
-    local isa2technique_vandermonde='reed_sol_van'
-    local isa2technique_cauchy='cauchy'
-    local jerasure2technique_vandermonde='reed_sol_van'
-    local jerasure2technique_cauchy='cauchy_good'
+
     for technique in ${TECHNIQUES} ; do
         for plugin in ${PLUGINS} ; do
-            eval technique_parameter=\$${plugin}2technique_${technique}
+            technique_parameter=$(get_technique_name $plugin $technique)
+            if [[ -z $technique_parameter ]]; then continue; fi
             echo "serie encode_${technique}_${plugin}"
             for k in $ks ; do
                 for m in ${k2ms[$k]} ; do
+                    if [ $m -ne 2 ] && technique_is_raid6 $technique; then continue; fi
                     bench $plugin $k $m encode $(($TOTAL_SIZE / $SIZE)) $SIZE 0 \
                         --parameter packetsize=$(packetsize $k $w $VECTOR_WORDSIZE $SIZE) \
                         ${PARAMETERS} \
                         --parameter technique=$technique_parameter
-
                 done
             done
         done
     done
     for technique in ${TECHNIQUES} ; do
         for plugin in ${PLUGINS} ; do
-            eval technique_parameter=\$${plugin}2technique_${technique}
+            technique_parameter=$(get_technique_name $plugin $technique)
+            if [[ -z $technique_parameter ]]; then continue; fi
             echo "serie decode_${technique}_${plugin}"
             for k in $ks ; do
                 for m in ${k2ms[$k]} ; do
+                    if [ $m -ne 2 ] && technique_is_raid6 $technique; then continue; fi
                     echo
                     for erasures in $(seq 1 $m) ; do
                         bench $plugin $k $m decode $(($TOTAL_SIZE / $SIZE)) $SIZE $erasures \
@@ -150,27 +183,42 @@ function bench_run() {
 }
 
 function fplot() {
-    local serie
-    bench_run | while read seconds total plugin k m workload iteration size erasures rest ; do 
+    local serie=""
+    local plot=""
+    local encode_table="var encode_table = [\n"
+    local decode_table="var decode_table = [\n"
+    while read seconds total plugin k m workload iteration size erasures rest ; do
         if [ -z $seconds ] ; then
-            echo null,
+            plot="$plot  null,\n"
         elif [ $seconds = serie ] ; then
             if [ "$serie" ] ; then
-                echo '];'
+                echo -e "$plot];\n"
             fi
             local serie=`echo $total | sed 's/cauchy_\([0-9]\)/cauchy_good_\1/g'`
-            echo "var $serie = ["
+            plot="var $serie = [\n"
         else
             local x
+            local row
+            local technique=`echo $rest | grep -Po "(?<=technique=)\w*"`
+            local packetsize=`echo $rest | grep -Po "(?<=packetsize=)\w*"`
             if [ $workload = encode ] ; then
                 x=$k/$m
+                row="[ '$plugin', '$technique', $seconds, $total, $k, $m, $iteration, $packetsize ],"
+                encode_table="$encode_table  $row\n"
+
             else
                 x=$k/$m/$erasures
+                row="[ '$plugin', '$technique', $seconds, $total, $k, $m, $iteration, $packetsize, $erasures ],"
+                decode_table="$decode_table  $row\n"
             fi
-            echo "[ '$x', " $(echo "( $total / 1024 / 1024 ) / $seconds" | bc -ql) " ], "
+            local out_time="$(echo "( $total / 1024 / 1024 ) / $seconds" | bc -ql)"
+            plot="$plot  [ '$x', $out_time ],\n"
         fi
-    done
-    echo '];'
+    done < <(bench_run)
+
+    echo -e "$plot];\n"
+    echo -e "$encode_table];\n"
+    echo -e "$decode_table];\n"
 }
 
 function main() {

--- a/qa/workunits/erasure-code/examples.css
+++ b/qa/workunits/erasure-code/examples.css
@@ -95,3 +95,21 @@ input[type=checkbox] {
 .legend table {
 	border-spacing: 5px;
 }
+
+#encode-table, #decode-table {
+  margin: 0px 0px 15px 15px;
+  font-size: 12px;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+#encode-table td, #decode-table td, #encode-table th, #decode-table th {
+  border: 1px solid #ddd;
+  padding: 4px;
+}
+
+#encode-table th, #decode-table th {
+  padding-top: 4px;
+  padding-bottom: 4px;
+  text-align: left;
+}

--- a/qa/workunits/erasure-code/plot.js
+++ b/qa/workunits/erasure-code/plot.js
@@ -32,6 +32,38 @@ $(function() {
 	    lines: { show: true },
 	});
     }
+    if (typeof encode_reed_sol_r6_op_jerasure != 'undefined') {
+        encode.push({
+            data: encode_reed_sol_r6_op_jerasure,
+            label: "Jerasure, Reed Solomon RAID6",
+            points: { show: true },
+            lines: { show: true },
+      });
+  }
+    if (typeof encode_liberation_jerasure != 'undefined') {
+        encode.push({
+            data: encode_liberation_jerasure,
+            label: "Jerasure, Liberation",
+            points: { show: true },
+            lines: { show: true },
+        });
+    }
+    if (typeof encode_liber8tion_jerasure != 'undefined') {
+        encode.push({
+            data: encode_liber8tion_jerasure,
+            label: "Jerasure, Liber8tion",
+            points: { show: true },
+            lines: { show: true },
+        });
+    }
+    if (typeof encode_blaum_roth_jerasure != 'undefined') {
+        encode.push({
+            data: encode_blaum_roth_jerasure,
+            label: "Jerasure, Blaum Roth",
+            points: { show: true },
+            lines: { show: true },
+      });
+    }
     $.plot("#encode", encode, {
 	xaxis: {
 	    mode: "categories",
@@ -72,11 +104,42 @@ $(function() {
 	    lines: { show: true },
 	});
     }
+    if (typeof decode_reed_sol_r6_op_jerasure != 'undefined') {
+        decode.push({
+            data: decode_reed_sol_r6_op_jerasure,
+            label: "Jerasure, Reed Solomon RAID6",
+            points: { show: true },
+            lines: { show: true },
+        });
+    }
+    if (typeof decode_liberation_jerasure != 'undefined') {
+        decode.push({
+            data: decode_liberation_jerasure,
+            label: "Jerasure, Liberation",
+            points: { show: true },
+            lines: { show: true },
+        });
+    }
+    if (typeof decode_liber8tion_jerasure != 'undefined') {
+        decode.push({
+            data: decode_liber8tion_jerasure,
+            label: "Jerasure, Liber8tion",
+            points: { show: true },
+            lines: { show: true },
+        });
+    }
+    if (typeof decode_blaum_roth_jerasure != 'undefined') {
+        decode.push({
+            data: decode_blaum_roth_jerasure,
+            label: "Jerasure, Blaum Roth",
+            points: { show: true },
+            lines: { show: true },
+        });
+    }
     $.plot("#decode", decode, {
 	xaxis: {
 	    mode: "categories",
 	    tickLength: 0
 	},
     });
-
 });

--- a/qa/workunits/erasure-code/tables.js
+++ b/qa/workunits/erasure-code/tables.js
@@ -1,0 +1,28 @@
+$(function() {
+    if (typeof encode_table != 'undefined') {
+        let table_rows = '';
+        for (let row of encode_table) {
+            table_rows += `<tr>`
+            for (let cell of row)
+            {
+                table_rows += `<td>${cell}</td>`
+            }
+            table_rows += `</tr>`;
+            console.log(table_rows);
+        }
+        $('#encode-table').append(table_rows);
+    }
+
+    if (typeof decode_table != 'undefined') {
+        let table_rows = '';
+        for (let row of decode_table) {
+            table_rows += `<tr>`
+            for (let cell of row)
+            {
+                table_rows += `<td>${cell}</td>`
+            }
+            table_rows += `</tr>`;
+        }
+        $('#decode-table').append(table_rows);
+    }
+});


### PR DESCRIPTION
This change updates a supporting script for the Erasure Code benchmark tool which produces comparison graphs for ISA and Jerasure, based off of results from the benchmark tool. This change adds graph support for several ISA techniques which were not originally supported when the tool was written, it also adds tables to the produced graph page which include statistics from the bench tool detailing packet sizes, iterations etc. which give some context to the results. This extra information is already produced in the command line output for the tool, but is not included with the graphs currently. The change to build up the table variables is a bit quick n’ dirty, but thought this was acceptable given the nature of the utility.

I could not find any supporting docs for this utility, aside from some old blog posts. Any help included in the files is still relevant after this change. Thus, I don’t think this needs any additional documentation changes, but please let me know if I missed something.

Signed-off-by: Connor Fawcett <[connorfa@uk.ibm.com](mailto:connorfa@uk.ibm.com)>

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
