### PR TITLE
mds/queisce-db: collect acks while bootstrapping

### DIFF
--- a/src/mds/QuiesceDb.h
+++ b/src/mds/QuiesceDb.h
@@ -681,6 +681,17 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const QuiesceMap& map)
 struct QuiesceDbPeerAck {
   QuiesceInterface::PeerId origin;
   QuiesceMap diff_map;
+
+  QuiesceDbPeerAck() = default;
+  QuiesceDbPeerAck(QuiesceDbPeerAck const&) = default;
+  QuiesceDbPeerAck(QuiesceDbPeerAck &&) = default;
+  QuiesceDbPeerAck(QuiesceInterface::PeerId origin, std::convertible_to<QuiesceMap> auto&& diff_map)
+      : origin(origin)
+      , diff_map(std::forward<QuiesceMap>(diff_map))
+  {}
+
+  QuiesceDbPeerAck& operator=(QuiesceDbPeerAck const&) = default;
+  QuiesceDbPeerAck& operator=(QuiesceDbPeerAck&&) = default;
 };
 
 template <class CharT, class Traits>

--- a/src/mds/QuiesceDbManager.h
+++ b/src/mds/QuiesceDbManager.h
@@ -100,7 +100,7 @@ class QuiesceDbManager {
         return -ESTALE;
       }
 
-      pending_acks.push(std::move(ack));
+      pending_acks.emplace_back(std::move(ack));
       submit_condition.notify_all();
       return 0;
     }
@@ -138,7 +138,7 @@ class QuiesceDbManager {
 
       if (cluster_membership->leader == cluster_membership->me) {
         // local delivery
-        pending_acks.push({ cluster_membership->me, std::move(diff_map) });
+        pending_acks.emplace_back(cluster_membership->me, std::move(diff_map));
         submit_condition.notify_all();
       } else {
         // send to the leader outside of the lock
@@ -201,7 +201,7 @@ class QuiesceDbManager {
     std::optional<AgentCallback> agent_callback;
     std::optional<QuiesceClusterMembership> cluster_membership;
     std::queue<QuiesceDbPeerListing> pending_db_updates;
-    std::queue<QuiesceDbPeerAck> pending_acks;
+    std::deque<QuiesceDbPeerAck> pending_acks;
     std::deque<RequestContext*> pending_requests;
     bool db_thread_should_exit = false;
     bool db_thread_should_clear_db = true;

--- a/src/test/mds/TestQuiesceDb.cc
+++ b/src/test/mds/TestQuiesceDb.cc
@@ -984,7 +984,7 @@ TEST_F(QuiesceDbTest, InterruptedQuiesceAwait)
   EXPECT_EQ(ERR(ETIMEDOUT), await2.wait_result());
 
   // shouldn't have taken much longer than the timeout configured on the set
-  auto epsilon = sec(0.01);
+  auto epsilon = sec(0.05);
   ASSERT_LE(QuiesceClock::now() - then - epsilon, last_request->response.sets.at("set2").timeout);
 
   // let's cancel set 1 while awaiting it a few times


### PR DESCRIPTION
Keeping the acks that come in will allow processing them immediately after the bootstrap is over, avoiding unnecessary set state transitions.

Fixes: https://tracker.ceph.com/issues/66119

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
- Component impact
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
