### PR TITLE
squid: qa/fsx: use a specified sha1 to build the xfstest-dev

### DIFF
--- a/qa/workunits/suites/fsx.sh
+++ b/qa/workunits/suites/fsx.sh
@@ -4,7 +4,6 @@ set -e
 
 git clone https://git.ceph.com/xfstests-dev.git
 cd xfstests-dev
-git checkout 12973fc04fd10d4af086901e10ffa8e48866b735
 make -j4
 cd ..
 cp xfstests-dev/ltp/fsx .

--- a/qa/workunits/suites/fsx.sh
+++ b/qa/workunits/suites/fsx.sh
@@ -4,6 +4,8 @@ set -e
 
 git clone https://git.ceph.com/xfstests-dev.git
 cd xfstests-dev
+# This sha1 is the latest master head and works well for our tests.
+git checkout 0e5c12dfd008efc2848c98108c9237487e91ef35
 make -j4
 cd ..
 cp xfstests-dev/ltp/fsx .


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66054

---

backport of https://github.com/ceph/ceph/pull/57275 and https://github.com/ceph/ceph/pull/55983
parent tracker: https://tracker.ceph.com/issues/64572


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
