### PR TITLE
test/pybind/test_rados.py: fix test_list_objects

### DIFF
--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -318,6 +318,7 @@ class TestIoctx(object):
         self.ioctx.read('a')
 
     def test_list_objects(self):
+        self.ioctx.write('a', b'')
         self.ioctx.write('b', b'foo')
         self.ioctx.write_full('c', b'bar')
         self.ioctx.append('d', b'jazz')


### PR DESCRIPTION
Commit 6662e6bc215c2d0bee16bc3674b07be1e239b4c0  from PR https://github.com/ceph/ceph/pull/55008 accidentally removed a line from this test.

```
2024-05-21T14:06:10.463 INFO:tasks.workunit.client.0.smithi031.stdout:=================================== FAILURES ===================================
2024-05-21T14:06:10.463 INFO:tasks.workunit.client.0.smithi031.stdout:_________________________ TestIoctx.test_list_objects __________________________
2024-05-21T14:06:10.463 INFO:tasks.workunit.client.0.smithi031.stdout:
2024-05-21T14:06:10.463 INFO:tasks.workunit.client.0.smithi031.stdout:self = <test_rados.TestIoctx object at 0x7fddcc6924c0>
2024-05-21T14:06:10.463 INFO:tasks.workunit.client.0.smithi031.stdout:
2024-05-21T14:06:10.463 INFO:tasks.workunit.client.0.smithi031.stdout:    def test_list_objects(self):
2024-05-21T14:06:10.463 INFO:tasks.workunit.client.0.smithi031.stdout:        self.ioctx.write('b', b'foo')
2024-05-21T14:06:10.463 INFO:tasks.workunit.client.0.smithi031.stdout:        self.ioctx.write_full('c', b'bar')
2024-05-21T14:06:10.463 INFO:tasks.workunit.client.0.smithi031.stdout:        self.ioctx.append('d', b'jazz')
2024-05-21T14:06:10.464 INFO:tasks.workunit.client.0.smithi031.stdout:        object_names = [obj.key for obj in self.ioctx.list_objects()]
2024-05-21T14:06:10.464 INFO:tasks.workunit.client.0.smithi031.stdout:>       eq(sorted(object_names), ['a', 'b', 'c', 'd'])
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
