### PR TITLE
squid: crimson/common/operation: fix and move exit() after entering the next phase

### DIFF
--- a/src/crimson/common/operation.h
+++ b/src/crimson/common/operation.h
@@ -528,18 +528,18 @@ public:
     if (wait_fut.has_value()) {
       return wait_fut.value().then([this, &stage, t=std::move(t)] () mutable {
         auto fut = t.maybe_record_blocking(stage.enter(t), stage);
-        exit();
         return std::move(fut).then(
           [this, t=std::move(t)](auto &&barrier_ref) mutable {
+          exit();
           barrier = std::move(barrier_ref);
           return seastar::now();
         });
       });
     } else {
         auto fut = t.maybe_record_blocking(stage.enter(t), stage);
-        exit();
         return std::move(fut).then(
           [this, t=std::move(t)](auto &&barrier_ref) mutable {
+          exit();
           barrier = std::move(barrier_ref);
           return seastar::now();
         });


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56912

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh