### PR TITLE
squid: crimson/osd/osd_operations/client_requests: we don't support rados locator keys

### DIFF
--- a/src/test/librados/misc_cxx.cc
+++ b/src/test/librados/misc_cxx.cc
@@ -50,6 +50,7 @@ TEST_F(LibRadosMiscPP, LongNamePP) {
 }
 
 TEST_F(LibRadosMiscPP, LongLocatorPP) {
+  SKIP_IF_CRIMSON();
   bufferlist bl;
   bl.append("content");
   int maxlen = g_conf()->osd_max_object_name_len;

--- a/src/test/neorados/misc.cc
+++ b/src/test/neorados/misc.cc
@@ -68,6 +68,7 @@ CORO_TEST_F(NeoRadosMisc, LongName, NeoRadosTest) {
 }
 
 CORO_TEST_F(NeoRadosMisc, LongLocator, NeoRadosTest) {
+  SKIP_IF_CRIMSON();
   const auto maxlen = rados().cct()->_conf->osd_max_object_name_len;
   const auto bl = to_buffer_list("content"sv);
   {

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -715,6 +715,8 @@ class TestIoctx(object):
             self.ioctx.operate_write_op(write_op, 'abc')
 
     def test_locator(self):
+        if os.getenv("CRIMSON_COMPAT") != None:
+            return
         self.ioctx.set_locator_key("bar")
         self.ioctx.write('foo', b'contents1')
         objects = [i for i in self.ioctx.list_objects()]


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56025

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh