### PR TITLE
cmake: Add gcov linker options when coverage option is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -637,7 +637,6 @@ if(WITH_BABELTRACE)
 endif(WITH_BABELTRACE)
 
 option(DEBUG_GATHER "C_Gather debugging is enabled" ON)
-option(ENABLE_COVERAGE "Coverage is enabled" OFF)
 option(PG_DEBUG_REFS "PG Ref debugging is enabled" OFF)
 
 option(WITH_TESTS "enable the build of ceph-test package scripts/binaries" ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -263,15 +263,18 @@ if(LINUX OR APPLE)
   list(APPEND EXTRALIBS ${LIB_RESOLV})
 endif()
 
+option(ENABLE_COVERAGE "Coverage is enabled" OFF)
 if(${ENABLE_COVERAGE})
   find_program(HAVE_GCOV gcov)
   if(NOT HAVE_GCOV)
     message(FATAL_ERROR "Coverage Enabled but gcov Not Found")
   endif()
   add_compile_options(
-    -fprofile-arcs
-    -ftest-coverage
+    --coverage
     -O0)
+  add_link_options(
+    --coverage
+  )
   list(APPEND EXTRALIBS gcov)
 endif(${ENABLE_COVERAGE})
 


### PR DESCRIPTION
A small tweak to the cmake files to address the following issues:

1. Setting the ENABLE_COVERAGE option to ON in the root directory cmake file does not get picked up in the src level file while the compile options are set (applying it via parameter to do_cmake.sh works)
2. As the gcov options are not linked, build seems to fail when trying to resolve some of the gcov functions:

`FAILED: bin/ceph-diff-sorted
: && /usr/lib64/ccache/g++ -Og -g -rdynamic -pie src/tools/CMakeFiles/ceph-diff-sorted.dir/ceph-diff-sorted.cc.o -o bin/ceph-diff-sorted  -Wl,--as-needed -latomic && :
/usr/bin/ld: src/tools/CMakeFiles/ceph-diff-sorted.dir/ceph-diff-sorted.cc.o: in function _sub_I_00100_0':
/ceph/src/tools/ceph-diff-sorted.cc:173: undefined reference to __gcov_init'
/usr/bin/ld: src/tools/CMakeFiles/ceph-diff-sorted.dir/ceph-diff-sorted.cc.o: in function _sub_D_00100_1':
/ceph/src/tools/ceph-diff-sorted.cc:173: undefined reference to __gcov_exit'
/usr/bin/ld: src/tools/CMakeFiles/ceph-diff-sorted.dir/ceph-diff-sorted.cc.o:(.data.rel+0x20): undefined reference to __gcov_merge_add'
collect2: error: ld returned 1 exit status
`

Have tested the fix with the following combinations:

- Setting flag to ON with cmake.sh parameter while set to OFF in the makefile - (Code is compiled with coverage)
- Setting flag to ON in the makefile only - (Code is compiled with coverage)
- Setting flag to OFF in the makefile only - (Code is not compiled with coverage)
- Setting flag to ON with cmake parameter and also ON in makefile - (Code is compiled with coverage)

Please let me know if there are existing relevant tests I should run, I couldn't see any, though I suspect they may exist somewhere!

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
