### PR TITLE
squid: crimson/osd: implement basic reactor-utilization stats report to log

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -31,6 +31,11 @@ options:
   desc: CPU cores on which alienstore threads will run in cpuset(7) format
   flags:
   - startup
+- name: crimson_osd_stat_interval
+  type: int
+  level: advanced
+  default: 0
+  desc: Report OSD status periodically in seconds, 0 to disable
 - name: seastore_segment_size
   type: size
   desc: Segment size to use for SegmentManager

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -128,6 +128,9 @@ class OSD final : public crimson::net::Dispatcher,
   std::unique_ptr<Heartbeat> heartbeat;
   seastar::timer<seastar::lowres_clock> tick_timer;
 
+  seastar::timer<seastar::lowres_clock> stats_timer;
+  std::vector<ShardServices::shard_stats_t> shard_stats;
+
   const char** get_tracked_conf_keys() const final;
   void handle_conf_change(const ConfigProxy& conf,
                           const std::set<std::string> &changed) final;

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -402,6 +402,13 @@ public:
     return local_state.store;
   }
 
+  struct shard_stats_t {
+    double reactor_utilization;
+  };
+  shard_stats_t report_stats() {
+    return {get_reactor_utilization()};
+  }
+
   auto remove_pg(spg_t pgid) {
     local_state.pg_map.remove_pg(pgid);
     return pg_to_shard_mapping.remove_pg_mapping(pgid);


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56775

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh