### PR TITLE
squid: crimson/osd: put snapmapper's key-value pairs into dedicated objs

### DIFF
--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -136,6 +136,19 @@ seastar::future<> AlienStore::stop()
   });
 }
 
+AlienStore::base_errorator::future<bool>
+AlienStore::exists(
+  CollectionRef ch,
+  const ghobject_t& oid)
+{
+  return seastar::with_gate(op_gate, [=, this] {
+    return tp->submit(ch->get_cid().hash_to_shard(tp->size()), [=, this] {
+      auto c = static_cast<AlienCollection*>(ch.get());
+      return store->exists(c->collection, oid);
+    });
+  });
+}
+
 AlienStore::mount_ertr::future<> AlienStore::mount()
 {
   logger().debug("{}", __func__);

--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -33,6 +33,9 @@ public:
   mount_ertr::future<> mount() final;
   seastar::future<> umount() final;
 
+  base_errorator::future<bool> exists(
+    CollectionRef c,
+    const ghobject_t& oid) final;
   mkfs_ertr::future<> mkfs(uuid_d new_osd_fsid) final;
   read_errorator::future<ceph::bufferlist> read(CollectionRef c,
                                    const ghobject_t& oid,

--- a/src/crimson/os/cyanstore/cyan_store.cc
+++ b/src/crimson/os/cyanstore/cyan_store.cc
@@ -242,6 +242,22 @@ CyanStore::Shard::list_collections()
   return seastar::make_ready_future<std::vector<coll_core_t>>(std::move(collections));
 }
 
+CyanStore::Shard::base_errorator::future<bool>
+CyanStore::Shard::exists(
+  CollectionRef ch,
+  const ghobject_t &oid)
+{
+  auto c = static_cast<Collection*>(ch.get());
+  if (!c->exists) {
+    return base_errorator::make_ready_future<bool>(false);
+  }
+  auto o = c->get_object(oid);
+  if (!o) {
+    return base_errorator::make_ready_future<bool>(false);
+  }
+  return base_errorator::make_ready_future<bool>(true);
+}
+
 CyanStore::Shard::read_errorator::future<ceph::bufferlist>
 CyanStore::Shard::read(
   CollectionRef ch,

--- a/src/crimson/os/cyanstore/cyan_store.h
+++ b/src/crimson/os/cyanstore/cyan_store.h
@@ -26,6 +26,7 @@ class Transaction;
 
 namespace crimson::os {
 class CyanStore final : public FuturizedStore {
+public:
   class Shard : public FuturizedStore::Shard {
   public:
     Shard(std::string path)
@@ -33,6 +34,10 @@ class CyanStore final : public FuturizedStore {
 
     seastar::future<struct stat> stat(
       CollectionRef c,
+      const ghobject_t& oid) final;
+
+    base_errorator::future<bool> exists(
+      CollectionRef ch,
       const ghobject_t& oid) final;
 
     read_errorator::future<ceph::bufferlist> read(
@@ -158,7 +163,6 @@ class CyanStore final : public FuturizedStore {
     std::map<coll_t, boost::intrusive_ptr<Collection>> new_coll_map;
   };
 
-public:
   CyanStore(const std::string& path);
   ~CyanStore() final;
 

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -36,6 +36,7 @@ public:
     const Shard& operator=(const Shard& o) = delete;
 
     using CollectionRef = boost::intrusive_ptr<FuturizedCollection>;
+    using base_errorator = crimson::errorator<crimson::ct_error::input_output_error>;
     using read_errorator = crimson::errorator<crimson::ct_error::enoent,
 					      crimson::ct_error::input_output_error>;
     virtual read_errorator::future<ceph::bufferlist> read(
@@ -50,6 +51,10 @@ public:
       const ghobject_t& oid,
       interval_set<uint64_t>& m,
       uint32_t op_flags = 0) = 0;
+
+    virtual base_errorator::future<bool> exists(
+      CollectionRef c,
+      const ghobject_t& oid) = 0;
 
     using get_attr_errorator = crimson::errorator<
       crimson::ct_error::enoent,

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -116,6 +116,10 @@ public:
       interval_set<uint64_t>& m,
       uint32_t op_flags = 0) final;
 
+    base_errorator::future<bool> exists(
+      CollectionRef c,
+      const ghobject_t& oid) final;
+
     get_attr_errorator::future<ceph::bufferlist> get_attr(
       CollectionRef c,
       const ghobject_t& oid,

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -1166,6 +1166,10 @@ static PG::interruptible_future<hobject_t> pgls_filter(
   }
 }
 
+static inline bool is_snapmapper_oid(const hobject_t &obj) {
+  return obj.oid.name == SNAPMAPPER_OID;
+}
+
 static PG::interruptible_future<ceph::bufferlist> do_pgnls_common(
   const hobject_t& pg_start,
   const hobject_t& pg_end,
@@ -1186,6 +1190,13 @@ static PG::interruptible_future<ceph::bufferlist> do_pgnls_common(
     [&backend, filter, nspace](auto&& ret)
     -> PG::interruptible_future<std::tuple<std::vector<hobject_t>, hobject_t>> {
       auto& [objects, next] = ret;
+      auto is_snapmapper = [](const hobject_t &obj) {
+	if (is_snapmapper_oid(obj)) {
+	  return false;
+	} else {
+	  return true;
+	}
+      };
       auto in_my_namespace = [&nspace](const hobject_t& obj) {
         using crimson::common::local_conf;
         if (obj.get_namespace() == local_conf()->osd_hit_set_namespace) {
@@ -1213,7 +1224,8 @@ static PG::interruptible_future<ceph::bufferlist> do_pgnls_common(
         }
       };
 
-      auto range = objects | boost::adaptors::filtered(in_my_namespace)
+      auto range = objects | boost::adaptors::filtered(is_snapmapper)
+			   | boost::adaptors::filtered(in_my_namespace)
                            | boost::adaptors::transformed(to_pglsed);
       logger().debug("do_pgnls_common: finishing the 1st stage of pgls");
       return seastar::when_all_succeed(std::begin(range),
@@ -1346,6 +1358,9 @@ static PG::interruptible_future<ceph::bufferlist> do_pgls_common(
         PG::interruptor::map_reduce(std::move(objects),
           [&backend, filter, nspace](const hobject_t& obj)
 	  -> PG::interruptible_future<hobject_t>{
+	    if (is_snapmapper_oid(obj)) {
+	      return seastar::make_ready_future<hobject_t>();
+	    }
             if (obj.get_namespace() == nspace) {
               if (filter) {
                 return pgls_filter(*filter, backend, obj);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -41,6 +41,8 @@
 #include "crimson/osd/object_context_loader.h"
 #include "crimson/osd/scrub/pg_scrubber.h"
 
+#define SNAPMAPPER_OID "snapmapper"
+
 class MQuery;
 class OSDMap;
 class PGBackend;
@@ -471,7 +473,7 @@ public:
   }
 
   /// initialize created PG
-  void init(
+  seastar::future<> init(
     int role,
     const std::vector<int>& up,
     int up_primary,
@@ -647,12 +649,22 @@ public:
 private:
   OSDriver osdriver;
   SnapMapper snap_mapper;
-
+  ghobject_t make_snapmapper_oid() const {
+    return ghobject_t(hobject_t(
+      sobject_t(
+       object_t(SNAPMAPPER_OID),
+       0),
+      std::string(),
+      pgid.ps(),
+      pgid.pool(),
+      std::string()));
+  }
 public:
   // PeeringListener
   void publish_stats_to_osd() final;
   void clear_publish_stats() final;
   pg_stat_t get_stats() const;
+
 private:
   std::optional<pg_stat_t> pg_stats;
 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/52267

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh