### PR TITLE
rgw/driver/posix: s/is_value()/success()/

### DIFF
--- a/src/rgw/driver/posix/zpp_bits.h
+++ b/src/rgw/driver/posix/zpp_bits.h
@@ -3454,7 +3454,7 @@ struct [[nodiscard]] value_or_errc
 
     constexpr value_or_errc(value_or_errc && other) noexcept
     {
-        if (other.is_value()) {
+        if (other.success()) {
             if constexpr (!std::is_void_v<Type>) {
                 if constexpr (!std::is_reference_v<Type>) {
                     ::new (std::addressof(m_return_value))


### PR DESCRIPTION
we have following build failure when building the tree:
```
 /home/kefu/dev/ceph/src/rgw/driver/posix/zpp_bits.h:3457:19: error: no member named 'is_value' in 'value_or_errc<Type>'
  3457 |         if (other.is_value()) {
       |             ~~~~~ ^
 In file included from /home/kefu/dev/ceph/src/rgw/driver/posix/rgw_sal_posix.cc:16:
 In file included from /home/kefu/dev/ceph/src/rgw/driver/posix/rgw_sal_posix.h:22:
```
it turns out the class of `value_or_errc` does not have the member function of `is_value()`, so let's use `success()` instead.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
