### PR TITLE
ec: free plugin memory when it destructs and repeated loads

### DIFF
--- a/src/erasure-code/ErasureCodePlugin.cc
+++ b/src/erasure-code/ErasureCodePlugin.cc
@@ -15,6 +15,7 @@
  * 
  */
 
+#include <cassert>
 #include <errno.h>
 
 #include "ceph_ver.h"
@@ -39,15 +40,14 @@ ErasureCodePluginRegistry::ErasureCodePluginRegistry() = default;
 
 ErasureCodePluginRegistry::~ErasureCodePluginRegistry()
 {
-  if (disable_dlclose)
-    return;
-
-  for (std::map<std::string,ErasureCodePlugin*>::iterator i = plugins.begin();
-       i != plugins.end();
-       ++i) {
-    void *library = i->second->library;
-    delete i->second;
-    dlclose(library);
+  for (auto& name_plugin : plugins) {
+    auto *plugin = name_plugin.second;
+    assert(plugin);
+    void *library = plugin->library;
+    delete plugin;
+    if (!disable_dlclose) {
+      dlclose(library);
+    }
   }
 }
 

--- a/src/erasure-code/clay/ErasureCodePluginClay.cc
+++ b/src/erasure-code/clay/ErasureCodePluginClay.cc
@@ -40,5 +40,10 @@ const char *__erasure_code_version() { return CEPH_GIT_NICE_VER; }
 int __erasure_code_init(char *plugin_name, char *directory)
 {
   auto& instance = ceph::ErasureCodePluginRegistry::instance();
-  return instance.add(plugin_name, new ErasureCodePluginClay());
+  auto plugin = std::make_unique<ErasureCodePluginClay>();
+  int r = instance.add(plugin_name, plugin.get());
+  if (r == 0) {
+    plugin.release();
+  }
+  return r;
 }

--- a/src/erasure-code/isa/ErasureCodePluginIsa.cc
+++ b/src/erasure-code/isa/ErasureCodePluginIsa.cc
@@ -77,6 +77,10 @@ const char *__erasure_code_version()
 int __erasure_code_init(char *plugin_name, char *directory)
 {
   auto& instance = ceph::ErasureCodePluginRegistry::instance();
-
-  return instance.add(plugin_name, new ErasureCodePluginIsa());
+  auto plugin = std::make_unique<ErasureCodePluginIsa>();
+  int r = instance.add(plugin_name, plugin.get());
+  if (r == 0) {
+    plugin.release();  
+  }
+  return r;
 }

--- a/src/erasure-code/jerasure/ErasureCodePluginJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodePluginJerasure.cc
@@ -80,5 +80,10 @@ int __erasure_code_init(char *plugin_name, char *directory)
   if (r) {
     return -r;
   }
-  return instance.add(plugin_name, new ErasureCodePluginJerasure());
+  auto plugin = std::make_unique<ErasureCodePluginJerasure>();
+  r = instance.add(plugin_name, plugin.get());
+  if (r == 0) {
+    plugin.release();
+  }
+  return r;
 }

--- a/src/erasure-code/lrc/ErasureCodePluginLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodePluginLrc.cc
@@ -44,5 +44,10 @@ const char *__erasure_code_version() { return CEPH_GIT_NICE_VER; }
 int __erasure_code_init(char *plugin_name, char *directory)
 {
   auto& instance = ceph::ErasureCodePluginRegistry::instance();
-  return instance.add(plugin_name, new ErasureCodePluginLrc());
+  auto plugin = std::make_unique<ErasureCodePluginLrc>();
+  int r = instance.add(plugin_name, plugin.get());
+  if (r == 0) {
+    plugin.release();
+  }
+  return r;
 }

--- a/src/erasure-code/shec/ErasureCodePluginShec.cc
+++ b/src/erasure-code/shec/ErasureCodePluginShec.cc
@@ -78,5 +78,10 @@ int __erasure_code_init(char *plugin_name, char *directory = (char *)"")
   if (r) {
     return -r;
   }
-  return instance.add(plugin_name, new ErasureCodePluginShec());
+  auto plugin = std::make_unique<ErasureCodePluginShec>();
+  r = instance.add(plugin_name, plugin.get());
+  if (r == 0) {
+    plugin.release();
+  }
+  return r;
 }


### PR DESCRIPTION
When sanitizer is enabled, unittest_erasure_code_shec_thread shows,

```
=================================================================
==737674==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1360 byte(s) in 5 object(s) allocated from:
    #0 0xaaaadddffb08 in operator new(unsigned long) (/root/ceph/build/bin/unittest_erasure_code_shec_thread+0x1bfb08) (BuildId: 187a0067c45bf30f4d0bd2df83a32e0127ef03a1)
    https://github.com/ceph/ceph/pull/1 0xffff800bb004 in __erasure_code_init /root/ceph/src/erasure-code/shec/ErasureCodePluginShec.cc:81:36
    https://github.com/ceph/ceph/pull/2 0xaaaadde08de0 in thread1(void*) /root/ceph/src/test/erasure-code/TestErasureCodeShec_thread.cc:100:5
    https://github.com/ceph/ceph/pull/3 0xffff7f45d5c4 in start_thread nptl/./nptl/pthread_create.c:442:8
    https://github.com/ceph/ceph/pull/4 0xffff7f4c5ed8  misc/../sysdeps/unix/sysv/linux/aarch64/clone.S:79

SUMMARY: AddressSanitizer: 1360 byte(s) leaked in 5 allocation(s).
```

When the plugin destructed, memory should be freed without unloading the
dynamic library. And repeated loading could cause fail, memory should be freed.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
