### PR TITLE
squid: crimson/osd/osd_meta: load incremental osdmap from "inc_osdmap.XXX"

### DIFF
--- a/src/crimson/osd/osd_meta.cc
+++ b/src/crimson/osd/osd_meta.cc
@@ -54,7 +54,7 @@ seastar::future<bufferlist> OSDMeta::load_map(epoch_t e)
 read_errorator::future<ceph::bufferlist> OSDMeta::load_inc_map(epoch_t e)
 {
   return store.read(coll,
-                    osdmap_oid(e), 0, 0,
+                    inc_osdmap_oid(e), 0, 0,
                     CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
 }
 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56875

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh