### PR TITLE
squid: crimson/osd/osd_operations/snaptrim_event: update PG's stats

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -1049,9 +1049,7 @@ ObjectContextRef OpsExecuter::prepare_clone(
 
 void OpsExecuter::apply_stats()
 {
-  pg->get_peering_state().apply_op_stats(get_target(), delta_stats);
-  pg->scrubber.handle_op_stats(get_target(), delta_stats);
-  pg->publish_stats_to_osd();
+  pg->apply_stats(get_target(), delta_stats);
 }
 
 OpsExecuter::OpsExecuter(Ref<PG> pg,

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -390,7 +390,6 @@ SnapTrimObjSubEvent::remove_or_update(
   }
 
   return seastar::do_with(ceph::os::Transaction{}, [=, this](auto &txn) {
-    int64_t num_objects_before_trim = delta_stats.num_objects;
     osd_op_p.at_version = pg->get_next_version();
     auto ret = remove_or_update_iertr::now();
     if (new_snaps.empty()) {
@@ -405,8 +404,7 @@ SnapTrimObjSubEvent::remove_or_update(
       ret = adjust_snaps(obc, head_obc, new_snaps, txn);
     }
     return std::move(ret).si_then(
-      [&txn, obc, num_objects_before_trim,
-      head_obc=std::move(head_obc), this]() mutable {
+      [&txn, obc, head_obc=std::move(head_obc), this]() mutable {
       // save head snapset
       logger().debug("{}: {} new snapset {} on {}",
 		     *this, coid, head_obc->ssc->snapset, head_obc->obs.oi);
@@ -416,11 +414,14 @@ SnapTrimObjSubEvent::remove_or_update(
 	update_head(obc, head_obc, txn);
       }
       // Stats reporting - Set number of objects trimmed
-      if (num_objects_before_trim > delta_stats.num_objects) {
-	//int64_t num_objects_trimmed =
-	//  num_objects_before_trim - delta_stats.num_objects;
-	//add_objects_trimmed_count(num_objects_trimmed);
+      if (delta_stats.num_objects < 0) {
+        int64_t num_objects_trimmed = std::abs(delta_stats.num_objects);
+        pg->get_peering_state().update_stats_wo_resched(
+          [num_objects_trimmed](auto &history, auto &stats) {
+          stats.objects_trimmed += num_objects_trimmed;
+        });
       }
+      pg->apply_stats(coid, delta_stats);
     }).si_then(
       [&txn] () mutable {
       return std::move(txn);

--- a/src/crimson/osd/osd_operations/snaptrim_event.h
+++ b/src/crimson/osd/osd_operations/snaptrim_event.h
@@ -134,8 +134,6 @@ public:
   CommonPGPipeline& client_pp();
 
 private:
-  /* TODO: we don't actually update the PG's stats
-   * https://tracker.ceph.com/issues/63307 */
   object_stat_sum_t delta_stats;
 
   snap_trim_obj_subevent_ret_t remove_clone(

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -212,6 +212,15 @@ pg_stat_t PG::get_stats() const
   return pg_stats.value_or(pg_stat_t{});
 }
 
+void PG::apply_stats(
+  const hobject_t &soid,
+  const object_stat_sum_t &delta_stats)
+{
+  peering_state.apply_op_stats(soid, delta_stats);
+  scrubber.handle_op_stats(soid, delta_stats);
+  publish_stats_to_osd();
+}
+
 void PG::queue_check_readable(epoch_t last_peering_reset, ceph::timespan delay)
 {
   // handle the peering event in the background

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -664,6 +664,9 @@ public:
   void publish_stats_to_osd() final;
   void clear_publish_stats() final;
   pg_stat_t get_stats() const;
+  void apply_stats(
+    const hobject_t &soid,
+    const object_stat_sum_t &delta_stats);
 
 private:
   std::optional<pg_stat_t> pg_stats;


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56378

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh