### PR TITLE
qa/tasks/mgr/test_progress.py: deal with pre-exisiting pool

### DIFF
--- a/qa/tasks/mgr/test_progress.py
+++ b/qa/tasks/mgr/test_progress.py
@@ -174,7 +174,15 @@ class TestProgress(MgrTestCase):
 
         # Remove all other pools
         for pool in self.mgr_cluster.mon_manager.get_osd_dump_json()['pools']:
-            self.mgr_cluster.mon_manager.remove_pool(pool['pool_name'])
+            # There might be some pools that wasn't created with this test.
+            # So we would use a raw cluster command to remove them.
+            pool_name = pool['pool_name']
+            if pool_name in self.mgr_cluster.mon_manager.pools:
+                self.mgr_cluster.mon_manager.remove_pool(pool_name)
+            else:
+                self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                    'osd', 'pool', 'rm', pool_name, pool_name,
+                    "--yes-i-really-really-mean-it")
 
         self._load_module("progress")
         self.mgr_cluster.mon_manager.raw_cluster_cmd('progress', 'clear')


### PR DESCRIPTION
Problem:
Currently, the test will fail we try
to remove a pool that was not created
by test_progress.py if we use the function
`remove_pool` from class CephManager
because it tracks the pools in a dictionary
and there is an assert to check if the pool
exists in the dictionary.

Solution:
Therefore, add a case where if
there is a pool that was not created
by the test, then we would delete it
through raw command instead of using
`remove_pool` from CephManager

Fixes: https://tracker.ceph.com/issues/65826

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
