### PR TITLE
neorados: remove unused symlink to completion.h

### DIFF
--- a/src/include/neorados/completion.h
+++ b/src/include/neorados/completion.h
@@ -1,1 +1,0 @@
-../../common/async/completion.h


### PR DESCRIPTION
this header is unused after ea67f3dee2a3f8fcdcbb0bc0e80e38ec70378f05 replaced uses of ceph::async::Completion with boost::asio::any_completion_handler

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
