### PR TITLE
squid: qa/suites/rados/singleton: add POOL_APP_NOT_ENABLED to ignorelist

### DIFF
--- a/qa/suites/rados/singleton/all/mon-config-keys.yaml
+++ b/qa/suites/rados/singleton/all/mon-config-keys.yaml
@@ -16,6 +16,8 @@ tasks:
 - ceph:
     pre-mgr-commands:
       - sudo ceph config set mgr mgr_pool false --force
+    log-ignorelist:
+    - \(POOL_APP_NOT_ENABLED\)
 - workunit:
     clients:
       all:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66041

---

backport of https://github.com/ceph/ceph/pull/56146
parent tracker: https://tracker.ceph.com/issues/64725

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh