### PR TITLE
squid: qa/suites/crimson-rados/thrash: enable chance_down

### DIFF
--- a/qa/suites/crimson-rados/thrash/thrashers/simple.yaml
+++ b/qa/suites/crimson-rados/thrash/thrashers/simple.yaml
@@ -25,6 +25,7 @@ tasks:
     sighup_delay: 0
     min_in: 3
     noscrub_toggle_delay: 0
+    chance_down: 0
     chance_thrash_pg_upmap: 0
     reweight_osd: 0
     thrash_primary_affinity: false


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56511

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh