### PR TITLE
reef: ceph.spec.in: remove command-with-macro line

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2635,6 +2635,5 @@ exit 0
 %dir %{python3_sitelib}/ceph_node_proxy
 %{python3_sitelib}/ceph_node_proxy/*
 %{python3_sitelib}/ceph_node_proxy-*
-#%{_mandir}/man8/ceph-node-proxy.8*
 
 %changelog


### PR DESCRIPTION
Manual backport as the original PR has no tracker ticket.