### PR TITLE
squid: crimson/osd/replicated_recovery_backend: Fix recovery obc usage

### DIFF
--- a/src/crimson/osd/object_context.cc
+++ b/src/crimson/osd/object_context.cc
@@ -53,6 +53,7 @@ std::optional<hobject_t> resolve_oid(
   if (oid.snap > ss.seq) {
     // Because oid.snap > ss.seq, we are trying to read from a snapshot
     // taken after the most recent write to this object. Read from head.
+    logger().debug("{} returning head", __func__);
     return oid.get_head();
   } else {
     // which clone would it be?

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -103,6 +103,11 @@ public:
     fully_loaded = true;
   }
 
+  void set_clone_ssc(SnapSetContextRef head_ssc) {
+    ceph_assert(!is_head());
+    ssc = head_ssc;
+  }
+
   /// pass the provided exception to any waiting consumers of this ObjectContext
   template<typename Exception>
   void interrupt(Exception ex) {

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -41,7 +41,7 @@ using crimson::common::local_conf;
   {
     LOG_PREFIX(ObjectContextLoader::with_clone_obc);
     assert(!oid.is_head());
-    return with_obc<RWState::RWREAD>(
+    return with_head_obc<RWState::RWREAD>(
       oid.get_head(),
       [FNAME, oid, func=std::move(func), this](auto head, auto) mutable
       -> load_obc_iertr::future<> {

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -75,6 +75,7 @@ using crimson::common::local_conf;
       auto loaded = get_or_load_obc<State>(clone, existed);
       return loaded.safe_then_interruptible(
         [func = std::move(func), head=std::move(head)](auto clone) mutable {
+        clone->set_clone_ssc(head->ssc);
         return std::move(func)(std::move(head), std::move(clone));
       });
     });
@@ -112,6 +113,7 @@ using crimson::common::local_conf;
         auto loaded = get_or_load_obc<State>(clone, existed);
         return loaded.safe_then_interruptible(
           [func = std::move(func), head=std::move(head)](auto clone) {
+          clone->set_clone_ssc(head->ssc);
           return std::move(func)(std::move(head), std::move(clone));
         });
       });
@@ -152,6 +154,9 @@ using crimson::common::local_conf;
         obc->set_head_state(std::move(md->os),
                             std::move(md->ssc));
       } else {
+        // we load and set the ssc only for head obc.
+        // For clones, the head's ssc will be referenced later.
+        // See set_clone_ssc
         obc->set_clone_state(std::move(md->os));
       }
       DEBUGDPP("returning obc {} for {}", dpp, obc->obs.oi, obc->obs.oi.soid);

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -9,11 +9,11 @@ using crimson::common::local_conf;
 
   template<RWState::State State>
   ObjectContextLoader::load_obc_iertr::future<>
-  ObjectContextLoader::with_head_obc(ObjectContextRef obc,
-                                     bool existed,
+  ObjectContextLoader::with_head_obc(const hobject_t& oid,
                                      with_obc_func_t&& func)
   {
     LOG_PREFIX(ObjectContextLoader::with_head_obc);
+    auto [obc, existed] = obc_registry.get_cached_obc(oid);
     DEBUGDPP("object {}", dpp, obc->get_oid());
     assert(obc->is_head());
     obc->append_to(obc_set_accessing);
@@ -36,7 +36,7 @@ using crimson::common::local_conf;
 
   template<RWState::State State>
   ObjectContextLoader::load_obc_iertr::future<>
-  ObjectContextLoader::with_clone_obc(hobject_t oid,
+  ObjectContextLoader::with_clone_obc(const hobject_t& oid,
                                       with_obc_func_t&& func)
   {
     LOG_PREFIX(ObjectContextLoader::with_clone_obc);
@@ -97,11 +97,7 @@ using crimson::common::local_conf;
                                 with_obc_func_t&& func)
   {
     if (oid.is_head()) {
-      auto [obc, existed] =
-        obc_registry.get_cached_obc(std::move(oid));
-      return with_head_obc<State>(std::move(obc),
-                                  existed,
-                                  std::move(func));
+      return with_head_obc<State>(oid, std::move(func));
     } else {
       return with_clone_obc<State>(oid, std::move(func));
     }

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -22,6 +22,10 @@ using crimson::common::local_conf;
       return get_or_load_obc<State>(obc, existed)
       .safe_then_interruptible(
         [func = std::move(func)](auto obc) {
+        // The template with_obc_func_t wrapper supports two obcs (head and clone).
+        // In the 'with_head_obc' case, however, only the head is in use.
+        // Pass the same head obc twice in order to
+        // to support the generic with_obc sturcture.
         return std::move(func)(obc, obc);
       });
     }).finally([FNAME, this, obc=std::move(obc)] {

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -37,14 +37,15 @@ using crimson::common::local_conf;
   template<RWState::State State>
   ObjectContextLoader::load_obc_iertr::future<>
   ObjectContextLoader::with_clone_obc(const hobject_t& oid,
-                                      with_obc_func_t&& func)
+                                      with_obc_func_t&& func,
+                                      bool resolve_clone)
   {
     LOG_PREFIX(ObjectContextLoader::with_clone_obc);
     assert(!oid.is_head());
     return with_head_obc<RWState::RWREAD>(
       oid.get_head(),
-      [FNAME, oid, func=std::move(func), this](auto head, auto) mutable
-      -> load_obc_iertr::future<> {
+      [FNAME, oid, func=std::move(func), resolve_clone, this]
+      (auto head, auto) mutable -> load_obc_iertr::future<> {
       if (!head->obs.exists) {
 	ERRORDPP("head doesn't exist for object {}", dpp, head->obs.oi.soid);
         return load_obc_iertr::future<>{
@@ -53,7 +54,8 @@ using crimson::common::local_conf;
       }
       return this->with_clone_obc_only<State>(std::move(head),
                                               oid,
-                                              std::move(func));
+                                              std::move(func),
+                                              resolve_clone);
     });
   }
 
@@ -61,23 +63,27 @@ using crimson::common::local_conf;
   ObjectContextLoader::load_obc_iertr::future<>
   ObjectContextLoader::with_clone_obc_only(ObjectContextRef head,
                                            hobject_t clone_oid,
-                                           with_obc_func_t&& func)
+                                           with_obc_func_t&& func,
+                                           bool resolve_clone)
   {
     LOG_PREFIX(ObjectContextLoader::with_clone_obc_only);
     DEBUGDPP("{}", clone_oid);
     assert(!clone_oid.is_head());
-    auto resolved_oid = resolve_oid(head->get_head_ss(), clone_oid);
-    if (!resolved_oid) {
-      ERRORDPP("clone {} not found", dpp, clone_oid);
-      return load_obc_iertr::future<>{
-        crimson::ct_error::enoent::make()
-      };
+    if (resolve_clone) {
+      auto resolved_oid = resolve_oid(head->get_head_ss(), clone_oid);
+      if (!resolved_oid) {
+        ERRORDPP("clone {} not found", dpp, clone_oid);
+        return load_obc_iertr::future<>{
+          crimson::ct_error::enoent::make()
+        };
+      }
+      if (resolved_oid->is_head()) {
+        // See resolve_oid
+        return std::move(func)(head, head);
+      }
+      clone_oid = *resolved_oid;
     }
-    if (resolved_oid->is_head()) {
-      // See resolve_oid
-      return std::move(func)(head, head);
-    }
-    auto [clone, existed] = obc_registry.get_cached_obc(*resolved_oid);
+    auto [clone, existed] = obc_registry.get_cached_obc(clone_oid);
     return clone->template with_lock<State, IOInterruptCondition>(
       [existed=existed, clone=std::move(clone),
        func=std::move(func), head=std::move(head), this]() mutable
@@ -94,12 +100,13 @@ using crimson::common::local_conf;
   template<RWState::State State>
   ObjectContextLoader::load_obc_iertr::future<>
   ObjectContextLoader::with_obc(hobject_t oid,
-                                with_obc_func_t&& func)
+                                with_obc_func_t&& func,
+                                bool resolve_clone)
   {
     if (oid.is_head()) {
       return with_head_obc<State>(oid, std::move(func));
     } else {
-      return with_clone_obc<State>(oid, std::move(func));
+      return with_clone_obc<State>(oid, std::move(func), resolve_clone);
     }
   }
 
@@ -192,17 +199,21 @@ using crimson::common::local_conf;
   // explicitly instantiate the used instantiations
   template ObjectContextLoader::load_obc_iertr::future<>
   ObjectContextLoader::with_obc<RWState::RWNONE>(hobject_t,
-                                                 with_obc_func_t&&);
+                                                 with_obc_func_t&&,
+                                                 bool resolve_clone);
 
   template ObjectContextLoader::load_obc_iertr::future<>
   ObjectContextLoader::with_obc<RWState::RWREAD>(hobject_t,
-                                                 with_obc_func_t&&);
+                                                 with_obc_func_t&&,
+                                                 bool resolve_clone);
 
   template ObjectContextLoader::load_obc_iertr::future<>
   ObjectContextLoader::with_obc<RWState::RWWRITE>(hobject_t,
-                                                  with_obc_func_t&&);
+                                                  with_obc_func_t&&,
+                                                 bool resolve_clone);
 
   template ObjectContextLoader::load_obc_iertr::future<>
   ObjectContextLoader::with_obc<RWState::RWEXCL>(hobject_t,
-                                                 with_obc_func_t&&);
+                                                 with_obc_func_t&&,
+                                                 bool resolve_clone);
 }

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -33,6 +33,8 @@ public:
     std::function<load_obc_iertr::future<> (ObjectContextRef, ObjectContextRef)>;
 
   // Use this variant by default
+  // If oid is a clone object, the clone obc *and* it's
+  // matching head obc will be locked and can be used in func.
   template<RWState::State State>
   load_obc_iertr::future<> with_obc(hobject_t oid,
                                     with_obc_func_t&& func);
@@ -45,14 +47,6 @@ public:
   load_obc_iertr::future<> with_clone_obc_only(ObjectContextRef head,
                                                hobject_t clone_oid,
                                                with_obc_func_t&& func);
-
-  // Use this variant in the case where both the head
-  // object *and* the matching clone object are being used
-  // in func.
-  template<RWState::State State>
-  load_obc_iertr::future<> with_clone_obc_direct(
-    hobject_t oid,
-    with_obc_func_t&& func);
 
   load_obc_iertr::future<> reload_obc(ObjectContext& obc) const;
 

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -35,9 +35,13 @@ public:
   // Use this variant by default
   // If oid is a clone object, the clone obc *and* it's
   // matching head obc will be locked and can be used in func.
+  // resolve_clone: For SnapTrim, it may be possible that it
+  //                won't be possible to resolve the clone.
+  // See SnapTrimObjSubEvent::remove_or_update - in_removed_snaps_queue usage.
   template<RWState::State State>
   load_obc_iertr::future<> with_obc(hobject_t oid,
-                                    with_obc_func_t&& func);
+                                    with_obc_func_t&& func,
+                                    bool resolve_clone = true);
 
   // Use this variant in the case where the head object
   // obc is already locked and only the clone obc is needed.
