### PR TITLE
mgr/smb: add custom config options to share and cluster resources

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -357,6 +357,21 @@ custom_dns
 placement
     Optional. A Ceph Orchestration :ref:`placement specifier
     <orchestrator-cli-placement-spec>`.  Defaults to one host if not provided
+custom_smb_share_options
+    Optional mapping. Specify key-value pairs that will be directly added to
+    the global ``smb.conf`` options (or equivalent) of a Samba server.  Do
+    *not* use this option unless you are prepared to debug the Samba instances
+    yourself.
+
+    This option is meant for developers, feature investigators, and other
+    advanced users to take more direct control of a share's options without
+    needing to make changes to the Ceph codebase. Entries in this map should
+    match parameters in ``smb.conf`` and their values. A special key
+    ``_allow_customization`` must appear somewhere in the mapping with the
+    value of ``i-take-responsibility-for-all-samba-configuration-errors`` as an
+    indicator that the user is aware that using this option can easily break
+    things in ways that the Ceph team can not help with. This special key will
+    automatically be removed from the list of options passed to Samba.
 
 
 .. _join-source-fields:
@@ -465,6 +480,20 @@ cephfs
     provider
         Optional. One of ``samba-vfs`` or ``kcephfs`` (``kcephfs`` is not yet
         supported) . Selects how CephFS storage should be provided to the share
+custom_smb_share_options
+    Optional mapping. Specify key-value pairs that will be directly added to
+    the ``smb.conf`` (or equivalent) of a Samba server.  Do *not* use this
+    option unless you are prepared to debug the Samba instances yourself.
+
+    This option is meant for developers, feature investigators, and other
+    advanced users to take more direct control of a share's options without
+    needing to make changes to the Ceph codebase. Entries in this map should
+    match parameters in ``smb.conf`` and their values. A special key
+    ``_allow_customization`` must appear somewhere in the mapping with the
+    value of ``i-take-responsibility-for-all-samba-configuration-errors`` as an
+    indicator that the user is aware that using this option can easily break
+    things in ways that the Ceph team can not help with. This special key will
+    automatically be removed from the list of options passed to Samba.
 
 The following is an example of a share:
 

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -6,7 +6,7 @@ import orchestrator
 from ceph.deployment.service_spec import PlacementSpec, SMBSpec
 from mgr_module import MgrModule, Option
 
-from . import cli, fs, handler, mon_store, rados_store, resources
+from . import cli, fs, handler, mon_store, rados_store, resources, results
 from .enums import AuthMode, JoinSourceType, UserGroupSourceType
 from .proto import AccessAuthorizer, Simplified
 
@@ -59,7 +59,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         )
 
     @cli.SMBCommand('apply', perm='rw')
-    def apply_resources(self, inbuf: str) -> handler.ResultGroup:
+    def apply_resources(self, inbuf: str) -> results.ResultGroup:
         """Create, update, or remove smb configuration resources based on YAML
         or JSON specs
         """
@@ -82,7 +82,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         define_user_pass: Optional[List[str]] = None,
         custom_dns: Optional[List[str]] = None,
         placement: Optional[str] = None,
-    ) -> handler.Result:
+    ) -> results.Result:
         """Create an smb cluster"""
         domain_settings = None
         user_group_settings = None
@@ -181,7 +181,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self._handler.apply(to_apply, create_only=True).squash(cluster)
 
     @cli.SMBCommand('cluster rm', perm='rw')
-    def cluster_rm(self, cluster_id: str) -> handler.Result:
+    def cluster_rm(self, cluster_id: str) -> results.Result:
         """Remove an smb cluster"""
         cluster = resources.RemovedCluster(cluster_id=cluster_id)
         return self._handler.apply([cluster]).one()
@@ -207,7 +207,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         share_name: str = '',
         subvolume: str = '',
         readonly: bool = False,
-    ) -> handler.Result:
+    ) -> results.Result:
         """Create an smb share"""
         share = resources.Share(
             cluster_id=cluster_id,
@@ -223,7 +223,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self._handler.apply([share], create_only=True).one()
 
     @cli.SMBCommand('share rm', perm='rw')
-    def share_rm(self, cluster_id: str, share_id: str) -> handler.Result:
+    def share_rm(self, cluster_id: str, share_id: str) -> results.Result:
         """Remove an smb share"""
         share = resources.RemovedShare(
             cluster_id=cluster_id, share_id=share_id

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -63,7 +63,14 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """Create, update, or remove smb configuration resources based on YAML
         or JSON specs
         """
-        return self._handler.apply(resources.load_text(inbuf))
+        try:
+            return self._handler.apply(resources.load_text(inbuf))
+        except resources.InvalidResourceError as err:
+            # convert the exception into a result and return it as the only
+            # item in the result group
+            return results.ResultGroup(
+                [results.InvalidResourceResult(err.resource_data, str(err))]
+            )
 
     @cli.SMBCommand('cluster ls', perm='r')
     def cluster_ls(self) -> List[str]:

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -32,6 +32,20 @@ def _present(data: Simplified) -> bool:
     return _get_intent(data) == Intent.PRESENT
 
 
+class InvalidResourceError(ValueError):
+    def __init__(self, msg: str, data: Simplified) -> None:
+        super().__init__(msg)
+        self.resource_data = data
+
+    @classmethod
+    def wrap(cls, err: Exception, data: Simplified) -> Exception:
+        if isinstance(err, ValueError) and not isinstance(
+            err, resourcelib.ResourceTypeError
+        ):
+            return cls(str(err), data)
+        return err
+
+
 class _RBase:
     # mypy doesn't currently (well?) support class decorators adding methods
     # so we use a base class to add this method to all our resource classes.
@@ -104,6 +118,7 @@ class RemovedShare(_RBase):
     @resourcelib.customize
     def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
         rc.on_condition(_removed)
+        rc.on_construction_error(InvalidResourceError.wrap)
         return rc
 
 
@@ -147,6 +162,7 @@ class Share(_RBase):
     @resourcelib.customize
     def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
         rc.on_condition(_present)
+        rc.on_construction_error(InvalidResourceError.wrap)
         return rc
 
 
@@ -226,6 +242,7 @@ class RemovedCluster(_RBase):
     @resourcelib.customize
     def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
         rc.on_condition(_removed)
+        rc.on_construction_error(InvalidResourceError.wrap)
         return rc
 
     def validate(self) -> None:
@@ -308,6 +325,7 @@ class Cluster(_RBase):
     @resourcelib.customize
     def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
         rc.on_condition(_present)
+        rc.on_construction_error(InvalidResourceError.wrap)
         return rc
 
 
@@ -332,6 +350,7 @@ class JoinAuth(_RBase):
     @resourcelib.customize
     def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
         rc.linked_to_cluster.quiet = True
+        rc.on_construction_error(InvalidResourceError.wrap)
         return rc
 
 
@@ -356,6 +375,7 @@ class UsersAndGroups(_RBase):
     @resourcelib.customize
     def _customize_resource(rc: resourcelib.Resource) -> resourcelib.Resource:
         rc.linked_to_cluster.quiet = True
+        rc.on_construction_error(InvalidResourceError.wrap)
         return rc
 
 

--- a/src/pybind/mgr/smb/results.py
+++ b/src/pybind/mgr/smb/results.py
@@ -56,6 +56,29 @@ class ErrorResult(Result, Exception):
         super().__init__(src, success=False, msg=msg, status=status)
 
 
+class InvalidResourceResult(Result):
+    def __init__(
+        self,
+        resource_data: Simplified,
+        msg: str = '',
+        status: Optional[Simplified] = None,
+    ) -> None:
+        self.resource_data = resource_data
+        self.success = False
+        self.msg = msg
+        self.status = status
+
+    def to_simplified(self) -> Simplified:
+        ds: Simplified = {}
+        ds['resource'] = self.resource_data
+        ds['success'] = self.success
+        if self.msg:
+            ds['msg'] = self.msg
+        if self.status:
+            ds.update(self.status)
+        return ds
+
+
 class ResultGroup:
     """Result of applying multiple smb resource updates to the system."""
 

--- a/src/pybind/mgr/smb/results.py
+++ b/src/pybind/mgr/smb/results.py
@@ -1,4 +1,4 @@
-from typing import Iterator, List, Optional
+from typing import Iterable, Iterator, List, Optional
 
 import errno
 
@@ -84,8 +84,10 @@ class ResultGroup:
 
     # Compatible with object formatter, thus suitable for being returned
     # directly to mgr module.
-    def __init__(self) -> None:
-        self._contents: List[Result] = []
+    def __init__(
+        self, initial_results: Optional[Iterable[Result]] = None
+    ) -> None:
+        self._contents: List[Result] = list(initial_results or [])
 
     def append(self, result: Result) -> None:
         self._contents.append(result)

--- a/src/pybind/mgr/smb/tests/test_validation.py
+++ b/src/pybind/mgr/smb/tests/test_validation.py
@@ -75,3 +75,38 @@ def test_valid_path(value, valid):
     else:
         with pytest.raises(ValueError):
             smb.validation.check_path(value)
+
+
+def _ovr(value):
+    value[
+        smb.validation.CUSTOM_CAUTION_KEY
+    ] = smb.validation.CUSTOM_CAUTION_VALUE
+    return value
+
+
+@pytest.mark.parametrize(
+    "value,errmatch",
+    [
+        ({"foo": "bar"}, "lack"),
+        (_ovr({"foo": "bar"}), ""),
+        (_ovr({"foo": "bar", "zip": "zap"}), ""),
+        (_ovr({"mod:foo": "bar", "zip": "zap"}), ""),
+        (_ovr({"foo\n": "bar"}), "newlines"),
+        (_ovr({"foo": "bar\n"}), "newlines"),
+        (_ovr({"[foo]": "bar\n"}), "brackets"),
+    ],
+)
+def test_check_custom_options(value, errmatch):
+    if not errmatch:
+        smb.validation.check_custom_options(value)
+    else:
+        with pytest.raises(ValueError, match=errmatch):
+            smb.validation.check_custom_options(value)
+
+
+def test_clean_custom_options():
+    orig = {'foo': 'bar', 'big': 'bad', 'bugs': 'bongo'}
+    updated = _ovr(dict(orig))
+    smb.validation.check_custom_options(updated)
+    assert smb.validation.clean_custom_options(updated) == orig
+    assert smb.validation.clean_custom_options(None) is None


### PR DESCRIPTION
Depends on #57293

Allow devs/testers/experimenters to add custom smb config params to our    managed shares or clusters. Use at your own risk.

Custom parameter dictionaries will be used to pass options to samba
    config without much filtering and control by the smb mgr module. Because
    the risks that it entails the user must "agree" that using these options
    can break their setup with a "magic" key-value pair.
    This pair will be filtered out of the eventual data passed to samba.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] Manually tested only. This is meant for custom hacks anyway.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
