### PR TITLE
squid: crimson/osd/replicated_recovery_backend: prepare_pull use pg_info

### DIFF
--- a/src/crimson/osd/replicated_recovery_backend.h
+++ b/src/crimson/osd/replicated_recovery_backend.h
@@ -67,8 +67,7 @@ protected:
     eversion_t need);
   ObjectRecoveryInfo set_recovery_info(
     const hobject_t& soid,
-    const crimson::osd::SnapSetContextRef ssc,
-    const hobject_t& last_backfill);
+    const crimson::osd::SnapSetContextRef ssc);
   std::vector<pg_shard_t> get_shards_to_push(
     const hobject_t& soid) const;
   interruptible_future<PushOp> build_push_op(


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56611

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh