### PR TITLE
squid: crimson: fixes for stack-use-after-return on recent clang and gcc versions

### DIFF
--- a/cmake/modules/FindSanitizers.cmake
+++ b/cmake/modules/FindSanitizers.cmake
@@ -57,6 +57,9 @@ string (REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${Sanitizers_COMPILE_OPTIONS}")
 set(CMAKE_REQUIRED_LIBRARIES ${Sanitizers_COMPILE_OPTIONS})
 check_cxx_source_compiles("int main() {}"
   Sanitizers_ARE_SUPPORTED)
+
+file (READ ${CMAKE_CURRENT_LIST_DIR}/code_tests/Sanitizers_fiber_test.cc _sanitizers_fiber_test_code)
+check_cxx_source_compiles ("${_sanitizers_fiber_test_code}" Sanitizers_FIBER_SUPPORT)
 cmake_pop_check_state()
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/modules/code_tests/Sanitizers_fiber_test.cc
+++ b/cmake/modules/code_tests/Sanitizers_fiber_test.cc
@@ -1,0 +1,11 @@
+#include <cstddef>
+
+extern "C" {
+    void __sanitizer_start_switch_fiber(void**, const void*, size_t);
+    void __sanitizer_finish_switch_fiber(void*, const void**, size_t*);
+}
+
+int main() {
+    __sanitizer_start_switch_fiber(nullptr, nullptr, 0);
+    __sanitizer_finish_switch_fiber(nullptr, nullptr, nullptr);
+}

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -809,7 +809,7 @@ seastar::future<MURef<MOSDMap>> OSDSingletonState::build_incremental_map_msg(
                             monc.get_fsid(),
                             osdmap->get_encoding_features()),
                           [this, &first, FNAME, last](unsigned int map_message_max,
-                                                      auto& m) {
+                                                      auto &m) {
     m->cluster_osdmap_trim_lower_bound = superblock.cluster_osdmap_trim_lower_bound;
     m->newest_map = superblock.get_newest_map();
     auto maybe_handle_mapgap = seastar::now();

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -808,7 +808,7 @@ seastar::future<MURef<MOSDMap>> OSDSingletonState::build_incremental_map_msg(
                           crimson::make_message<MOSDMap>(
                             monc.get_fsid(),
                             osdmap->get_encoding_features()),
-                          [this, &first, FNAME, last](unsigned int map_message_max,
+                          [this, &first, FNAME, last](auto &map_message_max,
                                                       auto &m) {
     m->cluster_osdmap_trim_lower_bound = superblock.cluster_osdmap_trim_lower_bound;
     m->newest_map = superblock.get_newest_map();


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55684

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

