### PR TITLE
test/pybind/test_rados.py: fix warnings

### DIFF
--- a/src/test/pybind/pytest.ini
+++ b/src/test/pybind/pytest.ini
@@ -7,3 +7,4 @@ markers =
     stats
     tier
     watch
+    wait

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -207,7 +207,7 @@ class TestRados(object):
 
     def test_get_fsid(self):
         fsid = self.rados.get_fsid()
-        assert re.match('[0-9a-f\-]{36}', fsid, re.I)
+        assert re.match(r'[0-9a-f\-]{36}', fsid, re.I)
 
     def test_blocklist_add(self):
         self.rados.blocklist_add("1.2.3.4/123", 1)


### PR DESCRIPTION
```
2024-05-21T14:06:10.464 INFO:tasks.workunit.client.0.smithi031.stdout:../../../clone.client.0/src/test/pybind/assertions.py:2: AssertionError
2024-05-21T14:06:10.464 INFO:tasks.workunit.client.0.smithi031.stdout:=============================== warnings summary ===============================
2024-05-21T14:06:10.465 INFO:tasks.workunit.client.0.smithi031.stdout:../../../clone.client.0/src/test/pybind/test_rados.py:210
2024-05-21T14:06:10.465 INFO:tasks.workunit.client.0.smithi031.stdout:  /home/ubuntu/cephtest/clone.client.0/src/test/pybind/test_rados.py:210: DeprecationWarning: invalid escape sequence \-
2024-05-21T14:06:10.465 INFO:tasks.workunit.client.0.smithi031.stdout:    assert re.match('[0-9a-f\-]{36}', fsid, re.I)
2024-05-21T14:06:10.465 INFO:tasks.workunit.client.0.smithi031.stdout:
2024-05-21T14:06:10.465 INFO:tasks.workunit.client.0.smithi031.stdout:../../../clone.client.0/src/test/pybind/test_rados.py:959
2024-05-21T14:06:10.465 INFO:tasks.workunit.client.0.smithi031.stdout:  /home/ubuntu/cephtest/clone.client.0/src/test/pybind/test_rados.py:959: PytestUnknownMarkWarning: Unknown pytest.mark.wait - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
2024-05-21T14:06:10.465 INFO:tasks.workunit.client.0.smithi031.stdout:    @pytest.mark.wait
2024-05-21T14:06:10.465 INFO:tasks.workunit.client.0.smithi031.stdout:
2024-05-21T14:06:10.465 INFO:tasks.workunit.client.0.smithi031.stdout:../../../clone.client.0/src/test/pybind/test_rados.py:995
2024-05-21T14:06:10.465 INFO:tasks.workunit.client.0.smithi031.stdout:  /home/ubuntu/cephtest/clone.client.0/src/test/pybind/test_rados.py:995: PytestUnknownMarkWarning: Unknown pytest.mark.wait - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
2024-05-21T14:06:10.465 INFO:tasks.workunit.client.0.smithi031.stdout:    @pytest.mark.wait
2024-05-21T14:06:10.465 INFO:tasks.workunit.client.0.smithi031.stdout:
2024-05-21T14:06:10.465 INFO:tasks.workunit.client.0.smithi031.stdout:../../../clone.client.0/src/test/pybind/test_rados.py:1023
2024-05-21T14:06:10.466 INFO:tasks.workunit.client.0.smithi031.stdout:  /home/ubuntu/cephtest/clone.client.0/src/test/pybind/test_rados.py:1023: PytestUnknownMarkWarning: Unknown pytest.mark.wait - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
2024-05-21T14:06:10.466 INFO:tasks.workunit.client.0.smithi031.stdout:    @pytest.mark.wait
2024-05-21T14:06:10.466 INFO:tasks.workunit.client.0.smithi031.stdout:
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
