### PR TITLE
mds: remove superfluous debug message

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1216,7 +1216,6 @@ bool MDSRank::is_valid_message(const cref_t<Message> &m) {
     return true;
   }
 
-  dout(10) << "invalid message type: " << std::hex << type << std::dec << dendl;
   return false;
 }
 


### PR DESCRIPTION
This is already caught by the messenger layer if no dispatcher handles the message.

Fixes: 82f3dbc3ef7b577219f8e1cfaeae4009a809029e
Fixes: https://tracker.ceph.com/issues/65846






<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
