### PR TITLE
squid: qa/cephadm: ignore CEPHADM_REFRESH_FAILED on timeout test

### DIFF
--- a/qa/suites/orch/cephadm/no-agent-workunits/task/test_cephadm_timeout.yaml
+++ b/qa/suites/orch/cephadm/no-agent-workunits/task/test_cephadm_timeout.yaml
@@ -6,6 +6,8 @@ roles:
   - client.0
 overrides:
   ceph:
+    log-ignorelist:
+      - CEPHADM_REFRESH_FAILED
     log-only-match:
       - CEPHADM_
 tasks:


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/57089

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
