### PR TITLE
squid: crimson: Add support for pool compression

### DIFF
--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -75,6 +75,8 @@ public:
   seastar::future<CollectionRef> create_new_collection(const coll_t& cid) final;
   seastar::future<CollectionRef> open_collection(const coll_t& cid) final;
   seastar::future<std::vector<coll_core_t>> list_collections() final;
+  seastar::future<> set_collection_opts(CollectionRef c,
+                                        const pool_opts_t& opts) final;
 
   seastar::future<> do_transaction_no_callbacks(
     CollectionRef c,
@@ -90,6 +92,7 @@ public:
     const std::string& key) final;
   uuid_d get_fsid() const final;
   seastar::future<store_statfs_t> stat() const final;
+  seastar::future<store_statfs_t> pool_statfs(int64_t pool_id) const final;
   unsigned get_max_attr_name_length() const final;
   seastar::future<struct stat> stat(
     CollectionRef,

--- a/src/crimson/os/cyanstore/cyan_collection.h
+++ b/src/crimson/os/cyanstore/cyan_collection.h
@@ -36,6 +36,8 @@ struct Collection final : public FuturizedCollection {
   std::map<std::string,bufferptr> xattr;
   bool exists = true;
 
+  pool_opts_t pool_opts;
+
   Collection(const coll_t& c);
   ~Collection() final;
 

--- a/src/crimson/os/cyanstore/cyan_store.cc
+++ b/src/crimson/os/cyanstore/cyan_store.cc
@@ -71,6 +71,11 @@ seastar::future<store_statfs_t> CyanStore::stat() const
   });
 }
 
+seastar::future<store_statfs_t> CyanStore::pool_statfs(int64_t pool_id) const
+{
+  return stat();
+}
+
 
 CyanStore::mkfs_ertr::future<> CyanStore::mkfs(uuid_d new_osd_fsid)
 {
@@ -256,6 +261,16 @@ CyanStore::Shard::exists(
     return base_errorator::make_ready_future<bool>(false);
   }
   return base_errorator::make_ready_future<bool>(true);
+}
+
+seastar::future<>
+CyanStore::Shard::set_collection_opts(CollectionRef ch,
+                                      const pool_opts_t& opts)
+{
+  auto c = static_cast<Collection*>(ch.get());
+  logger().debug("{} {}", __func__, c->get_cid());
+  c->pool_opts = opts;
+  return seastar::now();
 }
 
 CyanStore::Shard::read_errorator::future<ceph::bufferlist>

--- a/src/crimson/os/cyanstore/cyan_store.h
+++ b/src/crimson/os/cyanstore/cyan_store.h
@@ -88,6 +88,10 @@ public:
 
     seastar::future<CollectionRef> open_collection(const coll_t& cid) final;
 
+    seastar::future<> set_collection_opts(
+      CollectionRef c,
+      const pool_opts_t& opts) final;
+
     seastar::future<> do_transaction_no_callbacks(
       CollectionRef ch,
       ceph::os::Transaction&& txn) final;
@@ -201,6 +205,8 @@ public:
   mkfs_ertr::future<> mkfs(uuid_d new_osd_fsid) final;
 
   seastar::future<store_statfs_t> stat() const final;
+
+  seastar::future<store_statfs_t> pool_statfs(int64_t pool_id) const final;
 
   uuid_d get_fsid() const final;
 

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -102,6 +102,9 @@ public:
 
     virtual seastar::future<CollectionRef> open_collection(const coll_t& cid) = 0;
 
+    virtual seastar::future<> set_collection_opts(CollectionRef c,
+                                        const pool_opts_t& opts) = 0;
+
   protected:
     virtual seastar::future<> do_transaction_no_callbacks(
       CollectionRef ch,
@@ -180,6 +183,8 @@ public:
   virtual mkfs_ertr::future<> mkfs(uuid_d new_osd_fsid) = 0;
 
   virtual seastar::future<store_statfs_t> stat() const = 0;
+
+  virtual seastar::future<store_statfs_t> pool_statfs(int64_t pool_id) const = 0;
 
   virtual uuid_d get_fsid() const  = 0;
 

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -566,6 +566,12 @@ seastar::future<store_statfs_t> SeaStore::stat() const
   });
 }
 
+seastar::future<store_statfs_t> SeaStore::pool_statfs(int64_t pool_id) const
+{
+   //TODO
+   return SeaStore::stat();
+}
+
 TransactionManager::read_extent_iertr::future<std::optional<unsigned>>
 SeaStore::Shard::get_coll_bits(CollectionRef ch, Transaction &t) const
 {
@@ -777,6 +783,14 @@ SeaStore::Shard::open_collection(const coll_t& cid)
       return seastar::make_ready_future<CollectionRef>();
     }
   });
+}
+
+seastar::future<>
+SeaStore::Shard::set_collection_opts(CollectionRef c,
+                                        const pool_opts_t& opts)
+{
+  //TODO
+  return seastar::now();
 }
 
 seastar::future<std::vector<coll_core_t>>

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -158,6 +158,8 @@ public:
 
     seastar::future<CollectionRef> create_new_collection(const coll_t& cid) final;
     seastar::future<CollectionRef> open_collection(const coll_t& cid) final;
+    seastar::future<> set_collection_opts(CollectionRef c,
+                                        const pool_opts_t& opts) final;
 
     seastar::future<> do_transaction_no_callbacks(
       CollectionRef ch,
@@ -491,6 +493,7 @@ public:
 
   mkfs_ertr::future<> mkfs(uuid_d new_osd_fsid) final;
   seastar::future<store_statfs_t> stat() const final;
+  seastar::future<store_statfs_t> pool_statfs(int64_t pool_id) const final;
 
   uuid_d get_fsid() const final {
     ceph_assert(seastar::this_shard_id() == primary_core);

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -672,6 +672,11 @@ seastar::future<> PG::read_state(crimson::os::FuturizedStore::Shard* store)
 	PeeringState::Initialize());
 
     return seastar::now();
+  }).then([this, store]() {
+    logger().debug("{} setting collection options", __func__);
+    return store->set_collection_opts(
+          coll_ref,
+          get_pgpool().info.opts);
   });
 }
 
@@ -730,6 +735,16 @@ seastar::future<> PG::handle_initialize(PeeringCtx &rctx)
   return seastar::async([this, &rctx] {
     peering_state.handle_event(PeeringState::Initialize{}, &rctx);
   });
+}
+
+void PG::init_collection_pool_opts()
+{
+  std::ignore = shard_services.get_store().set_collection_opts(coll_ref, get_pgpool().info.opts);
+}
+
+void PG::on_pool_change()
+{
+  init_collection_pool_opts();
 }
 
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -309,9 +309,8 @@ public:
 
   unsigned get_target_pg_log_entries() const final;
 
-  void on_pool_change() final {
-    // Not needed yet
-  }
+  void init_collection_pool_opts();
+  void on_pool_change();
   void on_role_change() final {
     // Not needed yet
   }


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56277

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh