### PR TITLE
reef: cmake/arrow: don't treat warnings as errors

### DIFF
--- a/cmake/modules/BuildArrow.cmake
+++ b/cmake/modules/BuildArrow.cmake
@@ -86,6 +86,9 @@ function(build_arrow)
   else()
     list(APPEND arrow_CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release)
   endif()
+  # don't add -Werror or debug package builds fail with:
+  #warning _FORTIFY_SOURCE requires compiling with optimization (-O)
+  list(APPEND arrow_CMAKE_ARGS -DBUILD_WARNING_LEVEL=PRODUCTION)
 
   # we use an external project and copy the sources to bin directory to ensure
   # that object files are built outside of the source tree.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65885

---

backport of https://github.com/ceph/ceph/pull/55303
parent tracker: https://tracker.ceph.com/issues/63130

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh