### PR TITLE
crimson/os/seastore: OP_CLONE performance optimization

### DIFF
--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -103,6 +103,12 @@ public:
     laddr_t intermediate_key,
     laddr_t intermediate_base) = 0;
 
+  virtual alloc_extents_ret clone_mappings(
+    Transaction &t,
+    laddr_t hint,
+    const lba_pin_list_t &pins,
+    bool inc_ref) = 0;
+
   virtual alloc_extent_ret reserve_region(
     Transaction &t,
     laddr_t hint,

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -752,6 +752,56 @@ BtreeLBAManager::update_refcount(
   });
 }
 
+BtreeLBAManager::_update_mappings_ret
+BtreeLBAManager::_update_mappings(
+  Transaction &t,
+  std::pair<laddr_t, extent_len_t> range,
+  update_func_t &&f)
+{
+  LOG_PREFIX(BtreeLBAManager::_update_mappings);
+  TRACET("{}~{}", t, range.first, range.second);
+  auto c = get_context(t);
+  return seastar::do_with(
+    std::move(range),
+    std::move(f),
+    [c, this, FNAME](auto &range, auto &f) {
+    return with_btree<LBABtree>(
+      cache,
+      c,
+      [&range, &f, c, FNAME](auto &btree) {
+      auto start_addr = range.first;
+      return LBABtree::iterate_repeat(
+	c,
+	btree.lower_bound(c, start_addr),
+	[c, &btree, &range, &f, FNAME](auto &pos) {
+	auto laddr = range.first;
+	auto len = range.second;
+	auto pos_key = pos.get_key();
+	if (pos_key == laddr + len) {
+	  return typename LBABtree::iterate_repeat_ret_inner(
+	    interruptible::ready_future_marker{},
+	    seastar::stop_iteration::yes);
+	}
+	ceph_assert(!pos.is_end());
+	ceph_assert(pos_key >= laddr);
+	auto pos_val = pos.get_val();
+	ceph_assert(pos_key + pos_val.len <= laddr + len);
+	auto ret = f(pos_val);
+	ceph_assert(ret.refcount > 0); // TODO: we don't support removing
+				       // range during batch lba updates
+	TRACET("updated mapping for key {}, val {}", c.trans, pos_key, ret);
+	return btree.update(c, pos, ret, nullptr
+	).si_then([&pos] (auto iter) {
+	  pos = std::move(iter);
+	  return typename LBABtree::iterate_repeat_ret_inner(
+	    interruptible::ready_future_marker{},
+	    seastar::stop_iteration::no);
+	});
+      });
+    });
+  });
+}
+
 BtreeLBAManager::_update_mapping_ret
 BtreeLBAManager::_update_mapping(
   Transaction &t,

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -254,6 +254,147 @@ public:
     });
   }
 
+  alloc_extents_ret clone_mappings(
+    Transaction &t,
+    laddr_t hint,
+    const lba_pin_list_t &pins,
+    bool inc_ref) final
+  {
+    LOG_PREFIX(BtreeLBAManager::clone_mappings);
+    SUBTRACET(seastore_lba, "laddr: {}, {} pins",
+      t, hint, pins.size());
+    std::vector<alloc_mapping_info_t> alloc_infos;
+    std::list<std::pair<laddr_t, extent_len_t>> ranges;
+    laddr_t start = L_ADDR_NULL;
+    extent_len_t len = 0;
+    laddr_t offset = 0; // the laddr from which to pad
+    for (auto &pin : pins) {
+#ifndef NDEBUG
+      if (!offset) {
+	offset = pin->get_key();
+      }
+      assert(offset == pin->get_key());
+      offset += pin->get_length();
+#endif
+      alloc_infos.emplace_back(alloc_mapping_info_t{
+	pin->get_length(),
+	(pladdr_t)(pin->is_indirect()
+	  ? (pladdr_t)pin->get_intermediate_key()
+	  : (pin->get_val().is_zero()
+	      ? (pladdr_t)P_ADDR_ZERO
+	      : (pladdr_t)pin->get_key())),
+	(uint32_t)0,
+	(LogicalCachedExtent*)nullptr});
+
+      if (!pin->is_indirect() && pin->get_val().is_zero()) {
+	continue;
+      }
+      // calc the laddr ranges that are to increase refcount
+      if (pin->is_indirect() ||
+	  !pin->get_val().is_zero()) {
+	auto pin_start = pin->is_indirect() ?
+	  pin->get_intermediate_base() :
+	  pin->get_key();
+	auto pin_length = pin->is_indirect() ?
+	  pin->get_intermediate_length() :
+	  pin->get_length();
+	if (start == L_ADDR_NULL) {
+	  assert(len == 0);
+	  start = pin_start;
+	  len = pin_length;
+	} else {
+	  if (start + len == pin_start) {
+	    len += pin_length;
+	  } else {
+	    ranges.emplace_back(start, len);
+	    start = pin_start;
+	    len = pin_length;
+	  }
+	}
+      }
+    }
+    if (start != L_ADDR_NULL) {
+      assert(len != 0);
+      ranges.emplace_back(start, len);
+    }
+
+    return seastar::do_with(
+      std::move(alloc_infos),
+      std::vector<LBAMappingRef>(),
+      std::move(ranges),
+      [&t, hint, this, inc_ref, &pins]
+      (auto &alloc_infos, auto &ret, auto &ranges) {
+      return _alloc_extents(
+	t,
+	hint,
+	alloc_infos,
+	EXTENT_DEFAULT_REF_COUNT
+      ).si_then([this, &ret, &t, &pins, &ranges, inc_ref](auto mappings) {
+	auto it = pins.begin();
+	for (auto &mapping : mappings) {
+	  if (!mapping->is_indirect()) {
+	    it++;
+	    continue;
+	  }
+	  auto &pin = *it;
+	  auto bmapping = pin->duplicate();
+	  auto &base_mapping = static_cast<BtreeLBAMapping&>(*bmapping);
+	  if (base_mapping.is_indirect()) {
+	    assert(mapping->get_intermediate_key() >=
+	      base_mapping.get_intermediate_base());
+	    assert(
+	      (mapping->get_intermediate_length()
+		+ mapping->get_intermediate_key()) <=
+	      (base_mapping.get_intermediate_base()
+		+ base_mapping.get_intermediate_length()));
+	    base_mapping.adjust_mutable_indirect_attrs(
+	      mapping->get_key(),
+	      mapping->get_length(),
+	      mapping->get_intermediate_key());
+	  } else {
+	    assert(mapping->get_intermediate_key() >=
+	      base_mapping.get_key());
+	    assert(
+	      (mapping->get_intermediate_length()
+		+ mapping->get_intermediate_key()) <=
+	      (base_mapping.get_key()
+		+ base_mapping.get_length()));
+	    base_mapping.make_indirect(
+	      mapping->get_key(),
+	      mapping->get_length(),
+	      mapping->get_intermediate_key());
+	  }
+	  ret.emplace_back(std::move(bmapping));
+	  it++;
+	}
+	ceph_assert(it == pins.end());
+	if (inc_ref) {
+	  return trans_intr::do_for_each(
+	    ranges,
+	    [&t, this](auto &range) {
+	    return _update_mappings(
+	      t,
+	      range,
+	      [range](const lba_map_val_t &in) {
+	      lba_map_val_t out = in;
+	      assert(in.len <= range.second);
+	      out.refcount += 1;
+	      return out;
+	    });
+	  });
+	}
+	return _update_mappings_iertr::now();
+      }).si_then([&ret] {
+	return seastar::make_ready_future<
+	  std::vector<LBAMappingRef>>(
+	    std::move(ret));
+      }).handle_error_interruptible(
+	crimson::ct_error::enoent::assert_failure{"unexpected enoent"},
+	alloc_extent_iertr::pass_further{}
+      );
+    });
+  }
+
   alloc_extent_ret clone_mapping(
     Transaction &t,
     laddr_t laddr,

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -548,6 +548,13 @@ private:
     update_func_t &&f,
     LogicalCachedExtent*);
 
+  using _update_mappings_iertr = _update_mapping_iertr;
+  using _update_mappings_ret = _update_mapping_iertr::future<>;
+  _update_mappings_ret _update_mappings(
+    Transaction &t,
+    std::pair<laddr_t, extent_len_t> range,
+    update_func_t &&f);
+
   alloc_extents_ret _alloc_extents(
     Transaction &t,
     laddr_t hint,

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -251,7 +251,8 @@ private:
     context_t ctx,
     object_data_t &object_data,
     lba_pin_list_t &pins,
-    laddr_t data_base);
+    laddr_t data_base,
+    bool inc_ref);
 
 private:
   /**

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -571,6 +571,21 @@ public:
     );
   }
 
+  using clone_extents_iertr = LBAManager::alloc_extent_iertr;
+  using clone_extents_ret = LBAManager::alloc_extents_ret;
+  clone_extents_ret clone_pins(
+    Transaction &t,
+    laddr_t hint,
+    lba_pin_list_t &pins,
+    bool inc_ref)
+  {
+    return lba_manager->clone_mappings(
+      t,
+      hint,
+      pins,
+      inc_ref);
+  }
+
   /* alloc_extents
    *
    * allocates more than one new blocks of type T.


### PR DESCRIPTION
Before this PR, SeaStore's OP_CLONE handling is to clone each lba mapping of the src onode one by one. This PR changes this into cloning lba mappings of the src onode in batch

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
