### PR TITLE
osd: make the chunking in e.g. PG deletion controlable

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3744,6 +3744,22 @@ options:
   flags:
   - create
   with_legacy: true
+- name: osd_objectstore_ideal_list_max
+  type: uint
+  level: advanced
+  desc: The max number of results of ObjectStore::collection_list()
+  long_desc: This value caps the maximal number of entries a single
+    call to collection_list() can return. The configurable controls
+    this aspect of PG deletion and OSD::clear_temp_objects().
+    Increasing it trade-offs less agressive chunking (and thus less
+    CPU consumption overall) for higher memory pressure.
+    Please note that in the case of PG deletion the chunking is
+    steered by std::min of the this value and the value of
+    osd_target_transaction_size.
+  default: 64
+  see_also:
+  - osd_memory_target
+  with_legacy: true
 # true if LTTng-UST tracepoints should be enabled
 - name: osd_objectstore_tracing
   type: bool

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -111,3 +111,8 @@ int ObjectStore::read_meta(const std::string& key,
   *value = string(buf, r);
   return 0;
 }
+
+int ObjectStore::get_ideal_list_max()
+{
+  return cct->_conf->osd_objectstore_ideal_list_max;
+}

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -401,10 +401,8 @@ public:
 
   /**
    * get ideal max value for collection_list()
-   *
-   * default to some arbitrary values; the implementation will override.
    */
-  virtual int get_ideal_list_max() { return 64; }
+  int get_ideal_list_max();
 
 
   /**


### PR DESCRIPTION
The motivation behind this patch is to let users control the number of sweeps / number of objects per sweep during PG deletion which is currently restricited to `64` at max.

```
std::pair<ghobject_t, bool> PG::do_delete_work(
  ObjectStore::Transaction &t,
  ghobject_t _next)
{
  // ...
  int max = std::min(osd->store->get_ideal_list_max(),
                     (int)cct->_conf->osd_target_transaction_size);
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
