### PR TITLE
qa/rgw/d4n: run ceph_test_d4n_ tests

### DIFF
--- a/qa/suites/rgw/d4n/tasks/rgw_d4ntests.yaml
+++ b/qa/suites/rgw/d4n/tasks/rgw_d4ntests.yaml
@@ -19,3 +19,4 @@ tasks:
     clients:
       client.0:
       - rgw/run-d4n.sh
+      - rgw/test_d4n.sh

--- a/qa/workunits/rgw/test_d4n.sh
+++ b/qa/workunits/rgw/test_d4n.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+# run d4n workunits that depend on a running redis server
+ceph_test_rgw_d4n_directory
+ceph_test_rgw_d4n_policy
+ceph_test_rgw_redis_driver
+ceph_test_rgw_ssd_driver
+
+exit 0


### PR DESCRIPTION
followup to https://github.com/ceph/ceph/pull/56735#issuecomment-2088759779. adds d4n test cases to the rgw/d4n suite, because nothing else runs them

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
