### PR TITLE
test/rbd-mirror: free remote_journaler in PrepareRemoteImageRequest tests

### DIFF
--- a/src/test/rbd_mirror/image_replayer/test_mock_PrepareRemoteImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_PrepareRemoteImageRequest.cc
@@ -328,6 +328,8 @@ TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, SuccessJournal) {
   ASSERT_TRUE(mock_journal_state_builder.remote_journaler != nullptr);
   ASSERT_EQ(cls::journal::CLIENT_STATE_DISCONNECTED,
             mock_journal_state_builder.remote_client_state);
+  // owned by StateBuilder, normally freed in StateBuilder::close()
+  delete mock_journal_state_builder.remote_journaler;
 }
 
 TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, SuccessSnapshot) {
@@ -431,6 +433,8 @@ TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, SuccessNotRegistered) {
   ASSERT_TRUE(mock_journal_state_builder.remote_journaler != nullptr);
   ASSERT_EQ(cls::journal::CLIENT_STATE_CONNECTED,
             mock_journal_state_builder.remote_client_state);
+  // owned by StateBuilder, normally freed in StateBuilder::close()
+  delete mock_journal_state_builder.remote_journaler;
 }
 
 TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, GetMirrorImageIdError) {


### PR DESCRIPTION
When sanitizer is enabled, unittest_rbd_mirror shows

```
=================================================================
==1377627==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 2 byte(s) in 2 object(s) allocated from:
    #0 0xaaaac462d088 in operator new(unsigned long) (/root/ceph/build/bin/unittest_rbd_mirror+0x30cd088) (BuildId: 054d3b6699c622daad91c7f70e36616220fbd5ad)
    #1 0xaaaac522f13c in rbd::mirror::image_replayer::PrepareRemoteImageRequest<librbd::(anonymous namespace)::MockTestImageCtx>::get_client() /root/ceph/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.cc:148:24
    #2 0xaaaac522e60c in rbd::mirror::image_replayer::PrepareRemoteImageRequest<librbd::(anonymous namespace)::MockTestImageCtx>::handle_get_mirror_info(int) /root/ceph/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.cc:120:5
    #3 0xaaaac5232d1c in librbd::util::detail::C_CallbackAdapter<rbd::mirror::image_replayer::PrepareRemoteImageRequest<librbd::(anonymous namespace)::MockTestImageCtx>, &(rbd::mirror::image_replayer::PrepareRemoteImageRequest<librbd::(anonymous namespace)::MockTestImageCtx>::handle_get_mirror_info(int))>::finish(int) /root/ceph/src/librbd/Utils.h:63:5
    #4 0xaaaac4863428 in Context::complete(int) /root/ceph/src/include/Context.h:99:5
    #5 0xaaaac489ac30 in librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()::operator()() const /root/ceph/src/librbd/asio/ContextWQ.h:31:12
    #6 0xaaaac489aaf4 in boost::asio::detail::binder0<librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()>::operator()() /root/ceph/build/boost/include/boost/asio/detail/bind_handler.hpp:60:5
    #7 0xaaaac489aaac in void boost::asio::asio_handler_invoke<boost::asio::detail::binder0<librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()> >(boost::asio::detail::binder0<librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()>&, ...) /root/ceph/build/boost/include/boost/asio/handler_invoke_hook.hpp:88:3
    #8 0xaaaac489aa4c in void boost_asio_handler_invoke_helpers::invoke<boost::asio::detail::binder0<librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()>, librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()>(boost::asio::detail::binder0<librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()>&, librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()&) /root/ceph/build/boost/include/boost/asio/detail/handler_invoke_helpers.hpp:54:3
    #9 0xaaaac489a9ec in void boost::asio::detail::asio_handler_invoke<boost::asio::detail::binder0<librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()>, librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()>(boost::asio::detail::binder0<librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()>&, boost::asio::detail::binder0<librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()>*) /root/ceph/build/boost/include/boost/asio/detail/bind_handler.hpp:111:3
    #10 0xaaaac4899c00 in void boost_asio_handler_invoke_helpers::invoke<boost::asio::detail::binder0<librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()>, boost::asio::detail::binder0<librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()> >(boost::asio::detail::binder0<librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()>&, boost::asio::detail::binder0<librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()>&) /root/ceph/build/boost/include/boost/asio/detail/handler_invoke_helpers.hpp:54:3
    #11 0xaaaac489c814 in boost::asio::detail::executor_op<boost::asio::detail::binder0<librbd::asio::ContextWQ::queue(Context*, int)::'lambda'()>, std::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) /root/ceph/build/boost/include/boost/asio/detail/executor_op.hpp:71:7
    #12 0xaaaac489fb4c in boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) /root/ceph/build/boost/include/boost/asio/detail/scheduler_operation.hpp:40:5
    #13 0xaaaac489f074 in boost::asio::detail::strand_executor_service::run_ready_handlers(std::shared_ptr<boost::asio::detail::strand_executor_service::strand_impl>&) /root/ceph/build/boost/include/boost/asio/detail/impl/strand_executor_service.ipp:150:8
    #14 0xaaaac489ed2c in boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> const, void>::operator()() /root/ceph/build/boost/include/boost/asio/detail/impl/strand_executor_service.hpp:136:5
    #15 0xaaaac489ebd4 in void boost::asio::asio_handler_invoke<boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> const, void> >(boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> const, void>&, ...) /root/ceph/build/boost/include/boost/asio/handler_invoke_hook.hpp:88:3
    #16 0xaaaac489e284 in void boost_asio_handler_invoke_helpers::invoke<boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> const, void>, boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> const, void> >(boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> const, void>&, boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> const, void>&) /root/ceph/build/boost/include/boost/asio/detail/handler_invoke_helpers.hpp:54:3
    #17 0xaaaac48a3e08 in boost::asio::detail::executor_op<boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> const, void>, std::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) /root/ceph/build/boost/include/boost/asio/detail/executor_op.hpp:71:7
    #18 0xaaaac489fb4c in boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) /root/ceph/build/boost/include/boost/asio/detail/scheduler_operation.hpp:40:5
    #19 0xaaaac6766b1c in boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) /root/ceph/build/boost/include/boost/asio/detail/impl/scheduler.ipp:493:12
    #20 0xaaaac67660a4 in boost::asio::detail::scheduler::run(boost::system::error_code&) /root/ceph/build/boost/include/boost/asio/detail/impl/scheduler.ipp:210:10
    #21 0xaaaac7562d48 in boost::asio::io_context::run() /root/ceph/build/boost/include/boost/asio/impl/io_context.ipp:64:24
    #22 0xaaaac7562bcc in ceph::async::io_context_pool::start(short)::'lambda'()::operator()() const /root/ceph/src/common/async/context_pool.h:69:16
    #23 0xaaaac7562b18 in void std::__invoke_impl<void, ceph::async::io_context_pool::start(short)::'lambda'()>(std::__invoke_other, ceph::async::io_context_pool::start(short)::'lambda'()&&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #24 0xaaaac7562960 in std::__invoke_result<ceph::async::io_context_pool::start(short)::'lambda'()>::type std::__invoke<ceph::async::io_context_pool::start(short)::'lambda'()>(ceph::async::io_context_pool::start(short)::'lambda'()&&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #25 0xaaaac7562804 in std::invoke_result<ceph::async::io_context_pool::start(short)::'lambda'()>::type std::invoke<ceph::async::io_context_pool::start(short)::'lambda'()>(ceph::async::io_context_pool::start(short)::'lambda'()&&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/functional:97:14
    #26 0xaaaac75627dc in auto std::thread make_named_thread<ceph::async::io_context_pool::start(short)::'lambda'()>(std::basic_string_view<char, std::char_traits<char> >, ceph::async::io_context_pool::start(short)::'lambda'()&&)::'lambda'(ceph::async::io_context_pool::start(short)::'lambda'()&&)::operator()<ceph::async::io_context_pool::start(short)::'lambda'()>(ceph::async::io_context_pool::start(short)::'lambda'()&&) const /root/ceph/src/common/Thread.h:79:10
    #27 0xaaaac7562728 in ceph::async::io_context_pool::start(short)::'lambda'() std::__invoke_impl<void, std::thread make_named_thread<ceph::async::io_context_pool::start(short)::'lambda'()>(std::basic_string_view<char, std::char_traits<char> >, ceph::async::io_context_pool::start(short)::'lambda'()&&)::'lambda'(ceph::async::io_context_pool::start(short)::'lambda'()&&), ceph::async::io_context_pool::start(short)::'lambda'()>(std::__invoke_other, std::thread make_named_thread<ceph::async::io_context_pool::start(short)::'lambda'()>(std::basic_string_view<char, std::char_traits<char> >, ceph::async::io_context_pool::start(short)::'lambda'()&&)::'lambda'(ceph::async::io_context_pool::start(short)::'lambda'()&&)&&, ceph::async::io_context_pool::start(short)::'lambda'()&&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #28 0xaaaac75624ec in std::__invoke_result<ceph::async::io_context_pool::start(short)::'lambda'()>::type std::__invoke<std::thread make_named_thread<ceph::async::io_context_pool::start(short)::'lambda'()>(std::basic_string_view<char, std::char_traits<char> >, ceph::async::io_context_pool::start(short)::'lambda'()&&)::'lambda'(ceph::async::io_context_pool::start(short)::'lambda'()&&), ceph::async::io_context_pool::start(short)::'lambda'()>(ceph::async::io_context_pool::start(short)::'lambda'()&&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #29 0xaaaac756231c in void std::thread::_Invoker<std::tuple<std::thread make_named_thread<ceph::async::io_context_pool::start(short)::'lambda'()>(std::basic_string_view<char, std::char_traits<char> >, ceph::async::io_context_pool::start(short)::'lambda'()&&)::'lambda'(ceph::async::io_context_pool::start(short)::'lambda'()&&), ceph::async::io_context_pool::start(short)::'lambda'()> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/std_thread.h:259:13

SUMMARY: AddressSanitizer: 2 byte(s) leaked in 2 allocation(s).
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
