### PR TITLE
qa/cephfs: improvements for "mds fail" and "fs fail"

### DIFF
--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -104,24 +104,6 @@ class TestAdminCommands(CephFSTestCase):
         mds_id = mds_id.replace('mds.', '')
         return mds_id
 
-    def wait_till_health_warn(self, health_warn, active_mds_id, sleep=3,
-                              tries=10):
-        errmsg = (f'Expected health warning "{health_warn}" to eventually '
-                  'show up in output of command "ceph health detail". Tried '
-                  f'{tries} times with interval of {sleep} seconds but the '
-                  'health warning didn\'t turn up.')
-
-        with safe_while(sleep=sleep, tries=tries, action=errmsg) as proceed:
-            while proceed():
-                self.get_ceph_cmd_stdout(
-                    f'tell mds.{active_mds_id} cache status')
-
-                health_report = json.loads(self.get_ceph_cmd_stdout(
-                    'health detail --format json'))
-
-                if health_warn in health_report['checks']:
-                    return
-
     def gen_health_warn_mds_cache_oversized(self):
         health_warn = 'MDS_CACHE_OVERSIZED'
 
@@ -129,7 +111,7 @@ class TestAdminCommands(CephFSTestCase):
         self.config_set('mds', 'mds_health_cache_threshold', '1.00000')
         self.mount_a.open_n_background('.', 400)
 
-        self.wait_till_health_warn(health_warn, active_mds_id)
+        self.wait_for_health(health_warn, 30)
 
     def gen_health_warn_mds_trim(self):
         health_warn = 'MDS_TRIM'
@@ -142,7 +124,7 @@ class TestAdminCommands(CephFSTestCase):
         self.config_set('mds', 'mds_log_trim_threshold', '1')
         self.mount_a.open_n_background('.', 400)
 
-        self.wait_till_health_warn(health_warn, active_mds_id)
+        self.wait_for_health(health_warn, 30)
 
 
 @classhook('_add_valid_tell')

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -91,19 +91,6 @@ class TestAdminCommands(CephFSTestCase):
         if overwrites:
             self.run_ceph_cmd('osd', 'pool', 'set', n+"-data", 'allow_ec_overwrites', 'true')
 
-    def _get_unhealthy_mds_id(self, health_report, health_warn):
-        '''
-        Return MDS ID for which health warning in "health_warn" has been
-        generated.
-        '''
-        # variable "msg" should hold string something like this -
-        # 'mds.b(mds.0): Behind on trimming (865/10) max_segments: 10,
-        # num_segments: 86
-        msg = health_report['checks'][health_warn]['detail'][0]['message']
-        mds_id = msg.split('(')[0]
-        mds_id = mds_id.replace('mds.', '')
-        return mds_id
-
     def gen_health_warn_mds_cache_oversized(self):
         health_warn = 'MDS_CACHE_OVERSIZED'
 
@@ -2397,6 +2384,21 @@ class TestMDSFail(TestAdminCommands):
                               retval=1, errmsgs=health_warn)
         self.run_ceph_cmd(f'mds fail {active_mds_id} --yes-i-really-mean-it')
 
+    def _get_unhealthy_mds_id(self, health_warn):
+        '''
+        Return MDS ID for which health warning in "health_warn" has been
+        generated.
+        '''
+        health_report = json.loads(self.get_ceph_cmd_stdout('health detail '
+                                                            '--format json'))
+        # variable "msg" should hold string something like this -
+        # 'mds.b(mds.0): Behind on trimming (865/10) max_segments: 10,
+        # num_segments: 86
+        msg = health_report['checks'][health_warn]['detail'][0]['message']
+        mds_id = msg.split('(')[0]
+        mds_id = mds_id.replace('mds.', '')
+        return mds_id
+
     def test_with_health_warn_with_2_active_MDSs(self):
         '''
         Test when a CephFS has 2 active MDSs and one of them have either
@@ -2409,10 +2411,8 @@ class TestMDSFail(TestAdminCommands):
         self.gen_health_warn_mds_cache_oversized()
         mds1_id, mds2_id = self.fs.get_active_names()
 
-        health_report = json.loads(self.get_ceph_cmd_stdout('health detail '
-                                                            '--format json'))
         # MDS ID for which health warning has been generated.
-        hw_mds_id = self._get_unhealthy_mds_id(health_report, health_warn)
+        hw_mds_id = self._get_unhealthy_mds_id(health_warn)
         if mds1_id == hw_mds_id:
             non_hw_mds_id = mds2_id
         elif mds2_id == hw_mds_id:

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -122,6 +122,28 @@ class TestAdminCommands(CephFSTestCase):
                 if health_warn in health_report['checks']:
                     return
 
+    def gen_health_warn_mds_cache_oversized(self):
+        health_warn = 'MDS_CACHE_OVERSIZED'
+
+        self.config_set('mds', 'mds_cache_memory_limit', '1K')
+        self.config_set('mds', 'mds_health_cache_threshold', '1.00000')
+        self.mount_a.open_n_background('.', 400)
+
+        self.wait_till_health_warn(health_warn, active_mds_id)
+
+    def gen_health_warn_mds_trim(self):
+        health_warn = 'MDS_TRIM'
+
+        # for generating health warning MDS_TRIM
+        self.config_set('mds', 'mds_debug_subtrees', 'true')
+        # this will really really slow the trimming, so that MDS_TRIM stays
+        # for longer.
+        self.config_set('mds', 'mds_log_trim_decay_rate', '60')
+        self.config_set('mds', 'mds_log_trim_threshold', '1')
+        self.mount_a.open_n_background('.', 400)
+
+        self.wait_till_health_warn(health_warn, active_mds_id)
+
 
 @classhook('_add_valid_tell')
 class TestValidTell(TestAdminCommands):
@@ -2305,17 +2327,11 @@ class TestFSFail(TestAdminCommands):
         when confirmation flag is passed.
         '''
         health_warn = 'MDS_CACHE_OVERSIZED'
-        self.config_set('mds', 'mds_cache_memory_limit', '1K')
-        self.config_set('mds', 'mds_health_cache_threshold', '1.00000')
-        active_mds_id = self.fs.get_active_names()[0]
-
-        self.mount_a.open_n_background('.', 400)
-        self.wait_till_health_warn(health_warn, active_mds_id)
+        self.gen_health_warn_mds_cache_oversized()
 
         # actual testing begins now.
-        errmsg = 'mds_cache_oversized'
         self.negtest_ceph_cmd(args=f'fs fail {self.fs.name}',
-                              retval=1, errmsgs=errmsg)
+                              retval=1, errmsgs=health_warn)
         self.run_ceph_cmd(f'fs fail {self.fs.name} --yes-i-really-mean-it')
 
         # Bring and wait for MDS to be up since it is needed for unmounting
@@ -2330,21 +2346,11 @@ class TestFSFail(TestAdminCommands):
         confirmation flag is passed.
         '''
         health_warn = 'MDS_TRIM'
-        # for generating health warning MDS_TRIM
-        self.config_set('mds', 'mds_debug_subtrees', 'true')
-        # this will really really slow the trimming, so that MDS_TRIM stays
-        # for longer.
-        self.config_set('mds', 'mds_log_trim_decay_rate', '60')
-        self.config_set('mds', 'mds_log_trim_threshold', '1')
-        active_mds_id = self.fs.get_active_names()[0]
-
-        self.mount_a.open_n_background('.', 400)
-        self.wait_till_health_warn(health_warn, active_mds_id)
+        self.gen_health_warn_mds_trim()
 
         # actual testing begins now.
-        errmsg = 'mds_trim'
         self.negtest_ceph_cmd(args=f'fs fail {self.fs.name}',
-                              retval=1, errmsgs=errmsg)
+                              retval=1, errmsgs=health_warn)
         self.run_ceph_cmd(f'fs fail {self.fs.name} --yes-i-really-mean-it')
 
         # Bring and wait for MDS to be up since it is needed for unmounting
@@ -2361,19 +2367,11 @@ class TestFSFail(TestAdminCommands):
         '''
         health_warn = 'MDS_CACHE_OVERSIZED'
         self.fs.set_max_mds(2)
-        self.config_set('mds', 'mds_cache_memory_limit', '1K')
-        self.config_set('mds', 'mds_health_cache_threshold', '1.00000')
-        self.fs.wait_for_daemons()
-        mds1_id, mds2_id = self.fs.get_active_names()
-
-        self.mount_a.open_n_background('.', 400)
-        # MDS ID for which health warning has been generated.
-        self.wait_till_health_warn(health_warn, mds1_id)
+        self.gen_health_warn_mds_cache_oversized()
 
         # actual testing begins now.
-        errmsg = 'mds_cache_oversized'
         self.negtest_ceph_cmd(args=f'fs fail {self.fs.name}',
-                              retval=1, errmsgs=errmsg)
+                              retval=1, errmsgs=health_warn)
         self.run_ceph_cmd(f'fs fail {self.fs.name} --yes-i-really-mean-it')
 
         # Bring and wait for MDS to be up since it is needed for unmounting
