### PR TITLE
reef: cephfs_mirror: fix crash in update_fs_mirrors()

### DIFF
--- a/src/tools/cephfs_mirror/FSMirror.h
+++ b/src/tools/cephfs_mirror/FSMirror.h
@@ -47,9 +47,14 @@ public:
 
   bool is_failed() {
     std::scoped_lock locker(m_lock);
-    return m_init_failed ||
-           m_instance_watcher->is_failed() ||
-           m_mirror_watcher->is_failed();
+    bool failed = m_init_failed;
+    if (m_instance_watcher) {
+      failed |= m_instance_watcher->is_failed();
+    }
+    if (m_mirror_watcher) {
+      failed |= m_mirror_watcher->is_failed();
+    }
+    return failed;
   }
 
   utime_t get_failed_ts() {


### PR DESCRIPTION
Fixes the crash:
```
std::scoped_lock<std::mutex>::scoped_lock (__m=..., this=<optimized out>, this=<optimized out>, __m=...) at /usr/include/c++/11/mutex:655
cephfs::mirror::MirrorWatcher::is_failed (this=0x0) at /usr/src/debug/ceph-19.0.0-1578.g3d482f42.el9.x86_64/src/tools/cephfs_mirror/MirrorWatcher.h:56
cephfs::mirror::FSMirror::is_failed (this=0x557478284340) at /usr/src/debug/ceph-19.0.0-1578.g3d482f42.el9.x86_64/src/tools/cephfs_mirror/FSMirror.h:52
cephfs::mirror::Mirror::update_fs_mirrors (this=0x5574773c3e60) at /usr/src/debug/ceph-19.0.0-1578.g3d482f42.el9.x86_64/src/tools/cephfs_mirror/Mirror.cc:515

```

Fixes: https://tracker.ceph.com/issues/64751
(cherry picked from commit 5b8b9c2f7738e0341807c1e0971c3dec90ac5491)