### PR TITLE
reef: mon/MDSMonitor: fix assert crash in `fs swap`

### DIFF
--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -1298,6 +1298,10 @@ class SwapFilesystemHandler : public FileSystemCommandHandler
   {
   }
 
+  bool batched_propose() override {
+    return true;
+  }
+
   int handle(Monitor *mon, FSMap& fsmap, MonOpRequestRef op,
 	     const cmdmap_t& cmdmap, std::ostream &ss) override
   {


### PR DESCRIPTION
Paxos is plugged differently between main and reef.

Fixes: f11cf2b6dc5974d0e63d83f50e4e18e828df8e8e
Fixes: https://tracker.ceph.com/issues/65883

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
