### PR TITLE
pybind/mgr: mgr_module.py pep8/flake8 cleanups & tox updates

### DIFF
--- a/src/pybind/mgr/CMakeLists.txt
+++ b/src/pybind/mgr/CMakeLists.txt
@@ -13,7 +13,7 @@ if(WITH_MGR_ROOK_CLIENT)
 endif()
 if(WITH_TESTS)
   include(AddCephTest)
-  add_tox_test(mgr ${CMAKE_CURRENT_SOURCE_DIR} TOX_ENVS py3 py37 mypy flake8 jinjalint nooptional)
+  add_tox_test(mgr ${CMAKE_CURRENT_SOURCE_DIR} TOX_ENVS __tox_defaults__)
 endif()
 
 # Location needs to match default setting for mgr_module_path, currently:

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -555,7 +555,7 @@ def MgrModuleRecoverDB(func: Callable) -> Callable:
                     raise
                 self.log.debug(f"attempting reopen of database")
                 self.close_db()
-                self.open_db();
+                self.open_db()
                 # allow retry of func(...)
     check.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
     return check
@@ -1291,7 +1291,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
             if not self.have_enough_osds():
                 return None
             self.create_mgr_pool()
-        uri = f"file:///{self.MGR_POOL_NAME}:{self.module_name}/main.db?vfs=ceph";
+        uri = f"file:///{self.MGR_POOL_NAME}:{self.module_name}/main.db?vfs=ceph"
         self.log.debug(f"using uri {uri}")
         try:
             db = sqlite3.connect(uri, check_same_thread=False, uri=True, autocommit=False) # type: ignore[call-arg]
@@ -1322,10 +1322,10 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
             return self._db
         db_allowed = self.get_ceph_option("mgr_pool")
         if not db_allowed:
-            raise MgrDBNotReady();
+            raise MgrDBNotReady()
         self._db = self.open_db()
         if self._db is None:
-            raise MgrDBNotReady();
+            raise MgrDBNotReady()
         return self._db
 
     @property

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -84,6 +84,7 @@ PG_STATES = [
 NFS_GANESHA_SUPPORTED_FSALS = ['CEPH', 'RGW']
 NFS_POOL_NAME = '.nfs'
 
+
 class CephReleases(IntEnum):
     argonaut = 1
     bobtail = 2
@@ -105,6 +106,7 @@ class CephReleases(IntEnum):
     reef = 18
     squid = 19
     maximum = 20
+
 
 class NotifyType(str, Enum):
     mon_map = 'mon_map'
@@ -165,8 +167,12 @@ class HandleCommandResult(NamedTuple):
     stderr: str = ""            # Typically used for error messages.
 
 
-class MonCommandFailed(RuntimeError): pass
-class MgrDBNotReady(RuntimeError): pass
+class MonCommandFailed(RuntimeError):
+    pass
+
+
+class MgrDBNotReady(RuntimeError):
+    pass
 
 
 class OSDMap(ceph_module.BasePyOSDMap):
@@ -355,6 +361,7 @@ class CRUSHMap(ceph_module.BasePyCRUSH):
 
 HandlerFuncType = Callable[..., Tuple[int, str, str]]
 
+
 def _extract_target_func(
     f: HandlerFuncType
 ) -> Tuple[HandlerFuncType, Dict[str, Any]]:
@@ -538,9 +545,12 @@ def CLICheckNonemptyFileInput(desc: str) -> Callable[[HandlerFuncType], HandlerF
         return check
     return CheckFileInput
 
+
 # If the mgr loses its lock on the database because e.g. the pgs were
 # transiently down, then close it and allow it to be reopened.
 MAX_DBCLEANUP_RETRIES = 3
+
+
 def MgrModuleRecoverDB(func: Callable) -> Callable:
     @functools.wraps(func)
     def check(self: MgrModule, *args: Any, **kwargs: Any) -> Any:
@@ -560,6 +570,7 @@ def MgrModuleRecoverDB(func: Callable) -> Callable:
     check.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
     return check
 
+
 def CLIRequiresDB(func: HandlerFuncType) -> HandlerFuncType:
     @functools.wraps(func)
     def check(self: MgrModule, *args: Any, **kwargs: Any) -> Tuple[int, str, str]:
@@ -568,6 +579,7 @@ def CLIRequiresDB(func: HandlerFuncType) -> HandlerFuncType:
         return func(self, *args, **kwargs)
     check.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
     return check
+
 
 def _get_localized_key(prefix: str, key: str) -> str:
     return '{}/{}'.format(prefix, key)
@@ -584,11 +596,13 @@ if TYPE_CHECKING:
 # common/options.h: value_t
 OptionValue = Optional[Union[bool, int, float, str]]
 
+
 class OptionLevel(IntEnum):
     BASIC = 0
     ADVANCED = 1
     DEV = 2
     UNKNOWN = 3
+
 
 class Option(Dict):
     """
@@ -997,8 +1011,8 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
     MODULE_OPTION_DEFAULTS = {}  # type: Dict[str, Any]
 
     # Database Schema
-    SCHEMA = None # type: Optional[List[str]]
-    SCHEMA_VERSIONED = None # type: Optional[List[List[str]]]
+    SCHEMA = None  # type: Optional[List[str]]
+    SCHEMA_VERSIONED = None  # type: Optional[List[List[str]]]
 
     # Priority definitions for perf counters
     PRIO_CRITICAL = 10
@@ -1058,7 +1072,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         # for backwards compatibility
         self._logger = self.getLogger()
 
-        self._db = None # type: Optional[sqlite3.Connection]
+        self._db = None  # type: Optional[sqlite3.Connection]
 
         self._version = self._ceph_get_version()
 
@@ -1294,7 +1308,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         uri = f"file:///{self.MGR_POOL_NAME}:{self.module_name}/main.db?vfs=ceph"
         self.log.debug(f"using uri {uri}")
         try:
-            db = sqlite3.connect(uri, check_same_thread=False, uri=True, autocommit=False) # type: ignore[call-arg]
+            db = sqlite3.connect(uri, check_same_thread=False, uri=True, autocommit=False)  # type: ignore[call-arg]
         except TypeError:
             db = sqlite3.connect(uri, check_same_thread=False, uri=True, isolation_level=None)
         # if libcephsqlite reconnects, update the addrv for blocklist
@@ -1765,7 +1779,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         for fs in self.get("fs_map")['filesystems']:
             if fscid != fs["id"]:
                 continue
-            
+
             # quiesce leader is the lowest rank
             # with the highest state
             mdsmap = fs["mdsmap"]
@@ -1802,7 +1816,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
             command: str,
             tag: str,
             inbuf: Optional[str] = None,
-            *, # kw-only args go below
+            *,  # kw-only args go below
             one_shot: bool = False) -> None:
         """
         Called by the plugin to send a command to the mon
@@ -2397,7 +2411,6 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         return self._ceph_remove_mds_perf_query(query_id)
 
     @API.expose
-
     def reregister_mds_perf_queries(self) -> None:
         """
         Re-register MDS perf queries.

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -538,8 +538,12 @@ def CLICheckNonemptyFileInput(desc: str) -> Callable[[HandlerFuncType], HandlerF
                 # Delete new line separator at EOF (it may have been added by a text editor).
                 kwargs['inbuf'] = kwargs['inbuf'].rstrip('\r\n').rstrip('\n')
             if not kwargs['inbuf'] or not kwargs['inbuf'].strip():
-                return -errno.EINVAL, '', f'{ERROR_MSG_EMPTY_INPUT_FILE}: Please add {desc} to '\
-                                           'the file'
+                return (
+                    -errno.EINVAL,
+                    '',
+                    f'{ERROR_MSG_EMPTY_INPUT_FILE}: Please add {desc} to '
+                    'the file'
+                )
             return func(*args, **kwargs)
         check.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
         return check
@@ -560,10 +564,10 @@ def MgrModuleRecoverDB(func: Callable) -> Callable:
                 return func(self, *args, **kwargs)
             except sqlite3.DatabaseError as e:
                 self.log.error(f"Caught fatal database error: {e}")
-                retries = retries+1
+                retries = retries + 1
                 if retries > MAX_DBCLEANUP_RETRIES:
                     raise
-                self.log.debug(f"attempting reopen of database")
+                self.log.debug("attempting reopen of database")
                 self.close_db()
                 self.open_db()
                 # allow retry of func(...)
@@ -758,9 +762,9 @@ class MgrModuleLoggingMixin(object):
         # remove existing handlers:
         rm_handlers = [
             h for h in self._root_logger.handlers
-            if (isinstance(h, CPlusPlusHandler) or
-                isinstance(h, FileHandler) or
-                isinstance(h, ClusterLogHandler))]
+            if (isinstance(h, CPlusPlusHandler)
+                or isinstance(h, FileHandler)
+                or isinstance(h, ClusterLogHandler))]
         for h in rm_handlers:
             self._root_logger.removeHandler(h)
         self.log_to_file = False
@@ -986,7 +990,7 @@ class API:
         class DecoratorClass:
             _ATTR_TOKEN = f'__ATTR_{attr.upper()}__'
 
-            def __init__(self, value: Any=default) -> None:
+            def __init__(self, value: Any = default) -> None:
                 self.value = value
 
             def __call__(self, func: Callable) -> Any:
@@ -1198,15 +1202,15 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
 
     def create_skeleton_schema(self, db: sqlite3.Connection) -> None:
         SQL = [
-        """
-        CREATE TABLE IF NOT EXISTS MgrModuleKV (
-          key TEXT PRIMARY KEY,
-          value NOT NULL
-        ) WITHOUT ROWID;
-        """,
-        """
-        INSERT OR IGNORE INTO MgrModuleKV (key, value) VALUES ('__version', 0);
-        """,
+            """
+            CREATE TABLE IF NOT EXISTS MgrModuleKV (
+              key TEXT PRIMARY KEY,
+              value NOT NULL
+            ) WITHOUT ROWID;
+            """,
+            """
+            INSERT OR IGNORE INTO MgrModuleKV (key, value) VALUES ('__version', 0);
+            """,
         ]
 
         for sql in SQL:
@@ -1453,7 +1457,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
             All these structures have their own JSON representations: experiment
             or look at the C++ ``dump()`` methods to learn about them.
         """
-        obj =  self._ceph_get(data_name)
+        obj = self._ceph_get(data_name)
         if isinstance(obj, bytes):
             obj = json.loads(obj)
 
@@ -1775,7 +1779,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         return r
 
     def get_quiesce_leader_gid(self, fscid: str) -> Optional[int]:
-        leader_gid : Optional[int] = None
+        leader_gid: Optional[int] = None
         for fs in self.get("fs_map")['filesystems']:
             if fscid != fs["id"]:
                 continue
@@ -2152,10 +2156,19 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
 
     @API.expose
     @profile_method()
-    def get_unlabeled_perf_counters(self, prio_limit: int = PRIO_USEFUL,
-                              services: Sequence[str] = ("mds", "mon", "osd",
-                                                         "rbd-mirror", "cephfs-mirror", "rgw",
-                                                         "tcmu-runner")) -> Dict[str, dict]:
+    def get_unlabeled_perf_counters(
+        self,
+        prio_limit: int = PRIO_USEFUL,
+        services: Sequence[str] = (
+            "mds",
+            "mon",
+            "osd",
+            "rbd-mirror",
+            "cephfs-mirror",
+            "rgw",
+            "tcmu-runner",
+        ),
+    ) -> Dict[str, dict]:
         """
         Return the perf counters currently known to this ceph-mgr
         instance, filtered by priority equal to or greater than `prio_limit`.
@@ -2448,11 +2461,11 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
                               stdout_as_json: bool = True) -> Tuple[int, Union[str, dict], str]:
         try:
             cmd = [
-                    'radosgw-admin',
-                    '-c', str(self.get_ceph_conf_path()),
-                    '-k', str(self.get_ceph_option('keyring')),
-                    '-n', f'mgr.{self.get_mgr_id()}',
-                ] + args
+                'radosgw-admin',
+                '-c', str(self.get_ceph_conf_path()),
+                '-k', str(self.get_ceph_option('keyring')),
+                '-n', f'mgr.{self.get_mgr_id()}',
+            ] + args
             self.log.debug('Executing %s', str(cmd))
             result = subprocess.run(  # pylint: disable=subprocess-run-check
                 cmd,

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -1,7 +1,7 @@
 import os
 
 if 'UNITTEST' in os.environ:
-    import tests
+    import tests  # noqa
 
 import bcrypt
 import cephfs
@@ -147,7 +147,7 @@ class CephfsConnectionPool(object):
             fs_id = None
             try:
                 fs_id = self.get_fs_id()
-            except:
+            except:  # noqa
                 # the filesystem does not exist now -- connection is not valid.
                 pass
             logger.debug("self.fs_id={0}, fs_id={1}".format(self.fs_id, fs_id))
@@ -605,7 +605,7 @@ def verify_cacrt(cert_fname):
 def get_cert_issuer_info(crt: str) -> Tuple[Optional[str], Optional[str]]:
     """Basic validation of a ca cert"""
 
-    from OpenSSL import crypto, SSL
+    from OpenSSL import crypto, SSL  # noqa
     try:
         crt_buffer = crt.encode("ascii") if isinstance(crt, str) else crt
         (org_name, cn) = (None, None)

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -13,7 +13,7 @@ import time
 import logging
 import sys
 from ipaddress import ip_address
-from threading import Lock, Condition, Event
+from threading import Lock, Condition
 from typing import no_type_check, NewType
 import urllib
 from functools import wraps
@@ -70,6 +70,7 @@ class CephfsConnectionException(Exception):
     def __str__(self) -> str:
         return "{0} ({1})".format(self.errno, self.error_str)
 
+
 class RTimer(Timer):
     """
     recurring timer variant of Timer
@@ -84,6 +85,7 @@ class RTimer(Timer):
         except Exception as e:
             logger.error("task exception: %s", e)
             raise
+
 
 @contextlib.contextmanager
 def lock_timeout_log(lock: Lock, timeout: int = 5) -> Iterator[None]:
@@ -333,7 +335,6 @@ class CephfsClient(Generic[Module_T]):
         return fs_list
 
 
-
 @contextlib.contextmanager
 def open_filesystem(fsc: CephfsClient, fs_name: str) -> Generator["cephfs.LibCephFS", None, None]:
     """
@@ -516,7 +517,7 @@ def create_self_signed_cert(organisation: str = 'Ceph',
 
     :param organisation: String representing the Organisation(O) RDN (default='Ceph')
     :param common_name: String representing the Common Name(CN) RDN (default='mgr')
-    :param dname: Optional dictionary containing RDNs to use for crt/key generation 
+    :param dname: Optional dictionary containing RDNs to use for crt/key generation
 
     :return: ssl crt and key in utf-8 format
 
@@ -600,7 +601,8 @@ def verify_cacrt(cert_fname):
         raise ServerConfigException(
             'Invalid certificate {}: {}'.format(cert_fname, str(e)))
 
-def get_cert_issuer_info(crt: str) -> Tuple[Optional[str],Optional[str]]:
+
+def get_cert_issuer_info(crt: str) -> Tuple[Optional[str], Optional[str]]:
     """Basic validation of a ca cert"""
 
     from OpenSSL import crypto, SSL
@@ -617,6 +619,7 @@ def get_cert_issuer_info(crt: str) -> Tuple[Optional[str],Optional[str]]:
         return (org_name, cn)
     except (ValueError, crypto.Error) as e:
         raise ServerConfigException(f'Invalid certificate key: {e}')
+
 
 def verify_tls(crt, key):
     # type: (str, str) -> None
@@ -646,7 +649,6 @@ def verify_tls(crt, key):
         logger.warning('Private key and certificate do not match up: {}'.format(str(e)))
     except SSL.Error as e:
         raise ServerConfigException(f'Invalid cert/key pair: {e}')
-
 
 
 def verify_tls_files(cert_fname, pkey_fname):
@@ -716,6 +718,7 @@ def get_most_recent_rate(rates: Optional[List[Tuple[float, float]]]) -> float:
         return 0.0
     return rates[-1][1]
 
+
 def get_time_series_rates(data: List[Tuple[float, float]]) -> List[Tuple[float, float]]:
     """ Rates from time series data
 
@@ -743,6 +746,7 @@ def get_time_series_rates(data: List[Tuple[float, float]]) -> List[Tuple[float, 
         return []
     return [(data2[0], _derivative(data1, data2) if data1 is not None else 0.0) for data1, data2 in
             _pairwise(data)]
+
 
 def name_to_config_section(name: str) -> ConfEntity:
     """
@@ -840,12 +844,12 @@ def to_pretty_timedelta(n: datetime.timedelta) -> str:
     if n < datetime.timedelta(hours=48):
         return str(int(n.total_seconds()) // 3600) + 'h'
     if n < datetime.timedelta(days=14):
-        return str(int(n.total_seconds()) // (3600*24)) + 'd'
-    if n < datetime.timedelta(days=7*12):
-        return str(int(n.total_seconds()) // (3600*24*7)) + 'w'
-    if n < datetime.timedelta(days=365*2):
-        return str(int(n.total_seconds()) // (3600*24*30)) + 'M'
-    return str(int(n.total_seconds()) // (3600*24*365)) + 'y'
+        return str(int(n.total_seconds()) // (3600 * 24)) + 'd'
+    if n < datetime.timedelta(days=7 * 12):
+        return str(int(n.total_seconds()) // (3600 * 24 * 7)) + 'w'
+    if n < datetime.timedelta(days=365 * 2):
+        return str(int(n.total_seconds()) // (3600 * 24 * 30)) + 'M'
+    return str(int(n.total_seconds()) // (3600 * 24 * 365)) + 'y'
 
 
 def profile_method(skip_attribute: bool = False) -> Callable[[Callable[..., T]], Callable[..., T]]:

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 envlist =
-    py3
-    mypy
     flake8
+    mypy
     jinjalint
     nooptional
     check-black
     check-isort
+    py3
+    py37
 skipsdist = true
 skip_missing_interpreters = true
 

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -2,7 +2,6 @@
 envlist =
     py3
     mypy
-    fix
     flake8
     jinjalint
     nooptional
@@ -124,30 +123,6 @@ setenv = {[testenv]setenv}
 deps = {[testenv]deps}
 commands = {[testenv]commands}
 
-[testenv:fix]
-basepython = python3
-deps =
-    autopep8
-modules =
-    alerts \
-    balancer \
-    cephadm \
-    cli_api \
-    crash \
-    devicehealth \
-    diskprediction_local \
-    insights \
-    iostat \
-    nfs \
-    orchestrator \
-    prometheus \
-    rgw \
-    status \
-    telemetry
-commands =
-    python --version
-    autopep8 {[autopep8]addopts} \
-      {posargs:{[testenv:fix]modules}}
 
 [testenv:pylint]
 deps =

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -172,7 +172,10 @@ modules =
     hello \
     iostat \
     localpool \
+    mgr_module.py \
+    mgr_util.py \
     nfs \
+    object_format.py \
     orchestrator \
     prometheus \
     rbd_support \


### PR DESCRIPTION
Update the *.py files in src/pybind/mgr to be pep8 clean (via flake8).

Update the tox.ini so these file will be checked by flake8 in the future.

Update the tox.ini file to have an improved default envlist. Use that envlist when running "make check" via cmake - much like #56304 did for the src/cephadm dir. This allows the python to be checked with a simple `tox r` that will match what the CI will run, hopefully leading to fewer surprises.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests. There should be no functional changes in these patches.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
