### PR TITLE
rgw_kms: fix Realloc and free cct

### DIFF
--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -80,8 +80,8 @@ public:
 	return r;
     }
     void* Realloc(void* p, size_t old, size_t nw) {
-	void *r = nullptr;
-	if (nw) r = malloc(nw);
+        if (!nw) return 0;
+        void *r = Malloc(nw);
 	if (nw > old) nw = old;
 	if (r && old) memcpy(r, p, nw);
 	return r;

--- a/src/test/rgw/test_rgw_kms.cc
+++ b/src/test/rgw/test_rgw_kms.cc
@@ -56,6 +56,7 @@ protected:
     delete old_engine;
     delete kv_engine;
     delete transit_engine;
+    delete cct;
   }
 
 };


### PR DESCRIPTION
When sanitizer is enabled, unittest_rgw_kms shows,

```
=================================================================
==1415137==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 768 byte(s) in 1 object(s) allocated from:
    #0 0xaaaacb1381e0 in malloc (/root/ceph/build/bin/unittest_rgw_kms+0x4b81e0) (BuildId: 2005acbecb5cbd5bc928c98209bd613f20ecbacf)
    #1 0xaaaacb1ed768 in ZeroPoolAllocator::Realloc(void*, unsigned long, unsigned long) /root/ceph/src/rgw/rgw_kms.cc:84:14
    #2 0xaaaacb1ed728 in rapidjson::GenericMember<rapidjson::UTF8<char>, ZeroPoolAllocator>* rapidjson::Realloc<rapidjson::GenericMember<rapidjson::UTF8<char>, ZeroPoolAllocator>, ZeroPoolAllocator>(ZeroPoolAllocator&, rapidjson::GenericMember<rapidjson::UTF8<char>, ZeroPoolAllocator>*, unsigned long, unsigned long) /root/ceph/src/s3select/rapidjson/include/rapidjson/error/../internal/../allocators.h:437:30
    #3 0xaaaacb1ed4ec in rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>::DoReserveMembers(unsigned int, ZeroPoolAllocator&) /root/ceph/src/s3select/rapidjson/include/rapidjson/document.h:2260:34
    #4 0xaaaacb1ed2cc in rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>::DoAddMember(rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>&, rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>&, ZeroPoolAllocator&) /root/ceph/src/s3select/rapidjson/include/rapidjson/document.h:2292:13
    #5 0xaaaacb1ec344 in rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>::AddMember(rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>&, rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>&, ZeroPoolAllocator&) /root/ceph/src/s3select/rapidjson/include/rapidjson/document.h:1375:9
    #6 0xaaaacb19769c in void add_name_val_to_obj<rapidjson::UTF8<char>, ZeroPoolAllocator>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>&, ZeroPoolAllocator&) /root/ceph/src/rgw/rgw_kms.cc:149:5
    #7 0xaaaacb197058 in void add_name_val_to_obj<rapidjson::UTF8<char>, ZeroPoolAllocator>(char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>&, ZeroPoolAllocator&) /root/ceph/src/rgw/rgw_kms.cc:169:3
    #8 0xaaaacb1ac4a8 in TransitSecretEngine::make_actual_key(DoutPrefixProvider const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ceph::buffer::v15_2_0::list, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, ceph::buffer::v15_2_0::list> > >&, optional_yield, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /root/ceph/src/rgw/rgw_kms.cc:485:5
    #9 0xaaaacb188f88 in TestSSEKMS_test_transit_makekey_Test::TestBody() /root/ceph/src/test/rgw/test_rgw_kms.cc:192:29
    #10 0xaaaacb34549c in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #11 0xaaaacb2f864c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #12 0xaaaacb2aa958 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #13 0xaaaacb2ac89c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #14 0xaaaacb2ade9c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #15 0xaaaacb2c9c60 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #16 0xaaaacb34f310 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #17 0xaaaacb2ff588 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #18 0xaaaacb2c90d8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #19 0xaaaacb250ae4 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #20 0xaaaacb250a60 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #21 0xffff7cf773f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #22 0xffff7cf774c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #23 0xaaaacb0c102c in _start (/root/ceph/build/bin/unittest_rgw_kms+0x44102c) (BuildId: 2005acbecb5cbd5bc928c98209bd613f20ecbacf)

Direct leak of 768 byte(s) in 1 object(s) allocated from:
    #0 0xaaaacb1381e0 in malloc (/root/ceph/build/bin/unittest_rgw_kms+0x4b81e0) (BuildId: 2005acbecb5cbd5bc928c98209bd613f20ecbacf)
    #1 0xaaaacb1ed768 in ZeroPoolAllocator::Realloc(void*, unsigned long, unsigned long) /root/ceph/src/rgw/rgw_kms.cc:84:14
    #2 0xaaaacb1ed728 in rapidjson::GenericMember<rapidjson::UTF8<char>, ZeroPoolAllocator>* rapidjson::Realloc<rapidjson::GenericMember<rapidjson::UTF8<char>, ZeroPoolAllocator>, ZeroPoolAllocator>(ZeroPoolAllocator&, rapidjson::GenericMember<rapidjson::UTF8<char>, ZeroPoolAllocator>*, unsigned long, unsigned long) /root/ceph/src/s3select/rapidjson/include/rapidjson/error/../internal/../allocators.h:437:30
    #3 0xaaaacb1ed4ec in rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>::DoReserveMembers(unsigned int, ZeroPoolAllocator&) /root/ceph/src/s3select/rapidjson/include/rapidjson/document.h:2260:34
    #4 0xaaaacb1ed2cc in rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>::DoAddMember(rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>&, rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>&, ZeroPoolAllocator&) /root/ceph/src/s3select/rapidjson/include/rapidjson/document.h:2292:13
    #5 0xaaaacb1ec344 in rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>::AddMember(rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>&, rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>&, ZeroPoolAllocator&) /root/ceph/src/s3select/rapidjson/include/rapidjson/document.h:1375:9
    #6 0xaaaacb19769c in void add_name_val_to_obj<rapidjson::UTF8<char>, ZeroPoolAllocator>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>&, ZeroPoolAllocator&) /root/ceph/src/rgw/rgw_kms.cc:149:5
    #7 0xaaaacb197058 in void add_name_val_to_obj<rapidjson::UTF8<char>, ZeroPoolAllocator>(char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, rapidjson::GenericValue<rapidjson::UTF8<char>, ZeroPoolAllocator>&, ZeroPoolAllocator&) /root/ceph/src/rgw/rgw_kms.cc:169:3
    #8 0xaaaacb1b2298 in TransitSecretEngine::reconstitute_actual_key(DoutPrefixProvider const*, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ceph::buffer::v15_2_0::list, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, ceph::buffer::v15_2_0::list> > > const&, optional_yield, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /root/ceph/src/rgw/rgw_kms.cc:569:5
    #9 0xaaaacb18abcc in TestSSEKMS_test_transit_reconstitutekey_Test::TestBody() /root/ceph/src/test/rgw/test_rgw_kms.cc:216:29
    #10 0xaaaacb34549c in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #11 0xaaaacb2f864c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #12 0xaaaacb2aa958 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #13 0xaaaacb2ac89c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #14 0xaaaacb2ade9c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #15 0xaaaacb2c9c60 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #16 0xaaaacb34f310 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #17 0xaaaacb2ff588 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #18 0xaaaacb2c90d8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #19 0xaaaacb250ae4 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #20 0xaaaacb250a60 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #21 0xffff7cf773f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #22 0xffff7cf774c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #23 0xaaaacb0c102c in _start (/root/ceph/build/bin/unittest_rgw_kms+0x44102c) (BuildId: 2005acbecb5cbd5bc928c98209bd613f20ecbacf)

...
...

Indirect leak of 18 byte(s) in 1 object(s) allocated from:
    #0 0xaaaab6e3f148 in operator new(unsigned long) (/root/ceph/build/bin/unittest_rgw_kms+0x4ef148) (BuildId: 2005acbecb5cbd5bc928c98209bd613f20ecbacf)
    #1 0xffffac4a0fa0 in __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/ext/new_allocator.h:127:27
    #2 0xffffac4a0f1c in std::allocator<char>::allocate(unsigned long) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/allocator.h:185:32
    #3 0xffffac4a0f1c in std::allocator_traits<std::allocator<char> >::allocate(std::allocator<char>&, unsigned long) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:464:20
    #4 0xffffac4a0c1c in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_create(unsigned long&, unsigned long) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.tcc:153:14
    #5 0xffffac4a0618 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char*>(char*, char*, std::forward_iterator_tag) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.tcc:219:14
    #6 0xffffac4a0398 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct_aux<char*>(char*, char*, std::__false_type) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:255:11
    #7 0xffffac4a00d0 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char*>(char*, char*) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:274:4
    #8 0xffffac49fe0c in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:459:9
    #9 0xffffacc9b490 in std::enable_if<((__exactly_once<std::variant_alternative<__accepted_index<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>, std::variant<std::monostate, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned long, long, double, bool, entity_addr_t, entity_addrvec_t, std::chrono::duration<long, std::ratio<1l, 1l> >, std::chrono::duration<long, std::ratio<1l, 1000l> >, Option::size_t, uuid_d> >::type>) && (is_constructible_v<std::variant_alternative<__accepted_index<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>, std::variant<std::monostate, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned long, long, double, bool, entity_addr_t, entity_addrvec_t, std::chrono::duration<long, std::ratio<1l, 1l> >, std::chrono::duration<long, std::ratio<1l, 1000l> >, Option::size_t, uuid_d> >::type, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>)) && (is_assignable_v<std::variant_alternative<__accepted_index<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>, std::variant<std::monostate, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned long, long, double, bool, entity_addr_t, entity_addrvec_t, std::chrono::duration<long, std::ratio<1l, 1l> >, std::chrono::duration<long, std::ratio<1l, 1000l> >, Option::size_t, uuid_d> >::type&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>), std::variant<std::monostate, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned long, long, double, bool, entity_addr_t, entity_addrvec_t, std::chrono::duration<long, std::ratio<1l, 1l> >, std::chrono::duration<long, std::ratio<1l, 1000l> >, Option::size_t, uuid_d>&>::type std::variant<std::monostate, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned long, long, double, bool, entity_addr_t, entity_addrvec_t, std::chrono::duration<long, std::ratio<1l, 1l> >, std::chrono::duration<long, std::ratio<1l, 1000l> >, Option::size_t, uuid_d>::operator=<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /usr/bin/../lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/variant:1477:26
    #10 0xffffacc9298c in Option::parse_value(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::variant<std::monostate, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned long, long, double, bool, entity_addr_t, entity_addrvec_t, std::chrono::duration<long, std::ratio<1l, 1l> >, std::chrono::duration<long, std::ratio<1l, 1000l> >, Option::size_t, uuid_d>*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) const /root/ceph/src/common/options.cc:165:10
    #11 0xffffacb813cc in md_config_t::_set_val(ConfigValues&, ConfigTracker const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Option const&, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) /root/ceph/src/common/config.cc:1395:15
    #12 0xffffacb8f084 in md_config_t::set_val(ConfigValues&, ConfigTracker const&, std::basic_string_view<char, std::char_traits<char> >, char const*, std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >*) /root/ceph/src/common/config.cc:930:13
    #13 0xaaaab6ecb014 in md_config_t::set_val(ConfigValues&, ConfigTracker const&, std::basic_string_view<char, std::char_traits<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >*) /root/ceph/src/common/config.h:180:12
    #14 0xaaaab6e72464 in ceph::common::ConfigProxy::set_val(std::basic_string_view<char, std::char_traits<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >*) /root/ceph/src/common/config_proxy.h:239:19
    #15 0xaaaab6e53bf8 in TestSSEKMS_non_existent_vault_token_file_Test::TestBody() /root/ceph/src/test/rgw/test_rgw_kms.cc:84:14
    #16 0xaaaab701549c in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #17 0xaaaab6fc864c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #18 0xaaaab6f7a958 in testing::Test::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2680:5
    #19 0xaaaab6f7c89c in testing::TestInfo::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:2858:11
    #20 0xaaaab6f7de9c in testing::TestSuite::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:3012:28
    #21 0xaaaab6f99c60 in testing::internal::UnitTestImpl::RunAllTests() /root/ceph/src/googletest/googletest/src/gtest.cc:5723:44
    #22 0xaaaab701f310 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2605:10
    #23 0xaaaab6fcf588 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ceph/src/googletest/googletest/src/gtest.cc:2641:14
    #24 0xaaaab6f990d8 in testing::UnitTest::Run() /root/ceph/src/googletest/googletest/src/gtest.cc:5306:10
    #25 0xaaaab6f20ae4 in RUN_ALL_TESTS() /root/ceph/src/googletest/googletest/include/gtest/gtest.h:2486:46
    #26 0xaaaab6f20a60 in main /root/ceph/src/googletest/googlemock/src/gmock_main.cc:70:10
    #27 0xffffa99573f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #28 0xffffa99574c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    #29 0xaaaab6d9102c in _start (/root/ceph/build/bin/unittest_rgw_kms+0x44102c) (BuildId: 2005acbecb5cbd5bc928c98209bd613f20ecbacf)

SUMMARY: AddressSanitizer: 112735554 byte(s) leaked in 36910 allocation(s).
```

1. fix memory reallocate issue
2. free cct





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
