### PR TITLE
squid: crimson/os/alienstore: use homebrew counting_semaphore

### DIFF
--- a/src/crimson/os/alienstore/thread_pool.h
+++ b/src/crimson/os/alienstore/thread_pool.h
@@ -15,14 +15,10 @@
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
 
-#if __cplusplus > 201703L
-#include <semaphore>
-namespace crimson {
-  using std::counting_semaphore;
-}
-#else
+// std::counting_semaphore is buggy in libstdc++-11
+// (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104928),
+// so we switch back to the homebrew version for now.
 #include "semaphore.h"
-#endif
 
 namespace crimson::os {
 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55801

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh