### PR TITLE
rgw/pubsub: Waiter unlocks before suspend

### DIFF
--- a/src/rgw/driver/rados/rgw_pubsub_push.cc
+++ b/src/rgw/driver/rados/rgw_pubsub_push.cc
@@ -154,10 +154,10 @@ public:
       auto yield = y.get_yield_context();
       auto&& token = yield[ec];
       boost::asio::async_initiate<boost::asio::yield_context, Signature>(
-          [this] (auto handler, auto ex) {
+          [this, &l] (auto handler, auto ex) {
             completion = Completion::create(ex, std::move(handler));
+            l.unlock(); // unlock before suspend
           }, token, yield.get_executor());
-      l.unlock();
       return -ec.value();
     }
     cond.wait(l, [this]{return (done==true);});


### PR DESCRIPTION
resolves a recent regression from https://github.com/ceph/ceph/pull/55592#issuecomment-2124514803, where the unlock() was accidentally moved after the coroutine's suspend+resume

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
