### PR TITLE
squid: crimson/osd/osd.h: declare osdmap after OSDSingletonState

### DIFF
--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -80,7 +80,6 @@ class OSD final : public crimson::net::Dispatcher,
   std::unique_ptr<crimson::mgr::Client> mgrc;
 
   // TODO: use a wrapper for ObjectStore
-  OSDMapService::cached_map_t osdmap;
   crimson::os::FuturizedStore& store;
 
   /// _first_ epoch we were marked up (after this process started)
@@ -121,6 +120,8 @@ class OSD final : public crimson::net::Dispatcher,
   seastar::sharded<OSDSingletonState> osd_singleton_state;
   seastar::sharded<OSDState> osd_states;
   seastar::sharded<ShardServices> shard_services;
+
+  OSDMapService::cached_map_t osdmap;
 
   crimson::osd::PGShardManager pg_shard_manager;
 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56374

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh