### PR TITLE
squid: crimson: convert some of client_request to use coroutines

### DIFF
--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -98,7 +98,72 @@ bool ClientRequest::is_pg_op() const
     [](auto& op) { return ceph_osd_op_type_pg(op.op.op); });
 }
 
-seastar::future<> ClientRequest::with_pg_process(Ref<PG> pgref)
+ClientRequest::interruptible_future<> ClientRequest::with_pg_process_interruptible(
+  Ref<PG> pgref, const unsigned this_instance_id, instance_handle_t &ihref)
+{
+  LOG_PREFIX(ClientRequest::with_pg_process);
+  DEBUGDPP(
+    "{}: same_interval_since: {}",
+    *pgref, *this, pgref->get_interval_start_epoch());
+
+  DEBUGDPP("{} start", *pgref, *this);
+  PG &pg = *pgref;
+  if (pg.can_discard_op(*m)) {
+    return shard_services->send_incremental_map(
+      std::ref(get_foreign_connection()), m->get_map_epoch()
+    ).then([FNAME, this, this_instance_id, pgref] {
+      DEBUGDPP("{}: discarding {}", *pgref, *this, this_instance_id);
+      pgref->client_request_orderer.remove_request(*this);
+      complete_request();
+      return interruptor::now();
+    });
+  }
+  DEBUGDPP("{}.{}: entering await_map stage",
+	   *pgref, *this, this_instance_id);
+  return ihref.enter_stage<interruptor>(client_pp(pg).await_map, *this
+  ).then_interruptible([FNAME, this, this_instance_id, &pg, &ihref] {
+    DEBUGDPP("{}.{}: entered await_map stage, waiting for map",
+	     pg, *this, this_instance_id);
+    return ihref.enter_blocker(
+      *this, pg.osdmap_gate, &decltype(pg.osdmap_gate)::wait_for_map,
+      m->get_min_epoch(), nullptr);
+  }).then_interruptible(
+    [FNAME, this, this_instance_id, &pg, &ihref](auto map_epoch) {
+    DEBUGDPP("{}.{}: map epoch got {}, entering wait_for_active",
+	     pg, *this, this_instance_id, map_epoch);
+    return ihref.enter_stage<interruptor>(client_pp(pg).wait_for_active, *this);
+  }).then_interruptible([FNAME, this, this_instance_id, &pg, &ihref]() {
+    DEBUGDPP("{}.{}: entered wait_for_active stage, waiting for active",
+	     pg, *this, this_instance_id);
+    return ihref.enter_blocker(
+      *this,
+      pg.wait_for_active_blocker,
+      &decltype(pg.wait_for_active_blocker)::wait);
+  }).then_interruptible(
+    [FNAME, this, pgref, this_instance_id, &ihref]() mutable
+    -> interruptible_future<> {
+    DEBUGDPP("{}.{}: pg active, entering process[_pg]_op",
+	     *pgref, *this, this_instance_id);
+    if (is_pg_op()) {
+      return process_pg_op(pgref);
+    } else {
+      return process_op(ihref, pgref, this_instance_id);
+    }
+  }).then_interruptible([FNAME, this, this_instance_id, pgref, &ihref] {
+    DEBUGDPP("{}.{}: process[_pg]_op complete, completing handle",
+	     *pgref, *this, this_instance_id);
+    return ihref.handle.complete();
+  }).then_interruptible([FNAME, this, this_instance_id, pgref] {
+    DEBUGDPP("{}.{}: process[_pg]_op complete,"
+	     "removing request from orderer",
+	     *pgref, *this, this_instance_id);
+    pgref->client_request_orderer.remove_request(*this);
+    complete_request();
+  });
+}
+
+seastar::future<> ClientRequest::with_pg_process(
+  Ref<PG> pgref)
 {
   ceph_assert_always(shard_services);
   LOG_PREFIX(ClientRequest::with_pg_process);
@@ -110,61 +175,8 @@ seastar::future<> ClientRequest::with_pg_process(Ref<PG> pgref)
   auto instance_handle = get_instance_handle();
   auto &ihref = *instance_handle;
   return interruptor::with_interruption(
-    [FNAME, this, pgref, this_instance_id, &ihref]() mutable {
-      DEBUGDPP("{} start", *pgref, *this);
-      PG &pg = *pgref;
-      if (pg.can_discard_op(*m)) {
-	return shard_services->send_incremental_map(
-	  std::ref(get_foreign_connection()), m->get_map_epoch()
-	).then([FNAME, this, this_instance_id, pgref] {
-	  DEBUGDPP("{}: discarding {}", *pgref, *this, this_instance_id);
-	  pgref->client_request_orderer.remove_request(*this);
-	  complete_request();
-	  return interruptor::now();
-	});
-      }
-      DEBUGDPP("{}.{}: entering await_map stage",
-	       *pgref, *this, this_instance_id);
-      return ihref.enter_stage<interruptor>(client_pp(pg).await_map, *this
-      ).then_interruptible([FNAME, this, this_instance_id, &pg, &ihref] {
-	DEBUGDPP("{}.{}: entered await_map stage, waiting for map",
-		 pg, *this, this_instance_id);
-	return ihref.enter_blocker(
-	  *this, pg.osdmap_gate, &decltype(pg.osdmap_gate)::wait_for_map,
-	  m->get_min_epoch(), nullptr);
-      }).then_interruptible(
-	[FNAME, this, this_instance_id, &pg, &ihref](auto map_epoch) {
-	DEBUGDPP("{}.{}: map epoch got {}, entering wait_for_active",
-		 pg, *this, this_instance_id, map_epoch);
-	return ihref.enter_stage<interruptor>(client_pp(pg).wait_for_active, *this);
-      }).then_interruptible([FNAME, this, this_instance_id, &pg, &ihref]() {
-	DEBUGDPP("{}.{}: entered wait_for_active stage, waiting for active",
-		 pg, *this, this_instance_id);
-	return ihref.enter_blocker(
-	  *this,
-	  pg.wait_for_active_blocker,
-	  &decltype(pg.wait_for_active_blocker)::wait);
-	}).then_interruptible(
-	  [FNAME, this, pgref, this_instance_id, &ihref]() mutable
-	  -> interruptible_future<> {
-	DEBUGDPP("{}.{}: pg active, entering process[_pg]_op",
-		 *pgref, *this, this_instance_id);
-	if (is_pg_op()) {
-	  return process_pg_op(pgref);
-	} else {
-	  return process_op(ihref, pgref, this_instance_id);
-	}
-      }).then_interruptible([FNAME, this, this_instance_id, pgref, &ihref] {
-	DEBUGDPP("{}.{}: process[_pg]_op complete, completing handle",
-		 *pgref, *this, this_instance_id);
-        return ihref.handle.complete();
-      }).then_interruptible([FNAME, this, this_instance_id, pgref] {
-	DEBUGDPP("{}.{}: process[_pg]_op complete,"
-		 "removing request from orderer",
-		 *pgref, *this, this_instance_id);
-	pgref->client_request_orderer.remove_request(*this);
-	complete_request();
-      });
+    [this, pgref, this_instance_id, &ihref]() mutable {
+      return with_pg_process_interruptible(pgref, this_instance_id, ihref);
     }, [FNAME, this, this_instance_id, pgref](std::exception_ptr eptr) {
       DEBUGDPP("{}.{}: interrupted due to {}",
 	       *pgref, *this, this_instance_id, eptr);

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -105,9 +105,6 @@ seastar::future<> ClientRequest::with_pg_int(Ref<PG> pgref)
   LOG_PREFIX(ClientRequest::with_pg_int);
   epoch_t same_interval_since = pgref->get_interval_start_epoch();
   DEBUGDPP("{}: same_interval_since: {}", *pgref, *this, same_interval_since);
-  if (m->finish_decode()) {
-    m->clear_payload();
-  }
   const auto this_instance_id = instance_id++;
   OperationRef opref{this};
   auto instance_handle = get_instance_handle();
@@ -184,6 +181,11 @@ seastar::future<> ClientRequest::with_pg(
 {
   shard_services = &_shard_services;
   pgref->client_request_orderer.add_request(*this);
+
+  if (m->finish_decode()) {
+    m->clear_payload();
+  }
+
   auto ret = on_complete.get_future();
   std::ignore = with_pg_int(std::move(pgref));
   return ret;

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -209,7 +209,8 @@ ClientRequest::process_pg_op(
     get_foreign_connection().send_with_throttling(std::move(reply)));
 }
 
-auto ClientRequest::reply_op_error(const Ref<PG>& pg, int err)
+ClientRequest::interruptible_future<>
+ClientRequest::reply_op_error(const Ref<PG>& pg, int err)
 {
   LOG_PREFIX(ClientRequest::reply_op_error);
   DEBUGDPP("{}: replying with error {}", *pg, *this, err);
@@ -220,7 +221,9 @@ auto ClientRequest::reply_op_error(const Ref<PG>& pg, int err)
   reply->set_reply_versions(eversion_t(), 0);
   reply->set_op_returns(std::vector<pg_log_op_return_item_t>{});
   // TODO: gate the crosscore sending
-  return get_foreign_connection().send_with_throttling(std::move(reply));
+  return interruptor::make_interruptible(
+    get_foreign_connection().send_with_throttling(std::move(reply))
+  );
 }
 
 ClientRequest::interruptible_future<>

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -25,7 +25,7 @@ void ClientRequest::Orderer::requeue(Ref<PG> pg)
   for (auto &req: list) {
     DEBUGDPP("requeueing {}", *pg, req);
     req.reset_instance_handle();
-    std::ignore = req.with_pg_int(pg);
+    std::ignore = req.with_pg_process(pg);
   }
 }
 
@@ -98,11 +98,11 @@ bool ClientRequest::is_pg_op() const
     [](auto& op) { return ceph_osd_op_type_pg(op.op.op); });
 }
 
-seastar::future<> ClientRequest::with_pg_int(Ref<PG> pgref)
+seastar::future<> ClientRequest::with_pg_process(Ref<PG> pgref)
 {
   ceph_assert_always(shard_services);
+  LOG_PREFIX(ClientRequest::with_pg_process);
 
-  LOG_PREFIX(ClientRequest::with_pg_int);
   epoch_t same_interval_since = pgref->get_interval_start_epoch();
   DEBUGDPP("{}: same_interval_since: {}", *pgref, *this, same_interval_since);
   const auto this_instance_id = instance_id++;
@@ -187,7 +187,7 @@ seastar::future<> ClientRequest::with_pg(
   }
 
   auto ret = on_complete.get_future();
-  std::ignore = with_pg_int(std::move(pgref));
+  std::ignore = with_pg_process(std::move(pgref));
   return ret;
 }
 

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -4,6 +4,7 @@
 #include "messages/MOSDOp.h"
 #include "messages/MOSDOpReply.h"
 
+#include "crimson/common/coroutine.h"
 #include "crimson/common/exception.h"
 #include "crimson/common/log.h"
 #include "crimson/osd/pg.h"
@@ -109,57 +110,52 @@ ClientRequest::interruptible_future<> ClientRequest::with_pg_process_interruptib
   DEBUGDPP("{} start", *pgref, *this);
   PG &pg = *pgref;
   if (pg.can_discard_op(*m)) {
-    return shard_services->send_incremental_map(
-      std::ref(get_foreign_connection()), m->get_map_epoch()
-    ).then([FNAME, this, this_instance_id, pgref] {
-      DEBUGDPP("{}: discarding {}", *pgref, *this, this_instance_id);
-      pgref->client_request_orderer.remove_request(*this);
-      complete_request();
-      return interruptor::now();
-    });
+    co_await interruptor::make_interruptible(
+      shard_services->send_incremental_map(
+	std::ref(get_foreign_connection()), m->get_map_epoch()
+      ));
+    DEBUGDPP("{}: discarding {}", *pgref, *this, this_instance_id);
+    pgref->client_request_orderer.remove_request(*this);
+    complete_request();
+    co_return;
   }
   DEBUGDPP("{}.{}: entering await_map stage",
 	   *pgref, *this, this_instance_id);
-  return ihref.enter_stage<interruptor>(client_pp(pg).await_map, *this
-  ).then_interruptible([FNAME, this, this_instance_id, &pg, &ihref] {
-    DEBUGDPP("{}.{}: entered await_map stage, waiting for map",
-	     pg, *this, this_instance_id);
-    return ihref.enter_blocker(
+  co_await ihref.enter_stage<interruptor>(client_pp(pg).await_map, *this);
+  DEBUGDPP("{}.{}: entered await_map stage, waiting for map",
+	   pg, *this, this_instance_id);
+  auto map_epoch = co_await interruptor::make_interruptible(
+    ihref.enter_blocker(
       *this, pg.osdmap_gate, &decltype(pg.osdmap_gate)::wait_for_map,
-      m->get_min_epoch(), nullptr);
-  }).then_interruptible(
-    [FNAME, this, this_instance_id, &pg, &ihref](auto map_epoch) {
-    DEBUGDPP("{}.{}: map epoch got {}, entering wait_for_active",
-	     pg, *this, this_instance_id, map_epoch);
-    return ihref.enter_stage<interruptor>(client_pp(pg).wait_for_active, *this);
-  }).then_interruptible([FNAME, this, this_instance_id, &pg, &ihref]() {
-    DEBUGDPP("{}.{}: entered wait_for_active stage, waiting for active",
-	     pg, *this, this_instance_id);
-    return ihref.enter_blocker(
+      m->get_min_epoch(), nullptr));
+
+  DEBUGDPP("{}.{}: map epoch got {}, entering wait_for_active",
+	   pg, *this, this_instance_id, map_epoch);
+  co_await ihref.enter_stage<interruptor>(client_pp(pg).wait_for_active, *this);
+
+  DEBUGDPP("{}.{}: entered wait_for_active stage, waiting for active",
+	   pg, *this, this_instance_id);
+  co_await interruptor::make_interruptible(
+    ihref.enter_blocker(
       *this,
       pg.wait_for_active_blocker,
-      &decltype(pg.wait_for_active_blocker)::wait);
-  }).then_interruptible(
-    [FNAME, this, pgref, this_instance_id, &ihref]() mutable
-    -> interruptible_future<> {
-    DEBUGDPP("{}.{}: pg active, entering process[_pg]_op",
-	     *pgref, *this, this_instance_id);
-    if (is_pg_op()) {
-      return process_pg_op(pgref);
-    } else {
-      return process_op(ihref, pgref, this_instance_id);
-    }
-  }).then_interruptible([FNAME, this, this_instance_id, pgref, &ihref] {
-    DEBUGDPP("{}.{}: process[_pg]_op complete, completing handle",
-	     *pgref, *this, this_instance_id);
-    return ihref.handle.complete();
-  }).then_interruptible([FNAME, this, this_instance_id, pgref] {
-    DEBUGDPP("{}.{}: process[_pg]_op complete,"
-	     "removing request from orderer",
-	     *pgref, *this, this_instance_id);
-    pgref->client_request_orderer.remove_request(*this);
-    complete_request();
-  });
+      &decltype(pg.wait_for_active_blocker)::wait));
+
+  DEBUGDPP("{}.{}: pg active, entering process[_pg]_op",
+	   *pgref, *this, this_instance_id);
+
+  co_await (is_pg_op() ? process_pg_op(pgref) :
+	    process_op(ihref, pgref, this_instance_id));
+
+  DEBUGDPP("{}.{}: process[_pg]_op complete, completing handle",
+	   *pgref, *this, this_instance_id);
+  co_await interruptor::make_interruptible(ihref.handle.complete());
+
+  DEBUGDPP("{}.{}: process[_pg]_op complete,"
+	   "removing request from orderer",
+	   *pgref, *this, this_instance_id);
+  pgref->client_request_orderer.remove_request(*this);
+  complete_request();
 }
 
 seastar::future<> ClientRequest::with_pg_process(

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -231,74 +231,73 @@ ClientRequest::process_op(
   instance_handle_t &ihref, Ref<PG> pg, unsigned this_instance_id)
 {
   LOG_PREFIX(ClientRequest::process_op);
-  return ihref.enter_stage<interruptor>(
+  co_await ihref.enter_stage<interruptor>(
     client_pp(*pg).recover_missing, *this
-  ).then_interruptible([pg, this]() mutable {
-    return recover_missings(pg, m->get_hobj(), snaps_need_to_recover());
-  }).then_interruptible([FNAME, this, pg, this_instance_id, &ihref]() mutable {
-    DEBUGDPP("{}.{}: checking already_complete",
+  );
+  co_await recover_missings(pg, m->get_hobj(), snaps_need_to_recover());
+
+  DEBUGDPP("{}.{}: checking already_complete",
+	   *pg, *this, this_instance_id);
+  auto completed = co_await pg->already_complete(m->get_reqid());
+
+  if (completed) {
+    DEBUGDPP("{}.{}: already completed, sending reply",
 	     *pg, *this, this_instance_id);
-    return pg->already_complete(m->get_reqid()).then_interruptible(
-      [FNAME, this, pg, this_instance_id, &ihref](auto completed) mutable
-      -> PG::load_obc_iertr::future<> {
-      if (completed) {
-	DEBUGDPP("{}.{}: already completed, sending reply",
-		 *pg, *this, this_instance_id);
-        auto reply = crimson::make_message<MOSDOpReply>(
-          m.get(), completed->err, pg->get_osdmap_epoch(),
-          CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK, false);
-	reply->set_reply_versions(completed->version, completed->user_version);
-        // TODO: gate the crosscore sending
-        return get_foreign_connection().send_with_throttling(std::move(reply));
-      } else {
-	DEBUGDPP("{}.{}: not completed, entering get_obc stage",
-		 *pg, *this, this_instance_id);
-        return ihref.enter_stage<interruptor>(client_pp(*pg).get_obc, *this
-	).then_interruptible(
-          [FNAME, this, pg, this_instance_id, &ihref]() mutable
-	  -> PG::load_obc_iertr::future<> {
-	  DEBUGDPP("{}.{}: entered get_obc stage, about to wait_scrub",
+    auto reply = crimson::make_message<MOSDOpReply>(
+      m.get(), completed->err, pg->get_osdmap_epoch(),
+      CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK, false);
+    reply->set_reply_versions(completed->version, completed->user_version);
+    // TODO: gate the crosscore sending
+    co_await interruptor::make_interruptible(
+      get_foreign_connection().send_with_throttling(std::move(reply))
+    );
+    co_return;
+  }
+
+  DEBUGDPP("{}.{}: not completed, entering get_obc stage",
+	   *pg, *this, this_instance_id);
+  co_await ihref.enter_stage<interruptor>(client_pp(*pg).get_obc, *this);
+
+  DEBUGDPP("{}.{}: entered get_obc stage, about to wait_scrub",
+	   *pg, *this, this_instance_id);
+  if (int res = op_info.set_from_op(&*m, *pg->get_osdmap());
+      res != 0) {
+    co_await reply_op_error(pg, res);
+    co_return;
+  }
+  co_await ihref.enter_blocker(
+    *this, pg->scrubber, &decltype(pg->scrubber)::wait_scrub,
+    m->get_hobj());
+
+  DEBUGDPP("{}.{}: past scrub blocker, getting obc",
+	   *pg, *this, this_instance_id);
+  co_await pg->with_locked_obc(
+    m->get_hobj(), op_info,
+    [FNAME, this, pg, this_instance_id, &ihref] (
+      auto head, auto obc
+    ) -> interruptible_future<> {
+      DEBUGDPP("{}.{}: got obc {}, entering process stage",
+	       *pg, *this, this_instance_id, obc->obs);
+      return ihref.enter_stage<interruptor>(
+	client_pp(*pg).process, *this
+      ).then_interruptible(
+	[FNAME, this, pg, this_instance_id, obc, &ihref]() mutable {
+	  DEBUGDPP("{}.{}: in process stage, calling do_process",
 		   *pg, *this, this_instance_id);
-          if (int res = op_info.set_from_op(&*m, *pg->get_osdmap());
-              res != 0) {
-	    return reply_op_error(pg, res);
-          }
-	  return ihref.enter_blocker(
-	    *this,
-	    pg->scrubber,
-	    &decltype(pg->scrubber)::wait_scrub,
-	    m->get_hobj()
-	  ).then_interruptible(
-	    [FNAME, this, pg, this_instance_id, &ihref]() mutable {
-	      DEBUGDPP("{}.{}: past scrub blocker, getting obc",
-		       *pg, *this, this_instance_id);
-	    return pg->with_locked_obc(
-	      m->get_hobj(), op_info,
-	      [FNAME, this, pg, this_instance_id, &ihref](
-		auto head, auto obc) mutable {
-		DEBUGDPP("{}.{}: got obc {}, entering process stage",
-			 *pg, *this, this_instance_id, obc->obs);
-		return ihref.enter_stage<interruptor>(
-		  client_pp(*pg).process, *this
-		).then_interruptible(
-		  [FNAME, this, pg, this_instance_id, obc, &ihref]() mutable {
-		    DEBUGDPP("{}.{}: in process stage, calling do_process",
-			     *pg, *this, this_instance_id);
-		  return do_process(ihref, pg, obc, this_instance_id);
-		});
-	      });
-	  });
-        });
-      }
-    });
-  }).handle_error_interruptible(
+	  return do_process(ihref, pg, obc, this_instance_id);
+	});
+    }
+  ).handle_error_interruptible(
     PG::load_obc_ertr::all_same_way(
-      [FNAME, this, pg=std::move(pg), this_instance_id](const auto &code) {
-      DEBUGDPP("{}.{}: saw error code {}",
-	       *pg, *this, this_instance_id, code);
-      assert(code.value() > 0);
-      return reply_op_error(pg, -code.value());
-  }));
+      [FNAME, this, pg=std::move(pg), this_instance_id](
+	const auto &code
+      ) -> interruptible_future<> {
+	DEBUGDPP("{}.{}: saw error code {}",
+		 *pg, *this, this_instance_id, code);
+	assert(code.value() > 0);
+	return reply_op_error(pg, -code.value());
+      })
+  );
 }
 
 ClientRequest::interruptible_future<>

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -253,6 +253,9 @@ public:
     r_conn = make_local_shared_foreign(std::move(conn));
   }
 
+  interruptible_future<> with_pg_process_interruptible(
+    Ref<PG> pgref, const unsigned instance_id, instance_handle_t &ihref);
+
   seastar::future<> with_pg_process(Ref<PG> pg);
 
 public:

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -267,7 +267,12 @@ private:
   interruptible_future<> with_sequencer(FuncT&& func);
   interruptible_future<> reply_op_error(const Ref<PG>& pg, int err);
 
-  interruptible_future<> do_process(
+
+  using do_process_iertr =
+    ::crimson::interruptible::interruptible_errorator<
+      ::crimson::osd::IOInterruptCondition,
+      ::crimson::errorator<crimson::ct_error::eagain>>;
+  do_process_iertr::future<> do_process(
     instance_handle_t &ihref,
     Ref<PG> pg,
     crimson::osd::ObjectContextRef obc,

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -253,7 +253,7 @@ public:
     r_conn = make_local_shared_foreign(std::move(conn));
   }
 
-  seastar::future<> with_pg_int(Ref<PG> pg);
+  seastar::future<> with_pg_process(Ref<PG> pg);
 
 public:
   seastar::future<> with_pg(

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -265,7 +265,7 @@ public:
 private:
   template <typename FuncT>
   interruptible_future<> with_sequencer(FuncT&& func);
-  auto reply_op_error(const Ref<PG>& pg, int err);
+  interruptible_future<> reply_op_error(const Ref<PG>& pg, int err);
 
   interruptible_future<> do_process(
     instance_handle_t &ihref,

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -266,16 +266,16 @@ private:
 
   interruptible_future<> do_process(
     instance_handle_t &ihref,
-    Ref<PG>& pg,
+    Ref<PG> pg,
     crimson::osd::ObjectContextRef obc,
     unsigned this_instance_id);
   ::crimson::interruptible::interruptible_future<
     ::crimson::osd::IOInterruptCondition> process_pg_op(
-    Ref<PG> &pg);
+    Ref<PG> pg);
   ::crimson::interruptible::interruptible_future<
     ::crimson::osd::IOInterruptCondition> process_op(
       instance_handle_t &ihref,
-      Ref<PG> &pg,
+      Ref<PG> pg,
       unsigned this_instance_id);
   bool is_pg_op() const;
 
@@ -290,7 +290,7 @@ private:
   bool is_misdirected(const PG& pg) const;
 
   const SnapContext get_snapc(
-    Ref<PG>& pg,
+    PG &pg,
     crimson::osd::ObjectContextRef obc) const;
 
 public:


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55847

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh