### PR TITLE
journal: init m_object_bytes when constructing ObjectRecorder

### DIFF
--- a/src/journal/ObjectRecorder.cc
+++ b/src/journal/ObjectRecorder.cc
@@ -42,7 +42,13 @@ ObjectRecorder::ObjectRecorder(librados::IoCtx &ioctx, std::string_view oid,
   }
   m_compat_mode = require_osd_release < CEPH_RELEASE_OCTOPUS;
 
-  ldout(m_cct, 20) << dendl;
+  r = m_ioctx.stat(m_oid, &m_object_bytes, nullptr);
+  if (r < 0 && r != -ENOENT) {
+    ldout(m_cct, 0) << "failed to retrieve the size of object: "
+                    << cpp_strerror(r) << dendl;
+  }
+
+  ldout(m_cct, 20) << "m_object_bytes " << m_object_bytes << dendl;
 }
 
 ObjectRecorder::~ObjectRecorder() {


### PR DESCRIPTION
The object might overflow if skip this step.


```
$ rg "m_object_bytes" out/client.admin.*
out/client.admin.74578.log
826:2024-05-13T18:51:00.492+0800 7fbb6b4006c0 20 ObjectRecorder: 0x7fbb4c002770 ObjectRecorder (journal_data.1.10233cbe3df0.0): m_object_bytes 0
852:2024-05-13T18:51:00.493+0800 7fbb6b4006c0 20 ObjectRecorder: 0x7fbb4c004070 ObjectRecorder (journal_data.1.10233cbe3df0.1): m_object_bytes 0
878:2024-05-13T18:51:00.493+0800 7fbb6b4006c0 20 ObjectRecorder: 0x7fbb4c003b30 ObjectRecorder (journal_data.1.10233cbe3df0.2): m_object_bytes 0
904:2024-05-13T18:51:00.493+0800 7fbb6b4006c0 20 ObjectRecorder: 0x7fbb4c003d30 ObjectRecorder (journal_data.1.10233cbe3df0.3): m_object_bytes 0

out/client.admin.74621.log
26441:2024-05-13T18:51:41.246+0800 7f6c44c006c0 20 ObjectRecorder: 0x7f6c280026d0 ObjectRecorder (journal_data.1.10233cbe3df0.0): m_object_bytes 13353657
26466:2024-05-13T18:51:41.247+0800 7f6c44c006c0 20 ObjectRecorder: 0x7f6c28003f70 ObjectRecorder (journal_data.1.10233cbe3df0.1): m_object_bytes 13353657
26491:2024-05-13T18:51:41.248+0800 7f6c44c006c0 20 ObjectRecorder: 0x7f6c28003a90 ObjectRecorder (journal_data.1.10233cbe3df0.2): m_object_bytes 13353600
26516:2024-05-13T18:51:41.248+0800 7f6c44c006c0 20 ObjectRecorder: 0x7f6c28003cc0 ObjectRecorder (journal_data.1.10233cbe3df0.3): m_object_bytes 13353600
369259:2024-05-13T18:51:50.300+0800 7f6c5ca006c0 20 ObjectRecorder: 0x7f6c4c0096c0 ObjectRecorder (journal_data.1.10233cbe3df0.4): m_object_bytes 0
371478:2024-05-13T18:51:50.305+0800 7f6c5ca006c0 20 ObjectRecorder: 0x7f6c280026d0 ObjectRecorder (journal_data.1.10233cbe3df0.5): m_object_bytes 0
373699:2024-05-13T18:51:50.311+0800 7f6c5ca006c0 20 ObjectRecorder: 0x7f6c28003f70 ObjectRecorder (journal_data.1.10233cbe3df0.6): m_object_bytes 0
375932:2024-05-13T18:51:50.324+0800 7f6c5ca006c0 20 ObjectRecorder: 0x7f6c28003a90 ObjectRecorder (journal_data.1.10233cbe3df0.7): m_object_bytes 0

```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
