### PR TITLE
qa/suites/rbd/nvmeof: change gateway-name to host-name

### DIFF
--- a/qa/tasks/nvmeof.py
+++ b/qa/tasks/nvmeof.py
@@ -138,7 +138,7 @@ class Nvmeof(Task):
         gateway_ips = []
         nvmeof_daemons = self.ctx.daemons.iter_daemons_of_role('nvmeof', cluster=self.cluster_name)
         for daemon in nvmeof_daemons:
-            gateway_names += [daemon.name()]
+            gateway_names += [daemon.remote.shortname]
             gateway_ips += [daemon.remote.ip_address]
         conf_data = dedent(f"""
             NVMEOF_GATEWAY_IP_ADDRESSES={",".join(gateway_ips)}

--- a/qa/workunits/rbd/nvmeof_setup_subsystem.sh
+++ b/qa/workunits/rbd/nvmeof_setup_subsystem.sh
@@ -29,7 +29,7 @@ do
     ip="${gateway_ips[i]}"
     name="${gateway_names[i]}"
     echo "Adding gateway listener $index with IP ${ip} and name ${name}"
-    sudo podman run -it $NVMEOF_CLI_IMAGE --server-address $ip --server-port $NVMEOF_SRPORT listener add --subsystem $NVMEOF_NQN --gateway-name client.$name --traddr $ip --trsvcid $NVMEOF_PORT
+    sudo podman run -it $NVMEOF_CLI_IMAGE --server-address $ip --server-port $NVMEOF_SRPORT listener add --subsystem $NVMEOF_NQN --host-name $name --traddr $ip --trsvcid $NVMEOF_PORT
     sudo podman run -it $NVMEOF_CLI_IMAGE --server-address $ip --server-port $NVMEOF_SRPORT --format json subsystem list
 done
 


### PR DESCRIPTION
ceph-nvmeof "listener add" cmd used arg "--gateway-name" in nvmeof:1.0.0 (see nvmeof_setup_subsystem.sh script). 
This has been changed to "--host-name" in nvmeof:1.2.5

Following thing need to be done before merging this PR:
1. **Change quay.io/ceph/nvmeof-cli:latest to point to tag 1.2.5 (right now it points to tag 1.0.0)**
Reason: Default nvmeof gateway image has been changed to 1.2.5 in https://github.com/ceph/ceph/pull/57182. Because teuthology tests use ceph's default gateway image + nvmeof-cli "latest" - there's a version mismatch of nvmeof gateway v1.2.5 and nvmeof-cli v1.0.0 in tests on main branch which causes error `HA must be enabled for subsystems` as seen in https://pulpito.ceph.com/dis-2024-05-16_08:07:49-rbd-wip-dis-testing-distro-default-smithi/7708811/ 
(Tested the solution by running a test with both images using v1.2.5 and it was able to setup the subsystem)

2. Failing "nvme connect" test - "nvme list" it does not show any connected devices after doing a "nvme connect". It might be a bug in nvmeof, need to inspect. 
Seen in: https://pulpito.ceph.com/vallariag-2024-05-16_13:41:16-rbd:nvmeof-main-distro-default-smithi/



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
