### PR TITLE
squid: doc/dev/crimson: add Code Walkthroughs

### DIFF
--- a/doc/dev/crimson/crimson.rst
+++ b/doc/dev/crimson/crimson.rst
@@ -475,3 +475,10 @@ addresses in the backtrace::
   [root@3deb50a8ad51 ~]# dnf install -q -y file
   [root@3deb50a8ad51 ~]# python3 seastar-addr2line -e /usr/bin/crimson-osd
   # paste the backtrace here
+
+Code Walkthroughs
+=================
+
+* `Ceph Code Walkthroughs: Crimson <https://www.youtube.com/watch?v=rtkrHk6grsg>`_
+
+* `Ceph Code Walkthroughs: SeaStore <https://www.youtube.com/watch?v=0rr5oWDE2Ck>`_


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56027

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh