### PR TITLE
squid: crimson/os/seastore/collection_manager: allow empty-delta-buffer collection nodes

### DIFF
--- a/src/crimson/os/seastore/collection_manager/collection_flat_node.h
+++ b/src/crimson/os/seastore/collection_manager/collection_flat_node.h
@@ -153,10 +153,19 @@ struct CollectionNode
   }
 
   ceph::bufferlist get_delta() final {
-    assert(!delta_buffer.empty());
     ceph::bufferlist bl;
-    encode(delta_buffer, bl);
-    delta_buffer.clear();
+    // FIXME: CollectionNodes are always first mutated and
+    // 	      then checked whether they have enough space,
+    // 	      and if not, new ones will be created and the
+    // 	      mutation_pending ones are left untouched.
+    //
+    // 	      The above order should be reversed, nodes should
+    // 	      be mutated only if there are enough space for new
+    // 	      entries.
+    if (!delta_buffer.empty()) {
+      encode(delta_buffer, bl);
+      delta_buffer.clear();
+    }
     return bl;
   }
 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55981

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh