### PR TITLE
reef: osd: fix for segmentation fault on OSD fast shutdown

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -527,6 +527,15 @@ void OSDService::shutdown()
   next_osdmap = OSDMapRef();
 }
 
+void OSDService::fast_shutdown()
+{
+  mono_timer.suspend();
+  {
+    std::lock_guard l(watch_lock);
+    watch_timer.shutdown();
+  }
+}
+
 void OSDService::init()
 {
   reserver_finisher.start();
@@ -4576,6 +4585,7 @@ int OSD::shutdown()
 
     utime_t  start_time_umount = ceph_clock_now();
     store->prepare_for_fast_shutdown();
+    service.fast_shutdown();
     std::lock_guard lock(osd_lock);
     // TBD: assert in allocator that nothing is being add
     store->umount();

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -724,6 +724,7 @@ public:
   void start_shutdown();
   void shutdown_reserver();
   void shutdown();
+  void fast_shutdown();
 
   // -- stats --
   ceph::mutex stat_lock = ceph::make_mutex("OSDService::stat_lock");


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66148

--------
backport of #56804
parent tracker: https://tracker.ceph.com/issues/64373
