### PR TITLE
squid:osd/scrub: reinstate scrub reservation queuing

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -528,7 +528,7 @@ options:
     either success or failure (the pre-Squid version behaviour). This configuration
     option is introduced to support mixed-version clusters and debugging, and will
     be removed in the next release.
-  default: true
+  default: false
   with_legacy: false
 # where rados plugins are stored
 - name: osd_class_dir


### PR DESCRIPTION
Re-enabling the Reserver-based scrub queuing (undoing https://github.com/ceph/ceph/pull/56750),
as all known issues related to the reservation queuing have been fixed and back-ported.
