### PR TITLE
reef: cephfs_mirror: increment sync_failures when sync_perms() and sync_snaps() fails

### DIFF
--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -1532,7 +1532,7 @@ int PeerReplayer::do_sync_snaps(const std::string &dir_root) {
   return 0;
 }
 
-void PeerReplayer::sync_snaps(const std::string &dir_root,
+int PeerReplayer::sync_snaps(const std::string &dir_root,
                               std::unique_lock<ceph::mutex> &locker) {
   dout(20) << ": dir_root=" << dir_root << dendl;
   locker.unlock();
@@ -1543,12 +1543,10 @@ void PeerReplayer::sync_snaps(const std::string &dir_root,
   locker.lock();
   if (r < 0) {
     _inc_failed_count(dir_root);
-    if (m_perf_counters) {
-      m_perf_counters->inc(l_cephfs_mirror_peer_replayer_snap_sync_failures);
-    }
   } else {
     _reset_failed_count(dir_root);
   }
+  return r;
 }
 
 void PeerReplayer::run(SnapshotReplayerThread *replayer) {
@@ -1585,13 +1583,19 @@ void PeerReplayer::run(SnapshotReplayerThread *replayer) {
         dout(5) << ": picked dir_root=" << *dir_root << dendl;
         int r = register_directory(*dir_root, replayer);
         if (r == 0) {
-	  r = sync_perms(*dir_root);
-	  if (r < 0) {
-	    _inc_failed_count(*dir_root);
-	  } else {
-	    sync_snaps(*dir_root, locker);
-	  }
-	  unregister_directory(*dir_root);
+          r = sync_perms(*dir_root);
+          if (r == 0) {
+            r = sync_snaps(*dir_root, locker);
+            if (r < 0 && m_perf_counters) {
+              m_perf_counters->inc(l_cephfs_mirror_peer_replayer_snap_sync_failures);
+            }
+          } else {
+            _inc_failed_count(*dir_root);
+            if (m_perf_counters) {
+              m_perf_counters->inc(l_cephfs_mirror_peer_replayer_snap_sync_failures);
+            }
+          }
+          unregister_directory(*dir_root);
         }
       }
 

--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -279,7 +279,7 @@ private:
   int try_lock_directory(const std::string &dir_root, SnapshotReplayerThread *replayer,
                          DirRegistry *registry);
   void unlock_directory(const std::string &dir_root, const DirRegistry &registry);
-  void sync_snaps(const std::string &dir_root, std::unique_lock<ceph::mutex> &locker);
+  int sync_snaps(const std::string &dir_root, std::unique_lock<ceph::mutex> &locker);
 
 
   int build_snap_map(const std::string &dir_root, std::map<uint64_t, std::string> *snap_map,


### PR DESCRIPTION
Backport: When sync_perms() fails  _inc_failed_count() is called for incrementing the failed count.
So it's better reflect that in the metrics too. Does the same for sync_snaps() too.

Fixes: https://tracker.ceph.com/issues/65980
Original-issue: https://tracker.ceph.com/issues/65345
(cherry picked from commit 57ec7c76344253322dd8013f6ceb6b59bbd96113)
Original-PR: [56135](https://github.com/ceph/ceph/pull/56135)