### PR TITLE
squid: crimson/osd/ops_executer: fix snap overlap range error

### DIFF
--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -255,6 +255,14 @@ private:
       && snapc.snaps[0] > initial_obc.ssc->snapset.seq; // existing obj is old
   }
 
+  /**
+  * update_clone_overlap
+  *
+  * We need to update the most recent snapshot and the overlapping
+  * part of the head object for each write operation.
+  */
+  void update_clone_overlap();
+
   interruptible_future<std::vector<pg_log_entry_t>> flush_clone_metadata(
     std::vector<pg_log_entry_t>&& log_entries,
     SnapMapper& snap_mapper,

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -596,11 +596,11 @@ void PGBackend::update_size_and_usage(object_stat_sum_t& delta_stats,
   if (write_full) {
     if (oi.size) {
       ch.insert(0, oi.size);
-    } else if (length) {
-      ch.insert(offset, length);
     }
-    modified.union_of(ch);
+  } else if (length) {
+    ch.insert(offset, length);
   }
+  modified.union_of(ch);
   if (write_full ||
       (offset + length > oi.size && length)) {
     uint64_t new_size = offset + length;

--- a/src/test/librados/snapshots_cxx.cc
+++ b/src/test/librados/snapshots_cxx.cc
@@ -238,8 +238,6 @@ TEST_F(LibRadosSnapshotsSelfManagedPP, RollbackPP) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManagedPP, SnapOverlapPP) {
-  // WIP https://tracker.ceph.com/issues/58263
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   IoCtx readioctx;
   ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), readioctx));


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56606

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh