### PR TITLE
mds/quiesce: fix timeouts, a crash, and overdrive a tree export when possible

### DIFF
--- a/qa/tasks/cephfs/test_quiesce.py
+++ b/qa/tasks/cephfs/test_quiesce.py
@@ -470,7 +470,7 @@ class TestQuiesce(QuiesceTestCase):
         self.mount_a.run_shell_payload("ln -s ../.. subvol_quiesce")
         path = self.mount_a.cephfs_mntpt + "/subvol_quiesce"
 
-        J = self.fs.rank_tell(["quiesce", "path", path, '--wait'], check_status=False)
+        J = self.fs.rank_tell(["quiesce", "path", path, '--await'], check_status=False)
         log.debug(f"{J}")
         self.assertEqual(J['op']['result'], -20) # ENOTDIR: the link is not a directory
 
@@ -484,7 +484,7 @@ class TestQuiesce(QuiesceTestCase):
         self.mount_a.run_shell_payload("ln -s ../../.. _nogroup")
         path = self.mount_a.cephfs_mntpt + "/_nogroup/" + self.QUIESCE_SUBVOLUME
 
-        J = self.fs.rank_tell(["quiesce", "path", path, '--wait'], check_status=False)
+        J = self.fs.rank_tell(["quiesce", "path", path, '--await'], check_status=False)
         log.debug(f"{J}")
         self.assertEqual(J['op']['result'], -20) # ENOTDIR: path_traverse: the intermediate link is not a directory
 
@@ -498,7 +498,7 @@ class TestQuiesce(QuiesceTestCase):
         self.mount_a.run_shell_payload("mkdir dir")
         path = self.mount_a.cephfs_mntpt + "/dir"
 
-        J = self.fs.rank_tell(["quiesce", "path", path, '--wait'], check_status=False)
+        J = self.fs.rank_tell(["quiesce", "path", path, '--await'], check_status=False)
         reqid = self._reqid_tostr(J['op']['reqid'])
         self._wait_for_quiesce_complete(reqid, path=path)
         self._verify_quiesce(root=path)
@@ -513,7 +513,7 @@ class TestQuiesce(QuiesceTestCase):
         self.mount_a.run_shell_payload("touch file")
         path = self.mount_a.cephfs_mntpt + "/file"
 
-        J = self.fs.rank_tell(["quiesce", "path", path, '--wait'], check_status=False)
+        J = self.fs.rank_tell(["quiesce", "path", path, '--await'], check_status=False)
         log.debug(f"{J}")
         self.assertEqual(J['op']['result'], -20) # ENOTDIR
 
@@ -527,7 +527,7 @@ class TestQuiesce(QuiesceTestCase):
 
         op1 = self.fs.rank_tell(["quiesce", "path", self.subvolume], check_status=False)['op']
         op1_reqid = self._reqid_tostr(op1['reqid'])
-        op2 = self.fs.rank_tell(["quiesce", "path", self.subvolume, '--wait'], check_status=False)['op']
+        op2 = self.fs.rank_tell(["quiesce", "path", self.subvolume, '--await'], check_status=False)['op']
         op1 = self.fs.get_op(op1_reqid)['type_data'] # for possible dup result
         log.debug(f"op1 = {op1}")
         log.debug(f"op2 = {op2}")
@@ -545,7 +545,7 @@ class TestQuiesce(QuiesceTestCase):
         self.mount_a.run_shell_payload("touch file")
         self.mount_a.setfattr("file", "ceph.quiesce.block", "1")
 
-        J = self.fs.rank_tell(["quiesce", "path", self.subvolume, '--wait'], check_status=False)
+        J = self.fs.rank_tell(["quiesce", "path", self.subvolume, '--await'], check_status=False)
         log.debug(f"{J}")
         self.assertEqual(J['op']['result'], 0)
         self.assertEqual(J['state']['inodes_blocked'], 1)
@@ -684,7 +684,7 @@ class TestQuiesceMultiRank(QuiesceTestCase):
         self._client_background_workload()
         self._wait_distributed_subtrees(2*2, rank="all", path=self.mntpnt)
 
-        op = self.fs.rank_tell(["quiesce", "path", self.subvolume, '--wait'], rank=0, check_status=False)['op']
+        op = self.fs.rank_tell(["quiesce", "path", self.subvolume, '--await'], rank=0, check_status=False)['op']
         self.assertEqual(op['result'], -1) # EPERM
 
     @unittest.skip("https://tracker.ceph.com/issues/66152")

--- a/qa/tasks/cephfs/test_quiesce.py
+++ b/qa/tasks/cephfs/test_quiesce.py
@@ -470,7 +470,7 @@ class TestQuiesce(QuiesceTestCase):
         self.mount_a.run_shell_payload("ln -s ../.. subvol_quiesce")
         path = self.mount_a.cephfs_mntpt + "/subvol_quiesce"
 
-        J = self.fs.rank_tell(["quiesce", "path", path, '--wait'])
+        J = self.fs.rank_tell(["quiesce", "path", path, '--wait'], check_status=False)
         log.debug(f"{J}")
         self.assertEqual(J['op']['result'], -20) # ENOTDIR: the link is not a directory
 
@@ -484,7 +484,7 @@ class TestQuiesce(QuiesceTestCase):
         self.mount_a.run_shell_payload("ln -s ../../.. _nogroup")
         path = self.mount_a.cephfs_mntpt + "/_nogroup/" + self.QUIESCE_SUBVOLUME
 
-        J = self.fs.rank_tell(["quiesce", "path", path, '--wait'])
+        J = self.fs.rank_tell(["quiesce", "path", path, '--wait'], check_status=False)
         log.debug(f"{J}")
         self.assertEqual(J['op']['result'], -20) # ENOTDIR: path_traverse: the intermediate link is not a directory
 
@@ -498,7 +498,7 @@ class TestQuiesce(QuiesceTestCase):
         self.mount_a.run_shell_payload("mkdir dir")
         path = self.mount_a.cephfs_mntpt + "/dir"
 
-        J = self.fs.rank_tell(["quiesce", "path", path, '--wait'])
+        J = self.fs.rank_tell(["quiesce", "path", path, '--wait'], check_status=False)
         reqid = self._reqid_tostr(J['op']['reqid'])
         self._wait_for_quiesce_complete(reqid, path=path)
         self._verify_quiesce(root=path)
@@ -513,7 +513,7 @@ class TestQuiesce(QuiesceTestCase):
         self.mount_a.run_shell_payload("touch file")
         path = self.mount_a.cephfs_mntpt + "/file"
 
-        J = self.fs.rank_tell(["quiesce", "path", path, '--wait'])
+        J = self.fs.rank_tell(["quiesce", "path", path, '--wait'], check_status=False)
         log.debug(f"{J}")
         self.assertEqual(J['op']['result'], -20) # ENOTDIR
 
@@ -525,9 +525,9 @@ class TestQuiesce(QuiesceTestCase):
 
         self._configure_subvolume()
 
-        op1 = self.fs.rank_tell(["quiesce", "path", self.subvolume])['op']
+        op1 = self.fs.rank_tell(["quiesce", "path", self.subvolume], check_status=False)['op']
         op1_reqid = self._reqid_tostr(op1['reqid'])
-        op2 = self.fs.rank_tell(["quiesce", "path", self.subvolume, '--wait'])['op']
+        op2 = self.fs.rank_tell(["quiesce", "path", self.subvolume, '--wait'], check_status=False)['op']
         op1 = self.fs.get_op(op1_reqid)['type_data'] # for possible dup result
         log.debug(f"op1 = {op1}")
         log.debug(f"op2 = {op2}")
@@ -545,7 +545,7 @@ class TestQuiesce(QuiesceTestCase):
         self.mount_a.run_shell_payload("touch file")
         self.mount_a.setfattr("file", "ceph.quiesce.block", "1")
 
-        J = self.fs.rank_tell(["quiesce", "path", self.subvolume, '--wait'])
+        J = self.fs.rank_tell(["quiesce", "path", self.subvolume, '--wait'], check_status=False)
         log.debug(f"{J}")
         self.assertEqual(J['op']['result'], 0)
         self.assertEqual(J['state']['inodes_blocked'], 1)
@@ -560,7 +560,7 @@ class TestQuiesce(QuiesceTestCase):
         self._configure_subvolume()
         self._client_background_workload()
 
-        J = self.fs.rank_tell(["quiesce", "path", self.subvolume])
+        J = self.fs.rank_tell(["quiesce", "path", self.subvolume], check_status=False)
         log.debug(f"{J}")
         reqid = self._reqid_tostr(J['op']['reqid'])
         self._wait_for_quiesce_complete(reqid)
@@ -582,7 +582,7 @@ class TestQuiesce(QuiesceTestCase):
         # drop cache
         self.fs.rank_tell(["cache", "drop"])
 
-        J = self.fs.rank_tell(["quiesce", "path", self.subvolume])
+        J = self.fs.rank_tell(["quiesce", "path", self.subvolume], check_status=False)
         log.debug(f"{J}")
         reqid = self._reqid_tostr(J['op']['reqid'])
         self._wait_for_quiesce_complete(reqid)
@@ -684,7 +684,7 @@ class TestQuiesceMultiRank(QuiesceTestCase):
         self._client_background_workload()
         self._wait_distributed_subtrees(2*2, rank="all", path=self.mntpnt)
 
-        op = self.fs.rank_tell(["quiesce", "path", self.subvolume, '--wait'], rank=0)['op']
+        op = self.fs.rank_tell(["quiesce", "path", self.subvolume, '--wait'], rank=0, check_status=False)['op']
         self.assertEqual(op['result'], -1) # EPERM
 
     @unittest.skip("https://tracker.ceph.com/issues/66152")
@@ -934,8 +934,8 @@ class TestQuiesceSplitAuth(QuiesceTestCase):
 
         sleep(2)
 
