### PR TITLE
squid: ceph-volume: use os.makedirs for mkdir_p

### DIFF
--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -134,7 +134,7 @@ def mkdir_p(path, chown=True):
     A `mkdir -p` that defaults to chown the path to the ceph user
     """
     try:
-        os.mkdir(path)
+        os.makedirs(path)
     except OSError as e:
         if e.errno == errno.EEXIST:
             pass


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66021

---

backport of https://github.com/ceph/ceph/pull/57000
parent tracker: https://tracker.ceph.com/issues/65584

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh