### PR TITLE
squid: test/crimson/seastore/test_object_data_handler: remap pins through the transaction that created the pins

### DIFF
--- a/src/crimson/os/seastore/btree/btree_range_pin.cc
+++ b/src/crimson/os/seastore/btree/btree_range_pin.cc
@@ -14,6 +14,7 @@ BtreeNodeMapping<key_t, val_t>::get_logical_extent(
   assert(parent);
   assert(parent->is_valid());
   assert(pos != std::numeric_limits<uint16_t>::max());
+  ceph_assert(t.get_trans_id() == ctx.trans.get_trans_id());
   auto &p = (FixedKVNode<key_t>&)*parent;
   auto k = this->is_indirect()
     ? this->get_intermediate_base()

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -213,6 +213,15 @@ struct object_data_handler_test_t:
       }
     }
   }
+  std::list<LBAMappingRef> get_mappings(
+    Transaction &t,
+    objaddr_t offset,
+    extent_len_t length) {
+    auto ret = with_trans_intr(t, [&](auto &t) {
+      return tm->get_pins(t, offset, length);
+    }).unsafe_get0();
+    return ret;
+  }
   std::list<LBAMappingRef> get_mappings(objaddr_t offset, extent_len_t length) {
     auto t = create_mutate_transaction();
     auto ret = with_trans_intr(*t, [&](auto &t) {
@@ -758,7 +767,7 @@ TEST_P(object_data_handler_test_t, overwrite_then_read_within_transaction) {
 
     t = create_mutate_transaction();
     { 
-      auto pins = get_mappings(base, len);
+      auto pins = get_mappings(*t, base, len);
       assert(pins.size() == 1);
       auto pin1 = remap_pin(*t, std::move(pins.front()), 4096, 8192);
       auto ext = get_extent(*t, base + 4096, 4096 * 2);


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57035

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh