### PR TITLE
python-common/ceph/deployment: fix the bug which "False" option don't…

### DIFF
--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1067,7 +1067,7 @@ class ServiceSpec(object):
                 continue
             if hasattr(val, 'to_json'):
                 val = val.to_json()
-            if val:
+            if val or val == False:
                 c[key] = val
         if c:
             ret['spec'] = c


### PR DESCRIPTION
when the option's default val is True, but we need set the val to False in spec.yaml, It won't take effect