### PR TITLE
squid: crimson/osd/main: Enable multicore cluster messenger

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -186,14 +186,14 @@ int main(int argc, const char* argv[])
           const auto nonce = crimson::osd::get_nonce();
           crimson::net::MessengerRef cluster_msgr, client_msgr;
           crimson::net::MessengerRef hb_front_msgr, hb_back_msgr;
-          for (auto [msgr, name] : {make_pair(std::ref(client_msgr), "client"s)}) {
+          for (auto [msgr, name] : {make_pair(std::ref(client_msgr), "client"s),
+                                    make_pair(std::ref(cluster_msgr), "cluster"s)}) {
             msgr = crimson::net::Messenger::create(entity_name_t::OSD(whoami),
                                                    name,
                                                    nonce,
                                                    false);
           }
-          for (auto [msgr, name] : {make_pair(std::ref(cluster_msgr), "cluster"s),
-                                    make_pair(std::ref(hb_front_msgr), "hb_front"s),
+          for (auto [msgr, name] : {make_pair(std::ref(hb_front_msgr), "hb_front"s),
                                     make_pair(std::ref(hb_back_msgr), "hb_back"s)}) {
             msgr = crimson::net::Messenger::create(entity_name_t::OSD(whoami),
                                                    name,

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1268,7 +1268,6 @@ seastar::future<> OSD::handle_scrub_message(
   crimson::net::ConnectionRef conn,
   Ref<MOSDFastDispatchOp> m)
 {
-  ceph_assert(seastar::this_shard_id() == PRIMARY_CORE);
   return pg_shard_manager.start_pg_operation<
     crimson::osd::ScrubMessage
     >(m, conn, m->get_min_epoch(), m->get_spg()).second;


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55708

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh