### PR TITLE
test/rgw/notifications: skip reload tests when there is no realm

### DIFF
--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -4536,6 +4536,9 @@ def test_ps_s3_notification_push_kafka_security_sasl_scram():
 @attr('http_test')
 def test_persistent_ps_s3_reload():
     """ do a realm reload while we send notifications """
+    if get_config_cluster() == 'noname':
+        return SkipTest('realm is needed for reload test')
+
     conn = connection()
     zonegroup = get_config_zonegroup()
 
@@ -4642,6 +4645,8 @@ def test_persistent_ps_s3_reload():
 @attr('data_path_v2_test')
 def test_persistent_ps_s3_data_path_v2_migration():
     """ test data path v2 persistent migration """
+    if get_config_cluster() == 'noname':
+        return SkipTest('realm is needed for migration test')
     conn = connection()
     zonegroup = get_config_zonegroup()
 
@@ -4780,6 +4785,8 @@ def test_persistent_ps_s3_data_path_v2_migration():
 @attr('data_path_v2_test')
 def test_ps_s3_data_path_v2_migration():
     """ test data path v2 migration """
+    if get_config_cluster() == 'noname':
+        return SkipTest('realm is needed for migration test')
     conn = connection()
     zonegroup = get_config_zonegroup()
 
@@ -4895,6 +4902,8 @@ def test_ps_s3_data_path_v2_migration():
 @attr('data_path_v2_test')
 def test_ps_s3_data_path_v2_large_migration():
     """ test data path v2 large migration """
+    if get_config_cluster() == 'noname':
+        return SkipTest('realm is needed for migration test')
     conn = connection()
     connections_list = []
     connections_list.append(conn)
@@ -5023,6 +5032,8 @@ def test_ps_s3_data_path_v2_large_migration():
 @attr('data_path_v2_test')
 def test_ps_s3_data_path_v2_mixed_migration():
     """ test data path v2 mixed migration """
+    if get_config_cluster() == 'noname':
+        return SkipTest('realm is needed for migration test')
     conn = connection()
     connections_list = []
     connections_list.append(conn)


### PR DESCRIPTION
this does not impact teuthology, only local runs.
in teuthology all bucket notification tests are defined with a realm

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
