### PR TITLE
qa/cephfs: use wait_for_daemon() instead of sleep()-ing

### DIFF
--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -715,10 +715,12 @@ class TestRenameCommand(TestAdminCommands):
         self.run_ceph_cmd(f'fs fail {self.fs.name}')
         self.run_ceph_cmd(f'fs set {self.fs.name} refuse_client_session true')
         sleep(5)
+
         self.run_ceph_cmd(f'fs rename {orig_fs_name} {new_fs_name} --yes-i-really-mean-it')
+
         self.run_ceph_cmd(f'fs set {new_fs_name} joinable true')
         self.run_ceph_cmd(f'fs set {new_fs_name} refuse_client_session false')
-        sleep(5)
+        self.fs.wait_for_daemons()
 
         # authorize a cephx ID access to the renamed file system.
         # use the ID to write to the file system.
@@ -754,11 +756,13 @@ class TestRenameCommand(TestAdminCommands):
         self.run_ceph_cmd(f'fs fail {self.fs.name}')
         self.run_ceph_cmd(f'fs set {self.fs.name} refuse_client_session true')
         sleep(5)
+
         self.run_ceph_cmd(f'fs rename {orig_fs_name} {new_fs_name} --yes-i-really-mean-it')
         self.run_ceph_cmd(f'fs rename {orig_fs_name} {new_fs_name} --yes-i-really-mean-it')
+
         self.run_ceph_cmd(f'fs set {new_fs_name} joinable true')
         self.run_ceph_cmd(f'fs set {new_fs_name} refuse_client_session false')
-        sleep(5)
+        self.fs.wait_for_daemons()
 
         # original file system name does not appear in `fs ls` command
         self.assertFalse(self.fs.exists())
@@ -777,13 +781,16 @@ class TestRenameCommand(TestAdminCommands):
         new_fs_name = 'new_cephfs'
         data_pool = self.fs.get_data_pool_name()
         metadata_pool = self.fs.get_metadata_pool_name()
+
         self.run_ceph_cmd(f'fs fail {self.fs.name}')
         self.run_ceph_cmd(f'fs set {self.fs.name} refuse_client_session true')
         sleep(5)
+
         self.run_ceph_cmd(f'fs rename {orig_fs_name} {new_fs_name} --yes-i-really-mean-it')
+
         self.run_ceph_cmd(f'fs set {new_fs_name} joinable true')
         self.run_ceph_cmd(f'fs set {new_fs_name} refuse_client_session false')
-        sleep(5)
+        self.fs.wait_for_daemons()
 
         try:
             self.run_ceph_cmd(f"fs new {orig_fs_name} {metadata_pool} {data_pool}")
@@ -823,6 +830,7 @@ class TestRenameCommand(TestAdminCommands):
         self.run_ceph_cmd(f'fs fail {self.fs.name}')
         self.run_ceph_cmd(f'fs set {self.fs.name} refuse_client_session true')
         sleep(5)
+
         try:
             self.run_ceph_cmd(f"fs rename {self.fs.name} new_fs")
         except CommandFailedError as ce:
@@ -832,8 +840,10 @@ class TestRenameCommand(TestAdminCommands):
         else:
             self.fail("expected renaming of file system without the "
                       "'--yes-i-really-mean-it' flag to fail ")
+
         self.run_ceph_cmd(f'fs set {self.fs.name} joinable true')
         self.run_ceph_cmd(f'fs set {self.fs.name} refuse_client_session false')
+        self.fs.wait_for_daemons()
 
     def test_fs_rename_fails_for_non_existent_fs(self):
         """
@@ -845,6 +855,7 @@ class TestRenameCommand(TestAdminCommands):
         self.run_ceph_cmd(f'fs fail {self.fs.name}')
         self.run_ceph_cmd(f'fs set {self.fs.name} refuse_client_session true')
         sleep(5)
+
         try:
             self.run_ceph_cmd("fs rename non_existent_fs new_fs --yes-i-really-mean-it")
         except CommandFailedError as ce:
@@ -861,6 +872,7 @@ class TestRenameCommand(TestAdminCommands):
         self.run_ceph_cmd(f'fs fail {self.fs.name}')
         self.run_ceph_cmd(f'fs set {self.fs.name} refuse_client_session true')
         sleep(5)
+
         try:
             self.run_ceph_cmd(f"fs rename {self.fs.name} {self.fs2.name} --yes-i-really-mean-it")
         except CommandFailedError as ce:
@@ -868,8 +880,10 @@ class TestRenameCommand(TestAdminCommands):
                              "invalid error code on renaming to a fs name that is already in use")
         else:
             self.fail("expected renaming to a new file system name that is already in use to fail.")
+
         self.run_ceph_cmd(f'fs set {self.fs.name} joinable true')
         self.run_ceph_cmd(f'fs set {self.fs.name} refuse_client_session false')
+        self.fs.wait_for_daemons()
 
     def test_fs_rename_fails_with_mirroring_enabled(self):
         """
@@ -882,15 +896,18 @@ class TestRenameCommand(TestAdminCommands):
         self.run_ceph_cmd(f'fs fail {self.fs.name}')
         self.run_ceph_cmd(f'fs set {self.fs.name} refuse_client_session true')
         sleep(5)
+
         try:
             self.run_ceph_cmd(f'fs rename {orig_fs_name} {new_fs_name} --yes-i-really-mean-it')
         except CommandFailedError as ce:
             self.assertEqual(ce.exitstatus, errno.EPERM, "invalid error code on renaming a mirrored file system")
         else:
             self.fail("expected renaming of a mirrored file system to fail")
+
         self.run_ceph_cmd(f'fs mirror disable {orig_fs_name}')
         self.run_ceph_cmd(f'fs set {self.fs.name} joinable true')
         self.run_ceph_cmd(f'fs set {self.fs.name} refuse_client_session false')
+        self.fs.wait_for_daemons()
 
     def test_rename_when_fs_is_online(self):
         '''
@@ -901,6 +918,7 @@ class TestRenameCommand(TestAdminCommands):
         new_fs_name = 'new_cephfs'
 
         self.run_ceph_cmd(f'fs set {self.fs.name} refuse_client_session true')
+
         self.negtest_ceph_cmd(
             args=(f'fs rename {self.fs.name} {new_fs_name} '
                    '--yes-i-really-mean-it'),
@@ -908,6 +926,7 @@ class TestRenameCommand(TestAdminCommands):
                       "renaming a CephFS, it must be marked as down. See "
                       "`ceph fs fail`."),
             retval=errno.EPERM)
+
         self.run_ceph_cmd(f'fs set {self.fs.name} refuse_client_session false')
 
         self.fs.getinfo()
@@ -932,6 +951,7 @@ class TestRenameCommand(TestAdminCommands):
         self.mount_a.umount_wait(require_clean=True)
 
         self.run_ceph_cmd(f'fs fail {self.fs.name}')
+
         self.negtest_ceph_cmd(
             args=f"fs rename {self.fs.name} new_fs --yes-i-really-mean-it",
             errmsgs=(f"CephFS '{self.fs.name}' doesn't refuse clients. "
@@ -939,6 +959,7 @@ class TestRenameCommand(TestAdminCommands):
                       "'refuse_client_session' must be set. See "
                       "`ceph fs set`."),
             retval=errno.EPERM)
+
         self.run_ceph_cmd(f'fs fail {self.fs.name}')
 
 


### PR DESCRIPTION
This patch was originally written to prevent potential bugs along with fix for https://tracker.ceph.com/issues/66088. Since Venky posted a fix for it at PR #57619, I am posting this now.
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>