### PR TITLE
squid: crimson/os/seastore: cleanups around lba parent-child pointer

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -579,12 +579,12 @@ public:
           if constexpr (
             std::is_base_of_v<typename internal_node_t::base_t, child_node_t>)
           {
-            assert(!c.cache.query_cache(i->get_val(), nullptr));
+            assert(!c.cache.test_query_cache(i->get_val()));
           } else {
             if constexpr (leaf_has_children) {
               assert(i->get_val().pladdr.is_paddr()
-                ? (bool)!c.cache.query_cache(
-                    i->get_val().pladdr.get_paddr(), nullptr)
+                ? (bool)!c.cache.test_query_cache(
+                    i->get_val().pladdr.get_paddr())
                 : true);
             }
           }

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -430,6 +430,8 @@ struct FixedKVNode : ChildableCachedExtent {
 	// the foreign key is preserved
 	if (!child) {
 	  child = source.children[foreign_it.get_offset()];
+	  // child can be either valid if present, nullptr if absent,
+	  // or RESERVATION_PTR.
 	}
 	foreign_it++;
 	local_it++;

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1850,7 +1850,7 @@ Cache::replay_delta(
     };
     auto extent_fut = (delta.pversion == 0 ?
       // replay is not included by the cache hit metrics
-      _get_extent_by_type(
+      do_get_caching_extent_by_type(
         delta.type,
         delta.paddr,
         delta.laddr,
@@ -2012,7 +2012,8 @@ Cache::get_root_ret Cache::get_root(Transaction &t)
   }
 }
 
-Cache::get_extent_ertr::future<CachedExtentRef> Cache::_get_extent_by_type(
+Cache::get_extent_ertr::future<CachedExtentRef>
+Cache::do_get_caching_extent_by_type(
   extent_types_t type,
   paddr_t offset,
   laddr_t laddr,
@@ -2034,55 +2035,55 @@ Cache::get_extent_ertr::future<CachedExtentRef> Cache::_get_extent_by_type(
       ceph_assert(0 == "ROOT is never directly read");
       return get_extent_ertr::make_ready_future<CachedExtentRef>();
     case extent_types_t::BACKREF_INTERNAL:
-      return get_extent<backref::BackrefInternalNode>(
+      return do_get_caching_extent<backref::BackrefInternalNode>(
 	offset, length, p_metric_key, std::move(extent_init_func), std::move(on_cache)
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::BACKREF_LEAF:
-      return get_extent<backref::BackrefLeafNode>(
+      return do_get_caching_extent<backref::BackrefLeafNode>(
 	offset, length, p_metric_key, std::move(extent_init_func), std::move(on_cache)
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::LADDR_INTERNAL:
-      return get_extent<lba_manager::btree::LBAInternalNode>(
+      return do_get_caching_extent<lba_manager::btree::LBAInternalNode>(
 	offset, length, p_metric_key, std::move(extent_init_func), std::move(on_cache)
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::LADDR_LEAF:
-      return get_extent<lba_manager::btree::LBALeafNode>(
+      return do_get_caching_extent<lba_manager::btree::LBALeafNode>(
 	offset, length, p_metric_key, std::move(extent_init_func), std::move(on_cache)
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::OMAP_INNER:
-      return get_extent<omap_manager::OMapInnerNode>(
+      return do_get_caching_extent<omap_manager::OMapInnerNode>(
           offset, length, p_metric_key, std::move(extent_init_func), std::move(on_cache)
       ).safe_then([](auto extent) {
         return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::OMAP_LEAF:
-      return get_extent<omap_manager::OMapLeafNode>(
+      return do_get_caching_extent<omap_manager::OMapLeafNode>(
           offset, length, p_metric_key, std::move(extent_init_func), std::move(on_cache)
       ).safe_then([](auto extent) {
         return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::COLL_BLOCK:
-      return get_extent<collection_manager::CollectionNode>(
+      return do_get_caching_extent<collection_manager::CollectionNode>(
           offset, length, p_metric_key, std::move(extent_init_func), std::move(on_cache)
       ).safe_then([](auto extent) {
         return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::ONODE_BLOCK_STAGED:
-      return get_extent<onode::SeastoreNodeExtent>(
+      return do_get_caching_extent<onode::SeastoreNodeExtent>(
           offset, length, p_metric_key, std::move(extent_init_func), std::move(on_cache)
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::OBJECT_DATA_BLOCK:
-      return get_extent<ObjectDataBlock>(
+      return do_get_caching_extent<ObjectDataBlock>(
           offset, length, p_metric_key, std::move(extent_init_func), std::move(on_cache)
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
@@ -2091,13 +2092,13 @@ Cache::get_extent_ertr::future<CachedExtentRef> Cache::_get_extent_by_type(
       ceph_assert(0 == "impossible");
       return get_extent_ertr::make_ready_future<CachedExtentRef>();
     case extent_types_t::TEST_BLOCK:
-      return get_extent<TestBlock>(
+      return do_get_caching_extent<TestBlock>(
           offset, length, p_metric_key, std::move(extent_init_func), std::move(on_cache)
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::TEST_BLOCK_PHYSICAL:
-      return get_extent<TestBlockPhysical>(
+      return do_get_caching_extent<TestBlockPhysical>(
           offset, length, p_metric_key, std::move(extent_init_func), std::move(on_cache)
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -600,6 +600,12 @@ public:
     return epm.get_block_size();
   }
 
+// Interfaces only for tests.
+public:
+  CachedExtentRef test_query_cache(paddr_t offset) {
+    return query_cache(offset, nullptr);
+  }
+
 private:
   // This is a workaround std::move_only_function not being available,
   // not really worth generalizing at this time.
@@ -1732,16 +1738,6 @@ private:
       return CachedExtentRef();
     }
   }
-
-  template <
-    typename node_key_t,
-    typename node_val_t,
-    typename internal_node_t,
-    typename leaf_node_t,
-    typename pin_t,
-    size_t node_size,
-    bool leaf_has_children>
-  friend class FixedKVBtree;
 };
 using CacheRef = std::unique_ptr<Cache>;
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1343,6 +1343,7 @@ public:
     return stats.omap_tree_depth;
   }
 
+private:
   /// Update lru for access to ref
   void touch_extent(
       CachedExtent &ext,
@@ -1355,7 +1356,6 @@ public:
     }
   }
 
-private:
   ExtentPlacementManager& epm;
   RootBlockRef root;               ///< ref to current root
   ExtentIndex extents;             ///< set of live extents

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -449,6 +449,7 @@ public:
     Transaction &t,
     CachedExtentRef extent)
   {
+    assert(extent->is_valid());
     auto p_extent = extent->get_transactional_view(t);
     if (!p_extent->is_pending_in_trans(t.get_trans_id())) {
       t.add_to_read_set(p_extent);

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1244,8 +1244,6 @@ public:
 
   std::ostream &_print_detail(std::ostream &out) const final;
 
-  void on_replace_prior(Transaction &t) final;
-
   struct modified_region_t {
     extent_len_t offset;
     extent_len_t len;
@@ -1257,9 +1255,12 @@ public:
   virtual void clear_modified_region() {}
 
   virtual ~LogicalCachedExtent();
+
 protected:
+  void on_replace_prior(Transaction &t) final;
 
   virtual void apply_delta(const ceph::bufferlist &bl) = 0;
+
   virtual std::ostream &print_detail_l(std::ostream &out) const {
     return out;
   }

--- a/src/crimson/os/seastore/root_block.cc
+++ b/src/crimson/os/seastore/root_block.cc
@@ -10,16 +10,22 @@ namespace crimson::os::seastore {
 void RootBlock::on_replace_prior(Transaction &t) {
   if (!lba_root_node) {
     auto &prior = static_cast<RootBlock&>(*get_prior_instance());
-    lba_root_node = prior.lba_root_node;
-    if (lba_root_node) {
-      ((lba_manager::btree::LBANode*)lba_root_node)->root_block = this;
+    if (prior.lba_root_node) {
+      RootBlockRef this_ref = this;
+      link_phy_tree_root_node(
+        this_ref,
+        static_cast<lba_manager::btree::LBANode*>(prior.lba_root_node)
+      );
     }
   }
   if (!backref_root_node) {
     auto &prior = static_cast<RootBlock&>(*get_prior_instance());
-    backref_root_node = prior.backref_root_node;
-    if (backref_root_node) {
-      ((backref::BackrefNode*)backref_root_node)->root_block = this;
+    if (prior.backref_root_node) {
+      RootBlockRef this_ref = this;
+      link_phy_tree_root_node(
+        this_ref,
+        static_cast<backref::BackrefNode*>(prior.backref_root_node)
+      );
     }
   }
 }

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -425,12 +425,17 @@ public:
     for (auto &remap : remaps) {
       auto remap_offset = remap.offset;
       auto remap_len = remap.len;
+      assert(remap_len > 0);
       total_remap_len += remap.len;
-      ceph_assert(remap_offset >= (last_offset + last_len));
+      assert(remap_offset >= (last_offset + last_len));
       last_offset = remap_offset;
       last_len = remap_len;
     }
-    ceph_assert(total_remap_len < original_len);
+    if (remaps.size() == 1) {
+      assert(total_remap_len < original_len);
+    } else {
+      assert(total_remap_len <= original_len);
+    }
 #endif
 
     // FIXME: paddr can be absolute and pending

--- a/src/test/crimson/seastore/test_seastore.cc
+++ b/src/test/crimson/seastore/test_seastore.cc
@@ -794,26 +794,20 @@ TEST_P(seastore_test_t, clone_aligned_extents)
     test_obj.write(*sharded_seastore, 0, 4096, 'a');
 
     test_obj.clone(*sharded_seastore, 10);
-    std::cout << "reading origin after clone10" << std::endl;
     test_obj.read(*sharded_seastore, 0, 4096);
     test_obj.write(*sharded_seastore, 0, 4096, 'b');
     test_obj.write(*sharded_seastore, 4096, 4096, 'c');
-    std::cout << "reading origin after clone10 and write" << std::endl;
     test_obj.read(*sharded_seastore, 0, 8192);
     auto clone_obj10 = test_obj.get_clone(10);
-    std::cout << "reading clone after clone10 and write" << std::endl;
     clone_obj10.read(*sharded_seastore, 0, 8192);
 
     test_obj.clone(*sharded_seastore, 20);
-    std::cout << "reading origin after clone20" << std::endl;
     test_obj.read(*sharded_seastore, 0, 4096);
     test_obj.write(*sharded_seastore, 0, 4096, 'd');
     test_obj.write(*sharded_seastore, 4096, 4096, 'e');
     test_obj.write(*sharded_seastore, 8192, 4096, 'f');
-    std::cout << "reading origin after clone20 and write" << std::endl;
     test_obj.read(*sharded_seastore, 0, 12288);
     auto clone_obj20 = test_obj.get_clone(20);
-    std::cout << "reading clone after clone20 and write" << std::endl;
     clone_obj10.read(*sharded_seastore, 0, 12288);
     clone_obj20.read(*sharded_seastore, 0, 12288);
   });
@@ -829,31 +823,25 @@ TEST_P(seastore_test_t, clone_unaligned_extents)
 
     test_obj.clone(*sharded_seastore, 10);
     test_obj.write(*sharded_seastore, 4096, 12288, 'd');
-    std::cout << "reading origin after clone10 and write" << std::endl;
     test_obj.read(*sharded_seastore, 0, 24576);
 
     auto clone_obj10 = test_obj.get_clone(10);
-    std::cout << "reading clone after clone10 and write" << std::endl;
     clone_obj10.read(*sharded_seastore, 0, 24576);
 
     test_obj.clone(*sharded_seastore, 20);
     test_obj.write(*sharded_seastore, 8192, 12288, 'e');
-    std::cout << "reading origin after clone20 and write" << std::endl;
     test_obj.read(*sharded_seastore, 0, 24576);
 
     auto clone_obj20 = test_obj.get_clone(20);
-    std::cout << "reading clone after clone20 and write" << std::endl;
     clone_obj10.read(*sharded_seastore, 0, 24576);
     clone_obj20.read(*sharded_seastore, 0, 24576);
 
     test_obj.write(*sharded_seastore, 0, 24576, 'f');
     test_obj.clone(*sharded_seastore, 30);
     test_obj.write(*sharded_seastore, 8192, 4096, 'g');
-    std::cout << "reading origin after clone30 and write" << std::endl;
     test_obj.read(*sharded_seastore, 0, 24576);
 
     auto clone_obj30 = test_obj.get_clone(30);
-    std::cout << "reading clone after clone30 and write" << std::endl;
     clone_obj10.read(*sharded_seastore, 0, 24576);
     clone_obj20.read(*sharded_seastore, 0, 24576);
     clone_obj30.read(*sharded_seastore, 0, 24576);
@@ -909,7 +897,6 @@ TEST_P(seastore_test_t, attr)
     EXPECT_EQ(attrs.find(SS_ATTR), attrs.end());
     EXPECT_EQ(attrs.find("test_key"), attrs.end());
 
-    std::cout << "test_key passed" << std::endl;
     //create OI_ATTR with len > onode_layout_t::MAX_OI_LENGTH, rm OI_ATTR
     //create SS_ATTR with len > onode_layout_t::MAX_SS_LENGTH, rm SS_ATTR
     char oi_array[onode_layout_t::MAX_OI_LENGTH + 1] = {'a'};

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -76,7 +76,7 @@ struct cache_test_t : public seastar_test_suite_t {
     return with_trans_intr(
       t,
       [this](auto &&... args) {
-	return cache->get_extent<T>(args...);
+	return cache->get_caching_extent<T>(args...);
       },
       std::forward<Args>(args)...);
   }

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -1723,7 +1723,6 @@ TEST_P(tm_random_block_device_test_t, scatter_allocation)
     auto t = create_transaction();
     for (int i = 0; i < 1991; i++) {
       auto extents = alloc_extents(t, ADDR + i * 16384, 16384, 'a');
-      std::cout << "num of extents: " << extents.size() << std::endl;
     }
     alloc_extents_deemed_fail(t, ADDR + 1991 * 16384, 16384, 'a');
     check_mappings(t);


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56028

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh