### PR TITLE
squid: mgr/cephadm: don't mark daemons created/removed in the last minute as stray

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -730,6 +730,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self.offline_watcher = OfflineHostWatcher(self)
         self.offline_watcher.start()
 
+        # Maps daemon names to timestamps (creation/removal time) for recently created or
+        # removed daemons. Daemons are added to the dict upon creation or removal and cleared
+        # as part of the handling of stray daemons
+        self.recently_altered_daemons: Dict[str, datetime.datetime] = {}
+
     def shutdown(self) -> None:
         self.log.debug('shutdown')
         self._worker_pool.close()

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -466,6 +466,11 @@ class CephadmServe:
         for k in ['CEPHADM_STRAY_HOST',
                   'CEPHADM_STRAY_DAEMON']:
             self.mgr.remove_health_warning(k)
+        # clear recently altered daemons that were created/removed more than 60 seconds ago
+        self.mgr.recently_altered_daemons = {
+            d: t for (d, t) in self.mgr.recently_altered_daemons.items()
+            if ((datetime_now() - t).total_seconds() < 60)
+        }
         if self.mgr.warn_on_stray_hosts or self.mgr.warn_on_stray_daemons:
             ls = self.mgr.list_servers()
             self.log.debug(ls)
@@ -504,6 +509,11 @@ class CephadmServe:
                         # and don't have a way to check if the daemon is part of iscsi service
                         # we assume that all tcmu-runner daemons are managed by cephadm
                         managed.append(name)
+                    # Don't mark daemons we just created/removed in the last minute as stray.
+                    # It may take some time for the mgr to become aware the daemon
+                    # had been created/removed.
+                    if name in self.mgr.recently_altered_daemons:
+                        continue
                     if host not in self.mgr.inventory:
                         missing_names.append(name)
                         host_num_daemons += 1
@@ -1409,6 +1419,7 @@ class CephadmServe:
                     what = 'reconfigure' if reconfig else 'deploy'
                     self.mgr.events.for_daemon(
                         daemon_spec.name(), OrchestratorEvent.ERROR, f'Failed to {what}: {err}')
+                self.mgr.recently_altered_daemons[daemon_spec.name()] = datetime_now()
                 return msg
             except OrchestratorError:
                 redeploy = daemon_spec.name() in self.mgr.cache.get_daemon_names()
@@ -1508,6 +1519,7 @@ class CephadmServe:
                                                             daemon_type)].post_remove(daemon, is_failed_deploy=False))
                     self.mgr._kick_serve_loop()
 
+            self.mgr.recently_altered_daemons[name] = datetime_now()
             return "Removed {} from host '{}'".format(name, host)
 
     async def _run_cephadm_json(self,

--- a/src/pybind/mgr/cephadm/tests/test_remote_executables.py
+++ b/src/pybind/mgr/cephadm/tests/test_remote_executables.py
@@ -102,6 +102,24 @@ def _names(node):
         return [f"<JoinedStr: {node.values!r}>"]
     if isinstance(node, ast.Subscript):
         return [f"<Subscript: {node.value}{node.slice}>"]
+    if isinstance(node, ast.BinOp):
+        return [f"<BinaryOp: {_names(node.left)} {_names(node.op)} {_names(node.right)}"]
+    if (
+        isinstance(node, ast.Add)
+        or isinstance(node, ast.Sub)
+        or isinstance(node, ast.Mult)
+        or isinstance(node, ast.Div)
+        or isinstance(node, ast.FloorDiv)
+        or isinstance(node, ast.Mod)
+        or isinstance(node, ast.Pow)
+        or isinstance(node, ast.LShift)
+        or isinstance(node, ast.RShift)
+        or isinstance(node, ast.ButOr)
+        or isinstance(node, ast.BitXor)
+        or isinstance(node, ast.BitAnd)
+        or isinstance(node, ast.MatMult)
+    ):
+        return [repr(node)]
     raise ValueError(f"_names: unexpected type: {node}")
 
 


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/56957

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
