### PR TITLE
Crimson: Support basic deployments

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -31,6 +31,15 @@ options:
   desc: CPU cores on which alienstore threads will run in cpuset(7) format
   flags:
   - startup
+- name: crimson_seastar_num_threads
+  type: uint
+  level: advanced
+  default: 0
+  desc: The number of threads for serving seastar reactors without CPU pinning, overridden if crimson_seastar_cpu_cores is set
+  flags:
+  - startup
+  min: 0
+  max: 32
 - name: crimson_osd_stat_interval
   type: int
   level: advanced

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -361,7 +361,12 @@ seastar::future<> OSD::start()
 {
   LOG_PREFIX(OSD::start);
   INFO("seastar::smp::count {}", seastar::smp::count);
-
+  if (auto cpu_cores =
+        local_conf().get_val<std::string>("crimson_seastar_cpu_cores");
+      cpu_cores.empty()) {
+    clog->warn() << "for optimal performance please set "
+                    "crimson_seastar_cpu_cores";
+  }
   startup_time = ceph::mono_clock::now();
   ceph_assert(seastar::this_shard_id() == PRIMARY_CORE);
   return store.start().then([this] {


### PR DESCRIPTION
This new option is there to allow *basic* cluster deployments.
crimson_seastar_num_threads can be used globally for all the OSDs in the cluster:
```
osd:
  crimson_seastar_num_threads: <n>
  crimson_alien_op_num_threads: <m>
```

As a result, all the available CPUs will be allocated to *both* seastar reactor threads
and to Alienstore threads - without any exclusion.

Notes:

* The core allocation will most likely overlap between OSDS and/or Seastar and Alienstore.
An optiomal deployment requires `crimson_alien_thread_cpu_cores`
and `crimson_seastar_cpu_cores` to be set for each OSD based on the host its located at.

* Seastar reactor number (smp::count) will be deduced directly from crimson_seastar_num_threads

---

Documentation followup: https://github.com/ceph/ceph/pull/57352

---
### Option 1 (Optimal)
* CPUs are pinned to the provided sets (seastar and alien cpu sets)
* thread-affinity = 1 (seastar's default).
* smp (smp::count / reactor count): `seastar_cpu_set.size()`
* Seastar reactor threads: `seastar_cpu_set.size()`
* Alienstore threads num: `crimson_alien_op_num_threads`
---
### Option 2 (Basic):
* No CPU pinning.
* thread-affinity = 0
* smp (smp::count / reactor count) = `crimson_seastar_num_threads`
* Seastar reactor threads num: `crimson_seastar_num_threads`
* Alienstore threads num: `crimson_alien_op_num_threads`
---
Fixes: https://tracker.ceph.com/issues/65752



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
