### PR TITLE
squid: test/crimson/test_socket: complete write-side errors in test_unexpected_down()

### DIFF
--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -450,8 +450,11 @@ future<> test_unexpected_down(bool is_fixed_cpu) {
       return Connection::dispatch_rw_bounded(cs, 128, true
         ).handle_exception_type([](const std::system_error& e) {
         logger().error("test_unexpected_down(): client get error {}", e);
+        // union of errors from both read and write
+        // also see dispatch_write_unbounded() and dispatch_read_unbounded()
         ceph_assert(e.code() == error::read_eof ||
-		    e.code() == std::errc::connection_reset);
+		    e.code() == std::errc::connection_reset ||
+                    e.code() == std::errc::broken_pipe);
       });
     },
     [](auto ss) { return Connection::dispatch_rw_unbounded(ss); }


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55751

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh