### PR TITLE
osd: bypass messenger for local EC reads

### DIFF
--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -77,6 +77,11 @@ public:
     ECSubReadReply *reply,
     const ZTracer::Trace &trace
     );
+  void handle_sub_read_n_reply(
+    pg_shard_t from,
+    ECSubRead &op,
+    const ZTracer::Trace &trace
+    ) override;
   void handle_sub_write_reply(
     pg_shard_t from,
     const ECSubWriteReply &op,

--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -49,6 +49,7 @@ typedef crimson::osd::ObjectContextRef ObjectContextRef;
 
 //forward declaration
 struct ECSubWrite;
+struct ECSubRead;
 struct PGLog;
 
 // ECListener -- an interface decoupling the pipelines from
@@ -217,6 +218,12 @@ struct ECCommon {
     ECSubWrite &op,
     const ZTracer::Trace &trace,
     ECListener& eclistener
+    ) = 0;
+
+  virtual void handle_sub_read_n_reply(
+    pg_shard_t from,
+    ECSubRead &op,
+    const ZTracer::Trace &trace
     ) = 0;
 
   virtual void objects_read_and_reconstruct(
@@ -413,6 +420,7 @@ struct ECCommon {
     const ECUtil::stripe_info_t& sinfo;
     // TODO: lay an interface down here
     ECListener* parent;
+    ECCommon& ec_backend;
 
     ECListener *get_parent() const { return parent; }
     const OSDMapRef& get_osdmap() const { return get_parent()->pgb_get_osdmap(); }
@@ -422,11 +430,13 @@ struct ECCommon {
     ReadPipeline(CephContext* cct,
                 ceph::ErasureCodeInterfaceRef ec_impl,
                 const ECUtil::stripe_info_t& sinfo,
-                ECListener* parent)
+                ECListener* parent,
+		ECCommon& ec_backend)
       : cct(cct),
         ec_impl(std::move(ec_impl)),
         sinfo(sinfo),
-        parent(parent) {
+        parent(parent),
+        ec_backend(ec_backend) {
     }
 
     int get_remaining_shards(
@@ -459,6 +469,14 @@ struct ECCommon {
       ); ///< @return error code, 0 on success
 
     void schedule_recovery_work();
+
+    void handle_sub_read_n_reply(
+      pg_shard_t from,
+      ECSubRead &op,
+      const ZTracer::Trace &trace
+    ) {
+      ec_backend.handle_sub_read_n_reply(from, op, trace);
+    }
   };
 
   /**


### PR DESCRIPTION
In order to fulfill a read request, an OSD needs to fetch chunks from remote shards as well as from its local `ObjectStore`. Currently, there is no distinction in handling between these sources – even local reads are served through the messenger, using its loopback connection. However, this requires some extra work to be spent on handling buffers, workqueues and executing requests. This commit implements the messenger bypass for reading from local store.

CC: @markhpc, @bill-scales.

(this commit has been dissected from a bigger WIP branch for crimson)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