@@ -46,7 +50,8 @@ public:
   template<RWState::State State>
   load_obc_iertr::future<> with_clone_obc_only(ObjectContextRef head,
                                                hobject_t clone_oid,
-                                               with_obc_func_t&& func);
+                                               with_obc_func_t&& func,
+                                               bool resolve_clone = true);
 
   load_obc_iertr::future<> reload_obc(ObjectContext& obc) const;
 
@@ -60,7 +65,8 @@ private:
 
   template<RWState::State State>
   load_obc_iertr::future<> with_clone_obc(const hobject_t& oid,
-                                          with_obc_func_t&& func);
+                                          with_obc_func_t&& func,
+                                          bool resolve_clone);
 
   template<RWState::State State>
   load_obc_iertr::future<> with_head_obc(const hobject_t& oid,

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -59,12 +59,11 @@ private:
   obc_accessing_list_t obc_set_accessing;
 
   template<RWState::State State>
-  load_obc_iertr::future<> with_clone_obc(hobject_t oid,
+  load_obc_iertr::future<> with_clone_obc(const hobject_t& oid,
                                           with_obc_func_t&& func);
 
   template<RWState::State State>
-  load_obc_iertr::future<> with_head_obc(ObjectContextRef obc,
-                                         bool existed,
+  load_obc_iertr::future<> with_head_obc(const hobject_t& oid,
                                          with_obc_func_t&& func);
 
   template<RWState::State State>

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -43,7 +43,7 @@ public:
   // with an already locked head.
   template<RWState::State State>
   load_obc_iertr::future<> with_clone_obc_only(ObjectContextRef head,
-                                               hobject_t oid,
+                                               hobject_t clone_oid,
                                                with_obc_func_t&& func);
 
   // Use this variant in the case where both the head

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -451,8 +451,8 @@ SnapTrimObjSubEvent::start()
   }).then_interruptible([this] {
     logger().debug("{}: getting obc for {}", *this, coid);
     // end of commonality
-    // with_clone_obc_direct lock both clone's and head's obcs
-    return pg->obc_loader.with_clone_obc_direct<RWState::RWWRITE>(
+    // lock both clone's and head's obcs
+    return pg->obc_loader.with_obc<RWState::RWWRITE>(
       coid,
       [this](auto head_obc, auto clone_obc) {
       logger().debug("{}: got clone_obc={}", *this, clone_obc->get_oid());

--- a/src/crimson/osd/osd_operations/snaptrim_event.cc
+++ b/src/crimson/osd/osd_operations/snaptrim_event.cc
@@ -479,7 +479,8 @@ SnapTrimObjSubEvent::start()
           });
         });
       });
-    }).si_then([this] {
+    },
+    false).si_then([this] {
       logger().debug("{}: completed", *this);
       return handle.complete();
     }).handle_error_interruptible(

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -40,7 +40,7 @@ ReplicatedRecoveryBackend::recover_object(
       recovery_waiter.obc = obc;
       recovery_waiter.obc->wait_recovery_read();
       return maybe_push_shards(head, soid, need);
-    }).handle_error_interruptible(
+    }, false).handle_error_interruptible(
       crimson::osd::PG::load_obc_ertr::all_same_way([soid](auto& code) {
       // TODO: may need eio handling?
       logger().error("recover_object saw error code {}, ignoring object {}",
@@ -827,7 +827,7 @@ ReplicatedRecoveryBackend::_handle_pull_response(
                            pull_info.obc->ssc);
         }
         return crimson::osd::PG::load_obc_ertr::now();
-      }).handle_error_interruptible(crimson::ct_error::assert_all{});
+      }, false).handle_error_interruptible(crimson::ct_error::assert_all{});
   };
   return prepare_waiter.then_interruptible(
     [this, &pull_info, &push_op, t, response]() mutable {


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56610

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh