### PR TITLE
quincy: common/StackStringStream: update pointer to newly allocated memory in overflow()

### DIFF
--- a/src/common/StackStringStream.h
+++ b/src/common/StackStringStream.h
@@ -77,6 +77,8 @@ protected:
     if (traits_type::not_eof(c)) {
       char str = traits_type::to_char_type(c);
       vec.push_back(str);
+      setp(vec.data(), vec.data() + vec.size());
+      pbump(vec.size());
       return c;
     } else {
       return traits_type::eof();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65871

---

backport of https://github.com/ceph/ceph/pull/56810
parent tracker: https://tracker.ceph.com/issues/65805

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh