### PR TITLE
squid: crimson/os/seastore/btree: clean up `FixedKVLeafNode::get_logical_child()`

### DIFF
--- a/src/crimson/os/seastore/btree/btree_range_pin.cc
+++ b/src/crimson/os/seastore/btree/btree_range_pin.cc
@@ -15,7 +15,10 @@ BtreeNodeMapping<key_t, val_t>::get_logical_extent(
   assert(parent->is_valid());
   assert(pos != std::numeric_limits<uint16_t>::max());
   auto &p = (FixedKVNode<key_t>&)*parent;
-  auto v = p.get_logical_child(ctx, pos);
+  auto k = this->is_indirect()
+    ? this->get_intermediate_base()
+    : get_key();
+  auto v = p.template get_child<LogicalCachedExtent>(ctx, pos, k);
   if (!v.has_child()) {
     this->child_pos = v.get_child_pos();
   }


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56383

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh