### PR TITLE
bluestore: No extra files in osd_path directory

### DIFF
--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -200,7 +200,6 @@ public:
 
   static BlockDevice *create(
     CephContext* cct, const std::string& path, aio_callback_t cb, void *cbpriv, aio_callback_t d_cb, void *d_cbpriv);
-  virtual bool supported_bdev_label() { return true; }
   virtual bool is_rotational() { return rotational; }
 
   // HM-SMR-specific calls

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -216,6 +216,7 @@ int KernelDevice::open(const string& p)
     if (r < 0) {
       derr << __func__ << " failed to lock " << path << ": " << cpp_strerror(r)
 	   << dendl;
+      r = -EBUSY;
       goto out_fail;
     }
   }

--- a/src/blk/pmem/PMEMDevice.h
+++ b/src/blk/pmem/PMEMDevice.h
@@ -41,7 +41,6 @@ class PMEMDevice : public BlockDevice {
 public:
   PMEMDevice(CephContext *cct, aio_callback_t cb, void *cbpriv);
 
-  bool supported_bdev_label() override { return !devdax_device; }
   void aio_submit(IOContext *ioc) override;
 
   int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const override;

--- a/src/blk/spdk/NVMEDevice.h
+++ b/src/blk/spdk/NVMEDevice.h
@@ -52,8 +52,6 @@ class NVMEDevice : public BlockDevice {
 
   NVMEDevice(CephContext* cct, aio_callback_t cb, void *cbpriv);
 
-  bool supported_bdev_label() override { return false; }
-
   static bool support(const std::string& path);
 
   void aio_submit(IOContext *ioc) override;

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -117,6 +117,25 @@ static void usage()
   generic_server_usage();
 }
 
+int key_from_objectstore() {
+  std::string data_path = g_conf().get_val<std::string>("osd_data");
+  std::string store_type;
+  bool detected = ObjectStore::probe_objectstore_type(g_ceph_context, data_path, &store_type);
+  if (!detected) {
+    return -ENOENT;
+  }
+  std::unique_ptr<ObjectStore> store = ObjectStore::create(
+    g_ceph_context, store_type, data_path, std::string(), 0);
+  if (!store) {
+    return -EINVAL;
+  }
+  if (std::string osd_key; 0 == store->read_meta("osd_key", &osd_key)) {
+    g_conf().set_val("key", osd_key, nullptr);
+    ldout(g_ceph_context, 2) << "Retrieved osd_key=" << osd_key << dendl;
+  }
+  return 0;
+};
+
 int main(int argc, const char **argv)
 {
   auto args = argv_to_vec(argc, argv);
@@ -128,12 +147,9 @@ int main(int argc, const char **argv)
     usage();
     exit(0);
   }
-
-  auto cct = global_init(
-    nullptr,
+  global_pre_init(nullptr,
     args, CEPH_ENTITY_TYPE_OSD,
     CODE_ENVIRONMENT_DAEMON, 0);
-  ceph_heap_profiler_init();
 
   Preforker forker;
 
@@ -198,6 +214,15 @@ int main(int argc, const char **argv)
     cerr << "unrecognized arg " << args[0] << std::endl;
     exit(1);
   }
+
+  if (!mkfs && g_conf().get_val<bool>("osd_key_from_objectstore")) {
+    key_from_objectstore();
+  }
+  auto cct = global_init(
+    nullptr,
+    args, CEPH_ENTITY_TYPE_OSD,
+    CODE_ENVIRONMENT_DAEMON, 0, false);
+  ceph_heap_profiler_init();
 
   if (global_init_prefork(g_ceph_context) >= 0) {
     std::string err;

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -1420,3 +1420,11 @@ options:
   level: dev
   default: true
   with_legacy: true
+- name: osd_key_from_objectstore
+  type: bool
+  level: advanced
+  desc: Extract CephX authentication key from objectstore osd_key meta variable.
+  see_also:
+  - key
+  default: true
+  with_legacy: false

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -103,6 +103,10 @@ public:
     const std::string& path,
     uuid_d *fsid);
 
+  static bool probe_objectstore_type(
+    CephContext *cct,
+    const std::string& path,
+    std::string *store_type);
   /**
    * Fetch Object Store statistics.
    *

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -532,13 +532,6 @@ int BlueFS::add_block_device(unsigned id, const string& path, bool trim,
   return 0;
 }
 
-bool BlueFS::bdev_support_label(unsigned id)
-{
-  ceph_assert(id < bdev.size());
-  ceph_assert(bdev[id]);
-  return bdev[id]->supported_bdev_label();
-}
-
 uint64_t BlueFS::get_block_device_size(unsigned id) const
 {
   if (id < bdev.size() && bdev[id])

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -741,7 +741,6 @@ public:
 
   int add_block_device(unsigned bdev, const std::string& path, bool trim,
 		       bluefs_shared_alloc_context_t* _shared_alloc = nullptr);
-  bool bdev_support_label(unsigned id);
   uint64_t get_block_device_size(unsigned bdev) const;
 
   // handler for discard event

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8044,22 +8044,6 @@ int BlueStore::mkfs()
       return r; // idempotent
     }
   }
-
-  {
-    string type;
-    r = read_meta("type", &type);
-    if (r == 0) {
-      if (type != "bluestore") {
-	derr << __func__ << " expected bluestore, but type is " << type << dendl;
-	return -EIO;
-      }
-    } else {
-      r = write_meta("type", "bluestore");
-      if (r < 0)
-        return r;
-    }
-  }
-
   r = _open_path();
   if (r < 0)
     return r;
@@ -8108,11 +8092,14 @@ int BlueStore::mkfs()
     if (r < 0)
       goto out_close_fsid;
   }
-
   r = _open_bdev(true);
   if (r < 0)
     goto out_close_fsid;
-
+  {
+    r = write_meta("type", "bluestore");
+    if (r < 0)
+      return r;
+  }
   freelist_type = "bitmap";
   dout(10) << " freelist_type " << freelist_type << dendl;
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6636,11 +6636,9 @@ int BlueStore::_open_bdev(bool create)
     bdev->try_discard(whole_device, false);
   }
 
-  if (bdev->supported_bdev_label()) {
-    r = _check_or_set_bdev_label(p, bdev->get_size(), "main", create);
-    if (r < 0)
-      goto fail_close;
-  }
+  r = _check_or_set_bdev_label(p, bdev->get_size(), "main", create);
+  if (r < 0)
+    goto fail_close;
 
   // initialize global block parameters
   block_size = bdev->get_block_size();
@@ -7162,17 +7160,15 @@ int BlueStore::_minimal_open_bluefs(bool create)
       goto free_bluefs;
     }
 
-    if (bluefs->bdev_support_label(BlueFS::BDEV_DB)) {
-      r = _check_or_set_bdev_label(
-	bfn,
-	bluefs->get_block_device_size(BlueFS::BDEV_DB),
-        "bluefs db", create);
-      if (r < 0) {
-        derr << __func__
-	      << " check block device(" << bfn << ") label returned: "
-              << cpp_strerror(r) << dendl;
-        goto free_bluefs;
-      }
+    r = _check_or_set_bdev_label(
+      bfn,
+      bluefs->get_block_device_size(BlueFS::BDEV_DB),
+      "bluefs db", create);
+    if (r < 0) {
+      derr << __func__
+           << " check block device(" << bfn << ") label returned: "
+           << cpp_strerror(r) << dendl;
+      goto free_bluefs;
     }
     bluefs_layout.shared_bdev = BlueFS::BDEV_SLOW;
     bluefs_layout.dedicated_db = true;
@@ -7209,16 +7205,14 @@ int BlueStore::_minimal_open_bluefs(bool create)
       goto free_bluefs;
     }
 
-    if (bluefs->bdev_support_label(BlueFS::BDEV_WAL)) {
-      r = _check_or_set_bdev_label(
-	bfn,
-	bluefs->get_block_device_size(BlueFS::BDEV_WAL),
-        "bluefs wal", create);
-      if (r < 0) {
-        derr << __func__ << " check block device(" << bfn
-              << ") label returned: " << cpp_strerror(r) << dendl;
-        goto free_bluefs;
-      }
+    r = _check_or_set_bdev_label(
+      bfn,
+      bluefs->get_block_device_size(BlueFS::BDEV_WAL),
+      "bluefs wal", create);
+    if (r < 0) {
+      derr << __func__ << " check block device(" << bfn
+           << ") label returned: " << cpp_strerror(r) << dendl;
+      goto free_bluefs;
     }
 
     bluefs_layout.dedicated_wal = true;
@@ -8295,14 +8289,12 @@ int BlueStore::add_new_bluefs_device(int id, const string& dev_path)
 				 cct->_conf->bdev_enable_discard);
     ceph_assert(r == 0);
 
-    if (bluefs->bdev_support_label(BlueFS::BDEV_NEWWAL)) {
-      r = _check_or_set_bdev_label(
-	p,
-	bluefs->get_block_device_size(BlueFS::BDEV_NEWWAL),
-        "bluefs wal",
-	true);
-      ceph_assert(r == 0);
-    }
+    r = _check_or_set_bdev_label(
+      p,
+      bluefs->get_block_device_size(BlueFS::BDEV_NEWWAL),
+      "bluefs wal",
+      true);
+    ceph_assert(r == 0);
 
     bluefs_layout.dedicated_wal = true;
   } else if (id == BlueFS::BDEV_NEWDB) {
@@ -8316,14 +8308,12 @@ int BlueStore::add_new_bluefs_device(int id, const string& dev_path)
 				 cct->_conf->bdev_enable_discard);
     ceph_assert(r == 0);
 
-    if (bluefs->bdev_support_label(BlueFS::BDEV_NEWDB)) {
-      r = _check_or_set_bdev_label(
-	p,
-	bluefs->get_block_device_size(BlueFS::BDEV_NEWDB),
-        "bluefs db",
-	true);
-      ceph_assert(r == 0);
-    }
+    r = _check_or_set_bdev_label(
+      p,
+      bluefs->get_block_device_size(BlueFS::BDEV_NEWDB),
+      "bluefs db",
+      true);
+    ceph_assert(r == 0);
     bluefs_layout.shared_bdev = BlueFS::BDEV_SLOW;
     bluefs_layout.dedicated_db = true;
   }
@@ -8445,14 +8435,12 @@ int BlueStore::migrate_to_new_bluefs_device(const set<int>& devs_source,
 				 cct->_conf->bdev_enable_discard);
     ceph_assert(r == 0);
 
-    if (bluefs->bdev_support_label(BlueFS::BDEV_NEWWAL)) {
-      r = _check_or_set_bdev_label(
-	dev_path,
-	bluefs->get_block_device_size(BlueFS::BDEV_NEWWAL),
-        "bluefs wal",
-	true);
-      ceph_assert(r == 0);
-    }
+    r = _check_or_set_bdev_label(
+      dev_path,
+      bluefs->get_block_device_size(BlueFS::BDEV_NEWWAL),
+      "bluefs wal",
+      true);
+    ceph_assert(r == 0);
   } else if (id == BlueFS::BDEV_NEWDB) {
     target_name = "block.db";
     target_size = cct->_conf->bluestore_block_db_size;
@@ -8463,14 +8451,12 @@ int BlueStore::migrate_to_new_bluefs_device(const set<int>& devs_source,
 				 cct->_conf->bdev_enable_discard);
     ceph_assert(r == 0);
 
-    if (bluefs->bdev_support_label(BlueFS::BDEV_NEWDB)) {
-      r = _check_or_set_bdev_label(
-	dev_path,
-	bluefs->get_block_device_size(BlueFS::BDEV_NEWDB),
-        "bluefs db",
-	true);
-      ceph_assert(r == 0);
-    }
+    r = _check_or_set_bdev_label(
+      dev_path,
+      bluefs->get_block_device_size(BlueFS::BDEV_NEWDB),
+      "bluefs db",
+      true);
+    ceph_assert(r == 0);
   }
 
   bluefs->umount();
@@ -8568,12 +8554,10 @@ int BlueStore::expand_devices(ostream& out)
 	    <<": can't find device path " << dendl;
       continue;
     }
-    if (bluefs->bdev_support_label(devid)) {
-      if (_set_bdev_label_size(p, size) >= 0) {
-        out << devid
+    if (_set_bdev_label_size(p, size) >= 0) {
+      out << devid
           << " : size label updated to " << size
           << std::endl;
-      }
     }
   }
   uint64_t size0 = fm->get_size();
@@ -8583,12 +8567,10 @@ int BlueStore::expand_devices(ostream& out)
       << " : expanding " << " from 0x" << std::hex
       << size0 << " to 0x" << size << std::dec << std::endl;
     _write_out_fm_meta(size);
-    if (bdev->supported_bdev_label()) {
-      if (_set_bdev_label_size(path, size) >= 0) {
-        out << bluefs_layout.shared_bdev
-          << " : size label updated to " << size
-          << std::endl;
-      }
+    if (_set_bdev_label_size(path, size) >= 0) {
+      out << bluefs_layout.shared_bdev
+        << " : size label updated to " << size
+        << std::endl;
     }
     _close_db_and_around();
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5994,16 +5994,15 @@ int BlueStore::_set_cache_sizes()
 
 int BlueStore::write_meta(const std::string& key, const std::string& value)
 {
+  dout(5) << __func__ << " key=" << key << " value=" << value << dendl;
   bluestore_bdev_label_t label;
   string p = path + "/block";
   int r = _read_bdev_label(cct, p, &label);
-  if (r < 0) {
-    return ObjectStore::write_meta(key, value);
-  }
+  ceph_assert(r == 0);
   label.meta[key] = value;
   r = _write_bdev_label(cct, p, label);
   ceph_assert(r == 0);
-  return ObjectStore::write_meta(key, value);
+  return 0;
 }
 
 int BlueStore::read_meta(const std::string& key, std::string *value)
@@ -6011,12 +6010,12 @@ int BlueStore::read_meta(const std::string& key, std::string *value)
   bluestore_bdev_label_t label;
   string p = path + "/block";
   int r = _read_bdev_label(cct, p, &label);
-  if (r < 0) {
-    return ObjectStore::read_meta(key, value);
+  if (r != 0) {
+    return r;
   }
   auto i = label.meta.find(key);
   if (i == label.meta.end()) {
-    return ObjectStore::read_meta(key, value);
+    return -ENOENT;
   }
   *value = i->second;
   return 0;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2697,11 +2697,7 @@ private:
 
   int _open_path();
   void _close_path();
-  int _open_fsid(bool create);
-  int _lock_fsid();
   int _read_fsid(uuid_d *f);
-  int _write_fsid();
-  void _close_fsid();
   void _set_alloc_sizes();
   void _set_blob_size();
   void _set_finisher_num();

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1205,11 +1205,6 @@ EOF
             prun $SUDO $CEPH_BIN/$ceph_osd $extra_osd_args -i $osd $ARGS --mkfs --key $OSD_SECRET --osd-uuid $uuid $extra_seastar_args \
                 2>&1 | tee $CEPH_OUT_DIR/osd-mkfs.$osd.log
 
-            local key_fn=$CEPH_DEV_DIR/osd$osd/keyring
-            cat > $key_fn<<EOF
-[osd.$osd]
-        key = $OSD_SECRET
-EOF
         fi
         echo start osd.$osd
         local osd_pid


### PR DESCRIPTION
Disables creation and use of files in osd_path directory.
No meta values set and persisted in superlabel block are mirrored to files.
No keyring file - key is read directly from objectstore.
No fsid file - fsid is read from superlabel block, and locking is done via bdev exclusive locking.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
