### PR TITLE
squid: crimson/os/seastore: cache metadata during trimming to prevent from disk read

### DIFF
--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1342,8 +1342,11 @@ public:
       CachedExtent &ext,
       const Transaction::src_t* p_src=nullptr)
   {
-    if (p_src && is_background_transaction(*p_src))
+    if (p_src &&
+	is_background_transaction(*p_src) &&
+	is_logical_type(ext.get_type())) {
       return;
+    }
     if (ext.is_stable_clean() && !ext.is_placeholder()) {
       lru.move_to_top(ext);
     }


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56250

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh