### PR TITLE
squid: qa: unmount clients before damaging the fs

### DIFF
--- a/qa/tasks/cephfs/test_failover.py
+++ b/qa/tasks/cephfs/test_failover.py
@@ -583,6 +583,9 @@ class TestStandbyReplay(CephFSTestCase):
         That a standby-replay daemon can cause the rank to go damaged correctly.
         """
 
+        for mount in self.mounts:
+            mount.umount_wait()
+
         self._confirm_no_replay()
         self.config_set("mds", "mds_standby_replay_damaged", True)
         self.fs.set_allow_standby_replay(True)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66044

---

backport of https://github.com/ceph/ceph/pull/57329
parent tracker: https://tracker.ceph.com/issues/65837

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh