### PR TITLE
squid: crimson/common/tri_mutex: make locking/promotion atomic if possible

### DIFF
--- a/src/crimson/common/tri_mutex.cc
+++ b/src/crimson/common/tri_mutex.cc
@@ -35,10 +35,9 @@ void excl_lock::unlock()
   static_cast<tri_mutex*>(this)->unlock_for_excl();
 }
 
-seastar::future<> excl_lock_from_read::lock()
+void excl_lock_from_read::lock()
 {
   static_cast<tri_mutex*>(this)->promote_from_read();
-  return seastar::now();
 }
 
 void excl_lock_from_read::unlock()
@@ -46,24 +45,14 @@ void excl_lock_from_read::unlock()
   static_cast<tri_mutex*>(this)->demote_to_read();
 }
 
-seastar::future<> excl_lock_from_write::lock()
+void excl_lock_from_write::lock()
 {
   static_cast<tri_mutex*>(this)->promote_from_write();
-  return seastar::now();
 }
 
 void excl_lock_from_write::unlock()
 {
   static_cast<tri_mutex*>(this)->demote_to_write();
-}
-
-seastar::future<> excl_lock_from_excl::lock()
-{
-  return seastar::now();
-}
-
-void excl_lock_from_excl::unlock()
-{
 }
 
 tri_mutex::~tri_mutex()

--- a/src/crimson/common/tri_mutex.h
+++ b/src/crimson/common/tri_mutex.h
@@ -27,21 +27,14 @@ public:
 // promote from read to excl
 class excl_lock_from_read {
 public:
-  seastar::future<> lock();
+  void lock();
   void unlock();
 };
 
 // promote from write to excl
 class excl_lock_from_write {
 public:
-  seastar::future<> lock();
-  void unlock();
-};
-
-// promote from excl to excl
-class excl_lock_from_excl {
-public:
-  seastar::future<> lock();
+  void lock();
   void unlock();
 };
 
@@ -58,12 +51,14 @@ public:
 /// - readers
 /// - writers
 /// - exclusive users
+///
+/// For lock promotion, a read or a write lock is only allowed to be promoted
+/// atomically upon the first locking.
 class tri_mutex : private read_lock,
                           write_lock,
                           excl_lock,
                           excl_lock_from_read,
-                          excl_lock_from_write,
-                          excl_lock_from_excl
+                          excl_lock_from_write
 {
 public:
   tri_mutex() = default;
@@ -82,9 +77,6 @@ public:
     return *this;
   }
   excl_lock_from_write& excl_from_write() {
-    return *this;
-  }
-  excl_lock_from_excl& excl_from_excl() {
     return *this;
   }
 

--- a/src/crimson/common/tri_mutex.h
+++ b/src/crimson/common/tri_mutex.h
@@ -99,8 +99,8 @@ public:
   }
 
   // for shared writers
-  seastar::future<> lock_for_write(bool greedy);
-  bool try_lock_for_write(bool greedy) noexcept;
+  seastar::future<> lock_for_write();
+  bool try_lock_for_write() noexcept;
   void unlock_for_write();
   void promote_from_write();
   void demote_to_write();

--- a/src/crimson/common/tri_mutex.h
+++ b/src/crimson/common/tri_mutex.h
@@ -47,11 +47,11 @@ public:
 
 /// shared/exclusive mutual exclusion
 ///
-/// this lock design uses reader and writer is entirely and completely
-/// independent of the conventional reader/writer lock usage. Here, what we
-/// mean is that we can pipeline reads, and we can pipeline writes, but we
-/// cannot allow a read while writes are in progress or a write while reads are
-/// in progress. Any rmw operation is therefore exclusive.
+/// Unlike reader/write lock, tri_mutex does not enforce the exclusive access
+/// of write operations, on the contrary, multiple write operations are allowed
+/// to hold the same tri_mutex at the same time. Here, what we mean is that we
+/// can pipeline reads, and we can pipeline writes, but we cannot allow a read
+/// while writes are in progress or a write while reads are in progress.
 ///
 /// tri_mutex is based on seastar::shared_mutex, but instead of two kinds of
 /// waiters, tri_mutex keeps track of three kinds of lock users:


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56844

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh