### PR TITLE
squid: crimson/os/seastore: support extent checksum verification

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -83,6 +83,16 @@ options:
   level: dev
   desc: default logical address space reservation for seastore objects' metadata
   default: 16777216
+# TODO: implement sub-extent checksum and deprecate this configuration.
+- name: seastore_full_integrity_check
+  type: bool
+  level: dev
+  desc: Whether seastore need to fully check the integrity of each extent,
+        non-full integrity check means the integrity check might be skipped
+        during extent remapping for better performance, disable with caution
+  default: false
+# TODO: seastore_max_data_allocation_size should be dropped once the sub-extent
+#       read/checksum is implemented.
 - name: seastore_max_data_allocation_size
   type: size
   level: advanced

--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -83,6 +83,11 @@ options:
   level: dev
   desc: default logical address space reservation for seastore objects' metadata
   default: 16777216
+- name: seastore_max_data_allocation_size
+  type: size
+  level: advanced
+  desc: Max size in bytes that an extent can be
+  default: 32_K
 - name: seastore_cache_lru_size
   type: size
   level: advanced

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -1275,6 +1275,17 @@ private:
       init_internal
     ).si_then([FNAME, c, offset, init_internal, depth, begin, end](
               typename internal_node_t::Ref ret) {
+      if (unlikely(ret->get_in_extent_checksum()
+          != ret->get_last_committed_crc())) {
+        SUBERRORT(
+          seastore_fixedkv_tree,
+          "internal fixedkv extent checksum inconsistent, "
+          "recorded: {}, actually: {}",
+          c.trans,
+          ret->get_in_extent_checksum(),
+          ret->get_last_committed_crc());
+        ceph_abort();
+      }
       SUBTRACET(
         seastore_fixedkv_tree,
         "read internal at offset {} {}",
@@ -1349,6 +1360,16 @@ private:
       init_leaf
     ).si_then([FNAME, c, offset, init_leaf, begin, end]
       (typename leaf_node_t::Ref ret) {
+      if (unlikely(ret->get_in_extent_checksum()
+          != ret->get_last_committed_crc())) {
+        SUBERRORT(
+          seastore_fixedkv_tree,
+          "leaf fixedkv extent checksum inconsistent, recorded: {}, actually: {}",
+          c.trans,
+          ret->get_in_extent_checksum(),
+          ret->get_last_committed_crc());
+        ceph_abort();
+      }
       SUBTRACET(
         seastore_fixedkv_tree,
         "read leaf at offset {} {}",

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -662,6 +662,18 @@ struct FixedKVInternalNode
     return this->get_size();
   }
 
+  uint32_t get_crc32c() const final {
+    return this->calc_phy_checksum();
+  }
+
+  void update_in_extent_chksum_field(uint32_t crc) final {
+    this->set_phy_checksum(crc);
+  }
+
+  uint32_t get_in_extent_checksum() const {
+    return this->get_phy_checksum();
+  }
+
   typename node_layout_t::delta_buffer_t delta_buffer;
   typename node_layout_t::delta_buffer_t *maybe_get_delta_buffer() {
     return this->is_mutation_pending() 
@@ -887,7 +899,9 @@ struct FixedKVInternalNode
     typename node_layout_t::delta_buffer_t buffer;
     buffer.copy_in(bl.front().c_str(), bl.front().length());
     buffer.replay(*this);
-    this->set_last_committed_crc(this->get_crc32c());
+    auto crc = calc_crc32c();
+    this->set_last_committed_crc(crc);
+    this->update_in_extent_chksum_field(crc);
     resolve_relative_addrs(base);
   }
 
@@ -1086,6 +1100,18 @@ struct FixedKVLeafNode
     return this->get_size();
   }
 
+  uint32_t get_crc32c() const final {
+    return this->calc_phy_checksum();
+  }
+
+  void update_in_extent_chksum_field(uint32_t crc) final {
+    this->set_phy_checksum(crc);
+  }
+
+  uint32_t get_in_extent_checksum() const {
+    return this->get_phy_checksum();
+  }
+
   typename node_layout_t::delta_buffer_t delta_buffer;
   virtual typename node_layout_t::delta_buffer_t *maybe_get_delta_buffer() {
     return this->is_mutation_pending() ? &delta_buffer : nullptr;
@@ -1189,7 +1215,9 @@ struct FixedKVLeafNode
     typename node_layout_t::delta_buffer_t buffer;
     buffer.copy_in(bl.front().c_str(), bl.front().length());
     buffer.replay(*this);
-    this->set_last_committed_crc(this->get_crc32c());
+    auto crc = calc_crc32c();
+    this->set_last_committed_crc(crc);
+    this->update_in_extent_chksum_field(crc);
     this->resolve_relative_addrs(base);
   }
 

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -662,7 +662,7 @@ struct FixedKVInternalNode
     return this->get_size();
   }
 
-  uint32_t get_crc32c() const final {
+  uint32_t calc_crc32c() const final {
     return this->calc_phy_checksum();
   }
 
@@ -1100,7 +1100,7 @@ struct FixedKVLeafNode
     return this->get_size();
   }
 
-  uint32_t get_crc32c() const final {
+  uint32_t calc_crc32c() const final {
     return this->calc_phy_checksum();
   }
 

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1043,7 +1043,7 @@ CachedExtentRef Cache::duplicate_for_write(
   if (i->is_exist_clean()) {
     i->version++;
     i->state = CachedExtent::extent_state_t::EXIST_MUTATION_PENDING;
-    i->last_committed_crc = i->get_crc32c();
+    i->last_committed_crc = i->calc_crc32c();
     // deepcopy the buffer of exist clean extent beacuse it shares
     // buffer with original clean extent.
     auto bp = i->get_bptr();
@@ -1155,7 +1155,7 @@ record_t Cache::prepare_record(
     i->prepare_commit();
 
     assert(i->get_version() > 0);
-    auto final_crc = i->get_crc32c();
+    auto final_crc = i->calc_crc32c();
     if (i->get_type() == extent_types_t::ROOT) {
       SUBTRACET(seastore_t, "writing out root delta {}B -- {}",
                 t, delta_length, *i);
@@ -1530,7 +1530,7 @@ void Cache::complete_commit(
       is_inline = true;
       i->set_paddr(final_block_start.add_relative(i->get_paddr()));
     }
-    assert(i->get_last_committed_crc() == i->get_crc32c());
+    assert(i->get_last_committed_crc() == i->calc_crc32c());
     i->pending_for_transaction = TRANS_ID_NULL;
     i->on_initial_write();
 

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1520,7 +1520,7 @@ void Cache::complete_commit(
             t, final_block_start, start_seq);
 
   std::vector<backref_entry_ref> backref_list;
-  t.for_each_fresh_block([&](const CachedExtentRef &i) {
+  t.for_each_finalized_fresh_block([&](const CachedExtentRef &i) {
     if (!i->is_valid()) {
       return;
     }
@@ -1530,7 +1530,7 @@ void Cache::complete_commit(
       is_inline = true;
       i->set_paddr(final_block_start.add_relative(i->get_paddr()));
     }
-    i->last_committed_crc = i->get_crc32c();
+    assert(i->get_last_committed_crc() == i->get_crc32c());
     i->pending_for_transaction = TRANS_ID_NULL;
     i->on_initial_write();
 

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1015,13 +1015,15 @@ std::vector<CachedExtentRef> Cache::alloc_new_data_extents_by_type(
   switch (type) {
   case extent_types_t::OBJECT_DATA_BLOCK:
     {
-      auto extents = alloc_new_data_extents<ObjectDataBlock>(t, length, hint, gen);
+      auto extents = alloc_new_data_extents<
+	ObjectDataBlock>(t, length, hint, gen);
       res.insert(res.begin(), extents.begin(), extents.end());
     }
     return res;
   case extent_types_t::TEST_BLOCK:
     {
-      auto extents = alloc_new_data_extents<TestBlock>(t, length, hint, gen);
+      auto extents = alloc_new_data_extents<
+	TestBlock>(t, length, hint, gen);
       res.insert(res.begin(), extents.begin(), extents.end());
     }
     return res;

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1659,7 +1659,7 @@ private:
 	if (extent->is_valid()) {
 	  // crc will be checked against LBA leaf entry for logical extents,
 	  // or check against in-extent crc for physical extents.
-	  extent->last_committed_crc = extent->get_crc32c();
+	  extent->last_committed_crc = extent->calc_crc32c();
 	  extent->on_clean_read();
 	}
         extent->complete_io();

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1067,6 +1067,10 @@ public:
   virtual key_t get_intermediate_key() const { return min_max_t<key_t>::null; }
   virtual key_t get_intermediate_base() const { return min_max_t<key_t>::null; }
   virtual extent_len_t get_intermediate_length() const { return 0; }
+  virtual uint32_t get_checksum() const {
+    ceph_abort("impossible");
+    return 0;
+  }
   // The start offset of the pin, must be 0 if the pin is not indirect
   virtual extent_len_t get_intermediate_offset() const {
     return std::numeric_limits<extent_len_t>::max();

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -542,7 +542,7 @@ public:
   }
 
   /// Returns crc32c of buffer
-  virtual uint32_t get_crc32c() const {
+  virtual uint32_t calc_crc32c() const {
     return ceph_crc32c(
       1,
       reinterpret_cast<const unsigned char *>(get_bptr().c_str()),
@@ -1259,7 +1259,7 @@ public:
   void apply_delta_and_adjust_crc(
     paddr_t base, const ceph::bufferlist &bl) final {
     apply_delta(bl);
-    set_last_committed_crc(get_crc32c());
+    set_last_committed_crc(calc_crc32c());
   }
 
   bool is_logical() const final {

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -335,6 +335,14 @@ ExtentPlacementManager::write_delayed_ool_extents(
   return trans_intr::do_for_each(alloc_map, [&t](auto& p) {
     auto writer = p.first;
     auto& extents = p.second;
+#ifndef NDEBUG
+    std::for_each(
+      extents.begin(),
+      extents.end(),
+      [](auto &extent) {
+      assert(extent->is_valid());
+    });
+#endif
     return writer->alloc_write_ool_extents(t, extents);
   });
 }

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -41,7 +41,7 @@ public:
   using alloc_write_iertr = trans_iertr<alloc_write_ertr>;
   virtual alloc_write_iertr::future<> alloc_write_ool_extents(
     Transaction &t,
-    std::list<LogicalCachedExtentRef> &extents) = 0;
+    std::list<CachedExtentRef> &extents) = 0;
 
   using close_ertr = base_ertr;
   virtual close_ertr::future<> close() = 0;
@@ -74,7 +74,7 @@ public:
 
   alloc_write_iertr::future<> alloc_write_ool_extents(
     Transaction &t,
-    std::list<LogicalCachedExtentRef> &extents) final;
+    std::list<CachedExtentRef> &extents) final;
 
   close_ertr::future<> close() final {
     return write_guard.close().then([this] {
@@ -100,7 +100,7 @@ public:
 private:
   alloc_write_iertr::future<> do_write(
     Transaction& t,
-    std::list<LogicalCachedExtentRef> &extent);
+    std::list<CachedExtentRef> &extent);
 
   alloc_write_ertr::future<> write_record(
     Transaction& t,
@@ -126,7 +126,7 @@ public:
 
   alloc_write_iertr::future<> alloc_write_ool_extents(
     Transaction &t,
-    std::list<LogicalCachedExtentRef> &extents) final;
+    std::list<CachedExtentRef> &extents) final;
 
   close_ertr::future<> close() final {
     return write_guard.close().then([this] {
@@ -166,7 +166,7 @@ public:
 private:
   alloc_write_iertr::future<> do_write(
     Transaction& t,
-    std::list<LogicalCachedExtentRef> &extent);
+    std::list<CachedExtentRef> &extent);
 
   RBMCleaner* rb_cleaner;
   seastar::gate write_guard;
@@ -407,10 +407,10 @@ public:
    * usage is used to reserve projected space
    */
   using extents_by_writer_t =
-    std::map<ExtentOolWriter*, std::list<LogicalCachedExtentRef>>;
+    std::map<ExtentOolWriter*, std::list<CachedExtentRef>>;
   struct dispatch_result_t {
     extents_by_writer_t alloc_map;
-    std::list<LogicalCachedExtentRef> delayed_extents;
+    std::list<CachedExtentRef> delayed_extents;
     io_usage_t usage;
   };
 
@@ -439,7 +439,7 @@ public:
    */
   alloc_paddr_iertr::future<> write_preallocated_ool_extents(
     Transaction &t,
-    std::list<LogicalCachedExtentRef> extents);
+    std::list<CachedExtentRef> extents);
 
   seastar::future<> stop_background() {
     return background_process.stop_background();
@@ -562,7 +562,7 @@ private:
    * Specify the extent inline or ool
    * return true indicates inline otherwise ool
    */
-  bool dispatch_delayed_extent(LogicalCachedExtentRef& extent) {
+  bool dispatch_delayed_extent(CachedExtentRef& extent) {
     // TODO: all delayed extents are ool currently
     boost::ignore_unused(extent);
     return false;

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -223,7 +223,9 @@ class ExtentPlacementManager {
 public:
   ExtentPlacementManager()
     : ool_segment_seq_allocator(
-          std::make_unique<SegmentSeqAllocator>(segment_type_t::OOL))
+          std::make_unique<SegmentSeqAllocator>(segment_type_t::OOL)),
+      max_data_allocation_size(crimson::common::get_conf<Option::size_t>(
+	  "seastore_max_data_allocation_size"))
   {
     devices_by_id.resize(DEVICE_ID_MAX, nullptr);
   }
@@ -352,6 +354,7 @@ public:
     rewrite_gen_t gen
 #endif
   ) {
+    LOG_PREFIX(ExtentPlacementManager::alloc_new_data_extents);
     assert(hint < placement_hint_t::NUM_HINTS);
     assert(is_target_rewrite_generation(gen));
     assert(gen == INIT_GENERATION || hint == placement_hint_t::REWRITE);
@@ -379,10 +382,20 @@ public:
       auto addrs = data_writers_by_gen[
           generation_to_writer(gen)]->alloc_paddrs(length);
       for (auto &ext : addrs) {
-        auto bp = ceph::bufferptr(
-          buffer::create_page_aligned(ext.len));
-        bp.zero();
-        allocs.emplace_back(alloc_result_t{ext.start, std::move(bp), gen});
+        auto left = ext.len;
+        while (left > 0) {
+          auto len = std::min(max_data_allocation_size, left);
+          auto bp = ceph::bufferptr(buffer::create_page_aligned(len));
+          bp.zero();
+          auto start = ext.start.is_delayed()
+                        ? ext.start
+                        : ext.start + (ext.len - left);
+          allocs.emplace_back(alloc_result_t{start, std::move(bp), gen});
+          SUBDEBUGT(seastore_epm,
+                    "allocated {} {}B extent at {}, hint={}, gen={}",
+                    t, type, len, start, hint, gen);
+          left -= len;
+        }
       }
     }
     return allocs;
@@ -1012,6 +1025,7 @@ private:
   BackgroundProcess background_process;
   // TODO: drop once paddr->journal_seq_t is introduced
   SegmentSeqAllocatorRef ool_segment_seq_allocator;
+  extent_len_t max_data_allocation_size = 0;
 
   friend class ::transaction_manager_test_t;
 };

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -409,6 +409,14 @@ public:
       writer->prefill_fragmented_devices();
     }
   }
+
+  void set_max_extent_size(extent_len_t len) {
+    max_data_allocation_size = len;
+  }
+
+  extent_len_t get_max_extent_size() const {
+    return max_data_allocation_size;
+  }
 #endif
 
   /**

--- a/src/crimson/os/seastore/lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager.cc
@@ -13,6 +13,7 @@ LBAManager::update_mappings(
 {
   return trans_intr::do_for_each(extents,
 				 [this, &t](auto &extent) {
+    assert(extent->get_last_committed_crc());
     return update_mapping(
       t,
       extent->get_laddr(),
@@ -20,6 +21,7 @@ LBAManager::update_mappings(
       extent->get_prior_paddr_and_reset(),
       extent->get_length(),
       extent->get_paddr(),
+      extent->get_last_committed_crc(),
       nullptr	// all the extents should have already been
 		// added to the fixed_kv_btree
     ).discard_result();

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -88,6 +88,14 @@ public:
     LogicalCachedExtent &nextent,
     extent_ref_count_t refcount = EXTENT_DEFAULT_REF_COUNT) = 0;
 
+  using alloc_extents_ret = alloc_extent_iertr::future<
+    std::vector<LBAMappingRef>>;
+  virtual alloc_extents_ret alloc_extents(
+    Transaction &t,
+    laddr_t hint,
+    std::vector<LogicalCachedExtentRef> extents,
+    extent_ref_count_t refcount) = 0;
+
   virtual alloc_extent_ret clone_mapping(
     Transaction &t,
     laddr_t hint,

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -85,9 +85,6 @@ public:
   virtual alloc_extent_ret alloc_extent(
     Transaction &t,
     laddr_t hint,
-    extent_len_t len,
-    paddr_t addr,
-    uint32_t checksum,
     LogicalCachedExtent &nextent,
     extent_ref_count_t refcount = EXTENT_DEFAULT_REF_COUNT) = 0;
 
@@ -96,7 +93,6 @@ public:
     laddr_t hint,
     extent_len_t len,
     laddr_t intermediate_key,
-    paddr_t actual_addr,
     laddr_t intermediate_base) = 0;
 
   virtual alloc_extent_ret reserve_region(

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -87,6 +87,7 @@ public:
     laddr_t hint,
     extent_len_t len,
     paddr_t addr,
+    uint32_t checksum,
     LogicalCachedExtent &nextent,
     extent_ref_count_t refcount = EXTENT_DEFAULT_REF_COUNT) = 0;
 
@@ -196,6 +197,7 @@ public:
     paddr_t prev_addr,
     extent_len_t len,
     paddr_t paddr,
+    uint32_t checksum,
     LogicalCachedExtent *nextent) = 0;
 
   /**

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -306,7 +306,6 @@ BtreeLBAManager::_alloc_extent(
   laddr_t hint,
   extent_len_t len,
   pladdr_t addr,
-  paddr_t actual_addr,
   uint32_t checksum,
   LogicalCachedExtent* nextent,
   extent_ref_count_t refcount)
@@ -323,7 +322,6 @@ BtreeLBAManager::_alloc_extent(
   LOG_PREFIX(BtreeLBAManager::_alloc_extent);
   TRACET("{}~{}, hint={}, refcount={}", t, addr, len, hint, refcount);
 
-  ceph_assert(actual_addr != P_ADDR_NULL ? addr.is_laddr() : addr.is_paddr());
   auto c = get_context(t);
   ++stats.num_alloc_extents;
   auto lookup_attempts = stats.num_alloc_extents_iter_nexts;

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -141,6 +141,10 @@ public:
     return get_map_val().refcount > 1;
   }
 
+  uint32_t get_checksum() const final {
+    return get_map_val().checksum;
+  }
+
 protected:
   std::unique_ptr<BtreeNodeMapping<laddr_t, paddr_t>> _duplicate(
     op_context_t<laddr_t> ctx) const final {

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -221,6 +221,7 @@ public:
       len,
       P_ADDR_ZERO,
       P_ADDR_NULL,
+      0,
       nullptr,
       EXTENT_DEFAULT_REF_COUNT);
   }
@@ -241,6 +242,8 @@ public:
       len,
       intermediate_key,
       actual_addr,
+      0,	// crc will only be used and checked with LBA direct mappings
+		// also see pin_to_extent(_by_type)
       nullptr,
       EXTENT_DEFAULT_REF_COUNT
     ).si_then([&t, this, intermediate_base](auto indirect_mapping) {
@@ -267,6 +270,7 @@ public:
     laddr_t hint,
     extent_len_t len,
     paddr_t addr,
+    uint32_t checksum,
     LogicalCachedExtent &ext,
     extent_ref_count_t refcount = EXTENT_DEFAULT_REF_COUNT) final
   {
@@ -276,6 +280,7 @@ public:
       len,
       addr,
       P_ADDR_NULL,
+      checksum,
       &ext,
       refcount);
   }
@@ -341,6 +346,7 @@ public:
     paddr_t prev_addr,
     extent_len_t len,
     paddr_t paddr,
+    uint32_t checksum,
     LogicalCachedExtent*) final;
 
   get_physical_extent_if_live_ret get_physical_extent_if_live(
@@ -410,6 +416,7 @@ private:
     extent_len_t len,
     pladdr_t addr,
     paddr_t actual_addr,
+    uint32_t checksum,
     LogicalCachedExtent*,
     extent_ref_count_t refcount);
 

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -224,7 +224,6 @@ public:
       hint,
       len,
       P_ADDR_ZERO,
-      P_ADDR_NULL,
       0,
       nullptr,
       EXTENT_DEFAULT_REF_COUNT);
@@ -235,7 +234,6 @@ public:
     laddr_t hint,
     extent_len_t len,
     laddr_t intermediate_key,
-    paddr_t actual_addr,
     laddr_t intermediate_base)
   {
     assert(intermediate_key != L_ADDR_NULL);
@@ -245,7 +243,6 @@ public:
       hint,
       len,
       intermediate_key,
-      actual_addr,
       0,	// crc will only be used and checked with LBA direct mappings
 		// also see pin_to_extent(_by_type)
       nullptr,
@@ -272,19 +269,17 @@ public:
   alloc_extent_ret alloc_extent(
     Transaction &t,
     laddr_t hint,
-    extent_len_t len,
-    paddr_t addr,
-    uint32_t checksum,
     LogicalCachedExtent &ext,
     extent_ref_count_t refcount = EXTENT_DEFAULT_REF_COUNT) final
   {
+    // The real checksum will be updated upon transaction commit
+    assert(ext.get_last_committed_crc() == 0);
     return _alloc_extent(
       t,
       hint,
-      len,
-      addr,
-      P_ADDR_NULL,
-      checksum,
+      ext.get_length(),
+      ext.get_paddr(),
+      ext.get_last_committed_crc(),
       &ext,
       refcount);
   }
@@ -419,7 +414,6 @@ private:
     laddr_t hint,
     extent_len_t len,
     pladdr_t addr,
-    paddr_t actual_addr,
     uint32_t checksum,
     LogicalCachedExtent*,
     extent_ref_count_t refcount);

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -63,8 +63,8 @@ using lba_node_meta_le_t = fixed_kv_node_meta_le_t<laddr_le_t>;
  * LBA Tree.
  *
  * Layout (4k):
+ *   checksum   :                            4b
  *   size       : uint32_t[1]                4b
- *   (padding)  :                            4b
  *   meta       : lba_node_meta_le_t[3]      (1*24)b
  *   keys       : laddr_t[255]               (254*8)b
  *   values     : paddr_t[255]               (254*8)b
@@ -101,8 +101,8 @@ using LBAInternalNodeRef = LBAInternalNode::Ref;
  * LBA Tree.
  *
  * Layout (4k):
+ *   checksum   :                            4b
  *   size       : uint32_t[1]                4b
- *   (padding)  :                            4b
  *   meta       : lba_node_meta_le_t[3]      (1*24)b
  *   keys       : laddr_t[170]               (140*8)b
  *   values     : lba_map_val_t[170]         (140*21)b

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -333,9 +333,14 @@ public:
   }
 
   template <typename F>
-  auto for_each_fresh_block(F &&f) const {
+  auto for_each_finalized_fresh_block(F &&f) const {
     std::for_each(written_ool_block_list.begin(), written_ool_block_list.end(), f);
     std::for_each(inline_block_list.begin(), inline_block_list.end(), f);
+  }
+
+  template <typename F>
+  auto for_each_existing_block(F &&f) {
+    std::for_each(existing_block_list.begin(), existing_block_list.end(), f);
   }
 
   const io_stat_t& get_fresh_block_stats() const {

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -163,10 +163,10 @@ public:
       assert(ref->is_logical());
       ref->set_paddr(make_delayed_temp_paddr(delayed_temp_offset));
       delayed_temp_offset += ref->get_length();
-      delayed_alloc_list.emplace_back(ref->cast<LogicalCachedExtent>());
+      delayed_alloc_list.emplace_back(ref);
       fresh_block_stats.increment(ref->get_length());
     } else if (ref->get_paddr().is_absolute()) {
-      pre_alloc_list.emplace_back(ref->cast<LogicalCachedExtent>());
+      pre_alloc_list.emplace_back(ref);
       fresh_block_stats.increment(ref->get_length());
     } else {
       if (likely(ref->get_paddr() == make_record_relative_paddr(0))) {
@@ -187,7 +187,7 @@ public:
     return fresh_backref_extents;
   }
 
-  void mark_delayed_extent_inline(LogicalCachedExtentRef& ref) {
+  void mark_delayed_extent_inline(CachedExtentRef& ref) {
     write_set.erase(*ref);
     assert(ref->get_paddr().is_delayed());
     ref->set_paddr(make_record_relative_paddr(offset),
@@ -197,7 +197,7 @@ public:
     write_set.insert(*ref);
   }
 
-  void mark_delayed_extent_ool(LogicalCachedExtentRef& ref) {
+  void mark_delayed_extent_ool(CachedExtentRef& ref) {
     written_ool_block_list.push_back(ref);
   }
 
@@ -211,13 +211,13 @@ public:
     write_set.insert(*ref);
   }
 
-  void mark_allocated_extent_ool(LogicalCachedExtentRef& ref) {
+  void mark_allocated_extent_ool(CachedExtentRef& ref) {
     assert(ref->get_paddr().is_absolute());
     assert(!ref->is_inline());
     written_ool_block_list.push_back(ref);
   }
 
-  void mark_inplace_rewrite_extent_ool(LogicalCachedExtentRef& ref) {
+  void mark_inplace_rewrite_extent_ool(LogicalCachedExtentRef ref) {
     assert(ref->get_paddr().is_absolute());
     assert(!ref->is_inline());
     written_inplace_ool_block_list.push_back(ref);
@@ -269,7 +269,7 @@ public:
   }
 
   auto get_delayed_alloc_list() {
-    std::list<LogicalCachedExtentRef> ret;
+    std::list<CachedExtentRef> ret;
     for (auto& extent : delayed_alloc_list) {
       // delayed extents may be invalidated
       if (extent->is_valid()) {
@@ -283,7 +283,7 @@ public:
   }
 
   auto get_valid_pre_alloc_list() {
-    std::list<LogicalCachedExtentRef> ret;
+    std::list<CachedExtentRef> ret;
     assert(num_allocated_invalid_extents == 0);
     for (auto& extent : pre_alloc_list) {
       if (extent->is_valid()) {
@@ -553,10 +553,10 @@ private:
   uint64_t num_delayed_invalid_extents = 0;
   uint64_t num_allocated_invalid_extents = 0;
   /// fresh blocks with delayed allocation, may become inline or ool below
-  std::list<LogicalCachedExtentRef> delayed_alloc_list;
+  std::list<CachedExtentRef> delayed_alloc_list;
   /// fresh blocks with pre-allocated addresses with RBM,
   /// should be released upon conflicts, will be added to ool below
-  std::list<LogicalCachedExtentRef> pre_alloc_list;
+  std::list<CachedExtentRef> pre_alloc_list;
   /// dirty blocks for inplace rewrite with RBM, will be added to inplace ool below
   std::list<LogicalCachedExtentRef> pre_inplace_rewrite_list;
 

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -587,9 +587,6 @@ TransactionManager::rewrite_logical_extent(
           fut = lba_manager->alloc_extent(
             t,
             lextent->get_laddr() + off,
-            nlextent->get_length(),
-            nlextent->get_paddr(),
-            nlextent->get_last_committed_crc(),
             *nlextent,
 	    refcount
           ).si_then([lextent, nlextent, off](auto mapping) {

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -335,7 +335,7 @@ TransactionManager::update_lba_mappings(
         if (!extent->get_last_committed_crc()) {
           extent->set_last_committed_crc(extent->calc_crc32c());
         }
-        assert(extent->get_crc32c() == extent->get_last_committed_crc());
+        assert(extent->calc_crc32c() == extent->get_last_committed_crc());
         lextents.emplace_back(extent->template cast<LogicalCachedExtent>());
       } else {
         pextents.emplace_back(extent);

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -34,7 +34,10 @@ TransactionManager::TransactionManager(
     lba_manager(std::move(_lba_manager)),
     journal(std::move(_journal)),
     epm(std::move(_epm)),
-    backref_manager(std::move(_backref_manager))
+    backref_manager(std::move(_backref_manager)),
+    full_extent_integrity_check(
+      crimson::common::get_conf<bool>(
+        "seastore_full_integrity_check"))
 {
   epm->set_extent_callback(this);
   journal->set_write_pipeline(&write_pipeline);

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -309,6 +309,67 @@ TransactionManager::submit_transaction_direct(
     trim_alloc_to);
 }
 
+TransactionManager::update_lba_mappings_ret
+TransactionManager::update_lba_mappings(
+  Transaction &t,
+  std::list<CachedExtentRef> &pre_allocated_extents)
+{
+  LOG_PREFIX(TransactionManager::update_lba_mappings);
+  SUBTRACET(seastore_t, "update extent lba mappings", t);
+  return seastar::do_with(
+    std::list<LogicalCachedExtentRef>(),
+    std::list<CachedExtentRef>(),
+    [this, &t, &pre_allocated_extents](auto &lextents, auto &pextents) {
+    auto chksum_func = [&lextents, &pextents](auto &extent) {
+      if (!extent->is_valid() ||
+          !extent->is_fully_loaded() ||
+          // EXIST_MUTATION_PENDING extents' crc will be calculated when
+          // preparing records
+          extent->is_exist_mutation_pending()) {
+        return;
+      }
+      if (extent->is_logical()) {
+        // for rewritten extents, last_committed_crc should have been set
+        // because the crc of the original extent may be reused.
+        // also see rewrite_logical_extent()
+        if (!extent->get_last_committed_crc()) {
+          extent->set_last_committed_crc(extent->calc_crc32c());
+        }
+        assert(extent->get_crc32c() == extent->get_last_committed_crc());
+        lextents.emplace_back(extent->template cast<LogicalCachedExtent>());
+      } else {
+        pextents.emplace_back(extent);
+      }
+    };
+
+    // For delayed-ool fresh logical extents, update lba-leaf crc and paddr.
+    // For other fresh logical extents, update lba-leaf crc.
+    t.for_each_finalized_fresh_block(chksum_func);
+    // For existing-clean logical extents, update lba-leaf crc.
+    t.for_each_existing_block(chksum_func);
+    // For pre-allocated fresh logical extents, update lba-leaf crc.
+    // For inplace-rewrite dirty logical extents, update lba-leaf crc.
+    std::for_each(
+      pre_allocated_extents.begin(),
+      pre_allocated_extents.end(),
+      chksum_func);
+
+    return lba_manager->update_mappings(
+      t, lextents
+    ).si_then([&pextents] {
+      for (auto &extent : pextents) {
+        assert(!extent->is_logical() && extent->is_valid());
+        // for non-logical extents, we update its last_committed_crc
+        // and in-extent checksum fields
+        // For pre-allocated fresh physical extents, update in-extent crc.
+        auto crc = extent->calc_crc32c();
+        extent->set_last_committed_crc(crc);
+        extent->update_in_extent_chksum_field(crc);
+      }
+    });
+  });
+}
+
 TransactionManager::submit_transaction_direct_ret
 TransactionManager::do_submit_transaction(
   Transaction &tref,
@@ -318,29 +379,32 @@ TransactionManager::do_submit_transaction(
   LOG_PREFIX(TransactionManager::do_submit_transaction);
   SUBTRACET(seastore_t, "start", tref);
   return trans_intr::make_interruptible(
-    tref.get_handle().enter(write_pipeline.ool_writes)
-  ).then_interruptible([this, FNAME, &tref,
+    tref.get_handle().enter(write_pipeline.ool_writes_and_lba_updates)
+  ).then_interruptible([this, &tref,
 			dispatch_result = std::move(dispatch_result)] {
     return seastar::do_with(std::move(dispatch_result),
-			    [this, FNAME, &tref](auto &dispatch_result) {
+			    [this, &tref](auto &dispatch_result) {
       return epm->write_delayed_ool_extents(tref, dispatch_result.alloc_map
-      ).si_then([this, FNAME, &tref, &dispatch_result] {
-        SUBTRACET(seastore_t, "update delayed extent mappings", tref);
-        return lba_manager->update_mappings(tref, dispatch_result.delayed_extents);
-      }).handle_error_interruptible(
+      ).handle_error_interruptible(
         crimson::ct_error::input_output_error::pass_further(),
         crimson::ct_error::assert_all("invalid error")
       );
     });
-  }).si_then([this, FNAME, &tref] {
-    auto allocated_extents = tref.get_valid_pre_alloc_list();
-    auto num_extents = allocated_extents.size();
-    SUBTRACET(seastore_t, "process {} allocated extents", tref, num_extents);
-    return epm->write_preallocated_ool_extents(tref, allocated_extents
-    ).handle_error_interruptible(
-      crimson::ct_error::input_output_error::pass_further(),
-      crimson::ct_error::assert_all("invalid error")
-    );
+  }).si_then([&tref, FNAME, this] {
+    return seastar::do_with(
+      tref.get_valid_pre_alloc_list(),
+      [this, FNAME, &tref](auto &allocated_extents) {
+      return update_lba_mappings(tref, allocated_extents
+      ).si_then([this, FNAME, &tref, &allocated_extents] {
+        auto num_extents = allocated_extents.size();
+        SUBTRACET(seastore_t, "process {} allocated extents", tref, num_extents);
+        return epm->write_preallocated_ool_extents(tref, allocated_extents
+        ).handle_error_interruptible(
+          crimson::ct_error::input_output_error::pass_further(),
+          crimson::ct_error::assert_all("invalid error")
+        );
+      });
+    });
   }).si_then([this, FNAME, &tref] {
     SUBTRACET(seastore_t, "about to prepare", tref);
     return tref.get_handle().enter(write_pipeline.prepare);
@@ -401,7 +465,7 @@ seastar::future<> TransactionManager::flush(OrderingHandle &handle)
   SUBDEBUG(seastore_t, "H{} start", (void*)&handle);
   return handle.enter(write_pipeline.reserve_projected_usage
   ).then([this, &handle] {
-    return handle.enter(write_pipeline.ool_writes);
+    return handle.enter(write_pipeline.ool_writes_and_lba_updates);
   }).then([this, &handle] {
     return handle.enter(write_pipeline.prepare);
   }).then([this, &handle] {
@@ -454,6 +518,8 @@ TransactionManager::rewrite_logical_extent(
 
     DEBUGT("rewriting logical extent -- {} to {}", t, *lextent, *nlextent);
 
+    assert(lextent->get_last_committed_crc() == lextent->calc_crc32c());
+    nlextent->set_last_committed_crc(lextent->get_last_committed_crc());
     /* This update_mapping is, strictly speaking, unnecessary for delayed_alloc
      * extents since we're going to do it again once we either do the ool write
      * or allocate a relative inline addr.  TODO: refactor AsyncCleaner to
@@ -465,6 +531,7 @@ TransactionManager::rewrite_logical_extent(
       lextent->get_paddr(),
       nlextent->get_length(),
       nlextent->get_paddr(),
+      nlextent->get_last_committed_crc(),
       nlextent.get()).discard_result();
   } else {
     assert(get_extent_category(lextent->get_type()) == data_category_t::DATA);
@@ -494,6 +561,7 @@ TransactionManager::rewrite_logical_extent(
           nlextent->get_bptr().c_str());
         nlextent->set_laddr(lextent->get_laddr() + off);
         nlextent->set_modify_time(lextent->get_modify_time());
+        nlextent->set_last_committed_crc(nlextent->calc_crc32c());
         DEBUGT("rewriting logical extent -- {} to {}", t, *lextent, *nlextent);
 
         /* This update_mapping is, strictly speaking, unnecessary for delayed_alloc
@@ -509,6 +577,7 @@ TransactionManager::rewrite_logical_extent(
             lextent->get_paddr(),
             nlextent->get_length(),
             nlextent->get_paddr(),
+            nlextent->get_last_committed_crc(),
             nlextent.get()
 	  ).si_then([&refcount](auto c) {
 	    refcount = c;
@@ -520,6 +589,7 @@ TransactionManager::rewrite_logical_extent(
             lextent->get_laddr() + off,
             nlextent->get_length(),
             nlextent->get_paddr(),
+            nlextent->get_last_committed_crc(),
             *nlextent,
 	    refcount
           ).si_then([lextent, nlextent, off](auto mapping) {

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -864,18 +864,35 @@ private:
       pref.is_indirect() ?
 	pref.get_intermediate_length() :
 	pref.get_length(),
-      [pin=std::move(pin)]
+      [&pref]
       (T &extent) mutable {
 	assert(!extent.has_laddr());
 	assert(!extent.has_been_invalidated());
-	assert(!pin->has_been_invalidated());
-	assert(pin->get_parent());
-	pin->link_child(&extent);
-	extent.maybe_set_intermediate_laddr(*pin);
+	assert(!pref.has_been_invalidated());
+	assert(pref.get_parent());
+	pref.link_child(&extent);
+	extent.maybe_set_intermediate_laddr(pref);
       }
-    ).si_then([FNAME, &t](auto ref) mutable -> ret {
+    ).si_then([FNAME, &t, pin=std::move(pin)](auto ref) mutable -> ret {
       SUBTRACET(seastore_tm, "got extent -- {}", t, *ref);
       assert(ref->is_fully_loaded());
+      bool inconsistent = false;
+      if (pin->is_indirect()) {
+	inconsistent = (pin->get_checksum() != 0);
+      } else {
+	inconsistent = !(pin->get_checksum() == 0 || // TODO: remapped extents may
+						     // not have recorded chksums
+			 pin->get_checksum() == ref->get_crc32c());
+      }
+      if (unlikely(inconsistent)) {
+	SUBERRORT(seastore_tm,
+	  "extent checksum inconsistent, recorded: {}, actual: {}, {}",
+	  t,
+	  pin->get_checksum(),
+	  crc,
+	  *ref);
+	ceph_abort();
+      }
       return pin_to_extent_ret<T>(
 	interruptible::ready_future_marker{},
 	std::move(ref));
@@ -906,19 +923,36 @@ private:
       pref.is_indirect() ?
 	pref.get_intermediate_length() :
 	pref.get_length(),
-      [pin=std::move(pin)](CachedExtent &extent) mutable {
+      [&pref](CachedExtent &extent) mutable {
 	auto &lextent = static_cast<LogicalCachedExtent&>(extent);
 	assert(!lextent.has_laddr());
 	assert(!lextent.has_been_invalidated());
-	assert(!pin->has_been_invalidated());
-	assert(pin->get_parent());
-	assert(!pin->get_parent()->is_pending());
-	pin->link_child(&lextent);
-	lextent.maybe_set_intermediate_laddr(*pin);
+	assert(!pref.has_been_invalidated());
+	assert(pref.get_parent());
+	assert(!pref.get_parent()->is_pending());
+	pref.link_child(&lextent);
+	lextent.maybe_set_intermediate_laddr(pref);
       }
-    ).si_then([FNAME, &t](auto ref) {
+    ).si_then([FNAME, &t, pin=std::move(pin)](auto ref) {
       SUBTRACET(seastore_tm, "got extent -- {}", t, *ref);
       assert(ref->is_fully_loaded());
+      bool inconsistent = false;
+      if (pin->is_indirect()) {
+	inconsistent = (pin->get_checksum() != 0);
+      } else {
+	inconsistent = !(pin->get_checksum() == 0 || // TODO: remapped extents may
+						     // not have recorded chksums
+			 pin->get_checksum() == ref->get_crc32c());
+      }
+      if (unlikely(inconsistent)) {
+	SUBERRORT(seastore_tm,
+	  "extent checksum inconsistent, recorded: {}, actual: {}, {}",
+	  t,
+	  pin->get_checksum(),
+	  crc,
+	  *ref);
+	ceph_abort();
+      }
       return pin_to_extent_by_type_ret(
 	interruptible::ready_future_marker{},
 	std::move(ref->template cast<LogicalCachedExtent>()));

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -882,7 +882,7 @@ private:
       } else {
 	inconsistent = !(pin->get_checksum() == 0 || // TODO: remapped extents may
 						     // not have recorded chksums
-			 pin->get_checksum() == ref->get_crc32c());
+			 pin->get_checksum() == ref->calc_crc32c());
       }
       if (unlikely(inconsistent)) {
 	SUBERRORT(seastore_tm,
@@ -942,7 +942,7 @@ private:
       } else {
 	inconsistent = !(pin->get_checksum() == 0 || // TODO: remapped extents may
 						     // not have recorded chksums
-			 pin->get_checksum() == ref->get_crc32c());
+			 pin->get_checksum() == ref->calc_crc32c());
       }
       if (unlikely(inconsistent)) {
 	SUBERRORT(seastore_tm,
@@ -1006,7 +1006,7 @@ private:
       fut = lba_manager->alloc_extent(
 	t, remap_laddr, remap_length, remap_paddr,
 	//TODO: oringal_bptr must be present if crc is enabled
-	(original_bptr.has_value() ? ext->get_crc32c() : 0),
+	(original_bptr.has_value() ? ext->calc_crc32c() : 0),
 	*ext);
     } else {
       fut = lba_manager->clone_mapping(

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -311,6 +311,7 @@ public:
       laddr_hint,
       len,
       ext->get_paddr(),
+      0, // checksum will be updated upon transaction commit
       *ext
     ).si_then([ext=std::move(ext), laddr_hint, &t](auto &&) mutable {
       LOG_PREFIX(TransactionManager::alloc_non_data_extent);
@@ -360,6 +361,7 @@ public:
           laddr_hint,
           ext->get_length(),
           ext->get_paddr(),
+	  0, // checksum will be updated upon trans commit
           *ext
         ).si_then([&ext, &laddr_hint, &t](auto &&) mutable {
           LOG_PREFIX(TransactionManager::alloc_extents);
@@ -833,6 +835,11 @@ private:
     laddr_t offset,
     bool cascade_remove);
 
+  using update_lba_mappings_ret = LBAManager::update_mappings_ret;
+  update_lba_mappings_ret update_lba_mappings(
+    Transaction &t,
+    std::list<CachedExtentRef> &pre_allocated_extents);
+
   /**
    * pin_to_extent
    *
@@ -963,7 +970,10 @@ private:
 	original_laddr,
 	std::move(original_bptr));
       fut = lba_manager->alloc_extent(
-	t, remap_laddr, remap_length, remap_paddr, *ext);
+	t, remap_laddr, remap_length, remap_paddr,
+	//TODO: oringal_bptr must be present if crc is enabled
+	(original_bptr.has_value() ? ext->get_crc32c() : 0),
+	*ext);
     } else {
       fut = lba_manager->clone_mapping(
 	t,

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -426,9 +426,21 @@ public:
 #endif
 
     // The according extent might be stable or pending.
-    return cache->get_extent_if_cached(
-      t, pin->get_val(), T::TYPE
-    ).si_then([this, &t, remaps,
+    auto fut = base_iertr::make_ready_future<TCachedExtentRef<T>>();
+    if (full_extent_integrity_check) {
+      fut = read_pin<T>(t, pin->duplicate());
+    } else {
+      fut = cache->get_extent_if_cached(
+	t, pin->get_val(), T::TYPE
+      ).si_then([](auto extent) {
+	if (extent) {
+	  return extent->template cast<T>();
+	} else {
+	  return TCachedExtentRef<T>();
+	}
+      });
+    }
+    return fut.si_then([this, &t, remaps,
               original_laddr = pin->get_key(),
 	      intermediate_base = pin->is_indirect()
 				  ? pin->get_intermediate_base()
@@ -807,6 +819,8 @@ private:
 
   WritePipeline write_pipeline;
 
+  bool full_extent_integrity_check = true;
+
   rewrite_extent_ret rewrite_logical_extent(
     Transaction& t,
     LogicalCachedExtentRef extent);
@@ -860,16 +874,24 @@ private:
 	pref.link_child(&extent);
 	extent.maybe_set_intermediate_laddr(pref);
       }
-    ).si_then([FNAME, &t, pin=std::move(pin)](auto ref) mutable -> ret {
-      SUBTRACET(seastore_tm, "got extent -- {}", t, *ref);
+    ).si_then([FNAME, &t, pin=std::move(pin), this](auto ref) mutable -> ret {
+      auto crc = ref->calc_crc32c();
+      SUBTRACET(
+	seastore_tm,
+	"got extent -- {}, chksum in the lba tree: {}, actual chksum: {}",
+	t,
+	*ref,
+	pin->get_checksum(),
+	crc);
       assert(ref->is_fully_loaded());
       bool inconsistent = false;
       if (pin->is_indirect()) {
 	inconsistent = (pin->get_checksum() != 0);
-      } else {
-	inconsistent = !(pin->get_checksum() == 0 || // TODO: remapped extents may
-						     // not have recorded chksums
-			 pin->get_checksum() == ref->calc_crc32c());
+      } else if (full_extent_integrity_check) {
+	inconsistent = (pin->get_checksum() != crc);
+      } else { // !full_extent_integrity_check: remapped extent may be skipped
+	inconsistent = !(pin->get_checksum() == 0 ||
+			 pin->get_checksum() == crc);
       }
       if (unlikely(inconsistent)) {
 	SUBERRORT(seastore_tm,
@@ -920,16 +942,24 @@ private:
 	pref.link_child(&lextent);
 	lextent.maybe_set_intermediate_laddr(pref);
       }
-    ).si_then([FNAME, &t, pin=std::move(pin)](auto ref) {
-      SUBTRACET(seastore_tm, "got extent -- {}", t, *ref);
+    ).si_then([FNAME, &t, pin=std::move(pin), this](auto ref) {
+      auto crc = ref->calc_crc32c();
+      SUBTRACET(
+	seastore_tm,
+	"got extent -- {}, chksum in the lba tree: {}, actual chksum: {}",
+	t,
+	*ref,
+	pin->get_checksum(),
+	crc);
       assert(ref->is_fully_loaded());
       bool inconsistent = false;
       if (pin->is_indirect()) {
 	inconsistent = (pin->get_checksum() != 0);
-      } else {
-	inconsistent = !(pin->get_checksum() == 0 || // TODO: remapped extents may
-						     // not have recorded chksums
-			 pin->get_checksum() == ref->calc_crc32c());
+      } else if (full_extent_integrity_check) {
+	inconsistent = (pin->get_checksum() != crc);
+      } else { // !full_extent_integrity_check: remapped extent may be skipped
+	inconsistent = !(pin->get_checksum() == 0 ||
+			 pin->get_checksum() == crc);
       }
       if (unlikely(inconsistent)) {
 	SUBERRORT(seastore_tm,

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -318,8 +318,12 @@ TEST_P(fltree_onode_manager_test_t, 2_synthetic)
 INSTANTIATE_TEST_SUITE_P(
   fltree_onode__manager_test,
   fltree_onode_manager_test_t,
-  ::testing::Values (
-    "segmented",
-    "circularbounded"
+  ::testing::Combine(
+    ::testing::Values (
+      "segmented",
+      "circularbounded"
+    ),
+    ::testing::Values(
+      integrity_check_t::FULL_CHECK)
   )
 );

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1785,8 +1785,12 @@ TEST_P(d_seastore_tm_test_t, 7_tree_insert_erase_eagain)
 INSTANTIATE_TEST_SUITE_P(
   d_seastore_tm_test,
   d_seastore_tm_test_t,
-  ::testing::Values (
-    "segmented",
-    "circularbounded"
+  ::testing::Combine(
+    ::testing::Values (
+      "segmented",
+      "circularbounded"
+    ),
+    ::testing::Values(
+      integrity_check_t::FULL_CHECK)
   )
 );

--- a/src/test/crimson/seastore/test_block.h
+++ b/src/test/crimson/seastore/test_block.h
@@ -82,7 +82,7 @@ struct TestBlock : crimson::os::seastore::LogicalCachedExtent {
   }
 
   test_extent_desc_t get_desc() {
-    return { get_length(), get_crc32c() };
+    return { get_length(), calc_crc32c() };
   }
 
   void apply_delta(const ceph::bufferlist &bl) final;

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -309,14 +309,20 @@ struct lba_btree_test : btree_test_base {
 	  placement_hint_t::HOT,
 	  0,
 	  get_paddr());
-      assert(extents.size() == 1);
-      auto extent = extents.front();
-      return btree.insert(
-	get_op_context(t), addr, get_map_val(len), extent.get()
-      ).si_then([addr, extent](auto p){
-	auto& [iter, inserted] = p;
-	assert(inserted);
-	extent->set_laddr(addr);
+      return seastar::do_with(
+	std::move(extents),
+	[this, addr, &t, len, &btree](auto &extents) {
+	return trans_intr::do_for_each(
+	  extents,
+	  [this, addr, len, &t, &btree](auto &extent) {
+	  return btree.insert(
+	    get_op_context(t), addr, get_map_val(len), extent.get()
+	  ).si_then([addr, extent](auto p){
+	    auto& [iter, inserted] = p;
+	    assert(inserted);
+	    extent->set_laddr(addr);
+	  });
+	});
       });
     });
   }
@@ -505,11 +511,11 @@ struct btree_lba_manager_test : btree_test_base {
     return make_fake_paddr(next_off);
   }
 
-  auto alloc_mapping(
+  auto alloc_mappings(
     test_transaction_t &t,
     laddr_t hint,
     size_t len) {
-    auto ret = with_trans_intr(
+    auto rets = with_trans_intr(
       *t.t,
       [=, this](auto &t) {
 	auto extents = cache->alloc_new_data_extents<TestBlock>(
@@ -518,25 +524,29 @@ struct btree_lba_manager_test : btree_test_base {
 	    placement_hint_t::HOT,
 	    0,
 	    get_paddr());
-	assert(extents.size() == 1);
-	auto extent = extents.front();
-	return lba_manager->alloc_extent(
-	  t, hint, *extent);
+	return seastar::do_with(
+	  std::vector<LogicalCachedExtentRef>(
+	    extents.begin(), extents.end()),
+	  [this, &t, hint](auto &extents) {
+	  return lba_manager->alloc_extents(t, hint, std::move(extents), EXTENT_DEFAULT_REF_COUNT);
+	});
       }).unsafe_get0();
-    logger().debug("alloc'd: {}", *ret);
-    EXPECT_EQ(len, ret->get_length());
-    auto [b, e] = get_overlap(t, ret->get_key(), len);
-    EXPECT_EQ(b, e);
-    t.mappings.emplace(
-      std::make_pair(
-	ret->get_key(),
-	test_extent_t{
-	  ret->get_val(),
-	  ret->get_length(),
-	  1
-        }
-      ));
-    return ret;
+    for (auto &ret : rets) {
+      logger().debug("alloc'd: {}", *ret);
+      EXPECT_EQ(len, ret->get_length());
+      auto [b, e] = get_overlap(t, ret->get_key(), len);
+      EXPECT_EQ(b, e);
+      t.mappings.emplace(
+	std::make_pair(
+	  ret->get_key(),
+	  test_extent_t{
+	    ret->get_val(),
+	    ret->get_length(),
+	    1
+	  }
+	));
+    }
+    return rets;
   }
 
   auto decref_mapping(
@@ -676,7 +686,7 @@ TEST_F(btree_lba_manager_test, basic)
       auto t = create_transaction();
       check_mappings(t);  // check in progress transaction sees mapping
       check_mappings();   // check concurrent does not
-      auto ret = alloc_mapping(t, laddr, block_size);
+      alloc_mappings(t, laddr, block_size);
       submit_test_transaction(std::move(t));
     }
     check_mappings();     // check new transaction post commit sees it
@@ -690,7 +700,7 @@ TEST_F(btree_lba_manager_test, force_split)
       auto t = create_transaction();
       logger().debug("opened transaction");
       for (unsigned j = 0; j < 5; ++j) {
-	auto ret = alloc_mapping(t, 0, block_size);
+	alloc_mappings(t, 0, block_size);
 	if ((i % 10 == 0) && (j == 3)) {
 	  check_mappings(t);
 	  check_mappings();
@@ -710,14 +720,16 @@ TEST_F(btree_lba_manager_test, force_split_merge)
       auto t = create_transaction();
       logger().debug("opened transaction");
       for (unsigned j = 0; j < 5; ++j) {
-	auto ret = alloc_mapping(t, 0, block_size);
+	auto rets = alloc_mappings(t, 0, block_size);
 	// just to speed things up a bit
 	if ((i % 100 == 0) && (j == 3)) {
 	  check_mappings(t);
 	  check_mappings();
 	}
-	incref_mapping(t, ret->get_key());
-	decref_mapping(t, ret->get_key());
+	for (auto &ret : rets) {
+	  incref_mapping(t, ret->get_key());
+	  decref_mapping(t, ret->get_key());
+	}
       }
       logger().debug("submitting transaction");
       submit_test_transaction(std::move(t));
@@ -767,7 +779,7 @@ TEST_F(btree_lba_manager_test, single_transaction_split_merge)
     {
       auto t = create_transaction();
       for (unsigned i = 0; i < 400; ++i) {
-	alloc_mapping(t, 0, block_size);
+	alloc_mappings(t, 0, block_size);
       }
       check_mappings(t);
       submit_test_transaction(std::move(t));
@@ -790,7 +802,7 @@ TEST_F(btree_lba_manager_test, single_transaction_split_merge)
     {
       auto t = create_transaction();
       for (unsigned i = 0; i < 600; ++i) {
-	alloc_mapping(t, 0, block_size);
+	alloc_mappings(t, 0, block_size);
       }
       auto addresses = get_mapped_addresses(t);
       for (unsigned i = 0; i != addresses.size(); ++i) {
@@ -818,7 +830,7 @@ TEST_F(btree_lba_manager_test, split_merge_multi)
       }
     };
     iterate([&](auto &t, auto idx) {
-      alloc_mapping(t, idx * block_size, block_size);
+      alloc_mappings(t, idx * block_size, block_size);
     });
     check_mappings();
     iterate([&](auto &t, auto idx) {
@@ -829,7 +841,7 @@ TEST_F(btree_lba_manager_test, split_merge_multi)
     check_mappings();
     iterate([&](auto &t, auto idx) {
       if ((idx % 32) > 0) {
-	alloc_mapping(t, idx * block_size, block_size);
+	alloc_mappings(t, idx * block_size, block_size);
       }
     });
     check_mappings();

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -521,7 +521,7 @@ struct btree_lba_manager_test : btree_test_base {
 	assert(extents.size() == 1);
 	auto extent = extents.front();
 	return lba_manager->alloc_extent(
-	  t, hint, len, extent->get_paddr(), 0, *extent);
+	  t, hint, *extent);
       }).unsafe_get0();
     logger().debug("alloc'd: {}", *ret);
     EXPECT_EQ(len, ret->get_length());

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -161,7 +161,7 @@ struct btree_test_base :
 		  extent->set_last_committed_crc(crc);
 		  extent->update_in_extent_chksum_field(crc);
 		}
-		assert(extent->get_crc32c() == extent->get_last_committed_crc());
+		assert(extent->calc_crc32c() == extent->get_last_committed_crc());
 	      };
 	      t.for_each_finalized_fresh_block(chksum_func);
 	      t.for_each_existing_block(chksum_func);
@@ -252,7 +252,7 @@ struct lba_btree_test : btree_test_base {
 	      extent->set_last_committed_crc(crc);
 	      extent->update_in_extent_chksum_field(crc);
 	    }
-	    assert(extent->get_crc32c() == extent->get_last_committed_crc());
+	    assert(extent->calc_crc32c() == extent->get_last_committed_crc());
 	  };
 
 	  t->for_each_finalized_fresh_block(chksum_func);
@@ -453,7 +453,7 @@ struct btree_lba_manager_test : btree_test_base {
 		extent->set_last_committed_crc(crc);
 		extent->update_in_extent_chksum_field(crc);
 	      }
-	      assert(extent->get_crc32c() == extent->get_last_committed_crc());
+	      assert(extent->calc_crc32c() == extent->get_last_committed_crc());
 	      lextents.emplace_back(extent->template cast<LogicalCachedExtent>());
 	    } else {
 	      pextents.push_back(extent);

--- a/src/test/crimson/seastore/test_collection_manager.cc
+++ b/src/test/crimson/seastore/test_collection_manager.cc
@@ -188,8 +188,12 @@ TEST_P(collection_manager_test_t, update)
 INSTANTIATE_TEST_SUITE_P(
   collection_manager_test,
   collection_manager_test_t,
-  ::testing::Values (
-    "segmented",
-    "circularbounded"
+  ::testing::Combine(
+    ::testing::Values (
+      "segmented",
+      "circularbounded"
+    ),
+    ::testing::Values(
+      integrity_check_t::FULL_CHECK)
   )
 );

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -776,6 +776,7 @@ TEST_P(object_data_handler_test_t, random_overwrite) {
 
 TEST_P(object_data_handler_test_t, overwrite_then_read_within_transaction) {
   run_async([this] {
+    disable_max_extent_size();
     enable_delta_based_overwrite();
     auto t = create_mutate_transaction();
     auto base = 4096 * 4;
@@ -857,14 +858,20 @@ TEST_P(object_data_handler_test_t, overwrite_then_read_within_transaction) {
     EXPECT_EQ(committed.length(), pending.length());
     EXPECT_NE(committed, pending);
     disable_delta_based_overwrite();
+    enable_max_extent_size();
   });
 }
 
 INSTANTIATE_TEST_SUITE_P(
   object_data_handler_test,
   object_data_handler_test_t,
-  ::testing::Values (
-    "segmented",
-    "circularbounded"
+  ::testing::Combine(
+    ::testing::Values (
+      "segmented",
+      "circularbounded"
+    ),
+    ::testing::Values(
+      integrity_check_t::FULL_CHECK,
+      integrity_check_t::NONFULL_CHECK)
   )
 );

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -277,6 +277,17 @@ struct object_data_handler_test_t:
     crimson::common::local_conf().set_val("seastore_data_delta_based_overwrite", "0").get();
   }
 
+  void disable_max_extent_size() {
+    epm->set_max_extent_size(16777216);
+    crimson::common::local_conf().set_val(
+      "seastore_max_data_allocation_size", "16777216").get();
+  }
+  void enable_max_extent_size() {
+    epm->set_max_extent_size(8192);
+    crimson::common::local_conf().set_val(
+      "seastore_max_data_allocation_size", "8192").get();
+  }
+
   laddr_t get_random_laddr(size_t block_size, laddr_t limit) {
     return block_size *
       std::uniform_int_distribution<>(0, (limit / block_size) - 1)(gen);
@@ -602,6 +613,7 @@ TEST_P(object_data_handler_test_t, no_overwrite) {
 
 TEST_P(object_data_handler_test_t, remap_left) {
   run_async([this] {
+    disable_max_extent_size();
     write_right();
 
     auto pins = get_mappings(0, 128<<10);
@@ -615,11 +627,13 @@ TEST_P(object_data_handler_test_t, remap_left) {
       i++;
     }
     read(0, 128<<10);
+    enable_max_extent_size();
   });
 }
 
 TEST_P(object_data_handler_test_t, overwrite_right) {
   run_async([this] {
+    disable_max_extent_size();
     enable_delta_based_overwrite();
     write_right();
 
@@ -627,11 +641,13 @@ TEST_P(object_data_handler_test_t, overwrite_right) {
     EXPECT_EQ(pins.size(), 1);
     read(0, 128<<10);
     disable_delta_based_overwrite();
+    enable_max_extent_size();
   });
 }
 
 TEST_P(object_data_handler_test_t, remap_right) {
   run_async([this] {
+    disable_max_extent_size();
     write_left();
 
     auto pins = get_mappings(0, 128<<10);
@@ -645,22 +661,26 @@ TEST_P(object_data_handler_test_t, remap_right) {
       i++;
     }
     read(0, 128<<10);
+    enable_max_extent_size();
   });
 }
 
 TEST_P(object_data_handler_test_t, overwrite_left) {
   run_async([this] {
+    disable_max_extent_size();
     enable_delta_based_overwrite();
     write_left();
     auto pins = get_mappings(0, 128<<10);
     EXPECT_EQ(pins.size(), 1);
     read(0, 128<<10);
     disable_delta_based_overwrite();
+    enable_max_extent_size();
   });
 }
 
 TEST_P(object_data_handler_test_t, remap_right_left) {
   run_async([this] {
+    disable_max_extent_size();
     write_right_left();
 
     auto pins = get_mappings(0, 128<<10);
@@ -673,22 +693,26 @@ TEST_P(object_data_handler_test_t, remap_right_left) {
       EXPECT_EQ(pin->get_key() - base, res[i]);
       i++;
     }
+    enable_max_extent_size();
   });
 }
 
 TEST_P(object_data_handler_test_t, overwrite_right_left) {
   run_async([this] {
+    disable_max_extent_size();
     enable_delta_based_overwrite();
     write_right_left();
     auto pins = get_mappings(0, 128<<10);
     EXPECT_EQ(pins.size(), 1);
     read(0, 128<<10);
     disable_delta_based_overwrite();
+    enable_max_extent_size();
   });
 }
 
 TEST_P(object_data_handler_test_t, multiple_remap) {
   run_async([this] {
+    disable_max_extent_size();
     multiple_write();
     auto pins = get_mappings(0, 128<<10);
     EXPECT_EQ(pins.size(), 3);
@@ -701,17 +725,20 @@ TEST_P(object_data_handler_test_t, multiple_remap) {
       i++;
     }
     read(0, 128<<10);
+    enable_max_extent_size();
   });
 }
 
 TEST_P(object_data_handler_test_t, multiple_overwrite) {
   run_async([this] {
+    disable_max_extent_size();
     enable_delta_based_overwrite();
     multiple_write();
     auto pins = get_mappings(0, 128<<10);
     EXPECT_EQ(pins.size(), 1);
     read(0, 128<<10);
     disable_delta_based_overwrite();
+    enable_max_extent_size();
   });
 }
 

--- a/src/test/crimson/seastore/test_omap_manager.cc
+++ b/src/test/crimson/seastore/test_omap_manager.cc
@@ -723,8 +723,12 @@ TEST_P(omap_manager_test_t, internal_force_split_to_root)
 INSTANTIATE_TEST_SUITE_P(
   omap_manager_test,
   omap_manager_test_t,
-  ::testing::Values (
-    "segmented",
-    "circularbounded"
+  ::testing::Combine(
+    ::testing::Values (
+      "segmented",
+      "circularbounded"
+    ),
+    ::testing::Values(
+      integrity_check_t::FULL_CHECK)
   )
 );

--- a/src/test/crimson/seastore/test_seastore.cc
+++ b/src/test/crimson/seastore/test_seastore.cc
@@ -1280,8 +1280,13 @@ TEST_P(seastore_test_t, zero)
 INSTANTIATE_TEST_SUITE_P(
   seastore_test,
   seastore_test_t,
-  ::testing::Values (
-    "segmented",
-    "circularbounded"
+  ::testing::Combine(
+    ::testing::Values (
+      "segmented",
+      "circularbounded"
+    ),
+    ::testing::Values(
+      integrity_check_t::FULL_CHECK,
+      integrity_check_t::NONFULL_CHECK)
   )
 );

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -40,7 +40,7 @@ struct cache_test_t : public seastar_test_suite_t {
 	extent->set_last_committed_crc(crc);
 	extent->update_in_extent_chksum_field(crc);
       }
-      assert(extent->get_crc32c() == extent->get_last_committed_crc());
+      assert(extent->calc_crc32c() == extent->get_last_committed_crc());
     };
 
     t->for_each_finalized_fresh_block(chksum_func);
@@ -156,7 +156,7 @@ TEST_F(cache_test_t, test_addr_fixup)
 	placement_hint_t::HOT,
 	0);
       extent->set_contents('c');
-      csum = extent->get_crc32c();
+      csum = extent->calc_crc32c();
       submit_transaction(std::move(t)).get0();
       addr = extent->get_paddr();
     }
@@ -167,7 +167,7 @@ TEST_F(cache_test_t, test_addr_fixup)
 	addr,
 	TestBlockPhysical::SIZE).unsafe_get0();
       ASSERT_EQ(extent->get_paddr(), addr);
-      ASSERT_EQ(extent->get_crc32c(), csum);
+      ASSERT_EQ(extent->calc_crc32c(), csum);
     }
   });
 }
@@ -187,7 +187,7 @@ TEST_F(cache_test_t, test_dirty_extent)
 	placement_hint_t::HOT,
 	0);
       extent->set_contents('c');
-      csum = extent->get_crc32c();
+      csum = extent->calc_crc32c();
       auto reladdr = extent->get_paddr();
       ASSERT_TRUE(reladdr.is_relative());
       {
@@ -201,7 +201,7 @@ TEST_F(cache_test_t, test_dirty_extent)
 	ASSERT_TRUE(extent->is_pending());
 	ASSERT_TRUE(extent->get_paddr().is_relative());
 	ASSERT_EQ(extent->get_version(), 0);
-	ASSERT_EQ(csum, extent->get_crc32c());
+	ASSERT_EQ(csum, extent->calc_crc32c());
       }
       submit_transaction(std::move(t)).get0();
       addr = extent->get_paddr();
@@ -230,7 +230,7 @@ TEST_F(cache_test_t, test_dirty_extent)
       // duplicate and reset contents
       extent = cache->duplicate_for_write(*t, extent)->cast<TestBlockPhysical>();
       extent->set_contents('c');
-      csum2 = extent->get_crc32c();
+      csum2 = extent->calc_crc32c();
       ASSERT_EQ(extent->get_paddr(), addr);
       {
 	// test that concurrent read with fresh transaction sees old
@@ -244,7 +244,7 @@ TEST_F(cache_test_t, test_dirty_extent)
 	ASSERT_FALSE(extent->is_pending());
 	ASSERT_EQ(addr, extent->get_paddr());
 	ASSERT_EQ(extent->get_version(), 0);
-	ASSERT_EQ(csum, extent->get_crc32c());
+	ASSERT_EQ(csum, extent->calc_crc32c());
       }
       {
 	// test that read with same transaction sees new block
@@ -256,14 +256,14 @@ TEST_F(cache_test_t, test_dirty_extent)
 	ASSERT_TRUE(extent->is_pending());
 	ASSERT_EQ(addr, extent->get_paddr());
 	ASSERT_EQ(extent->get_version(), 1);
-	ASSERT_EQ(csum2, extent->get_crc32c());
+	ASSERT_EQ(csum2, extent->calc_crc32c());
       }
       // submit transaction
       submit_transaction(std::move(t)).get0();
       ASSERT_TRUE(extent->is_dirty());
       ASSERT_EQ(addr, extent->get_paddr());
       ASSERT_EQ(extent->get_version(), 1);
-      ASSERT_EQ(extent->get_crc32c(), csum2);
+      ASSERT_EQ(extent->calc_crc32c(), csum2);
     }
     {
       // test that fresh transaction now sees newly dirty block
@@ -275,7 +275,7 @@ TEST_F(cache_test_t, test_dirty_extent)
       ASSERT_TRUE(extent->is_dirty());
       ASSERT_EQ(addr, extent->get_paddr());
       ASSERT_EQ(extent->get_version(), 1);
-      ASSERT_EQ(csum2, extent->get_crc32c());
+      ASSERT_EQ(csum2, extent->calc_crc32c());
     }
   });
 }

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -1736,6 +1736,12 @@ struct tm_single_device_test_t :
   tm_single_device_test_t() : transaction_manager_test_t(1, 0) {}
 };
 
+struct tm_single_device_intergrity_check_test_t :
+  public transaction_manager_test_t {
+
+  tm_single_device_intergrity_check_test_t() : transaction_manager_test_t(1, 0) {}
+};
+
 struct tm_multi_device_test_t :
   public transaction_manager_test_t {
 
@@ -2120,7 +2126,7 @@ TEST_P(tm_single_device_test_t, find_hole_assert_trigger)
   });
 }
 
-TEST_P(tm_single_device_test_t, remap_lazy_read) 
+TEST_P(tm_single_device_intergrity_check_test_t, remap_lazy_read)
 {
   constexpr laddr_t offset = 0;
   constexpr size_t length = 256 << 10;
@@ -2186,12 +2192,12 @@ TEST_P(tm_single_device_test_t, parallel_extent_read)
   test_parallel_extent_read();
 }
 
-TEST_P(tm_single_device_test_t, test_remap_pin)
+TEST_P(tm_single_device_intergrity_check_test_t, test_remap_pin)
 {
   test_remap_pin();
 }
 
-TEST_P(tm_single_device_test_t, test_clone_and_remap_pin)
+TEST_P(tm_single_device_intergrity_check_test_t, test_clone_and_remap_pin)
 {
   test_clone_and_remap_pin();
 }
@@ -2201,7 +2207,7 @@ TEST_P(tm_single_device_test_t, test_overwrite_pin)
   test_overwrite_pin();
 }
 
-TEST_P(tm_single_device_test_t, test_remap_pin_concurrent)
+TEST_P(tm_single_device_intergrity_check_test_t, test_remap_pin_concurrent)
 {
   test_remap_pin_concurrent();
 }
@@ -2214,32 +2220,62 @@ TEST_P(tm_single_device_test_t, test_overwrite_pin_concurrent)
 INSTANTIATE_TEST_SUITE_P(
   transaction_manager_test,
   tm_single_device_test_t,
-  ::testing::Values (
-    "segmented",
-    "circularbounded"
+  ::testing::Combine(
+    ::testing::Values (
+      "segmented",
+      "circularbounded"
+    ),
+    ::testing::Values(
+      integrity_check_t::NONFULL_CHECK)
+  )
+);
+
+INSTANTIATE_TEST_SUITE_P(
+  transaction_manager_test,
+  tm_single_device_intergrity_check_test_t,
+  ::testing::Combine(
+    ::testing::Values (
+      "segmented",
+      "circularbounded"
+    ),
+    ::testing::Values(
+      integrity_check_t::FULL_CHECK,
+      integrity_check_t::NONFULL_CHECK)
   )
 );
 
 INSTANTIATE_TEST_SUITE_P(
   transaction_manager_test,
   tm_multi_device_test_t,
-  ::testing::Values (
-    "segmented"
+  ::testing::Combine(
+    ::testing::Values (
+      "segmented"
+    ),
+    ::testing::Values(
+      integrity_check_t::NONFULL_CHECK)
   )
 );
 
 INSTANTIATE_TEST_SUITE_P(
   transaction_manager_test,
   tm_multi_tier_device_test_t,
-  ::testing::Values (
-    "segmented"
+  ::testing::Combine(
+    ::testing::Values (
+      "segmented"
+    ),
+    ::testing::Values(
+      integrity_check_t::NONFULL_CHECK)
   )
 );
 
 INSTANTIATE_TEST_SUITE_P(
   transaction_manager_test,
   tm_random_block_device_test_t,
-  ::testing::Values (
-    "circularbounded"
+  ::testing::Combine(
+    ::testing::Values (
+      "circularbounded"
+    ),
+    ::testing::Values(
+      integrity_check_t::NONFULL_CHECK)
   )
 );

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -391,10 +391,12 @@ struct transaction_manager_test_t :
     }).unsafe_get0();
     assert(extents.size() == 1);
     auto extent = extents.front();
+    extent_len_t allocated_len = 0;
     extent->set_contents(contents);
     EXPECT_FALSE(test_mappings.contains(extent->get_laddr(), t.mapping_delta));
-    EXPECT_EQ(len, extent->get_length());
     test_mappings.alloced(hint, *extent, t.mapping_delta);
+    allocated_len += extent->get_length();
+    EXPECT_EQ(len, allocated_len);
     return extent;
   }
 
@@ -407,14 +409,16 @@ struct transaction_manager_test_t :
       return tm->alloc_data_extents<TestBlock>(trans, hint, len);
     }).unsafe_get0();
     size_t length = 0;
+    std::vector<TestBlockRef> exts;
     for (auto &extent : extents) {
       extent->set_contents(contents);
       length += extent->get_length();
       EXPECT_FALSE(test_mappings.contains(extent->get_laddr(), t.mapping_delta));
       test_mappings.alloced(hint, *extent, t.mapping_delta);
+      exts.push_back(extent->template cast<TestBlock>());
     }
     EXPECT_EQ(len, length);
-    return extents;
+    return exts;
   }
 
   void alloc_extents_deemed_fail(
@@ -437,6 +441,17 @@ struct transaction_manager_test_t :
     laddr_t hint,
     extent_len_t len) {
     return alloc_extent(
+      t,
+      hint,
+      len,
+      get_random_contents());
+  }
+
+  std::vector<TestBlockRef> alloc_extents(
+    test_transaction_t &t,
+    laddr_t hint,
+    extent_len_t len) {
+    return alloc_extents(
       t,
       hint,
       len,
@@ -762,13 +777,16 @@ struct transaction_manager_test_t :
 		  return tm->alloc_data_extents<TestBlock>(
 		    *(t.t), L_ADDR_MIN, size
 		  ).si_then([&t, this, size](auto extents) {
-		    assert(extents.size() == 1);
-		    auto extent = extents.front();
-		    extent->set_contents(get_random_contents());
-		    EXPECT_FALSE(
-		      test_mappings.contains(extent->get_laddr(), t.mapping_delta));
-		    EXPECT_EQ(size, extent->get_length());
-		    test_mappings.alloced(extent->get_laddr(), *extent, t.mapping_delta);
+		    extent_len_t length = 0;
+		    for (auto &extent : extents) {
+		      extent->set_contents(get_random_contents());
+		      EXPECT_FALSE(
+			test_mappings.contains(extent->get_laddr(), t.mapping_delta));
+		      test_mappings.alloced(
+			extent->get_laddr(), *extent, t.mapping_delta);
+		      length += extent->get_length();
+		    }
+		    EXPECT_EQ(size, length);
 		    return seastar::now();
 		  });
 		}).si_then([&t, this] {
@@ -2048,11 +2066,13 @@ TEST_P(tm_single_device_test_t, random_writes)
 	    BSIZE);
 	  auto mut = mutate_extent(t, ext);
 	  // pad out transaction
-	  auto padding = alloc_extent(
+	  auto paddings = alloc_extents(
 	    t,
 	    TOTAL + (k * PADDING_SIZE),
 	    PADDING_SIZE);
-	  dec_ref(t, padding->get_laddr());
+	  for (auto &padding : paddings) {
+	    dec_ref(t, padding->get_laddr());
+	  }
 	}
 	submit_transaction(std::move(t));
       }
@@ -2086,12 +2106,14 @@ TEST_P(tm_single_device_test_t, remap_lazy_read)
    run_async([this, offset] {
     {
       auto t = create_transaction();
-      auto extent = alloc_extent(
+      auto extents = alloc_extents(
 	t,
 	offset,
 	length,
 	'a');
-      ASSERT_EQ(offset, extent->get_laddr());
+      for (auto &extent : extents) {
+	ASSERT_EQ(offset, extent->get_laddr());
+      }
       check_mappings(t);
       submit_transaction(std::move(t));
       check();

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -369,6 +369,17 @@ struct transaction_manager_test_t :
     test_extents_t::delta_t mapping_delta;
   };
 
+  void disable_max_extent_size() {
+    epm->set_max_extent_size(16777216);
+    crimson::common::local_conf().set_val(
+      "seastore_max_data_allocation_size", "16777216").get();
+  }
+  void enable_max_extent_size() {
+    epm->set_max_extent_size(8192);
+    crimson::common::local_conf().set_val(
+      "seastore_max_data_allocation_size", "8192").get();
+  }
+
   test_transaction_t create_transaction() {
     return { create_mutate_transaction(), {} };
   }
@@ -1331,6 +1342,7 @@ struct transaction_manager_test_t :
 
   void test_remap_pin() {
     run_async([this] {
+      disable_max_extent_size();
       constexpr size_t l_offset = 32 << 10;
       constexpr size_t l_len = 32 << 10;
       constexpr size_t r_offset = 64 << 10;
@@ -1378,11 +1390,13 @@ struct transaction_manager_test_t :
       }
       replay();
       check();
+      enable_max_extent_size();
     });
   }
 
   void test_clone_and_remap_pin() {
     run_async([this] {
+      disable_max_extent_size();
       constexpr size_t l_offset = 32 << 10;
       constexpr size_t l_len = 32 << 10;
       constexpr size_t r_offset = 64 << 10;
@@ -1431,11 +1445,13 @@ struct transaction_manager_test_t :
       }
       replay();
       check();
+      enable_max_extent_size();
     });
   }
 
   void test_overwrite_pin() {
     run_async([this] {
+      disable_max_extent_size();
       constexpr size_t m_offset = 8 << 10;
       constexpr size_t m_len = 56 << 10;
       constexpr size_t l_offset = 64 << 10;
@@ -1511,11 +1527,13 @@ struct transaction_manager_test_t :
       }
       replay();
       check();
+      enable_max_extent_size();
     });
   }
 
   void test_remap_pin_concurrent() {
     run_async([this] {
+      disable_max_extent_size();
       constexpr unsigned REMAP_NUM = 32;
       constexpr size_t offset = 0;
       constexpr size_t length = 256 << 10;
@@ -1591,11 +1609,13 @@ struct transaction_manager_test_t :
       ASSERT_EQ(success + conflicted + early_exit, REMAP_NUM);
       replay();
       check();
+      enable_max_extent_size();
     });
   }
 
   void test_overwrite_pin_concurrent() {
     run_async([this] {
+      disable_max_extent_size();
       constexpr unsigned REMAP_NUM = 32;
       constexpr size_t offset = 0;
       constexpr size_t length = 256 << 10;
@@ -1705,6 +1725,7 @@ struct transaction_manager_test_t :
       ASSERT_EQ(success + conflicted + early_exit, REMAP_NUM);
       replay();
       check();
+      enable_max_extent_size();
     });
   }
 };
@@ -2104,6 +2125,7 @@ TEST_P(tm_single_device_test_t, remap_lazy_read)
   constexpr laddr_t offset = 0;
   constexpr size_t length = 256 << 10;
    run_async([this, offset] {
+    disable_max_extent_size();
     {
       auto t = create_transaction();
       auto extents = alloc_extents(
@@ -2140,6 +2162,7 @@ TEST_P(tm_single_device_test_t, remap_lazy_read)
       check();
     }
     replay();
+    enable_max_extent_size();
    });
 }
 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55449

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh