### PR TITLE
[WIP] mon/OSDMonitor: force-remove-snap --purged-snaps-only

### DIFF
--- a/qa/suites/rados/thrash/workloads/pool-snaps-few-objects-redelete.yaml
+++ b/qa/suites/rados/thrash/workloads/pool-snaps-few-objects-redelete.yaml
@@ -1,0 +1,23 @@
+overrides:
+  conf:
+    osd:
+      osd deep scrub update digest min age: 0
+  ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
+tasks:
+- thrashosds:
+    chance_force_remove_snap: 0.3
+- rados:
+    clients: [client.0]
+    ops: 4000
+    objects: 50
+    pool_snaps: true
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      snap_create: 50
+      snap_remove: 50
+      rollback: 50
+      copy_from: 50

--- a/qa/suites/rados/thrash/workloads/snaps-few-objects-redelete.yaml
+++ b/qa/suites/rados/thrash/workloads/snaps-few-objects-redelete.yaml
@@ -1,0 +1,19 @@
+overrides:
+  ceph:
+    log-ignorelist:
+    - \(POOL_APP_NOT_ENABLED\)
+tasks:
+- thrashosds:
+    chance_force_remove_snap: 0.3
+- rados:
+    clients: [client.0]
+    ops: 4000
+    objects: 50
+    op_weights:
+      read: 100
+      write: 100
+      delete: 50
+      snap_create: 50
+      snap_remove: 50
+      rollback: 50
+      copy_from: 50

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -236,6 +236,7 @@ class OSDThrasher(Thrasher):
         self.chance_force_recovery = self.config.get('chance_force_recovery', 0.3)
         self.chance_reset_purged_snaps_last = self.config.get('chance_reset_purged_snaps_last', 0.3)
         self.chance_trim_stale_osdmaps = self.config.get('chance_trim_stale_osdmaps', 0.3)
+        self.chance_force_remove_snap = self.config.get('chance_force_remove_snap', 0)
 
         num_osds = self.in_osds + self.out_osds
         self.max_pgs = self.config.get("max_pgs_per_pool_osd", 1200) * len(num_osds)
@@ -824,6 +825,26 @@ class OSDThrasher(Thrasher):
            except CommandFailedError:
                self.log('Failed to trim stale osdmaps, ignoring')
 
+    def force_remove_snap(self):
+        """
+        Force reremove snapshots already makred as purged.
+        Please note that internal snap ids are the ones being
+        used to detect purges snaps. The internal snap ids are
+        *not* the same snap ids used by thrasher.
+        """
+        self.log('force_remove_snap')
+        pool = self.ceph_manager.get_pool()
+        if pool is None:
+            self.log('Failed to get pool')
+            return
+        try:
+            self.ceph_manager.raw_cluster_cmd('osd', 'pool',
+                                              'force-remove-snap',
+                                              pool, '--purged-snaps-only')
+            self.chance_force_remove_snap = 0
+        except CommandFailedError:
+            self.log('Failed to force remove snap, ignoring')
+
     def all_up(self):
         """
         Make sure all osds are up and not out.
@@ -1292,6 +1313,8 @@ class OSDThrasher(Thrasher):
             actions.append((self.reset_purged_snaps_last, self.chance_reset_purged_snaps_last))
         if self.chance_trim_stale_osdmaps > 0:
             actions.append((self.trim_stale_osdmaps, self.chance_trim_stale_osdmaps))
+        if self.chance_force_remove_snap > 0:
+            actions.append((self.force_remove_snap, self.chance_force_remove_snap))
 
         for key in ['heartbeat_inject_failure', 'filestore_inject_stall']:
             for scenario in [

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1102,6 +1102,7 @@ COMMAND("osd pool force-remove-snap "
 	"name=pool,type=CephPoolname "
 	"name=lower_snapid_bound,type=CephInt,range=0,req=false "
 	"name=upper_snapid_bound,type=CephInt,range=0,req=false "
+	"name=purged_snaps_only,type=CephBool,req=false "
 	"name=dry_run,type=CephBool,req=false ",
 	"Forces removal of snapshots in the range "
 	"[lower_snapid_bound, upper_snapid_bound) on pool <pool> in "

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -13114,6 +13114,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
      *    marked as purged in the Monitor will be removed. Mostly useful
      *    for cases in which the snapid is leaked in the client side.
      *    See: https://tracker.ceph.com/issues/64646
+     *  * (Experimental) purged-snaps-only: Adding this flag will result
+     *    in the reremoval of snapids in the given range.
+     *    Only the snapids which are *already* marked as purged in the
+     *    Monitor will be removed again. This may be useful for cases in
+     *    which we would like to trigger OSD snap trimming again.
      */
     string poolstr;
     cmd_getval(cmdmap, "pool", poolstr);
@@ -13154,6 +13159,9 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     bool dry_run = false;
     cmd_getval(cmdmap, "dry_run", dry_run);
 
+    bool purged_snaps_only = false;
+    cmd_getval(cmdmap, "purged_snaps_only", purged_snaps_only);
+
     // don't redelete past pool's snap_seq
     auto snapid_limit = std::min(upper_snapid_bound, (int64_t)p->get_snap_seq());
 
@@ -13170,16 +13178,28 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       int res = lookup_purged_snap(pool, i, &before_begin, &before_end);
       if (res == 0) {
         ss << "snapids: " << i << " was already marked as purged. ";
+        // Reremove the already purged_snaps
+        if (purged_snaps_only) {
+          force_removed_snapids.insert(i);
+        }
       } else {
-        // Remove non purged_snaps
-        // See: https://tracker.ceph.com/issues/64646
-        force_removed_snapids.insert(i);
+        if (!purged_snaps_only) {
+          // Remove non purged_snaps
+          // See: https://tracker.ceph.com/issues/64646
+          force_removed_snapids.insert(i);
+        }
       }
     }
 
     for (const auto i : force_removed_snapids) {
       if (!dry_run) {
         pending_inc.new_removed_snaps[pool].insert(snapid_t(i));
+        if (purged_snaps_only) {
+          // Kludge: In order to make this compatible with
+          // OSDMap::apply_incremental use of interval_set,
+          // specifically the erasure from removed_snaps_queue.
+          pending_inc.new_purged_snaps[pool].insert(snapid_t(i));
+        }
       }
     }
 


### PR DESCRIPTION
Blocked By: #57548

---

```
    /*
     *  Forces removal of snapshots in the range of
     *  [lower_snapid_bound, upper_snapid_bound) on pool <pool>
     *  in order to cause OSDs to re-trim them.
     *  * purged-snaps-only: Adding this flag will result
     *    in the reremoval of snapids in the given range.
     *    Only the snapids which are *already* marked as purged in the
     *    Monitor will be removed again. This may be useful for cases in
     *    which we would like to trigger OSD snap trimming again.
     */
```


### Reremove snap ids in the range which are **already** marked as purged.
---
Notes:

*     `scrub_purged_snaps` can also be used to cause the OSD to re-trim
      purged snapshots. However, those will only get re-trimmed if they were
      marked as purged (PSN_ keys) in the OSD store.
      Using the command introduced here, the snapshots that were marked as
      purged (purged_snaps_ keys) in the mon's store will be also marked,
      correspondingly, in the OSD store.
      That way `scrub_purged_snaps` will be able to re-trim the snapshots that weren't
      marked as purged in the OSD side (for some reason).

*     The re-removed snapshots will be inserted to new_purged_snaps which
      will be used when handling the new MOSDMap. These new_purged_snaps
      are passed to SnapMapper::record_purged_snaps to be added to the OSD store.

---

Initial testing looks to be stable:
```
2023-09-19T14:33:10.222 INFO:teuthology.orchestra.run.smithi084.stderr:force reremoving snap ids in the range of [1,16) from pool 3. reremoved snapids: 2,3,6,8,14
2023-09-19T14:36:28.131 INFO:teuthology.orchestra.run.smithi084.stderr:force reremoving snap ids in the range of [1,206) from pool 3. reremoved snapids: 2,3,4,6,7,8,9,11,46,47,49,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,94,95,96,97,98,99,100,101,102,103,104,105,106,107,109,110,111,112,128,129,130,131,132,133,146,147,148,149,150,151,152,153,154,155,156,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,189,192,193,195,196,197,199,200,201,205
2023-09-19T14:36:42.319 INFO:teuthology.orchestra.run.smithi084.stderr:force reremoving snap ids in the range of [1,220) from pool 3. reremoved snapids: 2,3,4,6,7,8,9,11,46,47,49,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,94,95,96,97,98,99,100,101,102,103,104,105,106,107,109,110,111,112,128,129,130,131,132,133,146,147,148,149,150,151,152,153,154,155,156,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,189,192,193,195,196,197,199,200,201,205,206,207,208,212,213,215,218,219
2023-09-19T14:37:07.185 INFO:teuthology.orchestra.run.smithi084.stderr:force reremoving snap ids in the range of [1,234) from pool 3. reremoved snapids: 2,3,4,6,7,8,9,11,46,47,49,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,94,95,96,97,98,99,100,101,102,103,104,105,106,107,109,110,111,112,128,129,130,131,132,133,146,147,148,149,150,151,152,153,154,155,156,157,189,190,218,219,220,221,222,225,226,229,232,233
2023-09-19T14:42:13.540 INFO:teuthology.orchestra.run.smithi084.stderr:force reremoving snap ids in the range of [1,443) from pool 3. reremoved snapids: 2,3,4,6,7,8,9,11,46,47,49,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,94,95,96,97,98,99,100,101,102,103,104,105,106,107,109,110,111,112,128,129,130,131,132,133,146,147,148,149,150,151,152,153,154,155,156,157,189,190,218,219,220,221,222,223,224,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,283,284,285,286,287,347,348,349,350,383,384,385,386,387,388,389,394,395,396,426,427,428,429,432,433,434,438,441,442
2023-09-19T14:44:49.541 INFO:teuthology.orchestra.run.smithi084.stderr:force reremoving snap ids in the range of [1,563) from pool 3. reremoved snapids: 2,3,4,6,7,8,9,11,46,47,49,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,94,95,96,97,98,99,100,101,102,103,104,105,106,107,109,110,111,112,128,129,130,131,132,133,146,147,148,149,150,151,152,153,154,155,156,157,189,190,218,219,220,221,222,223,224,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,283,284,285,286,287,347,348,349,350,383,384,385,386,387,388,389,394,395,396,426,427,428,429,492,493,494,495,496,497,498,499,526,527,528,529,530,536,537,538,539,543,552,554,561
```

---

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
