### PR TITLE
tests/librados: do not use '0' as a string

### DIFF
--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -120,7 +120,7 @@ static inline void buf_to_hex(const unsigned char *buf, int len, char *str)
 }
 
 void check_fp_oid_refcount(librados::IoCtx& ioctx, std::string foid, uint64_t count,
-			   std::string fp_algo = NULL)
+			   std::string fp_algo = std::string{})
 {
   bufferlist t;
   int size = foid.length();
@@ -148,7 +148,7 @@ void check_fp_oid_refcount(librados::IoCtx& ioctx, std::string foid, uint64_t co
   ASSERT_LE(count, refs.count());
 }
 
-string get_fp_oid(string oid, std::string fp_algo = NULL)
+string get_fp_oid(string oid, std::string fp_algo = std::string{})
 {
   if (fp_algo == "sha1") {
     unsigned char fingerprint[CEPH_CRYPTO_SHA1_DIGESTSIZE + 1];


### PR DESCRIPTION
not even as a default string parameter to a
function.

C++23 does not allow int-to-string conversions,

