### PR TITLE
squid: crimson/osd/shard_services: make sure that only up/acting members can create pgs

### DIFF
--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -708,9 +708,9 @@ ShardServices::get_or_create_pg(
   std::unique_ptr<PGCreateInfo> info)
 {
   if (info) {
-    auto [fut, creating] = local_state.pg_map.wait_for_pg(
+    auto [fut, existed] = local_state.pg_map.wait_for_pg(
       std::move(trigger), pgid);
-    if (!creating) {
+    if (!existed) {
       local_state.pg_map.set_creating(pgid);
       (void)handle_pg_create_info(
 	std::move(info));


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55407

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh