### PR TITLE
squid: rgw/beast: fix crash observed in SSL stream.async_shutdown()

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -1043,9 +1043,11 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
                           conn->buffer, true, pause_mutex, scheduler.get(),
                           uri_prefix, ec, yield);
 
-        // ssl shutdown (ignoring errors)
-        stream.async_shutdown(yield[ec]);
-        
+        if (!ec || ec == http::error::end_of_stream) {
+          // ssl shutdown (ignoring errors)
+          stream.async_shutdown(yield[ec]);
+        }
+
         conn->socket.shutdown(tcp::socket::shutdown_both, ec);
       }, make_stack_allocator());
   } else {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65888

---

backport of https://github.com/ceph/ceph/pull/57155
parent tracker: https://tracker.ceph.com/issues/65664

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh