### PR TITLE
doc/cephfs: edit "Pinning Subvolumes..."

### DIFF
--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -811,31 +811,32 @@ to policies. This can distribute load across MDS ranks in predictable and
 stable ways.  Review :ref:`cephfs-pinning` and :ref:`cephfs-ephemeral-pinning`
 for details on how pinning works.
 
-Pinning is configured by:
+Run a command of the following form to configure pinning for subvolumegroups:
 
 .. prompt:: bash #
 
    ceph fs subvolumegroup pin <vol_name> <group_name> <pin_type> <pin_setting>
 
-or for subvolumes:
+Run a command of the following form to configure pinning for subvolumes:
 
 .. prompt:: bash #
 
    ceph fs subvolume pin <vol_name> <group_name> <pin_type> <pin_setting>
 
-Typically you will want to set subvolume group pins. The ``pin_type`` may be
-one of ``export``, ``distributed``, or ``random``. The ``pin_setting``
-corresponds to the extended attributed "value" as in the pinning documentation
-referenced above.
+Under most circumstances, you will want to set subvolume group pins. The
+``pin_type`` may be ``export``, ``distributed``, or ``random``. The
+``pin_setting`` corresponds to the extended attributed "value" as in the
+pinning documentation referenced above.
 
-So, for example, setting a distributed pinning strategy on a subvolume group:
+Here is an example of setting a distributed pinning strategy on a subvolume
+group:
 
 .. prompt:: bash #
 
    ceph fs subvolumegroup pin cephfilesystem-a csi distributed 1
 
-Will enable distributed subtree partitioning policy for the "csi" subvolume
-group.  This will cause every subvolume within the group to be automatically
+This enables distributed subtree partitioning policy for the "csi" subvolume
+group. This will cause every subvolume within the group to be automatically
 pinned to one of the available ranks on the file system.
 
 Subvolume quiesce


### PR DESCRIPTION
Edit the section "Pinning Subvolumes and Subvolume Groups" in doc/cephfs/fs-volumes.rst. This is merely a grammar edit.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
