### PR TITLE
squid: crimson/osd/replicated_backend: misc fixes

### DIFF
--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -251,7 +251,8 @@ ClientRequest::process_op(
   co_await ihref.enter_stage<interruptor>(
     client_pp(*pg).recover_missing, *this
   );
-  co_await recover_missings(pg, m->get_hobj(), snaps_need_to_recover());
+  co_await recover_missings(pg, m->get_hobj(),
+                            snaps_need_to_recover(), m->get_reqid());
 
   DEBUGDPP("{}.{}: checking already_complete",
 	   *pg, *this, this_instance_id);

--- a/src/crimson/osd/osd_operations/client_request_common.h
+++ b/src/crimson/osd/osd_operations/client_request_common.h
@@ -15,10 +15,14 @@ struct CommonClientRequest {
   recover_missings(
     Ref<PG> &pg,
     const hobject_t& soid,
-    std::set<snapid_t> &&snaps);
+    std::set<snapid_t> &&snaps,
+    const osd_reqid_t& reqid);
 
   static InterruptibleOperation::template interruptible_future<>
-  do_recover_missing(Ref<PG>& pg, const hobject_t& soid);
+  do_recover_missing(
+    Ref<PG>& pg,
+    const hobject_t& soid,
+    const osd_reqid_t& reqid);
 
   static bool should_abort_request(
     const crimson::Operation& op, std::exception_ptr eptr);

--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -69,7 +69,7 @@ seastar::future<> InternalClientRequest::start()
           return enter_stage<interruptor>(
             client_pp().recover_missing);
         }).then_interruptible([this] {
-          return do_recover_missing(pg, get_target_oid());
+          return do_recover_missing(pg, get_target_oid(), osd_reqid_t());
         }).then_interruptible([this] {
           return enter_stage<interruptor>(
             client_pp().get_obc);

--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -44,7 +44,7 @@ ReplicatedBackend::_submit_transaction(std::set<pg_shard_t>&& pg_shards,
 				       std::vector<pg_log_entry_t>&& log_entries)
 {
   LOG_PREFIX(ReplicatedBackend::_submit_transaction);
-  DEBUGDPP("object {}, {}", dpp, hoid);
+  DEBUGDPP("object {}", dpp, hoid);
 
   const ceph_tid_t tid = shard_services.get_tid();
   auto pending_txn =

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -401,7 +401,7 @@ ReplicatedRecoveryBackend::prep_push(
   push_info.recovery_info.ss = push_info_ss;
   push_info.recovery_info.soid = soid;
   push_info.recovery_info.oi = obc->obs.oi;
-  push_info.recovery_info.version = obc->obs.oi.version;
+  push_info.recovery_info.version = need;
   push_info.recovery_info.object_exist =
     missing_iter->second.clean_regions.object_is_exist();
   push_info.recovery_progress.omap_complete =


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56916

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh