### PR TITLE
reef: mgr/dashboard: add absolute path validation for pseudo path of nfs export

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -248,7 +248,8 @@
                    class="form-control"
                    name="pseudo"
                    id="pseudo"
-                   formControlName="pseudo">
+                   formControlName="pseudo"
+                   minlength="2">
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('pseudo', formDir, 'required')"
                   i18n>This field is required.</span>
@@ -258,6 +259,9 @@
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('pseudo', formDir, 'pattern')"
                   i18n>Pseudo needs to start with a '/' and can't contain any of the following: &gt;, &lt;, |, &, ( or ).</span>
+            <span class="invalid-feedback"
+                  *ngIf="nfsForm.showError('pseudo', formDir, 'minlength') && nfsForm.getValue('pseudo') === '/'"
+                  i18n>Pseudo path should be an absolute path and it cannot be just '/'</span>
           </div>
         </div>
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66175

---

backport of https://github.com/ceph/ceph/pull/53859
parent tracker: https://tracker.ceph.com/issues/63124

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh