### PR TITLE
tests/rgw: fix ints returned where a string is expected

### DIFF
--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -173,12 +173,12 @@ public:
 
   string get_acct_name() const override {
     abort();
-    return 0;
+    return string{};
   }
 
   string get_subuser() const override {
     abort();
-    return 0;
+    return string{};
   }
 
   const std::string& get_tenant() const override {


### PR DESCRIPTION
Modifying test_rgw_iam_policy.cc to avoid C++23
compilation errors. C++23 does not allow int-to-string conversions,
and '0' cannot be returned where a string is expected.
