### PR TITLE
quincy: mgr/stats: initialize mx_last_updated in FSPerfStats

### DIFF
--- a/src/pybind/mgr/stats/fs/perf_stats.py
+++ b/src/pybind/mgr/stats/fs/perf_stats.py
@@ -141,6 +141,7 @@ class FSPerfStats(object):
         self.module = module
         self.log = module.log
         self.prev_rank0_gid = None
+        self.mx_last_updated = 0.0
         # report processor thread
         self.report_processor = Thread(target=self.run)
         self.report_processor.start()


### PR DESCRIPTION
Fixes the error in teuthology log:
AttributeError: 'FSPerfStats' object has no attribute 'mx_last_updated'

Fixes: https://tracker.ceph.com/issues/65073
(cherry picked from commit b96ad6126110b292fca053fdfc6a956a6eb0f01e)