### PR TITLE
quincy: mon: stuck peering since warning is misleading

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3849,32 +3849,6 @@ static void _try_mark_pg_stale(
     newstat->last_unstale = ceph_clock_now();
   }
 
-    if ((cur.state & PG_STATE_PEERING) == 0 &&
-      cur.acting_primary != -1 &&
-      osdmap.is_down(cur.acting_primary)) {
-    pg_stat_t *newstat;
-    auto q = pending_inc->pg_stat_updates.find(pgid);
-    if (q != pending_inc->pg_stat_updates.end()) {
-      if ((q->second.acting_primary == cur.acting_primary) ||
-	  ((q->second.state & PG_STATE_PEERING) == 0 &&
-	   q->second.acting_primary != -1 &&
-	   osdmap.is_down(q->second.acting_primary))) {
-	newstat = &q->second;
-      } else {
-	// pending update is no longer down or already stale
-	return;
-      }
-    } else {
-      newstat = &pending_inc->pg_stat_updates[pgid];
-      *newstat = cur;
-    }
-    dout(10) << __func__ << " marking pg " << pgid
-	     << " stale (acting_primary " << newstat->acting_primary
-	     << ")" << dendl;
-    newstat->state |= PG_STATE_PEERING;
-    newstat->last_peered = ceph_clock_now();
-  }
-
 }
 
 void PGMapUpdater::check_down_pgs(

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -359,7 +359,8 @@ public:
   static const int STUCK_UNDERSIZED = (1<<2);
   static const int STUCK_DEGRADED = (1<<3);
   static const int STUCK_STALE = (1<<4);
-  
+  static const int STUCK_PEERING = (1<<5);
+
   PGMap()
     : version(0),
       last_osdmap_epoch(0), last_pg_scan(0)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62926

---

backport of https://github.com/ceph/ceph/pull/49332
parent tracker: https://tracker.ceph.com/issues/51688

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh