### PR TITLE
squid: doc/crimson: cleanup duplicate seastore description

### DIFF
--- a/doc/dev/crimson/crimson.rst
+++ b/doc/dev/crimson/crimson.rst
@@ -195,9 +195,6 @@ The following options can be used with ``vstart.sh``.
     Valid types include ``HDD``, ``SSD``(default), ``ZNS``, and ``RANDOM_BLOCK_SSD``
     Note secondary devices should not be faster than the main device.
 
-``--seastore``
-    Use SeaStore as the object store backend.
-
 To start a cluster with a single Crimson node, run::
 
   $  MGR=1 MON=1 OSD=1 MDS=0 RGW=0 ../src/vstart.sh -n -x \


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55699

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

See: https://gist.github.com/Matan-B/3366024c130634942d0b1227112663e1 

