### PR TITLE
rgw: only consider subuser perm for its user resources

### DIFF
--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -396,7 +396,6 @@ public:
                     bool ignore_public_acls=false) const;
   bool verify_permission(const DoutPrefixProvider* dpp,
                          const rgw::auth::Identity& auth_identity,
-                         uint32_t user_perm_mask,
                          uint32_t perm,
                          const char * http_referer = nullptr,
                          bool ignore_public_acls=false) const;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1280,7 +1280,7 @@ bool verify_user_permission_no_policy(const DoutPrefixProvider* dpp,
   if ((perm & (int)s->perm_mask) != perm)
     return false;
 
-  return user_acl.verify_permission(dpp, *s->identity, perm, perm);
+  return user_acl.verify_permission(dpp, *s->identity, perm);
 }
 
 bool verify_user_permission(const DoutPrefixProvider* dpp,
@@ -1401,17 +1401,14 @@ bool verify_bucket_permission_no_policy(const DoutPrefixProvider* dpp, struct pe
 					const RGWAccessControlPolicy& bucket_acl,
 					const int perm)
 {
-  if ((perm & (int)s->perm_mask) != perm)
-    return false;
-
-  if (bucket_acl.verify_permission(dpp, *s->identity, perm, perm,
+  if (bucket_acl.verify_permission(dpp, *s->identity, perm,
                                    s->get_referer(),
                                    s->bucket_access_conf &&
                                    s->bucket_access_conf->ignore_public_acls())) {
     ldpp_dout(dpp, 10) << __func__ << ": granted by bucket acl" << dendl;
     return true;
   }
-  if (user_acl.verify_permission(dpp, *s->identity, perm, perm)) {
+  if (user_acl.verify_permission(dpp, *s->identity, perm)) {
     ldpp_dout(dpp, 10) << __func__ << ": granted by user acl" << dendl;
     return true;
   }
@@ -1556,7 +1553,7 @@ bool verify_object_permission_no_policy(const DoutPrefixProvider* dpp,
     return true;
   }
 
-  bool ret = object_acl.verify_permission(dpp, *s->identity, s->perm_mask, perm,
+  bool ret = object_acl.verify_permission(dpp, *s->identity, perm,
 					  nullptr, /* http referrer */
 					  s->bucket_access_conf &&
 					  s->bucket_access_conf->ignore_public_acls());
@@ -1567,9 +1564,6 @@ bool verify_object_permission_no_policy(const DoutPrefixProvider* dpp,
 
   if (!s->cct->_conf->rgw_enforce_swift_acls)
     return ret;
-
-  if ((perm & (int)s->perm_mask) != perm)
-    return false;
 
   int swift_perm = 0;
   if (perm & (RGW_PERM_READ | RGW_PERM_READ_ACP))
@@ -1582,12 +1576,12 @@ bool verify_object_permission_no_policy(const DoutPrefixProvider* dpp,
 
   /* we already verified the user mask above, so we pass swift_perm as the mask here,
      otherwise the mask might not cover the swift permissions bits */
-  if (bucket_acl.verify_permission(dpp, *s->identity, swift_perm, swift_perm,
+  if (bucket_acl.verify_permission(dpp, *s->identity, swift_perm,
                                    s->get_referer())) {
     ldpp_dout(dpp, 10) << __func__ << ": granted by bucket acl" << dendl;
     return true;
   }
-  if (user_acl.verify_permission(dpp, *s->identity, swift_perm, swift_perm)) {
+  if (user_acl.verify_permission(dpp, *s->identity, swift_perm)) {
     ldpp_dout(dpp, 10) << __func__ << ": granted by user acl" << dendl;
     return true;
   }


### PR DESCRIPTION
Currently, subusers inherit ACL permissions from the parent account, and the permission check using `op_to_perm()`,
performed before considering the resource (bucket/object) ACLs, may deny access even if the resource has authenticated or public read/write permissions. Since ACLs do not support subusers, a subuser's permissions should only be considered for resources owned by their user.
For accessing other resources, subusers should only be granted access if public read/write permissions are available.

Fixes: https://tracker.ceph.com/issues/66105