### PR TITLE
squid: qa: ignore cluster warnings generated from forward-scrub task

### DIFF
--- a/qa/suites/fs/functional/tasks/forward-scrub.yaml
+++ b/qa/suites/fs/functional/tasks/forward-scrub.yaml
@@ -8,6 +8,7 @@ overrides:
       - Scrub error on dir
       - Metadata damage detected
       - object missing on disk
+      - Invalid tag char
 tasks:
   - cephfs_test_runner:
       modules:

--- a/qa/suites/fs/functional/tasks/forward-scrub.yaml
+++ b/qa/suites/fs/functional/tasks/forward-scrub.yaml
@@ -7,6 +7,7 @@ overrides:
       - Scrub error on inode
       - Scrub error on dir
       - Metadata damage detected
+      - object missing on disk
 tasks:
   - cephfs_test_runner:
       modules:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65988

---

backport of https://github.com/ceph/ceph/pull/56699
parent tracker: https://tracker.ceph.com/issues/48562

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh