### PR TITLE
qa: setting the config options value back to default at the end of th…

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -311,6 +311,12 @@ class TestVolumesHelper(CephFSTestCase):
             else:
                 raise
 
+    def _set_config_options_back_to_default(self):
+        self.config_set('mgr', 'mgr/volumes/max_concurrent_clones', 4)
+        self.config_set('mgr', 'mgr/volumes/snapshot_clone_delay', 0)
+        self.config_set('mgr', 'mgr/volumes/periodic_async_work', False)
+        self.config_set('mgr', 'mgr/volumes/snapshot_clone_no_wait', True)       
+
     def _assert_meta_location_and_version(self, vol_name, subvol_name, subvol_group=None, version=2, legacy=False):
         if legacy:
             subvol_path = self._get_subvolume_path(vol_name, subvol_name, group_name=subvol_group)
@@ -5791,6 +5797,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         for clone in clone_list:
             self._fs_cmd("subvolume", "rm", self.volname, clone)
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+        
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
@@ -5841,6 +5850,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self._fs_cmd("subvolume", "rm", self.volname, subvolume)
         for clone in clone_list:
             self._fs_cmd("subvolume", "rm", self.volname, clone)
+
+        # set the config options back to default
+        self._set_config_options_back_to_default()
 
         # verify trash dir is clean
         self._wait_for_trash_empty()
@@ -5897,6 +5909,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self._fs_cmd("subvolumegroup", "rm", self.volname, group)
         self._fs_cmd("subvolumegroup", "rm", self.volname, target_group)
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+        
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
@@ -5954,6 +5969,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
 
         # verify snapshot info (has_pending_clones should be no)
         self.assertEqual(res['has_pending_clones'], "no")
+
+        # set the config options back to default
+        self._set_config_options_back_to_default()
 
     def test_non_clone_status(self):
         subvolume = self._gen_subvol_name()
@@ -6113,6 +6131,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self._fs_cmd("subvolume", "rm", self.volname, subvolume)
         self._fs_cmd("subvolume", "rm", self.volname, clone)
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+        
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
@@ -6161,6 +6182,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self._fs_cmd("subvolume", "rm", self.volname, subvolume)
         self._fs_cmd("subvolume", "rm", self.volname, clone)
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+        
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
@@ -6209,6 +6233,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self._fs_cmd("subvolume", "rm", self.volname, subvolume)
         self._fs_cmd("subvolume", "rm", self.volname, clone)
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+        
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
@@ -6586,6 +6613,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self._fs_cmd("subvolume", "rm", self.volname, subvolume)
         self._fs_cmd("subvolume", "rm", self.volname, clone1)
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+        
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
@@ -6631,6 +6661,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         # remove subvolumes
         self._fs_cmd("subvolume", "rm", self.volname, subvolume)
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
@@ -6675,6 +6708,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         # remove subvolumes
         self._fs_cmd("subvolume", "rm", self.volname, subvolume)
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+        
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
@@ -6722,6 +6758,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         # remove subvolumes
         self._fs_cmd("subvolume", "rm", self.volname, subvolume)
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+        
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
@@ -6846,6 +6885,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         # remove subvolumes
         self._fs_cmd("subvolume", "rm", self.volname, subvolume)
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+        
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
@@ -6977,6 +7019,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self._fs_cmd("subvolume", "rm", self.volname, subvolume)
         self._fs_cmd("subvolume", "rm", self.volname, clone, "--force")
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+        
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
@@ -7048,6 +7093,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
             self._fs_cmd("subvolume", "rm", self.volname, clone)
         for clone in to_cancel:
             self._fs_cmd("subvolume", "rm", self.volname, clone, "--force")
+
+        # set the config options back to default
+        self._set_config_options_back_to_default()
 
         # verify trash dir is clean
         self._wait_for_trash_empty()
@@ -7395,6 +7443,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self._fs_cmd("subvolume", "rm", self.volname, subvolume)
         self._fs_cmd("subvolume", "rm", self.volname, clone)
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+        
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
@@ -7417,6 +7468,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         max_concurrent_clones = int(self.config_get('mgr', 'mgr/volumes/max_concurrent_clones'))
         self.assertEqual(max_concurrent_clones, 2)
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+
     def test_subvolume_snapshot_config_snapshot_clone_delay(self):
         """
         Validate 'snapshot_clone_delay' config option
@@ -7435,6 +7489,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self.config_set('mgr', 'mgr/volumes/max_concurrent_clones', 2)
         max_concurrent_clones = int(self.config_get('mgr', 'mgr/volumes/max_concurrent_clones'))
         self.assertEqual(max_concurrent_clones, 2)
+
+        # set the config options back to default
+        self._set_config_options_back_to_default()
 
     def test_periodic_async_work(self):
         """
@@ -7559,14 +7616,6 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         # verify clone3
         self._verify_clone(subvolume, snapshot, clone3)
 
-        # set number of cloner threads to default
-        self.config_set('mgr', 'mgr/volumes/max_concurrent_clones', 4)
-        max_concurrent_clones = int(self.config_get('mgr', 'mgr/volumes/max_concurrent_clones'))
-        self.assertEqual(max_concurrent_clones, 4)
-
-        # set the snapshot_clone_delay to default
-        self.config_set('mgr', 'mgr/volumes/snapshot_clone_delay', 0)
-
         # remove snapshot
         self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, snapshot)
 
@@ -7576,6 +7625,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self._fs_cmd("subvolume", "rm", self.volname, clone2)
         self._fs_cmd("subvolume", "rm", self.volname, clone3)
 
+        # set the config options back to default
+        self._set_config_options_back_to_default()
+        
         # verify trash dir is clean
         self._wait_for_trash_empty()
 
@@ -7630,16 +7682,6 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         # verify clone3
         self._verify_clone(subvolume, snapshot, clone3)
 
-        # set the snapshot_clone_no_wait config option to default
-        self.config_set('mgr', 'mgr/volumes/snapshot_clone_no_wait', True)
-        threads_available = self.config_get('mgr', 'mgr/volumes/snapshot_clone_no_wait')
-        self.assertEqual(threads_available, 'true')
-
-        # set number of cloner threads to default
-        self.config_set('mgr', 'mgr/volumes/max_concurrent_clones', 4)
-        max_concurrent_clones = int(self.config_get('mgr', 'mgr/volumes/max_concurrent_clones'))
-        self.assertEqual(max_concurrent_clones, 4)
-
         # remove snapshot
         self._fs_cmd("subvolume", "snapshot", "rm", self.volname, subvolume, snapshot)
 
@@ -7648,6 +7690,9 @@ class TestSubvolumeSnapshotClones(TestVolumesHelper):
         self._fs_cmd("subvolume", "rm", self.volname, clone1)
         self._fs_cmd("subvolume", "rm", self.volname, clone2)
         self._fs_cmd("subvolume", "rm", self.volname, clone3)
+
+        # set the config options back to default
+        self._set_config_options_back_to_default()
 
         # verify trash dir is clean
         self._wait_for_trash_empty()


### PR DESCRIPTION
…e tests

In order to avoid test failures due to setting the config 
option values different from default in a particular test
because the configs are retained across tests.

signed-off-by: Neeraj Pratap Singh <neesingh@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
