### PR TITLE
squid: qa/cephadm: ignore CEPHADM_STRAY_DAEMON in upgrade tests

### DIFF
--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/simple.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/simple.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-ignorelist:
+      - CEPHADM_STRAY_DAEMON
     log-only-match:
       - CEPHADM_
 tasks:

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
@@ -1,5 +1,7 @@
 overrides:
   ceph:
+    log-ignorelist:
+      - CEPHADM_STRAY_DAEMON
     log-only-match:
       - CEPHADM_
 tasks:


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/57214

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
