### PR TITLE
mgr/k8sevents: update V1Events to CoreV1Events

### DIFF
--- a/src/pybind/mgr/k8sevents/module.py
+++ b/src/pybind/mgr/k8sevents/module.py
@@ -67,7 +67,11 @@ else:
     # which causes an exception in the generator. A workaround is discussed for a similar issue
     # in https://github.com/kubernetes-client/python/issues/376 which has been used here
     # pylint: disable=no-member
-    from kubernetes.client.models.v1_event import V1Event
+    try:
+        from kubernetes.client.models.core_v1_event import CoreV1Event as V1Event
+    except ImportError:
+        from kubernetes.client.models.v1_event import V1Event
+
     def local_involved_object(self, involved_object):
         if involved_object is None:
             involved_object = client.V1ObjectReference(api_version="1")
@@ -409,14 +413,14 @@ class KubernetesEvent(object):
 
         event_source = client.V1EventSource(component="ceph-mgr", 
                                             host=self.host)
-        return  client.V1Event(
-                    involved_object=obj_ref, 
-                    metadata=obj_meta, 
-                    message=self.message, 
-                    count=self.count, 
+        return V1Event(
+                    involved_object=obj_ref,
+                    metadata=obj_meta,
+                    message=self.message,
+                    count=self.count,
                     type=self.event_type,
                     reason=self.event_reason,
-                    source=event_source, 
+                    source=event_source,
                     first_timestamp=self.first_timestamp,
                     last_timestamp=self.last_timestamp
                 )

--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -1,5 +1,5 @@
 -rrequirements-required.txt
 asyncssh==2.9
-kubernetes==11.0.0
+kubernetes
 urllib3==1.26.15
 pytest==7.4.4


### PR DESCRIPTION
@dmick encountered this issue on centos 9 container build: https://tracker.ceph.com/issues/65627

centos9 only provides kubernetes 26.1.0 as base dep and hence the k8sevents code needs to be updated accordingly. the api changes happened in kuberenetes while 19.0.0 was released





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
