### PR TITLE
os/bluestore: implement object content recompression/defragmentation when scrubbing

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4780,8 +4780,11 @@ options:
   desc: Default policy for using compression when pool does not specify
   long_desc: '''none'' means never use compression.  ''passive'' means use compression
     when clients hint that data is compressible.  ''aggressive'' means use compression
-    unless clients hint that data is not compressible.  This option is used when the
-    per-pool property for the compression mode is not present.'
+    unless clients hint that data is not compressible.  ''*_lazy'' counterparts instruct
+    to apply compression as per above during deep-scrubbing only. Which has to be
+    additionally enabled at per-pool level using ''deep_scrub_recompression'' pool
+    setting.
+    This option is used when the per-pool property for the compression mode is not present.'
   fmt_desc: The default policy for using compression if the per-pool property
     ``compression_mode`` is not set. ``none`` means never use
     compression. ``passive`` means use compression when
@@ -4789,16 +4792,24 @@ options:
     compressible.  ``aggressive`` means use compression unless
     clients hint that data is not compressible.  ``force`` means use
     compression under all circumstances even if the clients hint that
-    the data is not compressible.
+    the data is not compressible. ''*_lazy'' modes are similar to their
+    counterpart ones but compression to be performed during deep
+    scrubbing only. Which has to be additionally enabled on per-pool basis
+    using ''deep_scrub_recompress'' pool setting.
   default: none
   enum_values:
   - none
   - passive
   - aggressive
   - force
+  - passive_lazy
+  - aggressive_lazy
+  - force_lazy
   flags:
   - runtime
   with_legacy: true
+  see_also:
+  - bluestore_prefer_deferred_size
 - name: bluestore_compression_algorithm
   type: str
   level: advanced

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4845,21 +4845,31 @@ options:
     clients hint that data is compressible. aggressive means use compression unless
     clients hint that data is not compressible. force means use compression under all
     circumstances even if the clients hint that the data is not compressible.
+    *_lazy counterparts instruct to apply compression as per above during deep-scrubbing
+    only. Which has to be additionally enabled at per-pool level using ''deep_scrub_reformat''
+    pool setting.
   fmt_desc: The default policy for using compression if the per-pool property ``compression_mode``
     is not set. ``none`` means never use compression. ``passive`` means use compression
     when :c:func:`clients hint <rados_set_alloc_hint>` that data is compressible.  ``aggressive``
     means use compression unless clients hint that data is not compressible.  ``force``
     means use compression under all circumstances even if the clients hint that the
-    data is not compressible.
+    data is not compressible. ``*_lazy`` modes are similar to their counterpart ones
+    but compression to be performed during deep scrubbing only. Which has to be additionally
+    enabled on per-pool basis using ''deep_scrub_reformat'' pool setting.
   default: none
   enum_values:
   - none
   - passive
   - aggressive
   - force
+  - passive_lazy
+  - aggressive_lazy
+  - force_lazy
   flags:
   - runtime
   with_legacy: true
+  see_also:
+  - bluestore_prefer_deferred_size
 - name: bluestore_compression_algorithm
   type: str
   level: advanced

--- a/src/compressor/Compressor.cc
+++ b/src/compressor/Compressor.cc
@@ -55,6 +55,10 @@ const char *Compressor::get_comp_mode_name(int m) {
     case COMP_PASSIVE: return "passive";
     case COMP_AGGRESSIVE: return "aggressive";
     case COMP_FORCE: return "force";
+    case COMP_PASSIVE_LAZY: return "passive_lazy";
+    case COMP_AGGRESSIVE_LAZY: return "aggressive_lazy";
+    case COMP_FORCE_LAZY: return "force_lazy";
+
     default: return "???";
   }
 }
@@ -66,6 +70,12 @@ Compressor::get_comp_mode_type(std::string_view s) {
     return COMP_AGGRESSIVE;
   if (s == "passive")
     return COMP_PASSIVE;
+  if (s == "force_lazy")
+    return COMP_FORCE_LAZY;
+  if (s == "aggressive_lazy")
+    return COMP_AGGRESSIVE_LAZY;
+  if (s == "passive_lazy")
+    return COMP_PASSIVE_LAZY;
   if (s == "none")
     return COMP_NONE;
   return {};

--- a/src/compressor/Compressor.h
+++ b/src/compressor/Compressor.h
@@ -65,7 +65,10 @@ public:
     COMP_NONE,                  ///< compress never
     COMP_PASSIVE,               ///< compress if hinted COMPRESSIBLE
     COMP_AGGRESSIVE,            ///< compress unless hinted INCOMPRESSIBLE
-    COMP_FORCE                  ///< compress always
+    COMP_FORCE,                 ///< compress always
+    COMP_PASSIVE_LAZY,          ///< delayed compression during reformatting if hinted COMPRESSIBLE
+    COMP_AGGRESSIVE_LAZY,       ///< delayed_compression during reformatting unless hinted INCOMPRESSIBLE
+    COMP_FORCE_LAZY             ///< unconditional delayed_compression during reformatting
   };
 
   static const char* get_comp_alg_name(int a);

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -58,6 +58,7 @@ set(alien_store_srcs
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlueStore_debug.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlueAdmin.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/OnodeScan.cc
+  ${PROJECT_SOURCE_DIR}/src/os/bluestore/OnodeReformat.cc
   ${PROJECT_SOURCE_DIR}/src/os/memstore/MemStore.cc)
 
 # Merge alienstore + alien-common into a single archive.  The common sources

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -59,6 +59,7 @@ set(alien_store_srcs
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlueStore_debug.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlueAdmin.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/OnodeScan.cc
+  ${PROJECT_SOURCE_DIR}/src/os/bluestore/OnodeReformat.cc
   ${PROJECT_SOURCE_DIR}/src/os/memstore/MemStore.cc)
 
 # Merge alienstore + alien-common into a single archive.  The common sources

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1193,6 +1193,7 @@ COMMAND("osd pool get "
           "|dedup_cdc_chunk_size"
           "|dedup_chunk_algorithm"
           "|dedup_tier"
+          "|deep_scrub_reformat"
           "|ec_coding_shard_count"
           "|ec_data_shard_count"
           "|eio"
@@ -1260,6 +1261,7 @@ COMMAND("osd pool set "
           "|dedup_cdc_chunk_size"
           "|dedup_chunk_algorithm"
           "|dedup_tier"
+          "|deep_scrub_reformat"
           "|eio"
           "|fast_read"
           "|fingerprint_algorithm"
@@ -1301,9 +1303,9 @@ COMMAND("osd pool set "
           "|unset_pool_flags"
           "|use_gmt_hitset"
           "|write_fadvise_dontneed "
-	"name=val,type=CephString "
-	"name=yes_i_really_mean_it,type=CephBool,req=false",
-	"set pool parameter <var> to <val>", "osd", "rw")
+    "name=val,type=CephString "
+    "name=yes_i_really_mean_it,type=CephBool,req=false",
+    "set pool parameter <var> to <val>", "osd", "rw")
 // 'val' is a CephString because it can include a unit.  Perhaps
 // there should be a Python type for validation/conversion of strings
 // with units.

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1303,9 +1303,9 @@ COMMAND("osd pool set "
           "|unset_pool_flags"
           "|use_gmt_hitset"
           "|write_fadvise_dontneed "
-    "name=val,type=CephString "
-    "name=yes_i_really_mean_it,type=CephBool,req=false",
-    "set pool parameter <var> to <val>", "osd", "rw")
+	"name=val,type=CephString "
+	"name=yes_i_really_mean_it,type=CephBool,req=false",
+	"set pool parameter <var> to <val>", "osd", "rw")
 // 'val' is a CephString because it can include a unit.  Perhaps
 // there should be a Python type for validation/conversion of strings
 // with units.

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1335,9 +1335,9 @@ COMMAND("osd pool set "
           "|unset_pool_flags"
           "|use_gmt_hitset"
           "|write_fadvise_dontneed "
-    "name=val,type=CephString "
-    "name=yes_i_really_mean_it,type=CephBool,req=false",
-    "set pool parameter <var> to <val>", "osd", "rw")
+	"name=val,type=CephString "
+	"name=yes_i_really_mean_it,type=CephBool,req=false",
+	"set pool parameter <var> to <val>", "osd", "rw")
 // 'val' is a CephString because it can include a unit.  Perhaps
 // there should be a Python type for validation/conversion of strings
 // with units.

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1225,6 +1225,7 @@ COMMAND("osd pool get "
           "|dedup_cdc_chunk_size"
           "|dedup_chunk_algorithm"
           "|dedup_tier"
+          "|deep_scrub_reformat"
           "|ec_coding_shard_count"
           "|ec_data_shard_count"
           "|eio"
@@ -1292,6 +1293,7 @@ COMMAND("osd pool set "
           "|dedup_cdc_chunk_size"
           "|dedup_chunk_algorithm"
           "|dedup_tier"
+          "|deep_scrub_reformat"
           "|eio"
           "|fast_read"
           "|fingerprint_algorithm"
@@ -1333,9 +1335,9 @@ COMMAND("osd pool set "
           "|unset_pool_flags"
           "|use_gmt_hitset"
           "|write_fadvise_dontneed "
-	"name=val,type=CephString "
-	"name=yes_i_really_mean_it,type=CephBool,req=false",
-	"set pool parameter <var> to <val>", "osd", "rw")
+    "name=val,type=CephString "
+    "name=yes_i_really_mean_it,type=CephBool,req=false",
+    "set pool parameter <var> to <val>", "osd", "rw")
 // 'val' is a CephString because it can include a unit.  Perhaps
 // there should be a Python type for validation/conversion of strings
 // with units.

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5586,7 +5586,8 @@ namespace {
     PG_AUTOSCALE_BIAS, DEDUP_TIER, DEDUP_CHUNK_ALGORITHM, 
     DEDUP_CDC_CHUNK_SIZE, POOL_EIO, BULK, PG_NUM_MAX, READ_RATIO,
     EC_OPTIMIZATIONS, EC_DATA_SHARD_COUNT, EC_CODING_SHARD_COUNT,
-    SUPPORTS_OMAP };
+    SUPPORTS_OMAP,
+    DEEP_SCRUB_REFORMAT };
 
   std::set<osd_pool_get_choices>
     subtract_second_from_first(const std::set<osd_pool_get_choices>& first,
@@ -6396,6 +6397,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       {"ec_data_shard_count", EC_DATA_SHARD_COUNT},
       {"ec_coding_shard_count", EC_CODING_SHARD_COUNT},
       {"supports_omap", SUPPORTS_OMAP},
+      {"deep_scrub_reformat", DEEP_SCRUB_REFORMAT},
     };
 
     typedef std::set<osd_pool_get_choices> choices_set_t;
@@ -6643,6 +6645,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  case DEDUP_CHUNK_ALGORITHM:
 	  case DEDUP_CDC_CHUNK_SIZE:
           case READ_RATIO:
+	  case DEEP_SCRUB_REFORMAT:
 	    {
 	      pool_opts_t::key_t key = pool_opts_t::get_opt_desc(i->first).key;
 	      if (p->opts.is_set(key)) {
@@ -6824,6 +6827,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  case DEDUP_CHUNK_ALGORITHM:
 	  case DEDUP_CDC_CHUNK_SIZE:
           case READ_RATIO:
+	  case DEEP_SCRUB_REFORMAT:
 	    for (i = ALL_CHOICES.begin(); i != ALL_CHOICES.end(); ++i) {
 	      if (i->second == *it)
 		break;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5584,7 +5584,8 @@ namespace {
     PG_AUTOSCALE_BIAS, DEDUP_TIER, DEDUP_CHUNK_ALGORITHM, 
     DEDUP_CDC_CHUNK_SIZE, POOL_EIO, BULK, PG_NUM_MAX, READ_RATIO,
     EC_OPTIMIZATIONS, EC_DATA_SHARD_COUNT, EC_CODING_SHARD_COUNT,
-    SUPPORTS_OMAP };
+    SUPPORTS_OMAP,
+    DEEP_SCRUB_REFORMAT };
 
   std::set<osd_pool_get_choices>
     subtract_second_from_first(const std::set<osd_pool_get_choices>& first,
@@ -6407,6 +6408,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       {"ec_data_shard_count", EC_DATA_SHARD_COUNT},
       {"ec_coding_shard_count", EC_CODING_SHARD_COUNT},
       {"supports_omap", SUPPORTS_OMAP},
+      {"deep_scrub_reformat", DEEP_SCRUB_REFORMAT},
     };
 
     typedef std::set<osd_pool_get_choices> choices_set_t;
@@ -6654,6 +6656,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  case DEDUP_CHUNK_ALGORITHM:
 	  case DEDUP_CDC_CHUNK_SIZE:
           case READ_RATIO:
+	  case DEEP_SCRUB_REFORMAT:
 	    {
 	      pool_opts_t::key_t key = pool_opts_t::get_opt_desc(i->first).key;
 	      if (p->opts.is_set(key)) {
@@ -6835,6 +6838,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  case DEDUP_CHUNK_ALGORITHM:
 	  case DEDUP_CDC_CHUNK_SIZE:
           case READ_RATIO:
+	  case DEEP_SCRUB_REFORMAT:
 	    for (i = ALL_CHOICES.begin(); i != ALL_CHOICES.end(); ++i) {
 	      if (i->second == *it)
 		break;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18266,7 +18266,16 @@ void BlueStore::_choose_write_options(
      (cm == Compressor::COMP_AGGRESSIVE &&
       (alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_INCOMPRESSIBLE) == 0) ||
      (cm == Compressor::COMP_PASSIVE &&
-      (alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_COMPRESSIBLE)));
+      (alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_COMPRESSIBLE)) ||
+      (cm == Compressor::COMP_FORCE_LAZY &&
+	(fadvise_flags & CEPH_OSD_OP_FLAG_SCRUB)) ||
+      (cm == Compressor::COMP_AGGRESSIVE_LAZY &&
+	(fadvise_flags & CEPH_OSD_OP_FLAG_SCRUB) &&
+	(alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_INCOMPRESSIBLE) == 0) ||
+      (cm == Compressor::COMP_PASSIVE_LAZY &&
+	(fadvise_flags & CEPH_OSD_OP_FLAG_SCRUB) &&
+	(alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_COMPRESSIBLE))
+      );
 
   if ((alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_SEQUENTIAL_READ) &&
       (alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_RANDOM_READ) == 0 &&

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -65,6 +65,7 @@
 #include "Writer.h"
 #include "Compression.h"
 #include "BlueAdmin.h"
+#include "OnodeReformat.h"
 #include "extblkdev/ExtBlkDevPlugin.h"
 
 #if defined(WITH_LTTNG)
@@ -12855,97 +12856,9 @@ int BlueStore::set_collection_opts(
   return 0;
 }
 
-struct OnodeReformatEngine {
-  bool enabled = false;
-  std::string args;
-  std::function<bool(std::string_view)> validate = nullptr;
-  std::function<bool(std::string_view)> execute = nullptr;
-  OnodeReformatEngine() {}
-  OnodeReformatEngine(std::function<bool(std::string_view)> _validate,
-                      std::function<bool(std::string_view)> _execute) :
-    validate(_validate), execute(_execute) {
-  }
-};
-
-class OnodeReformatContext {
-public:
-  enum {
-    // This is effectively an engine priority, i.e. the order engines are called in.
-    RECOMPRESS_ENGINE = 0,
-    DEFRAGMENT_ENGINE = 1,
-    MAX_ENGINES
-  };
-private:
-
-  size_t enabled_engines_count = 0;
-  std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES> engines;
-
-  bool to_be_applied = false;
-  BlueStore::WriteContext wctx;
-  span_stat_t span_stat;
-  Allocator* alloc = nullptr;
-  PExtentVectorSlicer* prealloc_slicer = nullptr; // pointer to the one from wctx if configured
-public:
-  ~OnodeReformatContext() {
-    clear();
-  }
-  void setup_engines(const std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES>& e) {
-    engines = e;
-  }
-  void setup_allocations(Allocator* _alloc, PExtentVector&& _p, uint32_t _total) {
-    ceph_assert(!prealloc_slicer); // repetitive assignments aren't allowed
-    alloc = _alloc;
-    prealloc_slicer = &wctx.prealloc_slicer;
-    prealloc_slicer->setup(std::move(_p), _total);
-  }
-
-  bool is_enabled() const { return enabled_engines_count > 0; }
-  bool is_applied() const { return to_be_applied; }
-  BlueStore::WriteContext& get_write_context() { return wctx; }
-  span_stat_t& access_span_stats() {
-    return span_stat;
-  }
-  const span_stat_t& get_span_stats() const {
-    return span_stat;
-  }
-
-  void maybe_enable_engine(int pri, std::string_view args) {
-    ceph_assert(pri >= 0 && pri < MAX_ENGINES);
-    if (!engines[pri].enabled && engines[pri].validate(args)) {
-      engines[pri].enabled = true;
-      engines[pri].args = args;
-      enabled_engines_count++;
-    }
-  }
-  void exec_engines() {
-    int i = 0;
-    for(auto e : engines) {
-    i++;
-      if (e.enabled && e.execute(e.args)) {
-        to_be_applied = true;
-        break;
-      }
-    }
-  }
-  void clear() {
-    PExtentVector to_release;
-    if (prealloc_slicer && alloc && !prealloc_slicer->end() && prealloc_slicer->slice(to_release) > 0) {
-      alloc->release(to_release);
-    }
-    enabled_engines_count = 0;
-    for (auto e : engines) {
-      e.enabled = false;
-    }
-    to_be_applied = false;
-    wctx.reset();
-  }
-};
-
 void BlueStore::_maybe_need_reformat_onode(OnodeReformatContext& reformat_ctx,
   Collection* c)
 {
-  reformat_ctx.clear();
-
   std::string opt_reformat;
   c->pool_opts.get(pool_opts_t::DEEP_SCRUB_REFORMAT, &opt_reformat);
   boost::char_separator<char> sep(";,"); // Delimiters are semicolon and comma
@@ -13023,133 +12936,21 @@ int BlueStore::read(
   if (!c->exists)
     return -ENOENT;
 
-  OnodeReformatContext reformat_ctx;
-  auto basic_validate_reformat = [&](std::string_view args) ->bool {
-    bool will_reformat = false;
-    if (op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
-      // for the sake of simplicity do not apply data reformatting to reads
-      // unaligned at the beginning. Having unaligned tail is OK.
-      will_reformat = p2nphase(offset, min_alloc_size) == 0;
-      if (!will_reformat) {
-	dout(15) << "reformat '" << args << "'"
-	  << " skipped due to unaligned read bounds "
-	  << p2nphase(offset, min_alloc_size) << " "
-	  << p2nphase(offset + length, min_alloc_size)
-	  << dendl;
-      } else {
-	dout(15) << "reformat '" << args << "'"
-	  << " enabled "
-	  << dendl;
-      }
-    }
-    return will_reformat;
-  };
-  auto exec_recompress = [&](std::string_view args) -> bool {
-    const auto& span_stat = reformat_ctx.get_span_stats();
-    auto& wctx = reformat_ctx.get_write_context();
-    bool will_do = wctx.compress && span_stat.allocated > 0;
-    if (will_do) {
-      uint64_t need = 0;
-      auto bl_it = bl.begin();
-      uint64_t offs = offset;
-      uint64_t old_allocated = span_stat.allocated + span_stat.allocated_compressed;
-      while (bl_it != bl.end()) {
-
-	BlobRef blob = c->new_blob();
-	bufferlist from_bl;
-	uint64_t l = std::min(wctx.target_blob_size, uint64_t(bl_it.get_remaining()));
-	uint64_t res_len = l;
-	if (l >= min_alloc_size) {
-	  l = p2align(l, min_alloc_size);
-	  bl_it.copy(l, from_bl);
-
-	  //FIXME: add zero detection
-	  auto& wi = wctx.write(offs, blob, l, 0, from_bl, 0, l, false, true);
-
-	  res_len = from_bl.length();
-	  if (l > min_alloc_size &&
-	    wctx.compressor->compress(from_bl, wi.compressed_bl, wi.compressor_message) == 0) {
-
-	    res_len = wi.compressed_bl.length();
-	    // don't set wi.compress_len and wi.compressed as this is redundant
-	    // at this point, to be assigned in _do_alloc_write if needed.
-	  }
-	  dout(20) << " reformat: " << " precompress : 0x"
-	    << std::hex << offs << "~" << l << "->" << res_len
-	    << std::dec << " " << *blob
-	    << dendl;
-	} else {
-	  bl_it += l;
-	  dout(20) << " reformat: " << " precompress : 0x"
-	    << std::hex << offs << "~" << l << "-> remaining tail"
-	    << dendl;
-	}
-	need += p2roundup(res_len, min_alloc_size);
-	offs += l;
-	will_do = need < old_allocated;
-      }
-
-      // At this point will_do indicates if we definitely want recompression,
-      // will skip the remaining reformatting then.
-
-      // Keep compressed blobs until final processing no matter if we decided to
-      // enforce recompression or not. In the latter case they can be chosen
-      // for different engine optimization(s) or be rejected prior to writing out.
-      wctx.precompressed = true;
-      dout(10) << " reformat:'" << args << "'"
-	<< " need 0x"
-	<< std::hex << need << " vs. old_allocated 0x" << old_allocated << std::dec
-	<< " apply: " << will_do
-	<< dendl;
-
-      logger->inc(l_bluestore_reformat_compress_attempted);
-      if (!will_do)
-	logger->inc(l_bluestore_reformat_compress_omitted);
-    }
-    return will_do;
-  };
-  auto exec_defragment = [&](std::string_view args) -> bool {
-    bool will_do = false;
-    const auto& span_stat = reformat_ctx.get_span_stats();
-    auto need = p2roundup(length, min_alloc_size);
-    size_t frags = 0;
-    int64_t preallocated = 0;
-    if (span_stat.frags > 1) {
-      logger->inc(l_bluestore_reformat_defragment_attempted);
-      PExtentVector prealloc;
-      prealloc.reserve(need / min_alloc_size + 1);
-      auto start = mono_clock::now();
-      preallocated = alloc->allocate(
-	need, min_alloc_size, need,
-	0, &prealloc);
-      log_latency("allocator@_prepare_reformat",
-	l_bluestore_allocator_lat,
-	mono_clock::now() - start,
-	cct->_conf->bluestore_log_op_age);
-      will_do = preallocated >= (int64_t)need && prealloc.size() < span_stat.frags;
-      if (will_do) {
-	frags = prealloc.size();
-	reformat_ctx.setup_allocations(alloc, std::move(prealloc), preallocated);
-      } else {
-	logger->inc(l_bluestore_reformat_defragment_omitted);
-      }
-    }
-    dout(10) << " reformat:'" << args << "'"
-      << " preallocated: 0x" << std::hex << preallocated << std::dec
-      << " old frags:" << span_stat.frags
-      << " new frags:" << frags
-      << " apply: " << will_do
-      << dendl;
-    return will_do;
-  };
-
-  const std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES>
-    engines = {
-      OnodeReformatEngine(basic_validate_reformat, exec_recompress),
-      OnodeReformatEngine(basic_validate_reformat, exec_defragment),
-    };
-  reformat_ctx.setup_engines(engines);
-
+  OnodeReformatContext reformat_ctx(this, logger); // don't want to add new getter
+                                                   // for BlueStore::logger,
+						   // hence pass it from here
+  reformat_ctx.add_engine(
+    OnodeReformatContext::RECOMPRESS_ENGINE,
+    new OnodeReformatBasicValidateAction(
+      offset, length, op_flags, min_alloc_size),
+    new OnodeReformatRecompressAction(
+      c, offset, length, bl, min_alloc_size));
+  reformat_ctx.add_engine(
+    OnodeReformatContext::DEFRAGMENT_ENGINE,
+    new OnodeReformatBasicValidateAction(
+      offset, length, op_flags, min_alloc_size),
+    new OnodeReformatDefragmentAction(
+      offset, length, min_alloc_size));
   return _do_read(c, oid, offset, length, bl, op_flags, reformat_ctx);
 }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -16071,6 +16071,35 @@ int BlueStore::queue_transactions(
     txc->bytes += (*p).get_num_bytes();
     _txc_add_transaction(txc, &(*p));
   }
+  _txc_exec(txc, handle);
+
+  // we're immediately readable (unlike FileStore)
+  for (auto c : on_applied_sync) {
+    c->complete(0);
+  }
+  if (!on_applied.empty()) {
+    if (c->commit_queue) {
+      c->commit_queue->queue(on_applied);
+    } else {
+      finisher.queue(on_applied);
+    }
+  }
+
+#ifdef WITH_BLKIN
+  if (txc->trace) {
+    txc->trace.event("txc applied");
+  }
+#endif
+
+  log_latency("submit_transact",
+    l_bluestore_submit_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
+  return 0;
+}
+
+void BlueStore::_txc_exec(TransContext* txc, ThreadPool::TPHandle* handle)
+{
   _txc_calc_cost(txc);
 
   _txc_write_nodes(txc, txc->t);
@@ -16099,12 +16128,12 @@ int BlueStore::queue_transactions(
   auto tstart = mono_clock::now();
 
   if (!throttle.try_start_transaction(
-	*db,
-	*txc,
-	tstart)) {
+    *db,
+    *txc,
+    tstart)) {
     // ensure we do not block here because of deferred writes
     dout(10) << __func__ << " failed get throttle_deferred_bytes, aggressive"
-	     << dendl;
+      << dendl;
     ++deferred_aggressive;
     deferred_try_submit();
     {
@@ -16124,37 +16153,13 @@ int BlueStore::queue_transactions(
     handle->reset_tp_timeout();
 
   logger->inc(l_bluestore_txc);
-
-  // execute (start)
-  _txc_state_proc(txc);
-
-  // we're immediately readable (unlike FileStore)
-  for (auto c : on_applied_sync) {
-    c->complete(0);
-  }
-  if (!on_applied.empty()) {
-    if (c->commit_queue) {
-      c->commit_queue->queue(on_applied);
-    } else {
-      finisher.queue(on_applied);
-    }
-  }
-
-#ifdef WITH_BLKIN
-  if (txc->trace) {
-    txc->trace.event("txc applied");
-  }
-#endif
-
-  log_latency("submit_transact",
-    l_bluestore_submit_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
   log_latency("throttle_transact",
     l_bluestore_throttle_lat,
     tend - tstart,
     cct->_conf->bluestore_log_op_age);
-  return 0;
+
+  // execute (start)
+  _txc_state_proc(txc);
 }
 
 void BlueStore::_txc_aio_submit(TransContext *txc)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -16788,26 +16788,25 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
                    << tail_pad << std::dec << " of mutable " << *b << dendl;
 
           if (!g_conf()->bluestore_debug_omit_block_device_write) {
-          if (b_len < prefer_deferred_size) {
+            if (b_len < prefer_deferred_size) {
               dout(20) << __func__ << " deferring small 0x" << std::hex
-		       << b_len << std::dec << " unused write via deferred" << dendl;
+                       << b_len << std::dec << " unused write via deferred" << dendl;
               bluestore_deferred_op_t *op = _get_deferred_op(txc, bl.length());
               op->op = bluestore_deferred_op_t::OP_WRITE;
               b->get_blob().map(
-		b_off, b_len,
-                                [&](uint64_t offset, uint64_t length) {
-                                  op->extents.emplace_back(bluestore_pextent_t(offset, length));
-                                  return 0;
-                                });
+                b_off, b_len,
+                [&](uint64_t offset, uint64_t length) {
+                  op->extents.emplace_back(bluestore_pextent_t(offset, length));
+                  return 0;
+                });
               op->data = bl;
-          } else {
+            } else {
               b->get_blob().map_bl(
-                  b_off, bl,
-		[&](uint64_t offset, bufferlist& t) {
-                    bdev->aio_write(offset, t,
-				  &txc->ioc, wctx->buffered);
-                  });
-          }
+                b_off, bl,
+                [&](uint64_t offset, bufferlist& t) {
+                  bdev->aio_write(offset, t, &txc->ioc, wctx->buffered);
+              });
+            }
           }
           b->dirty_blob().calc_csum(b_off, bl);
           dout(20) << __func__ << "  lex old " << *ep << dendl;
@@ -16879,19 +16878,19 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
           b->dirty_blob().calc_csum(b_off, bl);
 
           if (!g_conf()->bluestore_debug_omit_block_device_write) {
-          bluestore_deferred_op_t *op = _get_deferred_op(txc, bl.length());
-          op->op = bluestore_deferred_op_t::OP_WRITE;
-          int r = b->get_blob().map(
+            bluestore_deferred_op_t *op = _get_deferred_op(txc, bl.length());
+            op->op = bluestore_deferred_op_t::OP_WRITE;
+            int r = b->get_blob().map(
               b_off, b_len,
-	      [&](uint64_t offset, uint64_t length) {
+              [&](uint64_t offset, uint64_t length) {
                 op->extents.emplace_back(bluestore_pextent_t(offset, length));
                 return 0;
               });
-          ceph_assert(r == 0);
-          op->data = std::move(bl);
-          dout(20) << __func__ << "  deferred write 0x" << std::hex << b_off
-                   << "~" << b_len << std::dec << " of mutable " << *b << " at "
-                   << op->extents << dendl;
+            ceph_assert(r == 0);
+            op->data = std::move(bl);
+            dout(20) << __func__ << "  deferred write 0x" << std::hex << b_off
+                     << "~" << b_len << std::dec << " of mutable " << *b << " at "
+                     << op->extents << dendl;
           }
 
           Extent *le = o->extent_map.set_lextent(c, offset, offset - bstart, length,
@@ -16907,7 +16906,7 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
 			      offset0 - bstart,
 			      &alloc_len)) {
 	  ceph_assert(alloc_len == min_alloc_size); // expecting data always
-					       // fit into reused blob
+                                                    // fit into reused blob
 	  // Need to check for pending writes desiring to
 	  // reuse the same pextent. The rationale is that during GC two chunks
 	  // from garbage blobs(compressed?) can share logical space within the same
@@ -16970,7 +16969,7 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
                             offset0 - bstart,
                             &alloc_len)) {
 	ceph_assert(alloc_len == min_alloc_size); // expecting data always
-					     // fit into reused blob
+                                                  // fit into reused blob
 	// Need to check for pending writes desiring to
 	// reuse the same pextent. The rationale is that during GC two chunks
 	// from garbage blobs(compressed?) can share logical space within the same

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9696,8 +9696,8 @@ int BlueStore::_mount()
 
   dout(1) << __func__
           << " v2 = " << use_write_v2
-	  << " segment_size = " << segment_size
-	  << " esb = " << elastic_shared_blobs
+          << " segment_size = " << segment_size
+          << " esb = " << elastic_shared_blobs
           << dendl;
   int r = _open_db_and_around(false);
   if (r < 0) {
@@ -12928,7 +12928,7 @@ void BlueStore::_maybe_do_reformat_onode(OnodeReformatContext& reformat_ctx,
 }
 
 int BlueStore::read(
-  CollectionHandle &ch,
+  CollectionHandle &c_,
   const ghobject_t& oid,
   uint64_t offset,
   size_t length,
@@ -12936,7 +12936,7 @@ int BlueStore::read(
   uint32_t op_flags)
 {
   auto start = mono_clock::now();
-  Collection *c = static_cast<Collection *>(ch.get());
+  Collection *c = static_cast<Collection *>(c_.get());
   const coll_t &cid = c->get_cid();
   dout(15) << __func__ << " " << cid << " " << oid
 	   << " 0x" << std::hex << offset << "~" << length
@@ -12944,9 +12944,9 @@ int BlueStore::read(
 	   << std::dec << dendl;
   if (!c->exists)
     return -ENOENT;
+
   bl.clear();
   int r;
-
   {
     read_context_t read_ctx(*this, offset, length, bl, op_flags);
     // we need a shared lock to access
@@ -12999,9 +12999,9 @@ int BlueStore::read(
     r = -EIO;
     derr << __func__ << " " << c->cid << " " << oid << " INJECT EIO" << dendl;
   } else if (oid.hobj.pool > 0 &&  /* FIXME, see #23029 */
-    cct->_conf->bluestore_debug_random_read_err &&
-    (rand() % (int)(cct->_conf->bluestore_debug_random_read_err *
-      100.0)) == 0) {
+	     cct->_conf->bluestore_debug_random_read_err &&
+	     (rand() % (int)(cct->_conf->bluestore_debug_random_read_err *
+			     100.0)) == 0) {
     dout(0) << __func__ << ": inject random EIO" << dendl;
     r = -EIO;
   }
@@ -13063,8 +13063,8 @@ void BlueStore::_read_cache(
           pc->first == pos) {
         l = pc->second.length();
         ready_regions[pos] = std::move(pc->second);
-	span_stat.cached += l;
-	dout(30) << __func__ << "    use cache 0x" << std::hex << pos << ": 0x"
+        span_stat.cached += l;
+        dout(30) << __func__ << "    use cache 0x" << std::hex << pos << ": 0x"
                  << pos << "~" << l << std::dec << dendl;
         ++pc;
       } else {
@@ -13126,7 +13126,7 @@ int BlueStore::_prepare_read_ioc(
   span_stat_t& span_stat = res_span_stat ? *res_span_stat : dummy_span_stat;
   interval_set<uint64_t> pintervals; // need to accumulate pextents in this set
                                      // to get them sorted by offset and merged
-				     // into larger intervals if possible.
+                                     // into larger intervals if possible.
   for (auto& p : blobs2read) {
     const BlobRef& bptr = p.first;
     regions2read_t& r2r = p.second;
@@ -13839,10 +13839,9 @@ int BlueStore::_do_readv(
   for (auto p = m.begin(); p != m.end(); p++, i++) {
     raw_results.push_back({});
     _read_cache(o, p.get_start(), p.get_len(), read_cache_policy,
-                std::get<0>(raw_results[i]), std::get<2>(raw_results[i]),
-		nullptr);
-    r = _prepare_read_ioc(std::get<2>(raw_results[i]), &std::get<1>(raw_results[i]),
-                          &ioc, nullptr);
+                std::get<0>(raw_results[i]), std::get<2>(raw_results[i]));
+    r = _prepare_read_ioc(std::get<2>(raw_results[i]), &std::get<1>(raw_results[i]), &ioc);
+    // we always issue aio for reading, so errors other than EIO are not allowed
     if (r < 0)
       return r;
     if (cct->_conf->bluestore_frag_runtime) {
@@ -16291,12 +16290,12 @@ void BlueStore::_txc_exec(TransContext* txc, ThreadPool::TPHandle* handle)
   auto tstart = mono_clock::now();
 
   if (!throttle.try_start_transaction(
-    *db,
-    *txc,
-    tstart)) {
+	*db,
+	*txc,
+	tstart)) {
     // ensure we do not block here because of deferred writes
     dout(10) << __func__ << " failed get throttle_deferred_bytes, aggressive"
-      << dendl;
+	     << dendl;
     ++deferred_aggressive;
     deferred_try_submit();
     {
@@ -16989,11 +16988,11 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
           if (!g_conf()->bluestore_debug_omit_block_device_write) {
             if (b_len < prefer_deferred_size) {
               dout(20) << __func__ << " deferring small 0x" << std::hex
-                       << b_len << std::dec << " unused write via deferred" << dendl;
+		       << b_len << std::dec << " unused write via deferred" << dendl;
               bluestore_deferred_op_t *op = _get_deferred_op(txc, bl.length());
               op->op = bluestore_deferred_op_t::OP_WRITE;
               b->get_blob().map(
-                b_off, b_len,
+		b_off, b_len,
                 [&](uint64_t offset, uint64_t length) {
                   op->extents.emplace_back(bluestore_pextent_t(offset, length));
                   return 0;
@@ -17002,8 +17001,9 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
             } else {
               b->get_blob().map_bl(
                 b_off, bl,
-                [&](uint64_t offset, bufferlist& t) {
-                  bdev->aio_write(offset, t, &txc->ioc, wctx->buffered);
+		[&](uint64_t offset, bufferlist& t) {
+                  bdev->aio_write(offset, t,
+				  &txc->ioc, wctx->buffered);
               });
             }
           }
@@ -17671,12 +17671,12 @@ int BlueStore::_do_alloc_write(
 
       if (r == 0 && rejected) {
 	dout(20) << __func__ << std::hex << "  0x" << wi.blob_length
-	  << " compressed to 0x" << compressed_len << " -> 0x" << result_len
-	  << " with " << wctx->compressor->get_type()
-	  << ", which is more than required 0x" << want_len_raw
-	  << " -> 0x" << want_len
-	  << ", leaving uncompressed"
-	  << std::dec << dendl;
+		 << " compressed to 0x" << compressed_len << " -> 0x" << result_len
+		 << " with " << wctx->compressor->get_type()
+		 << ", which is more than required 0x" << want_len_raw
+		 << " -> 0x" << want_len
+		 << ", leaving uncompressed"
+		 << std::dec << dendl;
 	logger->inc(l_bluestore_compress_rejected_count);
       }
 
@@ -17743,10 +17743,9 @@ int BlueStore::_do_alloc_write(
 
   dout(20) << __func__ << std::hex << " need=0x" << need << " data=0x" << data_size
 	   << " prealloc " << pextents << dendl;
-
-  int64_t prealloc_left = allocated + preallocated;
   auto prealloc_pos = pextents.begin();
   ceph_assert(prealloc_pos != pextents.end());
+  int64_t prealloc_left = allocated + preallocated;
 
   for (auto& wi : wctx->writes) {
     bluestore_blob_t& dblob = wi.b->dirty_blob();
@@ -18294,6 +18293,7 @@ int BlueStore::_do_write_v2(
   if (length == 0) {
     return 0;
   }
+
   if (bl.length() != length) {
     bl.splice(length, bl.length() - length);
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12910,7 +12910,7 @@ void BlueStore::_maybe_do_reformat_onode(OnodeReformatContext& reformat_ctx,
     _dump_onode<25>(cct, *o);
 
     ceph_assert(logger);
-    reformat_ctx.exec_engines(*logger, c, o);
+    reformat_ctx.exec_engines(*logger);
     if (reformat_ctx.is_applied()) {
       _txc_exec_reformat_write(c, o, offset, length, bl, wctx);
     }
@@ -12948,17 +12948,12 @@ int BlueStore::read(
   bl.clear();
   int r;
   {
-    read_context_t read_ctx(*this, offset, length, bl, op_flags);
-    // we need a shared lock to access
-    // reformat_engines from collection
+    // we need a shared lock to accesss
+    // reformat_engines from collection for validation,
+    // but once we want to apply reformatting we need
+    // unique lock
     std::shared_lock slock(c->lock);
-    OnodeReformatContext reformat_ctx(read_ctx, c->reformat_engines);
-
     std::unique_lock ulock(c->lock, std::defer_lock);
-    if (reformat_ctx.is_enabled()) {
-      slock.unlock();
-      ulock.lock();
-    }
 
     auto start1 = mono_clock::now();
     OnodeRef o = c->get_onode(oid, false);
@@ -12967,7 +12962,17 @@ int BlueStore::read(
       mono_clock::now() - start1,
       cct->_conf->bluestore_log_op_age,
       "", l_bluestore_slow_read_onode_meta_count);
-    if (o && o->exists) {
+
+    read_context_t read_ctx(*this, c_, o, offset, length, bl, op_flags);
+    OnodeReformatContext reformat_ctx(read_ctx, c->reformat_engines);
+    if (o && o->exists && reformat_ctx.is_enabled()) {
+      slock.unlock();
+      ulock.lock();
+    }
+
+    // either collection or onode could be removed while switching locks above,
+    // hence checking once again
+    if (c->exists && o && o->exists) {
       if (offset == length && offset == 0)
 	length = o->onode.size;
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9655,7 +9655,7 @@ int BlueStore::_umount_readonly()
 
 int BlueStore::_mount()
 {
-  dout(5) << __func__ << " path " << path << dendl;
+  dout(1) << __func__ << " path " << path << dendl;
 
   {
     int r = read_meta_conf_check_env();
@@ -9694,7 +9694,11 @@ int BlueStore::_mount()
     return -EINVAL;
   }
 
-  dout(5) << __func__ << "::NCB::calling open_db_and_around(read/write)" << dendl;
+  dout(1) << __func__
+          << " v2 = " << use_write_v2
+	  << " segment_size = " << segment_size
+	  << " esb = " << elastic_shared_blobs
+          << dendl;
   int r = _open_db_and_around(false);
   if (r < 0) {
     return r;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12857,31 +12857,34 @@ int BlueStore::set_collection_opts(
   if (c->pool_opts.get(pool_opts_t::COMPRESSION_REQUIRED_RATIO, &dval)) {
     c->compression_req_ratio = dval;
   }
+  _update_reformat_engines(c);
   return 0;
 }
 
-void BlueStore::_maybe_need_reformat_onode(OnodeReformatContext& reformat_ctx,
-  Collection* c)
+void BlueStore::_update_reformat_engines(Collection* c)
 {
   std::string opt_reformat;
   c->pool_opts.get(pool_opts_t::DEEP_SCRUB_REFORMAT, &opt_reformat);
   boost::char_separator<char> sep(";,"); // Delimiters are semicolon and comma
   boost::tokenizer<boost::char_separator<char>> tokens(opt_reformat, sep);
-
+  reformat_engines_t new_engines;
   for (const auto& t : tokens) {
-    std::string_view sv(t);
-    sv.remove_prefix(std::min(sv.find_first_not_of(" \t\n\r\f\v"), sv.size()));
-    int pri = -1;
-    if (sv.starts_with("recompress")) {
-      pri = OnodeReformatContext::RECOMPRESS_ENGINE;
-    } else if (sv.starts_with("defragment")) {
-      pri = OnodeReformatContext::DEFRAGMENT_ENGINE;
+    std::string_view args(t);
+    args.remove_prefix(
+      std::min(args.find_first_not_of(" \t\n\r\f\v"), args.size()));
+    int e = -1;
+    OnodeReformatEngine* engine = nullptr;
+    if (args.starts_with("recompress")) {
+      e = RECOMPRESS_ENGINE;
+      engine = new OnodeReformatRecompressEngine(args);
+    } else if (args.starts_with("defragment")) {
+      e = DEFRAGMENT_ENGINE;
+      engine = new OnodeReformatDefragmentEngine(args);
     }
-    ceph_assert(pri < OnodeReformatContext::MAX_ENGINES);
-    if (pri >= 0) {
-      reformat_ctx.maybe_enable_engine(pri, sv);
-    }
+    ceph_assert(e < MAX_REFORMAT_ENGINES);
+    new_engines[e].reset(engine);
   }
+  std::swap(c->reformat_engines, new_engines);
 }
 
 void BlueStore::_maybe_do_reformat_onode(OnodeReformatContext& reformat_ctx,
@@ -12906,7 +12909,8 @@ void BlueStore::_maybe_do_reformat_onode(OnodeReformatContext& reformat_ctx,
     dout(25) << __func__ << " span stat {" << span_stat << "}" << dendl;
     _dump_onode<25>(cct, *o);
 
-    reformat_ctx.exec_engines();
+    ceph_assert(logger);
+    reformat_ctx.exec_engines(*logger, c, o);
     if (reformat_ctx.is_applied()) {
       _txc_exec_reformat_write(c, o, offset, length, bl, wctx);
     }
@@ -12939,23 +12943,7 @@ int BlueStore::read(
 	   << std::dec << dendl;
   if (!c->exists)
     return -ENOENT;
-
-  OnodeReformatContext reformat_ctx(this, logger); // don't want to add new getter
-                                                   // for BlueStore::logger,
-						   // hence pass it from here
-  reformat_ctx.add_engine(
-    OnodeReformatContext::RECOMPRESS_ENGINE,
-    new OnodeReformatBasicValidateAction(
-      offset, length, op_flags, min_alloc_size),
-    new OnodeReformatRecompressAction(
-      c, offset, length, bl, min_alloc_size));
-  reformat_ctx.add_engine(
-    OnodeReformatContext::DEFRAGMENT_ENGINE,
-    new OnodeReformatBasicValidateAction(
-      offset, length, op_flags, min_alloc_size),
-    new OnodeReformatDefragmentAction(
-      offset, length, min_alloc_size));
-  return _do_read(c, oid, offset, length, bl, op_flags, reformat_ctx);
+  return _do_read(c, oid, offset, length, bl, op_flags);
 }
 
 int BlueStore::_do_read(Collection* c,
@@ -12963,19 +12951,20 @@ int BlueStore::_do_read(Collection* c,
 			uint64_t offset,
 			size_t length,
 			bufferlist& bl,
-			uint32_t op_flags,
-			OnodeReformatContext& reformat_ctx)
+			uint32_t op_flags)
 {
   int r;
   auto start = mono_clock::now();
-  _maybe_need_reformat_onode(reformat_ctx, c);
   {
-    std::shared_lock slock(c->lock, std::defer_lock);
+    read_context_t read_ctx(*this, offset, length, bl, op_flags);
+    std::shared_lock slock(c->lock); // we need a shared lock to access
+                                     // reformat_engines from collection
+    OnodeReformatContext reformat_ctx(read_ctx, c->reformat_engines);
+
     std::unique_lock ulock(c->lock, std::defer_lock);
     if (reformat_ctx.is_enabled()) {
+      slock.unlock();
       ulock.lock();
-    } else {
-      slock.lock();
     }
 
     auto start1 = mono_clock::now();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -28,6 +28,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_real.hpp>
+#include <boost/tokenizer.hpp>
 
 #include "common/dout.h"
 #include "include/ceph_assert.h"
@@ -4583,7 +4584,7 @@ int BlueStore::ExtentMap::compress_extent_map(
 }
 
 void BlueStore::ExtentMap::punch_hole(
-  CollectionRef &c, 
+  CollectionRef &c,
   uint64_t offset,
   uint64_t length,
   old_extent_map_t *old_extents)
@@ -6692,6 +6693,37 @@ void BlueStore::_init_logger()
     "slow_op_scrub_count",
     "Slow Scrub op count in BlueStore",
     "ssoc",
+    PerfCountersBuilder::PRIO_USEFUL);
+
+  // reformatting counters
+  //****************************************
+  b.add_time_avg(l_bluestore_reformat_lat, "reformat_lat",
+    "Average reformatting latency",
+    "rf_l", PerfCountersBuilder::PRIO_CRITICAL);
+  b.add_u64_counter(l_bluestore_reformat_compress_attempted,
+    "reformat_compress_attempted",
+    "Recompression attempts done",
+    "rfca",
+    PerfCountersBuilder::PRIO_USEFUL);
+  b.add_u64_counter(l_bluestore_reformat_compress_omitted,
+    "reformat_compress_omitted",
+    "Recompression attempts omitted",
+    "rfco",
+    PerfCountersBuilder::PRIO_USEFUL);
+  b.add_u64_counter(l_bluestore_reformat_defragment_attempted,
+    "reformat_defragment_attempted",
+    "Defragmentation attempts done",
+    "rfda",
+    PerfCountersBuilder::PRIO_USEFUL);
+  b.add_u64_counter(l_bluestore_reformat_defragment_omitted,
+    "reformat_defragment_omitted",
+    "Defragmentation attempts omitted",
+    "rfdo",
+    PerfCountersBuilder::PRIO_USEFUL);
+  b.add_u64_counter(l_bluestore_reformat_issued,
+    "reformat_issued",
+    "Reformatting requests issued",
+    "rfi",
     PerfCountersBuilder::PRIO_USEFUL);
 
   // Resulting size axis configuration for op histograms, values are in bytes
@@ -10989,7 +11021,7 @@ void BlueStore::_fsck_check_objects(
           uint64_t offset = 0;
           do {
             uint64_t l = std::min(uint64_t(o->onode.size - offset), max_read_block);
-            int r = _do_read(c.get(), o, offset, l, bl,
+            int r = _do_basic_read(c.get(), o, offset, l, bl,
               CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
             if (r < 0) {
               ++errors;
@@ -12823,27 +12855,324 @@ int BlueStore::set_collection_opts(
   return 0;
 }
 
+struct OnodeReformatEngine {
+  bool enabled = false;
+  std::string args;
+  std::function<bool(std::string_view)> validate = nullptr;
+  std::function<bool(std::string_view)> execute = nullptr;
+  OnodeReformatEngine() {}
+  OnodeReformatEngine(std::function<bool(std::string_view)> _validate,
+                      std::function<bool(std::string_view)> _execute) :
+    validate(_validate), execute(_execute) {
+  }
+};
+
+class OnodeReformatContext {
+public:
+  enum {
+    // This is effectively an engine priority, i.e. the order engines are called in.
+    RECOMPRESS_ENGINE = 0,
+    DEFRAGMENT_ENGINE = 1,
+    MAX_ENGINES
+  };
+private:
+
+  size_t enabled_engines_count = 0;
+  std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES> engines;
+
+  bool to_be_applied = false;
+  BlueStore::WriteContext wctx;
+  span_stat_t span_stat;
+  Allocator* alloc = nullptr;
+  PExtentVectorSlicer* prealloc_slicer = nullptr; // pointer to the one from wctx if configured
+public:
+  ~OnodeReformatContext() {
+    clear();
+  }
+  void setup_engines(const std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES>& e) {
+    engines = e;
+  }
+  void setup_allocations(Allocator* _alloc, PExtentVector&& _p, uint32_t _total) {
+    ceph_assert(!prealloc_slicer); // repetitive assignments aren't allowed
+    alloc = _alloc;
+    prealloc_slicer = &wctx.prealloc_slicer;
+    prealloc_slicer->setup(std::move(_p), _total);
+  }
+
+  bool is_enabled() const { return enabled_engines_count > 0; }
+  bool is_applied() const { return to_be_applied; }
+  BlueStore::WriteContext& get_write_context() { return wctx; }
+  span_stat_t& access_span_stats() {
+    return span_stat;
+  }
+  const span_stat_t& get_span_stats() const {
+    return span_stat;
+  }
+
+  void maybe_enable_engine(int pri, std::string_view args) {
+    ceph_assert(pri >= 0 && pri < MAX_ENGINES);
+    if (!engines[pri].enabled && engines[pri].validate(args)) {
+      engines[pri].enabled = true;
+      engines[pri].args = args;
+      enabled_engines_count++;
+    }
+  }
+  void exec_engines() {
+    int i = 0;
+    for(auto e : engines) {
+    i++;
+      if (e.enabled && e.execute(e.args)) {
+        to_be_applied = true;
+        break;
+      }
+    }
+  }
+  void clear() {
+    PExtentVector to_release;
+    if (prealloc_slicer && alloc && !prealloc_slicer->end() && prealloc_slicer->slice(to_release) > 0) {
+      alloc->release(to_release);
+    }
+    enabled_engines_count = 0;
+    for (auto e : engines) {
+      e.enabled = false;
+    }
+    to_be_applied = false;
+    wctx.reset();
+  }
+};
+
+void BlueStore::_maybe_need_reformat_onode(OnodeReformatContext& reformat_ctx,
+  Collection* c)
+{
+  reformat_ctx.clear();
+
+  std::string opt_reformat;
+  c->pool_opts.get(pool_opts_t::DEEP_SCRUB_REFORMAT, &opt_reformat);
+  boost::char_separator<char> sep(";,"); // Delimiters are semicolon and comma
+  boost::tokenizer<boost::char_separator<char>> tokens(opt_reformat, sep);
+
+  for (const auto& t : tokens) {
+    std::string_view sv(t);
+    sv.remove_prefix(std::min(sv.find_first_not_of(" \t\n\r\f\v"), sv.size()));
+    int pri = -1;
+    if (sv.starts_with("recompress")) {
+      pri = OnodeReformatContext::RECOMPRESS_ENGINE;
+    } else if (sv.starts_with("defragment")) {
+      pri = OnodeReformatContext::DEFRAGMENT_ENGINE;
+    }
+    ceph_assert(pri < OnodeReformatContext::MAX_ENGINES);
+    if (pri >= 0) {
+      reformat_ctx.maybe_enable_engine(pri, sv);
+    }
+  }
+}
+
+void BlueStore::_maybe_do_reformat_onode(OnodeReformatContext& reformat_ctx,
+  Collection* c, OnodeRef& o,
+  uint64_t offset, size_t length,
+  const bufferlist& bl,
+  uint32_t op_flags)
+{
+  // do reformat if
+  // - reformat preapproved
+  // - object isn't cached (meaning it's not being written at the moment),
+  // - and there are no shared blobs within the span as this might increase
+  //   used space.
+  const auto& span_stat = reformat_ctx.get_span_stats(); // just make an alias
+  if (reformat_ctx.is_enabled() && span_stat.cached == 0 && span_stat.allocated_shared == 0) {
+    auto start2 = mono_clock::now();
+    // will probably need write context, make an alias for the one from
+    // reformat ctx
+    auto& wctx = reformat_ctx.get_write_context();
+    _choose_write_options(c, o, op_flags, &wctx);
+
+    dout(25) << __func__ << " span stat {" << span_stat << "}" << dendl;
+    _dump_onode<25>(cct, *o);
+
+    reformat_ctx.exec_engines();
+    if (reformat_ctx.is_applied()) {
+      _txc_exec_reformat_write(c, o, offset, length, bl, wctx);
+    }
+    log_latency(__func__,
+      l_bluestore_reformat_lat,
+      mono_clock::now() - start2,
+      cct->_conf->bluestore_log_op_age);
+  } else {
+    dout(15) << __func__ << " skipping reformat:"
+     << reformat_ctx.is_enabled() << " "
+     << span_stat.cached << " "
+     << span_stat.allocated_shared << " "
+     << dendl;
+  }
+}
+
 int BlueStore::read(
-  CollectionHandle &c_,
+  CollectionHandle &ch,
   const ghobject_t& oid,
   uint64_t offset,
   size_t length,
   bufferlist& bl,
   uint32_t op_flags)
 {
-  auto start = mono_clock::now();
-  Collection *c = static_cast<Collection *>(c_.get());
+  Collection *c = static_cast<Collection *>(ch.get());
   const coll_t &cid = c->get_cid();
   dout(15) << __func__ << " " << cid << " " << oid
-	   << " 0x" << std::hex << offset << "~" << length << std::dec
-	   << dendl;
+	   << " 0x" << std::hex << offset << "~" << length
+	   << " flags 0x" << op_flags
+	   << std::dec << dendl;
   if (!c->exists)
     return -ENOENT;
 
-  bl.clear();
+  OnodeReformatContext reformat_ctx;
+  auto basic_validate_reformat = [&](std::string_view args) ->bool {
+    bool will_reformat = false;
+    if (op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
+      // for the sake of simplicity do not apply data reformatting to reads
+      // unaligned at the beginning. Having unaligned tail is OK.
+      will_reformat = p2nphase(offset, min_alloc_size) == 0;
+      if (!will_reformat) {
+	dout(15) << "reformat '" << args << "'"
+	  << " skipped due to unaligned read bounds "
+	  << p2nphase(offset, min_alloc_size) << " "
+	  << p2nphase(offset + length, min_alloc_size)
+	  << dendl;
+      } else {
+	dout(15) << "reformat '" << args << "'"
+	  << " enabled "
+	  << dendl;
+      }
+    }
+    return will_reformat;
+  };
+  auto exec_recompress = [&](std::string_view args) -> bool {
+    const auto& span_stat = reformat_ctx.get_span_stats();
+    auto& wctx = reformat_ctx.get_write_context();
+    bool will_do = wctx.compress && span_stat.allocated > 0;
+    if (will_do) {
+      uint64_t need = 0;
+      auto bl_it = bl.begin();
+      uint64_t offs = offset;
+      uint64_t old_allocated = span_stat.allocated + span_stat.allocated_compressed;
+      while (bl_it != bl.end()) {
+
+	BlobRef blob = c->new_blob();
+	bufferlist from_bl;
+	uint64_t l = std::min(wctx.target_blob_size, uint64_t(bl_it.get_remaining()));
+	uint64_t res_len = l;
+	if (l >= min_alloc_size) {
+	  l = p2align(l, min_alloc_size);
+	  bl_it.copy(l, from_bl);
+
+	  //FIXME: add zero detection
+	  auto& wi = wctx.write(offs, blob, l, 0, from_bl, 0, l, false, true);
+
+	  res_len = from_bl.length();
+	  if (l > min_alloc_size &&
+	    wctx.compressor->compress(from_bl, wi.compressed_bl, wi.compressor_message) == 0) {
+
+	    res_len = wi.compressed_bl.length();
+	    // don't set wi.compress_len and wi.compressed as this is redundant
+	    // at this point, to be assigned in _do_alloc_write if needed.
+	  }
+	  dout(20) << " reformat: " << " precompress : 0x"
+	    << std::hex << offs << "~" << l << "->" << res_len
+	    << std::dec << " " << *blob
+	    << dendl;
+	} else {
+	  bl_it += l;
+	  dout(20) << " reformat: " << " precompress : 0x"
+	    << std::hex << offs << "~" << l << "-> remaining tail"
+	    << dendl;
+	}
+	need += p2roundup(res_len, min_alloc_size);
+	offs += l;
+	will_do = need < old_allocated;
+      }
+
+      // At this point will_do indicates if we definitely want recompression,
+      // will skip the remaining reformatting then.
+
+      // Keep compressed blobs until final processing no matter if we decided to
+      // enforce recompression or not. In the latter case they can be chosen
+      // for different engine optimization(s) or be rejected prior to writing out.
+      wctx.precompressed = true;
+      dout(10) << " reformat:'" << args << "'"
+	<< " need 0x"
+	<< std::hex << need << " vs. old_allocated 0x" << old_allocated << std::dec
+	<< " apply: " << will_do
+	<< dendl;
+
+      logger->inc(l_bluestore_reformat_compress_attempted);
+      if (!will_do)
+	logger->inc(l_bluestore_reformat_compress_omitted);
+    }
+    return will_do;
+  };
+  auto exec_defragment = [&](std::string_view args) -> bool {
+    bool will_do = false;
+    const auto& span_stat = reformat_ctx.get_span_stats();
+    auto need = p2roundup(length, min_alloc_size);
+    size_t frags = 0;
+    int64_t preallocated = 0;
+    if (span_stat.frags > 1) {
+      logger->inc(l_bluestore_reformat_defragment_attempted);
+      PExtentVector prealloc;
+      prealloc.reserve(need / min_alloc_size + 1);
+      auto start = mono_clock::now();
+      preallocated = alloc->allocate(
+	need, min_alloc_size, need,
+	0, &prealloc);
+      log_latency("allocator@_prepare_reformat",
+	l_bluestore_allocator_lat,
+	mono_clock::now() - start,
+	cct->_conf->bluestore_log_op_age);
+      will_do = preallocated >= (int64_t)need && prealloc.size() < span_stat.frags;
+      if (will_do) {
+	frags = prealloc.size();
+	reformat_ctx.setup_allocations(alloc, std::move(prealloc), preallocated);
+      } else {
+	logger->inc(l_bluestore_reformat_defragment_omitted);
+      }
+    }
+    dout(10) << " reformat:'" << args << "'"
+      << " preallocated: 0x" << std::hex << preallocated << std::dec
+      << " old frags:" << span_stat.frags
+      << " new frags:" << frags
+      << " apply: " << will_do
+      << dendl;
+    return will_do;
+  };
+
+  const std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES>
+    engines = {
+      OnodeReformatEngine(basic_validate_reformat, exec_recompress),
+      OnodeReformatEngine(basic_validate_reformat, exec_defragment),
+    };
+  reformat_ctx.setup_engines(engines);
+
+  return _do_read(c, oid, offset, length, bl, op_flags, reformat_ctx);
+}
+
+int BlueStore::_do_read(Collection* c,
+			const ghobject_t& oid,
+			uint64_t offset,
+			size_t length,
+			bufferlist& bl,
+			uint32_t op_flags,
+			OnodeReformatContext& reformat_ctx)
+{
   int r;
+  auto start = mono_clock::now();
+  _maybe_need_reformat_onode(reformat_ctx, c);
   {
-    std::shared_lock l(c->lock);
+    std::shared_lock slock(c->lock, std::defer_lock);
+    std::unique_lock ulock(c->lock, std::defer_lock);
+    if (reformat_ctx.is_enabled()) {
+      ulock.lock();
+    } else {
+      slock.lock();
+    }
+
     auto start1 = mono_clock::now();
     OnodeRef o = c->get_onode(oid, false);
     log_latency("get_onode@read",
@@ -12851,21 +13180,34 @@ int BlueStore::read(
       mono_clock::now() - start1,
       cct->_conf->bluestore_log_op_age,
       "", l_bluestore_slow_read_onode_meta_count);
-    if (!o || !o->exists) {
+    if (o && o->exists) {
+      if (offset == length && offset == 0)
+	length = o->onode.size;
+
+      r = _do_basic_read(c, o, offset, length, bl, op_flags, 0,
+	reformat_ctx.is_enabled() ? &reformat_ctx.access_span_stats() : nullptr);
+      if (r == -EIO) {
+	logger->inc(l_bluestore_read_eio);
+      }
+      if (op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
+	log_latency_scrub(__func__,
+	  l_bluestore_read_lat,
+	  mono_clock::now() - start,
+	  cct->_conf->bluestore_log_scrub_op_age);
+      } else {
+	log_latency(__func__,
+	  l_bluestore_read_lat,
+	  mono_clock::now() - start,
+	  cct->_conf->bluestore_log_op_age);
+      }
+      if (r >= 0) {
+        _maybe_do_reformat_onode(reformat_ctx, c, o, offset, length, bl, op_flags);
+      }
+    } else {
       r = -ENOENT;
-      goto out;
-    }
-
-    if (offset == length && offset == 0)
-      length = o->onode.size;
-
-    r = _do_read(c, o, offset, length, bl, op_flags);
-    if (r == -EIO) {
-      logger->inc(l_bluestore_read_eio);
     }
   }
 
- out:
   if (r >= 0 && _debug_data_eio(oid)) {
     r = -EIO;
     derr << __func__ << " " << c->cid << " " << oid << " INJECT EIO" << dendl;
@@ -12876,21 +13218,9 @@ int BlueStore::read(
     dout(0) << __func__ << ": inject random EIO" << dendl;
     r = -EIO;
   }
-  dout(10) << __func__ << " " << cid << " " << oid
+  dout(10) << __func__ << " " << c->cid << " " << oid
 	   << " 0x" << std::hex << offset << "~" << length << std::dec
 	   << " = " << r << dendl;
-
-  if (op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
-    log_latency_scrub(__func__,
-      l_bluestore_read_lat,
-      mono_clock::now() - start,
-      cct->_conf->bluestore_log_scrub_op_age);
-  } else {
-    log_latency(__func__,
-      l_bluestore_read_lat,
-      mono_clock::now() - start,
-      cct->_conf->bluestore_log_op_age);
-  }
   return r;
 }
 
@@ -12900,11 +13230,15 @@ void BlueStore::_read_cache(
   size_t length,
   int read_cache_policy,
   ready_regions_t& ready_regions,
-  blobs2read_t& blobs2read)
+  blobs2read_t& blobs2read,
+  span_stat_t* res_span_stat)
 {
   // build blob-wise list to of stuff read (that isn't cached)
   unsigned left = length;
   uint64_t pos = offset;
+  span_stat_t dummy_span_stat;
+  span_stat_t& span_stat = res_span_stat ? *res_span_stat : dummy_span_stat;
+  span_stat.stored = length;
   auto lp = o->extent_map.seek_lextent(offset);
   while (left > 0 && lp != o->extent_map.extent_map.end()) {
     if (pos < lp->logical_offset) {
@@ -12916,7 +13250,9 @@ void BlueStore::_read_cache(
                << std::dec << dendl;
       pos += hole;
       left -= hole;
+      span_stat.stored -= hole;
     }
+    span_stat.extents++;
     BlobRef& bptr = lp->blob;
     unsigned l_off = pos - lp->logical_offset;
     unsigned b_off = l_off + lp->blob_offset;
@@ -12940,7 +13276,8 @@ void BlueStore::_read_cache(
           pc->first == pos) {
         l = pc->second.length();
         ready_regions[pos] = std::move(pc->second);
-        dout(30) << __func__ << "    use cache 0x" << std::hex << pos << ": 0x"
+	span_stat.cached += l;
+	dout(30) << __func__ << "    use cache 0x" << std::hex << pos << ": 0x"
                  << pos << "~" << l << std::dec << dendl;
         ++pc;
       } else {
@@ -12989,18 +13326,38 @@ void BlueStore::_read_cache(
     }
     ++lp;
   }
+  span_stat.stored -= left; // finally adjust if we haven't seen the full length
 }
 
 int BlueStore::_prepare_read_ioc(
   blobs2read_t& blobs2read,
   vector<bufferlist>* compressed_blob_bls,
-  IOContext* ioc)
+  IOContext* ioc,
+  span_stat_t* res_span_stat)
 {
+  span_stat_t dummy_span_stat;
+  span_stat_t& span_stat = res_span_stat ? *res_span_stat : dummy_span_stat;
+  interval_set<uint64_t> pintervals; // need to accumulate pextents in this set
+                                     // to get them sorted by offset and merged
+				     // into larger intervals if possible.
   for (auto& p : blobs2read) {
     const BlobRef& bptr = p.first;
     regions2read_t& r2r = p.second;
     dout(20) << __func__ << "  blob " << *bptr << " need "
              << r2r << dendl;
+    SharedBlobRef sb;
+    bool has_shared = false;
+    if (bptr->get_blob().is_shared() && res_span_stat) {
+      sb = bptr->get_shared_blob();
+      bptr->collection->load_shared_blob(sb);
+      has_shared = true;
+    }
+    auto shared_cb = [&](uint64_t o, uint32_t len, uint32_t refs) {
+       if (refs > 1) {
+         span_stat.allocated_shared += len;
+       }
+       return 0;
+    };
     if (bptr->get_blob().is_compressed()) {
       // read the whole thing
       if (compressed_blob_bls->empty()) {
@@ -13009,9 +13366,18 @@ int BlueStore::_prepare_read_ioc(
       }
       compressed_blob_bls->push_back(bufferlist());
       bufferlist& bl = compressed_blob_bls->back();
+      auto on_disk_size = bptr->get_blob().get_ondisk_size();
+      span_stat.stored_compressed += bptr->get_blob().get_logical_length();
+      span_stat.allocated_compressed += on_disk_size;
       auto r = bptr->get_blob().map(
-        0, bptr->get_blob().get_ondisk_size(),
+        0, on_disk_size,
         [&](uint64_t offset, uint64_t length) {
+	  if (res_span_stat) {
+	    pintervals.insert(offset, length);
+	    if (has_shared) {
+	      sb->map_fn(offset, length, shared_cb);
+	    }
+	  }
           int r = bdev->aio_read(offset, length, &bl, ioc);
           if (r < 0)
             return r;
@@ -13036,10 +13402,17 @@ int BlueStore::_prepare_read_ioc(
                  << dendl;
 
         // read it
-        auto r = bptr->get_blob().map(
+	span_stat.allocated += req.r_len;
+	auto r = bptr->get_blob().map(
           req.r_off, req.r_len,
           [&](uint64_t offset, uint64_t length) {
-            int r = bdev->aio_read(offset, length, &req.bl, ioc);
+	    if (res_span_stat) {
+	      pintervals.insert(offset, length);
+	      if (has_shared) {
+		sb->map_fn(offset, length, shared_cb);
+	      }
+	    }
+	    int r = bdev->aio_read(offset, length, &req.bl, ioc);
             if (r < 0)
               return r;
             return 0;
@@ -13057,6 +13430,7 @@ int BlueStore::_prepare_read_ioc(
       }
     }
   }
+  span_stat.frags += pintervals.num_intervals();
   return 0;
 }
 
@@ -13202,14 +13576,15 @@ void BlueStore::_measure_static_frag(
   logger->tinc_with_max(l_bluestore_static_frag_lat, finish - start);
 }
 
-int BlueStore::_do_read(
+int BlueStore::_do_basic_read(
   Collection *c,
   OnodeRef& o,
   uint64_t offset,
   size_t length,
   bufferlist& bl,
   uint32_t op_flags,
-  uint64_t retry_count)
+  uint64_t retry_count,
+  span_stat_t* span_stat)
 {
   FUNCTRACE(cct);
   int r = 0;
@@ -13260,7 +13635,7 @@ int BlueStore::_do_read(
   // build blob-wise list to of stuff read (that isn't cached)
   ready_regions_t ready_regions;
   blobs2read_t blobs2read;
-  _read_cache(o, offset, length, read_cache_policy, ready_regions, blobs2read);
+  _read_cache(o, offset, length, read_cache_policy, ready_regions, blobs2read, span_stat);
 
 
   // read raw blob data.
@@ -13269,7 +13644,7 @@ int BlueStore::_do_read(
                              // The error isn't that much...
   vector<bufferlist> compressed_blob_bls;
   IOContext ioc(cct, NULL, !cct->_conf->bluestore_fail_eio);
-  r = _prepare_read_ioc(blobs2read, &compressed_blob_bls, &ioc);
+  r = _prepare_read_ioc(blobs2read, &compressed_blob_bls, &ioc, span_stat);
   // we always issue aio for reading, so errors other than EIO are not allowed
   if (r < 0)
     return r;
@@ -13333,7 +13708,7 @@ int BlueStore::_do_read(
     if (retry_count >= cct->_conf->bluestore_retry_disk_reads) {
       return -EIO;
     }
-    return _do_read(c, o, offset, length, bl, op_flags, retry_count + 1);
+    return _do_basic_read(c, o, offset, length, bl, op_flags, retry_count + 1);
   }
   r = bl.length();
   if (retry_count) {
@@ -13354,7 +13729,7 @@ void inline BlueStore::_do_read_and_pad(
   uint32_t length,
   ceph::buffer::list& bl)
 {
-  int r = _do_read(c, o, offset, length, bl, 0);
+  int r = _do_basic_read(c, o, offset, length, bl, 0);
   ceph_assert(r >= 0 && r <= (int)length);
   size_t zlen = length - r;
   if (zlen > 0) {
@@ -13677,9 +14052,10 @@ int BlueStore::_do_readv(
   for (auto p = m.begin(); p != m.end(); p++, i++) {
     raw_results.push_back({});
     _read_cache(o, p.get_start(), p.get_len(), read_cache_policy,
-                std::get<0>(raw_results[i]), std::get<2>(raw_results[i]));
-    r = _prepare_read_ioc(std::get<2>(raw_results[i]), &std::get<1>(raw_results[i]), &ioc);
-    // we always issue aio for reading, so errors other than EIO are not allowed
+                std::get<0>(raw_results[i]), std::get<2>(raw_results[i]),
+		nullptr);
+    r = _prepare_read_ioc(std::get<2>(raw_results[i]), &std::get<1>(raw_results[i]),
+                          &ioc, nullptr);
     if (r < 0)
       return r;
     if (cct->_conf->bluestore_frag_runtime) {
@@ -16554,7 +16930,38 @@ void BlueStore::_txc_add_transaction(TransContext *txc, Transaction *t)
   }
 }
 
+void BlueStore::_txc_exec_reformat_write(Collection* c,  OnodeRef o,
+  uint64_t offset, size_t length, const bufferlist& bl,
+  WriteContext& wctx)
+{
+  dout(10) << __func__ << " " << o->oid
+           << std::hex << " 0x" << offset << "~" << length
+	   << std::dec << dendl;
+  TransContext* txc =
+    _txc_create(c, c->osr.get(), nullptr);
+  txc->bytes += length;
 
+  // initialize osd_pool_id and do a smoke test that all collections belong
+  // to the same pool
+  ceph_assert(!!c);
+  spg_t pgid;
+  if (c->cid.is_pg(&pgid) ) {
+    txc->osd_pool_id = pgid.pool();
+  }
+  // object operations
+  ceph_assert(o->exists);
+  int r = _do_write(txc, txc->ch, o, offset, length, bl, wctx);
+
+  if (r < 0) {
+    dout(5) << __func__ << " got an error: " << cpp_strerror(r) << dendl;
+    txc->osr->undo_queue(txc);
+    delete txc;
+  } else {
+    txc->write_onode(o);
+    logger->inc(l_bluestore_reformat_issued);
+    _txc_exec(txc, nullptr);
+  }
+}
 
 // -----------------
 // write operations
@@ -16638,7 +17045,7 @@ void BlueStore::_do_write_small(
     CollectionRef &c,
     OnodeRef& o,
     uint64_t offset, uint64_t length,
-    bufferlist::iterator& blp,
+    bufferlist::const_iterator& blp,
     WriteContext *wctx)
 {
   dout(10) << __func__ << " 0x" << std::hex << offset << "~" << length
@@ -16850,7 +17257,7 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
 		   << " and tail 0x" << tail_read << std::dec << dendl;
 	  if (head_read) {
 	    bufferlist head_bl;
-	    int r = _do_read(c.get(), o, offset - head_pad - head_read, head_read,
+	    int r = _do_basic_read(c.get(), o, offset - head_pad - head_read, head_read,
 			     head_bl, 0);
 	    ceph_assert(r >= 0 && r <= (int)head_read);
 	    size_t zlen = head_read - r;
@@ -16864,7 +17271,7 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
 	  }
 	  if (tail_read) {
 	    bufferlist tail_bl;
-	    int r = _do_read(c.get(), o, offset + length + tail_pad, tail_read,
+	    int r = _do_basic_read(c.get(), o, offset + length + tail_pad, tail_read,
 			     tail_bl, 0);
 	    ceph_assert(r >= 0 && r <= (int)tail_read);
 	    size_t zlen = tail_read - r;
@@ -17105,14 +17512,14 @@ void BlueStore::_do_write_big_apply_deferred(
     CollectionRef& c,
     OnodeRef& o,
     BlueStore::BigDeferredWriteContext& dctx,
-    bufferlist::iterator& blp,
+    bufferlist::const_iterator& blp,
     WriteContext* wctx)
 {
   bufferlist bl;
   dout(20) << __func__ << "  reading head 0x" << std::hex << dctx.head_read
     << " and tail 0x" << dctx.tail_read << std::dec << dendl;
   if (dctx.head_read) {
-    int r = _do_read(c.get(), o,
+    int r = _do_basic_read(c.get(), o,
       dctx.off - dctx.head_read,
       dctx.head_read,
       bl,
@@ -17129,7 +17536,7 @@ void BlueStore::_do_write_big_apply_deferred(
 
   if (dctx.tail_read) {
     bufferlist tail_bl;
-    int r = _do_read(c.get(), o,
+    int r = _do_basic_read(c.get(), o,
       dctx.off + dctx.used, dctx.tail_read,
       tail_bl, 0);
     ceph_assert(r >= 0 && r <= (int)dctx.tail_read);
@@ -17168,7 +17575,7 @@ void BlueStore::_do_write_big(
     CollectionRef &c,
     OnodeRef& o,
     uint64_t offset, uint64_t length,
-    bufferlist::iterator& blp,
+    bufferlist::const_iterator& blp,
     WriteContext *wctx)
 {
   dout(10) << __func__ << " 0x" << std::hex << offset << "~" << length
@@ -17177,6 +17584,12 @@ void BlueStore::_do_write_big(
 	   << dendl;
   logger->inc(l_bluestore_write_big);
   logger->inc(l_bluestore_write_big_bytes, length);
+  if (wctx->precompressed) {
+    dout(20) << __func__ << " has been precompressed, omitting." << dendl;
+    o->extent_map.punch_hole(c, offset, length, &wctx->old_extents);
+    blp += length;
+    return;
+  }
   auto max_bsize = std::max(wctx->target_blob_size, min_alloc_size);
   uint64_t prefer_deferred_size_snapshot = prefer_deferred_size.load();
   while (length > 0) {
@@ -17186,7 +17599,7 @@ void BlueStore::_do_write_big(
     uint32_t l = 0;
 
     //attempting to reuse existing blob
-    if (!wctx->compress && !wctx->full_write) {
+    if (!wctx->compress && !wctx->full_write && !wctx->preallocated()) {
       // enforce target blob alignment with max_bsize
       l = max_bsize - p2phase(offset, max_bsize);
       l = std::min(uint64_t(l), length);
@@ -17339,10 +17752,10 @@ void BlueStore::_do_write_big(
 	}
       } while (b == nullptr && any_change);
     } else {
-      // trying to utilize as longer chunk as permitted in case of compression.
+      // trying to utilize as longer chunk as permitted in case of compression/reformatting.
       l = std::min(max_bsize, length);
       o->extent_map.punch_hole(c, offset, l, &wctx->old_extents);
-    } // if (!wctx->compress)
+    } // if (!wctx->compress && !wctx->preallocated)
 
     if (b == nullptr) {
       b = c->new_blob();
@@ -17408,20 +17821,25 @@ int BlueStore::_do_alloc_write(
 
   auto max_bsize = std::max(wctx->target_blob_size, min_alloc_size);
   for (auto& wi : wctx->writes) {
+    wi.compressed = false; // unsetting now to indicate actual status at the end
     if (wctx->compressor && wi.blob_length > min_alloc_size) {
       auto start = mono_clock::now();
-
       // compress
       ceph_assert(wi.b_off == 0);
       ceph_assert(wi.blob_length == wi.bl.length());
 
       // FIXME: memory alignment here is bad
       bufferlist t;
-      std::optional<int32_t> compressor_message;
-      int r = wctx->compressor->compress(wi.bl, t, compressor_message);
+      int r = 0;
+      if (!wctx->precompressed) {
+        r = wctx->compressor->compress(wi.bl, t, wi.compressor_message);
+      } else {
+        std::swap(t, wi.compressed_bl);
+      }
+
       uint64_t want_len_raw = wi.blob_length * wctx->crr;
       uint64_t want_len = p2roundup(want_len_raw, min_alloc_size);
-      bool rejected = false;
+      bool rejected = true;
       uint64_t compressed_len = t.length();
       // do an approximate (fast) estimation for resulting blob size
       // that doesn't take header overhead  into account
@@ -17429,8 +17847,8 @@ int BlueStore::_do_alloc_write(
       if (r == 0 && result_len <= want_len && result_len < wi.blob_length) {
 	bluestore_compression_header_t chdr;
 	chdr.type = wctx->compressor->get_type();
-	chdr.length = t.length();
-	chdr.compressor_message = compressor_message;
+	chdr.length = compressed_len;
+	chdr.compressor_message = wi.compressor_message;
 	encode(chdr, wi.compressed_bl);
 	wi.compressed_bl.claim_append(t);
 
@@ -17453,8 +17871,7 @@ int BlueStore::_do_alloc_write(
 	  logger->inc(l_bluestore_compress_success_count);
 	  need += result_len;
 	  data_size += result_len;
-	} else {
-	  rejected = true;
+	  rejected = false;
 	}
       } else if (r != 0) {
 	dout(5) << __func__ << std::hex << "  0x" << wi.blob_length
@@ -17463,63 +17880,86 @@ int BlueStore::_do_alloc_write(
 		 << " failed with errcode = " << r
 		 << ", leaving uncompressed"
 		 << dendl;
-	logger->inc(l_bluestore_compress_rejected_count);
-	need += wi.blob_length;
-	data_size += wi.bl.length();
-      } else {
-	rejected = true;
       }
 
-      if (rejected) {
+      if (r == 0 && rejected) {
 	dout(20) << __func__ << std::hex << "  0x" << wi.blob_length
-		 << " compressed to 0x" << compressed_len << " -> 0x" << result_len
-		 << " with " << wctx->compressor->get_type()
-		 << ", which is more than required 0x" << want_len_raw
-		 << " -> 0x" << want_len
-		 << ", leaving uncompressed"
-		 << std::dec << dendl;
+	  << " compressed to 0x" << compressed_len << " -> 0x" << result_len
+	  << " with " << wctx->compressor->get_type()
+	  << ", which is more than required 0x" << want_len_raw
+	  << " -> 0x" << want_len
+	  << ", leaving uncompressed"
+	  << std::dec << dendl;
 	logger->inc(l_bluestore_compress_rejected_count);
-	need += wi.blob_length;
-	data_size += wi.bl.length();
       }
-      log_latency("compress@_do_alloc_write",
-	l_bluestore_compress_lat,
-        mono_clock::now() - start,
-	cct->_conf->bluestore_log_op_age );
-    } else {
+
+      if (!wctx->precompressed) {
+        log_latency("compress@_do_alloc_write",
+	  l_bluestore_compress_lat,
+          mono_clock::now() - start,
+	  cct->_conf->bluestore_log_op_age );
+      }
+    }
+    if (!wi.compressed) {
       need += wi.blob_length;
       data_size += wi.bl.length();
+      wi.compressed_bl.clear();
+      wi.compressed_len = 0;
     }
   }
-  PExtentVector prealloc;
-  prealloc.reserve(2 * wctx->writes.size());
-  int64_t prealloc_left = 0;
-  auto start = mono_clock::now();
-  prealloc_left = alloc->allocate(
-    need, min_alloc_size, need,
-    use_last_allocator_lookup_position ? -1 : 0,
-    &prealloc);
-  log_latency("allocator@_do_alloc_write",
-    l_bluestore_allocator_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
-  if (prealloc_left < 0 || prealloc_left < (int64_t)need) {
-    derr << __func__ << " failed to allocate 0x" << std::hex << need
-         << " allocated 0x " << (prealloc_left < 0 ? 0 : prealloc_left)
-         << " min_alloc_size 0x" << min_alloc_size
-         << " available 0x " << alloc->get_free()
+  auto need0 = need;
+  PExtentVector pextents;
+  pextents.reserve(2 * wctx->writes.size());
+  uint64_t preallocated = 0;
+
+  if (!wctx->prealloc_slicer.end()) {
+    preallocated = wctx->prealloc_slicer.slice(pextents, need);
+    dout(20) << __func__ << " using wxtx prealloc, consumed 0x"
+      << std::hex << preallocated
+      << ", needed 0x " << need
+      << std::dec << dendl;
+    ceph_assert(preallocated <= need);
+    need -= preallocated;
+  }
+
+  int64_t allocated = 0;
+  if (need > 0)  {
+    auto start = mono_clock::now();
+    allocated = alloc->allocate(
+      need, min_alloc_size, need,
+      use_last_allocator_lookup_position ? -1 : 0,
+      &pextents);
+    log_latency("allocator@_do_alloc_write",
+      l_bluestore_allocator_lat,
+      mono_clock::now() - start,
+      cct->_conf->bluestore_log_op_age);
+    if (allocated < (int64_t)need) {
+      derr << __func__ << " failed to allocate 0x" << std::hex << need
+	<< " allocated 0x " << (allocated < 0 ? 0 : allocated)
+	<< " min_alloc_size 0x" << min_alloc_size
+	<< " available 0x " << alloc->get_free()
+	<< std::dec << dendl;
+      allocated = 0;
+    }
+  }
+  if (preallocated + allocated < need0) {
+    derr << __func__ << " failed to get 0x" << std::hex << need0
+         << ", preallocated = 0x" << preallocated
+         << ", allocated = 0x" << allocated
          << std::dec << dendl;
-    if (prealloc.size()) {
-      alloc->release(prealloc);
+    if (pextents.size()) {
+      alloc->release(pextents);
     }
     return -ENOSPC;
   }
-  _collect_allocation_stats(need, min_alloc_size, prealloc);
+  _collect_allocation_stats(need, min_alloc_size, pextents);
 
   dout(20) << __func__ << std::hex << " need=0x" << need << " data=0x" << data_size
-	   << " prealloc " << prealloc << dendl;
-  auto prealloc_pos = prealloc.begin();
-  ceph_assert(prealloc_pos != prealloc.end());
+	   << " prealloc " << pextents << dendl;
+
+  int64_t prealloc_left = allocated + preallocated;
+  auto prealloc_pos = pextents.begin();
+  ceph_assert(prealloc_pos != pextents.end());
 
   for (auto& wi : wctx->writes) {
     bluestore_blob_t& dblob = wi.b->dirty_blob();
@@ -17663,7 +18103,7 @@ int BlueStore::_do_alloc_write(
       }
     }
   }
-  ceph_assert(prealloc_pos == prealloc.end());
+  ceph_assert(prealloc_pos == pextents.end());
   ceph_assert(prealloc_left == 0);
   return 0;
 }
@@ -17740,11 +18180,11 @@ void BlueStore::_do_write_data(
   OnodeRef& o,
   uint64_t offset,
   uint64_t length,
-  bufferlist& bl,
+  const bufferlist& bl,
   WriteContext *wctx)
 {
   uint64_t end = offset + length;
-  bufferlist::iterator p = bl.begin();
+  bufferlist::const_iterator p = bl.cbegin();
 
   wctx->full_write = offset == 0 && length >= o->onode.size;
 
@@ -17791,7 +18231,7 @@ void BlueStore::_do_write_data(
 }
 
 void BlueStore::_choose_write_options(
-   CollectionRef& c,
+   Collection* c,
    OnodeRef& o,
    uint32_t fadvise_flags,
    WriteContext *wctx)
@@ -17907,7 +18347,7 @@ int BlueStore::_do_gc(
     dout(20) << __func__ << " processing " << std::hex
             << offset << "~" << length << std::dec
 	    << dendl;
-    int r = _do_read(c.get(), o, offset, length, bl, 0);
+    int r = _do_basic_read(c.get(), o, offset, length, bl, 0);
     ceph_assert(r == (int)length);
 
     _do_write_data(txc, c, o, offset, length, bl, &wctx_gc);
@@ -17945,8 +18385,8 @@ int BlueStore::_do_write(
   OnodeRef& o,
   uint64_t offset,
   uint64_t length,
-  bufferlist& bl,
-  uint32_t fadvise_flags)
+  const bufferlist& bl,
+  WriteContext& wctx)
 {
   int r = 0;
 
@@ -17956,7 +18396,6 @@ int BlueStore::_do_write(
 	   << " - have 0x" << o->onode.size
 	   << " (" << std::dec << o->onode.size << ")"
 	   << " bytes" << std::hex
-	   << " fadvise_flags 0x" << fadvise_flags
 	   << " alloc_hint 0x" << o->onode.alloc_hint_flags
            << " expected_object_size " << o->onode.expected_object_size
            << " expected_write_size " << o->onode.expected_write_size
@@ -17975,8 +18414,6 @@ int BlueStore::_do_write(
   auto dirty_start = offset;
   auto dirty_end = end;
 
-  WriteContext wctx;
-  _choose_write_options(c, o, fadvise_flags, &wctx);
   o->extent_map.fault_range(db, offset, length);
   _do_write_data(txc, c, o, offset, length, bl, &wctx);
   r = _do_alloc_write(txc, c, o, &wctx);
@@ -18061,13 +18498,12 @@ int BlueStore::_do_write_v2(
   if (length == 0) {
     return 0;
   }
-
   if (bl.length() != length) {
     bl.splice(length, bl.length() - length);
   }
 
   WriteContext wctx;
-  _choose_write_options(c, o, fadvise_flags, &wctx);
+  _choose_write_options(c.get(), o, fadvise_flags, &wctx);
   if (wctx.compressor) {
     uint32_t end = offset + length;
     uint32_t segment_size = o->onode.segment_size;
@@ -18181,8 +18617,9 @@ int BlueStore::_write(TransContext *txc,
 		      uint32_t fadvise_flags)
 {
   dout(15) << __func__ << " " << c->cid << " " << o->oid
-	   << " 0x" << std::hex << offset << "~" << length << std::dec
-	   << dendl;
+	   << " 0x" << std::hex << offset << "~" << length
+           << " fadvise_flags 0x" << fadvise_flags
+	   << std::dec << dendl;
   auto start = mono_clock::now();
   int r = 0;
   if (offset + length >= OBJECT_MAX_SIZE) {
@@ -18192,7 +18629,9 @@ int BlueStore::_write(TransContext *txc,
     if (use_write_v2) {
       r = _do_write_v2(txc, c, o, offset, length, bl, fadvise_flags);
     } else {
-      r = _do_write(txc, c, o, offset, length, bl, fadvise_flags);
+      WriteContext wctx;
+      _choose_write_options(c.get(), o, fadvise_flags, &wctx);
+      r = _do_write(txc, c, o, offset, length, bl, wctx);
     }
     txc->write_onode(o);
   }
@@ -18812,10 +19251,12 @@ int BlueStore::_clone(TransContext *txc,
     _do_clone_range(txc, c, oldo, newo, 0, oldo->onode.size, 0);
   } else {
     bufferlist bl;
-    r = _do_read(c.get(), oldo, 0, oldo->onode.size, bl, 0);
+    r = _do_basic_read(c.get(), oldo, 0, oldo->onode.size, bl, 0);
     if (r < 0)
       goto out;
-    r = _do_write(txc, c, newo, 0, oldo->onode.size, bl, 0);
+    WriteContext wctx;
+    _choose_write_options(c.get(), newo, 0, &wctx);
+    r = _do_write(txc, c, newo, 0, oldo->onode.size, bl, wctx);
     if (r < 0)
       goto out;
   }
@@ -18933,10 +19374,12 @@ int BlueStore::_clone_range(TransContext *txc,
       _do_clone_range(txc, c, oldo, newo, srcoff, length, dstoff);
     } else {
       bufferlist bl;
-      r = _do_read(c.get(), oldo, srcoff, length, bl, 0);
+      r = _do_basic_read(c.get(), oldo, srcoff, length, bl, 0);
       if (r < 0)
 	goto out;
-      r = _do_write(txc, c, newo, dstoff, bl.length(), bl, 0);
+      WriteContext wctx;
+      _choose_write_options(c.get(), newo, 0, &wctx);
+      r = _do_write(txc, c, newo, dstoff, bl.length(), bl, wctx);
       if (r < 0)
 	goto out;
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11026,7 +11026,7 @@ void BlueStore::_fsck_check_objects(
           uint64_t offset = 0;
           do {
             uint64_t l = std::min(uint64_t(o->onode.size - offset), max_read_block);
-            int r = _do_basic_read(c.get(), o, offset, l, bl,
+            int r = _do_read(c.get(), o, offset, l, bl,
               CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
             if (r < 0) {
               ++errors;
@@ -12935,6 +12935,7 @@ int BlueStore::read(
   bufferlist& bl,
   uint32_t op_flags)
 {
+  auto start = mono_clock::now();
   Collection *c = static_cast<Collection *>(ch.get());
   const coll_t &cid = c->get_cid();
   dout(15) << __func__ << " " << cid << " " << oid
@@ -12943,22 +12944,14 @@ int BlueStore::read(
 	   << std::dec << dendl;
   if (!c->exists)
     return -ENOENT;
-  return _do_read(c, oid, offset, length, bl, op_flags);
-}
-
-int BlueStore::_do_read(Collection* c,
-			const ghobject_t& oid,
-			uint64_t offset,
-			size_t length,
-			bufferlist& bl,
-			uint32_t op_flags)
-{
+  bl.clear();
   int r;
-  auto start = mono_clock::now();
+
   {
     read_context_t read_ctx(*this, offset, length, bl, op_flags);
-    std::shared_lock slock(c->lock); // we need a shared lock to access
-                                     // reformat_engines from collection
+    // we need a shared lock to access
+    // reformat_engines from collection
+    std::shared_lock slock(c->lock);
     OnodeReformatContext reformat_ctx(read_ctx, c->reformat_engines);
 
     std::unique_lock ulock(c->lock, std::defer_lock);
@@ -12978,7 +12971,7 @@ int BlueStore::_do_read(Collection* c,
       if (offset == length && offset == 0)
 	length = o->onode.size;
 
-      r = _do_basic_read(c, o, offset, length, bl, op_flags, 0,
+      r = _do_read(c, o, offset, length, bl, op_flags, 0,
 	reformat_ctx.is_enabled() ? &reformat_ctx.access_span_stats() : nullptr);
       if (r == -EIO) {
 	logger->inc(l_bluestore_read_eio);
@@ -12995,7 +12988,7 @@ int BlueStore::_do_read(Collection* c,
 	  cct->_conf->bluestore_log_op_age);
       }
       if (r >= 0) {
-        _maybe_do_reformat_onode(reformat_ctx, c, o, offset, length, bl, op_flags);
+	_maybe_do_reformat_onode(reformat_ctx, c, o, offset, length, bl, op_flags);
       }
     } else {
       r = -ENOENT;
@@ -13006,15 +12999,15 @@ int BlueStore::_do_read(Collection* c,
     r = -EIO;
     derr << __func__ << " " << c->cid << " " << oid << " INJECT EIO" << dendl;
   } else if (oid.hobj.pool > 0 &&  /* FIXME, see #23029 */
-	     cct->_conf->bluestore_debug_random_read_err &&
-	     (rand() % (int)(cct->_conf->bluestore_debug_random_read_err *
-			     100.0)) == 0) {
+    cct->_conf->bluestore_debug_random_read_err &&
+    (rand() % (int)(cct->_conf->bluestore_debug_random_read_err *
+      100.0)) == 0) {
     dout(0) << __func__ << ": inject random EIO" << dendl;
     r = -EIO;
   }
   dout(10) << __func__ << " " << c->cid << " " << oid
-	   << " 0x" << std::hex << offset << "~" << length << std::dec
-	   << " = " << r << dendl;
+    << " 0x" << std::hex << offset << "~" << length << std::dec
+    << " = " << r << dendl;
   return r;
 }
 
@@ -13370,7 +13363,7 @@ void BlueStore::_measure_static_frag(
   logger->tinc_with_max(l_bluestore_static_frag_lat, finish - start);
 }
 
-int BlueStore::_do_basic_read(
+int BlueStore::_do_read(
   Collection *c,
   OnodeRef& o,
   uint64_t offset,
@@ -13502,7 +13495,7 @@ int BlueStore::_do_basic_read(
     if (retry_count >= cct->_conf->bluestore_retry_disk_reads) {
       return -EIO;
     }
-    return _do_basic_read(c, o, offset, length, bl, op_flags, retry_count + 1);
+    return _do_read(c, o, offset, length, bl, op_flags, retry_count + 1);
   }
   r = bl.length();
   if (retry_count) {
@@ -13523,7 +13516,7 @@ void inline BlueStore::_do_read_and_pad(
   uint32_t length,
   ceph::buffer::list& bl)
 {
-  int r = _do_basic_read(c, o, offset, length, bl, 0);
+  int r = _do_read(c, o, offset, length, bl, 0);
   ceph_assert(r >= 0 && r <= (int)length);
   size_t zlen = length - r;
   if (zlen > 0) {
@@ -17051,7 +17044,7 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
 		   << " and tail 0x" << tail_read << std::dec << dendl;
 	  if (head_read) {
 	    bufferlist head_bl;
-	    int r = _do_basic_read(c.get(), o, offset - head_pad - head_read, head_read,
+	    int r = _do_read(c.get(), o, offset - head_pad - head_read, head_read,
 			     head_bl, 0);
 	    ceph_assert(r >= 0 && r <= (int)head_read);
 	    size_t zlen = head_read - r;
@@ -17065,7 +17058,7 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
 	  }
 	  if (tail_read) {
 	    bufferlist tail_bl;
-	    int r = _do_basic_read(c.get(), o, offset + length + tail_pad, tail_read,
+	    int r = _do_read(c.get(), o, offset + length + tail_pad, tail_read,
 			     tail_bl, 0);
 	    ceph_assert(r >= 0 && r <= (int)tail_read);
 	    size_t zlen = tail_read - r;
@@ -17313,7 +17306,7 @@ void BlueStore::_do_write_big_apply_deferred(
   dout(20) << __func__ << "  reading head 0x" << std::hex << dctx.head_read
     << " and tail 0x" << dctx.tail_read << std::dec << dendl;
   if (dctx.head_read) {
-    int r = _do_basic_read(c.get(), o,
+    int r = _do_read(c.get(), o,
       dctx.off - dctx.head_read,
       dctx.head_read,
       bl,
@@ -17330,7 +17323,7 @@ void BlueStore::_do_write_big_apply_deferred(
 
   if (dctx.tail_read) {
     bufferlist tail_bl;
-    int r = _do_basic_read(c.get(), o,
+    int r = _do_read(c.get(), o,
       dctx.off + dctx.used, dctx.tail_read,
       tail_bl, 0);
     ceph_assert(r >= 0 && r <= (int)dctx.tail_read);
@@ -18150,7 +18143,7 @@ int BlueStore::_do_gc(
     dout(20) << __func__ << " processing " << std::hex
             << offset << "~" << length << std::dec
 	    << dendl;
-    int r = _do_basic_read(c.get(), o, offset, length, bl, 0);
+    int r = _do_read(c.get(), o, offset, length, bl, 0);
     ceph_assert(r == (int)length);
 
     _do_write_data(txc, c, o, offset, length, bl, &wctx_gc);
@@ -19054,7 +19047,7 @@ int BlueStore::_clone(TransContext *txc,
     _do_clone_range(txc, c, oldo, newo, 0, oldo->onode.size, 0);
   } else {
     bufferlist bl;
-    r = _do_basic_read(c.get(), oldo, 0, oldo->onode.size, bl, 0);
+    r = _do_read(c.get(), oldo, 0, oldo->onode.size, bl, 0);
     if (r < 0)
       goto out;
     WriteContext wctx;
@@ -19177,7 +19170,7 @@ int BlueStore::_clone_range(TransContext *txc,
       _do_clone_range(txc, c, oldo, newo, srcoff, length, dstoff);
     } else {
       bufferlist bl;
-      r = _do_basic_read(c.get(), oldo, srcoff, length, bl, 0);
+      r = _do_read(c.get(), oldo, srcoff, length, bl, 0);
       if (r < 0)
 	goto out;
       WriteContext wctx;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -16640,20 +16640,16 @@ void BlueStore::_do_write_small(
 	   << std::dec << dendl;
   ceph_assert(length < min_alloc_size);
 
-  uint64_t end_offs = offset + length;
-
   logger->inc(l_bluestore_write_small);
   logger->inc(l_bluestore_write_small_bytes, length);
 
   bufferlist bl;
   blp.copy(length, bl);
 
+  uint32_t alloc_len = min_alloc_size;
+
   auto max_bsize = std::max(wctx->target_blob_size, min_alloc_size);
   auto min_off = offset >= max_bsize ? offset - max_bsize : 0;
-  uint32_t alloc_len = min_alloc_size;
-  auto offset0 = p2align<uint64_t>(offset, alloc_len);
-
-  bool any_change;
 
   // search suitable extent in both forward and reverse direction in
   // [offset - target_max_blob_size, offset + target_max_blob_size] range
@@ -16661,6 +16657,52 @@ void BlueStore::_do_write_small(
   // direct/deferred write (the latter for extents including or higher
   // than 'offset' only).
   o->extent_map.fault_range(db, min_off, offset + max_bsize - min_off);
+
+  if (!wctx->full_write) {
+    alloc_len = _do_write_small_with_maybe_blob_reuse(txc,
+      c, o, offset, length, bl, wctx);
+  }
+  if (alloc_len) {
+    // we still need new blob allocation
+    uint64_t b_off = p2phase<uint64_t>(offset, alloc_len);
+    uint64_t b_off0 = b_off;
+    o->extent_map.punch_hole(c, offset, length, &wctx->old_extents);
+
+    // Zero detection -- small block
+    if (!cct->_conf->bluestore_zero_block_detection || !bl.is_zero()) {
+      // new blob.
+      BlobRef b = c->new_blob();
+      _pad_zeros(&bl, &b_off0, block_size);
+      wctx->write(offset, b, alloc_len, b_off0, bl, b_off, length,
+	  min_alloc_size != block_size, // use 'unused' bitmap when alloc granularity
+					// doesn't match disk one only
+	  true);
+    } else { // if (bl.is_zero())
+      dout(20) << __func__ << " skip small zero block " << std::hex
+	<< " (0x" << b_off0 << "~" << bl.length() << ")"
+	<< " (0x" << b_off << "~" << length << ")"
+	<< std::dec << dendl;
+      logger->inc(l_bluestore_write_small_skipped);
+      logger->inc(l_bluestore_write_small_skipped_bytes, length);
+    }
+  }
+}
+
+uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
+      TransContext* txc,
+      CollectionRef& c,
+      OnodeRef& o,
+      uint64_t offset, uint64_t length,
+      bufferlist& bl,
+      WriteContext* wctx)
+{
+  uint32_t alloc_len = min_alloc_size;
+  auto offset0 = p2align<uint64_t>(offset, alloc_len);
+
+  auto max_bsize = std::max(wctx->target_blob_size, min_alloc_size);
+  auto min_off = offset >= max_bsize ? offset - max_bsize : 0;
+
+  uint64_t end_offs = offset + length;
 
   // Look for an existing mutable blob we can use.
   auto begin = o->extent_map.extent_map.begin();
@@ -16689,6 +16731,7 @@ void BlueStore::_do_write_small(
   uint64_t max_off = 0;
   auto start_ep = ep;
   auto end_ep = ep; // exclusively
+  bool any_change;
   do {
     any_change = false;
 
@@ -16776,7 +16819,7 @@ void BlueStore::_do_write_small(
 	  txc->statfs_delta.stored() += le->length;
 	  dout(20) << __func__ << "  lex " << *le << dendl;
 	  logger->inc(l_bluestore_write_small_unused);
-	  return;
+	  return 0;
 	}
 	// read some data to fill out the chunk?
 	uint64_t head_read = p2phase(b_off, chunk_size);
@@ -16856,7 +16899,7 @@ void BlueStore::_do_write_small(
           b->dirty_blob().mark_used(le->blob_offset, le->length);
           txc->statfs_delta.stored() += le->length;
           dout(20) << __func__ << "  lex " << *le << dendl;
-          return;
+          return 0;
         }
         // try to reuse blob if we can
         if (b->can_reuse_blob(min_alloc_size,
@@ -16902,8 +16945,7 @@ void BlueStore::_do_write_small(
 	      logger->inc(l_bluestore_write_small_skipped);
 	      logger->inc(l_bluestore_write_small_skipped_bytes, length);
 	    }
-
-	    return;
+	    return 0;
 	  }
 	}
       }
@@ -16966,7 +17008,7 @@ void BlueStore::_do_write_small(
 	    logger->inc(l_bluestore_write_small_skipped_bytes, length);
 	  }
 
-	  return;
+	  return 0;
 	}
       } 
       if (prev_ep != begin) {
@@ -16996,29 +17038,7 @@ void BlueStore::_do_write_small(
               << std::hex << offset << "~" << length
 	      << std::dec << dendl;
   }
-  uint64_t b_off = p2phase<uint64_t>(offset, alloc_len);
-  uint64_t b_off0 = b_off;
-  o->extent_map.punch_hole(c, offset, length, &wctx->old_extents);
-
-  // Zero detection -- small block
-  if (!cct->_conf->bluestore_zero_block_detection || !bl.is_zero()) {
-    // new blob.
-    BlobRef b = c->new_blob();
-    _pad_zeros(&bl, &b_off0, block_size);
-    wctx->write(offset, b, alloc_len, b_off0, bl, b_off, length,
-	min_alloc_size != block_size, // use 'unused' bitmap when alloc granularity
-                                      // doesn't match disk one only
-	true);
-  } else { // if (bl.is_zero())
-    dout(20) << __func__ << " skip small zero block " << std::hex
-      << " (0x" << b_off0 << "~" << bl.length() << ")"
-      << " (0x" << b_off << "~" << length << ")"
-      << std::dec << dendl;
-    logger->inc(l_bluestore_write_small_skipped);
-    logger->inc(l_bluestore_write_small_skipped_bytes, length);
-  }
-
-  return;
+  return alloc_len;
 }
 
 bool BlueStore::BigDeferredWriteContext::can_defer(
@@ -17162,7 +17182,7 @@ void BlueStore::_do_write_big(
     uint32_t l = 0;
 
     //attempting to reuse existing blob
-    if (!wctx->compress) {
+    if (!wctx->compress && !wctx->full_write) {
       // enforce target blob alignment with max_bsize
       l = max_bsize - p2phase(offset, max_bsize);
       l = std::min(uint64_t(l), length);
@@ -17721,6 +17741,8 @@ void BlueStore::_do_write_data(
 {
   uint64_t end = offset + length;
   bufferlist::iterator p = bl.begin();
+
+  wctx->full_write = offset == 0 && length >= o->onode.size;
 
   if (offset / min_alloc_size == (end - 1) / min_alloc_size &&
       (length != min_alloc_size)) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9685,7 +9685,7 @@ int BlueStore::_umount_readonly()
 
 int BlueStore::_mount()
 {
-  dout(5) << __func__ << " path " << path << dendl;
+  dout(1) << __func__ << " path " << path << dendl;
 
   {
     int r = read_meta_conf_check_env();
@@ -9724,7 +9724,11 @@ int BlueStore::_mount()
     return -EINVAL;
   }
 
-  dout(5) << __func__ << "::NCB::calling open_db_and_around(read/write)" << dendl;
+  dout(1) << __func__
+          << " v2 = " << use_write_v2
+	  << " segment_size = " << segment_size
+	  << " esb = " << elastic_shared_blobs
+          << dendl;
   int r = _open_db_and_around(false);
   if (r < 0) {
     return r;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -65,6 +65,7 @@
 #include "Writer.h"
 #include "Compression.h"
 #include "BlueAdmin.h"
+#include "OnodeReformat.h"
 #include "extblkdev/ExtBlkDevPlugin.h"
 
 #if defined(WITH_LTTNG)
@@ -12936,97 +12937,9 @@ int BlueStore::set_collection_opts(
   return 0;
 }
 
-struct OnodeReformatEngine {
-  bool enabled = false;
-  std::string args;
-  std::function<bool(std::string_view)> validate = nullptr;
-  std::function<bool(std::string_view)> execute = nullptr;
-  OnodeReformatEngine() {}
-  OnodeReformatEngine(std::function<bool(std::string_view)> _validate,
-                      std::function<bool(std::string_view)> _execute) :
-    validate(_validate), execute(_execute) {
-  }
-};
-
-class OnodeReformatContext {
-public:
-  enum {
-    // This is effectively an engine priority, i.e. the order engines are called in.
-    RECOMPRESS_ENGINE = 0,
-    DEFRAGMENT_ENGINE = 1,
-    MAX_ENGINES
-  };
-private:
-
-  size_t enabled_engines_count = 0;
-  std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES> engines;
-
-  bool to_be_applied = false;
-  BlueStore::WriteContext wctx;
-  span_stat_t span_stat;
-  Allocator* alloc = nullptr;
-  PExtentVectorSlicer* prealloc_slicer = nullptr; // pointer to the one from wctx if configured
-public:
-  ~OnodeReformatContext() {
-    clear();
-  }
-  void setup_engines(const std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES>& e) {
-    engines = e;
-  }
-  void setup_allocations(Allocator* _alloc, PExtentVector&& _p, uint32_t _total) {
-    ceph_assert(!prealloc_slicer); // repetitive assignments aren't allowed
-    alloc = _alloc;
-    prealloc_slicer = &wctx.prealloc_slicer;
-    prealloc_slicer->setup(std::move(_p), _total);
-  }
-
-  bool is_enabled() const { return enabled_engines_count > 0; }
-  bool is_applied() const { return to_be_applied; }
-  BlueStore::WriteContext& get_write_context() { return wctx; }
-  span_stat_t& access_span_stats() {
-    return span_stat;
-  }
-  const span_stat_t& get_span_stats() const {
-    return span_stat;
-  }
-
-  void maybe_enable_engine(int pri, std::string_view args) {
-    ceph_assert(pri >= 0 && pri < MAX_ENGINES);
-    if (!engines[pri].enabled && engines[pri].validate(args)) {
-      engines[pri].enabled = true;
-      engines[pri].args = args;
-      enabled_engines_count++;
-    }
-  }
-  void exec_engines() {
-    int i = 0;
-    for(auto e : engines) {
-    i++;
-      if (e.enabled && e.execute(e.args)) {
-        to_be_applied = true;
-        break;
-      }
-    }
-  }
-  void clear() {
-    PExtentVector to_release;
-    if (prealloc_slicer && alloc && !prealloc_slicer->end() && prealloc_slicer->slice(to_release) > 0) {
-      alloc->release(to_release);
-    }
-    enabled_engines_count = 0;
-    for (auto e : engines) {
-      e.enabled = false;
-    }
-    to_be_applied = false;
-    wctx.reset();
-  }
-};
-
 void BlueStore::_maybe_need_reformat_onode(OnodeReformatContext& reformat_ctx,
   Collection* c)
 {
-  reformat_ctx.clear();
-
   std::string opt_reformat;
   c->pool_opts.get(pool_opts_t::DEEP_SCRUB_REFORMAT, &opt_reformat);
   boost::char_separator<char> sep(";,"); // Delimiters are semicolon and comma
@@ -13104,133 +13017,21 @@ int BlueStore::read(
   if (!c->exists)
     return -ENOENT;
 
-  OnodeReformatContext reformat_ctx;
-  auto basic_validate_reformat = [&](std::string_view args) ->bool {
-    bool will_reformat = false;
-    if (op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
-      // for the sake of simplicity do not apply data reformatting to reads
-      // unaligned at the beginning. Having unaligned tail is OK.
-      will_reformat = p2nphase(offset, min_alloc_size) == 0;
-      if (!will_reformat) {
-	dout(15) << "reformat '" << args << "'"
-	  << " skipped due to unaligned read bounds "
-	  << p2nphase(offset, min_alloc_size) << " "
-	  << p2nphase(offset + length, min_alloc_size)
-	  << dendl;
-      } else {
-	dout(15) << "reformat '" << args << "'"
-	  << " enabled "
-	  << dendl;
-      }
-    }
-    return will_reformat;
-  };
-  auto exec_recompress = [&](std::string_view args) -> bool {
-    const auto& span_stat = reformat_ctx.get_span_stats();
-    auto& wctx = reformat_ctx.get_write_context();
-    bool will_do = wctx.compress && span_stat.allocated > 0;
-    if (will_do) {
-      uint64_t need = 0;
-      auto bl_it = bl.begin();
-      uint64_t offs = offset;
-      uint64_t old_allocated = span_stat.allocated + span_stat.allocated_compressed;
-      while (bl_it != bl.end()) {
-
-	BlobRef blob = c->new_blob();
-	bufferlist from_bl;
-	uint64_t l = std::min(wctx.target_blob_size, uint64_t(bl_it.get_remaining()));
-	uint64_t res_len = l;
-	if (l >= min_alloc_size) {
-	  l = p2align(l, min_alloc_size);
-	  bl_it.copy(l, from_bl);
-
-	  //FIXME: add zero detection
-	  auto& wi = wctx.write(offs, blob, l, 0, from_bl, 0, l, false, true);
-
-	  res_len = from_bl.length();
-	  if (l > min_alloc_size &&
-	    wctx.compressor->compress(from_bl, wi.compressed_bl, wi.compressor_message) == 0) {
-
-	    res_len = wi.compressed_bl.length();
-	    // don't set wi.compress_len and wi.compressed as this is redundant
-	    // at this point, to be assigned in _do_alloc_write if needed.
-	  }
-	  dout(20) << " reformat: " << " precompress : 0x"
-	    << std::hex << offs << "~" << l << "->" << res_len
-	    << std::dec << " " << *blob
-	    << dendl;
-	} else {
-	  bl_it += l;
-	  dout(20) << " reformat: " << " precompress : 0x"
-	    << std::hex << offs << "~" << l << "-> remaining tail"
-	    << dendl;
-	}
-	need += p2roundup(res_len, min_alloc_size);
-	offs += l;
-	will_do = need < old_allocated;
-      }
-
-      // At this point will_do indicates if we definitely want recompression,
-      // will skip the remaining reformatting then.
-
-      // Keep compressed blobs until final processing no matter if we decided to
-      // enforce recompression or not. In the latter case they can be chosen
-      // for different engine optimization(s) or be rejected prior to writing out.
-      wctx.precompressed = true;
-      dout(10) << " reformat:'" << args << "'"
-	<< " need 0x"
-	<< std::hex << need << " vs. old_allocated 0x" << old_allocated << std::dec
-	<< " apply: " << will_do
-	<< dendl;
-
-      logger->inc(l_bluestore_reformat_compress_attempted);
-      if (!will_do)
-	logger->inc(l_bluestore_reformat_compress_omitted);
-    }
-    return will_do;
-  };
-  auto exec_defragment = [&](std::string_view args) -> bool {
-    bool will_do = false;
-    const auto& span_stat = reformat_ctx.get_span_stats();
-    auto need = p2roundup(length, min_alloc_size);
-    size_t frags = 0;
-    int64_t preallocated = 0;
-    if (span_stat.frags > 1) {
-      logger->inc(l_bluestore_reformat_defragment_attempted);
-      PExtentVector prealloc;
-      prealloc.reserve(need / min_alloc_size + 1);
-      auto start = mono_clock::now();
-      preallocated = alloc->allocate(
-	need, min_alloc_size, need,
-	0, &prealloc);
-      log_latency("allocator@_prepare_reformat",
-	l_bluestore_allocator_lat,
-	mono_clock::now() - start,
-	cct->_conf->bluestore_log_op_age);
-      will_do = preallocated >= (int64_t)need && prealloc.size() < span_stat.frags;
-      if (will_do) {
-	frags = prealloc.size();
-	reformat_ctx.setup_allocations(alloc, std::move(prealloc), preallocated);
-      } else {
-	logger->inc(l_bluestore_reformat_defragment_omitted);
-      }
-    }
-    dout(10) << " reformat:'" << args << "'"
-      << " preallocated: 0x" << std::hex << preallocated << std::dec
-      << " old frags:" << span_stat.frags
-      << " new frags:" << frags
-      << " apply: " << will_do
-      << dendl;
-    return will_do;
-  };
-
-  const std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES>
-    engines = {
-      OnodeReformatEngine(basic_validate_reformat, exec_recompress),
-      OnodeReformatEngine(basic_validate_reformat, exec_defragment),
-    };
-  reformat_ctx.setup_engines(engines);
-
+  OnodeReformatContext reformat_ctx(this, logger); // don't want to add new getter
+                                                   // for BlueStore::logger,
+						   // hence pass it from here
+  reformat_ctx.add_engine(
+    OnodeReformatContext::RECOMPRESS_ENGINE,
+    new OnodeReformatBasicValidateAction(
+      offset, length, op_flags, min_alloc_size),
+    new OnodeReformatRecompressAction(
+      c, offset, length, bl, min_alloc_size));
+  reformat_ctx.add_engine(
+    OnodeReformatContext::DEFRAGMENT_ENGINE,
+    new OnodeReformatBasicValidateAction(
+      offset, length, op_flags, min_alloc_size),
+    new OnodeReformatDefragmentAction(
+      offset, length, min_alloc_size));
   return _do_read(c, oid, offset, length, bl, op_flags, reformat_ctx);
 }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -18349,7 +18349,16 @@ void BlueStore::_choose_write_options(
      (cm == Compressor::COMP_AGGRESSIVE &&
       (alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_INCOMPRESSIBLE) == 0) ||
      (cm == Compressor::COMP_PASSIVE &&
-      (alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_COMPRESSIBLE)));
+      (alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_COMPRESSIBLE)) ||
+      (cm == Compressor::COMP_FORCE_LAZY &&
+	(fadvise_flags & CEPH_OSD_OP_FLAG_SCRUB)) ||
+      (cm == Compressor::COMP_AGGRESSIVE_LAZY &&
+	(fadvise_flags & CEPH_OSD_OP_FLAG_SCRUB) &&
+	(alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_INCOMPRESSIBLE) == 0) ||
+      (cm == Compressor::COMP_PASSIVE_LAZY &&
+	(fadvise_flags & CEPH_OSD_OP_FLAG_SCRUB) &&
+	(alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_COMPRESSIBLE))
+      );
 
   if ((alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_SEQUENTIAL_READ) &&
       (alloc_hints & CEPH_OSD_ALLOC_HINT_FLAG_RANDOM_READ) == 0 &&

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9726,8 +9726,8 @@ int BlueStore::_mount()
 
   dout(1) << __func__
           << " v2 = " << use_write_v2
-	  << " segment_size = " << segment_size
-	  << " esb = " << elastic_shared_blobs
+          << " segment_size = " << segment_size
+          << " esb = " << elastic_shared_blobs
           << dendl;
   int r = _open_db_and_around(false);
   if (r < 0) {
@@ -13009,7 +13009,7 @@ void BlueStore::_maybe_do_reformat_onode(OnodeReformatContext& reformat_ctx,
 }
 
 int BlueStore::read(
-  CollectionHandle &ch,
+  CollectionHandle &c_,
   const ghobject_t& oid,
   uint64_t offset,
   size_t length,
@@ -13017,7 +13017,7 @@ int BlueStore::read(
   uint32_t op_flags)
 {
   auto start = mono_clock::now();
-  Collection *c = static_cast<Collection *>(ch.get());
+  Collection *c = static_cast<Collection *>(c_.get());
   const coll_t &cid = c->get_cid();
   dout(15) << __func__ << " " << cid << " " << oid
 	   << " 0x" << std::hex << offset << "~" << length
@@ -13025,9 +13025,9 @@ int BlueStore::read(
 	   << std::dec << dendl;
   if (!c->exists)
     return -ENOENT;
+
   bl.clear();
   int r;
-
   {
     read_context_t read_ctx(*this, offset, length, bl, op_flags);
     // we need a shared lock to access
@@ -13080,9 +13080,9 @@ int BlueStore::read(
     r = -EIO;
     derr << __func__ << " " << c->cid << " " << oid << " INJECT EIO" << dendl;
   } else if (oid.hobj.pool > 0 &&  /* FIXME, see #23029 */
-    cct->_conf->bluestore_debug_random_read_err &&
-    (rand() % (int)(cct->_conf->bluestore_debug_random_read_err *
-      100.0)) == 0) {
+	     cct->_conf->bluestore_debug_random_read_err &&
+	     (rand() % (int)(cct->_conf->bluestore_debug_random_read_err *
+			     100.0)) == 0) {
     dout(0) << __func__ << ": inject random EIO" << dendl;
     r = -EIO;
   }
@@ -13144,8 +13144,8 @@ void BlueStore::_read_cache(
           pc->first == pos) {
         l = pc->second.length();
         ready_regions[pos] = std::move(pc->second);
-	span_stat.cached += l;
-	dout(30) << __func__ << "    use cache 0x" << std::hex << pos << ": 0x"
+        span_stat.cached += l;
+        dout(30) << __func__ << "    use cache 0x" << std::hex << pos << ": 0x"
                  << pos << "~" << l << std::dec << dendl;
         ++pc;
       } else {
@@ -13207,7 +13207,7 @@ int BlueStore::_prepare_read_ioc(
   span_stat_t& span_stat = res_span_stat ? *res_span_stat : dummy_span_stat;
   interval_set<uint64_t> pintervals; // need to accumulate pextents in this set
                                      // to get them sorted by offset and merged
-				     // into larger intervals if possible.
+                                     // into larger intervals if possible.
   for (auto& p : blobs2read) {
     const BlobRef& bptr = p.first;
     regions2read_t& r2r = p.second;
@@ -13920,10 +13920,9 @@ int BlueStore::_do_readv(
   for (auto p = m.begin(); p != m.end(); p++, i++) {
     raw_results.push_back({});
     _read_cache(o, p.get_start(), p.get_len(), read_cache_policy,
-                std::get<0>(raw_results[i]), std::get<2>(raw_results[i]),
-		nullptr);
-    r = _prepare_read_ioc(std::get<2>(raw_results[i]), &std::get<1>(raw_results[i]),
-                          &ioc, nullptr);
+                std::get<0>(raw_results[i]), std::get<2>(raw_results[i]));
+    r = _prepare_read_ioc(std::get<2>(raw_results[i]), &std::get<1>(raw_results[i]), &ioc);
+    // we always issue aio for reading, so errors other than EIO are not allowed
     if (r < 0)
       return r;
     if (cct->_conf->bluestore_frag_runtime) {
@@ -16374,12 +16373,12 @@ void BlueStore::_txc_exec(TransContext* txc, ThreadPool::TPHandle* handle)
   auto tstart = mono_clock::now();
 
   if (!throttle.try_start_transaction(
-    *db,
-    *txc,
-    tstart)) {
+	*db,
+	*txc,
+	tstart)) {
     // ensure we do not block here because of deferred writes
     dout(10) << __func__ << " failed get throttle_deferred_bytes, aggressive"
-      << dendl;
+	     << dendl;
     ++deferred_aggressive;
     deferred_try_submit();
     {
@@ -17072,11 +17071,11 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
           if (!g_conf()->bluestore_debug_omit_block_device_write) {
             if (b_len < prefer_deferred_size) {
               dout(20) << __func__ << " deferring small 0x" << std::hex
-                       << b_len << std::dec << " unused write via deferred" << dendl;
+		       << b_len << std::dec << " unused write via deferred" << dendl;
               bluestore_deferred_op_t *op = _get_deferred_op(txc, bl.length());
               op->op = bluestore_deferred_op_t::OP_WRITE;
               b->get_blob().map(
-                b_off, b_len,
+		b_off, b_len,
                 [&](uint64_t offset, uint64_t length) {
                   op->extents.emplace_back(bluestore_pextent_t(offset, length));
                   return 0;
@@ -17085,8 +17084,9 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
             } else {
               b->get_blob().map_bl(
                 b_off, bl,
-                [&](uint64_t offset, bufferlist& t) {
-                  bdev->aio_write(offset, t, &txc->ioc, wctx->buffered);
+		[&](uint64_t offset, bufferlist& t) {
+                  bdev->aio_write(offset, t,
+				  &txc->ioc, wctx->buffered);
               });
             }
           }
@@ -17754,12 +17754,12 @@ int BlueStore::_do_alloc_write(
 
       if (r == 0 && rejected) {
 	dout(20) << __func__ << std::hex << "  0x" << wi.blob_length
-	  << " compressed to 0x" << compressed_len << " -> 0x" << result_len
-	  << " with " << wctx->compressor->get_type()
-	  << ", which is more than required 0x" << want_len_raw
-	  << " -> 0x" << want_len
-	  << ", leaving uncompressed"
-	  << std::dec << dendl;
+		 << " compressed to 0x" << compressed_len << " -> 0x" << result_len
+		 << " with " << wctx->compressor->get_type()
+		 << ", which is more than required 0x" << want_len_raw
+		 << " -> 0x" << want_len
+		 << ", leaving uncompressed"
+		 << std::dec << dendl;
 	logger->inc(l_bluestore_compress_rejected_count);
       }
 
@@ -17826,10 +17826,9 @@ int BlueStore::_do_alloc_write(
 
   dout(20) << __func__ << std::hex << " need=0x" << need << " data=0x" << data_size
 	   << " prealloc " << pextents << dendl;
-
-  int64_t prealloc_left = allocated + preallocated;
   auto prealloc_pos = pextents.begin();
   ceph_assert(prealloc_pos != pextents.end());
+  int64_t prealloc_left = allocated + preallocated;
 
   for (auto& wi : wctx->writes) {
     bluestore_blob_t& dblob = wi.b->dirty_blob();
@@ -18377,6 +18376,7 @@ int BlueStore::_do_write_v2(
   if (length == 0) {
     return 0;
   }
+
   if (bl.length() != length) {
     bl.splice(length, bl.length() - length);
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11078,7 +11078,7 @@ void BlueStore::_fsck_check_objects(
           uint64_t offset = 0;
           do {
             uint64_t l = std::min(uint64_t(o->onode.size - offset), max_read_block);
-            int r = _do_basic_read(c.get(), o, offset, l, bl,
+            int r = _do_read(c.get(), o, offset, l, bl,
               CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
             if (r < 0) {
               ++errors;
@@ -13016,6 +13016,7 @@ int BlueStore::read(
   bufferlist& bl,
   uint32_t op_flags)
 {
+  auto start = mono_clock::now();
   Collection *c = static_cast<Collection *>(ch.get());
   const coll_t &cid = c->get_cid();
   dout(15) << __func__ << " " << cid << " " << oid
@@ -13024,22 +13025,14 @@ int BlueStore::read(
 	   << std::dec << dendl;
   if (!c->exists)
     return -ENOENT;
-  return _do_read(c, oid, offset, length, bl, op_flags);
-}
-
-int BlueStore::_do_read(Collection* c,
-			const ghobject_t& oid,
-			uint64_t offset,
-			size_t length,
-			bufferlist& bl,
-			uint32_t op_flags)
-{
+  bl.clear();
   int r;
-  auto start = mono_clock::now();
+
   {
     read_context_t read_ctx(*this, offset, length, bl, op_flags);
-    std::shared_lock slock(c->lock); // we need a shared lock to access
-                                     // reformat_engines from collection
+    // we need a shared lock to access
+    // reformat_engines from collection
+    std::shared_lock slock(c->lock);
     OnodeReformatContext reformat_ctx(read_ctx, c->reformat_engines);
 
     std::unique_lock ulock(c->lock, std::defer_lock);
@@ -13059,7 +13052,7 @@ int BlueStore::_do_read(Collection* c,
       if (offset == length && offset == 0)
 	length = o->onode.size;
 
-      r = _do_basic_read(c, o, offset, length, bl, op_flags, 0,
+      r = _do_read(c, o, offset, length, bl, op_flags, 0,
 	reformat_ctx.is_enabled() ? &reformat_ctx.access_span_stats() : nullptr);
       if (r == -EIO) {
 	logger->inc(l_bluestore_read_eio);
@@ -13076,7 +13069,7 @@ int BlueStore::_do_read(Collection* c,
 	  cct->_conf->bluestore_log_op_age);
       }
       if (r >= 0) {
-        _maybe_do_reformat_onode(reformat_ctx, c, o, offset, length, bl, op_flags);
+	_maybe_do_reformat_onode(reformat_ctx, c, o, offset, length, bl, op_flags);
       }
     } else {
       r = -ENOENT;
@@ -13087,15 +13080,15 @@ int BlueStore::_do_read(Collection* c,
     r = -EIO;
     derr << __func__ << " " << c->cid << " " << oid << " INJECT EIO" << dendl;
   } else if (oid.hobj.pool > 0 &&  /* FIXME, see #23029 */
-	     cct->_conf->bluestore_debug_random_read_err &&
-	     (rand() % (int)(cct->_conf->bluestore_debug_random_read_err *
-			     100.0)) == 0) {
+    cct->_conf->bluestore_debug_random_read_err &&
+    (rand() % (int)(cct->_conf->bluestore_debug_random_read_err *
+      100.0)) == 0) {
     dout(0) << __func__ << ": inject random EIO" << dendl;
     r = -EIO;
   }
   dout(10) << __func__ << " " << c->cid << " " << oid
-	   << " 0x" << std::hex << offset << "~" << length << std::dec
-	   << " = " << r << dendl;
+    << " 0x" << std::hex << offset << "~" << length << std::dec
+    << " = " << r << dendl;
   return r;
 }
 
@@ -13451,7 +13444,7 @@ void BlueStore::_measure_static_frag(
   logger->tinc_with_max(l_bluestore_static_frag_lat, finish - start);
 }
 
-int BlueStore::_do_basic_read(
+int BlueStore::_do_read(
   Collection *c,
   OnodeRef& o,
   uint64_t offset,
@@ -13583,7 +13576,7 @@ int BlueStore::_do_basic_read(
     if (retry_count >= cct->_conf->bluestore_retry_disk_reads) {
       return -EIO;
     }
-    return _do_basic_read(c, o, offset, length, bl, op_flags, retry_count + 1);
+    return _do_read(c, o, offset, length, bl, op_flags, retry_count + 1);
   }
   r = bl.length();
   if (retry_count) {
@@ -13604,7 +13597,7 @@ void inline BlueStore::_do_read_and_pad(
   uint32_t length,
   ceph::buffer::list& bl)
 {
-  int r = _do_basic_read(c, o, offset, length, bl, 0);
+  int r = _do_read(c, o, offset, length, bl, 0);
   ceph_assert(r >= 0 && r <= (int)length);
   size_t zlen = length - r;
   if (zlen > 0) {
@@ -17134,7 +17127,7 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
 		   << " and tail 0x" << tail_read << std::dec << dendl;
 	  if (head_read) {
 	    bufferlist head_bl;
-	    int r = _do_basic_read(c.get(), o, offset - head_pad - head_read, head_read,
+	    int r = _do_read(c.get(), o, offset - head_pad - head_read, head_read,
 			     head_bl, 0);
 	    ceph_assert(r >= 0 && r <= (int)head_read);
 	    size_t zlen = head_read - r;
@@ -17148,7 +17141,7 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
 	  }
 	  if (tail_read) {
 	    bufferlist tail_bl;
-	    int r = _do_basic_read(c.get(), o, offset + length + tail_pad, tail_read,
+	    int r = _do_read(c.get(), o, offset + length + tail_pad, tail_read,
 			     tail_bl, 0);
 	    ceph_assert(r >= 0 && r <= (int)tail_read);
 	    size_t zlen = tail_read - r;
@@ -17396,7 +17389,7 @@ void BlueStore::_do_write_big_apply_deferred(
   dout(20) << __func__ << "  reading head 0x" << std::hex << dctx.head_read
     << " and tail 0x" << dctx.tail_read << std::dec << dendl;
   if (dctx.head_read) {
-    int r = _do_basic_read(c.get(), o,
+    int r = _do_read(c.get(), o,
       dctx.off - dctx.head_read,
       dctx.head_read,
       bl,
@@ -17413,7 +17406,7 @@ void BlueStore::_do_write_big_apply_deferred(
 
   if (dctx.tail_read) {
     bufferlist tail_bl;
-    int r = _do_basic_read(c.get(), o,
+    int r = _do_read(c.get(), o,
       dctx.off + dctx.used, dctx.tail_read,
       tail_bl, 0);
     ceph_assert(r >= 0 && r <= (int)dctx.tail_read);
@@ -18233,7 +18226,7 @@ int BlueStore::_do_gc(
     dout(20) << __func__ << " processing " << std::hex
             << offset << "~" << length << std::dec
 	    << dendl;
-    int r = _do_basic_read(c.get(), o, offset, length, bl, 0);
+    int r = _do_read(c.get(), o, offset, length, bl, 0);
     ceph_assert(r == (int)length);
 
     _do_write_data(txc, c, o, offset, length, bl, &wctx_gc);
@@ -19137,7 +19130,7 @@ int BlueStore::_clone(TransContext *txc,
     _do_clone_range(txc, c, oldo, newo, 0, oldo->onode.size, 0);
   } else {
     bufferlist bl;
-    r = _do_basic_read(c.get(), oldo, 0, oldo->onode.size, bl, 0);
+    r = _do_read(c.get(), oldo, 0, oldo->onode.size, bl, 0);
     if (r < 0)
       goto out;
     WriteContext wctx;
@@ -19260,7 +19253,7 @@ int BlueStore::_clone_range(TransContext *txc,
       _do_clone_range(txc, c, oldo, newo, srcoff, length, dstoff);
     } else {
       bufferlist bl;
-      r = _do_basic_read(c.get(), oldo, srcoff, length, bl, 0);
+      r = _do_read(c.get(), oldo, srcoff, length, bl, 0);
       if (r < 0)
 	goto out;
       WriteContext wctx;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12938,31 +12938,34 @@ int BlueStore::set_collection_opts(
   if (c->pool_opts.get(pool_opts_t::COMPRESSION_REQUIRED_RATIO, &dval)) {
     c->compression_req_ratio = dval;
   }
+  _update_reformat_engines(c);
   return 0;
 }
 
-void BlueStore::_maybe_need_reformat_onode(OnodeReformatContext& reformat_ctx,
-  Collection* c)
+void BlueStore::_update_reformat_engines(Collection* c)
 {
   std::string opt_reformat;
   c->pool_opts.get(pool_opts_t::DEEP_SCRUB_REFORMAT, &opt_reformat);
   boost::char_separator<char> sep(";,"); // Delimiters are semicolon and comma
   boost::tokenizer<boost::char_separator<char>> tokens(opt_reformat, sep);
-
+  reformat_engines_t new_engines;
   for (const auto& t : tokens) {
-    std::string_view sv(t);
-    sv.remove_prefix(std::min(sv.find_first_not_of(" \t\n\r\f\v"), sv.size()));
-    int pri = -1;
-    if (sv.starts_with("recompress")) {
-      pri = OnodeReformatContext::RECOMPRESS_ENGINE;
-    } else if (sv.starts_with("defragment")) {
-      pri = OnodeReformatContext::DEFRAGMENT_ENGINE;
+    std::string_view args(t);
+    args.remove_prefix(
+      std::min(args.find_first_not_of(" \t\n\r\f\v"), args.size()));
+    int e = -1;
+    OnodeReformatEngine* engine = nullptr;
+    if (args.starts_with("recompress")) {
+      e = RECOMPRESS_ENGINE;
+      engine = new OnodeReformatRecompressEngine(args);
+    } else if (args.starts_with("defragment")) {
+      e = DEFRAGMENT_ENGINE;
+      engine = new OnodeReformatDefragmentEngine(args);
     }
-    ceph_assert(pri < OnodeReformatContext::MAX_ENGINES);
-    if (pri >= 0) {
-      reformat_ctx.maybe_enable_engine(pri, sv);
-    }
+    ceph_assert(e < MAX_REFORMAT_ENGINES);
+    new_engines[e].reset(engine);
   }
+  std::swap(c->reformat_engines, new_engines);
 }
 
 void BlueStore::_maybe_do_reformat_onode(OnodeReformatContext& reformat_ctx,
@@ -12987,7 +12990,8 @@ void BlueStore::_maybe_do_reformat_onode(OnodeReformatContext& reformat_ctx,
     dout(25) << __func__ << " span stat {" << span_stat << "}" << dendl;
     _dump_onode<25>(cct, *o);
 
-    reformat_ctx.exec_engines();
+    ceph_assert(logger);
+    reformat_ctx.exec_engines(*logger, c, o);
     if (reformat_ctx.is_applied()) {
       _txc_exec_reformat_write(c, o, offset, length, bl, wctx);
     }
@@ -13020,23 +13024,7 @@ int BlueStore::read(
 	   << std::dec << dendl;
   if (!c->exists)
     return -ENOENT;
-
-  OnodeReformatContext reformat_ctx(this, logger); // don't want to add new getter
-                                                   // for BlueStore::logger,
-						   // hence pass it from here
-  reformat_ctx.add_engine(
-    OnodeReformatContext::RECOMPRESS_ENGINE,
-    new OnodeReformatBasicValidateAction(
-      offset, length, op_flags, min_alloc_size),
-    new OnodeReformatRecompressAction(
-      c, offset, length, bl, min_alloc_size));
-  reformat_ctx.add_engine(
-    OnodeReformatContext::DEFRAGMENT_ENGINE,
-    new OnodeReformatBasicValidateAction(
-      offset, length, op_flags, min_alloc_size),
-    new OnodeReformatDefragmentAction(
-      offset, length, min_alloc_size));
-  return _do_read(c, oid, offset, length, bl, op_flags, reformat_ctx);
+  return _do_read(c, oid, offset, length, bl, op_flags);
 }
 
 int BlueStore::_do_read(Collection* c,
@@ -13044,19 +13032,20 @@ int BlueStore::_do_read(Collection* c,
 			uint64_t offset,
 			size_t length,
 			bufferlist& bl,
-			uint32_t op_flags,
-			OnodeReformatContext& reformat_ctx)
+			uint32_t op_flags)
 {
   int r;
   auto start = mono_clock::now();
-  _maybe_need_reformat_onode(reformat_ctx, c);
   {
-    std::shared_lock slock(c->lock, std::defer_lock);
+    read_context_t read_ctx(*this, offset, length, bl, op_flags);
+    std::shared_lock slock(c->lock); // we need a shared lock to access
+                                     // reformat_engines from collection
+    OnodeReformatContext reformat_ctx(read_ctx, c->reformat_engines);
+
     std::unique_lock ulock(c->lock, std::defer_lock);
     if (reformat_ctx.is_enabled()) {
+      slock.unlock();
       ulock.lock();
-    } else {
-      slock.lock();
     }
 
     auto start1 = mono_clock::now();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12991,7 +12991,7 @@ void BlueStore::_maybe_do_reformat_onode(OnodeReformatContext& reformat_ctx,
     _dump_onode<25>(cct, *o);
 
     ceph_assert(logger);
-    reformat_ctx.exec_engines(*logger, c, o);
+    reformat_ctx.exec_engines(*logger);
     if (reformat_ctx.is_applied()) {
       _txc_exec_reformat_write(c, o, offset, length, bl, wctx);
     }
@@ -13029,17 +13029,12 @@ int BlueStore::read(
   bl.clear();
   int r;
   {
-    read_context_t read_ctx(*this, offset, length, bl, op_flags);
-    // we need a shared lock to access
-    // reformat_engines from collection
+    // we need a shared lock to accesss
+    // reformat_engines from collection for validation,
+    // but once we want to apply reformatting we need
+    // unique lock
     std::shared_lock slock(c->lock);
-    OnodeReformatContext reformat_ctx(read_ctx, c->reformat_engines);
-
     std::unique_lock ulock(c->lock, std::defer_lock);
-    if (reformat_ctx.is_enabled()) {
-      slock.unlock();
-      ulock.lock();
-    }
 
     auto start1 = mono_clock::now();
     OnodeRef o = c->get_onode(oid, false);
@@ -13048,7 +13043,17 @@ int BlueStore::read(
       mono_clock::now() - start1,
       cct->_conf->bluestore_log_op_age,
       "", l_bluestore_slow_read_onode_meta_count);
-    if (o && o->exists) {
+
+    read_context_t read_ctx(*this, c_, o, offset, length, bl, op_flags);
+    OnodeReformatContext reformat_ctx(read_ctx, c->reformat_engines);
+    if (o && o->exists && reformat_ctx.is_enabled()) {
+      slock.unlock();
+      ulock.lock();
+    }
+
+    // either collection or onode could be removed while switching locks above,
+    // hence checking once again
+    if (c->exists && o && o->exists) {
       if (offset == length && offset == 0)
 	length = o->onode.size;
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -28,6 +28,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_real.hpp>
+#include <boost/tokenizer.hpp>
 
 #include "common/dout.h"
 #include "include/ceph_assert.h"
@@ -4586,7 +4587,7 @@ int BlueStore::ExtentMap::compress_extent_map(
 }
 
 void BlueStore::ExtentMap::punch_hole(
-  CollectionRef &c, 
+  CollectionRef &c,
   uint64_t offset,
   uint64_t length,
   old_extent_map_t *old_extents)
@@ -6700,6 +6701,37 @@ void BlueStore::_init_logger()
     "slow_op_scrub_count",
     "Slow Scrub op count in BlueStore",
     "ssoc",
+    PerfCountersBuilder::PRIO_USEFUL);
+
+  // reformatting counters
+  //****************************************
+  b.add_time_avg(l_bluestore_reformat_lat, "reformat_lat",
+    "Average reformatting latency",
+    "rf_l", PerfCountersBuilder::PRIO_CRITICAL);
+  b.add_u64_counter(l_bluestore_reformat_compress_attempted,
+    "reformat_compress_attempted",
+    "Recompression attempts done",
+    "rfca",
+    PerfCountersBuilder::PRIO_USEFUL);
+  b.add_u64_counter(l_bluestore_reformat_compress_omitted,
+    "reformat_compress_omitted",
+    "Recompression attempts omitted",
+    "rfco",
+    PerfCountersBuilder::PRIO_USEFUL);
+  b.add_u64_counter(l_bluestore_reformat_defragment_attempted,
+    "reformat_defragment_attempted",
+    "Defragmentation attempts done",
+    "rfda",
+    PerfCountersBuilder::PRIO_USEFUL);
+  b.add_u64_counter(l_bluestore_reformat_defragment_omitted,
+    "reformat_defragment_omitted",
+    "Defragmentation attempts omitted",
+    "rfdo",
+    PerfCountersBuilder::PRIO_USEFUL);
+  b.add_u64_counter(l_bluestore_reformat_issued,
+    "reformat_issued",
+    "Reformatting requests issued",
+    "rfi",
     PerfCountersBuilder::PRIO_USEFUL);
 
   // Resulting size axis configuration for op histograms, values are in bytes
@@ -11041,7 +11073,7 @@ void BlueStore::_fsck_check_objects(
           uint64_t offset = 0;
           do {
             uint64_t l = std::min(uint64_t(o->onode.size - offset), max_read_block);
-            int r = _do_read(c.get(), o, offset, l, bl,
+            int r = _do_basic_read(c.get(), o, offset, l, bl,
               CEPH_OSD_OP_FLAG_FADVISE_NOCACHE);
             if (r < 0) {
               ++errors;
@@ -12904,27 +12936,324 @@ int BlueStore::set_collection_opts(
   return 0;
 }
 
+struct OnodeReformatEngine {
+  bool enabled = false;
+  std::string args;
+  std::function<bool(std::string_view)> validate = nullptr;
+  std::function<bool(std::string_view)> execute = nullptr;
+  OnodeReformatEngine() {}
+  OnodeReformatEngine(std::function<bool(std::string_view)> _validate,
+                      std::function<bool(std::string_view)> _execute) :
+    validate(_validate), execute(_execute) {
+  }
+};
+
+class OnodeReformatContext {
+public:
+  enum {
+    // This is effectively an engine priority, i.e. the order engines are called in.
+    RECOMPRESS_ENGINE = 0,
+    DEFRAGMENT_ENGINE = 1,
+    MAX_ENGINES
+  };
+private:
+
+  size_t enabled_engines_count = 0;
+  std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES> engines;
+
+  bool to_be_applied = false;
+  BlueStore::WriteContext wctx;
+  span_stat_t span_stat;
+  Allocator* alloc = nullptr;
+  PExtentVectorSlicer* prealloc_slicer = nullptr; // pointer to the one from wctx if configured
+public:
+  ~OnodeReformatContext() {
+    clear();
+  }
+  void setup_engines(const std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES>& e) {
+    engines = e;
+  }
+  void setup_allocations(Allocator* _alloc, PExtentVector&& _p, uint32_t _total) {
+    ceph_assert(!prealloc_slicer); // repetitive assignments aren't allowed
+    alloc = _alloc;
+    prealloc_slicer = &wctx.prealloc_slicer;
+    prealloc_slicer->setup(std::move(_p), _total);
+  }
+
+  bool is_enabled() const { return enabled_engines_count > 0; }
+  bool is_applied() const { return to_be_applied; }
+  BlueStore::WriteContext& get_write_context() { return wctx; }
+  span_stat_t& access_span_stats() {
+    return span_stat;
+  }
+  const span_stat_t& get_span_stats() const {
+    return span_stat;
+  }
+
+  void maybe_enable_engine(int pri, std::string_view args) {
+    ceph_assert(pri >= 0 && pri < MAX_ENGINES);
+    if (!engines[pri].enabled && engines[pri].validate(args)) {
+      engines[pri].enabled = true;
+      engines[pri].args = args;
+      enabled_engines_count++;
+    }
+  }
+  void exec_engines() {
+    int i = 0;
+    for(auto e : engines) {
+    i++;
+      if (e.enabled && e.execute(e.args)) {
+        to_be_applied = true;
+        break;
+      }
+    }
+  }
+  void clear() {
+    PExtentVector to_release;
+    if (prealloc_slicer && alloc && !prealloc_slicer->end() && prealloc_slicer->slice(to_release) > 0) {
+      alloc->release(to_release);
+    }
+    enabled_engines_count = 0;
+    for (auto e : engines) {
+      e.enabled = false;
+    }
+    to_be_applied = false;
+    wctx.reset();
+  }
+};
+
+void BlueStore::_maybe_need_reformat_onode(OnodeReformatContext& reformat_ctx,
+  Collection* c)
+{
+  reformat_ctx.clear();
+
+  std::string opt_reformat;
+  c->pool_opts.get(pool_opts_t::DEEP_SCRUB_REFORMAT, &opt_reformat);
+  boost::char_separator<char> sep(";,"); // Delimiters are semicolon and comma
+  boost::tokenizer<boost::char_separator<char>> tokens(opt_reformat, sep);
+
+  for (const auto& t : tokens) {
+    std::string_view sv(t);
+    sv.remove_prefix(std::min(sv.find_first_not_of(" \t\n\r\f\v"), sv.size()));
+    int pri = -1;
+    if (sv.starts_with("recompress")) {
+      pri = OnodeReformatContext::RECOMPRESS_ENGINE;
+    } else if (sv.starts_with("defragment")) {
+      pri = OnodeReformatContext::DEFRAGMENT_ENGINE;
+    }
+    ceph_assert(pri < OnodeReformatContext::MAX_ENGINES);
+    if (pri >= 0) {
+      reformat_ctx.maybe_enable_engine(pri, sv);
+    }
+  }
+}
+
+void BlueStore::_maybe_do_reformat_onode(OnodeReformatContext& reformat_ctx,
+  Collection* c, OnodeRef& o,
+  uint64_t offset, size_t length,
+  const bufferlist& bl,
+  uint32_t op_flags)
+{
+  // do reformat if
+  // - reformat preapproved
+  // - object isn't cached (meaning it's not being written at the moment),
+  // - and there are no shared blobs within the span as this might increase
+  //   used space.
+  const auto& span_stat = reformat_ctx.get_span_stats(); // just make an alias
+  if (reformat_ctx.is_enabled() && span_stat.cached == 0 && span_stat.allocated_shared == 0) {
+    auto start2 = mono_clock::now();
+    // will probably need write context, make an alias for the one from
+    // reformat ctx
+    auto& wctx = reformat_ctx.get_write_context();
+    _choose_write_options(c, o, op_flags, &wctx);
+
+    dout(25) << __func__ << " span stat {" << span_stat << "}" << dendl;
+    _dump_onode<25>(cct, *o);
+
+    reformat_ctx.exec_engines();
+    if (reformat_ctx.is_applied()) {
+      _txc_exec_reformat_write(c, o, offset, length, bl, wctx);
+    }
+    log_latency(__func__,
+      l_bluestore_reformat_lat,
+      mono_clock::now() - start2,
+      cct->_conf->bluestore_log_op_age);
+  } else {
+    dout(15) << __func__ << " skipping reformat:"
+     << reformat_ctx.is_enabled() << " "
+     << span_stat.cached << " "
+     << span_stat.allocated_shared << " "
+     << dendl;
+  }
+}
+
 int BlueStore::read(
-  CollectionHandle &c_,
+  CollectionHandle &ch,
   const ghobject_t& oid,
   uint64_t offset,
   size_t length,
   bufferlist& bl,
   uint32_t op_flags)
 {
-  auto start = mono_clock::now();
-  Collection *c = static_cast<Collection *>(c_.get());
+  Collection *c = static_cast<Collection *>(ch.get());
   const coll_t &cid = c->get_cid();
   dout(15) << __func__ << " " << cid << " " << oid
-	   << " 0x" << std::hex << offset << "~" << length << std::dec
-	   << dendl;
+	   << " 0x" << std::hex << offset << "~" << length
+	   << " flags 0x" << op_flags
+	   << std::dec << dendl;
   if (!c->exists)
     return -ENOENT;
 
-  bl.clear();
+  OnodeReformatContext reformat_ctx;
+  auto basic_validate_reformat = [&](std::string_view args) ->bool {
+    bool will_reformat = false;
+    if (op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
+      // for the sake of simplicity do not apply data reformatting to reads
+      // unaligned at the beginning. Having unaligned tail is OK.
+      will_reformat = p2nphase(offset, min_alloc_size) == 0;
+      if (!will_reformat) {
+	dout(15) << "reformat '" << args << "'"
+	  << " skipped due to unaligned read bounds "
+	  << p2nphase(offset, min_alloc_size) << " "
+	  << p2nphase(offset + length, min_alloc_size)
+	  << dendl;
+      } else {
+	dout(15) << "reformat '" << args << "'"
+	  << " enabled "
+	  << dendl;
+      }
+    }
+    return will_reformat;
+  };
+  auto exec_recompress = [&](std::string_view args) -> bool {
+    const auto& span_stat = reformat_ctx.get_span_stats();
+    auto& wctx = reformat_ctx.get_write_context();
+    bool will_do = wctx.compress && span_stat.allocated > 0;
+    if (will_do) {
+      uint64_t need = 0;
+      auto bl_it = bl.begin();
+      uint64_t offs = offset;
+      uint64_t old_allocated = span_stat.allocated + span_stat.allocated_compressed;
+      while (bl_it != bl.end()) {
+
+	BlobRef blob = c->new_blob();
+	bufferlist from_bl;
+	uint64_t l = std::min(wctx.target_blob_size, uint64_t(bl_it.get_remaining()));
+	uint64_t res_len = l;
+	if (l >= min_alloc_size) {
+	  l = p2align(l, min_alloc_size);
+	  bl_it.copy(l, from_bl);
+
+	  //FIXME: add zero detection
+	  auto& wi = wctx.write(offs, blob, l, 0, from_bl, 0, l, false, true);
+
+	  res_len = from_bl.length();
+	  if (l > min_alloc_size &&
+	    wctx.compressor->compress(from_bl, wi.compressed_bl, wi.compressor_message) == 0) {
+
+	    res_len = wi.compressed_bl.length();
+	    // don't set wi.compress_len and wi.compressed as this is redundant
+	    // at this point, to be assigned in _do_alloc_write if needed.
+	  }
+	  dout(20) << " reformat: " << " precompress : 0x"
+	    << std::hex << offs << "~" << l << "->" << res_len
+	    << std::dec << " " << *blob
+	    << dendl;
+	} else {
+	  bl_it += l;
+	  dout(20) << " reformat: " << " precompress : 0x"
+	    << std::hex << offs << "~" << l << "-> remaining tail"
+	    << dendl;
+	}
+	need += p2roundup(res_len, min_alloc_size);
+	offs += l;
+	will_do = need < old_allocated;
+      }
+
+      // At this point will_do indicates if we definitely want recompression,
+      // will skip the remaining reformatting then.
+
+      // Keep compressed blobs until final processing no matter if we decided to
+      // enforce recompression or not. In the latter case they can be chosen
+      // for different engine optimization(s) or be rejected prior to writing out.
+      wctx.precompressed = true;
+      dout(10) << " reformat:'" << args << "'"
+	<< " need 0x"
+	<< std::hex << need << " vs. old_allocated 0x" << old_allocated << std::dec
+	<< " apply: " << will_do
+	<< dendl;
+
+      logger->inc(l_bluestore_reformat_compress_attempted);
+      if (!will_do)
+	logger->inc(l_bluestore_reformat_compress_omitted);
+    }
+    return will_do;
+  };
+  auto exec_defragment = [&](std::string_view args) -> bool {
+    bool will_do = false;
+    const auto& span_stat = reformat_ctx.get_span_stats();
+    auto need = p2roundup(length, min_alloc_size);
+    size_t frags = 0;
+    int64_t preallocated = 0;
+    if (span_stat.frags > 1) {
+      logger->inc(l_bluestore_reformat_defragment_attempted);
+      PExtentVector prealloc;
+      prealloc.reserve(need / min_alloc_size + 1);
+      auto start = mono_clock::now();
+      preallocated = alloc->allocate(
+	need, min_alloc_size, need,
+	0, &prealloc);
+      log_latency("allocator@_prepare_reformat",
+	l_bluestore_allocator_lat,
+	mono_clock::now() - start,
+	cct->_conf->bluestore_log_op_age);
+      will_do = preallocated >= (int64_t)need && prealloc.size() < span_stat.frags;
+      if (will_do) {
+	frags = prealloc.size();
+	reformat_ctx.setup_allocations(alloc, std::move(prealloc), preallocated);
+      } else {
+	logger->inc(l_bluestore_reformat_defragment_omitted);
+      }
+    }
+    dout(10) << " reformat:'" << args << "'"
+      << " preallocated: 0x" << std::hex << preallocated << std::dec
+      << " old frags:" << span_stat.frags
+      << " new frags:" << frags
+      << " apply: " << will_do
+      << dendl;
+    return will_do;
+  };
+
+  const std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES>
+    engines = {
+      OnodeReformatEngine(basic_validate_reformat, exec_recompress),
+      OnodeReformatEngine(basic_validate_reformat, exec_defragment),
+    };
+  reformat_ctx.setup_engines(engines);
+
+  return _do_read(c, oid, offset, length, bl, op_flags, reformat_ctx);
+}
+
+int BlueStore::_do_read(Collection* c,
+			const ghobject_t& oid,
+			uint64_t offset,
+			size_t length,
+			bufferlist& bl,
+			uint32_t op_flags,
+			OnodeReformatContext& reformat_ctx)
+{
   int r;
+  auto start = mono_clock::now();
+  _maybe_need_reformat_onode(reformat_ctx, c);
   {
-    std::shared_lock l(c->lock);
+    std::shared_lock slock(c->lock, std::defer_lock);
+    std::unique_lock ulock(c->lock, std::defer_lock);
+    if (reformat_ctx.is_enabled()) {
+      ulock.lock();
+    } else {
+      slock.lock();
+    }
+
     auto start1 = mono_clock::now();
     OnodeRef o = c->get_onode(oid, false);
     log_latency("get_onode@read",
@@ -12932,21 +13261,34 @@ int BlueStore::read(
       mono_clock::now() - start1,
       cct->_conf->bluestore_log_op_age,
       "", l_bluestore_slow_read_onode_meta_count);
-    if (!o || !o->exists) {
+    if (o && o->exists) {
+      if (offset == length && offset == 0)
+	length = o->onode.size;
+
+      r = _do_basic_read(c, o, offset, length, bl, op_flags, 0,
+	reformat_ctx.is_enabled() ? &reformat_ctx.access_span_stats() : nullptr);
+      if (r == -EIO) {
+	logger->inc(l_bluestore_read_eio);
+      }
+      if (op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
+	log_latency_scrub(__func__,
+	  l_bluestore_read_lat,
+	  mono_clock::now() - start,
+	  cct->_conf->bluestore_log_scrub_op_age);
+      } else {
+	log_latency(__func__,
+	  l_bluestore_read_lat,
+	  mono_clock::now() - start,
+	  cct->_conf->bluestore_log_op_age);
+      }
+      if (r >= 0) {
+        _maybe_do_reformat_onode(reformat_ctx, c, o, offset, length, bl, op_flags);
+      }
+    } else {
       r = -ENOENT;
-      goto out;
-    }
-
-    if (offset == length && offset == 0)
-      length = o->onode.size;
-
-    r = _do_read(c, o, offset, length, bl, op_flags);
-    if (r == -EIO) {
-      logger->inc(l_bluestore_read_eio);
     }
   }
 
- out:
   if (r >= 0 && _debug_data_eio(oid)) {
     r = -EIO;
     derr << __func__ << " " << c->cid << " " << oid << " INJECT EIO" << dendl;
@@ -12957,21 +13299,9 @@ int BlueStore::read(
     dout(0) << __func__ << ": inject random EIO" << dendl;
     r = -EIO;
   }
-  dout(10) << __func__ << " " << cid << " " << oid
+  dout(10) << __func__ << " " << c->cid << " " << oid
 	   << " 0x" << std::hex << offset << "~" << length << std::dec
 	   << " = " << r << dendl;
-
-  if (op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
-    log_latency_scrub(__func__,
-      l_bluestore_read_lat,
-      mono_clock::now() - start,
-      cct->_conf->bluestore_log_scrub_op_age);
-  } else {
-    log_latency(__func__,
-      l_bluestore_read_lat,
-      mono_clock::now() - start,
-      cct->_conf->bluestore_log_op_age);
-  }
   return r;
 }
 
@@ -12981,11 +13311,15 @@ void BlueStore::_read_cache(
   size_t length,
   int read_cache_policy,
   ready_regions_t& ready_regions,
-  blobs2read_t& blobs2read)
+  blobs2read_t& blobs2read,
+  span_stat_t* res_span_stat)
 {
   // build blob-wise list to of stuff read (that isn't cached)
   unsigned left = length;
   uint64_t pos = offset;
+  span_stat_t dummy_span_stat;
+  span_stat_t& span_stat = res_span_stat ? *res_span_stat : dummy_span_stat;
+  span_stat.stored = length;
   auto lp = o->extent_map.seek_lextent(offset);
   while (left > 0 && lp != o->extent_map.extent_map.end()) {
     if (pos < lp->logical_offset) {
@@ -12997,7 +13331,9 @@ void BlueStore::_read_cache(
                << std::dec << dendl;
       pos += hole;
       left -= hole;
+      span_stat.stored -= hole;
     }
+    span_stat.extents++;
     BlobRef& bptr = lp->blob;
     unsigned l_off = pos - lp->logical_offset;
     unsigned b_off = l_off + lp->blob_offset;
@@ -13021,7 +13357,8 @@ void BlueStore::_read_cache(
           pc->first == pos) {
         l = pc->second.length();
         ready_regions[pos] = std::move(pc->second);
-        dout(30) << __func__ << "    use cache 0x" << std::hex << pos << ": 0x"
+	span_stat.cached += l;
+	dout(30) << __func__ << "    use cache 0x" << std::hex << pos << ": 0x"
                  << pos << "~" << l << std::dec << dendl;
         ++pc;
       } else {
@@ -13070,18 +13407,38 @@ void BlueStore::_read_cache(
     }
     ++lp;
   }
+  span_stat.stored -= left; // finally adjust if we haven't seen the full length
 }
 
 int BlueStore::_prepare_read_ioc(
   blobs2read_t& blobs2read,
   vector<bufferlist>* compressed_blob_bls,
-  IOContext* ioc)
+  IOContext* ioc,
+  span_stat_t* res_span_stat)
 {
+  span_stat_t dummy_span_stat;
+  span_stat_t& span_stat = res_span_stat ? *res_span_stat : dummy_span_stat;
+  interval_set<uint64_t> pintervals; // need to accumulate pextents in this set
+                                     // to get them sorted by offset and merged
+				     // into larger intervals if possible.
   for (auto& p : blobs2read) {
     const BlobRef& bptr = p.first;
     regions2read_t& r2r = p.second;
     dout(20) << __func__ << "  blob " << *bptr << " need "
              << r2r << dendl;
+    SharedBlobRef sb;
+    bool has_shared = false;
+    if (bptr->get_blob().is_shared() && res_span_stat) {
+      sb = bptr->get_shared_blob();
+      bptr->collection->load_shared_blob(sb);
+      has_shared = true;
+    }
+    auto shared_cb = [&](uint64_t o, uint32_t len, uint32_t refs) {
+       if (refs > 1) {
+         span_stat.allocated_shared += len;
+       }
+       return 0;
+    };
     if (bptr->get_blob().is_compressed()) {
       // read the whole thing
       if (compressed_blob_bls->empty()) {
@@ -13090,9 +13447,18 @@ int BlueStore::_prepare_read_ioc(
       }
       compressed_blob_bls->push_back(bufferlist());
       bufferlist& bl = compressed_blob_bls->back();
+      auto on_disk_size = bptr->get_blob().get_ondisk_size();
+      span_stat.stored_compressed += bptr->get_blob().get_logical_length();
+      span_stat.allocated_compressed += on_disk_size;
       auto r = bptr->get_blob().map(
-        0, bptr->get_blob().get_ondisk_size(),
+        0, on_disk_size,
         [&](uint64_t offset, uint64_t length) {
+	  if (res_span_stat) {
+	    pintervals.insert(offset, length);
+	    if (has_shared) {
+	      sb->map_fn(offset, length, shared_cb);
+	    }
+	  }
           int r = bdev->aio_read(offset, length, &bl, ioc);
           if (r < 0)
             return r;
@@ -13117,10 +13483,17 @@ int BlueStore::_prepare_read_ioc(
                  << dendl;
 
         // read it
-        auto r = bptr->get_blob().map(
+	span_stat.allocated += req.r_len;
+	auto r = bptr->get_blob().map(
           req.r_off, req.r_len,
           [&](uint64_t offset, uint64_t length) {
-            int r = bdev->aio_read(offset, length, &req.bl, ioc);
+	    if (res_span_stat) {
+	      pintervals.insert(offset, length);
+	      if (has_shared) {
+		sb->map_fn(offset, length, shared_cb);
+	      }
+	    }
+	    int r = bdev->aio_read(offset, length, &req.bl, ioc);
             if (r < 0)
               return r;
             return 0;
@@ -13138,6 +13511,7 @@ int BlueStore::_prepare_read_ioc(
       }
     }
   }
+  span_stat.frags += pintervals.num_intervals();
   return 0;
 }
 
@@ -13283,14 +13657,15 @@ void BlueStore::_measure_static_frag(
   logger->tinc_with_max(l_bluestore_static_frag_lat, finish - start);
 }
 
-int BlueStore::_do_read(
+int BlueStore::_do_basic_read(
   Collection *c,
   OnodeRef& o,
   uint64_t offset,
   size_t length,
   bufferlist& bl,
   uint32_t op_flags,
-  uint64_t retry_count)
+  uint64_t retry_count,
+  span_stat_t* span_stat)
 {
   FUNCTRACE(cct);
   int r = 0;
@@ -13341,7 +13716,7 @@ int BlueStore::_do_read(
   // build blob-wise list to of stuff read (that isn't cached)
   ready_regions_t ready_regions;
   blobs2read_t blobs2read;
-  _read_cache(o, offset, length, read_cache_policy, ready_regions, blobs2read);
+  _read_cache(o, offset, length, read_cache_policy, ready_regions, blobs2read, span_stat);
 
 
   // read raw blob data.
@@ -13350,7 +13725,7 @@ int BlueStore::_do_read(
                              // The error isn't that much...
   vector<bufferlist> compressed_blob_bls;
   IOContext ioc(cct, NULL, !cct->_conf->bluestore_fail_eio);
-  r = _prepare_read_ioc(blobs2read, &compressed_blob_bls, &ioc);
+  r = _prepare_read_ioc(blobs2read, &compressed_blob_bls, &ioc, span_stat);
   // we always issue aio for reading, so errors other than EIO are not allowed
   if (r < 0)
     return r;
@@ -13414,7 +13789,7 @@ int BlueStore::_do_read(
     if (retry_count >= cct->_conf->bluestore_retry_disk_reads) {
       return -EIO;
     }
-    return _do_read(c, o, offset, length, bl, op_flags, retry_count + 1);
+    return _do_basic_read(c, o, offset, length, bl, op_flags, retry_count + 1);
   }
   r = bl.length();
   if (retry_count) {
@@ -13435,7 +13810,7 @@ void inline BlueStore::_do_read_and_pad(
   uint32_t length,
   ceph::buffer::list& bl)
 {
-  int r = _do_read(c, o, offset, length, bl, 0);
+  int r = _do_basic_read(c, o, offset, length, bl, 0);
   ceph_assert(r >= 0 && r <= (int)length);
   size_t zlen = length - r;
   if (zlen > 0) {
@@ -13758,9 +14133,10 @@ int BlueStore::_do_readv(
   for (auto p = m.begin(); p != m.end(); p++, i++) {
     raw_results.push_back({});
     _read_cache(o, p.get_start(), p.get_len(), read_cache_policy,
-                std::get<0>(raw_results[i]), std::get<2>(raw_results[i]));
-    r = _prepare_read_ioc(std::get<2>(raw_results[i]), &std::get<1>(raw_results[i]), &ioc);
-    // we always issue aio for reading, so errors other than EIO are not allowed
+                std::get<0>(raw_results[i]), std::get<2>(raw_results[i]),
+		nullptr);
+    r = _prepare_read_ioc(std::get<2>(raw_results[i]), &std::get<1>(raw_results[i]),
+                          &ioc, nullptr);
     if (r < 0)
       return r;
     if (cct->_conf->bluestore_frag_runtime) {
@@ -16637,7 +17013,38 @@ void BlueStore::_txc_add_transaction(TransContext *txc, Transaction *t)
   }
 }
 
+void BlueStore::_txc_exec_reformat_write(Collection* c,  OnodeRef o,
+  uint64_t offset, size_t length, const bufferlist& bl,
+  WriteContext& wctx)
+{
+  dout(10) << __func__ << " " << o->oid
+           << std::hex << " 0x" << offset << "~" << length
+	   << std::dec << dendl;
+  TransContext* txc =
+    _txc_create(c, c->osr.get(), nullptr);
+  txc->bytes += length;
 
+  // initialize osd_pool_id and do a smoke test that all collections belong
+  // to the same pool
+  ceph_assert(!!c);
+  spg_t pgid;
+  if (c->cid.is_pg(&pgid) ) {
+    txc->osd_pool_id = pgid.pool();
+  }
+  // object operations
+  ceph_assert(o->exists);
+  int r = _do_write(txc, txc->ch, o, offset, length, bl, wctx);
+
+  if (r < 0) {
+    dout(5) << __func__ << " got an error: " << cpp_strerror(r) << dendl;
+    txc->osr->undo_queue(txc);
+    delete txc;
+  } else {
+    txc->write_onode(o);
+    logger->inc(l_bluestore_reformat_issued);
+    _txc_exec(txc, nullptr);
+  }
+}
 
 // -----------------
 // write operations
@@ -16721,7 +17128,7 @@ void BlueStore::_do_write_small(
     CollectionRef &c,
     OnodeRef& o,
     uint64_t offset, uint64_t length,
-    bufferlist::iterator& blp,
+    bufferlist::const_iterator& blp,
     WriteContext *wctx)
 {
   dout(10) << __func__ << " 0x" << std::hex << offset << "~" << length
@@ -16933,7 +17340,7 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
 		   << " and tail 0x" << tail_read << std::dec << dendl;
 	  if (head_read) {
 	    bufferlist head_bl;
-	    int r = _do_read(c.get(), o, offset - head_pad - head_read, head_read,
+	    int r = _do_basic_read(c.get(), o, offset - head_pad - head_read, head_read,
 			     head_bl, 0);
 	    ceph_assert(r >= 0 && r <= (int)head_read);
 	    size_t zlen = head_read - r;
@@ -16947,7 +17354,7 @@ uint32_t BlueStore::_do_write_small_with_maybe_blob_reuse(
 	  }
 	  if (tail_read) {
 	    bufferlist tail_bl;
-	    int r = _do_read(c.get(), o, offset + length + tail_pad, tail_read,
+	    int r = _do_basic_read(c.get(), o, offset + length + tail_pad, tail_read,
 			     tail_bl, 0);
 	    ceph_assert(r >= 0 && r <= (int)tail_read);
 	    size_t zlen = tail_read - r;
@@ -17188,14 +17595,14 @@ void BlueStore::_do_write_big_apply_deferred(
     CollectionRef& c,
     OnodeRef& o,
     BlueStore::BigDeferredWriteContext& dctx,
-    bufferlist::iterator& blp,
+    bufferlist::const_iterator& blp,
     WriteContext* wctx)
 {
   bufferlist bl;
   dout(20) << __func__ << "  reading head 0x" << std::hex << dctx.head_read
     << " and tail 0x" << dctx.tail_read << std::dec << dendl;
   if (dctx.head_read) {
-    int r = _do_read(c.get(), o,
+    int r = _do_basic_read(c.get(), o,
       dctx.off - dctx.head_read,
       dctx.head_read,
       bl,
@@ -17212,7 +17619,7 @@ void BlueStore::_do_write_big_apply_deferred(
 
   if (dctx.tail_read) {
     bufferlist tail_bl;
-    int r = _do_read(c.get(), o,
+    int r = _do_basic_read(c.get(), o,
       dctx.off + dctx.used, dctx.tail_read,
       tail_bl, 0);
     ceph_assert(r >= 0 && r <= (int)dctx.tail_read);
@@ -17251,7 +17658,7 @@ void BlueStore::_do_write_big(
     CollectionRef &c,
     OnodeRef& o,
     uint64_t offset, uint64_t length,
-    bufferlist::iterator& blp,
+    bufferlist::const_iterator& blp,
     WriteContext *wctx)
 {
   dout(10) << __func__ << " 0x" << std::hex << offset << "~" << length
@@ -17260,6 +17667,12 @@ void BlueStore::_do_write_big(
 	   << dendl;
   logger->inc(l_bluestore_write_big);
   logger->inc(l_bluestore_write_big_bytes, length);
+  if (wctx->precompressed) {
+    dout(20) << __func__ << " has been precompressed, omitting." << dendl;
+    o->extent_map.punch_hole(c, offset, length, &wctx->old_extents);
+    blp += length;
+    return;
+  }
   auto max_bsize = std::max(wctx->target_blob_size, min_alloc_size);
   uint64_t prefer_deferred_size_snapshot = prefer_deferred_size.load();
   while (length > 0) {
@@ -17269,7 +17682,7 @@ void BlueStore::_do_write_big(
     uint32_t l = 0;
 
     //attempting to reuse existing blob
-    if (!wctx->compress && !wctx->full_write) {
+    if (!wctx->compress && !wctx->full_write && !wctx->preallocated()) {
       // enforce target blob alignment with max_bsize
       l = max_bsize - p2phase(offset, max_bsize);
       l = std::min(uint64_t(l), length);
@@ -17422,10 +17835,10 @@ void BlueStore::_do_write_big(
 	}
       } while (b == nullptr && any_change);
     } else {
-      // trying to utilize as longer chunk as permitted in case of compression.
+      // trying to utilize as longer chunk as permitted in case of compression/reformatting.
       l = std::min(max_bsize, length);
       o->extent_map.punch_hole(c, offset, l, &wctx->old_extents);
-    } // if (!wctx->compress)
+    } // if (!wctx->compress && !wctx->preallocated)
 
     if (b == nullptr) {
       b = c->new_blob();
@@ -17491,20 +17904,25 @@ int BlueStore::_do_alloc_write(
 
   auto max_bsize = std::max(wctx->target_blob_size, min_alloc_size);
   for (auto& wi : wctx->writes) {
+    wi.compressed = false; // unsetting now to indicate actual status at the end
     if (wctx->compressor && wi.blob_length > min_alloc_size) {
       auto start = mono_clock::now();
-
       // compress
       ceph_assert(wi.b_off == 0);
       ceph_assert(wi.blob_length == wi.bl.length());
 
       // FIXME: memory alignment here is bad
       bufferlist t;
-      std::optional<int32_t> compressor_message;
-      int r = wctx->compressor->compress(wi.bl, t, compressor_message);
+      int r = 0;
+      if (!wctx->precompressed) {
+        r = wctx->compressor->compress(wi.bl, t, wi.compressor_message);
+      } else {
+        std::swap(t, wi.compressed_bl);
+      }
+
       uint64_t want_len_raw = wi.blob_length * wctx->crr;
       uint64_t want_len = p2roundup(want_len_raw, min_alloc_size);
-      bool rejected = false;
+      bool rejected = true;
       uint64_t compressed_len = t.length();
       // do an approximate (fast) estimation for resulting blob size
       // that doesn't take header overhead  into account
@@ -17512,8 +17930,8 @@ int BlueStore::_do_alloc_write(
       if (r == 0 && result_len <= want_len && result_len < wi.blob_length) {
 	bluestore_compression_header_t chdr;
 	chdr.type = wctx->compressor->get_type();
-	chdr.length = t.length();
-	chdr.compressor_message = compressor_message;
+	chdr.length = compressed_len;
+	chdr.compressor_message = wi.compressor_message;
 	encode(chdr, wi.compressed_bl);
 	wi.compressed_bl.claim_append(t);
 
@@ -17536,8 +17954,7 @@ int BlueStore::_do_alloc_write(
 	  logger->inc(l_bluestore_compress_success_count);
 	  need += result_len;
 	  data_size += result_len;
-	} else {
-	  rejected = true;
+	  rejected = false;
 	}
       } else if (r != 0) {
 	dout(5) << __func__ << std::hex << "  0x" << wi.blob_length
@@ -17546,63 +17963,86 @@ int BlueStore::_do_alloc_write(
 		 << " failed with errcode = " << r
 		 << ", leaving uncompressed"
 		 << dendl;
-	logger->inc(l_bluestore_compress_rejected_count);
-	need += wi.blob_length;
-	data_size += wi.bl.length();
-      } else {
-	rejected = true;
       }
 
-      if (rejected) {
+      if (r == 0 && rejected) {
 	dout(20) << __func__ << std::hex << "  0x" << wi.blob_length
-		 << " compressed to 0x" << compressed_len << " -> 0x" << result_len
-		 << " with " << wctx->compressor->get_type()
-		 << ", which is more than required 0x" << want_len_raw
-		 << " -> 0x" << want_len
-		 << ", leaving uncompressed"
-		 << std::dec << dendl;
+	  << " compressed to 0x" << compressed_len << " -> 0x" << result_len
+	  << " with " << wctx->compressor->get_type()
+	  << ", which is more than required 0x" << want_len_raw
+	  << " -> 0x" << want_len
+	  << ", leaving uncompressed"
+	  << std::dec << dendl;
 	logger->inc(l_bluestore_compress_rejected_count);
-	need += wi.blob_length;
-	data_size += wi.bl.length();
       }
-      log_latency("compress@_do_alloc_write",
-	l_bluestore_compress_lat,
-        mono_clock::now() - start,
-	cct->_conf->bluestore_log_op_age );
-    } else {
+
+      if (!wctx->precompressed) {
+        log_latency("compress@_do_alloc_write",
+	  l_bluestore_compress_lat,
+          mono_clock::now() - start,
+	  cct->_conf->bluestore_log_op_age );
+      }
+    }
+    if (!wi.compressed) {
       need += wi.blob_length;
       data_size += wi.bl.length();
+      wi.compressed_bl.clear();
+      wi.compressed_len = 0;
     }
   }
-  PExtentVector prealloc;
-  prealloc.reserve(2 * wctx->writes.size());
-  int64_t prealloc_left = 0;
-  auto start = mono_clock::now();
-  prealloc_left = alloc->allocate(
-    need, min_alloc_size, need,
-    use_last_allocator_lookup_position ? -1 : 0,
-    &prealloc);
-  log_latency("allocator@_do_alloc_write",
-    l_bluestore_allocator_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
-  if (prealloc_left < 0 || prealloc_left < (int64_t)need) {
-    derr << __func__ << " failed to allocate 0x" << std::hex << need
-         << " allocated 0x " << (prealloc_left < 0 ? 0 : prealloc_left)
-         << " min_alloc_size 0x" << min_alloc_size
-         << " available 0x " << alloc->get_free()
+  auto need0 = need;
+  PExtentVector pextents;
+  pextents.reserve(2 * wctx->writes.size());
+  uint64_t preallocated = 0;
+
+  if (!wctx->prealloc_slicer.end()) {
+    preallocated = wctx->prealloc_slicer.slice(pextents, need);
+    dout(20) << __func__ << " using wxtx prealloc, consumed 0x"
+      << std::hex << preallocated
+      << ", needed 0x " << need
+      << std::dec << dendl;
+    ceph_assert(preallocated <= need);
+    need -= preallocated;
+  }
+
+  int64_t allocated = 0;
+  if (need > 0)  {
+    auto start = mono_clock::now();
+    allocated = alloc->allocate(
+      need, min_alloc_size, need,
+      use_last_allocator_lookup_position ? -1 : 0,
+      &pextents);
+    log_latency("allocator@_do_alloc_write",
+      l_bluestore_allocator_lat,
+      mono_clock::now() - start,
+      cct->_conf->bluestore_log_op_age);
+    if (allocated < (int64_t)need) {
+      derr << __func__ << " failed to allocate 0x" << std::hex << need
+	<< " allocated 0x " << (allocated < 0 ? 0 : allocated)
+	<< " min_alloc_size 0x" << min_alloc_size
+	<< " available 0x " << alloc->get_free()
+	<< std::dec << dendl;
+      allocated = 0;
+    }
+  }
+  if (preallocated + allocated < need0) {
+    derr << __func__ << " failed to get 0x" << std::hex << need0
+         << ", preallocated = 0x" << preallocated
+         << ", allocated = 0x" << allocated
          << std::dec << dendl;
-    if (prealloc.size()) {
-      alloc->release(prealloc);
+    if (pextents.size()) {
+      alloc->release(pextents);
     }
     return -ENOSPC;
   }
-  _collect_allocation_stats(need, min_alloc_size, prealloc);
+  _collect_allocation_stats(need, min_alloc_size, pextents);
 
   dout(20) << __func__ << std::hex << " need=0x" << need << " data=0x" << data_size
-	   << " prealloc " << prealloc << dendl;
-  auto prealloc_pos = prealloc.begin();
-  ceph_assert(prealloc_pos != prealloc.end());
+	   << " prealloc " << pextents << dendl;
+
+  int64_t prealloc_left = allocated + preallocated;
+  auto prealloc_pos = pextents.begin();
+  ceph_assert(prealloc_pos != pextents.end());
 
   for (auto& wi : wctx->writes) {
     bluestore_blob_t& dblob = wi.b->dirty_blob();
@@ -17746,7 +18186,7 @@ int BlueStore::_do_alloc_write(
       }
     }
   }
-  ceph_assert(prealloc_pos == prealloc.end());
+  ceph_assert(prealloc_pos == pextents.end());
   ceph_assert(prealloc_left == 0);
   return 0;
 }
@@ -17823,11 +18263,11 @@ void BlueStore::_do_write_data(
   OnodeRef& o,
   uint64_t offset,
   uint64_t length,
-  bufferlist& bl,
+  const bufferlist& bl,
   WriteContext *wctx)
 {
   uint64_t end = offset + length;
-  bufferlist::iterator p = bl.begin();
+  bufferlist::const_iterator p = bl.cbegin();
 
   wctx->full_write = offset == 0 && length >= o->onode.size;
 
@@ -17874,7 +18314,7 @@ void BlueStore::_do_write_data(
 }
 
 void BlueStore::_choose_write_options(
-   CollectionRef& c,
+   Collection* c,
    OnodeRef& o,
    uint32_t fadvise_flags,
    WriteContext *wctx)
@@ -17990,7 +18430,7 @@ int BlueStore::_do_gc(
     dout(20) << __func__ << " processing " << std::hex
             << offset << "~" << length << std::dec
 	    << dendl;
-    int r = _do_read(c.get(), o, offset, length, bl, 0);
+    int r = _do_basic_read(c.get(), o, offset, length, bl, 0);
     ceph_assert(r == (int)length);
 
     _do_write_data(txc, c, o, offset, length, bl, &wctx_gc);
@@ -18028,8 +18468,8 @@ int BlueStore::_do_write(
   OnodeRef& o,
   uint64_t offset,
   uint64_t length,
-  bufferlist& bl,
-  uint32_t fadvise_flags)
+  const bufferlist& bl,
+  WriteContext& wctx)
 {
   int r = 0;
 
@@ -18039,7 +18479,6 @@ int BlueStore::_do_write(
 	   << " - have 0x" << o->onode.size
 	   << " (" << std::dec << o->onode.size << ")"
 	   << " bytes" << std::hex
-	   << " fadvise_flags 0x" << fadvise_flags
 	   << " alloc_hint 0x" << o->onode.alloc_hint_flags
            << " expected_object_size " << o->onode.expected_object_size
            << " expected_write_size " << o->onode.expected_write_size
@@ -18058,8 +18497,6 @@ int BlueStore::_do_write(
   auto dirty_start = offset;
   auto dirty_end = end;
 
-  WriteContext wctx;
-  _choose_write_options(c, o, fadvise_flags, &wctx);
   o->extent_map.fault_range(db, offset, length);
   _do_write_data(txc, c, o, offset, length, bl, &wctx);
   r = _do_alloc_write(txc, c, o, &wctx);
@@ -18144,13 +18581,12 @@ int BlueStore::_do_write_v2(
   if (length == 0) {
     return 0;
   }
-
   if (bl.length() != length) {
     bl.splice(length, bl.length() - length);
   }
 
   WriteContext wctx;
-  _choose_write_options(c, o, fadvise_flags, &wctx);
+  _choose_write_options(c.get(), o, fadvise_flags, &wctx);
   if (wctx.compressor) {
     uint32_t end = offset + length;
     uint32_t segment_size = o->onode.segment_size;
@@ -18264,8 +18700,9 @@ int BlueStore::_write(TransContext *txc,
 		      uint32_t fadvise_flags)
 {
   dout(15) << __func__ << " " << c->cid << " " << o->oid
-	   << " 0x" << std::hex << offset << "~" << length << std::dec
-	   << dendl;
+	   << " 0x" << std::hex << offset << "~" << length
+           << " fadvise_flags 0x" << fadvise_flags
+	   << std::dec << dendl;
   auto start = mono_clock::now();
   int r = 0;
   if (offset + length >= OBJECT_MAX_SIZE) {
@@ -18275,7 +18712,9 @@ int BlueStore::_write(TransContext *txc,
     if (use_write_v2) {
       r = _do_write_v2(txc, c, o, offset, length, bl, fadvise_flags);
     } else {
-      r = _do_write(txc, c, o, offset, length, bl, fadvise_flags);
+      WriteContext wctx;
+      _choose_write_options(c.get(), o, fadvise_flags, &wctx);
+      r = _do_write(txc, c, o, offset, length, bl, wctx);
     }
     txc->write_onode(o);
   }
@@ -18895,10 +19334,12 @@ int BlueStore::_clone(TransContext *txc,
     _do_clone_range(txc, c, oldo, newo, 0, oldo->onode.size, 0);
   } else {
     bufferlist bl;
-    r = _do_read(c.get(), oldo, 0, oldo->onode.size, bl, 0);
+    r = _do_basic_read(c.get(), oldo, 0, oldo->onode.size, bl, 0);
     if (r < 0)
       goto out;
-    r = _do_write(txc, c, newo, 0, oldo->onode.size, bl, 0);
+    WriteContext wctx;
+    _choose_write_options(c.get(), newo, 0, &wctx);
+    r = _do_write(txc, c, newo, 0, oldo->onode.size, bl, wctx);
     if (r < 0)
       goto out;
   }
@@ -19016,10 +19457,12 @@ int BlueStore::_clone_range(TransContext *txc,
       _do_clone_range(txc, c, oldo, newo, srcoff, length, dstoff);
     } else {
       bufferlist bl;
-      r = _do_read(c.get(), oldo, srcoff, length, bl, 0);
+      r = _do_basic_read(c.get(), oldo, srcoff, length, bl, 0);
       if (r < 0)
 	goto out;
-      r = _do_write(txc, c, newo, dstoff, bl.length(), bl, 0);
+      WriteContext wctx;
+      _choose_write_options(c.get(), newo, 0, &wctx);
+      r = _do_write(txc, c, newo, dstoff, bl.length(), bl, wctx);
       if (r < 0)
 	goto out;
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -16154,6 +16154,35 @@ int BlueStore::queue_transactions(
     txc->bytes += (*p).get_num_bytes();
     _txc_add_transaction(txc, &(*p));
   }
+  _txc_exec(txc, handle);
+
+  // we're immediately readable (unlike FileStore)
+  for (auto c : on_applied_sync) {
+    c->complete(0);
+  }
+  if (!on_applied.empty()) {
+    if (c->commit_queue) {
+      c->commit_queue->queue(on_applied);
+    } else {
+      finisher.queue(on_applied);
+    }
+  }
+
+#ifdef WITH_BLKIN
+  if (txc->trace) {
+    txc->trace.event("txc applied");
+  }
+#endif
+
+  log_latency("submit_transact",
+    l_bluestore_submit_lat,
+    mono_clock::now() - start,
+    cct->_conf->bluestore_log_op_age);
+  return 0;
+}
+
+void BlueStore::_txc_exec(TransContext* txc, ThreadPool::TPHandle* handle)
+{
   _txc_calc_cost(txc);
 
   _txc_write_nodes(txc, txc->t);
@@ -16182,12 +16211,12 @@ int BlueStore::queue_transactions(
   auto tstart = mono_clock::now();
 
   if (!throttle.try_start_transaction(
-	*db,
-	*txc,
-	tstart)) {
+    *db,
+    *txc,
+    tstart)) {
     // ensure we do not block here because of deferred writes
     dout(10) << __func__ << " failed get throttle_deferred_bytes, aggressive"
-	     << dendl;
+      << dendl;
     ++deferred_aggressive;
     deferred_try_submit();
     {
@@ -16207,37 +16236,13 @@ int BlueStore::queue_transactions(
     handle->reset_tp_timeout();
 
   logger->inc(l_bluestore_txc);
-
-  // execute (start)
-  _txc_state_proc(txc);
-
-  // we're immediately readable (unlike FileStore)
-  for (auto c : on_applied_sync) {
-    c->complete(0);
-  }
-  if (!on_applied.empty()) {
-    if (c->commit_queue) {
-      c->commit_queue->queue(on_applied);
-    } else {
-      finisher.queue(on_applied);
-    }
-  }
-
-#ifdef WITH_BLKIN
-  if (txc->trace) {
-    txc->trace.event("txc applied");
-  }
-#endif
-
-  log_latency("submit_transact",
-    l_bluestore_submit_lat,
-    mono_clock::now() - start,
-    cct->_conf->bluestore_log_op_age);
   log_latency("throttle_transact",
     l_bluestore_throttle_lat,
     tend - tstart,
     cct->_conf->bluestore_log_op_age);
-  return 0;
+
+  // execute (start)
+  _txc_state_proc(txc);
 }
 
 void BlueStore::_txc_aio_submit(TransContext *txc)

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -250,6 +250,17 @@ enum {
   l_bluestore_runtime_frag_lat,
   l_bluestore_static_frag_lat,
   //****************************************
+
+  // reformatting counters
+  //****************************************
+  l_bluestore_reformat_lat,
+  l_bluestore_reformat_compress_attempted,
+  l_bluestore_reformat_compress_omitted,
+  l_bluestore_reformat_defragment_attempted,
+  l_bluestore_reformat_defragment_omitted,
+  l_bluestore_reformat_issued,
+  //****************************************
+
   l_bluestore_last
 };
 
@@ -258,11 +269,15 @@ using bptr_c_it_t = buffer::ptr::const_iterator;
 
 extern const std::vector<uint64_t> bdev_label_positions;
 
+class OnodeReformatContext;
+
 class BlueStore : public ObjectStore,
 		  public md_config_obs_t {
   // -----------------------------------------------------
   // types
+
 public:
+  struct WriteContext;
   // config observer
   std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
@@ -601,7 +616,14 @@ public:
     inline bool is_loaded() const {
       return loaded;
     }
-
+    /// Calls back function for any inidividual extent within the specified range.
+    /// The functions gets mapped extent offset, remaining length and references
+    /// count.
+    template<class F>
+    int map_fn(uint32_t x_off, uint32_t x_len, F&& f) const {
+      ceph_assert(loaded && persistent);
+      return persistent->ref_map.map_fn(x_off, x_len, f);
+    }
   };
   typedef boost::intrusive_ptr<SharedBlob> SharedBlobRef;
 
@@ -2067,6 +2089,7 @@ public:
     }
   private:
     state_t state = STATE_PREPARE;
+
   };
 
   class BlueStoreThrottle {
@@ -2960,6 +2983,10 @@ private:
   void _txc_exec(TransContext* txc, ThreadPool::TPHandle* handle);
   void _txc_update_store_statfs(TransContext *txc);
   void _txc_add_transaction(TransContext *txc, Transaction *t);
+  void _txc_exec_reformat_write(Collection* c, OnodeRef o,
+                                uint64_t offset, size_t length,
+			        const bufferlist& bl,
+                                WriteContext& wctx);
   void _txc_calc_cost(TransContext *txc);
   void _txc_write_nodes(TransContext *txc, KeyValueDB::Transaction t);
   void _txc_state_proc(TransContext *txc);
@@ -3354,13 +3381,15 @@ private:
     size_t length,
     int read_cache_policy,
     ready_regions_t& ready_regions,
-    blobs2read_t& blobs2read);
+    blobs2read_t& blobs2read,
+    span_stat_t* span_stat);
 
 
   int _prepare_read_ioc(
     blobs2read_t& blobs2read,
     std::vector<ceph::buffer::list>* compressed_blob_bls,
-    IOContext* ioc);
+    IOContext* ioc,
+    span_stat_t* span_stat);
 
   int _generate_read_result_bl(
     OnodeRef& o,
@@ -3378,13 +3407,23 @@ private:
   void _measure_static_frag(Collection *c, const OnodeRef& o);
 
   int _do_read(
+    Collection* c,
+    const ghobject_t& oid,
+    uint64_t offset,
+    size_t len,
+    ceph::buffer::list& bl,
+    uint32_t op_flags,
+    OnodeReformatContext& reformat_ctx);
+
+  int _do_basic_read(
     Collection *c,
     OnodeRef& o,
     uint64_t offset,
     size_t len,
     ceph::buffer::list& bl,
     uint32_t op_flags = 0,
-    uint64_t retry_count = 0);
+    uint64_t retry_count = 0,
+    span_stat_t* span_stat = nullptr);
 
   void _do_read_and_pad(
     Collection* c,
@@ -3776,6 +3815,13 @@ private:
     unsigned csum_order = 0;        ///< target checksum chunk order
     uint64_t target_blob_size = 0;  ///< target (max) blob size
 
+    bool precompressed = false;     ///< reformatting write,
+                                    ///< ctx has precompressed data
+
+    PExtentVectorSlicer prealloc_slicer; ///< Prealloc vector incremental slicer
+
+    uint32_t preallocated() const { return prealloc_slicer.size(); }
+
     old_extent_map_t old_extents;   ///< must deref these blobs
     interval_set<uint64_t> extents_to_gc; ///< extents for garbage collection
 
@@ -3796,7 +3842,7 @@ private:
       bool compressed = false;
       ceph::buffer::list compressed_bl;
       size_t compressed_len = 0;
-
+      std::optional<int32_t> compressor_message;
       write_item(
 	uint64_t logical_offs,
         BlobRef b,
@@ -3828,17 +3874,16 @@ private:
       csum_type = other.csum_type;
       csum_order = other.csum_order;
     }
-    void write(
-      uint64_t loffs,
-      BlobRef b,
-      uint64_t blob_len,
-      uint64_t o,
-      ceph::buffer::list& bl,
-      uint64_t o0,
-      uint64_t len0,
-      bool _mark_unused,
-      bool _new_blob) {
-      writes.emplace_back(loffs,
+    write_item& write(uint64_t loffs,
+                      BlobRef b,
+                      uint64_t blob_len,
+                      uint64_t o,
+                      ceph::buffer::list& bl,
+                      uint64_t o0,
+                      uint64_t len0,
+                      bool _mark_unused,
+                      bool _new_blob) {
+      return writes.emplace_back(loffs,
                           b,
                           blob_len,
                           o,
@@ -3854,6 +3899,10 @@ private:
       uint64_t loffs,
       uint64_t loffs_end,
       uint64_t min_alloc_size);
+    void reset() {
+      WriteContext wctx0;
+      std::swap(*this, wctx0);
+    }
   };
   private:
   BlueStore::extent_map_t::iterator _punch_hole_2(
@@ -3870,7 +3919,7 @@ private:
     CollectionRef &c,
     OnodeRef& o,
     uint64_t offset, uint64_t length,
-    ceph::buffer::list::iterator& blp,
+    ceph::buffer::list::const_iterator& blp,
     WriteContext *wctx);
 
   /// Determines if small write can reuse existing blob
@@ -3891,20 +3940,30 @@ private:
     CollectionRef& c,
     OnodeRef& o,
     BigDeferredWriteContext& dctx,
-    bufferlist::iterator& blp,
+    bufferlist::const_iterator& blp,
     WriteContext* wctx);
   void _do_write_big(
     TransContext *txc,
     CollectionRef &c,
     OnodeRef& o,
     uint64_t offset, uint64_t length,
-    ceph::buffer::list::iterator& blp,
+    ceph::buffer::list::const_iterator& blp,
     WriteContext *wctx);
   int _do_alloc_write(
     TransContext *txc,
     CollectionRef c,
     OnodeRef& o,
     WriteContext *wctx);
+
+  void _maybe_need_reformat_onode(OnodeReformatContext& ctx,
+    Collection* c);
+  void _maybe_do_reformat_onode(OnodeReformatContext& ctx,
+    Collection* c,
+    OnodeRef& o,
+    uint64_t offset,
+    size_t length,
+    const bufferlist& bl,
+    uint32_t op_flags);
   void _wctx_finish(
     TransContext *txc,
     CollectionRef& c,
@@ -3921,7 +3980,7 @@ private:
   void _pad_zeros(ceph::buffer::list *bl, uint64_t *offset,
 		  uint64_t chunk_size);
 
-  void _choose_write_options(CollectionRef& c,
+  void _choose_write_options(Collection* c,
                              OnodeRef& o,
                              uint32_t fadvise_flags,
                              WriteContext *wctx);
@@ -3937,14 +3996,14 @@ private:
 		CollectionRef &c,
 		OnodeRef& o,
 		uint64_t offset, uint64_t length,
-		ceph::buffer::list& bl,
-		uint32_t fadvise_flags);
+		const ceph::buffer::list& bl,
+                WriteContext& wctx);
   void _do_write_data(TransContext *txc,
                       CollectionRef& c,
                       OnodeRef& o,
                       uint64_t offset,
                       uint64_t length,
-                      ceph::buffer::list& bl,
+                      const ceph::buffer::list& bl,
                       WriteContext *wctx);
   int _do_write_v2(
     TransContext *txc,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -73,6 +73,9 @@ class FreelistManager;
 class BlueStoreRepairer;
 class SimpleBitmap;
 class OnodeReformatContext;
+class OnodeReformatEngine;
+using reformat_engines_t =
+  std::array<std::shared_ptr<OnodeReformatEngine>, MAX_REFORMAT_ENGINES>;
 
 //#define DEBUG_CACHE
 //#define DEBUG_DEFERRED
@@ -1759,6 +1762,7 @@ public:
     std::optional<int64_t> comp_min_blob_size;
     std::optional<int64_t> comp_max_blob_size;
     std::optional<double> compression_req_ratio;
+    reformat_engines_t reformat_engines;
 
     ContextQueue *commit_queue;
     std::unique_ptr<Estimator> estimator;
@@ -1817,6 +1821,34 @@ public:
     void flush_all_but_last();
 
     Collection(BlueStore *ns, OnodeCacheShard *oc, BufferCacheShard *bc, coll_t c);
+  };
+
+  struct read_context_t {
+    BlueStore& store;
+    uint64_t offset;
+    size_t length;
+    bufferlist& bl;
+    uint32_t op_flags;
+    read_context_t(BlueStore& _store,
+        uint64_t _offset,
+        size_t _length,
+        bufferlist& _bl,
+        uint32_t _op_flags) :
+      store(_store),
+      offset(_offset),
+      length(_length),
+      bl(_bl),
+      op_flags(_op_flags)
+    {
+    }
+    read_context_t(const read_context_t& other) :
+      store(other.store),
+      offset(other.offset),
+      length(other.length),
+      bl(other.bl),
+      op_flags(other.op_flags)
+    {
+    }
   };
 
   struct volatile_statfs{
@@ -3412,8 +3444,7 @@ private:
     uint64_t offset,
     size_t len,
     ceph::buffer::list& bl,
-    uint32_t op_flags,
-    OnodeReformatContext& reformat_ctx);
+    uint32_t op_flags);
 
   int _do_basic_read(
     Collection *c,
@@ -3958,8 +3989,7 @@ private:
     OnodeRef& o,
     WriteContext *wctx);
 
-  void _maybe_need_reformat_onode(OnodeReformatContext& ctx,
-    Collection* c);
+  void _update_reformat_engines(Collection* c);
   void _maybe_do_reformat_onode(OnodeReformatContext& ctx,
     Collection* c,
     OnodeRef& o,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -278,7 +278,6 @@ class BlueStore : public ObjectStore,
 		  public md_config_obs_t {
   // -----------------------------------------------------
   // types
-
 public:
   struct WriteContext;
   // config observer
@@ -2121,7 +2120,6 @@ public:
     }
   private:
     state_t state = STATE_PREPARE;
-
   };
 
   class BlueStoreThrottle {
@@ -3017,7 +3015,7 @@ private:
   void _txc_add_transaction(TransContext *txc, Transaction *t);
   void _txc_exec_reformat_write(Collection* c, OnodeRef o,
                                 uint64_t offset, size_t length,
-			        const bufferlist& bl,
+                                const bufferlist& bl,
                                 WriteContext& wctx);
   void _txc_calc_cost(TransContext *txc);
   void _txc_write_nodes(TransContext *txc, KeyValueDB::Transaction t);
@@ -3414,14 +3412,14 @@ private:
     int read_cache_policy,
     ready_regions_t& ready_regions,
     blobs2read_t& blobs2read,
-    span_stat_t* span_stat);
+    span_stat_t* span_stat = nullptr);
 
 
   int _prepare_read_ioc(
     blobs2read_t& blobs2read,
     std::vector<ceph::buffer::list>* compressed_blob_bls,
     IOContext* ioc,
-    span_stat_t* span_stat);
+    span_stat_t* span_stat = nullptr);
 
   int _generate_read_result_bl(
     OnodeRef& o,
@@ -4022,7 +4020,7 @@ private:
 		OnodeRef& o,
 		uint64_t offset, uint64_t length,
 		const ceph::buffer::list& bl,
-                WriteContext& wctx);
+		WriteContext& wctx);
   void _do_write_data(TransContext *txc,
                       CollectionRef& c,
                       OnodeRef& o,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2957,6 +2957,7 @@ private:
   TransContext *_txc_create(Collection *c, OpSequencer *osr,
 			    std::list<Context*> *on_commits,
 			    TrackedOpRef osd_op=TrackedOpRef());
+  void _txc_exec(TransContext* txc, ThreadPool::TPHandle* handle);
   void _txc_update_store_statfs(TransContext *txc);
   void _txc_add_transaction(TransContext *txc, Transaction *t);
   void _txc_calc_cost(TransContext *txc);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -72,6 +72,8 @@ class Allocator;
 class FreelistManager;
 class BlueStoreRepairer;
 class SimpleBitmap;
+class OnodeReformatContext;
+
 //#define DEBUG_CACHE
 //#define DEBUG_DEFERRED
 #ifdef WITH_CPUTRACE
@@ -268,8 +270,6 @@ enum {
 using bptr_c_it_t = buffer::ptr::const_iterator;
 
 extern const std::vector<uint64_t> bdev_label_positions;
-
-class OnodeReformatContext;
 
 class BlueStore : public ObjectStore,
 		  public md_config_obs_t {
@@ -3581,6 +3581,9 @@ public:
   BlockDevice* get_bdev() {
     return bdev;
   }
+  Allocator* get_allocator() {
+    return alloc;
+  }
 
   int queue_transactions(
     CollectionHandle& ch,
@@ -3696,7 +3699,7 @@ public:
     OnodeRef o = c->get_onode(hoid, false);
     return o;
   }
-  inline void log_latency(const char* name,
+  void log_latency(const char* name,
     int idx,
     const ceph::timespan& lat,
     double lat_threshold,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1824,16 +1824,22 @@ public:
 
   struct read_context_t {
     BlueStore& store;
+    CollectionHandle ch;
+    OnodeRef o;
     uint64_t offset;
     size_t length;
     bufferlist& bl;
     uint32_t op_flags;
     read_context_t(BlueStore& _store,
+        CollectionHandle _ch,
+        OnodeRef _o,
         uint64_t _offset,
         size_t _length,
         bufferlist& _bl,
         uint32_t _op_flags) :
       store(_store),
+      ch(_ch),
+      o(_o),
       offset(_offset),
       length(_length),
       bl(_bl),
@@ -1842,6 +1848,8 @@ public:
     }
     read_context_t(const read_context_t& other) :
       store(other.store),
+      ch(other.ch),
+      o(other.o),
       offset(other.offset),
       length(other.length),
       bl(other.bl),

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3778,6 +3778,8 @@ private:
     old_extent_map_t old_extents;   ///< must deref these blobs
     interval_set<uint64_t> extents_to_gc; ///< extents for garbage collection
 
+    bool full_write = false;        /// < whether full object is overwritten
+
     struct write_item {
       uint64_t logical_offset;      ///< write logical offset
       BlobRef b;
@@ -3869,6 +3871,20 @@ private:
     uint64_t offset, uint64_t length,
     ceph::buffer::list::iterator& blp,
     WriteContext *wctx);
+
+  /// Determines if small write can reuse existing blob
+  /// and hence omit blob relocation.
+  /// Returns the amount of remaining bytes which need relocation,
+  /// effectively the possibe return values are for now:
+  /// * 0 - blob has been reused and writing has been staged
+  /// * min_alloc_size - no writing staged, blob to be relocated.
+  uint32_t _do_write_small_with_maybe_blob_reuse(
+    TransContext* txc,
+    CollectionRef& c,
+    OnodeRef& o,
+    uint64_t offset, uint64_t length,
+    bufferlist& bl,
+    WriteContext* wctx);
   void _do_write_big_apply_deferred(
     TransContext* txc,
     CollectionRef& c,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3439,14 +3439,6 @@ private:
   void _measure_static_frag(Collection *c, const OnodeRef& o);
 
   int _do_read(
-    Collection* c,
-    const ghobject_t& oid,
-    uint64_t offset,
-    size_t len,
-    ceph::buffer::list& bl,
-    uint32_t op_flags);
-
-  int _do_basic_read(
     Collection *c,
     OnodeRef& o,
     uint64_t offset,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -72,6 +72,8 @@ class Allocator;
 class FreelistManager;
 class BlueStoreRepairer;
 class SimpleBitmap;
+class OnodeReformatContext;
+
 //#define DEBUG_CACHE
 //#define DEBUG_DEFERRED
 #ifdef WITH_CPUTRACE
@@ -268,8 +270,6 @@ enum {
 using bptr_c_it_t = buffer::ptr::const_iterator;
 
 extern const std::vector<uint64_t> bdev_label_positions;
-
-class OnodeReformatContext;
 
 class BlueStore : public ObjectStore,
 		  public md_config_obs_t {
@@ -3595,6 +3595,9 @@ public:
   BlockDevice* get_bdev() {
     return bdev;
   }
+  Allocator* get_allocator() {
+    return alloc;
+  }
 
   int queue_transactions(
     CollectionHandle& ch,
@@ -3710,7 +3713,7 @@ public:
     OnodeRef o = c->get_onode(hoid, false);
     return o;
   }
-  inline void log_latency(const char* name,
+  void log_latency(const char* name,
     int idx,
     const ceph::timespan& lat,
     double lat_threshold,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -73,6 +73,9 @@ class FreelistManager;
 class BlueStoreRepairer;
 class SimpleBitmap;
 class OnodeReformatContext;
+class OnodeReformatEngine;
+using reformat_engines_t =
+  std::array<std::shared_ptr<OnodeReformatEngine>, MAX_REFORMAT_ENGINES>;
 
 //#define DEBUG_CACHE
 //#define DEBUG_DEFERRED
@@ -1762,6 +1765,7 @@ public:
     std::optional<int64_t> comp_min_blob_size;
     std::optional<int64_t> comp_max_blob_size;
     std::optional<double> compression_req_ratio;
+    reformat_engines_t reformat_engines;
 
     ContextQueue *commit_queue;
     std::unique_ptr<Estimator> estimator;
@@ -1820,6 +1824,34 @@ public:
     void flush_all_but_last();
 
     Collection(BlueStore *ns, OnodeCacheShard *oc, BufferCacheShard *bc, coll_t c);
+  };
+
+  struct read_context_t {
+    BlueStore& store;
+    uint64_t offset;
+    size_t length;
+    bufferlist& bl;
+    uint32_t op_flags;
+    read_context_t(BlueStore& _store,
+        uint64_t _offset,
+        size_t _length,
+        bufferlist& _bl,
+        uint32_t _op_flags) :
+      store(_store),
+      offset(_offset),
+      length(_length),
+      bl(_bl),
+      op_flags(_op_flags)
+    {
+    }
+    read_context_t(const read_context_t& other) :
+      store(other.store),
+      offset(other.offset),
+      length(other.length),
+      bl(other.bl),
+      op_flags(other.op_flags)
+    {
+    }
   };
 
   struct volatile_statfs{
@@ -3426,8 +3458,7 @@ private:
     uint64_t offset,
     size_t len,
     ceph::buffer::list& bl,
-    uint32_t op_flags,
-    OnodeReformatContext& reformat_ctx);
+    uint32_t op_flags);
 
   int _do_basic_read(
     Collection *c,
@@ -3974,8 +4005,7 @@ private:
     OnodeRef& o,
     WriteContext *wctx);
 
-  void _maybe_need_reformat_onode(OnodeReformatContext& ctx,
-    Collection* c);
+  void _update_reformat_engines(Collection* c);
   void _maybe_do_reformat_onode(OnodeReformatContext& ctx,
     Collection* c,
     OnodeRef& o,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2971,6 +2971,7 @@ private:
   TransContext *_txc_create(Collection *c, OpSequencer *osr,
 			    std::list<Context*> *on_commits,
 			    TrackedOpRef osd_op=TrackedOpRef());
+  void _txc_exec(TransContext* txc, ThreadPool::TPHandle* handle);
   void _txc_update_store_statfs(TransContext *txc);
   void _txc_add_transaction(TransContext *txc, Transaction *t);
   void _txc_calc_cost(TransContext *txc);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3453,14 +3453,6 @@ private:
   void _measure_static_frag(Collection *c, const OnodeRef& o);
 
   int _do_read(
-    Collection* c,
-    const ghobject_t& oid,
-    uint64_t offset,
-    size_t len,
-    ceph::buffer::list& bl,
-    uint32_t op_flags);
-
-  int _do_basic_read(
     Collection *c,
     OnodeRef& o,
     uint64_t offset,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -278,7 +278,6 @@ class BlueStore : public ObjectStore,
 		  public md_config_obs_t {
   // -----------------------------------------------------
   // types
-
 public:
   struct WriteContext;
   // config observer
@@ -2124,7 +2123,6 @@ public:
     }
   private:
     state_t state = STATE_PREPARE;
-
   };
 
   class BlueStoreThrottle {
@@ -3031,7 +3029,7 @@ private:
   void _txc_add_transaction(TransContext *txc, Transaction *t);
   void _txc_exec_reformat_write(Collection* c, OnodeRef o,
                                 uint64_t offset, size_t length,
-			        const bufferlist& bl,
+                                const bufferlist& bl,
                                 WriteContext& wctx);
   void _txc_calc_cost(TransContext *txc);
   void _txc_write_nodes(TransContext *txc, KeyValueDB::Transaction t);
@@ -3428,14 +3426,14 @@ private:
     int read_cache_policy,
     ready_regions_t& ready_regions,
     blobs2read_t& blobs2read,
-    span_stat_t* span_stat);
+    span_stat_t* span_stat = nullptr);
 
 
   int _prepare_read_ioc(
     blobs2read_t& blobs2read,
     std::vector<ceph::buffer::list>* compressed_blob_bls,
     IOContext* ioc,
-    span_stat_t* span_stat);
+    span_stat_t* span_stat = nullptr);
 
   int _generate_read_result_bl(
     OnodeRef& o,
@@ -4038,7 +4036,7 @@ private:
 		OnodeRef& o,
 		uint64_t offset, uint64_t length,
 		const ceph::buffer::list& bl,
-                WriteContext& wctx);
+		WriteContext& wctx);
   void _do_write_data(TransContext *txc,
                       CollectionRef& c,
                       OnodeRef& o,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -250,6 +250,17 @@ enum {
   l_bluestore_runtime_frag_lat,
   l_bluestore_static_frag_lat,
   //****************************************
+
+  // reformatting counters
+  //****************************************
+  l_bluestore_reformat_lat,
+  l_bluestore_reformat_compress_attempted,
+  l_bluestore_reformat_compress_omitted,
+  l_bluestore_reformat_defragment_attempted,
+  l_bluestore_reformat_defragment_omitted,
+  l_bluestore_reformat_issued,
+  //****************************************
+
   l_bluestore_last
 };
 
@@ -258,11 +269,15 @@ using bptr_c_it_t = buffer::ptr::const_iterator;
 
 extern const std::vector<uint64_t> bdev_label_positions;
 
+class OnodeReformatContext;
+
 class BlueStore : public ObjectStore,
 		  public md_config_obs_t {
   // -----------------------------------------------------
   // types
+
 public:
+  struct WriteContext;
   // config observer
   std::vector<std::string> get_tracked_keys() const noexcept override;
   void handle_conf_change(const ConfigProxy& conf,
@@ -601,7 +616,14 @@ public:
     inline bool is_loaded() const {
       return loaded;
     }
-
+    /// Calls back function for any inidividual extent within the specified range.
+    /// The functions gets mapped extent offset, remaining length and references
+    /// count.
+    template<class F>
+    int map_fn(uint32_t x_off, uint32_t x_len, F&& f) const {
+      ceph_assert(loaded && persistent);
+      return persistent->ref_map.map_fn(x_off, x_len, f);
+    }
   };
   typedef boost::intrusive_ptr<SharedBlob> SharedBlobRef;
 
@@ -2070,6 +2092,7 @@ public:
     }
   private:
     state_t state = STATE_PREPARE;
+
   };
 
   class BlueStoreThrottle {
@@ -2974,6 +2997,10 @@ private:
   void _txc_exec(TransContext* txc, ThreadPool::TPHandle* handle);
   void _txc_update_store_statfs(TransContext *txc);
   void _txc_add_transaction(TransContext *txc, Transaction *t);
+  void _txc_exec_reformat_write(Collection* c, OnodeRef o,
+                                uint64_t offset, size_t length,
+			        const bufferlist& bl,
+                                WriteContext& wctx);
   void _txc_calc_cost(TransContext *txc);
   void _txc_write_nodes(TransContext *txc, KeyValueDB::Transaction t);
   void _txc_state_proc(TransContext *txc);
@@ -3368,13 +3395,15 @@ private:
     size_t length,
     int read_cache_policy,
     ready_regions_t& ready_regions,
-    blobs2read_t& blobs2read);
+    blobs2read_t& blobs2read,
+    span_stat_t* span_stat);
 
 
   int _prepare_read_ioc(
     blobs2read_t& blobs2read,
     std::vector<ceph::buffer::list>* compressed_blob_bls,
-    IOContext* ioc);
+    IOContext* ioc,
+    span_stat_t* span_stat);
 
   int _generate_read_result_bl(
     OnodeRef& o,
@@ -3392,13 +3421,23 @@ private:
   void _measure_static_frag(Collection *c, const OnodeRef& o);
 
   int _do_read(
+    Collection* c,
+    const ghobject_t& oid,
+    uint64_t offset,
+    size_t len,
+    ceph::buffer::list& bl,
+    uint32_t op_flags,
+    OnodeReformatContext& reformat_ctx);
+
+  int _do_basic_read(
     Collection *c,
     OnodeRef& o,
     uint64_t offset,
     size_t len,
     ceph::buffer::list& bl,
     uint32_t op_flags = 0,
-    uint64_t retry_count = 0);
+    uint64_t retry_count = 0,
+    span_stat_t* span_stat = nullptr);
 
   void _do_read_and_pad(
     Collection* c,
@@ -3792,6 +3831,13 @@ private:
     unsigned csum_order = 0;        ///< target checksum chunk order
     uint64_t target_blob_size = 0;  ///< target (max) blob size
 
+    bool precompressed = false;     ///< reformatting write,
+                                    ///< ctx has precompressed data
+
+    PExtentVectorSlicer prealloc_slicer; ///< Prealloc vector incremental slicer
+
+    uint32_t preallocated() const { return prealloc_slicer.size(); }
+
     old_extent_map_t old_extents;   ///< must deref these blobs
     interval_set<uint64_t> extents_to_gc; ///< extents for garbage collection
 
@@ -3812,7 +3858,7 @@ private:
       bool compressed = false;
       ceph::buffer::list compressed_bl;
       size_t compressed_len = 0;
-
+      std::optional<int32_t> compressor_message;
       write_item(
 	uint64_t logical_offs,
         BlobRef b,
@@ -3844,17 +3890,16 @@ private:
       csum_type = other.csum_type;
       csum_order = other.csum_order;
     }
-    void write(
-      uint64_t loffs,
-      BlobRef b,
-      uint64_t blob_len,
-      uint64_t o,
-      ceph::buffer::list& bl,
-      uint64_t o0,
-      uint64_t len0,
-      bool _mark_unused,
-      bool _new_blob) {
-      writes.emplace_back(loffs,
+    write_item& write(uint64_t loffs,
+                      BlobRef b,
+                      uint64_t blob_len,
+                      uint64_t o,
+                      ceph::buffer::list& bl,
+                      uint64_t o0,
+                      uint64_t len0,
+                      bool _mark_unused,
+                      bool _new_blob) {
+      return writes.emplace_back(loffs,
                           b,
                           blob_len,
                           o,
@@ -3870,6 +3915,10 @@ private:
       uint64_t loffs,
       uint64_t loffs_end,
       uint64_t min_alloc_size);
+    void reset() {
+      WriteContext wctx0;
+      std::swap(*this, wctx0);
+    }
   };
   private:
   BlueStore::extent_map_t::iterator _punch_hole_2(
@@ -3886,7 +3935,7 @@ private:
     CollectionRef &c,
     OnodeRef& o,
     uint64_t offset, uint64_t length,
-    ceph::buffer::list::iterator& blp,
+    ceph::buffer::list::const_iterator& blp,
     WriteContext *wctx);
 
   /// Determines if small write can reuse existing blob
@@ -3907,20 +3956,30 @@ private:
     CollectionRef& c,
     OnodeRef& o,
     BigDeferredWriteContext& dctx,
-    bufferlist::iterator& blp,
+    bufferlist::const_iterator& blp,
     WriteContext* wctx);
   void _do_write_big(
     TransContext *txc,
     CollectionRef &c,
     OnodeRef& o,
     uint64_t offset, uint64_t length,
-    ceph::buffer::list::iterator& blp,
+    ceph::buffer::list::const_iterator& blp,
     WriteContext *wctx);
   int _do_alloc_write(
     TransContext *txc,
     CollectionRef c,
     OnodeRef& o,
     WriteContext *wctx);
+
+  void _maybe_need_reformat_onode(OnodeReformatContext& ctx,
+    Collection* c);
+  void _maybe_do_reformat_onode(OnodeReformatContext& ctx,
+    Collection* c,
+    OnodeRef& o,
+    uint64_t offset,
+    size_t length,
+    const bufferlist& bl,
+    uint32_t op_flags);
   void _wctx_finish(
     TransContext *txc,
     CollectionRef& c,
@@ -3937,7 +3996,7 @@ private:
   void _pad_zeros(ceph::buffer::list *bl, uint64_t *offset,
 		  uint64_t chunk_size);
 
-  void _choose_write_options(CollectionRef& c,
+  void _choose_write_options(Collection* c,
                              OnodeRef& o,
                              uint32_t fadvise_flags,
                              WriteContext *wctx);
@@ -3953,14 +4012,14 @@ private:
 		CollectionRef &c,
 		OnodeRef& o,
 		uint64_t offset, uint64_t length,
-		ceph::buffer::list& bl,
-		uint32_t fadvise_flags);
+		const ceph::buffer::list& bl,
+                WriteContext& wctx);
   void _do_write_data(TransContext *txc,
                       CollectionRef& c,
                       OnodeRef& o,
                       uint64_t offset,
                       uint64_t length,
-                      ceph::buffer::list& bl,
+                      const ceph::buffer::list& bl,
                       WriteContext *wctx);
   int _do_write_v2(
     TransContext *txc,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1827,16 +1827,22 @@ public:
 
   struct read_context_t {
     BlueStore& store;
+    CollectionHandle ch;
+    OnodeRef o;
     uint64_t offset;
     size_t length;
     bufferlist& bl;
     uint32_t op_flags;
     read_context_t(BlueStore& _store,
+        CollectionHandle _ch,
+        OnodeRef _o,
         uint64_t _offset,
         size_t _length,
         bufferlist& _bl,
         uint32_t _op_flags) :
       store(_store),
+      ch(_ch),
+      o(_o),
       offset(_offset),
       length(_length),
       bl(_bl),
@@ -1845,6 +1851,8 @@ public:
     }
     read_context_t(const read_context_t& other) :
       store(other.store),
+      ch(other.ch),
+      o(other.o),
       offset(other.offset),
       length(other.length),
       bl(other.bl),

--- a/src/os/bluestore/CMakeLists.txt
+++ b/src/os/bluestore/CMakeLists.txt
@@ -21,7 +21,8 @@ add_library(bluestore OBJECT
   Compression.cc
   OnodeScan.cc
   BlueAdmin.cc
-  BlueEnv.cc)
+  BlueEnv.cc
+  OnodeReformat.cc)
 
 target_link_libraries(bluestore
   PRIVATE

--- a/src/os/bluestore/OnodeReformat.cc
+++ b/src/os/bluestore/OnodeReformat.cc
@@ -51,10 +51,12 @@ bool OnodeReformatEngine::validate(OnodeReformatContext& ctx)
 #define dout_prefix *_dout << "OnodeReformatRecompress "
 
 bool OnodeReformatRecompressEngine::execute(OnodeReformatContext& ctx,
-  PerfCounters& logger, BlueStore::Collection* c, BlueStore::OnodeRef& o)
+  PerfCounters& logger)
 {
   auto& rctx = ctx.rctx;
   ceph_assert(rctx.store.cct);
+  BlueStore::Collection* c =
+    static_cast<BlueStore::Collection*>(rctx.ch.get());
   ceph_assert(c);
 
   const auto& span_stat = ctx.get_span_stats();
@@ -129,10 +131,14 @@ bool OnodeReformatRecompressEngine::execute(OnodeReformatContext& ctx,
 #define dout_prefix *_dout << "OnodeReformatDefragment "
 
 bool OnodeReformatDefragmentEngine::execute(OnodeReformatContext& ctx,
-  PerfCounters& logger, BlueStore::Collection* c, BlueStore::OnodeRef& o)
+  PerfCounters& logger)
 {
   auto& rctx = ctx.rctx;
   ceph_assert(rctx.store.cct);
+  BlueStore::Collection* c =
+    static_cast<BlueStore::Collection*>(rctx.ch.get());
+  ceph_assert(c);
+
   auto min_alloc_size = rctx.store.get_min_alloc_size();
 
   bool will_do = false;
@@ -214,12 +220,12 @@ bool OnodeReformatContext::maybe_allocate(size_t need, size_t min_alloc_size,
 }
 
 void OnodeReformatContext::exec_engines(
-  PerfCounters& logger, BlueStore::Collection* c, BlueStore::OnodeRef& o)
+  PerfCounters& logger)
 {
   // Enumerate all the validated engines and try to execute them
   // in their priority order until the first success indicated
   for (auto& e : engines) {
-    if (e.get() && e->execute(*this, logger, c, o)) {
+    if (e.get() && e->execute(*this, logger)) {
       to_be_applied = true;
       break;
     }

--- a/src/os/bluestore/OnodeReformat.cc
+++ b/src/os/bluestore/OnodeReformat.cc
@@ -13,30 +13,30 @@
 #define dout_subsys ceph_subsys_bluestore
 
 /////////////////////////////////////////
-/// OnodeReformatBasicValidateAction
+/// OnodeReformatEngine
 /////////////////////////////////////////
 #undef dout_prefix
-#define dout_prefix *_dout << "OnodeReformatBasicValidate "
+#define dout_prefix *_dout << "OnodeReformatEngine "
 
-bool OnodeReformatBasicValidateAction::call(OnodeReformatContext* ctx,
-  std::string_view args)
+bool OnodeReformatEngine::validate(OnodeReformatContext& ctx)
 {
-  ceph_assert(ctx);
-  ceph_assert(ctx->store);
-  ceph_assert(ctx->store->cct);
+  auto& rctx = ctx.rctx;
+  ceph_assert(rctx.store.cct);
   bool will_reformat = false;
-  if (op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
+  auto min_alloc_size = rctx.store.get_min_alloc_size();
+  if (rctx.op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
     // for the sake of simplicity do not apply data reformatting to reads
     // unaligned at the beginning. Having unaligned tail is OK.
-    will_reformat = p2nphase(offset, min_alloc_size) == 0;
+    will_reformat = p2nphase(rctx.offset, min_alloc_size) == 0;
     if (!will_reformat) {
-      ldout(ctx->store->cct, 15) << "reformat '" << args << "'"
+      ldout(rctx.store.cct, 15) << "reformat '" << args << "'"
 	<< " skipped due to unaligned read bounds "
-	<< p2nphase(offset, min_alloc_size) << " "
-	<< p2nphase(offset + length, min_alloc_size)
+	<< p2nphase(rctx.offset, min_alloc_size) << " "
+	<< p2nphase(rctx.offset + rctx.length, min_alloc_size)
 	<< dendl;
-    } else {
-      ldout(ctx->store->cct, 15) << "reformat '" << args << "'"
+    }
+    else {
+      ldout(rctx.store.cct, 15) << "reformat '" << args << "'"
 	<< " enabled "
 	<< dendl;
     }
@@ -45,28 +45,28 @@ bool OnodeReformatBasicValidateAction::call(OnodeReformatContext* ctx,
 }
 
 /////////////////////////////////////////
-/// OnodeReformatRecompressAction
+/// OnodeReformatRecompressEngine
 /////////////////////////////////////////
 #undef dout_prefix
 #define dout_prefix *_dout << "OnodeReformatRecompress "
 
-bool OnodeReformatRecompressAction::call(OnodeReformatContext* ctx,
-  std::string_view args)
+bool OnodeReformatRecompressEngine::execute(OnodeReformatContext& ctx,
+  PerfCounters& logger, BlueStore::Collection* c, BlueStore::OnodeRef& o)
 {
-  ceph_assert(ctx);
-  ceph_assert(ctx->store);
-  ceph_assert(ctx->store->cct);
-  ceph_assert(ctx->logger);
+  auto& rctx = ctx.rctx;
+  ceph_assert(rctx.store.cct);
+  ceph_assert(c);
 
-  const auto& span_stat = ctx->get_span_stats();
-  auto& wctx = ctx->get_write_context();
+  const auto& span_stat = ctx.get_span_stats();
+  auto& wctx = ctx.get_write_context();
+  auto min_alloc_size = rctx.store.get_min_alloc_size();
   bool will_do = wctx.compress && span_stat.allocated > 0;
   if (will_do) {
     uint64_t need = 0;
-    auto bl_it = bl.begin();
-    uint64_t offs = offset;
+    auto bl_it = rctx.bl.begin();
+    uint64_t offs = rctx.offset;
     uint64_t old_allocated = span_stat.allocated + span_stat.allocated_compressed;
-    while (bl_it != bl.end()) {
+    while (bl_it != rctx.bl.end()) {
 
       BlueStore::BlobRef blob = c->new_blob();
       bufferlist from_bl;
@@ -87,13 +87,13 @@ bool OnodeReformatRecompressAction::call(OnodeReformatContext* ctx,
 	  // don't set wi.compress_len and wi.compressed as this is redundant
 	  // at this point, to be assigned in _do_alloc_write if needed.
 	}
-	ldout(ctx->store->cct, 20) << " reformat: " << " precompress : 0x"
+	ldout(rctx.store.cct, 20) << " reformat: " << " precompress : 0x"
 	  << std::hex << offs << "~" << l << "->" << res_len
 	  << std::dec << " " << *blob
 	  << dendl;
       } else {
 	bl_it += l;
-	ldout(ctx->store->cct, 20) << " reformat: " << " precompress : 0x"
+	ldout(rctx.store.cct, 20) << " reformat: " << " precompress : 0x"
 	  << std::hex << offs << "~" << l << "-> remaining tail"
 	  << dendl;
       }
@@ -109,51 +109,50 @@ bool OnodeReformatRecompressAction::call(OnodeReformatContext* ctx,
     // enforce recompression or not. In the latter case they can be chosen
     // for different engine optimization(s) or be rejected prior to writing out.
     wctx.precompressed = true;
-    ldout(ctx->store->cct, 10) << " reformat:'" << args << "'"
+    ldout(rctx.store.cct, 10) << " reformat:'" << args << "'"
       << " need 0x"
       << std::hex << need << " vs. old_allocated 0x" << old_allocated << std::dec
       << " apply: " << will_do
       << dendl;
 
-    ctx->logger->inc(l_bluestore_reformat_compress_attempted);
+    logger.inc(l_bluestore_reformat_compress_attempted);
     if (!will_do)
-      ctx->logger->inc(l_bluestore_reformat_compress_omitted);
+      logger.inc(l_bluestore_reformat_compress_omitted);
   }
   return will_do;
 }
 
 /////////////////////////////////////////
-/// OnodeReformatDefragmentAction
+/// OnodeReformatDefragmentEnging
 /////////////////////////////////////////
 #undef dout_prefix
 #define dout_prefix *_dout << "OnodeReformatDefragment "
 
-bool OnodeReformatDefragmentAction::call(OnodeReformatContext* ctx,
-  std::string_view args)
+bool OnodeReformatDefragmentEngine::execute(OnodeReformatContext& ctx,
+  PerfCounters& logger, BlueStore::Collection* c, BlueStore::OnodeRef& o)
 {
-  ceph_assert(ctx);
-  ceph_assert(ctx->store);
-  ceph_assert(ctx->store->cct);
-  ceph_assert(ctx->logger);
+  auto& rctx = ctx.rctx;
+  ceph_assert(rctx.store.cct);
+  auto min_alloc_size = rctx.store.get_min_alloc_size();
 
   bool will_do = false;
-  const auto& span_stat = ctx->get_span_stats();
-  auto need = p2roundup(length, min_alloc_size);
+  const auto& span_stat = ctx.get_span_stats();
+  auto need = p2roundup(rctx.length, min_alloc_size);
   size_t frags = 0;
   int64_t allocated = 0;
   if (span_stat.frags > 1) {
-    ctx->logger->inc(l_bluestore_reformat_defragment_attempted);
-    will_do = ctx->maybe_allocate(need, min_alloc_size,
+    logger.inc(l_bluestore_reformat_defragment_attempted);
+    will_do = ctx.maybe_allocate(need, min_alloc_size,
       [&](int64_t num_bytes, size_t num_frags) {
 	allocated = num_bytes;
 	frags = num_frags;
 	return allocated >= (int64_t)need && frags < span_stat.frags;
       });
     if (!will_do) {
-      ctx->logger->inc(l_bluestore_reformat_defragment_omitted);
+      logger.inc(l_bluestore_reformat_defragment_omitted);
     }
   }
-  ldout(ctx->store->cct, 10) << " reformat:'" << args << "'"
+  ldout(rctx.store.cct, 10) << " reformat:'" << args << "'"
     << " preallocated: 0x" << std::hex << allocated << std::dec
     << " old frags:" << span_stat.frags
     << " new frags:" << frags
@@ -168,29 +167,21 @@ bool OnodeReformatDefragmentAction::call(OnodeReformatContext* ctx,
 #undef dout_prefix
 #define dout_prefix *_dout << "OnodeReformatContext "
 
-OnodeReformatContext::OnodeReformatContext(BlueStore* store,
-  PerfCounters* _logger)
-  : store(store)
+OnodeReformatContext::OnodeReformatContext(BlueStore::read_context_t& _rctx,
+					   const reformat_engines_t& _engines)
+  : rctx(_rctx)
 {
-  ceph_assert(store);
-
-  alloc = store->get_allocator();
-  logger = _logger;
-
-  ceph_assert(alloc);
-  ceph_assert(logger);
+  // Choose the engines that should be offered to execution
+  for (size_t i = 0; i < _engines.size(); i++) {
+    if (_engines[i] && _engines[i]->validate(*this)) {
+      engines[i] = _engines[i];
+      enabled_engines_count++;
+    }
+  }
 }
 OnodeReformatContext::~OnodeReformatContext()
 {
   clear();
-}
-void OnodeReformatContext::add_engine(int pri,
-  OnodeReformatAction* _validate,
-  OnodeReformatAction* _execute)
-{
-  ceph_assert(pri >= 0 && pri < MAX_ENGINES);
-  OnodeReformatEngine e(_validate, _execute);
-  std::swap(engines[pri], e);
 }
 bool OnodeReformatContext::maybe_allocate(size_t need, size_t min_alloc_size,
   std::function<bool(int64_t, size_t)> acceptor)
@@ -198,39 +189,37 @@ bool OnodeReformatContext::maybe_allocate(size_t need, size_t min_alloc_size,
   if (prealloc_slicer) {
     return false; // repetitive assignments aren't allowed
   }
+  ceph_assert(rctx.store.cct);
+  alloc = rctx.store.get_allocator();
+  ceph_assert(alloc);
+
   PExtentVector alloc_vector;
   alloc_vector.reserve(need / min_alloc_size + 1);
   auto start = mono_clock::now();
   auto allocated = alloc->allocate(
     need, min_alloc_size, need,
     0, &alloc_vector);
-  store->log_latency("allocator@_prepare_reformat",
+  rctx.store.log_latency("allocator@_prepare_reformat",
     l_bluestore_allocator_lat,
     mono_clock::now() - start,
-    store->cct->_conf->bluestore_log_op_age);
+    rctx.store.cct->_conf->bluestore_log_op_age);
   bool will_do = acceptor(allocated, alloc_vector.size());
   if (will_do) {
     prealloc_slicer = &wctx.prealloc_slicer;
     prealloc_slicer->setup(std::move(alloc_vector), allocated);
-  }
-  else {
+  } else {
     alloc->release(alloc_vector);
   }
   return will_do;
 }
-void OnodeReformatContext::maybe_enable_engine(int pri, std::string_view args)
+
+void OnodeReformatContext::exec_engines(
+  PerfCounters& logger, BlueStore::Collection* c, BlueStore::OnodeRef& o)
 {
-  ceph_assert(pri >= 0 && pri < MAX_ENGINES);
-  if (!engines[pri].enabled && engines[pri].validate->call(this, args)) {
-    engines[pri].enabled = true;
-    engines[pri].args = args;
-    enabled_engines_count++;
-  }
-}
-void OnodeReformatContext::exec_engines()
-{
+  // Enumerate all the validated engines and try to execute them
+  // in their priority order until the first success indicated
   for (auto& e : engines) {
-    if (e.enabled && e.execute->call(this, e.args)) {
+    if (e.get() && e->execute(*this, logger, c, o)) {
       to_be_applied = true;
       break;
     }
@@ -242,11 +231,11 @@ void OnodeReformatContext::clear()
   if (prealloc_slicer && alloc && !prealloc_slicer->end() && prealloc_slicer->slice(to_release) > 0) {
     alloc->release(to_release);
   }
-  enabled_engines_count = 0;
   for (auto& e : engines) {
-    OnodeReformatEngine e0;
-    std::swap(e, e0);
+    e.reset();
   }
+  enabled_engines_count = 0;
   to_be_applied = false;
   wctx.reset();
+  alloc = nullptr;
 }

--- a/src/os/bluestore/OnodeReformat.cc
+++ b/src/os/bluestore/OnodeReformat.cc
@@ -1,0 +1,252 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include "common/ceph_context.h"
+#include "common/dout.h"
+
+#include "include/intarith.h"
+#include "include/ceph_assert.h"
+
+#include "OnodeReformat.h"
+#include "Allocator.h"
+
+#define dout_subsys ceph_subsys_bluestore
+
+/////////////////////////////////////////
+/// OnodeReformatBasicValidateAction
+/////////////////////////////////////////
+#undef dout_prefix
+#define dout_prefix *_dout << "OnodeReformatBasicValidate "
+
+bool OnodeReformatBasicValidateAction::call(OnodeReformatContext* ctx,
+  std::string_view args)
+{
+  ceph_assert(ctx);
+  ceph_assert(ctx->store);
+  ceph_assert(ctx->store->cct);
+  bool will_reformat = false;
+  if (op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
+    // for the sake of simplicity do not apply data reformatting to reads
+    // unaligned at the beginning. Having unaligned tail is OK.
+    will_reformat = p2nphase(offset, min_alloc_size) == 0;
+    if (!will_reformat) {
+      ldout(ctx->store->cct, 15) << "reformat '" << args << "'"
+	<< " skipped due to unaligned read bounds "
+	<< p2nphase(offset, min_alloc_size) << " "
+	<< p2nphase(offset + length, min_alloc_size)
+	<< dendl;
+    } else {
+      ldout(ctx->store->cct, 15) << "reformat '" << args << "'"
+	<< " enabled "
+	<< dendl;
+    }
+  }
+  return will_reformat;
+}
+
+/////////////////////////////////////////
+/// OnodeReformatRecompressAction
+/////////////////////////////////////////
+#undef dout_prefix
+#define dout_prefix *_dout << "OnodeReformatRecompress "
+
+bool OnodeReformatRecompressAction::call(OnodeReformatContext* ctx,
+  std::string_view args)
+{
+  ceph_assert(ctx);
+  ceph_assert(ctx->store);
+  ceph_assert(ctx->store->cct);
+  ceph_assert(ctx->logger);
+
+  const auto& span_stat = ctx->get_span_stats();
+  auto& wctx = ctx->get_write_context();
+  bool will_do = wctx.compress && span_stat.allocated > 0;
+  if (will_do) {
+    uint64_t need = 0;
+    auto bl_it = bl.begin();
+    uint64_t offs = offset;
+    uint64_t old_allocated = span_stat.allocated + span_stat.allocated_compressed;
+    while (bl_it != bl.end()) {
+
+      BlueStore::BlobRef blob = c->new_blob();
+      bufferlist from_bl;
+      uint64_t l = std::min(wctx.target_blob_size, uint64_t(bl_it.get_remaining()));
+      uint64_t res_len = l;
+      if (l >= min_alloc_size) {
+	l = p2align(l, min_alloc_size);
+	bl_it.copy(l, from_bl);
+
+	//FIXME: add zero detection
+	auto& wi = wctx.write(offs, blob, l, 0, from_bl, 0, l, false, true);
+
+	res_len = from_bl.length();
+	if (l > min_alloc_size &&
+	  wctx.compressor->compress(from_bl, wi.compressed_bl, wi.compressor_message) == 0) {
+
+	  res_len = wi.compressed_bl.length();
+	  // don't set wi.compress_len and wi.compressed as this is redundant
+	  // at this point, to be assigned in _do_alloc_write if needed.
+	}
+	ldout(ctx->store->cct, 20) << " reformat: " << " precompress : 0x"
+	  << std::hex << offs << "~" << l << "->" << res_len
+	  << std::dec << " " << *blob
+	  << dendl;
+      } else {
+	bl_it += l;
+	ldout(ctx->store->cct, 20) << " reformat: " << " precompress : 0x"
+	  << std::hex << offs << "~" << l << "-> remaining tail"
+	  << dendl;
+      }
+      need += p2roundup(res_len, min_alloc_size);
+      offs += l;
+      will_do = need < old_allocated;
+    }
+
+    // At this point will_do indicates if we definitely want recompression,
+    // will skip the remaining reformatting then.
+
+    // Keep compressed blobs until final processing no matter if we decided to
+    // enforce recompression or not. In the latter case they can be chosen
+    // for different engine optimization(s) or be rejected prior to writing out.
+    wctx.precompressed = true;
+    ldout(ctx->store->cct, 10) << " reformat:'" << args << "'"
+      << " need 0x"
+      << std::hex << need << " vs. old_allocated 0x" << old_allocated << std::dec
+      << " apply: " << will_do
+      << dendl;
+
+    ctx->logger->inc(l_bluestore_reformat_compress_attempted);
+    if (!will_do)
+      ctx->logger->inc(l_bluestore_reformat_compress_omitted);
+  }
+  return will_do;
+}
+
+/////////////////////////////////////////
+/// OnodeReformatDefragmentAction
+/////////////////////////////////////////
+#undef dout_prefix
+#define dout_prefix *_dout << "OnodeReformatDefragment "
+
+bool OnodeReformatDefragmentAction::call(OnodeReformatContext* ctx,
+  std::string_view args)
+{
+  ceph_assert(ctx);
+  ceph_assert(ctx->store);
+  ceph_assert(ctx->store->cct);
+  ceph_assert(ctx->logger);
+
+  bool will_do = false;
+  const auto& span_stat = ctx->get_span_stats();
+  auto need = p2roundup(length, min_alloc_size);
+  size_t frags = 0;
+  int64_t allocated = 0;
+  if (span_stat.frags > 1) {
+    ctx->logger->inc(l_bluestore_reformat_defragment_attempted);
+    will_do = ctx->maybe_allocate(need, min_alloc_size,
+      [&](int64_t num_bytes, size_t num_frags) {
+	allocated = num_bytes;
+	frags = num_frags;
+	return allocated >= (int64_t)need && frags < span_stat.frags;
+      });
+    if (!will_do) {
+      ctx->logger->inc(l_bluestore_reformat_defragment_omitted);
+    }
+  }
+  ldout(ctx->store->cct, 10) << " reformat:'" << args << "'"
+    << " preallocated: 0x" << std::hex << allocated << std::dec
+    << " old frags:" << span_stat.frags
+    << " new frags:" << frags
+    << " apply: " << will_do
+    << dendl;
+  return will_do;
+};
+
+/////////////////////////////////////////
+/// OnodeReformatContext
+/////////////////////////////////////////
+#undef dout_prefix
+#define dout_prefix *_dout << "OnodeReformatContext "
+
+OnodeReformatContext::OnodeReformatContext(BlueStore* store,
+  PerfCounters* _logger)
+  : store(store)
+{
+  ceph_assert(store);
+
+  alloc = store->get_allocator();
+  logger = _logger;
+
+  ceph_assert(alloc);
+  ceph_assert(logger);
+}
+OnodeReformatContext::~OnodeReformatContext()
+{
+  clear();
+}
+void OnodeReformatContext::add_engine(int pri,
+  OnodeReformatAction* _validate,
+  OnodeReformatAction* _execute)
+{
+  ceph_assert(pri >= 0 && pri < MAX_ENGINES);
+  OnodeReformatEngine e(_validate, _execute);
+  std::swap(engines[pri], e);
+}
+bool OnodeReformatContext::maybe_allocate(size_t need, size_t min_alloc_size,
+  std::function<bool(int64_t, size_t)> acceptor)
+{
+  if (prealloc_slicer) {
+    return false; // repetitive assignments aren't allowed
+  }
+  PExtentVector alloc_vector;
+  alloc_vector.reserve(need / min_alloc_size + 1);
+  auto start = mono_clock::now();
+  auto allocated = alloc->allocate(
+    need, min_alloc_size, need,
+    0, &alloc_vector);
+  store->log_latency("allocator@_prepare_reformat",
+    l_bluestore_allocator_lat,
+    mono_clock::now() - start,
+    store->cct->_conf->bluestore_log_op_age);
+  bool will_do = acceptor(allocated, alloc_vector.size());
+  if (will_do) {
+    prealloc_slicer = &wctx.prealloc_slicer;
+    prealloc_slicer->setup(std::move(alloc_vector), allocated);
+  }
+  else {
+    alloc->release(alloc_vector);
+  }
+  return will_do;
+}
+void OnodeReformatContext::maybe_enable_engine(int pri, std::string_view args)
+{
+  ceph_assert(pri >= 0 && pri < MAX_ENGINES);
+  if (!engines[pri].enabled && engines[pri].validate->call(this, args)) {
+    engines[pri].enabled = true;
+    engines[pri].args = args;
+    enabled_engines_count++;
+  }
+}
+void OnodeReformatContext::exec_engines()
+{
+  for (auto& e : engines) {
+    if (e.enabled && e.execute->call(this, e.args)) {
+      to_be_applied = true;
+      break;
+    }
+  }
+}
+void OnodeReformatContext::clear()
+{
+  PExtentVector to_release;
+  if (prealloc_slicer && alloc && !prealloc_slicer->end() && prealloc_slicer->slice(to_release) > 0) {
+    alloc->release(to_release);
+  }
+  enabled_engines_count = 0;
+  for (auto& e : engines) {
+    OnodeReformatEngine e0;
+    std::swap(e, e0);
+  }
+  to_be_applied = false;
+  wctx.reset();
+}

--- a/src/os/bluestore/OnodeReformat.cc
+++ b/src/os/bluestore/OnodeReformat.cc
@@ -20,23 +20,22 @@
 
 bool OnodeReformatEngine::validate(OnodeReformatContext& ctx)
 {
-  auto& rctx = ctx.rctx;
-  ceph_assert(rctx.store.cct);
+  ceph_assert(ctx.store.cct);
   bool will_reformat = false;
-  auto min_alloc_size = rctx.store.get_min_alloc_size();
-  if (rctx.op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
+  auto min_alloc_size = ctx.store.get_min_alloc_size();
+  if (ctx.op_flags & CEPH_OSD_OP_FLAG_SCRUB) {
     // for the sake of simplicity do not apply data reformatting to reads
     // unaligned at the beginning. Having unaligned tail is OK.
-    will_reformat = p2nphase(rctx.offset, min_alloc_size) == 0;
+    will_reformat = p2nphase(ctx.offset, min_alloc_size) == 0;
     if (!will_reformat) {
-      ldout(rctx.store.cct, 15) << "reformat '" << args << "'"
+      ldout(ctx.store.cct, 15) << "reformat '" << args << "'"
 	<< " skipped due to unaligned read bounds "
-	<< p2nphase(rctx.offset, min_alloc_size) << " "
-	<< p2nphase(rctx.offset + rctx.length, min_alloc_size)
+	<< p2nphase(ctx.offset, min_alloc_size) << " "
+	<< p2nphase(ctx.offset + ctx.length, min_alloc_size)
 	<< dendl;
     }
     else {
-      ldout(rctx.store.cct, 15) << "reformat '" << args << "'"
+      ldout(ctx.store.cct, 15) << "reformat '" << args << "'"
 	<< " enabled "
 	<< dendl;
     }
@@ -53,22 +52,20 @@ bool OnodeReformatEngine::validate(OnodeReformatContext& ctx)
 bool OnodeReformatRecompressEngine::execute(OnodeReformatContext& ctx,
   PerfCounters& logger)
 {
-  auto& rctx = ctx.rctx;
-  ceph_assert(rctx.store.cct);
-  BlueStore::Collection* c =
-    static_cast<BlueStore::Collection*>(rctx.ch.get());
+  ceph_assert(ctx.store.cct);
+  auto* c = static_cast<BlueStore::Collection*>(ctx.ch.get());
   ceph_assert(c);
 
   const auto& span_stat = ctx.get_span_stats();
   auto& wctx = ctx.get_write_context();
-  auto min_alloc_size = rctx.store.get_min_alloc_size();
+  auto min_alloc_size = ctx.store.get_min_alloc_size();
   bool will_do = wctx.compress && span_stat.allocated > 0;
   if (will_do) {
     uint64_t need = 0;
-    auto bl_it = rctx.bl.begin();
-    uint64_t offs = rctx.offset;
+    auto bl_it = ctx.bl.begin();
+    uint64_t offs = ctx.offset;
     uint64_t old_allocated = span_stat.allocated + span_stat.allocated_compressed;
-    while (bl_it != rctx.bl.end()) {
+    while (bl_it != ctx.bl.end()) {
 
       BlueStore::BlobRef blob = c->new_blob();
       bufferlist from_bl;
@@ -89,13 +86,13 @@ bool OnodeReformatRecompressEngine::execute(OnodeReformatContext& ctx,
 	  // don't set wi.compress_len and wi.compressed as this is redundant
 	  // at this point, to be assigned in _do_alloc_write if needed.
 	}
-	ldout(rctx.store.cct, 20) << " reformat: " << " precompress : 0x"
+	ldout(ctx.store.cct, 20) << " reformat: " << " precompress : 0x"
 	  << std::hex << offs << "~" << l << "->" << res_len
 	  << std::dec << " " << *blob
 	  << dendl;
       } else {
 	bl_it += l;
-	ldout(rctx.store.cct, 20) << " reformat: " << " precompress : 0x"
+	ldout(ctx.store.cct, 20) << " reformat: " << " precompress : 0x"
 	  << std::hex << offs << "~" << l << "-> remaining tail"
 	  << dendl;
       }
@@ -111,7 +108,7 @@ bool OnodeReformatRecompressEngine::execute(OnodeReformatContext& ctx,
     // enforce recompression or not. In the latter case they can be chosen
     // for different engine optimization(s) or be rejected prior to writing out.
     wctx.precompressed = true;
-    ldout(rctx.store.cct, 10) << " reformat:'" << args << "'"
+    ldout(ctx.store.cct, 10) << " reformat:'" << args << "'"
       << " need 0x"
       << std::hex << need << " vs. old_allocated 0x" << old_allocated << std::dec
       << " apply: " << will_do
@@ -133,17 +130,15 @@ bool OnodeReformatRecompressEngine::execute(OnodeReformatContext& ctx,
 bool OnodeReformatDefragmentEngine::execute(OnodeReformatContext& ctx,
   PerfCounters& logger)
 {
-  auto& rctx = ctx.rctx;
-  ceph_assert(rctx.store.cct);
-  BlueStore::Collection* c =
-    static_cast<BlueStore::Collection*>(rctx.ch.get());
+  ceph_assert(ctx.store.cct);
+  auto *c = static_cast<BlueStore::Collection*>(ctx.ch.get());
   ceph_assert(c);
 
-  auto min_alloc_size = rctx.store.get_min_alloc_size();
+  auto min_alloc_size = ctx.store.get_min_alloc_size();
 
   bool will_do = false;
   const auto& span_stat = ctx.get_span_stats();
-  auto need = p2roundup(rctx.length, min_alloc_size);
+  auto need = p2roundup(ctx.length, min_alloc_size);
   size_t frags = 0;
   int64_t allocated = 0;
   if (span_stat.frags > 1) {
@@ -158,7 +153,7 @@ bool OnodeReformatDefragmentEngine::execute(OnodeReformatContext& ctx,
       logger.inc(l_bluestore_reformat_defragment_omitted);
     }
   }
-  ldout(rctx.store.cct, 10) << " reformat:'" << args << "'"
+  ldout(ctx.store.cct, 10) << " reformat:'" << args << "'"
     << " preallocated: 0x" << std::hex << allocated << std::dec
     << " old frags:" << span_stat.frags
     << " new frags:" << frags
@@ -173,9 +168,9 @@ bool OnodeReformatDefragmentEngine::execute(OnodeReformatContext& ctx,
 #undef dout_prefix
 #define dout_prefix *_dout << "OnodeReformatContext "
 
-OnodeReformatContext::OnodeReformatContext(BlueStore::read_context_t& _rctx,
+OnodeReformatContext::OnodeReformatContext(const BlueStore::read_context_t& _ctx,
 					   const reformat_engines_t& _engines)
-  : rctx(_rctx)
+  : read_context_t(_ctx)
 {
   // Choose the engines that should be offered to execution
   for (size_t i = 0; i < _engines.size(); i++) {
@@ -195,8 +190,8 @@ bool OnodeReformatContext::maybe_allocate(size_t need, size_t min_alloc_size,
   if (prealloc_slicer) {
     return false; // repetitive assignments aren't allowed
   }
-  ceph_assert(rctx.store.cct);
-  alloc = rctx.store.get_allocator();
+  ceph_assert(store.cct);
+  alloc = store.get_allocator();
   ceph_assert(alloc);
 
   PExtentVector alloc_vector;
@@ -205,10 +200,10 @@ bool OnodeReformatContext::maybe_allocate(size_t need, size_t min_alloc_size,
   auto allocated = alloc->allocate(
     need, min_alloc_size, need,
     0, &alloc_vector);
-  rctx.store.log_latency("allocator@_prepare_reformat",
+  store.log_latency("allocator@_prepare_reformat",
     l_bluestore_allocator_lat,
     mono_clock::now() - start,
-    rctx.store.cct->_conf->bluestore_log_op_age);
+    store.cct->_conf->bluestore_log_op_age);
   bool will_do = acceptor(allocated, alloc_vector.size());
   if (will_do) {
     prealloc_slicer = &wctx.prealloc_slicer;

--- a/src/os/bluestore/OnodeReformat.h
+++ b/src/os/bluestore/OnodeReformat.h
@@ -17,7 +17,7 @@ public:
   virtual ~OnodeReformatEngine() {}
   virtual bool validate(OnodeReformatContext& ctx);
   virtual bool execute(OnodeReformatContext& ctx,
-    PerfCounters& _logger, BlueStore::Collection*, BlueStore::OnodeRef&) = 0;
+    PerfCounters& _logger) = 0;
 };
 
 class OnodeReformatRecompressEngine : public OnodeReformatEngine {
@@ -28,7 +28,7 @@ public:
   {
   }
   bool execute(OnodeReformatContext& ctx,
-    PerfCounters& _logger, BlueStore::Collection*, BlueStore::OnodeRef&) override;
+    PerfCounters& _logger) override;
 };
 
 class OnodeReformatDefragmentEngine : public OnodeReformatEngine {
@@ -39,7 +39,7 @@ public:
   {
   }
   bool execute(OnodeReformatContext& ctx,
-    PerfCounters& _logger, BlueStore::Collection*, BlueStore::OnodeRef&) override;
+    PerfCounters& _logger) override;
 };
 
 class OnodeReformatContext {
@@ -74,8 +74,7 @@ public:
     return span_stat;
   }
 
-  void exec_engines(PerfCounters& _logger,
-    BlueStore::Collection* c, BlueStore::OnodeRef& o);
+  void exec_engines(PerfCounters& _logger);
   void clear();
 };
 

--- a/src/os/bluestore/OnodeReformat.h
+++ b/src/os/bluestore/OnodeReformat.h
@@ -1,0 +1,134 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#ifndef CEPH_OSD_ONODE_REFORMAT_H
+#define CEPH_OSD_ONODE_REFORMAT_H
+
+#include <string>
+#include <memory>
+#include "BlueStore.h"
+
+class OnodeReformatAction {
+protected:
+public:
+  virtual ~OnodeReformatAction() {}
+  virtual bool call(OnodeReformatContext* ctx, std::string_view) = 0;
+};
+
+class OnodeReformatBasicValidateAction : public OnodeReformatAction {
+  uint64_t offset;
+  size_t length;
+  uint32_t op_flags;
+  uint64_t min_alloc_size;
+public:
+  OnodeReformatBasicValidateAction(
+    uint64_t offset,
+    size_t length,
+    uint32_t op_flags,
+    uint64_t mas) :
+    offset(offset),
+    length(length),
+    op_flags(op_flags),
+    min_alloc_size(mas) {
+  }
+  bool call(OnodeReformatContext* ctx, std::string_view args);
+};
+
+class OnodeReformatRecompressAction : public OnodeReformatAction {
+  BlueStore::Collection* c;
+  uint64_t offset;
+  size_t length;
+  bufferlist& bl;
+  uint64_t min_alloc_size;
+public:
+  OnodeReformatRecompressAction(
+    BlueStore::Collection* c,
+    uint64_t offset,
+    size_t length,
+    bufferlist& bl,
+    uint64_t mas) :
+    c(c),
+    offset(offset),
+    length(length),
+    bl(bl),
+    min_alloc_size(mas) {
+    ceph_assert(c);
+  }
+  bool call(OnodeReformatContext* ctx, std::string_view args);
+};
+
+class OnodeReformatDefragmentAction : public OnodeReformatAction {
+  uint64_t offset;
+  size_t length;
+  uint64_t min_alloc_size;
+public:
+  OnodeReformatDefragmentAction(
+    uint64_t offset,
+    size_t length,
+    uint64_t mas) :
+    offset(offset),
+    length(length),
+    min_alloc_size(mas) {
+  }
+  bool call(OnodeReformatContext* ctx, std::string_view args);
+};
+
+struct OnodeReformatEngine {
+  bool enabled = false;
+  std::string args;
+  std::unique_ptr<OnodeReformatAction> validate;
+  std::unique_ptr<OnodeReformatAction> execute;
+  OnodeReformatEngine() {}
+  OnodeReformatEngine(OnodeReformatAction* _validate,
+    OnodeReformatAction* _execute) :
+    validate(_validate), execute(_execute) {
+  }
+};
+
+class OnodeReformatContext {
+public:
+  enum {
+    // This is effectively an engine priority, i.e. the order engines are called in.
+    RECOMPRESS_ENGINE = 0,
+    DEFRAGMENT_ENGINE = 1,
+    MAX_ENGINES
+  };
+private:
+
+  size_t enabled_engines_count = 0;
+  std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES> engines;
+
+  bool to_be_applied = false;
+  BlueStore::WriteContext wctx;
+  span_stat_t span_stat;
+  Allocator* alloc = nullptr;
+  PExtentVectorSlicer* prealloc_slicer = nullptr; // pointer to the one from wctx if configured
+public:
+  BlueStore* store = nullptr;
+  PerfCounters* logger = nullptr;
+
+  OnodeReformatContext(BlueStore* store, PerfCounters* _logger);
+  ~OnodeReformatContext();
+
+  void add_engine(int pri,
+    OnodeReformatAction* _validate,
+    OnodeReformatAction* _execute);
+  bool maybe_allocate(size_t need, size_t min_alloc_size,
+    std::function<bool(int64_t, size_t)> acceptor);
+
+  bool is_enabled() const { return enabled_engines_count > 0; }
+  bool is_applied() const { return to_be_applied; }
+  BlueStore::WriteContext& get_write_context() { return wctx; }
+  span_stat_t& access_span_stats() {
+    return span_stat;
+  }
+  const span_stat_t& get_span_stats() const {
+    return span_stat;
+  }
+
+  void maybe_enable_engine(int pri, std::string_view args);
+  void exec_engines();
+  void clear();
+};
+
+#endif

--- a/src/os/bluestore/OnodeReformat.h
+++ b/src/os/bluestore/OnodeReformat.h
@@ -8,95 +8,46 @@
 #include <memory>
 #include "BlueStore.h"
 
-class OnodeReformatAction {
+class OnodeReformatEngine {
 protected:
-public:
-  virtual ~OnodeReformatAction() {}
-  virtual bool call(OnodeReformatContext* ctx, std::string_view) = 0;
-};
-
-class OnodeReformatBasicValidateAction : public OnodeReformatAction {
-  uint64_t offset;
-  size_t length;
-  uint32_t op_flags;
-  uint64_t min_alloc_size;
-public:
-  OnodeReformatBasicValidateAction(
-    uint64_t offset,
-    size_t length,
-    uint32_t op_flags,
-    uint64_t mas) :
-    offset(offset),
-    length(length),
-    op_flags(op_flags),
-    min_alloc_size(mas) {
-  }
-  bool call(OnodeReformatContext* ctx, std::string_view args);
-};
-
-class OnodeReformatRecompressAction : public OnodeReformatAction {
-  BlueStore::Collection* c;
-  uint64_t offset;
-  size_t length;
-  bufferlist& bl;
-  uint64_t min_alloc_size;
-public:
-  OnodeReformatRecompressAction(
-    BlueStore::Collection* c,
-    uint64_t offset,
-    size_t length,
-    bufferlist& bl,
-    uint64_t mas) :
-    c(c),
-    offset(offset),
-    length(length),
-    bl(bl),
-    min_alloc_size(mas) {
-    ceph_assert(c);
-  }
-  bool call(OnodeReformatContext* ctx, std::string_view args);
-};
-
-class OnodeReformatDefragmentAction : public OnodeReformatAction {
-  uint64_t offset;
-  size_t length;
-  uint64_t min_alloc_size;
-public:
-  OnodeReformatDefragmentAction(
-    uint64_t offset,
-    size_t length,
-    uint64_t mas) :
-    offset(offset),
-    length(length),
-    min_alloc_size(mas) {
-  }
-  bool call(OnodeReformatContext* ctx, std::string_view args);
-};
-
-struct OnodeReformatEngine {
-  bool enabled = false;
   std::string args;
-  std::unique_ptr<OnodeReformatAction> validate;
-  std::unique_ptr<OnodeReformatAction> execute;
-  OnodeReformatEngine() {}
-  OnodeReformatEngine(OnodeReformatAction* _validate,
-    OnodeReformatAction* _execute) :
-    validate(_validate), execute(_execute) {
+public:
+  OnodeReformatEngine(std::string_view args) {
   }
+  virtual ~OnodeReformatEngine() {}
+  virtual bool validate(OnodeReformatContext& ctx);
+  virtual bool execute(OnodeReformatContext& ctx,
+    PerfCounters& _logger, BlueStore::Collection*, BlueStore::OnodeRef&) = 0;
+};
+
+class OnodeReformatRecompressEngine : public OnodeReformatEngine {
+  BlueStore::Collection* c;
+public:
+  OnodeReformatRecompressEngine(std::string_view args)
+    : OnodeReformatEngine(args)
+  {
+  }
+  bool execute(OnodeReformatContext& ctx,
+    PerfCounters& _logger, BlueStore::Collection*, BlueStore::OnodeRef&) override;
+};
+
+class OnodeReformatDefragmentEngine : public OnodeReformatEngine {
+  BlueStore::Collection* c;
+public:
+  OnodeReformatDefragmentEngine(std::string_view args)
+    : OnodeReformatEngine(args)
+  {
+  }
+  bool execute(OnodeReformatContext& ctx,
+    PerfCounters& _logger, BlueStore::Collection*, BlueStore::OnodeRef&) override;
 };
 
 class OnodeReformatContext {
-public:
-  enum {
-    // This is effectively an engine priority, i.e. the order engines are called in.
-    RECOMPRESS_ENGINE = 0,
-    DEFRAGMENT_ENGINE = 1,
-    MAX_ENGINES
-  };
+
 private:
 
   size_t enabled_engines_count = 0;
-  std::array<OnodeReformatEngine, OnodeReformatContext::MAX_ENGINES> engines;
+  reformat_engines_t engines;
 
   bool to_be_applied = false;
   BlueStore::WriteContext wctx;
@@ -104,15 +55,12 @@ private:
   Allocator* alloc = nullptr;
   PExtentVectorSlicer* prealloc_slicer = nullptr; // pointer to the one from wctx if configured
 public:
-  BlueStore* store = nullptr;
-  PerfCounters* logger = nullptr;
+  BlueStore::read_context_t rctx;
 
-  OnodeReformatContext(BlueStore* store, PerfCounters* _logger);
+  OnodeReformatContext(BlueStore::read_context_t& _rctx,
+    const reformat_engines_t& _engines);
   ~OnodeReformatContext();
 
-  void add_engine(int pri,
-    OnodeReformatAction* _validate,
-    OnodeReformatAction* _execute);
   bool maybe_allocate(size_t need, size_t min_alloc_size,
     std::function<bool(int64_t, size_t)> acceptor);
 
@@ -126,8 +74,8 @@ public:
     return span_stat;
   }
 
-  void maybe_enable_engine(int pri, std::string_view args);
-  void exec_engines();
+  void exec_engines(PerfCounters& _logger,
+    BlueStore::Collection* c, BlueStore::OnodeRef& o);
   void clear();
 };
 

--- a/src/os/bluestore/OnodeReformat.h
+++ b/src/os/bluestore/OnodeReformat.h
@@ -42,7 +42,7 @@ public:
     PerfCounters& _logger) override;
 };
 
-class OnodeReformatContext {
+class OnodeReformatContext : public BlueStore::read_context_t {
 
 private:
 
@@ -55,9 +55,8 @@ private:
   Allocator* alloc = nullptr;
   PExtentVectorSlicer* prealloc_slicer = nullptr; // pointer to the one from wctx if configured
 public:
-  BlueStore::read_context_t rctx;
 
-  OnodeReformatContext(BlueStore::read_context_t& _rctx,
+  OnodeReformatContext(const BlueStore::read_context_t& _rctx,
     const reformat_engines_t& _engines);
   ~OnodeReformatContext();
 

--- a/src/os/bluestore/Writer.cc
+++ b/src/os/bluestore/Writer.cc
@@ -804,7 +804,7 @@ inline bufferlist BlueStore::Writer::_read_self(
   if (test_read_divertor == nullptr) {
     bufferlist result;
     int r;
-    r = bstore->_do_read(onode->c, onode, position, length, result);
+    r = bstore->_do_basic_read(onode->c, onode, position, length, result);
     ceph_assert(r >= 0 && r <= (int)length);
     size_t zlen = length - r;
     if (zlen) {

--- a/src/os/bluestore/Writer.cc
+++ b/src/os/bluestore/Writer.cc
@@ -804,7 +804,7 @@ inline bufferlist BlueStore::Writer::_read_self(
   if (test_read_divertor == nullptr) {
     bufferlist result;
     int r;
-    r = bstore->_do_basic_read(onode->c, onode, position, length, result);
+    r = bstore->_do_read(onode->c, onode, position, length, result);
     ceph_assert(r >= 0 && r <= (int)length);
     size_t zlen = length - r;
     if (zlen) {

--- a/src/os/bluestore/bluestore_common.h
+++ b/src/os/bluestore/bluestore_common.h
@@ -76,5 +76,18 @@ static constexpr uint64_t BLUEFS_SUPER_POSITION = 4096;
 static constexpr uint64_t BLUEFS_SUPER_BLOCK_SIZE = 4096;
 static constexpr uint64_t SUPER_RESERVED = BDEV_LABEL_BLOCK_SIZE + BLUEFS_SUPER_BLOCK_SIZE;
 
+enum {
+  // This is both reformatting engine identifier and its priority,
+  // which determines the order the engines are validated/executed in.
+  // Engines are inherited from OnodeReformatEngine class.
+  // All enabled engines are validated via OnodeReformatEngine::validate() call
+  // prior to execution.
+  // Then the engines passed the validation are offered to execution
+  // by OnodeReformatEngine::execute() call.
+  // And the first successful one terminates the enumeration.
+  RECOMPRESS_ENGINE = 0,
+  DEFRAGMENT_ENGINE = 1,
+  MAX_REFORMAT_ENGINES
+};
 
 #endif

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -1676,3 +1676,11 @@ bool shared_blob_2hash_tracker_t::test_all_zero_range(
   }
   return true;
 }
+
+std::ostream& operator<<(std::ostream& out, const span_stat_t& s)
+{
+  return out << "s=" << s.stored << " ch=" << s.cached << " a=" << s.allocated
+             << " sc=" << s.stored_compressed << " ac=" << s.allocated_compressed
+	     << " sh=" << s.allocated_shared
+	     << " e=" << s.extents << " f=" << s.frags;
+}

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -1693,3 +1693,11 @@ bool shared_blob_2hash_tracker_t::test_all_zero_range(
   }
   return true;
 }
+
+std::ostream& operator<<(std::ostream& out, const span_stat_t& s)
+{
+  return out << "s=" << s.stored << " ch=" << s.cached << " a=" << s.allocated
+             << " sc=" << s.stored_compressed << " ac=" << s.allocated_compressed
+	     << " sh=" << s.allocated_shared
+	     << " e=" << s.extents << " f=" << s.frags;
+}

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -132,6 +132,71 @@ std::ostream& operator<<(std::ostream& out, const bluestore_pextent_t& o);
 
 typedef mempool::bluestore_cache_other::vector<bluestore_pextent_t> PExtentVector;
 
+class PExtentVectorSlicer
+{
+  size_t idx = 0;
+  uint32_t entry_pos = 0;
+  uint32_t pos = 0;
+  uint32_t total = 0;
+  PExtentVector pext;
+public:
+  uint32_t size() const {
+    return total;
+  }
+  void setup(PExtentVector&& _p, uint32_t _total) {
+    reset();
+    std::swap(pext, _p);
+    total = _total;
+  }
+  void reset() {
+    idx = 0;
+    entry_pos = pos = 0;
+    total = 0;
+    pext.clear();
+  }
+  inline bool begin() const {
+    return idx == 0  && pos == 0;
+  }
+  inline bool end() const {
+    return idx >= pext.size();
+  }
+
+  uint32_t slice(PExtentVector& res,
+             uint32_t len = std::numeric_limits<uint32_t>::max()) {
+    res.clear();
+    if (end()) {
+      return 0;
+    } else if (begin() && len == total ) {
+      // fast track
+      res = pext;
+      idx = pext.size();
+      pos = entry_pos = 0;
+      return total;
+    }
+    size_t i;
+    uint32_t ret = 0; // amount of bytes returned
+    for (i = idx; i < pext.size() && len > 0; i++) {
+      ceph_assert(pos >= entry_pos);
+      uint32_t delta = pos - entry_pos;
+      uint32_t remaining = pext[i].length - delta;
+      uint32_t l;
+      if (len < remaining) {
+        l = len;
+	pos += l;
+      }	else {
+        l = remaining;
+        entry_pos += pext[i].length;
+	pos = entry_pos;
+	idx = i + 1;
+      }
+      res.emplace_back(bluestore_pextent_t(pext[i].offset + delta, l));
+      ret += l;
+      len -= l;
+    }
+    return ret;
+  }
+};
+
 template<>
 struct denc_traits<PExtentVector> {
   static constexpr bool supported = true;
@@ -250,6 +315,35 @@ struct bluestore_extent_ref_map_t {
 	ref_map[pos].decode(p);
       }
     }
+  }
+  /// Calls back function for any inidividual extent within the specified range.
+  /// The functions gets mapped extent offset, remaining length and references
+  /// count.
+  template<class F>
+  int map_fn(uint64_t offset, uint32_t len, F&& f) const {
+    auto p = ref_map.lower_bound(offset);
+    auto pend = ref_map.end();
+    auto end = offset + len;
+    if ((p == pend || p->first > offset) && p != ref_map.begin()) {
+      --p;
+      if (p->first + p->second.length > offset) {
+	uint32_t l = std::min(uint32_t(p->first + p->second.length - offset), len);
+	int r = f(offset, l, p->second.refs);
+	if (r < 0)
+	  return r;
+	offset +=l;
+      }
+      ++p;
+    }
+    while (p != pend && end > offset && end > p->first) {
+      uint32_t l = std::min(p->second.length, uint32_t(end - p->first));
+      int r = f(p->first, l, p->second.refs);
+      if (r < 0)
+	return r;
+      offset = p->first + p->second.length;
+      ++p;
+    }
+    return 0;
   }
 
   void dump(ceph::Formatter *f) const;
@@ -1647,5 +1741,17 @@ private:
     return *aux_items.emplace(it, id);
   }
 };
+
+struct span_stat_t {
+  int64_t stored = 0;  // total bytes stored within a span
+  int64_t cached = 0;  // bytes from span kept in cache, not included in the analysis below
+  int64_t allocated = 0;
+  int64_t stored_compressed = 0;
+  int64_t allocated_compressed = 0;
+  int64_t allocated_shared = 0;
+  size_t extents = 0;
+  size_t frags = 0;
+};
+std::ostream& operator<<(std::ostream& out, const span_stat_t&);
 
 #endif

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -167,6 +167,71 @@ std::ostream& operator<<(std::ostream& out, const bluestore_pextent_t& o);
 
 typedef mempool::bluestore_cache_other::vector<bluestore_pextent_t> PExtentVector;
 
+class PExtentVectorSlicer
+{
+  size_t idx = 0;
+  uint32_t entry_pos = 0;
+  uint32_t pos = 0;
+  uint32_t total = 0;
+  PExtentVector pext;
+public:
+  uint32_t size() const {
+    return total;
+  }
+  void setup(PExtentVector&& _p, uint32_t _total) {
+    reset();
+    std::swap(pext, _p);
+    total = _total;
+  }
+  void reset() {
+    idx = 0;
+    entry_pos = pos = 0;
+    total = 0;
+    pext.clear();
+  }
+  inline bool begin() const {
+    return idx == 0  && pos == 0;
+  }
+  inline bool end() const {
+    return idx >= pext.size();
+  }
+
+  uint32_t slice(PExtentVector& res,
+             uint32_t len = std::numeric_limits<uint32_t>::max()) {
+    res.clear();
+    if (end()) {
+      return 0;
+    } else if (begin() && len == total ) {
+      // fast track
+      res = pext;
+      idx = pext.size();
+      pos = entry_pos = 0;
+      return total;
+    }
+    size_t i;
+    uint32_t ret = 0; // amount of bytes returned
+    for (i = idx; i < pext.size() && len > 0; i++) {
+      ceph_assert(pos >= entry_pos);
+      uint32_t delta = pos - entry_pos;
+      uint32_t remaining = pext[i].length - delta;
+      uint32_t l;
+      if (len < remaining) {
+        l = len;
+	pos += l;
+      }	else {
+        l = remaining;
+        entry_pos += pext[i].length;
+	pos = entry_pos;
+	idx = i + 1;
+      }
+      res.emplace_back(bluestore_pextent_t(pext[i].offset + delta, l));
+      ret += l;
+      len -= l;
+    }
+    return ret;
+  }
+};
+
 template<>
 struct denc_traits<PExtentVector> {
   static constexpr bool supported = true;
@@ -286,6 +351,35 @@ struct bluestore_extent_ref_map_t {
 	ref_map[pos].decode(p);
       }
     }
+  }
+  /// Calls back function for any inidividual extent within the specified range.
+  /// The functions gets mapped extent offset, remaining length and references
+  /// count.
+  template<class F>
+  int map_fn(uint64_t offset, uint32_t len, F&& f) const {
+    auto p = ref_map.lower_bound(offset);
+    auto pend = ref_map.end();
+    auto end = offset + len;
+    if ((p == pend || p->first > offset) && p != ref_map.begin()) {
+      --p;
+      if (p->first + p->second.length > offset) {
+	uint32_t l = std::min(uint32_t(p->first + p->second.length - offset), len);
+	int r = f(offset, l, p->second.refs);
+	if (r < 0)
+	  return r;
+	offset +=l;
+      }
+      ++p;
+    }
+    while (p != pend && end > offset && end > p->first) {
+      uint32_t l = std::min(p->second.length, uint32_t(end - p->first));
+      int r = f(p->first, l, p->second.refs);
+      if (r < 0)
+	return r;
+      offset = p->first + p->second.length;
+      ++p;
+    }
+    return 0;
   }
 
   void dump(ceph::Formatter *f) const;
@@ -1684,5 +1778,17 @@ private:
     return *aux_items.emplace(it, id);
   }
 };
+
+struct span_stat_t {
+  int64_t stored = 0;  // total bytes stored within a span
+  int64_t cached = 0;  // bytes from span kept in cache, not included in the analysis below
+  int64_t allocated = 0;
+  int64_t stored_compressed = 0;
+  int64_t allocated_compressed = 0;
+  int64_t allocated_shared = 0;
+  size_t extents = 0;
+  size_t frags = 0;
+};
+std::ostream& operator<<(std::ostream& out, const span_stat_t&);
 
 #endif

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1409,7 +1409,9 @@ static opt_mapping_t opt_mapping = boost::assign::map_list_of
 	   ("read_ratio", pool_opts_t::opt_desc_t(
              pool_opts_t::READ_RATIO, pool_opts_t::INT))
 	   ("pct_update_delay", pool_opts_t::opt_desc_t(
-             pool_opts_t::PCT_UPDATE_DELAY, pool_opts_t::INT));
+             pool_opts_t::PCT_UPDATE_DELAY, pool_opts_t::INT))
+           ("deep_scrub_reformat", pool_opts_t::opt_desc_t(
+	     pool_opts_t::DEEP_SCRUB_REFORMAT, pool_opts_t::STR));
 
 bool pool_opts_t::is_opt_name(const std::string& name)
 {

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1410,8 +1410,8 @@ static opt_mapping_t opt_mapping = boost::assign::map_list_of
              pool_opts_t::READ_RATIO, pool_opts_t::INT))
 	   ("pct_update_delay", pool_opts_t::opt_desc_t(
              pool_opts_t::PCT_UPDATE_DELAY, pool_opts_t::INT))
-           ("deep_scrub_reformat", pool_opts_t::opt_desc_t(
-	     pool_opts_t::DEEP_SCRUB_REFORMAT, pool_opts_t::STR));
+	   ("deep_scrub_reformat", pool_opts_t::opt_desc_t(
+             pool_opts_t::DEEP_SCRUB_REFORMAT, pool_opts_t::STR));
 
 bool pool_opts_t::is_opt_name(const std::string& name)
 {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1145,6 +1145,7 @@ public:
      * completion if there are no other in progress writes.
      */
     PCT_UPDATE_DELAY,
+    DEEP_SCRUB_REFORMAT,   // perform data reformatting when deep-scrubbing
   };
 
   enum type_t {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1147,6 +1147,7 @@ public:
      * completion if there are no other in progress writes.
      */
     PCT_UPDATE_DELAY,
+    DEEP_SCRUB_REFORMAT,   // perform data reformatting when deep-scrubbing
   };
 
   enum type_t {

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -495,6 +495,22 @@ public:
   }
 };
 
+class StoreTestReformatting : public StoreTestFixture,
+                              public ::testing::WithParamInterface<const char*> {
+public:
+  StoreTestReformatting()
+    : StoreTestFixture("bluestore")
+  {
+  }
+  void SetUp() override {
+    //do nothing
+  }
+protected:
+  void DeferredSetup() {
+    StoreTestFixture::SetUp();
+  }
+};
+
 struct MatrixArg
 {
   std::string param;
@@ -13021,9 +13037,7 @@ TEST_P(StoreTestSpecificAUSize, OverwriteDeferredV2Test) {
   doOverwriteDeferredTest(store.get(), true);
 }
 
-TEST_P(StoreTestSpecificAUSize, BasicReformattingTest) {
-  if (string(GetParam()) != "bluestore")
-    return;
+TEST_P(StoreTestReformatting, BasicTest) {
 
   // enforce 'ssd' settings to avoid deferred writes
   // which result in cached data blocks and hence
@@ -13033,9 +13047,9 @@ TEST_P(StoreTestSpecificAUSize, BasicReformattingTest) {
   // space fragmentation as new allocations tend to occupy new extents
   // in this mode.
   SetVal(g_conf(), "bluestore_allocator_lookup_policy", "hdd_optimized");
+  SetVal(g_conf(), "bluestore_write_v2", GetParam());
   g_conf().apply_changes(nullptr);
-
-  StartDeferred(0x1000);
+  DeferredSetup();
 
   int r;
   coll_t cid;
@@ -13286,9 +13300,7 @@ TEST_P(StoreTestSpecificAUSize, BasicReformattingTest) {
   }
 }
 
-TEST_P(StoreTestSpecificAUSize, CompressedReformattingTest) {
-  if (string(GetParam()) != "bluestore")
-    return;
+TEST_P(StoreTestReformatting, CompressedTest) {
 
   // enforce 'ssd' settings to avoid deferred writes
   // which result in cached data blocks and hence
@@ -13298,20 +13310,19 @@ TEST_P(StoreTestSpecificAUSize, CompressedReformattingTest) {
   // space fragmentation as new allocations tend to occupy new extents
   // in this mode.
   SetVal(g_conf(), "bluestore_allocator_lookup_policy", "hdd_optimized");
+  SetVal(g_conf(), "bluestore_write_v2", GetParam());
+  // disable write v2 recompression
+  SetVal(g_conf(), "bluestore_recompression_min_gain", "1000");
   g_conf().apply_changes(nullptr);
-
-  StartDeferred(0x1000);
+  DeferredSetup();
 
   int r;
   coll_t cid;
 
   SetVal(g_conf(), "bluestore_compression_algorithm", "lz4");
   SetVal(g_conf(), "bluestore_compression_mode", "force");
-//  SetVal(g_conf(), "bluestore_write_v2", "false");
-//  SetVal(g_conf(), "bluefs_wal_envelope_mode", "false");
 
   g_ceph_context->_conf.apply_changes(nullptr);
-
   ghobject_t obj(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
   ghobject_t objw(hobject_t(sobject_t("Object 2", CEPH_NOSNAP)));
   auto ch = store->create_new_collection(cid);
@@ -13337,8 +13348,6 @@ TEST_P(StoreTestSpecificAUSize, CompressedReformattingTest) {
     ch.reset();
     int r = store->umount();
     ASSERT_EQ(0, r);
-    //r = store->fsck(true);
-    //ASSERT_EQ(0, r);
     r = store->mount();
     ASSERT_EQ(0, r);
     ch = store->open_collection(cid);
@@ -13346,13 +13355,22 @@ TEST_P(StoreTestSpecificAUSize, CompressedReformattingTest) {
   };
   bufferlist bl;
   bufferlist expected_bl;
-  uint64_t len = 512 * 1024 - 10;
+  uint64_t len1 = 508 * 1024;
+  uint64_t len2 = 4096 - 10; // make an independent "small" write
+                             // to simulate v1 writing scheme where
+			     // tail gets independent uncompressed blob.
+  uint64_t len = len1 + len2;
   size_t len4K = 4096;
-  bl.append(std::string(len, 'a'));
+  bl.append(std::string(len1, 'a'));
+  bl.append(std::string(len2, 'A'));
   {
     C_SaferCond c;
     ObjectStore::Transaction t;
-    t.write(cid, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    bufferlist bl0;
+    bl0.substr_of(bl, 0, len1);
+    t.write(cid, obj, 0, len1, bl0, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    bl0.substr_of(bl, len1, len2);
+    t.write(cid, obj, len1, len2, bl0, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
     t.register_on_complete(&c);
     r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
@@ -13604,9 +13622,7 @@ TEST_P(StoreTestSpecificAUSize, CompressedReformattingTest) {
   }
 }
 
-TEST_P(StoreTestSpecificAUSize, LazyCompressionReformattingTest) {
-  if (string(GetParam()) != "bluestore")
-    return;
+TEST_P(StoreTestReformatting, LazyCompressionTest) {
 
   // enforce 'ssd' settings to avoid deferred writes
   // which result in cached data blocks and hence
@@ -13616,10 +13632,10 @@ TEST_P(StoreTestSpecificAUSize, LazyCompressionReformattingTest) {
   // space fragmentation as new allocations tend to occupy new extents
   // in this mode.
   SetVal(g_conf(), "bluestore_allocator_lookup_policy", "hdd_optimized");
+  SetVal(g_conf(), "bluestore_write_v2", GetParam());
 
   g_conf().apply_changes(nullptr);
-
-  StartDeferred(0x1000);
+  DeferredSetup();
 
   int r;
   coll_t cid;
@@ -13843,6 +13859,16 @@ TEST_P(StoreTestSpecificAUSize, LazyCompressionReformattingTest) {
     ASSERT_EQ(r, 0);
   }
 }
+// Vary write_v2 mode
+INSTANTIATE_TEST_SUITE_P(
+  BlueStore,
+  StoreTestReformatting,
+  ::testing::Values(
+    "false",
+    "true"
+  ));
+
+
 #endif  // WITH_BLUESTORE
 
 int main(int argc, char **argv) {

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -12796,6 +12796,223 @@ TEST_P(StoreTest, BlueFS_truncate_remove_race) {
   EXPECT_EQ(store->mount(), 0);
 }
 
+// This test case checks:
+//  * if full onode overwrite triggers non-deferred write
+//  * if full small tail overwrite trigger deferred write
+//  * if partial small tail overwrite trigger deferred write
+//
+void doOverwriteDeferredTest(ObjectStore* store, bool v2) {
+  size_t basic_size = 0x11000; // be that large to avoid deferring for big blob
+  size_t extra = 4;
+
+  int r;
+  coll_t cid;
+  ghobject_t obj(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  ghobject_t obj_clone = obj;
+  obj_clone.hobj.snap = 1;
+
+  auto ch = store->create_new_collection(cid);
+  const PerfCounters* logger = store->get_perf_counters();
+
+  cerr << "Creating collection " << cid << std::endl;
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  cerr << "Making object " << cid << " " << obj << std::endl;
+  bufferlist bl;
+  bufferlist expected_bl;
+  uint64_t len = basic_size + extra;
+  bl.append(std::string(len, 'a'));
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, 0);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  ASSERT_EQ(0, logger->get(l_bluestore_issued_deferred_writes));
+
+  cerr << "Overwriting object (exact size match) " << cid << " " << obj << std::endl;
+  bl.clear();
+  bl.append(std::string(len, 'b'));
+  expected_bl.clear();
+  expected_bl.append(std::string(len, 'b'));
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, 0);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+    EXPECT_EQ(0, logger->get(l_bluestore_issued_deferred_writes));
+  }
+  {
+    bl.clear();
+    int r = store->read(ch, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    ASSERT_EQ(r, (int)expected_bl.length());
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+  }
+
+  cerr << "Overwriting tail only (size match)" << cid << " " << obj << std::endl;
+  bl.clear();
+  bl.append(std::string(extra, '0'));
+  expected_bl.clear();
+  expected_bl.append(std::string(basic_size, 'b'));
+  expected_bl.append(std::string(extra, '0'));
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, basic_size, extra, bl, 0);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+    EXPECT_EQ(1, logger->get(l_bluestore_issued_deferred_writes));
+  }
+  {
+    bl.clear();
+    int r = store->read(ch, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    ASSERT_EQ(r, (int)expected_bl.length());
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+  }
+
+  cerr << "Overwriting object (overwrite size is greater) " << cid << " " << obj << std::endl;
+  bl.clear();
+  len = basic_size + extra + 1;
+  bl.append(std::string(len, 'c'));
+  expected_bl.clear();
+  expected_bl.append(std::string(len, 'c'));
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, 0);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+    EXPECT_EQ(1, logger->get(l_bluestore_issued_deferred_writes));
+  }
+  {
+    bl.clear();
+    int r = store->read(ch, obj, 0, basic_size + extra + 1, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    ASSERT_EQ(r, (int)expected_bl.length());
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+  }
+
+  cerr << "Overwriting tail only (size is greater)" << cid << " " << obj << std::endl;
+  bl.clear();
+  len = extra + 2;
+  bl.append(std::string(len, '2'));
+  expected_bl.clear();
+  expected_bl.append(std::string(basic_size, 'c'));
+  expected_bl.append(std::string(len, '2'));
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, basic_size, len, bl, 0);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+    EXPECT_EQ(2, logger->get(l_bluestore_issued_deferred_writes));
+  }
+  {
+    bl.clear();
+    int r = store->read(ch, obj, 0, basic_size + extra + 2, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    ASSERT_EQ(r, (int)expected_bl.length());
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+  }
+
+  cerr << "Overwriting tail only (size is less)" << cid << " " << obj << std::endl;
+  bl.clear();
+  len = extra - 1;
+  bl.append(std::string(len, '1'));
+  expected_bl.clear();
+  expected_bl.append(std::string(basic_size, 'c'));
+  expected_bl.append(std::string(len, '1'));
+  expected_bl.append(std::string(1, '2'));
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, basic_size, len, bl, 0);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+    EXPECT_EQ(3, logger->get(l_bluestore_issued_deferred_writes));
+  }
+  {
+    bl.clear();
+    int r = store->read(ch, obj, 0, basic_size + extra, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    ASSERT_EQ(r, (int)expected_bl.length());
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+  }
+
+  cerr << "Overwriting object (overwrite size is less) " << cid << " " << obj << std::endl;
+  bl.clear();
+  len = basic_size + extra - 1;
+  bl.append(std::string(len, 'd'));
+  expected_bl.clear();
+  expected_bl.append(std::string(len, 'd'));
+  expected_bl.append(std::string(1, '2'));
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, 0);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+    // Write v2 behaves differently for now and omits deferred write even
+    // when it's not a full overwrite
+    EXPECT_EQ(v2 ? 3 : 4, logger->get(l_bluestore_issued_deferred_writes));
+  }
+  {
+    bl.clear();
+    int r = store->read(ch, obj, 0, basic_size + extra, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    ASSERT_EQ(r, (int)expected_bl.length());
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+  }
+
+}
+
+TEST_P(StoreTestSpecificAUSize, OverwriteDeferredTest) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  // enforce 'hddd' settings to enable deferred writes
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "hdd");
+  SetVal(g_conf(), "bluestore_write_v2", "false");
+
+  g_conf().apply_changes(nullptr);
+
+  size_t min_alloc_size = 0x1000;
+  StartDeferred(min_alloc_size);
+
+  doOverwriteDeferredTest(store.get(), false);
+}
+
+TEST_P(StoreTestSpecificAUSize, OverwriteDeferredV2Test) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  // enforce 'hddd' settings to enable deferred writes
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "hdd");
+  SetVal(g_conf(), "bluestore_write_v2", "true");
+
+  g_conf().apply_changes(nullptr);
+
+  size_t min_alloc_size = 0x1000;
+  StartDeferred(min_alloc_size);
+
+  doOverwriteDeferredTest(store.get(), true);
+}
 #endif  // WITH_BLUESTORE
 
 int main(int argc, char **argv) {

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -13020,6 +13020,829 @@ TEST_P(StoreTestSpecificAUSize, OverwriteDeferredV2Test) {
 
   doOverwriteDeferredTest(store.get(), true);
 }
+
+TEST_P(StoreTestSpecificAUSize, BasicReformattingTest) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  // enforce 'ssd' settings to avoid deferred writes
+  // which result in cached data blocks and hence
+  // prevents from reformatting
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "ssd");
+  // enforce hdd-optimized allocation strategy to increase resulting
+  // space fragmentation as new allocations tend to occupy new extents
+  // in this mode.
+  SetVal(g_conf(), "bluestore_allocator_lookup_policy", "hdd_optimized");
+  g_conf().apply_changes(nullptr);
+
+  StartDeferred(0x1000);
+
+  int r;
+  coll_t cid;
+  ghobject_t obj(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  ghobject_t obj_clone = obj;
+  obj_clone.hobj.snap = 1;
+
+  auto ch = store->create_new_collection(cid);
+  const PerfCounters* logger = store->get_perf_counters();
+
+  pool_opts_t popts;
+  popts.set(pool_opts_t::DEEP_SCRUB_REFORMAT, "defragment");
+  store->set_collection_opts(ch, popts);
+
+  cerr << "Creating collection " << cid << std::endl;
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  auto wait_fn = [&]() {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.touch(cid, obj);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  };
+  cerr << "Making object " << cid << " " << obj << std::endl;
+  bufferlist bl;
+  bufferlist expected_bl;
+  uint64_t len = 127 * 1024;
+  uint64_t len4K = 4096;
+  bl.append(std::string(len, 'a'));
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, 0);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_issued));
+  }
+  cerr << "Fragmenting object " << std::endl;
+  {
+    C_SaferCond c;
+    bufferlist bl1;
+    uint64_t pos = 0;
+    bl1.append(std::string(len4K, 'c'));
+    ObjectStore::Transaction t;
+    auto p = bl.begin();
+    while (pos + len4K <= len) {
+      t.write(cid, obj, pos, len4K, bl1, 0);
+      expected_bl.append(bl1);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    p.copy(p.get_remaining(), expected_bl);
+
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  // object with shared blobs
+  cerr << "Making and fragmenting shared object " << std::endl;
+  {
+    expected_bl.clear();
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, 0);
+    {
+      bufferlist bl1;
+      uint64_t pos = 0;
+      bl1.append(std::string(len4K, 'c'));
+      auto p = bl.begin();
+      while (pos + len4K <= len) {
+    t.write(cid, obj, pos, len4K, bl1, 0);
+    expected_bl.append(bl1);
+    p += len4K;
+    p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+    pos += 2 * len4K;
+      }
+      p.copy(p.get_remaining(), expected_bl);
+    }
+
+    t.clone(cid, obj, obj_clone);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  {
+    // remove the clone hence enabling reformatting
+    ObjectStore::Transaction t;
+    t.remove(cid, obj_clone);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+
+  // object with mostly contiguous allocation but having a small gap
+  cerr << "Making and fragmenting object, single small gap" << std::endl;
+  {
+    uint64_t o = 4096;
+    uint64_t l = 4096;
+    expected_bl.clear();
+    auto p = bl.begin();
+    p.copy(o, expected_bl);
+    expected_bl.append_zero(l);
+    p += l;
+    p.copy_all(expected_bl);
+
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.remove(cid, obj);
+    t.write(cid, obj, 0, len, bl, 0);
+    t.zero(cid, obj, 4096, 4096);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  // check none reformatting setting
+  popts.set(pool_opts_t::DEEP_SCRUB_REFORMAT, "");
+  store->set_collection_opts(ch, popts);
+  cerr << "Making and fragmenting object, single small gap, no reformatting" << std::endl;
+  {
+    // reuse existing expected_bl
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.remove(cid, obj);
+    t.write(cid, obj, 0, len, bl, 0);
+    t.zero(cid, obj, 4096, 4096);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    ObjectStore::Transaction t;
+    t.remove(cid, obj);
+    t.remove(cid, obj_clone);
+    t.remove_collection(cid);
+    cerr << "Cleaning" << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+}
+
+TEST_P(StoreTestSpecificAUSize, CompressedReformattingTest) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  // enforce 'ssd' settings to avoid deferred writes
+  // which result in cached data blocks and hence
+  // prevents from reformatting
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "ssd");
+  // enforce hdd-optimized allocation strategy to increase resulting
+  // space fragmentation as new allocations tend to occupy new extents
+  // in this mode.
+  SetVal(g_conf(), "bluestore_allocator_lookup_policy", "hdd_optimized");
+  g_conf().apply_changes(nullptr);
+
+  StartDeferred(0x1000);
+
+  int r;
+  coll_t cid;
+
+  SetVal(g_conf(), "bluestore_compression_algorithm", "lz4");
+  SetVal(g_conf(), "bluestore_compression_mode", "force");
+//  SetVal(g_conf(), "bluestore_write_v2", "false");
+//  SetVal(g_conf(), "bluefs_wal_envelope_mode", "false");
+
+  g_ceph_context->_conf.apply_changes(nullptr);
+
+  ghobject_t obj(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  ghobject_t objw(hobject_t(sobject_t("Object 2", CEPH_NOSNAP)));
+  auto ch = store->create_new_collection(cid);
+  const PerfCounters* logger = store->get_perf_counters();
+
+  pool_opts_t popts;
+  popts.set(pool_opts_t::DEEP_SCRUB_REFORMAT, "recompress");
+
+  store->set_collection_opts(ch, popts);
+
+  cerr << "Creating collection " << cid << std::endl;
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  cerr << "Making object " << cid << " " << obj << std::endl;
+  auto wait_fn = [&]() {
+    ch.reset();
+    int r = store->umount();
+    ASSERT_EQ(0, r);
+    //r = store->fsck(true);
+    //ASSERT_EQ(0, r);
+    r = store->mount();
+    ASSERT_EQ(0, r);
+    ch = store->open_collection(cid);
+    store->set_collection_opts(ch, popts);
+  };
+  bufferlist bl;
+  bufferlist expected_bl;
+  uint64_t len = 512 * 1024 - 10;
+  size_t len4K = 4096;
+  bl.append(std::string(len, 'a'));
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_issued));
+  }
+  cerr << "Fragmenting object " << std::endl;
+  {
+    C_SaferCond c;
+    bufferlist bl1;
+    uint64_t pos = 0;
+    bl1.append(std::string(len4K, 'b'));
+    ObjectStore::Transaction t;
+    auto p = bl.begin();
+    while (pos + len4K <= len) {
+      t.write(cid, obj, pos, len4K, bl1, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      expected_bl.append(bl1);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    p.copy(p.get_remaining(), expected_bl);
+
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  // now let's write non-compressible data
+  cerr << "Fragmenting non-compressible object " << std::endl;
+  {
+    C_SaferCond c;
+    uint64_t pos = 0;
+    ObjectStore::Transaction t;
+    expected_bl.clear();
+    auto p = bl.begin();
+
+    // have to make full buffer in a single shot as repetitive gen_buffer calls
+    // produce the same output which is inappropriate
+    bufferlist bl1;
+    bl1.append(gen_buffer(len).get(), len);
+    auto p1 = bl1.begin();
+    while (pos + len4K <= len) {
+      bufferlist b;
+      p1.copy(len4K, b);
+      t.write(cid, obj, pos, len4K, b, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      expected_bl.append(b);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    p.copy(p.get_remaining(), expected_bl);
+
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(4, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+
+  //check both reformatting options enabled, data is compressible
+  popts.set(pool_opts_t::DEEP_SCRUB_REFORMAT, "recompress, defragment");
+  store->set_collection_opts(ch, popts);
+  cerr << "Making and fragmenting compressible object, 'both' reformatting mode" << std::endl;
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    bufferlist bl1;
+    uint64_t pos = 0;
+    expected_bl.clear();
+    bl1.append(std::string(len4K, 'b'));
+    auto p = bl.begin();
+    while (pos + len4K < len) {
+      t.write(cid, obj, pos, len4K, bl1, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      expected_bl.append(bl1);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    p.copy(p.get_remaining(), expected_bl);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(5, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(6, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(4, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+  // now write non-compressible data but this will perform recompression anyway due
+  // to defragmentation
+  //
+  cerr << "Making and fragmenting non-compressible object, 'both' reformatting mode" << std::endl;
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    C_SaferCond c;
+    uint64_t pos = 0;
+    ObjectStore::Transaction t;
+    expected_bl.clear();
+    auto p = bl.begin();
+
+    // have to make full buffer in a single shot as repetitive gen_buffer calls
+    // produce the same output which is inappropriate
+    bufferlist bl1;
+    bl1.append(gen_buffer(len).get(), len);
+    auto p1 = bl1.begin();
+    while (pos + len4K <= len) {
+      bufferlist b;
+      p1.copy(len4K, b);
+      t.write(cid, obj, pos, len4K, b, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      expected_bl.append(b);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    p.copy(p.get_remaining(), expected_bl);
+
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(7, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(5, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(8, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(6, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(1,  logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+
+  {
+    ObjectStore::Transaction t;
+    t.remove(cid, obj);
+    t.remove_collection(cid);
+    cerr << "Cleaning" << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+}
+
+TEST_P(StoreTestSpecificAUSize, LazyCompressionReformattingTest) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  // enforce 'ssd' settings to avoid deferred writes
+  // which result in cached data blocks and hence
+  // prevents from reformatting
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "ssd");
+  // enforce hdd-optimized allocation strategy to increase resulting
+  // space fragmentation as new allocations tend to occupy new extents
+  // in this mode.
+  SetVal(g_conf(), "bluestore_allocator_lookup_policy", "hdd_optimized");
+
+  g_conf().apply_changes(nullptr);
+
+  StartDeferred(0x1000);
+
+  int r;
+  coll_t cid;
+
+  SetVal(g_conf(), "bluestore_compression_algorithm", "lz4");
+  g_ceph_context->_conf.apply_changes(nullptr);
+
+  ghobject_t obj(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  ghobject_t objw(hobject_t(sobject_t("Object 2", CEPH_NOSNAP)));
+  auto ch = store->create_new_collection(cid);
+  const PerfCounters* logger = store->get_perf_counters();
+
+  pool_opts_t popts;
+  popts.set(pool_opts_t::DEEP_SCRUB_REFORMAT, "recompress");
+  popts.set(pool_opts_t::COMPRESSION_MODE, "force_lazy");
+
+  store->set_collection_opts(ch, popts);
+
+  cerr << "Creating collection " << cid << std::endl;
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  cerr << "Making object " << cid << " " << obj << std::endl;
+  auto wait_fn = [&]() {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.touch(cid, obj);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  };
+  bufferlist bl;
+  bufferlist expected_bl;
+  uint64_t len = 500 * 1024;
+  uint64_t len4K = 4096;
+  bl.append(std::string(len, 'a'));
+  expected_bl = bl;
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  cerr << "Lazy object compression" << std::endl;
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  cerr << "Fragmenting object " << std::endl;
+  {
+    expected_bl.clear();
+    C_SaferCond c;
+    bufferlist bl1;
+    uint64_t pos = 0;
+    bl1.append(std::string(len4K, 'b'));
+    ObjectStore::Transaction t;
+    auto p = bl.begin();
+    while (pos + len4K <= len) {
+      t.write(cid, obj, pos, len4K, bl1, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      expected_bl.append(bl1);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    p.copy(p.get_remaining(), expected_bl);
+
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+  // now let's write non-compressible data
+  cerr << "Writing non-compressible object " << std::endl;
+  {
+    C_SaferCond c;
+    uint64_t pos = 0;
+    ObjectStore::Transaction t;
+    expected_bl.clear();
+    bufferlist bl1;
+    bl1.append(gen_buffer(len).get(), len);
+    auto p1 = bl1.begin();
+    while (pos + len4K <= len) {
+      bufferlist b;
+      p1.copy(len4K, b);
+      t.write(cid, obj, pos, len4K, b, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      pos += len4K;
+    }
+    expected_bl.claim_append(bl1);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+
+  //check both reformatting options enabled, data is compressible
+  popts.set(pool_opts_t::DEEP_SCRUB_REFORMAT, "recompress, defragment");
+  store->set_collection_opts(ch, popts);
+  cerr << "Making and fragmenting compressible object, 'both' reformatting mode" << std::endl;
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    bufferlist bl1;
+    uint64_t pos = 0;
+    expected_bl.clear();
+    bl1.append(std::string(len4K, 'b'));
+    auto p = bl.begin();
+    while (pos < len) {
+      t.write(cid, obj, pos, len4K, bl1, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      expected_bl.append(bl1);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(4, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(4, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  {
+    ObjectStore::Transaction t;
+    t.remove(cid, obj);
+    t.remove_collection(cid);
+    cerr << "Cleaning" << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+}
 #endif  // WITH_BLUESTORE
 
 int main(int argc, char **argv) {

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <memory>
 #include <time.h>
+#include <random>
 #include <sys/mount.h>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
@@ -108,7 +109,13 @@ static bool bl_eq(bufferlist& expected, bufferlist& actual)
   }
   return false;
 }
-
+std::unique_ptr<char[]> gen_buffer(uint64_t size)
+{
+  std::unique_ptr<char[]> buffer = std::make_unique<char[]>(size);
+  std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned char> e;
+  std::generate(buffer.get(), buffer.get() + size, std::ref(e));
+  return buffer;
+}
 void dump_bluefs_stats()
 {
   AdminSocket* admin_socket = g_ceph_context->get_admin_socket();

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <memory>
 #include <time.h>
+#include <random>
 #include <sys/mount.h>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
@@ -110,7 +111,13 @@ static bool bl_eq(bufferlist& expected, bufferlist& actual)
   }
   return false;
 }
-
+std::unique_ptr<char[]> gen_buffer(uint64_t size)
+{
+  std::unique_ptr<char[]> buffer = std::make_unique<char[]>(size);
+  std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned char> e;
+  std::generate(buffer.get(), buffer.get() + size, std::ref(e));
+  return buffer;
+}
 void dump_bluefs_stats()
 {
   AdminSocket* admin_socket = g_ceph_context->get_admin_socket();

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -497,6 +497,22 @@ public:
   }
 };
 
+class StoreTestReformatting : public StoreTestFixture,
+                              public ::testing::WithParamInterface<const char*> {
+public:
+  StoreTestReformatting()
+    : StoreTestFixture("bluestore")
+  {
+  }
+  void SetUp() override {
+    //do nothing
+  }
+protected:
+  void DeferredSetup() {
+    StoreTestFixture::SetUp();
+  }
+};
+
 struct MatrixArg
 {
   std::string param;
@@ -13295,9 +13311,7 @@ TEST_P(StoreTestSpecificAUSize, OverwriteDeferredV2Test) {
   doOverwriteDeferredTest(store.get(), true);
 }
 
-TEST_P(StoreTestSpecificAUSize, BasicReformattingTest) {
-  if (string(GetParam()) != "bluestore")
-    return;
+TEST_P(StoreTestReformatting, BasicTest) {
 
   // enforce 'ssd' settings to avoid deferred writes
   // which result in cached data blocks and hence
@@ -13307,9 +13321,9 @@ TEST_P(StoreTestSpecificAUSize, BasicReformattingTest) {
   // space fragmentation as new allocations tend to occupy new extents
   // in this mode.
   SetVal(g_conf(), "bluestore_allocator_lookup_policy", "hdd_optimized");
+  SetVal(g_conf(), "bluestore_write_v2", GetParam());
   g_conf().apply_changes(nullptr);
-
-  StartDeferred(0x1000);
+  DeferredSetup();
 
   int r;
   coll_t cid;
@@ -13560,9 +13574,7 @@ TEST_P(StoreTestSpecificAUSize, BasicReformattingTest) {
   }
 }
 
-TEST_P(StoreTestSpecificAUSize, CompressedReformattingTest) {
-  if (string(GetParam()) != "bluestore")
-    return;
+TEST_P(StoreTestReformatting, CompressedTest) {
 
   // enforce 'ssd' settings to avoid deferred writes
   // which result in cached data blocks and hence
@@ -13572,20 +13584,19 @@ TEST_P(StoreTestSpecificAUSize, CompressedReformattingTest) {
   // space fragmentation as new allocations tend to occupy new extents
   // in this mode.
   SetVal(g_conf(), "bluestore_allocator_lookup_policy", "hdd_optimized");
+  SetVal(g_conf(), "bluestore_write_v2", GetParam());
+  // disable write v2 recompression
+  SetVal(g_conf(), "bluestore_recompression_min_gain", "1000");
   g_conf().apply_changes(nullptr);
-
-  StartDeferred(0x1000);
+  DeferredSetup();
 
   int r;
   coll_t cid;
 
   SetVal(g_conf(), "bluestore_compression_algorithm", "lz4");
   SetVal(g_conf(), "bluestore_compression_mode", "force");
-//  SetVal(g_conf(), "bluestore_write_v2", "false");
-//  SetVal(g_conf(), "bluefs_wal_envelope_mode", "false");
 
   g_ceph_context->_conf.apply_changes(nullptr);
-
   ghobject_t obj(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
   ghobject_t objw(hobject_t(sobject_t("Object 2", CEPH_NOSNAP)));
   auto ch = store->create_new_collection(cid);
@@ -13611,8 +13622,6 @@ TEST_P(StoreTestSpecificAUSize, CompressedReformattingTest) {
     ch.reset();
     int r = store->umount();
     ASSERT_EQ(0, r);
-    //r = store->fsck(true);
-    //ASSERT_EQ(0, r);
     r = store->mount();
     ASSERT_EQ(0, r);
     ch = store->open_collection(cid);
@@ -13620,13 +13629,22 @@ TEST_P(StoreTestSpecificAUSize, CompressedReformattingTest) {
   };
   bufferlist bl;
   bufferlist expected_bl;
-  uint64_t len = 512 * 1024 - 10;
+  uint64_t len1 = 508 * 1024;
+  uint64_t len2 = 4096 - 10; // make an independent "small" write
+                             // to simulate v1 writing scheme where
+			     // tail gets independent uncompressed blob.
+  uint64_t len = len1 + len2;
   size_t len4K = 4096;
-  bl.append(std::string(len, 'a'));
+  bl.append(std::string(len1, 'a'));
+  bl.append(std::string(len2, 'A'));
   {
     C_SaferCond c;
     ObjectStore::Transaction t;
-    t.write(cid, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    bufferlist bl0;
+    bl0.substr_of(bl, 0, len1);
+    t.write(cid, obj, 0, len1, bl0, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    bl0.substr_of(bl, len1, len2);
+    t.write(cid, obj, len1, len2, bl0, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
     t.register_on_complete(&c);
     r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
@@ -13878,9 +13896,7 @@ TEST_P(StoreTestSpecificAUSize, CompressedReformattingTest) {
   }
 }
 
-TEST_P(StoreTestSpecificAUSize, LazyCompressionReformattingTest) {
-  if (string(GetParam()) != "bluestore")
-    return;
+TEST_P(StoreTestReformatting, LazyCompressionTest) {
 
   // enforce 'ssd' settings to avoid deferred writes
   // which result in cached data blocks and hence
@@ -13890,10 +13906,10 @@ TEST_P(StoreTestSpecificAUSize, LazyCompressionReformattingTest) {
   // space fragmentation as new allocations tend to occupy new extents
   // in this mode.
   SetVal(g_conf(), "bluestore_allocator_lookup_policy", "hdd_optimized");
+  SetVal(g_conf(), "bluestore_write_v2", GetParam());
 
   g_conf().apply_changes(nullptr);
-
-  StartDeferred(0x1000);
+  DeferredSetup();
 
   int r;
   coll_t cid;
@@ -14117,6 +14133,16 @@ TEST_P(StoreTestSpecificAUSize, LazyCompressionReformattingTest) {
     ASSERT_EQ(r, 0);
   }
 }
+// Vary write_v2 mode
+INSTANTIATE_TEST_SUITE_P(
+  BlueStore,
+  StoreTestReformatting,
+  ::testing::Values(
+    "false",
+    "true"
+  ));
+
+
 #endif  // WITH_BLUESTORE
 
 int main(int argc, char **argv) {

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -13294,6 +13294,829 @@ TEST_P(StoreTestSpecificAUSize, OverwriteDeferredV2Test) {
 
   doOverwriteDeferredTest(store.get(), true);
 }
+
+TEST_P(StoreTestSpecificAUSize, BasicReformattingTest) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  // enforce 'ssd' settings to avoid deferred writes
+  // which result in cached data blocks and hence
+  // prevents from reformatting
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "ssd");
+  // enforce hdd-optimized allocation strategy to increase resulting
+  // space fragmentation as new allocations tend to occupy new extents
+  // in this mode.
+  SetVal(g_conf(), "bluestore_allocator_lookup_policy", "hdd_optimized");
+  g_conf().apply_changes(nullptr);
+
+  StartDeferred(0x1000);
+
+  int r;
+  coll_t cid;
+  ghobject_t obj(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  ghobject_t obj_clone = obj;
+  obj_clone.hobj.snap = 1;
+
+  auto ch = store->create_new_collection(cid);
+  const PerfCounters* logger = store->get_perf_counters();
+
+  pool_opts_t popts;
+  popts.set(pool_opts_t::DEEP_SCRUB_REFORMAT, "defragment");
+  store->set_collection_opts(ch, popts);
+
+  cerr << "Creating collection " << cid << std::endl;
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  auto wait_fn = [&]() {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.touch(cid, obj);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  };
+  cerr << "Making object " << cid << " " << obj << std::endl;
+  bufferlist bl;
+  bufferlist expected_bl;
+  uint64_t len = 127 * 1024;
+  uint64_t len4K = 4096;
+  bl.append(std::string(len, 'a'));
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, 0);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_issued));
+  }
+  cerr << "Fragmenting object " << std::endl;
+  {
+    C_SaferCond c;
+    bufferlist bl1;
+    uint64_t pos = 0;
+    bl1.append(std::string(len4K, 'c'));
+    ObjectStore::Transaction t;
+    auto p = bl.begin();
+    while (pos + len4K <= len) {
+      t.write(cid, obj, pos, len4K, bl1, 0);
+      expected_bl.append(bl1);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    p.copy(p.get_remaining(), expected_bl);
+
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  // object with shared blobs
+  cerr << "Making and fragmenting shared object " << std::endl;
+  {
+    expected_bl.clear();
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, 0);
+    {
+      bufferlist bl1;
+      uint64_t pos = 0;
+      bl1.append(std::string(len4K, 'c'));
+      auto p = bl.begin();
+      while (pos + len4K <= len) {
+    t.write(cid, obj, pos, len4K, bl1, 0);
+    expected_bl.append(bl1);
+    p += len4K;
+    p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+    pos += 2 * len4K;
+      }
+      p.copy(p.get_remaining(), expected_bl);
+    }
+
+    t.clone(cid, obj, obj_clone);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  {
+    // remove the clone hence enabling reformatting
+    ObjectStore::Transaction t;
+    t.remove(cid, obj_clone);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+
+  // object with mostly contiguous allocation but having a small gap
+  cerr << "Making and fragmenting object, single small gap" << std::endl;
+  {
+    uint64_t o = 4096;
+    uint64_t l = 4096;
+    expected_bl.clear();
+    auto p = bl.begin();
+    p.copy(o, expected_bl);
+    expected_bl.append_zero(l);
+    p += l;
+    p.copy_all(expected_bl);
+
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.remove(cid, obj);
+    t.write(cid, obj, 0, len, bl, 0);
+    t.zero(cid, obj, 4096, 4096);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  // check none reformatting setting
+  popts.set(pool_opts_t::DEEP_SCRUB_REFORMAT, "");
+  store->set_collection_opts(ch, popts);
+  cerr << "Making and fragmenting object, single small gap, no reformatting" << std::endl;
+  {
+    // reuse existing expected_bl
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.remove(cid, obj);
+    t.write(cid, obj, 0, len, bl, 0);
+    t.zero(cid, obj, 4096, 4096);
+    t.register_on_commit(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    ObjectStore::Transaction t;
+    t.remove(cid, obj);
+    t.remove(cid, obj_clone);
+    t.remove_collection(cid);
+    cerr << "Cleaning" << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+}
+
+TEST_P(StoreTestSpecificAUSize, CompressedReformattingTest) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  // enforce 'ssd' settings to avoid deferred writes
+  // which result in cached data blocks and hence
+  // prevents from reformatting
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "ssd");
+  // enforce hdd-optimized allocation strategy to increase resulting
+  // space fragmentation as new allocations tend to occupy new extents
+  // in this mode.
+  SetVal(g_conf(), "bluestore_allocator_lookup_policy", "hdd_optimized");
+  g_conf().apply_changes(nullptr);
+
+  StartDeferred(0x1000);
+
+  int r;
+  coll_t cid;
+
+  SetVal(g_conf(), "bluestore_compression_algorithm", "lz4");
+  SetVal(g_conf(), "bluestore_compression_mode", "force");
+//  SetVal(g_conf(), "bluestore_write_v2", "false");
+//  SetVal(g_conf(), "bluefs_wal_envelope_mode", "false");
+
+  g_ceph_context->_conf.apply_changes(nullptr);
+
+  ghobject_t obj(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  ghobject_t objw(hobject_t(sobject_t("Object 2", CEPH_NOSNAP)));
+  auto ch = store->create_new_collection(cid);
+  const PerfCounters* logger = store->get_perf_counters();
+
+  pool_opts_t popts;
+  popts.set(pool_opts_t::DEEP_SCRUB_REFORMAT, "recompress");
+
+  store->set_collection_opts(ch, popts);
+
+  cerr << "Creating collection " << cid << std::endl;
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  cerr << "Making object " << cid << " " << obj << std::endl;
+  auto wait_fn = [&]() {
+    ch.reset();
+    int r = store->umount();
+    ASSERT_EQ(0, r);
+    //r = store->fsck(true);
+    //ASSERT_EQ(0, r);
+    r = store->mount();
+    ASSERT_EQ(0, r);
+    ch = store->open_collection(cid);
+    store->set_collection_opts(ch, popts);
+  };
+  bufferlist bl;
+  bufferlist expected_bl;
+  uint64_t len = 512 * 1024 - 10;
+  size_t len4K = 4096;
+  bl.append(std::string(len, 'a'));
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_issued));
+  }
+  cerr << "Fragmenting object " << std::endl;
+  {
+    C_SaferCond c;
+    bufferlist bl1;
+    uint64_t pos = 0;
+    bl1.append(std::string(len4K, 'b'));
+    ObjectStore::Transaction t;
+    auto p = bl.begin();
+    while (pos + len4K <= len) {
+      t.write(cid, obj, pos, len4K, bl1, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      expected_bl.append(bl1);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    p.copy(p.get_remaining(), expected_bl);
+
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  // now let's write non-compressible data
+  cerr << "Fragmenting non-compressible object " << std::endl;
+  {
+    C_SaferCond c;
+    uint64_t pos = 0;
+    ObjectStore::Transaction t;
+    expected_bl.clear();
+    auto p = bl.begin();
+
+    // have to make full buffer in a single shot as repetitive gen_buffer calls
+    // produce the same output which is inappropriate
+    bufferlist bl1;
+    bl1.append(gen_buffer(len).get(), len);
+    auto p1 = bl1.begin();
+    while (pos + len4K <= len) {
+      bufferlist b;
+      p1.copy(len4K, b);
+      t.write(cid, obj, pos, len4K, b, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      expected_bl.append(b);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    p.copy(p.get_remaining(), expected_bl);
+
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(4, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+
+  //check both reformatting options enabled, data is compressible
+  popts.set(pool_opts_t::DEEP_SCRUB_REFORMAT, "recompress, defragment");
+  store->set_collection_opts(ch, popts);
+  cerr << "Making and fragmenting compressible object, 'both' reformatting mode" << std::endl;
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    bufferlist bl1;
+    uint64_t pos = 0;
+    expected_bl.clear();
+    bl1.append(std::string(len4K, 'b'));
+    auto p = bl.begin();
+    while (pos + len4K < len) {
+      t.write(cid, obj, pos, len4K, bl1, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      expected_bl.append(bl1);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    p.copy(p.get_remaining(), expected_bl);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(5, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(6, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(4, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+  // now write non-compressible data but this will perform recompression anyway due
+  // to defragmentation
+  //
+  cerr << "Making and fragmenting non-compressible object, 'both' reformatting mode" << std::endl;
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    C_SaferCond c;
+    uint64_t pos = 0;
+    ObjectStore::Transaction t;
+    expected_bl.clear();
+    auto p = bl.begin();
+
+    // have to make full buffer in a single shot as repetitive gen_buffer calls
+    // produce the same output which is inappropriate
+    bufferlist bl1;
+    bl1.append(gen_buffer(len).get(), len);
+    auto p1 = bl1.begin();
+    while (pos + len4K <= len) {
+      bufferlist b;
+      p1.copy(len4K, b);
+      t.write(cid, obj, pos, len4K, b, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      expected_bl.append(b);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    p.copy(p.get_remaining(), expected_bl);
+
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(7, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(5, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(8, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(6, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(1,  logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+
+  {
+    ObjectStore::Transaction t;
+    t.remove(cid, obj);
+    t.remove_collection(cid);
+    cerr << "Cleaning" << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+}
+
+TEST_P(StoreTestSpecificAUSize, LazyCompressionReformattingTest) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  // enforce 'ssd' settings to avoid deferred writes
+  // which result in cached data blocks and hence
+  // prevents from reformatting
+  SetVal(g_conf(), "bluestore_debug_enforce_settings", "ssd");
+  // enforce hdd-optimized allocation strategy to increase resulting
+  // space fragmentation as new allocations tend to occupy new extents
+  // in this mode.
+  SetVal(g_conf(), "bluestore_allocator_lookup_policy", "hdd_optimized");
+
+  g_conf().apply_changes(nullptr);
+
+  StartDeferred(0x1000);
+
+  int r;
+  coll_t cid;
+
+  SetVal(g_conf(), "bluestore_compression_algorithm", "lz4");
+  g_ceph_context->_conf.apply_changes(nullptr);
+
+  ghobject_t obj(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  ghobject_t objw(hobject_t(sobject_t("Object 2", CEPH_NOSNAP)));
+  auto ch = store->create_new_collection(cid);
+  const PerfCounters* logger = store->get_perf_counters();
+
+  pool_opts_t popts;
+  popts.set(pool_opts_t::DEEP_SCRUB_REFORMAT, "recompress");
+  popts.set(pool_opts_t::COMPRESSION_MODE, "force_lazy");
+
+  store->set_collection_opts(ch, popts);
+
+  cerr << "Creating collection " << cid << std::endl;
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  cerr << "Making object " << cid << " " << obj << std::endl;
+  auto wait_fn = [&]() {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.touch(cid, obj);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  };
+  bufferlist bl;
+  bufferlist expected_bl;
+  uint64_t len = 500 * 1024;
+  uint64_t len4K = 4096;
+  bl.append(std::string(len, 'a'));
+  expected_bl = bl;
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  cerr << "Lazy object compression" << std::endl;
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  cerr << "Fragmenting object " << std::endl;
+  {
+    expected_bl.clear();
+    C_SaferCond c;
+    bufferlist bl1;
+    uint64_t pos = 0;
+    bl1.append(std::string(len4K, 'b'));
+    ObjectStore::Transaction t;
+    auto p = bl.begin();
+    while (pos + len4K <= len) {
+      t.write(cid, obj, pos, len4K, bl1, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      expected_bl.append(bl1);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    p.copy(p.get_remaining(), expected_bl);
+
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+  // now let's write non-compressible data
+  cerr << "Writing non-compressible object " << std::endl;
+  {
+    C_SaferCond c;
+    uint64_t pos = 0;
+    ObjectStore::Transaction t;
+    expected_bl.clear();
+    bufferlist bl1;
+    bl1.append(gen_buffer(len).get(), len);
+    auto p1 = bl1.begin();
+    while (pos + len4K <= len) {
+      bufferlist b;
+      p1.copy(len4K, b);
+      t.write(cid, obj, pos, len4K, b, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      pos += len4K;
+    }
+    expected_bl.claim_append(bl1);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(2, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+
+  //check both reformatting options enabled, data is compressible
+  popts.set(pool_opts_t::DEEP_SCRUB_REFORMAT, "recompress, defragment");
+  store->set_collection_opts(ch, popts);
+  cerr << "Making and fragmenting compressible object, 'both' reformatting mode" << std::endl;
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    t.write(cid, obj, 0, len, bl, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    C_SaferCond c;
+    ObjectStore::Transaction t;
+    bufferlist bl1;
+    uint64_t pos = 0;
+    expected_bl.clear();
+    bl1.append(std::string(len4K, 'b'));
+    auto p = bl.begin();
+    while (pos < len) {
+      t.write(cid, obj, pos, len4K, bl1, CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
+      expected_bl.append(bl1);
+      p += len4K;
+      p.copy(std::min(len4K, (uint64_t)p.get_remaining()), expected_bl);
+      pos += 2 * len4K;
+    }
+    t.register_on_complete(&c);
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+    c.wait();
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(4, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  wait_fn();
+  {
+    bufferlist bl;
+    int r = store->read(ch, obj, 0, len, bl,
+      CEPH_OSD_OP_FLAG_FADVISE_DONTNEED | CEPH_OSD_OP_FLAG_SCRUB);
+    ASSERT_EQ(r, (int)len);
+    ASSERT_TRUE(bl_eq(expected_bl, bl));
+    ASSERT_EQ(4, logger->get(l_bluestore_reformat_compress_attempted));
+    ASSERT_EQ(1, logger->get(l_bluestore_reformat_compress_omitted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_attempted));
+    ASSERT_EQ(0, logger->get(l_bluestore_reformat_defragment_omitted));
+    ASSERT_EQ(3, logger->get(l_bluestore_reformat_issued));
+  }
+  {
+    ObjectStore::Transaction t;
+    t.remove(cid, obj);
+    t.remove_collection(cid);
+    cerr << "Cleaning" << std::endl;
+    r = queue_transaction(store, ch, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+}
 #endif  // WITH_BLUESTORE
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This PR adds an ability for BlueStore to perform object content recompression and defragmentation when handling read requests during deep-scrubbing.
After reading object's chunk BlueStore assesses if it can improve space saving by recompressing an object and/or it can optimize physical layout of the object.
Per-pool option 'data_layout_reformatting' has been introduced to control the behavior. It support the following options:
* recompress - enables object content recompression
* defragment - enabled object defragmentation
* both - enables both recompression and defragmentation
*  <everything else> - original behavior, no object reformatting





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
