### PR TITLE
squid: src/ceph_release: dev -> rc

### DIFF
--- a/.github/milestone.yml
+++ b/.github/milestone.yml
@@ -5,3 +5,4 @@ base-branch:
   - "(pacific)"
   - "(quincy)"
   - "(reef)"
+  - "(squid)"

--- a/doc/dev/release-checklists.rst
+++ b/doc/dev/release-checklists.rst
@@ -150,7 +150,7 @@ After dev freeze
 First release candidate
 =======================
 
-- [ ] src/ceph_release: change type to `rc`
+- [x] src/ceph_release: change type to `rc`
 - [ ] opt-in to all telemetry channels, generate telemetry reports, and verify no sensitive details (like pools names) are collected
 - [ ] check if new pool flags exist in pg_pool_t (osd/osd_types.h), and add them to telemetry's basic_pool_flags collection, in case they are not sensitive
 

--- a/doc/dev/release-checklists.rst
+++ b/doc/dev/release-checklists.rst
@@ -145,7 +145,7 @@ After dev freeze
 ================
 
 - [x] add release name to redmine (using https://tracker.ceph.com/custom_fields/16/edit)
-- [ ] add release name to .github/milestone.yml for github actions to automatically add milestone to backports (this commit must be backported to the release branch)
+- [x] add release name to .github/milestone.yml for github actions to automatically add milestone to backports (this commit must be backported to the release branch)
 
 First release candidate
 =======================

--- a/doc/dev/release-checklists.rst
+++ b/doc/dev/release-checklists.rst
@@ -144,7 +144,7 @@ See https://github.com/ceph/ceph-container/pull/2109 as an example for what to d
 After dev freeze
 ================
 
-- [ ] add release name to redmine (using https://tracker.ceph.com/custom_fields/16/edit)
+- [x] add release name to redmine (using https://tracker.ceph.com/custom_fields/16/edit)
 - [ ] add release name to .github/milestone.yml for github actions to automatically add milestone to backports (this commit must be backported to the release branch)
 
 First release candidate

--- a/src/ceph_release
+++ b/src/ceph_release
@@ -1,3 +1,3 @@
 19
 squid
-dev
+rc


### PR DESCRIPTION



squid is in rc phase

We need a PR equivalent to https://github.com/ceph/ceph/pull/50482 and its backport to squid to handle automatic labeling on milestones.
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
