### PR TITLE
squid: crimson/os/seastore: handle OP_COLL_MOVE_RENAME

### DIFF
--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -377,6 +377,10 @@ public:
       internal_context_t &ctx,
       OnodeRef &onode,
       OnodeRef &d_onode);
+    tm_ret _rename(
+      internal_context_t &ctx,
+      OnodeRef &onode,
+      OnodeRef &d_onode);
     tm_ret _zero(
       internal_context_t &ctx,
       OnodeRef &onode,


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55947

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh