### PR TITLE
test/crimson/seastore/transaction_manager_test_state: fix compilation…

### DIFF
--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -284,6 +284,7 @@ protected:
     auto sec_devices = devices->get_secondary_devices();
     auto p_dev = devices->get_primary_device();
     auto fut = seastar::now();
+#ifdef UNIT_TESTS_BUILT
     if (std::get<1>(GetParam()) == integrity_check_t::FULL_CHECK) {
       fut = crimson::common::local_conf().set_val(
 	"seastore_full_integrity_check", "true");
@@ -291,6 +292,7 @@ protected:
       fut = crimson::common::local_conf().set_val(
 	"seastore_full_integrity_check", "false");
     }
+#endif
     tm = make_transaction_manager(p_dev, sec_devices, true);
     epm = tm->get_epm();
     lba_manager = tm->get_lba_manager();
@@ -436,6 +438,7 @@ protected:
 
   virtual seastar::future<> _init() final {
     auto fut = seastar::now();
+#ifdef UNIT_TESTS_BUILT
     if (std::get<1>(GetParam()) == integrity_check_t::FULL_CHECK) {
       fut = crimson::common::local_conf().set_val(
 	"seastore_full_integrity_check", "true");
@@ -443,6 +446,7 @@ protected:
       fut = crimson::common::local_conf().set_val(
 	"seastore_full_integrity_check", "false");
     }
+#endif
     seastore = make_test_seastore(
       std::make_unique<TestMDStoreState::Store>(mdstore_state.get_mdstore()));
     return fut.then([this] {


### PR DESCRIPTION
… error

Introduced in: https://github.com/ceph/ceph/commit/898efa78e2cde90a2bdf8e6f7eda1d4def736705

Followup: https://github.com/ceph/ceph/pull/53433

```
FAILED: src/crimson/tools/CMakeFiles/perf-staged-fltree.dir/perf_staged_fltree.cc.o
 error: ‘GetParam’ was not declared in this scope
  287 |     if (std::get<1>(GetParam()) == integrity_check_t::FULL_CHECK) {
      |                     ^~~~~~~~
/home/yogisha/ceph/src/test/crimson/seastore/transaction_manager_test_state.h: In member function ‘virtual seastar::future<> SeaStoreTestState::_init()’:
/home/yogisha/ceph/src/test/crimson/seastore/transaction_manager_test_state.h:439:21: error: ‘GetParam’ was not declared in this scope
  439 |     if (std::get<1>(GetParam()) == integrity_check_t::FULL_CHECK) {
      |                     ^~~~~~~~
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
