### PR TITLE
quincy: rados: Set snappy as default value in ms_osd_compression_algorithm

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1012,8 +1012,10 @@ options:
   type: str
   level: advanced
   desc: Compression algorithm to use in Messenger when communicating with OSD
-  long_desc: Compression algorithm for connections with OSD in order of preference
-  default: snappy zlib zstd lz4
+  long_desc: Compression algorithm for connections with OSD in order of preference 
+    Although the default value is set to snappy, a list
+    (like snappy zlib zstd etc.) is acceptable as well. 
+  default: snappy
   services:
   - osd
   see_also:

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -2991,6 +2991,9 @@ CtPtr ProtocolV2::handle_compression_request(ceph::bufferlist &payload) {
         peer_type, auth_meta->is_mode_secure());
       mode != Compressor::COMP_NONE && request.is_compress()) {
     comp_meta.con_method = messenger->comp_registry.pick_method(peer_type, request.preferred_methods());
+    ldout(cct, 10) << __func__ << " Compressor(pick_method=" 
+                   << Compressor::get_comp_alg_name(comp_meta.get_method())
+                   << ")" << dendl;
     if (comp_meta.con_method != Compressor::COMP_ALG_NONE) {
       comp_meta.con_mode = mode;
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/58815

---

backport of https://github.com/ceph/ceph/pull/49843
parent tracker: https://tracker.ceph.com/issues/58410

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh