### PR TITLE
squid: crimson/os/seastore/transaction_manager: remove incorrect assertions

### DIFF
--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -885,9 +885,7 @@ private:
 	crc);
       assert(ref->is_fully_loaded());
       bool inconsistent = false;
-      if (pin->is_indirect()) {
-	inconsistent = (pin->get_checksum() != 0);
-      } else if (full_extent_integrity_check) {
+      if (full_extent_integrity_check) {
 	inconsistent = (pin->get_checksum() != crc);
       } else { // !full_extent_integrity_check: remapped extent may be skipped
 	inconsistent = !(pin->get_checksum() == 0 ||
@@ -953,9 +951,7 @@ private:
 	crc);
       assert(ref->is_fully_loaded());
       bool inconsistent = false;
-      if (pin->is_indirect()) {
-	inconsistent = (pin->get_checksum() != 0);
-      } else if (full_extent_integrity_check) {
+      if (full_extent_integrity_check) {
 	inconsistent = (pin->get_checksum() != crc);
       } else { // !full_extent_integrity_check: remapped extent may be skipped
 	inconsistent = !(pin->get_checksum() == 0 ||


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57135

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh