### PR TITLE
smb: add login control access parameters to share resource

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -480,6 +480,21 @@ cephfs
     provider
         Optional. One of ``samba-vfs`` or ``kcephfs`` (``kcephfs`` is not yet
         supported) . Selects how CephFS storage should be provided to the share
+restrict_access
+    Optional boolean, defaulting to false. If true the share will only permit
+    access by users explicitly listed in ``login_control``.
+login_control
+    Optional list of objects. Fields:
+
+    name
+        Required string. Name of the user or group.
+    category
+        Optional. One of ``user`` (default) or ``group``.
+    access
+        One of ``read`` (alias ``r``), ``read-write`` (alias ``rw``), ``none``,
+        or ``admin``. Specific access level to grant to the user or group when
+        logging into this share. The ``none`` value denies access to the share
+        regardless of the ``restrict_access`` value.
 custom_smb_share_options
     Optional mapping. Specify key-value pairs that will be directly added to
     the ``smb.conf`` (or equivalent) of a Samba server.  Do *not* use this

--- a/src/pybind/mgr/smb/enums.py
+++ b/src/pybind/mgr/smb/enums.py
@@ -54,3 +54,26 @@ class ConfigNS(_StrEnum):
     SHARES = 'shares'
     USERS_AND_GROUPS = 'users_and_groups'
     JOIN_AUTHS = 'join_auths'
+
+
+class LoginCategory(_StrEnum):
+    USER = 'user'
+    GROUP = 'group'
+
+
+class LoginAccess(_StrEnum):
+    ADMIN = 'admin'
+    NONE = 'none'
+    READ_ONLY = 'read'
+    READ_ONLY_SHORT = 'r'
+    READ_WRITE = 'read-write'
+    READ_WRITE_SHORT = 'rw'
+
+    def expand(self) -> 'LoginAccess':
+        """Exapend abbreviated enum values into their full forms."""
+        # the extra LoginAccess(...) calls are to appease mypy
+        if self == self.READ_ONLY_SHORT:
+            return LoginAccess(self.READ_ONLY)
+        if self == self.READ_WRITE_SHORT:
+            return LoginAccess(self.READ_WRITE)
+        return self

--- a/src/pybind/mgr/smb/tests/test_validation.py
+++ b/src/pybind/mgr/smb/tests/test_validation.py
@@ -110,3 +110,23 @@ def test_clean_custom_options():
     smb.validation.check_custom_options(updated)
     assert smb.validation.clean_custom_options(updated) == orig
     assert smb.validation.clean_custom_options(None) is None
+
+
+@pytest.mark.parametrize(
+    "value,ok,err_match",
+    [
+        ("tim", True, ""),
+        ("britons\\arthur", True, ""),
+        ("lance a lot", False, "spaces, tabs, or newlines"),
+        ("tabs\ta\tlot", False, "spaces, tabs, or newlines"),
+        ("bed\nivere", False, "spaces, tabs, or newlines"),
+        ("runawa" + ("y" * 122), True, ""),
+        ("runawa" + ("y" * 123), False, "128"),
+    ],
+)
+def test_check_access_name(value, ok, err_match):
+    if ok:
+        smb.validation.check_access_name(value)
+    else:
+        with pytest.raises(ValueError, match=err_match):
+            smb.validation.check_access_name(value)

--- a/src/pybind/mgr/smb/validation.py
+++ b/src/pybind/mgr/smb/validation.py
@@ -103,3 +103,12 @@ def clean_custom_options(
     if opts is None:
         return None
     return {k: v for k, v in opts.items() if k != CUSTOM_CAUTION_KEY}
+
+
+def check_access_name(name: str) -> None:
+    if ' ' in name or '\t' in name or '\n' in name:
+        raise ValueError(
+            'login name may not contain spaces, tabs, or newlines'
+        )
+    if len(name) > 128:
+        raise ValueError('login name may not exceed 128 characters')


### PR DESCRIPTION
Depends on #57294


The login_control attribute contains a list of objects that will be mapped to samba share access parameters. The restrict_access attribute is a boolean that makes access to the share contingent on being listed in the login_control list, as either a listed user or member of a listed group, for any access level other than 'none' (as that always denies access).


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
