### PR TITLE
rgw: remove Ali Maredia from MAINTAINERS.md

### DIFF
--- a/src/rgw/MAINTAINERS.md
+++ b/src/rgw/MAINTAINERS.md
@@ -14,7 +14,6 @@ Maintainers are the default assignee for related tracker issues and pull request
 | lua scripting                   | Yuval Lifshitz                  |
 | multisite                       | Casey Bodley                    |
 | object i/o                      | Casey Bodley                    |
-| rgw orchestration, admin APIs   | Ali Maredia                     |
 | radosgw-admin                   | Daniel Gryniewicz               |
 | rest ops                        | Daniel Gryniewicz               |
 | rgw-nfs                         | Matt Benjamin                   |
@@ -26,3 +25,5 @@ Maintainers are the default assignee for related tracker issues and pull request
 
 * security (crypto, SSE, CVEs)
 * swift api
+* rgw orchestration
+* admin APIs


### PR DESCRIPTION
Ali has moved on to another project

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
