### PR TITLE
rgw: implement ConfirmRemoveSelfBucketAccess header for bucket policy

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -82,6 +82,10 @@
   redistribution. In contrast, a stretch rule with a single-take configuration
   will not cause any data movement during the upgrade process.
 
+* RGW: The `x-amz-confirm-remove-self-bucket-access` header is now supported by
+  `PutBucketPolicy`. Additionally, the root user will always have access to modify
+  the bucket policy, even if the current policy explicitly denies access.
+
 >=19.2.1
 
 * CephFS: Command `fs subvolume create` now allows tagging subvolumes through option

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -246,6 +246,13 @@ static auto transform_old_authinfo(const RGWUserInfo& user,
       return match_owner(o, id, account);
     }
 
+    bool is_root() const override {
+      if (account)
+        return get_identity_type() == TYPE_ROOT;
+
+      return get_perm_mask() == RGW_PERM_FULL_CONTROL;
+    }
+
     bool is_identity(const Principal& p) const override {
       if (p.is_wildcard()) {
         return true;
@@ -838,6 +845,11 @@ bool rgw::auth::RemoteApplier::is_owner_of(const rgw_owner& o) const
   return info.acct_user == *uid;
 }
 
+bool rgw::auth::RemoteApplier::is_root() const
+{
+  return get_perm_mask() == RGW_PERM_FULL_CONTROL;
+}
+
 bool rgw::auth::RemoteApplier::is_identity(const Principal& p) const {
   // We also need to cover cases where rgw_keystone_implicit_tenants
   // was enabled.
@@ -1060,6 +1072,14 @@ bool rgw::auth::LocalApplier::is_admin_of(const rgw_owner& o) const
 bool rgw::auth::LocalApplier::is_owner_of(const rgw_owner& o) const
 {
   return match_owner(o, user_info.user_id, account);
+}
+
+bool rgw::auth::LocalApplier::is_root() const
+{
+  if (account)
+    return get_identity_type() == TYPE_ROOT;
+
+  return get_perm_mask() == RGW_PERM_FULL_CONTROL;
 }
 
 bool rgw::auth::LocalApplier::is_identity(const Principal& p) const {

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -56,6 +56,15 @@ public:
    * On internal error throws rgw::auth::Exception storing the reason. */
   virtual bool is_owner_of(const rgw_owner& o) const = 0;
 
+  /* Verify whether a given identity is the root user. */
+  virtual bool is_root() const = 0;
+
+  /* Verify whether a given identity is the root user and the owner of the
+   * rgw_owner specified in @o. */
+  virtual bool is_root_of(const rgw_owner& o) const {
+    return is_root() && is_owner_of(o);
+  }
+
   /* Return the permission mask that is used to narrow down the set of
    * operations allowed for a given identity. This method reflects the idea
    * of subuser tied to RGWUserInfo. On  error throws rgw::auth::Exception
@@ -477,6 +486,10 @@ public:
 
   bool is_owner_of(const rgw_owner& o) const override;
 
+  bool is_root() const override {
+    return false;
+  }
+
   uint32_t get_perm_mask() const override {
     return RGW_PERM_NONE;
   }
@@ -653,6 +666,7 @@ public:
   uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override;
   bool is_admin_of(const rgw_owner& o) const override;
   bool is_owner_of(const rgw_owner& o) const override;
+  bool is_root() const override;
   bool is_identity(const Principal& p) const override;
 
   uint32_t get_perm_mask() const override { return info.perm_mask; }
@@ -718,6 +732,7 @@ public:
   uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override;
   bool is_admin_of(const rgw_owner& o) const override;
   bool is_owner_of(const rgw_owner& o) const override;
+  bool is_root() const override;
   bool is_identity(const Principal& p) const override;
   uint32_t get_perm_mask() const override {
     if (this->perm_mask == RGW_PERM_INVALID) {
@@ -798,6 +813,9 @@ public:
     return false;
   }
   bool is_owner_of(const rgw_owner& o) const override;
+  bool is_root() const override {
+    return false;
+  }
   bool is_identity(const Principal& p) const override;
   uint32_t get_perm_mask() const override {
     return RGW_PERM_NONE; 

--- a/src/rgw/rgw_auth_filters.h
+++ b/src/rgw/rgw_auth_filters.h
@@ -81,6 +81,10 @@ public:
     return get_decoratee().is_owner_of(o);
   }
 
+  bool is_root() const override {
+    return get_decoratee().is_root();
+  }
+
   bool is_anonymous() const override {
     return get_decoratee().is_anonymous();
   }

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -163,10 +163,11 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_OBJ_REPLICATION_TIMESTAMP RGW_ATTR_PREFIX "replicated-at"
 
 /* IAM Policy */
-#define RGW_ATTR_IAM_POLICY	RGW_ATTR_PREFIX "iam-policy"
-#define RGW_ATTR_USER_POLICY    RGW_ATTR_PREFIX "user-policy"
-#define RGW_ATTR_MANAGED_POLICY RGW_ATTR_PREFIX "managed-policy"
-#define RGW_ATTR_PUBLIC_ACCESS  RGW_ATTR_PREFIX "public-access"
+#define RGW_ATTR_IAM_POLICY                    RGW_ATTR_PREFIX "iam-policy"
+#define RGW_ATTR_USER_POLICY                   RGW_ATTR_PREFIX "user-policy"
+#define RGW_ATTR_MANAGED_POLICY                RGW_ATTR_PREFIX "managed-policy"
+#define RGW_ATTR_PUBLIC_ACCESS                 RGW_ATTR_PREFIX "public-access"
+#define RGW_ATTR_IAM_POLICY_REMOVE_SELF_ACCESS RGW_ATTR_PREFIX "iam-policy-remove-self-access"
 
 /* RGW File Attributes */
 #define RGW_ATTR_UNIX_KEY1      RGW_ATTR_PREFIX "unix-key1"

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -8481,6 +8481,14 @@ void RGWPutBucketPolicy::send_response()
 
 int RGWPutBucketPolicy::verify_permission(optional_yield y)
 {
+  // If the user is the root account of the bucket owner,
+  // and x-amz-confirm-remove-self-bucket-access was not set,
+  // then the user can put bucket policy.
+  if (s->auth.identity->is_root_of(s->bucket_owner.id) &&
+      s->bucket_attrs.find(RGW_ATTR_IAM_POLICY_REMOVE_SELF_ACCESS) == s->bucket_attrs.end()) {
+    return 0;
+  }
+
   auto [has_s3_existing_tag, has_s3_resource_tag] = rgw_check_policy_condition(this, s, false);
   if (has_s3_resource_tag)
     rgw_iam_add_buckettags(this, s);
@@ -8530,10 +8538,15 @@ void RGWPutBucketPolicy::execute(optional_yield y)
     }
 
     op_ret = retry_raced_bucket_write(this, s->bucket.get(), [&p, this, &attrs] {
-	attrs[RGW_ATTR_IAM_POLICY].clear();
-	attrs[RGW_ATTR_IAM_POLICY].append(p.text);
-	op_ret = s->bucket->merge_and_store_attrs(this, attrs, s->yield);
-	return op_ret;
+        attrs[RGW_ATTR_IAM_POLICY].clear();
+        attrs[RGW_ATTR_IAM_POLICY].append(p.text);
+        if (s->info.env->exists("HTTP_X_AMZ_CONFIRM_REMOVE_SELF_BUCKET_ACCESS")) {
+          attrs[RGW_ATTR_IAM_POLICY_REMOVE_SELF_ACCESS].clear();
+        } else {
+          attrs.erase(RGW_ATTR_IAM_POLICY_REMOVE_SELF_ACCESS);
+        }
+        op_ret = s->bucket->merge_and_store_attrs(this, attrs, s->yield);
+        return op_ret;
       }, y);
   } catch (rgw::IAM::PolicyParseException& e) {
     ldpp_dout(this, 5) << "failed to parse policy: " << e.what() << dendl;
@@ -8554,6 +8567,14 @@ void RGWGetBucketPolicy::send_response()
 
 int RGWGetBucketPolicy::verify_permission(optional_yield y)
 {
+  // If the user is the root account of the bucket owner,
+  // and x-amz-confirm-remove-self-bucket-access was not set,
+  // then the user can put bucket policy.
+  if (s->auth.identity->is_root_of(s->bucket_owner.id) &&
+      s->bucket_attrs.find(RGW_ATTR_IAM_POLICY_REMOVE_SELF_ACCESS) == s->bucket_attrs.end()) {
+    return 0;
+  }
+
   auto [has_s3_existing_tag, has_s3_resource_tag] = rgw_check_policy_condition(this, s, false);
   if (has_s3_resource_tag)
     rgw_iam_add_buckettags(this, s);
@@ -8603,6 +8624,14 @@ void RGWDeleteBucketPolicy::send_response()
 
 int RGWDeleteBucketPolicy::verify_permission(optional_yield y)
 {
+  // If the user is the root account of the bucket owner,
+  // and x-amz-confirm-remove-self-bucket-access was not set,
+  // then the user can put bucket policy.
+  if (s->auth.identity->is_root_of(s->bucket_owner.id) &&
+      s->bucket_attrs.find(RGW_ATTR_IAM_POLICY_REMOVE_SELF_ACCESS) == s->bucket_attrs.end()) {
+    return 0;
+  }
+
   auto [has_s3_existing_tag, has_s3_resource_tag] = rgw_check_policy_condition(this, s, false);
   if (has_s3_resource_tag)
     rgw_iam_add_buckettags(this, s);
@@ -8626,6 +8655,7 @@ void RGWDeleteBucketPolicy::execute(optional_yield y)
   op_ret = retry_raced_bucket_write(this, s->bucket.get(), [this] {
       rgw::sal::Attrs& attrs = s->bucket->get_attrs();
       attrs.erase(RGW_ATTR_IAM_POLICY);
+      attrs.erase(RGW_ATTR_IAM_POLICY_REMOVE_SELF_ACCESS);
       op_ret = s->bucket->put_info(this, false, real_time(), s->yield);
       return op_ret;
     }, y);

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -168,6 +168,11 @@ public:
     return false;
   }
 
+  bool is_root() const override {
+    ceph_abort();
+    return false;
+  }
+
   virtual uint32_t get_perm_mask() const override {
     ceph_abort();
     return 0;

--- a/src/test/rgw/test_rgw_lua.cc
+++ b/src/test/rgw/test_rgw_lua.cc
@@ -50,6 +50,10 @@ public:
     return false;
   }
 
+  bool is_root() const override {
+    return false;
+  }
+
   virtual uint32_t get_perm_mask() const override {
     return 0;
   }


### PR DESCRIPTION
According to https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketPolicy.html root user should always have access to do Put/Get/DeleteBucketPolicy. By implementing the `x-amz-confirm-remove-self-bucket-access` header this privilege can also be dropped from the root user.

Fixes: https://tracker.ceph.com/issues/66177