### PR TITLE
squid: crimson: introduce INTERNAL_PG_LOCAL_NS, use for snapmapper

### DIFF
--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -310,6 +310,26 @@ public:
     return nspace;
   }
 
+  /**
+   * PG_LOCAL_NS
+   *
+   * Used exclusively by crimson at this time.
+   *
+   * Namespace for objects maintained by the local pg instantiation updated
+   * independently of the pg log.  librados IO to this namespace should fail.
+   * Listing operations related to pg objects should exclude objects in this
+   * namespace along with temp objects, ec rollback objects, and the pg
+   * meta object. Such operations include:
+   * - scrub
+   * - backfill
+   * - pgls
+   * See crimson/osd/pg_backend PGBackend::list_objects
+   */
+  static constexpr std::string_view INTERNAL_PG_LOCAL_NS = ".internal_pg_local";
+  bool is_internal_pg_local() const {
+    return nspace == INTERNAL_PG_LOCAL_NS;
+  }
+
   bool parse(const std::string& s);
 
   void encode(ceph::buffer::list& bl) const;
@@ -428,6 +448,10 @@ struct ghobject_t {
   bool is_pgmeta() const {
     // make sure we are distinct from hobject_t(), which has pool INT64_MIN
     return hobj.pool >= 0 && hobj.oid.name.empty();
+  }
+
+  bool is_internal_pg_local() const {
+    return hobj.is_internal_pg_local();
   }
 
   bool match(uint32_t bits, uint32_t match) const {

--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -454,6 +454,26 @@ struct ghobject_t {
     return hobj.is_internal_pg_local();
   }
 
+  /**
+   * SNAPMAPPER_OID, make_snapmapper, is_snapmapper
+   *
+   * Used exclusively by crimson at this time.
+   * 
+   * Unlike classic, crimson uses a snap mapper object for each pg.
+   * The snapmapper object provides an index for efficient trimming of clones as
+   * snapshots are removed.
+   *
+   * As with the pgmeta object, we pin the hash to the pg hash.
+   */
+  static constexpr std::string_view SNAPMAPPER_OID = "snapmapper";
+  static ghobject_t make_snapmapper(
+    int64_t pool, uint32_t hash, shard_id_t shard) {
+    hobject_t h(object_t(SNAPMAPPER_OID), std::string(),
+		CEPH_NOSNAP, hash, pool,
+		std::string(hobject_t::INTERNAL_PG_LOCAL_NS));
+    return ghobject_t(h, NO_GEN, shard);
+  }
+
   bool match(uint32_t bits, uint32_t match) const {
     return hobj.match_hash(hobj.hash, bits, match);
   }

--- a/src/common/hobject_fmt.h
+++ b/src/common/hobject_fmt.h
@@ -28,9 +28,10 @@ static inline void append_out_escaped(const std::string& in, std::string* out)
 
 template <> struct fmt::formatter<hobject_t> {
 
-  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+  constexpr auto parse(format_parse_context& ctx) const { return ctx.begin(); }
 
-  template <typename FormatContext> auto format(const hobject_t& ho, FormatContext& ctx)
+  template <typename FormatContext> auto
+  format(const hobject_t& ho, FormatContext& ctx) const
   {
     if (ho == hobject_t{}) {
       return fmt::format_to(ctx.out(), "MIN");

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -1166,10 +1166,6 @@ static PG::interruptible_future<hobject_t> pgls_filter(
   }
 }
 
-static inline bool is_snapmapper_oid(const hobject_t &obj) {
-  return obj.oid.name == SNAPMAPPER_OID;
-}
-
 static PG::interruptible_future<ceph::bufferlist> do_pgnls_common(
   const hobject_t& pg_start,
   const hobject_t& pg_end,
@@ -1190,13 +1186,6 @@ static PG::interruptible_future<ceph::bufferlist> do_pgnls_common(
     [&backend, filter, nspace](auto&& ret)
     -> PG::interruptible_future<std::tuple<std::vector<hobject_t>, hobject_t>> {
       auto& [objects, next] = ret;
-      auto is_snapmapper = [](const hobject_t &obj) {
-	if (is_snapmapper_oid(obj)) {
-	  return false;
-	} else {
-	  return true;
-	}
-      };
       auto in_my_namespace = [&nspace](const hobject_t& obj) {
         using crimson::common::local_conf;
         if (obj.get_namespace() == local_conf()->osd_hit_set_namespace) {
@@ -1224,8 +1213,7 @@ static PG::interruptible_future<ceph::bufferlist> do_pgnls_common(
         }
       };
 
-      auto range = objects | boost::adaptors::filtered(is_snapmapper)
-			   | boost::adaptors::filtered(in_my_namespace)
+      auto range = objects | boost::adaptors::filtered(in_my_namespace)
                            | boost::adaptors::transformed(to_pglsed);
       logger().debug("do_pgnls_common: finishing the 1st stage of pgls");
       return seastar::when_all_succeed(std::begin(range),
@@ -1358,9 +1346,6 @@ static PG::interruptible_future<ceph::bufferlist> do_pgls_common(
         PG::interruptor::map_reduce(std::move(objects),
           [&backend, filter, nspace](const hobject_t& obj)
 	  -> PG::interruptible_future<hobject_t>{
-	    if (is_snapmapper_oid(obj)) {
-	      return seastar::make_ready_future<hobject_t>();
-	    }
             if (obj.get_namespace() == nspace) {
               if (filter) {
                 return pgls_filter(*filter, backend, obj);

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -324,6 +324,9 @@ ClientRequest::do_process(
     return reply_op_error(pg, -ENAMETOOLONG);
   } else if (m->get_hobj().oid.name.empty()) {
     return reply_op_error(pg, -EINVAL);
+  } else if (m->get_hobj().is_internal_pg_local()) {
+    // clients are not allowed to write to hobject_t::INTERNAL_PG_LOCAL_NS
+    return reply_op_error(pg, -EINVAL);
   } else if (pg->get_osdmap()->is_blocklisted(
         get_foreign_connection().get_peer_addr())) {
     DEBUGDPP("{}.{}: {} is blocklisted",

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -136,7 +136,7 @@ PG::PG(
     osdriver(
       &shard_services.get_store(),
       coll_ref,
-      make_snapmapper_oid()),
+      pgid.make_snapmapper_oid()),
     snap_mapper(
       this->shard_services.get_cct(),
       &osdriver,
@@ -609,10 +609,10 @@ seastar::future<> PG::init(
     new_acting_primary, history, pi, t);
   assert(coll_ref);
   return shard_services.get_store().exists(
-    get_collection_ref(), make_snapmapper_oid()
+    get_collection_ref(), pgid.make_snapmapper_oid()
   ).safe_then([&t, this](bool existed) {
       if (!existed) {
-        t.touch(coll_ref->get_cid(), make_snapmapper_oid());
+        t.touch(coll_ref->get_cid(), pgid.make_snapmapper_oid());
       }
     },
     ::crimson::ct_error::assert_all{"unexpected eio"}

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -41,8 +41,6 @@
 #include "crimson/osd/object_context_loader.h"
 #include "crimson/osd/scrub/pg_scrubber.h"
 
-#define SNAPMAPPER_OID "snapmapper"
-
 class MQuery;
 class OSDMap;
 class PGBackend;
@@ -649,16 +647,6 @@ public:
 private:
   OSDriver osdriver;
   SnapMapper snap_mapper;
-  ghobject_t make_snapmapper_oid() const {
-    return ghobject_t(hobject_t(
-      sobject_t(
-       object_t(SNAPMAPPER_OID),
-       0),
-      std::string(),
-      pgid.ps(),
-      pgid.pool(),
-      std::string()));
-  }
 public:
   // PeeringListener
   void publish_stats_to_osd() final;

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -1097,6 +1097,8 @@ PGBackend::list_objects(
 	return false;
       } else if (o.hobj.is_temp()) {
 	return false;
+      } else if (o.is_internal_pg_local()) {
+	return false;
       } else {
 	return o.is_no_gen();
       }

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -1080,12 +1080,14 @@ PGBackend::remove(ObjectState& os, ceph::os::Transaction& txn,
 }
 
 PGBackend::interruptible_future<std::tuple<std::vector<hobject_t>, hobject_t>>
-PGBackend::list_objects(const hobject_t& start, uint64_t limit) const
+PGBackend::list_objects(
+  const hobject_t& start, const hobject_t &end, uint64_t limit) const
 {
   auto gstart = start.is_min() ? ghobject_t{} : ghobject_t{start, 0, shard};
+  auto gend = end.is_max() ? ghobject_t::get_max() : ghobject_t{end, 0, shard};
   return interruptor::make_interruptible(store->list_objects(coll,
 					 gstart,
-					 ghobject_t::get_max(),
+					 gend,
 					 limit))
     .then_interruptible([](auto ret) {
       auto& [gobjects, next] = ret;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -589,6 +589,10 @@ struct spg_t {
     return ghobject_t::make_pgmeta(pgid.pool(), pgid.ps(), shard);
   }
 
+  ghobject_t make_snapmapper_oid() const {
+    return ghobject_t::make_snapmapper(pgid.pool(), pgid.ps(), shard);
+  }
+
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);
     encode(pgid, bl);


### PR DESCRIPTION
**Manual** backport of https://github.com/ceph/ceph/pull/56534

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh