### PR TITLE
mgr/cephadm: add ability to write custom logrotate configs to all hosts

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -401,6 +401,62 @@ run on the host.
   profiles with the same name are not overwritten.
 
 
+Custom Logrotate Configs
+========================
+
+Cephadm can write out custom logrotate configs for either the
+cephadm.log or the cluster logs to all hosts in the cluster. It's
+recommended to take the existing logrotate file and then add fields
+to it. The cluster log in particular makes use of certain template
+fields to generate the name of the directory in which to rotate the
+logs and for the postrotate actions
+
+In order to have cephadm write out the custom logrotate config
+use a command of the following form:
+
+.. prompt:: bash #
+
+   ceph orch write-custom-logrotate <type> -i <logrotate-file>
+
+where <type> should be either ``cephadm`` or ``cluster`` depending on
+whether you are overwriting the logrotate file for the cluster logs
+or the cephadm.log. For example
+
+.. prompt:: bash #
+
+  [ceph: root@vm-00 /]# cat cluster-logrotate-config
+  # created by cephadm
+  /var/log/ceph/{{ fsid }}/*.log {
+      rotate 20
+      size 1G
+      daily
+      compress
+      sharedscripts
+      postrotate
+          killall -q -1 {{ targets|join(' ') }} || pkill -1 -x '{{ targets|join('|') }}' || true
+      endscript
+      missingok
+      notifempty
+      su root root
+  }
+
+  [ceph: root@vm-00 /]# ceph orch write-custom-logrotate cluster -i cluster-logrotate-config
+
+  .. note:: 
+
+    When the command to write the custom logrotate file is run, it only schedules
+    the logrotate configs to be written. If cephadm is busy with other operations
+    such as deploying daemons or an upgrade, there could be a notable delay in the
+    logrotate configs being written out.
+
+  .. note:: 
+
+    Cephadm will only attempt to write the logrotate config out to each host once
+    and will not repeatedly check the config in each host to make sure it's "correct".
+    If you want to re-trigger the operation to write the logrotate configs either
+    rerun the ``write-custom-logrotate`` command or restart the mgr daemon.
+
+
 Viewing Profiles
 ----------------
 

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -18,6 +18,7 @@ import jinja2
 from copy import deepcopy
 from io import BytesIO, StringIO
 from tarfile import ReadError
+from tasks.ceph import Rotater
 from tasks.ceph_manager import CephManager
 from teuthology import misc as teuthology
 from teuthology import contextutil
@@ -105,7 +106,9 @@ def _role_to_remote(rctx, role):
     return None
 
 
-def _shell(ctx, cluster_name, remote, args, extra_cephadm_args=[], **kwargs):
+def _shell(ctx, cluster_name, remote, args, extra_cephadm_args=None, **kwargs):
+    if extra_cephadm_args is None:
+        extra_cephadm_args = []
     teuthology.get_testdir(ctx)
     return remote.run(
         args=[
@@ -816,6 +819,49 @@ def ceph_bootstrap(ctx, config):
                     '*', '--mode', '0755'],
                    check_status=False)
 
+        # default logrotate config for cluster logs does not work for teuthology
+        # where debug logging tends to be enabled and massive log files that
+        # are multiple Gigabytes can be generate in tests that last an hour or two
+        teuth_cluster_logrotate_config = """# created by cephadm
+/var/log/ceph/{{ fsid }}/*.log {
+    rotate 100
+    size 2G
+    compress
+    sharedscripts
+    postrotate
+        killall -q -1 {{ targets|join(' ') }} || pkill -1 -x '{{ targets|join('|') }}' || true
+    endscript
+    missingok
+    notifempty
+    su root root
+}"""
+        bootstrap_remote.write_file(
+            path='/etc/ceph/logrotate.conf',
+            data=teuth_cluster_logrotate_config)
+
+        # It is necessary for upgrade tests to manually write the logrotate
+        # config files to the hosts as the version we're upgrading from (which
+        # is what we would have bootstrapped with here) won't support the
+        # ceph orch write-custom-logrotate command
+        require_manual_writing_of_logrotate_configs = False
+        try:
+            _shell(ctx, cluster_name, bootstrap_remote,
+                   ['ceph', 'orch', 'write-custom-logrotate', 'cluster', '-i', '/mnt/logrotate.conf'],
+                   extra_cephadm_args=['--mount', '/etc/ceph/logrotate.conf'])
+        except CommandFailedError as e:
+            if e.exitstatus == 22:  # invalid command, likely means we're bootstrapping an earlier version
+                require_manual_writing_of_logrotate_configs = True
+                log.info('Using a version that doesn\'t support write-custom-logrotate. '
+                         'Falling back to manual writing of logrotate configs')
+            else:
+                raise e
+
+        # we are setting ignore_missing to True for our Rotater instance as there
+        # will be a delay between when the Rotater starts running and when cephadm
+        # has the chance to actually write the logrotate configs out
+        logrotater = Rotater(ctx, f'/etc/logrotate.d/ceph-{fsid}', ignore_missing=True)
+        logrotater.begin()
+
         # add other hosts
         for remote, roles in _cephadm_remotes(ctx, log_excluded=True):
             if remote == bootstrap_remote:
@@ -830,6 +876,12 @@ def ceph_bootstrap(ctx, config):
             remote.write_file(
                 path='/etc/ceph/{}.client.admin.keyring'.format(cluster_name),
                 data=ctx.ceph[cluster_name].admin_keyring)
+
+            if require_manual_writing_of_logrotate_configs:
+                log.info(f'Manually writing logrotate config to {remote.shortname}')
+                remote.write_file(
+                    path=f'/etc/logrotate.d/ceph-{fsid}',
+                    data=teuth_cluster_logrotate_config)
 
             log.info('Adding host %s to orchestrator...' % remote.shortname)
             _shell(ctx, cluster_name, bootstrap_remote, [

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -132,6 +132,8 @@ from cephadmlib.logging import (
     cephadm_init_logging,
     Highlight,
     LogDestination,
+    write_cephadm_logrotate_config,
+    write_cluster_logrotate_config,
 )
 from cephadmlib.systemd import check_unit, check_units, terminate_service
 from cephadmlib import systemd_unit
@@ -4653,6 +4655,32 @@ def command_gather_facts(ctx: CephadmContext) -> None:
 ##################################
 
 
+def command_custom_logrotate(ctx: CephadmContext) -> str:
+    """Writes out custom logrotate config for either cephadm.log or a cluster's cluster logs"""
+    custom_template: str = ''
+    if 'logrotate_config_file' in ctx and ctx.logrotate_config_file:
+        logger.info('Grabbing logrotate config from filepath...')
+        try:
+            with open(ctx.logrotate_config_file) as f:
+                custom_template = f.read()
+        except FileNotFoundError:
+            raise Error(f'Failed to find logrotate config at {os.path.abspath(ctx.logrotate_config_file)}')
+    else:
+        logger.info('Grabbing logrotate config from stdin...')
+        custom_template = sys.stdin.read()
+
+    if 'cluster' in ctx and ctx.cluster:
+        if not ctx.fsid:
+            raise Error('--cluster requires also passing the FSID with --fsid <FSID>')
+        write_cluster_logrotate_config(ctx, ctx.fsid, custom_template, overwrite=True)
+    else:
+        write_cephadm_logrotate_config(ctx, custom_template, overwrite=True)
+
+    return 'Successfully wrote out logrotate config'
+
+##################################
+
+
 def systemd_target_state(ctx: CephadmContext, target_name: str, subsystem: str = 'ceph') -> bool:
     # TODO: UNITTEST
     return os.path.exists(
@@ -5503,6 +5531,35 @@ def _get_parser():
     parser_disk_rescan = subparsers.add_parser(
         'disk-rescan', help='rescan all HBAs to detect new/removed devices')
     parser_disk_rescan.set_defaults(func=command_rescan_disks)
+
+    parser_custom_logrotate = subparsers.add_parser(
+        'write-custom-logrotate-config',
+        help='Takes a jinja2 template for a logrotate config and writes it to logrotate dir')
+    parser_custom_logrotate.set_defaults(func=command_custom_logrotate)
+    logrotate_pass_in_group = parser_custom_logrotate.add_mutually_exclusive_group(required=True)
+    logrotate_pass_in_group.add_argument(
+        '--logrotate-config-file',
+        help='Filepath to custom logrotate template'
+    )
+    logrotate_pass_in_group.add_argument(
+        '--logrotate-config-stdin',
+        help='Custom logrotate template passed over stdin',
+        action='store_true'
+    )
+    logrotate_choice_group = parser_custom_logrotate.add_mutually_exclusive_group(required=True)
+    logrotate_choice_group.add_argument(
+        '--cluster',
+        help='Custom template is for cluster logs logrotate config. Requires passing --fsid as well',
+        action='store_true'
+    )
+    logrotate_choice_group.add_argument(
+        '--cephadm',
+        help='Custom template is for cephadm.log logrotate config',
+        action='store_true'
+    )
+    parser_custom_logrotate.add_argument(
+        '--fsid',
+        help='cluster FSID')
 
     return parser
 

--- a/src/cephadm/cephadmlib/systemd_unit.py
+++ b/src/cephadm/cephadmlib/systemd_unit.py
@@ -190,10 +190,6 @@ def _install_base_units(ctx: CephadmContext, fsid: str) -> None:
         call_throws(ctx, ['systemctl', 'enable', 'ceph-%s.target' % fsid])
         call_throws(ctx, ['systemctl', 'start', 'ceph-%s.target' % fsid])
 
-    # don't overwrite file in order to allow users to manipulate it
-    if os.path.exists(ctx.logrotate_dir + f'/ceph-{fsid}'):
-        return
-
     write_cluster_logrotate_config(ctx, fsid)
 
 

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -725,6 +725,7 @@ class HostCache():
         self.loading_osdspec_preview = set()  # type: Set[str]
         self.last_client_files: Dict[str, Dict[str, Tuple[str, int, int, int]]] = {}
         self.registry_login_queue: Set[str] = set()
+        self.custom_logrotate_write_queue: Set[str] = set()
 
         self.scheduled_daemon_actions: Dict[str, Dict[str, str]] = {}
 
@@ -782,6 +783,7 @@ class HostCache():
                     self.last_tuned_profile_update[host] = str_to_datetime(
                         j['last_tuned_profile_update'])
                 self.registry_login_queue.add(host)
+                self.custom_logrotate_write_queue.add(host)
                 self.scheduled_daemon_actions[host] = j.get('scheduled_daemon_actions', {})
                 self.metadata_up_to_date[host] = j.get('metadata_up_to_date', False)
 
@@ -923,6 +925,7 @@ class HostCache():
         self.network_refresh_queue.append(host)
         self.osdspec_previews_refresh_queue.append(host)
         self.registry_login_queue.add(host)
+        self.custom_logrotate_write_queue.add(host)
         self.last_client_files[host] = {}
 
     def refresh_all_host_info(self, host):
@@ -931,6 +934,7 @@ class HostCache():
         self.last_host_check.pop(host, None)
         self.daemon_refresh_queue.append(host)
         self.registry_login_queue.add(host)
+        self.custom_logrotate_write_queue.add(host)
         self.device_refresh_queue.append(host)
         self.last_facts_update.pop(host, None)
         self.osdspec_previews_refresh_queue.append(host)
@@ -959,6 +963,9 @@ class HostCache():
 
     def distribute_new_registry_login_info(self) -> None:
         self.registry_login_queue = set(self.mgr.inventory.keys())
+
+    def distribute_custom_logrotate_config(self) -> None:
+        self.custom_logrotate_write_queue = set(self.mgr.inventory.keys())
 
     def save_host(self, host: str) -> None:
         j: Dict[str, Any] = {
@@ -1449,6 +1456,14 @@ class HostCache():
             return False
         if host in self.registry_login_queue:
             self.registry_login_queue.remove(host)
+            return True
+        return False
+
+    def host_needs_custom_logrotate_file(self, host: str) -> bool:
+        if host in self.mgr.offline_hosts:
+            return False
+        if host in self.custom_logrotate_write_queue:
+            self.custom_logrotate_write_queue.remove(host)
             return True
         return False
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -92,8 +92,15 @@ from .inventory import (
 )
 from .upgrade import CephadmUpgrade
 from .template import TemplateMgr
-from .utils import CEPH_IMAGE_TYPES, RESCHEDULE_FROM_OFFLINE_HOSTS_TYPES, forall_hosts, \
-    cephadmNoImage, CEPH_UPGRADE_ORDER, SpecialHostLabels
+from .utils import (
+    CEPH_IMAGE_TYPES,
+    RESCHEDULE_FROM_OFFLINE_HOSTS_TYPES,
+    forall_hosts,
+    cephadmNoImage,
+    CEPH_UPGRADE_ORDER,
+    SpecialHostLabels,
+    LogrotateConfigType,
+)
 from .configchecks import CephadmConfigChecks
 from .offline_watcher import OfflineHostWatcher
 from .tuned_profiles import TunedProfileUtils
@@ -1371,6 +1378,18 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                 if item.startswith('host %s ' % host):
                     self.event.set()
         return 0, '%s (%s) ok' % (host, addr), '\n'.join(err)
+
+    @orchestrator._cli_read_command(
+        'orch write-custom-logrotate')
+    def write_custom_logrotate_config(self, logrotate_type: LogrotateConfigType, inbuf: Optional[str] = None) -> Tuple[int, str, str]:
+        """Write logrotate file with custom template to all cluster hosts"""
+        if not inbuf:
+            raise OrchestratorError('write-custom-logrotate requires "-i LOGROTATE_CONFIG"')
+
+        self.set_store(logrotate_type.config_key_entry, inbuf)
+        self.cache.distribute_custom_logrotate_config()
+        self._kick_serve_loop()
+        return 0, f'Scheduled all hosts to receive new {str(logrotate_type)} logrotate config', ''
 
     @orchestrator._cli_write_command(
         prefix='cephadm set-extra-ceph-conf')

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -27,8 +27,16 @@ from orchestrator import OrchestratorError, set_exception_subject, OrchestratorE
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.schedule import HostAssignment
 from cephadm.autotune import MemoryAutotuner
-from cephadm.utils import forall_hosts, cephadmNoImage, is_repo_digest, \
-    CephadmNoImage, CEPH_TYPES, ContainerInspectInfo, SpecialHostLabels
+from cephadm.utils import (
+    forall_hosts,
+    cephadmNoImage,
+    is_repo_digest,
+    CephadmNoImage,
+    CEPH_TYPES,
+    ContainerInspectInfo,
+    SpecialHostLabels,
+    LogrotateConfigType,
+)
 from mgr_module import MonCommandFailed
 from mgr_util import format_bytes, verify_tls, get_cert_issuer_info, ServerConfigException
 
@@ -312,6 +320,16 @@ class CephadmServe:
                         host, json.loads(str(self.mgr.get_store('registry_credentials')))))
                 if r:
                     bad_hosts.append(r)
+
+            if self.mgr.cache.host_needs_custom_logrotate_file(host):
+                for logrotate_type in LogrotateConfigType:
+                    if self.mgr.get_store(logrotate_type.config_key_entry):
+                        self.log.debug(f"Writing custom {str(logrotate_type)} logrotate file to `{host}`")
+                        with self.mgr.async_timeout_handler(host, 'cephadm write-custom-logrotate-config'):
+                            r = self.mgr.wait_async(self._write_custom_logrotate_config(
+                                host, str(self.mgr.get_store(logrotate_type.config_key_entry)), logrotate_type))
+                        if r:
+                            bad_hosts.append(r)
 
             if self.mgr.cache.host_needs_osdspec_preview_refresh(host):
                 self.log.debug(f"refreshing OSDSpec previews for {host}")
@@ -1761,6 +1779,27 @@ class CephadmServe:
             ['--registry-json', '-'], stdin=json.dumps(registry_json), error_ok=True)
         if code:
             return f"Host {host} failed to login to {registry_json['url']} as {registry_json['username']} with given password"
+        return None
+
+    # function responsible for writing a custom logrotate config to a single host
+    async def _write_custom_logrotate_config(
+        self,
+        host: str,
+        custom_template: str,
+        logrotate_config_type: LogrotateConfigType
+    ) -> Optional[str]:
+        self.log.debug(f"Attempting to write {str(logrotate_config_type)} custom logrotate config to {host}")
+        # want to pass info over stdin rather than through normal list of args
+        args = [
+            f'--{str(logrotate_config_type)}',
+            '--logrotate-config-stdin'
+        ]
+        if logrotate_config_type == LogrotateConfigType.cluster:
+            args.extend(['--fsid', self.mgr._cluster_fsid])
+        out, err, code = await self._run_cephadm(
+            host, 'mon', 'write-custom-logrotate-config', args, stdin=custom_template, error_ok=True)
+        if code:
+            return f"Failed to write {str(logrotate_config_type)} custom logrotate config to {host} "
         return None
 
     async def _deploy_cephadm_binary(self, host: str, addr: Optional[str] = None) -> None:

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -61,6 +61,21 @@ class SpecialHostLabels(str, Enum):
         return self.value
 
 
+class LogrotateConfigType(str, Enum):
+    cephadm: str = 'cephadm'
+    cluster: str = 'cluster'
+
+    def to_json(self) -> str:
+        return self.value
+
+    def __str__(self) -> str:
+        return self.value
+
+    @property
+    def config_key_entry(self) -> str:
+        return f'{self.value}_logrotate_config'
+
+
 def name_to_config_section(name: str) -> ConfEntity:
     """
     Map from daemon names to ceph entity names (as seen in config)


### PR DESCRIPTION
For either the cephadm.log or the cluster logs. Additionally, this tries to integrate the feature into the cephadm task in order to rotate logs during teuthology runs

Fixes: https://tracker.ceph.com/issues/65827


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