-        op0 = self.fs.rank_tell(["quiesce", "path", self.subvolume], rank=0)['op']
-        op1 = self.fs.rank_tell(["quiesce", "path", self.subvolume], rank=1)['op']
+        op0 = self.fs.rank_tell(["quiesce", "path", self.subvolume], rank=0, check_status=False)['op']
+        op1 = self.fs.rank_tell(["quiesce", "path", self.subvolume], rank=1, check_status=False)['op']
         reqid0 = self._reqid_tostr(op0['reqid'])
         reqid1 = self._reqid_tostr(op1['reqid'])
         op0 = self._wait_for_quiesce_complete(reqid0, rank=0, timeout=300)

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -54,7 +54,6 @@ public:
   bool acquire_locks(const MDRequestRef& mdr,
 		     MutationImpl::LockOpVec& lov,
 		     CInode *auth_pin_freeze=NULL,
-                     std::set<MDSCacheObject*> mustpin = {},
 		     bool auth_pin_nonblocking=false,
                      bool skip_quiesce=false);
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -13758,6 +13758,7 @@ void MDCache::dispatch_quiesce_inode(const MDRequestRef& mdr)
       dout(25) << " iterating " << *dir << dendl;
       // overdrive syncrhonously since we aren't yet on the waiting list
       quiesce_overdrive_fragmenting(dir, false);
+      migrator->quiesce_overdrive_export(dir);
       for (auto& [dnk, dn] : *dir) {
         dout(25) << " evaluating (" << dnk << ", " << *dn << ")" << dendl;
         auto* in = dn->get_projected_inode();
@@ -13795,6 +13796,7 @@ void MDCache::dispatch_quiesce_inode(const MDRequestRef& mdr)
       }
     }
     if (gather.has_subs()) {
+      mdr->mark_event("quiescing children");
       dout(20) << __func__ << ": waiting for sub-ops to gather" << dendl;
       gather.activate();
       return;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -12095,7 +12095,7 @@ void MDCache::dispatch_fragment_dir(const MDRequestRef& mdr, bool abort_if_freez
       // prevent a racing gather on any other scatterlocks too
       lov.lock_scatter_gather(&diri->nestlock);
       lov.lock_scatter_gather(&diri->filelock);
-      if (mds->locker->acquire_locks(mdr, lov, NULL, {}, true)) {
+      if (mds->locker->acquire_locks(mdr, lov, NULL, true)) {
         mdr->locking_state |= MutationImpl::ALL_LOCKED;
       } else {
         if (!mdr->aborted) {
@@ -13702,7 +13702,7 @@ void MDCache::dispatch_quiesce_inode(const MDRequestRef& mdr)
       // as a result of the auth taking the above locks.
     }
 
-    if (!mds->locker->acquire_locks(mdr, lov, nullptr, {in}, false, true)) {
+    if (!mds->locker->acquire_locks(mdr, lov, nullptr, false, true)) {
       return;
     }
     mdr->locking_state |= MutationImpl::ALL_LOCKED;
@@ -13733,6 +13733,14 @@ void MDCache::dispatch_quiesce_inode(const MDRequestRef& mdr)
       mds->locker->drop_lock(mdr.get(), &in->linklock);
       mds->locker->drop_lock(mdr.get(), &in->xattrlock);
     }
+
+    // The quiescelock doesn't attempt to take remote authpins,
+    // but one could have been acquired when rdlock-ing the policylock.
+    // We are calling drop_remote_locks here to get rid of any remote
+    // authpins. That's the only side effect of this call, since we
+    // aren't really holding any remote locks (x/wr)
+    // See https://tracker.ceph.com/issues/66152 for more info.
+    mds->locker->request_drop_remote_locks(mdr);
   }
 
   if (in->is_dir()) {
@@ -14031,7 +14039,7 @@ void MDCache::dispatch_lock_path(const MDRequestRef& mdr)
     }
   }
 
-  if (!mds->locker->acquire_locks(mdr, lov, lps.config.ap_freeze ? in : nullptr, {in}, lps.config.ap_dont_block, true)) {
+  if (!mds->locker->acquire_locks(mdr, lov, lps.config.ap_freeze ? in : nullptr, lps.config.ap_dont_block, true)) {
     if (lps.config.ap_dont_block && mdr->aborted) {
       mds->server->respond_to_request(mdr, -CEPHFS_EWOULDBLOCK);
     }
@@ -14044,6 +14052,7 @@ void MDCache::dispatch_lock_path(const MDRequestRef& mdr)
   }
 
   mdr->mark_event("object locked");
+  mdr->result = 0;
   if (auto c = mdr->internal_op_finish) {
     mdr->internal_op_finish = nullptr;
     c->complete(0);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1478,7 +1478,7 @@ private:
   void finish_uncommitted_fragment(dirfrag_t basedirfrag, int op);
   void rollback_uncommitted_fragment(dirfrag_t basedirfrag, frag_vec_t&& old_frags);
 
-  void quiesce_overdrive_fragmenting(CDir* dir, bool async);
+  void quiesce_overdrive_fragmenting_async(CDir* dir);
   void dispatch_quiesce_path(const MDRequestRef& mdr);
   void dispatch_quiesce_inode(const MDRequestRef& mdr);
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -627,8 +627,10 @@ private:
   void add_quiesce(CInode* parent, CInode* in);
 
   struct LockPathConfig {
+    using Lifetime = std::chrono::milliseconds;
     filepath fpath;
     std::vector<std::string> locks;
+    std::optional<Lifetime> lifetime;
     bool ap_dont_block = false;
     bool ap_freeze = false;
   };

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -375,7 +375,7 @@ void MDSDaemon::set_up_admin_socket()
   ceph_assert(r == 0);
   r = admin_socket->register_command("quiesce path"
                                      " name=path,type=CephString,req=true"
-                                     " name=wait,type=CephBool,req=false"
+                                     " name=await,type=CephBool,req=false"
 				     ,asok_hook
 				     ,"quiesce a subtree");
   ceph_assert(r == 0);

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -366,6 +366,7 @@ void MDSDaemon::set_up_admin_socket()
                                      " name=ap_dont_block,type=CephBool,req=false"
                                      " name=ap_freeze,type=CephBool,req=false"
                                      " name=await,type=CephBool,req=false"
+                                     " name=lifetime,type=CephFloat,req=false"
 				     ,asok_hook
 				     ,"lock a path");
   ceph_assert(r == 0);

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3531,6 +3531,10 @@ void MDSRank::command_lock_path(Formatter* f, const cmdmap_t& cmdmap, std::funct
   config.ap_dont_block = cmd_getval_or<bool>(cmdmap, "ap_dont_block", false);
   config.ap_freeze = cmd_getval_or<bool>(cmdmap, "ap_freeze", false);
   config.fpath = filepath(path);
+  if (double lifetime; cmd_getval(cmdmap, "lifetime", lifetime)) {
+    using std::chrono::duration_cast;
+    config.lifetime = duration_cast<MDCache::LockPathConfig::Lifetime>(std::chrono::duration<double>(lifetime));
+  }
   bool await = cmd_getval_or<bool>(cmdmap, "await", false);
 
   auto respond = [f, on_finish=std::move(on_finish)](MDRequestRef const& req) {

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -3482,7 +3482,7 @@ void MDSRank::command_quiesce_path(Formatter* f, const cmdmap_t& cmdmap, std::fu
     return;
   }
 
-  bool wait = cmd_getval_or<bool>(cmdmap, "wait", false);
+  bool await = cmd_getval_or<bool>(cmdmap, "await", false);
 
   C_SaferCond cond;
   auto* quiesce_ctx = new C_MDS_QuiescePathCommand(mdcache);
@@ -3509,7 +3509,7 @@ void MDSRank::command_quiesce_path(Formatter* f, const cmdmap_t& cmdmap, std::fu
   // We should still be under the mds lock for this test to be valid.
   // MDCache will delete the quiesce_ctx if it manages to complete syncrhonously,
   // so we are testing the `mdr->internal_op_finish` to see if that has happend
-  if (!wait && mdr && mdr->internal_op_finish) {
+  if (!await && mdr && mdr->internal_op_finish) {
     ceph_assert(mdr->internal_op_finish == quiesce_ctx);
     quiesce_ctx->finish(mdr->result.value_or(0));
   }

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -526,7 +526,7 @@ class MDSRank {
         std::ostream &ss);
     void command_openfiles_ls(Formatter *f);
     void command_dump_tree(const cmdmap_t &cmdmap, std::ostream &ss, Formatter *f);
-    int command_quiesce_path(Formatter *f, const cmdmap_t &cmdmap, std::ostream &ss);
+    void command_quiesce_path(Formatter *f, const cmdmap_t &cmdmap, std::function<void(int, const std::string&, bufferlist&)> on_finish);
     void command_lock_path(Formatter* f, const cmdmap_t& cmdmap, std::function<void(int, const std::string&, bufferlist&)> on_finish);
     void command_dump_inode(Formatter *f, const cmdmap_t &cmdmap, std::ostream &ss);
     void command_dump_dir(Formatter *f, const cmdmap_t &cmdmap, std::ostream &ss);

--- a/src/mds/MDSRankQuiesce.cc
+++ b/src/mds/MDSRankQuiesce.cc
@@ -432,7 +432,11 @@ void MDSRank::quiesce_agent_setup() {
 
   using RequestHandle = QuiesceInterface::RequestHandle;
   using QuiescingRoot = std::pair<RequestHandle, Context*>;
-  auto dummy_requests = std::make_shared<std::unordered_map<QuiesceRoot, QuiescingRoot>>();
+
+  std::shared_ptr<std::unordered_map<QuiesceRoot, QuiescingRoot>> dummy_requests;
+#ifdef QUIESCE_ROOT_DEBUG_PARAMS
+  dummy_requests = std::make_shared<std::unordered_map<QuiesceRoot, QuiescingRoot>>();
+#endif
 
   QuiesceAgent::ControlInterface ci;
 
@@ -447,7 +451,9 @@ void MDSRank::quiesce_agent_setup() {
 
     dout(10) << "submit_request: " << uri << dendl;
 
+    bool the_real_deal = true;
     std::chrono::milliseconds quiesce_delay_ms = 0ms;
+#ifdef QUIESCE_ROOT_DEBUG_PARAMS
     if (auto pit = uri->params().find("delayms"); pit != uri->params().end()) {
       try {
         quiesce_delay_ms = std::chrono::milliseconds((*pit).has_value ? std::stoul((*pit).value) : 1000);
@@ -496,12 +502,14 @@ void MDSRank::quiesce_agent_setup() {
         return std::nullopt;
     }
 
+    the_real_deal = !debug_quiesce_after && !debug_fail_after && !debug_rank;
+#endif
+
     auto path = uri->path();
 
     std::lock_guard l(mds_lock);
 
-    if (!debug_quiesce_after && !debug_fail_after && !debug_rank) {
-      // the real deal!
+    if (the_real_deal) {
       if (mdsmap->is_degraded()) {
         dout(3) << "DEGRADED: refusing to quiesce" << dendl;
         c->complete(EPERM);
@@ -511,6 +519,9 @@ void MDSRank::quiesce_agent_setup() {
       auto mdr = mdcache->quiesce_path(filepath(path), qc, nullptr, quiesce_delay_ms);
       return mdr ? mdr->reqid : std::optional<RequestHandle>();
     } else {
+#ifndef QUIESCE_ROOT_DEBUG_PARAMS
+      ceph_abort("quiesce debug parameters are disabled");
+#else
       /* we use this branch to allow for quiesce emulation for testing purposes */
       // always create a new request id
       auto req_id = metareqid_t(entity_name_t::MDS(whoami), issue_tid());
@@ -562,6 +573,7 @@ void MDSRank::quiesce_agent_setup() {
         timer.add_event_after(delay, quiesce_task);
       }
       return it->second.first;
+#endif // QUIESCE_ROOT_DEBUG_PARAMS
     }
   };
 
@@ -575,6 +587,7 @@ void MDSRank::quiesce_agent_setup() {
       return 0;
     }
 
+#ifdef QUIESCE_ROOT_DEBUG_PARAMS
     // if we get here then it could be a test (dummy) quiesce
     auto it = std::ranges::find(*dummy_requests, h, [](auto x) { return x.second.first; });
     if (it != dummy_requests->end()) {
@@ -585,6 +598,7 @@ void MDSRank::quiesce_agent_setup() {
       dummy_requests->erase(it);
       return 0;
     }
+#endif // QUIESCE_ROOT_DEBUG_PARAMS
 
     // we must indicate that the handle wasn't found
     // so that the agent can properly report a missing

--- a/src/mds/Migrator.h
+++ b/src/mds/Migrator.h
@@ -182,6 +182,7 @@ public:
   void handle_mds_failure_or_stop(mds_rank_t who);
 
   void audit();
+  void quiesce_overdrive_export(CDir *dir);
 
   // -- import/export --
   // exporter

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -398,6 +398,7 @@ struct MDRequestImpl : public MutationImpl {
   
   More* more();
   More const* more() const;
+  bool is_live() const { return !(killed || dead); }
   bool has_more() const;
   bool has_witnesses();
   bool peer_did_prepare();

--- a/src/mds/QuiesceAgent.cc
+++ b/src/mds/QuiesceAgent.cc
@@ -82,8 +82,9 @@ bool QuiesceAgent::db_update(QuiesceMap& map)
   // ack with the known state stored in `map`
   set_pending_roots(map.db_version, std::move(new_roots));
 
-  // always send a synchronous ack
-  return true;
+  // to avoid ack races with the agent_thread,
+  // never send a synchronous ack
+  return false;
 }
 
 void* QuiesceAgent::agent_thread_main() {

--- a/src/mds/QuiesceAgent.h
+++ b/src/mds/QuiesceAgent.h
@@ -237,7 +237,7 @@ class QuiesceAgent {
       return std::max(current.db_version, pending.db_version);
     }
 
-    void set_pending_roots(QuiesceDbVersion db_version, TrackedRoots&& new_roots);
+    virtual void set_pending_roots(QuiesceDbVersion db_version, TrackedRoots&& new_roots);
 
     void set_upkeep_needed();
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3105,7 +3105,7 @@ void Server::dispatch_peer_request(const MDRequestRef& mdr)
         // will want to take other locks is to prevent issuing unwanted client capabilities,
         // but since replicas can't issue capabilities, it should be fine allowing remote locks
         // without taking the quiesce lock.
-	if (!mds->locker->acquire_locks(mdr, lov, nullptr, {}, false, true))
+	if (!mds->locker->acquire_locks(mdr, lov, nullptr, false, true))
 	  return;
 	
 	// ack

--- a/src/test/mds/TestQuiesceAgent.cc
+++ b/src/test/mds/TestQuiesceAgent.cc
@@ -10,15 +10,21 @@
  *
  */
 #include "common/Cond.h"
+#include "common/debug.h"
 #include "mds/QuiesceAgent.h"
 #include "gtest/gtest.h"
 #include <algorithm>
 #include <functional>
+#include <future>
 #include <queue>
 #include <ranges>
 #include <system_error>
 #include <thread>
-#include <future>
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_mds_quiesce
+#undef dout_prefix
+#define dout_prefix *_dout << "== test == "
 
 class QuiesceAgentTest : public testing::Test {
   using RequestHandle = QuiesceInterface::RequestHandle;
@@ -70,8 +76,24 @@ class QuiesceAgentTest : public testing::Test {
           (*f)(pending, current);
         }
       }
+
+      bool wait_for_agent_in_set_roots = false;
+      void set_pending_roots(QuiesceDbVersion db_version, TrackedRoots&& new_roots) override {
+        // just like the original version,
+        // but allows to simulate a case when the context
+        // switches to the agent thread and processes the new version
+        // before the calling has the chance to continue
+
+        QuiesceAgent::set_pending_roots(db_version, std::move(new_roots));
+
+        while(wait_for_agent_in_set_roots && db_version != await_idle()) {
+          dout(3) << __func__ << ": awaiting agent on version " << db_version << dendl;
+        }
+      }
+
+      ControlInterface& get_control_interface() { return quiesce_control; }
     };
-    QuiesceMap latest_ack;
+    QuiesceMap async_ack;
     std::unordered_map<QuiesceRoot, QuiescingRoot> quiesce_requests;
     ceph_tid_t last_tid;
     std::mutex mutex;
@@ -134,7 +156,7 @@ class QuiesceAgentTest : public testing::Test {
 
       ci.agent_ack = [this](QuiesceMap const& update) {
         std::lock_guard l(mutex);
-        latest_ack = update;
+        async_ack = update;
         return 0;
       };
 
@@ -157,8 +179,9 @@ class QuiesceAgentTest : public testing::Test {
 
     using R = QuiesceMap::Roots::value_type;
     using RootInitList = std::initializer_list<R>;
+    enum struct WaitForAgent { IfAsync, No };
 
-    std::optional<QuiesceMap> update(QuiesceDbVersion v, RootInitList roots)
+    std::optional<QuiesceMap> update(QuiesceDbVersion v, RootInitList roots, WaitForAgent wait = WaitForAgent::IfAsync)
     {
       QuiesceMap map(v, QuiesceMap::Roots { roots });
 
@@ -166,17 +189,22 @@ class QuiesceAgentTest : public testing::Test {
         return map;
       }
 
-      return std::nullopt;
+      if (WaitForAgent::No == wait) {
+        return std::nullopt;
+      } else {
+        assert(await_idle_v(v.set_version));
+        return async_ack;
+      }
     }
 
-    std::optional<QuiesceMap> update(QuiesceSetVersion v, RootInitList roots)
+    std::optional<QuiesceMap> update(QuiesceSetVersion v, RootInitList roots, WaitForAgent wait = WaitForAgent::IfAsync)
     {
-      return update(QuiesceDbVersion { 1, v }, roots);
+      return update(QuiesceDbVersion { 1, v }, roots, wait);
     }
 
-    std::optional<QuiesceMap> update(RootInitList roots)
+    std::optional<QuiesceMap> update(RootInitList roots, WaitForAgent wait = WaitForAgent::IfAsync)
     {
-      return update(agent->get_latest_version() + 1, roots);
+      return update({1, agent->get_latest_version().set_version + 1}, roots, wait);
     }
 
     template <class _Rep = std::chrono::seconds::rep, class _Period = std::chrono::seconds::period, typename D = std::chrono::duration<_Rep, _Period>>
@@ -338,22 +366,22 @@ TEST_F(QuiesceAgentTest, QuiesceProtocol) {
 
   EXPECT_TRUE(await_idle());
   // we should have seen an ack sent
-  EXPECT_EQ(1, latest_ack.db_version);
-  EXPECT_EQ(1, latest_ack.roots.size());
-  EXPECT_EQ(QS_QUIESCED, latest_ack.roots.at("root1").state);
+  EXPECT_EQ(1, async_ack.db_version);
+  EXPECT_EQ(1, async_ack.roots.size());
+  EXPECT_EQ(QS_QUIESCED, async_ack.roots.at("root1").state);
 
-  latest_ack.clear();
+  async_ack.clear();
 
   // complete the other root with failure
   EXPECT_TRUE(complete_quiesce("root2", -1));
 
   EXPECT_TRUE(await_idle());
-  EXPECT_EQ(1, latest_ack.db_version);
-  ASSERT_EQ(2, latest_ack.roots.size());
-  EXPECT_EQ(QS_QUIESCED, latest_ack.roots.at("root1").state);
-  EXPECT_EQ(QS_FAILED, latest_ack.roots.at("root2").state);
+  EXPECT_EQ(1, async_ack.db_version);
+  ASSERT_EQ(2, async_ack.roots.size());
+  EXPECT_EQ(QS_QUIESCED, async_ack.roots.at("root1").state);
+  EXPECT_EQ(QS_FAILED, async_ack.roots.at("root2").state);
 
-  latest_ack.clear();
+  async_ack.clear();
 
   // complete the third root with success
   // complete one root with success
@@ -362,11 +390,11 @@ TEST_F(QuiesceAgentTest, QuiesceProtocol) {
   EXPECT_TRUE(await_idle());
 
   // we should see the two quiesced roots in the ack,
-  EXPECT_EQ(1, latest_ack.db_version);
-  ASSERT_EQ(3, latest_ack.roots.size());
-  EXPECT_EQ(QS_QUIESCED, latest_ack.roots.at("root1").state);
-  EXPECT_EQ(QS_FAILED, latest_ack.roots.at("root2").state);
-  EXPECT_EQ(QS_QUIESCED, latest_ack.roots.at("root3").state);
+  EXPECT_EQ(1, async_ack.db_version);
+  ASSERT_EQ(3, async_ack.roots.size());
+  EXPECT_EQ(QS_QUIESCED, async_ack.roots.at("root1").state);
+  EXPECT_EQ(QS_FAILED, async_ack.roots.at("root2").state);
+  EXPECT_EQ(QS_QUIESCED, async_ack.roots.at("root3").state);
 
   {
     auto ack = update(2, {
@@ -380,7 +408,7 @@ TEST_F(QuiesceAgentTest, QuiesceProtocol) {
     // root2 is still quiescing, no updates for it
     // root3 is released asyncrhonously so for now it should be QUIESCED
     ASSERT_EQ(2, ack->roots.size());
-    EXPECT_EQ(QS_FAILED, latest_ack.roots.at("root2").state);
+    EXPECT_EQ(QS_FAILED, async_ack.roots.at("root2").state);
     EXPECT_EQ(QS_QUIESCED, ack->roots.at("root3").state);
   }
 
@@ -466,7 +494,7 @@ TEST_F(QuiesceAgentTest, DuplicateQuiesceRequest) {
   EXPECT_TRUE(quiesce_requests.contains("root1"));
   EXPECT_TRUE(quiesce_requests.contains("root2"));
 
-  latest_ack.clear();
+  async_ack.clear();
   // now, bring the roots back
   {
     auto ack = update(3, { 
@@ -486,10 +514,10 @@ TEST_F(QuiesceAgentTest, DuplicateQuiesceRequest) {
 
   // root1 and root2 are still registered internally
   // so it should result in a failure to quiesce them again
-  EXPECT_EQ(3, latest_ack.db_version);
-  EXPECT_EQ(2, latest_ack.roots.size());
-  EXPECT_EQ(QS_FAILED, latest_ack.roots.at("root1").state);
-  EXPECT_EQ(QS_FAILED, latest_ack.roots.at("root2").state);
+  EXPECT_EQ(3, async_ack.db_version);
+  EXPECT_EQ(2, async_ack.roots.size());
+  EXPECT_EQ(QS_FAILED, async_ack.roots.at("root1").state);
+  EXPECT_EQ(QS_FAILED, async_ack.roots.at("root2").state);
 
   // the actual state of the pinned objects shouldn't have changed
   EXPECT_EQ(QS_QUIESCED, pinned1->get_actual_state());
@@ -508,11 +536,11 @@ TEST_F(QuiesceAgentTest, DuplicateQuiesceRequest) {
   EXPECT_TRUE(complete_quiesce("root3"));
 
   EXPECT_TRUE(await_idle());
-  EXPECT_EQ(3, latest_ack.db_version);
-  EXPECT_EQ(3, latest_ack.roots.size());
-  EXPECT_EQ(QS_FAILED, latest_ack.roots.at("root1").state);
-  EXPECT_EQ(QS_FAILED, latest_ack.roots.at("root2").state);
-  EXPECT_EQ(QS_QUIESCED, latest_ack.roots.at("root3").state);
+  EXPECT_EQ(3, async_ack.db_version);
+  EXPECT_EQ(3, async_ack.roots.size());
+  EXPECT_EQ(QS_FAILED, async_ack.roots.at("root1").state);
+  EXPECT_EQ(QS_FAILED, async_ack.roots.at("root2").state);
+  EXPECT_EQ(QS_QUIESCED, async_ack.roots.at("root3").state);
 }
 
 TEST_F(QuiesceAgentTest, TimeoutBeforeComplete)
@@ -594,8 +622,8 @@ TEST_F(QuiesceAgentTest, RapidDbUpdates)
   // nothing should be in the ack
   // if we incorrectly submit root1 twice
   // then it should be repored here as FAILED
-  EXPECT_EQ(2, latest_ack.db_version);
-  EXPECT_EQ(0, latest_ack.roots.size());
+  EXPECT_EQ(2, async_ack.db_version);
+  EXPECT_EQ(0, async_ack.roots.size());
 
   {
     auto tracked = agent->tracked_roots();
@@ -603,3 +631,31 @@ TEST_F(QuiesceAgentTest, RapidDbUpdates)
   }
 }
 
+TEST_F(QuiesceAgentTest, RapidAsyncAck)
+{
+  // This validates that if the agent thread manages to
+  // process a db update and generate a QUIESCED ack
+  // before the updating thread gets the CPU to progress,
+  // then the outdated synchronous ack is not sent
+
+  agent->wait_for_agent_in_set_roots = true;
+
+  // make the agent complete the request synchronosuly with the submit
+  auto && old_submit = agent->get_control_interface().submit_request;
+  agent->get_control_interface().submit_request = [this, old_submit = std::move(old_submit)](QuiesceRoot root, Context* ctx) {
+    auto result = old_submit(root, ctx);
+    dout(10) << "quiescing the root `" << root << "` in submit" << dendl;
+    complete_quiesce(root, 0);
+    return result;
+  };
+
+  auto ack = update(1, {
+                            { "root1", QS_QUIESCING },
+                        });
+
+  auto && latest_ack = ack.value_or(async_ack);
+
+  EXPECT_EQ(1, latest_ack.db_version);
+  ASSERT_EQ(1, latest_ack.roots.size());
+  EXPECT_EQ(QS_QUIESCED, latest_ack.roots.at("root1").state);
+}

--- a/src/test/mds/TestQuiesceAgent.cc
+++ b/src/test/mds/TestQuiesceAgent.cc
@@ -278,16 +278,19 @@ TEST_F(QuiesceAgentTest, DbUpdates) {
   
     // manipulate root0 and root1 as if they were quiesced and root2 as if it was released
     auto& root0 = *roots.at("root0");
-    root0.quiesce_result = 0;
-    EXPECT_EQ(QS_QUIESCED, root0.get_actual_state());
+    complete_quiesce("root0", 0);
 
     auto& root1 = *roots.at("root1");
-    root1.quiesce_result = 0;
-    EXPECT_EQ(QS_QUIESCED, root1.get_actual_state());
+    complete_quiesce("root1", 0);
 
     auto& root2 = *roots.at("root2");
-    root2.quiesce_result = 0;
-    root2.cancel_result = 0;
+    complete_quiesce("root2", 0);
+    root2.cancel_result = root2.cancel(*root2.quiesce_request);
+
+    EXPECT_TRUE(await_idle());
+
+    EXPECT_EQ(QS_QUIESCED, root0.get_actual_state());
+    EXPECT_EQ(QS_QUIESCED, root1.get_actual_state());
     EXPECT_EQ(QS_RELEASED, root2.get_actual_state());
   }
 
@@ -501,13 +504,10 @@ TEST_F(QuiesceAgentTest, DuplicateQuiesceRequest) {
       { "root1", QS_QUIESCING },
       { "root2", QS_QUIESCING },
       { "root3", QS_QUIESCING },
-    });
+    }, WaitForAgent::No);
 
-    ASSERT_TRUE(ack.has_value());
-    EXPECT_EQ(3, ack->db_version);
-    // even though root1 is already quiesced,
-    // we should not know about it synchronously
-    EXPECT_EQ(0, ack->roots.size());
+    // no sync update
+    EXPECT_FALSE(ack.has_value());
   }
 
   EXPECT_TRUE(await_idle());
@@ -600,21 +600,17 @@ TEST_F(QuiesceAgentTest, RapidDbUpdates)
     auto ack = update(2, {
                              { "root1", QS_QUIESCING },
                              { "root2", QS_QUIESCING },
-                         });
+                         }, WaitForAgent::No);
 
-    ASSERT_TRUE(ack.has_value());
-    EXPECT_EQ(2, ack->db_version);
-    EXPECT_EQ(0, ack->roots.size());
+    EXPECT_FALSE(ack.has_value());
   };
 
   {
     auto ack = update(1, {
                              { "root1", QS_QUIESCING },
-                         });
+                         }, WaitForAgent::No);
 
-    ASSERT_TRUE(ack.has_value());
-    EXPECT_EQ(1, ack->db_version);
-    EXPECT_EQ(0, ack->roots.size());
+    EXPECT_FALSE(ack.has_value());
   }
 
   EXPECT_TRUE(await_idle_v(2));


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/66152 - mds/quiesce: holding remote authpins for the duration of the quiesce op may cause deadlocks
Fixes: https://tracker.ceph.com/issues/66123 - Quiesce timeout due to exporting
Fixes: https://tracker.ceph.com/issues/66208 - Segfault when `quiesce_overdrive_fragmenting` synchronously calls `dispatch_fragment_dir` for an abort
Fixes: https://tracker.ceph.com/issues/66219 - [quiesce timeout] QuiesceAgent may send an async QUIESCED ack before the QuiesceManager does the sync QUIESCING ack, which causes the QUIESCED ack to be lost
Fixes: https://tracker.ceph.com/issues/66225 - [quiesce] disable debug parameters on quiesce roots

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