@@ -2394,17 +2392,12 @@ class TestMDSFail(TestAdminCommands):
         passes when confirmation flag is passed.
         '''
         health_warn = 'MDS_CACHE_OVERSIZED'
-        self.config_set('mds', 'mds_cache_memory_limit', '1K')
-        self.config_set('mds', 'mds_health_cache_threshold', '1.00000')
-        active_mds_id = self.fs.get_active_names()[0]
-
-        self.mount_a.open_n_background('.', 400)
-        self.wait_till_health_warn(health_warn, active_mds_id)
+        self.gen_health_warn_mds_cache_oversized()
 
         # actual testing begins now.
-        errmsg = 'mds_cache_oversized'
+        active_mds_id = self.fs.get_active_names()[0]
         self.negtest_ceph_cmd(args=f'mds fail {active_mds_id}',
-                              retval=1, errmsgs=errmsg)
+                              retval=1, errmsgs=health_warn)
         self.run_ceph_cmd(f'mds fail {active_mds_id} --yes-i-really-mean-it')
 
     def test_with_health_warn_trim(self):
@@ -2414,21 +2407,12 @@ class TestMDSFail(TestAdminCommands):
         confirmation is passed.
         '''
         health_warn = 'MDS_TRIM'
-        # for generating health warning MDS_TRIM
-        self.config_set('mds', 'mds_debug_subtrees', 'true')
-        # this will really really slow the trimming, so that MDS_TRIM stays
-        # for longer.
-        self.config_set('mds', 'mds_log_trim_decay_rate', '60')
-        self.config_set('mds', 'mds_log_trim_threshold', '1')
-        active_mds_id = self.fs.get_active_names()[0]
-
-        self.mount_a.open_n_background('.', 400)
-        self.wait_till_health_warn(health_warn, active_mds_id)
+        self.gen_health_warn_mds_trim()
 
         # actual testing begins now...
-        errmsg = 'mds_trim'
+        active_mds_id = self.fs.get_active_names()[0]
         self.negtest_ceph_cmd(args=f'mds fail {active_mds_id}',
-                              retval=1, errmsgs=errmsg)
+                              retval=1, errmsgs=health_warn)
         self.run_ceph_cmd(f'mds fail {active_mds_id} --yes-i-really-mean-it')
 
     def test_with_health_warn_with_2_active_MDSs(self):
@@ -2440,13 +2424,8 @@ class TestMDSFail(TestAdminCommands):
         '''
         health_warn = 'MDS_CACHE_OVERSIZED'
         self.fs.set_max_mds(2)
-        self.config_set('mds', 'mds_cache_memory_limit', '1K')
-        self.config_set('mds', 'mds_health_cache_threshold', '1.00000')
-        self.fs.wait_for_daemons()
+        self.gen_health_warn_mds_cache_oversized()
         mds1_id, mds2_id = self.fs.get_active_names()
-
-        self.mount_a.open_n_background('.', 400)
-        self.wait_till_health_warn(health_warn, mds1_id)
 
         health_report = json.loads(self.get_ceph_cmd_stdout('health detail '
                                                             '--format json'))
@@ -2462,10 +2441,9 @@ class TestMDSFail(TestAdminCommands):
                                'than these two. This is definitely an error.')
 
         # actual testing begins now...
-        errmsg = 'mds_cache_oversized'
         self.negtest_ceph_cmd(args=f'mds fail {non_hw_mds_id}', retval=1,
-                              errmsgs=errmsg)
+                              errmsgs=health_warn)
         self.negtest_ceph_cmd(args=f'mds fail {hw_mds_id}', retval=1,
-                              errmsgs=errmsg)
+                              errmsgs=health_warn)
         self.run_ceph_cmd(f'mds fail {mds1_id} --yes-i-really-mean-it')
         self.run_ceph_cmd(f'mds fail {mds2_id} --yes-i-really-mean-it')

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -2289,7 +2289,7 @@ class TestFSFail(TestAdminCommands):
     MDSS_REQUIRED = 2
     CLIENTS_REQUIRED = 1
 
-    def test_with_health_warn_oversize_cache(self):
+    def test_with_health_warn_cache_oversized(self):
         '''
         Test that, when health warning MDS_CACHE_OVERSIZE is present for an
         MDS, command "ceph fs fail" fails without confirmation flag and passes
@@ -2354,7 +2354,7 @@ class TestMDSFail(TestAdminCommands):
     MDSS_REQUIRED = 2
     CLIENTS_REQUIRED = 1
 
-    def test_with_health_warn_oversize_cache(self):
+    def test_with_health_warn_cache_oversized(self):
         '''
         Test that, when health warning MDS_CACHE_OVERSIZE is present for an
         MDS, command "ceph mds fail" fails without confirmation flag and


### PR DESCRIPTION
**NOTE:** Originally part of PR #57333 but these commits are moved here to keep only inter-dependent bug fixes in it.

First couple of commits on this PR branch are kept here for since latter commits depend on them. They'll vanish when this PR is rebased on latest main after merging of PR #57333.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>