### PR TITLE
crush/builder: free 'crush_rule' before return

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -2351,6 +2351,7 @@ int CrushWrapper::add_simple_rule_at(
   int ret = crush_add_rule(crush, rule, rno);
   if(ret < 0) {
     *err << "failed to add rule " << rno << " because " << cpp_strerror(ret);
+    free(rule);
     return ret;
   }
   set_rule_name(rno, name);
@@ -2455,6 +2456,7 @@ int CrushWrapper::add_multi_osd_per_failure_domain_rule_at(
   int ret = crush_add_rule(crush, rule, rno);
   if(ret < 0) {
     *err << "failed to add rule " << rno << " because " << cpp_strerror(ret);
+    free(rule);
     return ret;
   }
   set_rule_name(rno, name);

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1172,6 +1172,9 @@ public:
     crush_rule *n = crush_make_rule(len, type);
     ceph_assert(n);
     ruleno = crush_add_rule(crush, n, ruleno);
+    if (ruleno < 0) {
+      free(n);
+    }
     return ruleno;
   }
   int set_rule_step(unsigned ruleno, unsigned step, int op, int arg1, int arg2) {


### PR DESCRIPTION
When sanitizer is enabled, unittest_erasure_code_shec shows:

```
=================================================================
==437976==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 2021708 byte(s) in 29731 object(s) allocated from:
    #0 0xaaaab0144820 in malloc (/root/ceph-19.0.0/build/bin/unittest_erasure_code_shec+0x1d4820) (BuildId: c0999ecf82504ed7e184ea4b4b9ae9d32faa1c46)
    #1 0xffffa770057c in crush_make_rule /root/ceph-19.0.0/src/crush/builder.c:104:9
    #2 0xffffa7751638 in CrushWrapper::add_simple_rule_at(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, int, std::ostream*) /root/ceph-19.0.0/src/crush/CrushWrapper.cc:2327:22
    #3 0xffffa7751d2c in CrushWrapper::add_simple_rule(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, std::ostream*) /root/ceph-19.0.0/src/crush/CrushWrapper.cc:2369:10
    #4 0xffffa39d6198 in ceph::ErasureCode::create_rule(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CrushWrapper&, std::ostream*) const /root/ceph-19.0.0/src/erasure-code/ErasureCode.cc:76:18
    #5 0xaaaab01f5a6c in thread3(void*) /root/ceph-19.0.0/src/test/erasure-code/TestErasureCodeShec.cc:2756:11
    #6 0xffffa2dad5c4 in start_thread nptl/./nptl/pthread_create.c:442:8
    #7 0xffffa2e15ed8  misc/../sysdeps/unix/sysv/linux/aarch64/clone.S:79

SUMMARY: AddressSanitizer: 2021708 byte(s) leaked in 29731 allocation(s).
```

When crush_add_rule exceeds the number of max_rules, crush_rule shoule be freed right before returning.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
