### PR TITLE
squid: crimson/os/seastore: cleanup and use LBAMapping::is_stable()

### DIFF
--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -433,8 +433,7 @@ public:
     ceph_assert(total_remap_len < original_len);
 #endif
 
-    // FIXME: paddr can be absolute and pending
-    ceph_assert(pin->get_val().is_absolute());
+    // The according extent might be stable or pending.
     return cache->get_extent_if_cached(
       t, pin->get_val(), T::TYPE
     ).si_then([this, &t, remaps,

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -657,10 +657,9 @@ TEST_P(object_data_handler_test_t, multiple_remap) {
   run_async([this] {
     multiple_write();
     auto pins = get_mappings(0, 128<<10);
-    EXPECT_EQ(pins.size(), 10);
+    EXPECT_EQ(pins.size(), 3);
 
-    size_t res[10] = {0, 4<<10, 12<<10, 20<<10, 32<<10,
-		      36<<10, 60<<10, 96<<10, 120<<10, 124<<10};
+    size_t res[3] = {0, 120<<10, 124<<10};
     auto base = pins.front()->get_key();
     int i = 0;
     for (auto &pin : pins) {


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55888

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh