### PR TITLE
squid: crimson/os/seastore/omap_manager: expand omap tree nodes

### DIFF
--- a/src/crimson/os/seastore/omap_manager.h
+++ b/src/crimson/os/seastore/omap_manager.h
@@ -14,8 +14,10 @@
 #include "crimson/os/seastore/seastore_types.h"
 #include "crimson/os/seastore/transaction_manager.h"
 
-#define OMAP_INNER_BLOCK_SIZE 4096
-#define OMAP_LEAF_BLOCK_SIZE 8192
+//TODO: calculate the max key and value sizes the current layout supports,
+//	and return errors during insert if the max is exceeded.
+#define OMAP_INNER_BLOCK_SIZE 8192
+#define OMAP_LEAF_BLOCK_SIZE 65536
 
 namespace crimson::os::seastore {
 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55840

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh