### PR TITLE
squid: crimson/osd/recovery_backends: discard outdated recovery ops

### DIFF
--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -740,7 +740,7 @@ public:
 
   template <typename MsgType>
   bool can_discard_replica_op(const MsgType& m) const {
-    return can_discard_replica_op(m, m.map_epoch);
+    return can_discard_replica_op(m, m.get_map_epoch());
   }
 
 private:

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -162,10 +162,7 @@ RecoveryBackend::handle_backfill_remove(
 {
   logger().debug("{} m.ls={}", __func__, m.ls);
   assert(m.get_type() == MSG_OSD_PG_BACKFILL_REMOVE);
-  if (pg.can_discard_replica_op(m)) {
-    logger().debug("{}: discarding {}", __func__, m);
-    return seastar::now();
-  }
+
   ObjectStore::Transaction t;
   for ([[maybe_unused]] const auto& [soid, ver] : m.ls) {
     // TODO: the reserved space management. PG::try_reserve_recovery_space().

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -1307,6 +1307,11 @@ ReplicatedRecoveryBackend::handle_recovery_op(
   Ref<MOSDFastDispatchOp> m,
   crimson::net::ConnectionXcoreRef conn)
 {
+  if (pg.can_discard_replica_op(*m)) {
+    logger().debug("{}: discarding {}", __func__, *m);
+    return seastar::now();
+  }
+
   switch (m->get_header().type) {
   case MSG_OSD_PG_PULL:
     return handle_pull(boost::static_pointer_cast<MOSDPGPull>(m));


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56848

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh