### PR TITLE
squid: crimson/os/seastore/transaction_manager: fix write pipeline phase leak

### DIFF
--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -385,6 +385,7 @@ public:
   }
 
   ~Transaction() {
+    get_handle().exit();
     on_destruct(*this);
     invalidate_clear_write_set();
   }
@@ -422,6 +423,7 @@ public:
     if (!has_reset) {
       has_reset = true;
     }
+    get_handle().exit();
   }
 
   bool did_reset() const {

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -392,8 +392,6 @@ TransactionManager::do_submit_transaction(
 	ceph_assert(0 == "Hit error submitting to journal");
       })
     );
-  }).finally([&tref]() {
-      tref.get_handle().exit();
   });
 }
 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57129

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh