### PR TITLE
script/: add cpu-map.sh to aid manual selection of CPU cores for threads for profiling

### DIFF
--- a/src/script/cpu-map.sh
+++ b/src/script/cpu-map.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# !
+# ! Usage: ./cpu-map.sh -p <process_PIDs comma separated> -n <process_Name>
+# !                     -g <group-name:affinity-range>
+# !
+# ! Set the CPU affinity for a list of running processes
+# !
+# ! Ex.: ./cpu-map.sh -n crimson -g "alien:4-31"
+# !      ./cpu-map.sh -p ($pgrep osd) -g "rocksdb:4-7"
+# !
+# !  Important: the "affinity-range" must be a vlid argument for taskset.
+########################################################
+# Please edit the following to suit your own needs
+#
+# Regex to define the group of threads names we want to set their affinity:
+proc_group_re="alien-store-tp|rocksdb|bstore|cfin"
+# Associate array to identify the group and the thread names
+declare -A thr_grp_re_name_map=([alien]="$proc_group_re")
+# Ditto for their default affinity range:
+declare -A thr_grp_range_map=([alien]="4-7")
+# You can define further groups as needed
+
+# Range of CPU cores available: i.e. nprocs - rectors
+free_cpu_avail="8-31"
+
+# Regex of threads to ignore: do not change their affinity
+proc_ignore_re="crimson-osd|reactor|log|syscall"
+########################################################
+# Examples:
+
+# Run with 4 cores on a dual socket 8 CPucores per socket system, no hyperthreading
+#declare -A thr_grp_map=([alien-store-tp]="4-7" [rocksdb]="4-7" [bstore]="4-7" [cfin]="4-7" )
+
+########################################################
+# svcdev3 -- 56 cpus
+#declare -A thr_grp_map=([io_context_pool]="0-12" [msg-worker]="13-25" [ceph-osd]="26-38" )
+#free_cpu_avail="39-55"
+#proc_group_re="io_context_pool|msg-worker|ceph-osd"
+
+########################################################
+# sv1-cephX-- 32 cpus
+#declare -A thr_grp_map=([io_context_pool]="0-9" [msg-worker]="10-19" [ceph-osd]="20-29" )
+
+# Run with  2 cores:
+# busiest threads is msgr-worker-1, the rest of the threads segregated to the other core -- this is per OSD process
+#declare -A thr_grp_map=([msgr-worker]="0-0")
+#free_cpu_avail="1-1"
+# Regex to define the group of threads we want on its own cpu core
+#proc_group_re="msgr-worker"
+
+# Run with  4 cores:
+#declare -A thr_grp_map=([msgr-worker]="0-0" [bstore_kv]="1-1" [tp_osd_tp]="2-2")
+#free_cpu_avail="3-3"
+#proc_group_re="msgr-worker|bstore_kv|tp_osd_tp"
+
+# Run with  8 cores:
+#declare -A thr_grp_map=([msgr-worker]="0-1" [bstore_kv]="2-3" [tp_osd_tp]="4-5")
+#free_cpu_avail="6-7"
+#proc_group_re="msgr-worker|bstore_kv|tp_osd_tp"
+
+# Run with  16 cores:
+#declare -A thr_grp_map=([msgr-worker]="0-1" [bstore_kv]="2-3" [tp_osd_tp]="4-5" [rocksdb]="6-7")
+#free_cpu_avail="8-15"
+#proc_group_re="msgr-worker|bstore_kv|tp_osd_tp|rocksdb"
+
+########################################################
+
+# cores 16-31 are for FIO only
+
+usage() {
+    cat $0 | grep ^"# !" | cut -d"!" -f2-
+}
+
+# Given a thread name, find its affinity from $thr_grp_map[]
+getaffinity() {
+    local name="$1"
+    local regex="$2"
+    if [ -z "$regex" ]; then
+        echo ''
+    fi
+}
+
+# process arguments
+while getopts 'p:n:g:' option; do
+  case "$option" in
+    p) PROCESSES=$OPTARG # this should be a , separated list of pids
+        ;;
+    n) PROCESSES=$(pgrep --newest --exact $OPTARG)
+        ;;
+        # TBD. extend this argument into a map {thread_name:cpu-range}
+    g) CPUGROUP_STR=$OPTARG 
+       CPUGROUP=true
+	IFS=':' read -r -a cpu_grp_lst <<< "$CPUGROUP_STR"
+	#echo ${cpu_grp_lst[@]} #ok
+	# cpu_grp_lst[0] is the group name,
+	# cpu_grp_lst[1] is the group cpu range
+        ;;
+    :) printf "missing argument for -%s\n" "$OPTARG" >&2
+       usage >&2
+       exit 1
+       ;;
+    \?) printf "illegal option: -%s\n" "$OPTARG" >&2
+       usage >&2
+       exit 1
+       ;;
+  esac
+done
+
+if [ $# -eq 0 ]; then usage >&2; exit 1; fi
+
+declare -a other=()
+next_avail_cpu=0
+max_cpus=$(nproc)
+cpu_used=1
+j=0 # last index of the other[] array
+
+function get_affinity() {
+	local i="$1"
+}
+
+IFS=', ' read -r -a proc_list <<< "$PROCESSES"
+for PID in "${proc_list[@]}"; do
+    if [ -e "/proc/$PID/task" ]; then
+        # get list of threads for given PID
+	THREADS=$(ls /proc/$PID/task)
+	for i in $THREADS; do
+		if [ "$CPUGROUP" = true ]; then
+			pgroup_re=${thr_grp_re_name_map[${cpu_grp_lst[0]}]}
+			t_name=$(grep -E "$pgroup_re" /proc/$i/comm )
+			if [ -n "$t_name" ]; then
+				affinity=${cpu_grp_lst[1]}
+			else
+				# this thread is not in the group, check if we want to skip it
+				t_name=$(grep -E "$proc_ignore_re" /proc/$i/comm )
+
+				if [ -n "$t_name" ] && [ "$CPUGROUP" = true ]; then
+					echo "Skipping $i"
+					continue
+				else
+					# so its affinity will be on the remaining cpu set
+					other[$(( j++ ))]="$i"
+				fi
+			fi
+		else
+			# if we use them all CPUs, rotate
+			affinity=$(( next_avail_cpu++ % max_cpus ))
+			cpu_used=$(( cpu_used | ( 1 << $affinity )))
+			printf "cpu_used: 0x%x\n" $cpu_used
+		fi
+		echo "$t_name: taskset -c -p $affinity $i"
+		taskset -c -p $affinity $i
+	done # threads
+    else
+        echo "Process $PID does not exist"
+    fi
+done # PID
+
+# Assign the affinity to the other threads on the remaining non-used cpus
+echo "Threads in the remaining set all with the remaining processor ids:"
+#echo "${other[@]}"
+for x in "${other[@]}"; do
+    if [ "$CPUGROUP" ]; then
+        echo taskset -c -p $free_cpu_avail $x
+    else
+        rem_affinity=$(printf "0x%x\n" $(( cpu_used ^ 0xfffffff )))
+        echo taskset -p  $rem_affinity $x
+    fi
+done


### PR DESCRIPTION
This PR adds a set of utility scripts (inspired/based on previous existing scripts), adapted for learning exercises.
# [script/cpu_map.sh]

tool (based on `scripts/seastar-cpu-map.sh`) to set the CPU core affinity for a group of threads within a process. This is useful when experimenting to set different groups of threads on different CPU cores.

## Usage:

` cpu-map.sh -p <process_PIDs comma separated> -n <process_Name> -g <group-name:affinity-range>`

The user needs to edit the associative arrays in the script to suit for particular requirements.
There are examples at the top of the script, which should make it easier to edit accordingly.

## Example:

This is an example of the execution and the resulting CPU core assignment.
Lets assume you create a cluster with vstart as follows:

`MDS=0 MON=1 OSD=1 MGR=1 ../src/vstart.sh --new -x --localhost --without-dashboard --bluestore --redirect-output --bluestore-devs /dev/sdf --crimson --no-restart`

The alien threads are set (by default) on the range 1-31  CPU cores:

```bash
# taskset -acp $(pgrep crimson-osd)
pid 1672's current affinity list: 0
pid 1681's current affinity list: 0
pid 1682's current affinity list: 0
pid 1683's current affinity list: 1-31
pid 1684's current affinity list: 1-31
pid 1685's current affinity list: 1-31
pid 1686's current affinity list: 1-31
pid 1687's current affinity list: 1-31
pid 1688's current affinity list: 1-31
pid 1689's current affinity list: 0
pid 1690's current affinity list: 1-31
pid 1692's current affinity list: 1-31
pid 1693's current affinity list: 1-31
pid 1694's current affinity list: 1-31
pid 1695's current affinity list: 1-31
pid 1876's current affinity list: 1-31
pid 2057's current affinity list: 1-31
pid 2058's current affinity list: 1-31
pid 2059's current affinity list: 1-31
pid 2060's current affinity list: 1-31
pid 2061's current affinity list: 1-31
```
Suppose you want to segregate the alien threads to CPU cores 1-4 only. You can run the script as follows:

`cpu-map.sh -p $(pgrep crimson-osd) -g alien:"1-4"`

Here is a snippet of the output:

```bash
Skipping 1672
Skipping 1681
Skipping 1682
alien-store-tp: taskset -c -p 1-4 1683
pid 1683's current affinity list: 1-31
pid 1683's new affinity list: 1-4
alien-store-tp: taskset -c -p 1-4 1684
pid 1684's current affinity list: 1-31
pid 1684's new affinity list: 1-4
```

And here is the end result:

```bash
# ps -p $(pgrep crimson-osd) -L -o pid,tid,comm,psr --no-headers >> _threads.out
# taskset -acp $(pgrep crimson-osd) >> _tasks.out
# paste _threads.out _tasks.out
   1672    1672 crimson-osd       0     pid 1672's current affinity list: 0
   1672    1681 syscall-0         0     pid 1681's current affinity list: 0
   1672    1682 log               0     pid 1682's current affinity list: 0
   1672    1683 alien-store-tp    1     pid 1683's current affinity list: 1-4
   1672    1684 alien-store-tp    1     pid 1684's current affinity list: 1-4
   1672    1685 alien-store-tp    2     pid 1685's current affinity list: 1-4
   1672    1686 alien-store-tp    2     pid 1686's current affinity list: 1-4
   1672    1687 alien-store-tp    3     pid 1687's current affinity list: 1-4
   1672    1688 alien-store-tp    3     pid 1688's current affinity list: 1-4
   1672    1689 crimson-osd       0     pid 1689's current affinity list: 0
   1672    1690 bstore_aio        1     pid 1690's current affinity list: 1-4
   1672    1692 rocksdb:low       9     pid 1692's current affinity list: 1-4
   1672    1693 rocksdb:low      26     pid 1693's current affinity list: 1-4
   1672    1694 rocksdb:low       8     pid 1694's current affinity list: 1-4
   1672    1695 rocksdb:high      8     pid 1695's current affinity list: 1-4
   1672    1876 bstore_aio        2     pid 1876's current affinity list: 1-4
   1672    2057 alien-store-tp    1     pid 2057's current affinity list: 1-4
   1672    2058 cfin             26     pid 2058's current affinity list: 1-4
   1672    2059 bstore_kv_sync   19     pid 2059's current affinity list: 1-4
   1672    2060 bstore_kv_final  31     pid 2060's current affinity list: 1-4
   1672    2061 bstore_mempool    2     pid 2061's current affinity list: 1-4
```

### What to edit in the script:

You may only need to add a new group, (as an associative array) which is composed by:

- name of the group
- regular expression identifying the names for the threads to match for,
- a valid range of CPU to be accepted by taskset. This is the default CPU range for this group.
- modify the CPU cores that would be available after the mapping,
- finally, if needed, the regular expression for the threads names that you do not want to modify.

In the script, each of the above items are at the top:

```bash
 12 ########################################################
 13 # Please edit the following to suit your own needs
 14 #
 15 # Regex to define the group of threads names we want to set their affinity:
 16 proc_group_re="alien-store-tp|rocksdb|bstore|cfin"
 17 # Associate array to identify the group and the thread names
 18 declare -A thr_grp_re_name_map=([alien]="$proc_group_re")
 19 # Ditto for their default affinity range:
 20 declare -A thr_grp_range_map=([alien]="4-7")
 21 # You can define further groups as needed
 22
 23 # Range of CPU cores available: i.e. nprocs - rectors
 24 free_cpu_avail="8-31"
 25
 26 # Regex of threads to ignore: do not change their affinity
 27 proc_ignore_re="crimson-osd|reactor|log|syscall"

```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
