### PR TITLE
squid: crimson/os/seastore: only update onode sizes when necessary

### DIFF
--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -1639,8 +1639,8 @@ SeaStore::Shard::_write(
 {
   LOG_PREFIX(SeaStore::_write);
   DEBUGT("onode={} {}~{}", *ctx.transaction, *onode, offset, len);
-  {
-    const auto &object_size = onode->get_layout().size;
+  const auto &object_size = onode->get_layout().size;
+  if (offset + len > object_size) {
     onode->update_onode_size(
       *ctx.transaction,
       std::max<uint64_t>(offset + len, object_size));


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57088

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh