### PR TITLE
reef: mgr/snap_schedule: restore yearly spec to lowercase y

### DIFF
--- a/doc/cephfs/snap-schedule.rst
+++ b/doc/cephfs/snap-schedule.rst
@@ -31,7 +31,7 @@ Snapshot schedules are identified by path, their repeat interval and their start
 time. The
 repeat interval defines the time between two subsequent snapshots. It is
 specified by a number and a period multiplier, one of `h(our)`, `d(ay)`,
-`w(eek)`, `M(onth)` and `Y(ear)`. E.g. a repeat interval of `12h` specifies one
+`w(eek)`, `M(onth)` and `y(ear)`. E.g. a repeat interval of `12h` specifies one
 snapshot every 12 hours.
 The start time is specified as a time string (more details about passing times
 below). By default
@@ -53,7 +53,7 @@ The semantics are that a spec will ensure `<number>` snapshots are kept that are
 at least `<time period>` apart. For Example `7d` means the user wants to keep 7
 snapshots that are at least one day (but potentially longer) apart from each other.
 The following time periods are recognized: `h(our)`, `d(ay)`, `w(eek)`, `M(onth)`, 
-`Y(ear)` and `n`. The latter is a special modifier where e.g. `10n` means keep
+`y(ear)` and `n`. The latter is a special modifier where e.g. `10n` means keep
 the last 10 snapshots regardless of timing,
 
 All subcommands take optional `fs` argument to specify paths in

--- a/qa/tasks/cephfs/test_snap_schedules.py
+++ b/qa/tasks/cephfs/test_snap_schedules.py
@@ -568,7 +568,7 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
 
         test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/yearly"
         self.mount_a.run_shell(['mkdir', '-p', test_dir])
-        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1Y')
+        self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='1y')
 
         test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/bad_period_spec"
         self.mount_a.run_shell(['mkdir', '-p', test_dir])

--- a/src/pybind/mgr/snap_schedule/fs/schedule.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule.py
@@ -65,7 +65,7 @@ def parse_retention(retention: str) -> Dict[str, int]:
     return ret
 
 
-RETENTION_MULTIPLIERS = ['n', 'm', 'h', 'd', 'w', 'M', 'Y']
+RETENTION_MULTIPLIERS = ['n', 'm', 'h', 'd', 'w', 'M', 'y']
 
 TableRowT = Dict[str, Union[int, str]]
 
@@ -108,7 +108,7 @@ class Schedule(object):
         # test to see if period and spec are valid
         # this test will throw a ValueError exception if
         # period is negative or zero
-        # spec is empty or other than n,m,h,d,w,M,Y
+        # spec is empty or other than n,m,h,d,w,M,y
         rep = self.repeat
         self.retention = json.loads(retention_policy)
         if start is None:
@@ -412,7 +412,7 @@ class Schedule(object):
         except ValueError:
             raise ValueError('invalid schedule specified - period should be '
                              'non-zero positive value and multiplier should '
-                             'be one of h,d,w,M,Y e.g. 1h or 4d etc.')
+                             'be one of h,d,w,M,y e.g. 1h or 4d etc.')
         if period <= 0:
             raise ValueError('invalid schedule specified - period must be a '
                              'non-zero positive value e.g. 1h or 4d etc.')
@@ -427,11 +427,11 @@ class Schedule(object):
             return period * 60 * 60 * 24 * 7
         elif mult == 'M':
             return period * 60 * 60 * 24 * 30
-        elif mult == 'Y':
+        elif mult == 'y':
             return period * 60 * 60 * 24 * 365
         else:
             raise ValueError('invalid schedule specified - multiplier should '
-                             'be one of h,d,w,M,Y')
+                             'be one of h,d,w,M,y')
 
     UPDATE_LAST = '''UPDATE schedules_meta
     SET

--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -84,7 +84,7 @@ def get_prune_set(candidates: Set[Tuple[cephfs.DirEntry, datetime]],
         ("d", '%Y-%m-%d'),
         ("w", '%G-%V'),
         ("M", '%Y-%m'),
-        ("Y", '%Y'),
+        ("y", '%Y'),
     ])
     keep = []
     if not retention:
@@ -414,7 +414,7 @@ class SnapSchedClient(CephfsClient):
         if sched.parse_schedule(sched.schedule)[1] == 'm' and not self.allow_minute_snaps:
             log.error('not allowed')
             raise ValueError('invalid schedule specified - multiplier should '
-                             'be one of h,d,w,M,Y')
+                             'be one of h,d,w,M,y')
         log.debug(f'attempting to add schedule {sched}')
         with self.get_schedule_db(fs) as conn_mgr:
             db = conn_mgr.dbinfo.db


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65898

---

backport of https://github.com/ceph/ceph/pull/56732
parent tracker: https://tracker.ceph.com/issues/65350

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh