### PR TITLE
tools/ceph-dencoder: unregister dencoders in dtor

### DIFF
--- a/src/tools/ceph-dencoder/denc_plugin.h
+++ b/src/tools/ceph-dencoder/denc_plugin.h
@@ -23,6 +23,7 @@ public:
     other.dencoders.clear();
   }
   ~DencoderPlugin() {
+    unregister_dencoders();
 #if !defined(__FreeBSD__)
     if (mod) {
       dlclose(mod);


### PR DESCRIPTION
we have leak reports from ASan like

```
Direct leak of 512 byte(s) in 1 object(s) allocated from:
    #0 0x557c5ca1aa88 in __interceptor_calloc (/home/jenkins-build/build/workspace/ceph-pull-requests/build/bin/ceph-dencoder+0xc0a88) (BuildId: 0431ba72332bcadbbda97c424e0d5e66a10e88d7)
    #1 0x7f3093a4e7e5  (<unknown module>)

Direct leak of 464 byte(s) in 1 object(s) allocated from:
    #0 0x557c5ca1aa88 in __interceptor_calloc (/home/jenkins-build/build/workspace/ceph-pull-requests/build/bin/ceph-dencoder+0xc0a88) (BuildId: 0431ba72332bcadbbda97c424e0d5e66a10e88d7)
    #1 0x7f3093a5de3e  (<unknown module>)

Direct leak of 248 byte(s) in 1 object(s) allocated from:
    #0 0x557c5ca1aa88 in __interceptor_calloc (/home/jenkins-build/build/workspace/ceph-pull-requests/build/bin/ceph-dencoder+0xc0a88) (BuildId: 0431ba72332bcadbbda97c424e0d5e66a10e88d7)
    #1 0x7f30939e05a9  (<unknown module>)

Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x557c5ca5566d in operator new(unsigned long) (/home/jenkins-build/build/workspace/ceph-pull-requests/build/bin/ceph-dencoder+0xfb66d) (BuildId: 0431ba72332bcadbbda97c424e0d5e66a10e88d7)
    #1 0x7f3094c27087  (<unknown module>)
    #2 0x7f3094c21d64  (<unknown module>)
    #3 0x557c5ca680bb in DencoderPlugin::register_dencoders[abi:cxx11]() /home/jenkins-build/build/workspace/ceph-pull-requests/src/tools/ceph-dencoder/denc_plugin.h:44:5
    #4 0x557c5ca5f9ea in main /home/jenkins-build/build/workspace/ceph-pull-requests/src/tools/ceph-dencoder/ceph_dencoder.cc:100:38
    #5 0x7f309f33ad8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x557c5ca5566d in operator new(unsigned long) (/home/jenkins-build/build/workspace/ceph-pull-requests/build/bin/ceph-dencoder+0xfb66d) (BuildId: 0431ba72332bcadbbda97c424e0d5e66a10e88d7)
    #1 0x7f308c91f257  (<unknown module>)
    #2 0x7f308c8fd0df  (<unknown module>)
    #3 0x557c5ca680bb in DencoderPlugin::register_dencoders[abi:cxx11]() /home/jenkins-build/build/workspace/ceph-pull-requests/src/tools/ceph-dencoder/denc_plugin.h:44:5
    #4 0x557c5ca5f9ea in main /home/jenkins-build/build/workspace/ceph-pull-requests/src/tools/ceph-dencoder/ceph_dencoder.cc:100:38
    #5 0x7f309f33ad8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
```

it turns out the dencoders allocated by `register_dencoders()` are never unregistered, so let's do the proper cleanup when done with the dencoders.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
