### PR TITLE
TestErasureCodeShec_arguments: fix stack-use-after-scope

### DIFF
--- a/src/test/erasure-code/TestErasureCodeShec_arguments.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_arguments.cc
@@ -86,12 +86,12 @@ void create_table_shec432() {
           continue;
         }
         if (std::popcount(avails) == 4) {
-	  auto a = to_array<std::initializer_list<int>>({
+          std::initializer_list<std::initializer_list<int>> a {
 	      {0,1,2,3}, {0,1,2,4}, {0,1,2,6}, {0,1,3,4}, {0,1,3,6}, {0,1,4,6},
 	      {0,2,3,4}, {0,2,3,5}, {0,2,4,5}, {0,2,4,6}, {0,2,5,6}, {0,3,4,5},
 	      {0,3,4,6}, {0,3,5,6}, {0,4,5,6}, {1,2,3,4}, {1,2,3,5}, {1,2,4,5},
 	      {1,2,4,6}, {1,2,5,6}, {1,3,4,5}, {1,3,4,6}, {1,3,5,6}, {1,4,5,6},
-	      {2,3,4,5}, {2,4,5,6}, {3,4,5,6}});
+	      {2,3,4,5}, {2,4,5,6}, {3,4,5,6}};
           if (ranges::any_of(a, std::bind_front(cmp_equal<uint, int>, avails),
 			     getint)) {
 	    vec.push_back(avails);


### PR DESCRIPTION
When sanitizer is enabled, unittest_erasure_code_shec_arguments shows,

```
==412235==ERROR: AddressSanitizer: stack-use-after-scope on address 0xffffca8362c0 at pc 0xaaaab4f1d2b8 bp 0xffffca8356d0 sp 0xffffca8356c8
READ of size 4 at 0xffffca8362c0 thread T0
    #0 0xaaaab4f1d2b4 in getint(std::initializer_list<int>) /root/ceph/src/test/erasure-code/TestErasureCodeShec_arguments.cc:46:21
    #1 0xaaaab4f25cac in int std::__invoke_impl<int, int (*&)(std::initializer_list<int>), std::initializer_list<int>&>(std::__invoke_other, int (*&)(std::initializer_list<int>), std::initializer_list<int>&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #2 0xaaaab4f24e90 in std::__invoke_result<int (*&)(std::initializer_list<int>), std::initializer_list<int>&>::type std::__invoke<int (*&)(std::initializer_list<int>), std::initializer_list<int>&>(int (*&)(std::initializer_list<int>), std::initializer_list<int>&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #3 0xaaaab4f248e8 in bool std::ranges::__any_of_fn::operator()<std::initializer_list<int>*, std::initializer_list<int>*, int (*)(std::initializer_list<int>), std::_Bind_front<bool (*)(unsigned int, int) noexcept, unsigned int> >(std::initializer_list<int>*, std::initializer_list<int>*, std::_Bind_front<bool (*)(unsigned int, int) noexcept, unsigned int>, int (*)(std::initializer_list<int>)) const /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/ranges_algo.h:109:30
    #4 0xaaaab4f1d72c in bool std::ranges::__any_of_fn::operator()<std::array<std::initializer_list<int>, 27ul>&, int (*)(std::initializer_list<int>), std::_Bind_front<bool (*)(unsigned int, int) noexcept, unsigned int> >(std::array<std::initializer_list<int>, 27ul>&, std::_Bind_front<bool (*)(unsigned int, int) noexcept, unsigned int>, int (*)(std::initializer_list<int>)) const /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/ranges_algo.h:120:9
    #5 0xaaaab4f0fca8 in create_table_shec432() /root/ceph/src/test/erasure-code/TestErasureCodeShec_arguments.cc:96:15
    #6 0xaaaab4f1b140 in main /root/ceph/src/test/erasure-code/TestErasureCodeShec_arguments.cc:361:3
    #7 0xffff9b9673f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #8 0xffff9b9674c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #9 0xaaaab4e5b8ac in _start (/root/ceph/build/bin/unittest_erasure_code_shec_arguments+0x11b8ac) (BuildId: c1fce44a2cd8b7e33e7f07b2de20b9a2f57c314a)
```

keep a as initializer_list could fix this error.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
