### PR TITLE
squid: crimson: add coroutine support for errorated and interruptible futures

### DIFF
--- a/src/crimson/common/coroutine.h
+++ b/src/crimson/common/coroutine.h
@@ -1,0 +1,310 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab expandtab
+
+#pragma once
+
+#include <seastar/core/coroutine.hh>
+
+#include "crimson/common/errorator.h"
+#include "crimson/common/interruptible_future.h"
+
+
+namespace crimson {
+namespace internal {
+
+template <typename Interruptor, typename Errorator>
+struct to_future {
+  template <typename T>
+  using future = crimson::interruptible::interruptible_future_detail<
+    typename Interruptor::condition,
+    typename Errorator::template future<T>>;
+};
+
+template <typename Errorator>
+struct to_future<void, Errorator> {
+  template <typename T>
+  using future = typename Errorator::template future<T>;
+};
+
+
+template <typename Interruptor>
+struct to_future<Interruptor, void> {
+  template <typename T>
+  using future = ::crimson::interruptible::interruptible_future<
+    typename Interruptor::condition, T>;
+};
+
+template <>
+struct to_future<void, void> {
+  template <typename T>
+  using future = seastar::future<T>;
+};
+
+
+template <typename Future>
+struct cond_checker {
+  using ref = std::unique_ptr<cond_checker>;
+  virtual std::optional<Future> may_interrupt() = 0;
+  virtual ~cond_checker() = default;
+};
+
+template <typename Interruptor>
+struct interrupt_cond_capture {
+  using InterruptCond = typename Interruptor::condition;
+  interruptible::InterruptCondRef<InterruptCond> cond;
+
+  template <typename Future>
+  struct type_erased_cond_checker final : cond_checker<Future> {
+    interruptible::InterruptCondRef<InterruptCond> cond;
+
+    template <typename T>
+    type_erased_cond_checker(T &&t) : cond(std::forward<T>(t)) {}
+
+    std::optional<Future> may_interrupt() final {
+      return cond->template may_interrupt<Future>();
+    }
+  };
+
+  template <typename Future>
+  typename cond_checker<Future>::ref capture_and_get_checker() {
+    ceph_assert(interruptible::interrupt_cond<InterruptCond>.interrupt_cond);
+    cond = interruptible::interrupt_cond<InterruptCond>.interrupt_cond;
+    return typename cond_checker<Future>::ref{
+      new type_erased_cond_checker<Future>{cond}
+    };
+  }
+
+  void restore() {
+    ceph_assert(cond);
+    interruptible::interrupt_cond<InterruptCond>.set(cond);
+  }
+
+  void reset() {
+    interruptible::interrupt_cond<InterruptCond>.reset();
+  }
+};
+
+template <>
+struct interrupt_cond_capture<void> {
+  template <typename Future>
+  typename cond_checker<Future>::ref capture_and_get_checker() {
+    return nullptr;
+  }
+};
+
+template <typename Interruptor>
+struct seastar_task_ancestor : protected seastar::task {};
+
+template <>
+struct seastar_task_ancestor<void> : public seastar::task {};
+
+template <typename Interruptor, typename Errorator, typename T>
+class promise_base : public seastar_task_ancestor<Interruptor> {
+protected:
+  seastar::promise<T> _promise;
+
+public:
+  interrupt_cond_capture<Interruptor> cond;
+
+  using errorator_type = Errorator;
+  using interruptor = Interruptor;
+  static constexpr bool is_errorated = !std::is_void<Errorator>::value;
+  static constexpr bool is_interruptible = !std::is_void<Interruptor>::value;
+
+  using _to_future =  to_future<Interruptor, Errorator>;
+
+  template <typename U=void>
+  using future = typename _to_future::template future<U>;
+
+  promise_base() = default;
+  promise_base(promise_base&&) = delete;
+  promise_base(const promise_base&) = delete;
+
+  void set_exception(std::exception_ptr&& eptr) noexcept {
+    _promise.set_exception(std::move(eptr));
+  }
+
+  void unhandled_exception() noexcept {
+    _promise.set_exception(std::current_exception());
+  }
+
+  future<T> get_return_object() noexcept {
+    return _promise.get_future();
+  }
+
+  std::suspend_never initial_suspend() noexcept { return { }; }
+  std::suspend_never final_suspend() noexcept { return { }; }
+
+  void run_and_dispose() noexcept final {
+    if constexpr (is_interruptible) {
+      cond.restore();
+    }
+    auto handle = std::coroutine_handle<promise_base>::from_promise(*this);
+    handle.resume();
+    if constexpr (is_interruptible) {
+      cond.reset();
+    }
+  }
+
+  seastar::task *waiting_task() noexcept override {
+    return _promise.waiting_task();
+  }
+  seastar::task *get_seastar_task() { return this; }
+};
+
+template <typename Interruptor, typename Errorator, typename T=void>
+class coroutine_traits {
+public:
+  class promise_type final : public promise_base<Interruptor, Errorator, T> {
+    using base = promise_base<Interruptor, Errorator, T>;
+  public:
+    template <typename... U>
+    void return_value(U&&... value) {
+      base::_promise.set_value(std::forward<U>(value)...);
+    }
+  };
+};
+
+
+template <typename Interruptor, typename Errorator>
+class coroutine_traits<Interruptor, Errorator> {
+public:
+  class promise_type final : public promise_base<Interruptor, Errorator, void> {
+    using base = promise_base<Interruptor, Errorator, void>;
+  public:
+    void return_void() noexcept {
+      base::_promise.set_value();
+    }
+  };
+};
+
+template <typename Interruptor, typename Errorator,
+	  bool CheckPreempt, typename T=void>
+struct awaiter {
+  static constexpr bool is_errorated = !std::is_void<Errorator>::value;
+  static constexpr bool is_interruptible = !std::is_void<Interruptor>::value;
+
+  template <typename U=void>
+  using future = typename to_future<Interruptor, Errorator>::template future<U>;
+
+  future<T> _future;
+
+  typename cond_checker<future<T>>::ref checker;
+public:
+  explicit awaiter(future<T>&& f) noexcept : _future(std::move(f)) { }
+
+  awaiter(const awaiter&) = delete;
+  awaiter(awaiter&&) = delete;
+
+  bool await_ready() const noexcept {
+    return _future.available() && (!CheckPreempt || !seastar::need_preempt());
+  }
+
+  template <typename U>
+  void await_suspend(std::coroutine_handle<U> hndl) noexcept {
+    if constexpr (is_errorated) {
+      using dest_errorator_t  = typename U::errorator_type;
+      static_assert(dest_errorator_t::template contains_once_v<Errorator>,
+		    "conversion is possible to more-or-eq errorated future!");
+    }
+
+    checker =
+      hndl.promise().cond.template capture_and_get_checker<future<T>>();
+    if (!CheckPreempt || !_future.available()) {
+      _future.set_coroutine(*hndl.promise().get_seastar_task());
+    } else {
+      ::seastar::schedule(hndl.promise().get_seastar_task());
+    }
+  }
+
+  T await_resume() {
+    if (auto maybe_fut = checker ? checker->may_interrupt() : std::nullopt) {
+      // silence warning that we are discarding an exceptional future
+      if (_future.failed()) _future.get_exception();
+      if constexpr (is_errorated) {
+	return maybe_fut->unsafe_get0();
+      } else {
+	return maybe_fut->get0();
+      }
+    } else {
+      if constexpr (is_errorated) {
+	return _future.unsafe_get0();
+      } else {
+	return _future.get0();
+      }
+    }
+  }
+};
+
+}
+}
+
+template <template <typename> typename Container, typename T>
+auto operator co_await(
+  Container<crimson::errorated_future_marker<T>> f) noexcept {
+  using Errorator = typename seastar::futurize<decltype(f)>::errorator_type;
+  return crimson::internal::awaiter<void, Errorator, true, T>(std::move(f));
+}
+
+template <typename InterruptCond, typename T>
+auto operator co_await(
+  crimson::interruptible::interruptible_future_detail<
+    InterruptCond, seastar::future<T>
+  > f) noexcept {
+  return crimson::internal::awaiter<
+    crimson::interruptible::interruptor<InterruptCond>, void, true, T>(
+  std::move(f));
+}
+
+template <template <typename> typename Container,
+	  typename InterruptCond, typename T>
+auto operator co_await(
+  crimson::interruptible::interruptible_future_detail<
+    InterruptCond, Container<crimson::errorated_future_marker<T>>
+  > f) noexcept {
+  using Errorator = typename seastar::futurize<decltype(f)>::errorator_type;
+  return crimson::internal::awaiter<
+    crimson::interruptible::interruptor<InterruptCond>,
+    typename Errorator::base_ertr, true, T>(
+  std::move(f));
+}
+
+namespace std {
+
+template <template <typename> typename Container,
+	  typename T, typename... Args>
+class coroutine_traits<Container<crimson::errorated_future_marker<T>>, Args...> :
+    public crimson::internal::coroutine_traits<
+      void,
+      typename seastar::futurize<
+	Container<crimson::errorated_future_marker<T>>
+	>::errorator_type,
+  T> {};
+
+template <typename InterruptCond,
+	  typename T, typename... Args>
+class coroutine_traits<
+  crimson::interruptible::interruptible_future_detail<
+    InterruptCond, seastar::future<T>
+    >, Args...> : public crimson::internal::coroutine_traits<
+  crimson::interruptible::interruptor<InterruptCond>,
+  void,
+  T> {};
+
+template <template <typename> typename Container,
+	  typename InterruptCond,
+	  typename T, typename... Args>
+class coroutine_traits<
+  crimson::interruptible::interruptible_future_detail<
+    InterruptCond, Container<crimson::errorated_future_marker<T>>
+    >, Args...> :
+    public crimson::internal::coroutine_traits<
+      crimson::interruptible::interruptor<InterruptCond>,
+      typename seastar::futurize<
+        crimson::interruptible::interruptible_future_detail<
+	  InterruptCond,
+          Container<crimson::errorated_future_marker<T>>
+	  >
+      >::errorator_type::base_ertr,
+      T> {};
+}

--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -522,9 +522,9 @@ private:
     }
 
   protected:
-    using base_t::get_exception;
     friend class ::transaction_manager_test_t;
   public:
+    using base_t::get_exception;
     using errorator_type = ::crimson::errorator<AllowedErrors...>;
     using promise_type = seastar::promise<ValueT>;
 

--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -607,6 +607,10 @@ private:
                     "ErrorT is not enlisted in errorator");
     }
 
+    void set_coroutine(seastar::task& coroutine) noexcept {
+      base_t::set_coroutine(coroutine);
+    }
+
     template <class ValueFuncT, class ErrorVisitorT>
     auto safe_then(ValueFuncT&& valfunc, ErrorVisitorT&& errfunc) {
       static_assert((... && std::is_invocable_v<ErrorVisitorT,

--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -354,17 +354,10 @@ public:
         // to throwing an exception by the handler.
         std::invoke(std::forward<ErrorVisitorT>(errfunc),
                     ErrorT::error_t::from_exception_ptr(std::move(ep)));
-      } else if constexpr (seastar::Future<decltype(result)>) {
-        // result is seastar::future but return_t is e.g. int. If so,
-        // the else clause cannot be used as seastar::future lacks
-        // errorator_type member.
-        result = seastar::make_ready_future<return_t>(
-          std::invoke(std::forward<ErrorVisitorT>(errfunc),
-                      ErrorT::error_t::from_exception_ptr(std::move(ep))));
       } else {
-        result = FuturatorT::type::errorator_type::template make_ready_future<return_t>(
-          std::invoke(std::forward<ErrorVisitorT>(errfunc),
-                      ErrorT::error_t::from_exception_ptr(std::move(ep))));
+        result = FuturatorT::invoke(
+	  std::forward<ErrorVisitorT>(errfunc),
+	  ErrorT::error_t::from_exception_ptr(std::move(ep)));
       }
     }
   }

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -692,6 +692,12 @@ struct interruptible_errorator {
 	Errorator::template make_ready_future<ValueT>(
 	  std::forward<A>(value)...));
   }
+
+  template <template <typename> typename FutureType, typename ValueT>
+  static future<ValueT> make_interruptible(FutureType<ValueT> &&fut) {
+    return std::move(fut);
+  }
+
   static interruptible_future_detail<
     InterruptCond,
     typename Errorator::template future<>> now() {

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -1094,6 +1094,9 @@ struct interruptor
 public:
   using condition = InterruptCond;
 
+  template <typename T>
+  using future = interruptible_future<InterruptCond, T>;
+
   static const void *get_interrupt_cond() {
     return (const void*)interrupt_cond<InterruptCond>.interrupt_cond.get();
   }

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -719,6 +719,7 @@ class [[nodiscard]] interruptible_future_detail<
 {
 public:
   using core_type = ErroratedFuture<crimson::errorated_future_marker<T>>;
+  using core_type::unsafe_get0;
   using errorator_type = typename core_type::errorator_type;
   using interrupt_errorator_type =
     interruptible_errorator<InterruptCond, errorator_type>;

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -418,6 +418,10 @@ public:
     : core_type(std::move(base))
   {}
 
+  void set_coroutine(seastar::task& coroutine) noexcept {
+    core_type::set_coroutine(coroutine);
+  }
+
   using value_type = typename seastar::future<T>::value_type;
   using tuple_type = typename seastar::future<T>::tuple_type;
 
@@ -769,6 +773,10 @@ public:
   [[gnu::always_inline]]
   interruptible_future_detail(exception_future_marker, std::exception_ptr&& ep) noexcept
     : core_type(::seastar::futurize<core_type>::make_exception_future(std::move(ep))) {
+  }
+
+  void set_coroutine(seastar::task& coroutine) noexcept {
+    core_type::set_coroutine(coroutine);
   }
 
   template<bool interruptible = true, typename ValueInterruptCondT, typename ErrorVisitorT,

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -1454,7 +1454,7 @@ static PG::interruptible_future<> do_pgls_filtered(
 PgOpsExecuter::interruptible_future<>
 PgOpsExecuter::execute_op(OSDOp& osd_op)
 {
-  logger().warn("handling op {}", ceph_osd_op_name(osd_op.op.op));
+  logger().debug("handling op {}", ceph_osd_op_name(osd_op.op.op));
   switch (const ceph_osd_op& op = osd_op.op; op.op) {
   case CEPH_OSD_OP_PGLS:
     return do_pgls(pg, nspace, osd_op);

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -111,6 +111,14 @@ target_link_libraries(
 add_ceph_unittest(unittest-seastar-errorator
   --memory 256M --smp 1)
 
+add_executable(unittest-crimson-coroutine
+  test_crimson_coroutine.cc)
+target_link_libraries(
+  unittest-crimson-coroutine
+  crimson::gtest)
+add_ceph_unittest(unittest-crimson-coroutine
+  --memory 256M --smp 1)
+
 add_executable(unittest-crimson-scrub
   test_crimson_scrub.cc
   ${PROJECT_SOURCE_DIR}/src/crimson/osd/scrub/scrub_machine.cc

--- a/src/test/crimson/gtest_seastar.h
+++ b/src/test/crimson/gtest_seastar.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "crimson/common/errorator.h"
 #include "gtest/gtest.h"
 
 #include "seastar_runner.h"
@@ -16,11 +17,37 @@ struct seastar_test_suite_t : public ::testing::Test {
   }
 
   template <typename Func>
+  void run_ertr(Func &&func) {
+    return run(
+      [func=std::forward<Func>(func)]() mutable {
+	return std::invoke(std::move(func)).handle_error(
+	  crimson::ct_error::assert_all("error"));
+      });
+  }
+
+  template <typename Func>
   void run_async(Func &&func) {
     run(
       [func=std::forward<Func>(func)]() mutable {
 	return seastar::async(std::forward<Func>(func));
       });
+  }
+
+  template <typename F>
+  auto scl(F &&f) {
+    return [fptr = std::make_unique<F>(std::forward<F>(f))]() mutable {
+      return std::invoke(*fptr).finally([fptr=std::move(fptr)] {});
+    };
+  }
+
+  auto run_scl(auto &&f) {
+    return run([this, f=std::forward<decltype(f)>(f)]() mutable {
+      return std::invoke(scl(std::move(f)));
+    });
+  }
+
+  auto run_ertr_scl(auto &&f) {
+    return run_ertr(scl(std::forward<decltype(f)>(f)));
   }
 
   virtual seastar::future<> set_up_fut() { return seastar::now(); }

--- a/src/test/crimson/test_crimson_coroutine.cc
+++ b/src/test/crimson/test_crimson_coroutine.cc
@@ -1,0 +1,327 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <boost/iterator/counting_iterator.hpp>
+#include <numeric>
+
+#include "seastar/core/sleep.hh"
+
+#include "crimson/common/coroutine.h"
+#include "crimson/common/errorator.h"
+#include "crimson/common/interruptible_future.h"
+#include "crimson/common/log.h"
+
+#include "test/crimson/gtest_seastar.h"
+
+struct coroutine_test_t : public seastar_test_suite_t {
+  struct interruption_state_t {
+    bool interrupted = false;
+  } interruption_state;
+
+  class test_interruption : public std::exception
+  {};
+
+  class test_interrupt_cond {
+    interruption_state_t *int_state = nullptr;
+  public:
+    test_interrupt_cond() = delete;
+    test_interrupt_cond(interruption_state_t *int_state)
+      : int_state(int_state) {}
+
+    template <typename T>
+    std::optional<T> may_interrupt() {
+      ceph_assert(int_state);
+      if (int_state->interrupted) {
+	return seastar::futurize<T>::make_exception_future(
+	  test_interruption()
+	);
+      } else {
+	return std::nullopt;
+      }
+    }
+
+    template <typename T>
+    static constexpr bool is_interruption_v = std::is_same_v<
+      T, test_interruption>;
+
+    static bool is_interruption(std::exception_ptr& eptr) {
+      if (*eptr.__cxa_exception_type() == typeid(test_interruption))
+	return true;
+      return false;
+    }
+  };
+  using interruptor = crimson::interruptible::interruptor<test_interrupt_cond>;
+
+  using ertr = crimson::errorator<crimson::ct_error::invarg>;
+  using iertr = crimson::interruptible::interruptible_errorator<
+    test_interrupt_cond,
+    ertr>;
+
+  using ertr2 = ertr::extend<
+    crimson::ct_error::eagain>;
+  using iertr2 = crimson::interruptible::interruptible_errorator<
+    test_interrupt_cond,
+    ertr2>;
+
+  using ertr3 = ertr::extend<
+    crimson::ct_error::enoent>;
+  using iertr3 = crimson::interruptible::interruptible_errorator<
+    test_interrupt_cond,
+    ertr3>;
+
+  void interrupt() {
+    interruption_state.interrupted = true;
+  }
+
+  seastar::future<> set_up_fut() final {
+    interruption_state.interrupted = false;
+    return seastar::now();
+  }
+
+
+  template <typename E, typename F>
+  auto cwi(E &&errf, F &&f) {
+    return interruptor::with_interruption(
+      scl(std::forward<F>(f)),
+      std::forward<E>(errf),
+      &interruption_state);
+  }
+};
+
+namespace crimson::interruptible {
+template
+thread_local interrupt_cond_t<coroutine_test_t::test_interrupt_cond>
+interrupt_cond<coroutine_test_t::test_interrupt_cond>;
+}
+
+TEST_F(coroutine_test_t, test_coroutine)
+{
+  run_scl([]() -> seastar::future<> {
+    constexpr int CHECK = 20;
+    auto unwrapped = co_await seastar::make_ready_future<int>(CHECK);
+    EXPECT_EQ(unwrapped, CHECK);
+  });
+}
+
+TEST_F(coroutine_test_t, test_ertr_coroutine_basic)
+{
+  run_ertr_scl([]() -> ertr::future<> {
+    constexpr int CHECK = 20;
+    auto unwrapped = co_await ertr::make_ready_future<int>(CHECK);
+    EXPECT_EQ(unwrapped, CHECK);
+  });
+}
+
+TEST_F(coroutine_test_t, test_ertr_coroutine_vanilla_future)
+{
+  run_ertr_scl([]() -> ertr::future<> {
+    constexpr int CHECK = 20;
+    auto unwrapped = co_await seastar::make_ready_future<int>(CHECK);
+    EXPECT_EQ(unwrapped, CHECK);
+  });
+}
+
+TEST_F(coroutine_test_t, test_ertr_coroutine_error)
+{
+  run_scl([this]() -> seastar::future<> {
+    auto fut = scl([]() -> ertr::future<int> {
+      std::ignore = co_await ertr::future<int>(
+	crimson::ct_error::invarg::make()
+      );
+      EXPECT_EQ("above co_await should throw", nullptr);
+      co_return 10;
+    })();
+    auto ret = co_await std::move(fut).handle_error(
+      [](const crimson::ct_error::invarg &e) {
+	return 20;
+      }
+    );
+    EXPECT_EQ(ret, 20);
+  });
+}
+
+#if 0
+// This one is left in, but commented out, as a test which *should fail to
+// build* due to trying to co_await a more errorated future.
+TEST_F(coroutine_test_t, test_basic_ertr_coroutine_error_should_not_build)
+{
+  run_ertr_scl([]() -> ertr::future<int> {
+    constexpr int CHECK = 20;
+    auto unwrapped = co_await ertr2::make_ready_future<int>(CHECK);
+    EXPECT_EQ(unwrapped, CHECK);
+    co_return 10;
+  });
+}
+#endif
+
+TEST_F(coroutine_test_t, interruptible_coroutine_basic)
+{
+  run_scl([this]() -> seastar::future<> {
+    seastar::promise<int> p;
+    auto ret = cwi(
+      [](auto) { return 2; },
+      [f=p.get_future()]() mutable -> interruptor::future<int> {
+	auto x = co_await interruptor::make_interruptible(std::move(f));
+	co_return x;
+      });
+    p.set_value(0);
+    auto awaited = co_await std::move(ret);
+    EXPECT_EQ(awaited, 0);
+  });
+}
+
+TEST_F(coroutine_test_t, interruptible_coroutine_interrupted)
+{
+  run_scl([this]() -> seastar::future<> {
+    seastar::promise<int> p;
+    auto ret = cwi(
+      [](auto) { return 2; },
+      [f=p.get_future()]() mutable -> interruptor::future<int> {
+	auto x = co_await interruptor::make_interruptible(std::move(f));
+	co_return x;
+      });
+    interrupt();
+    p.set_value(0);
+    auto awaited = co_await std::move(ret);
+    EXPECT_EQ(awaited, 2);
+  });
+}
+
+TEST_F(coroutine_test_t, dual_interruptible_coroutine)
+{
+  run_scl([this]() -> seastar::future<> {
+    seastar::promise<int> p, p2;
+    auto fut1 = cwi(
+      [](auto) { return 2; },
+      [&p, f=p2.get_future()]() mutable -> interruptor::future<int> {
+	auto x = co_await interruptor::make_interruptible(std::move(f));
+	p.set_value(1);
+	co_return x;
+      });
+    auto fut2 = cwi(
+      [](auto) { return 2; },
+      [&p2, f=p.get_future()]() mutable -> interruptor::future<int> {
+	p2.set_value(0);
+	auto x = co_await interruptor::make_interruptible(std::move(f));
+	co_return x;
+      });
+
+    auto ret1 = co_await std::move(fut1);
+    auto ret2 = co_await std::move(fut2);
+    EXPECT_EQ(ret1, 0);
+    EXPECT_EQ(ret2, 1);
+  });
+}
+
+TEST_F(coroutine_test_t, dual_interruptible_coroutine_interrupted)
+{
+  run_scl([this]() -> seastar::future<> {
+    seastar::promise<int> p, p2;
+    auto fut1 = cwi(
+      [](auto) { return 2; },
+      [this, &p, f=p2.get_future()]() mutable -> interruptor::future<int> {
+	auto x = co_await interruptor::make_interruptible(std::move(f));
+	interrupt();
+	p.set_value(1);
+	co_return x;
+      });
+    auto fut2 = cwi(
+      [](auto) { return 2; },
+      [&p2, f=p.get_future()]() mutable -> interruptor::future<int> {
+	p2.set_value(0);
+	auto x = co_await interruptor::make_interruptible(std::move(f));
+	co_return x;
+      });
+
+    auto ret1 = co_await std::move(fut1);
+    auto ret2 = co_await std::move(fut2);
+    EXPECT_EQ(ret1, 0);
+    EXPECT_EQ(ret2, 2);
+  });
+}
+
+TEST_F(coroutine_test_t, test_iertr_coroutine_basic)
+{
+  run_ertr_scl([this]() -> ertr2::future<> {
+    auto ret = co_await cwi(
+      [](auto) { return 10; },
+      []() -> iertr::future<int> {
+	co_return 20;
+      });
+    EXPECT_EQ(ret, 20);
+  });
+}
+
+TEST_F(coroutine_test_t, test_iertr_coroutine_interruption_as_error)
+{
+  run_ertr_scl([this]() -> ertr2::future<> {
+    auto ret = co_await cwi(
+      [](auto) {
+	return ertr2::future<int>(crimson::ct_error::eagain::make());
+      },
+      []() -> iertr::future<int> {
+	co_return 20;
+      });
+    EXPECT_EQ(ret, 20);
+  });
+}
+
+TEST_F(coroutine_test_t, test_iertr_coroutine_interruption_as_error_interrupted)
+{
+  run_ertr_scl([this]() -> ertr::future<> {
+    seastar::promise<> p;
+    auto f = cwi(
+      [](auto) {
+	return ertr2::future<int>(crimson::ct_error::eagain::make());
+      },
+      [&p]() -> iertr::future<int> {
+        co_await iertr::make_interruptible(p.get_future());
+	co_return 20;
+      });
+    interrupt();
+    p.set_value();
+    auto ret = co_await f.handle_error(
+      crimson::ct_error::eagain::handle([](const auto &) {
+	return 30;
+      }),
+      crimson::ct_error::pass_further_all{}
+    );
+    EXPECT_EQ(ret, 30);
+  });
+}
+
+#if 0
+// the cwi invocation below would yield an ertr2 due to the interruption handler
+TEST_F(coroutine_test_t, test_iertr_coroutine_interruption_should_not_compile)
+{
+  run_ertr_scl([this]() -> ertr::future<> {
+    auto ret = co_await cwi(
+      [](auto) {
+	ertr2::future<int>(crimson::ct_error::eagain::make());
+      },
+      []() -> iertr::future<int> {
+	co_return 20;
+      });
+    EXPECT_EQ(ret, 20);
+  });
+}
+#endif
+
+#if 0
+// can't co_await a vanilla future from an interruptible coroutine
+TEST_F(coroutine_test_t, test_iertr_coroutine_interruption_should_not_compile2)
+{
+  run_ertr_scl([this]() -> ertr2::future<> {
+    auto ret = co_await cwi(
+      [](auto) {
+	return ertr2::future<int>(crimson::ct_error::eagain::make());
+      },
+      []() -> iertr::future<int> {
+	co_await seastar::now();
+	co_return 20;
+      });
+    EXPECT_EQ(ret, 20);
+  });
+}
+#endif
+

--- a/src/test/crimson/test_errorator.cc
+++ b/src/test/crimson/test_errorator.cc
@@ -13,7 +13,20 @@
 
 struct errorator_test_t : public seastar_test_suite_t {
   using ertr = crimson::errorator<crimson::ct_error::invarg>;
-  ertr::future<> test_do_until() {
+
+  struct noncopyable_t {
+    constexpr noncopyable_t() = default;
+    ~noncopyable_t() = default;
+    noncopyable_t(noncopyable_t&&) = default;
+  private:
+    noncopyable_t(const noncopyable_t&) = delete;
+    noncopyable_t& operator=(const noncopyable_t&) = delete;
+  };
+};
+
+TEST_F(errorator_test_t, basic)
+{
+  run_async([] {
     return crimson::repeat([i=0]() mutable {
       if (i < 5) {
         ++i;
@@ -23,37 +36,44 @@ struct errorator_test_t : public seastar_test_suite_t {
         return ertr::make_ready_future<seastar::stop_iteration>(
           seastar::stop_iteration::yes);
       }
-    });
-  }
-  static constexpr int SIZE = 42;
-  ertr::future<> test_parallel_for_each() {
+    }).unsafe_get0();
+  });
+}
+
+TEST_F(errorator_test_t, parallel_for_each)
+{
+  run_async([] {
+    static constexpr int SIZE = 42;
     auto sum = std::make_unique<int>(0);
     return ertr::parallel_for_each(
       boost::make_counting_iterator(0),
       boost::make_counting_iterator(SIZE),
       [sum=sum.get()](int i) {
 	*sum += i;
-    }).safe_then([sum=std::move(sum)] {
-      int expected = std::accumulate(boost::make_counting_iterator(0),
-				     boost::make_counting_iterator(SIZE),
-				     0);
-      ASSERT_EQ(*sum, expected);
-    });
-  }
-  struct noncopyable_t {
-    constexpr noncopyable_t() = default;
-    ~noncopyable_t() = default;
-    noncopyable_t(noncopyable_t&&) = default;
-  private:
-    noncopyable_t(const noncopyable_t&) = delete;
-    noncopyable_t& operator=(const noncopyable_t&) = delete;
-  };
-  ertr::future<> test_non_copy_then() {
-    return create_noncopyable().safe_then([](auto t) {
+      }).safe_then([sum=std::move(sum)] {
+	int expected = std::accumulate(boost::make_counting_iterator(0),
+				       boost::make_counting_iterator(SIZE),
+				       0);
+	ASSERT_EQ(*sum, expected);
+      }).unsafe_get0();
+  });
+}
+
+TEST_F(errorator_test_t, non_copy_then)
+{
+  run_async([] {
+    auto create_noncopyable = [] {
+      return ertr::make_ready_future<noncopyable_t>();
+    };
+    return create_noncopyable().safe_then([](auto) {
       return ertr::now();
-    });
-  }
-  ertr::future<int> test_futurization() {
+    }).unsafe_get0();
+  });
+}
+
+TEST_F(errorator_test_t, test_futurization)
+{
+  run_async([] {
     // we don't want to be enforced to always do `make_ready_future(...)`.
     // as in seastar::future, the futurization should take care about
     // turning non-future types (e.g. int) into futurized ones (e.g.
@@ -62,38 +82,6 @@ struct errorator_test_t : public seastar_test_suite_t {
       return 42;
     }).safe_then([](int life) {
       return ertr::make_ready_future<int>(life);
-    });
-  }
-private:
-  ertr::future<noncopyable_t> create_noncopyable() {
-    return ertr::make_ready_future<noncopyable_t>();
-  }
-};
-
-TEST_F(errorator_test_t, basic)
-{
-  run_async([this] {
-    test_do_until().unsafe_get0();
-  });
-}
-
-TEST_F(errorator_test_t, parallel_for_each)
-{
-  run_async([this] {
-    test_parallel_for_each().unsafe_get0();
-  });
-}
-
-TEST_F(errorator_test_t, non_copy_then)
-{
-  run_async([this] {
-    test_non_copy_then().unsafe_get0();
-  });
-}
-
-TEST_F(errorator_test_t, test_futurization)
-{
-  run_async([this] {
-    test_futurization().unsafe_get0();
+    }).unsafe_get0();
   });
 }


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55846

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh