### PR TITLE
squid: crimson/os/seastore: adjust SeaStore::_omap_set_kvs() params

### DIFF
--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1615,7 +1615,7 @@ SeaStore::Shard::_zero(
 
 SeaStore::Shard::omap_set_kvs_ret
 SeaStore::Shard::_omap_set_kvs(
-  OnodeRef &onode,
+  const OnodeRef &onode,
   const omap_root_le_t& omap_root,
   Transaction& t,
   std::map<std::string, ceph::bufferlist>&& kvs)

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -412,7 +412,7 @@ public:
       const coll_t& cid);
     using omap_set_kvs_ret = tm_iertr::future<omap_root_t>;
     omap_set_kvs_ret _omap_set_kvs(
-      OnodeRef &onode,
+      const OnodeRef &onode,
       const omap_root_le_t& omap_root,
       Transaction& t,
       std::map<std::string, ceph::bufferlist>&& kvs);


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55855

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh