### PR TITLE
.github: expand tests label to all files under qa

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -287,8 +287,7 @@ ceph-volume:
   - src/python-common/ceph/deployment/drive_selection/**
 
 tests:
-  - qa/tasks/**
-  - qa/workunits/**
+  - qa/**
   - src/test/**
 
 nfs:


### PR DESCRIPTION
The test job definition under qa/suites is an integral part of almost any test.  Often, the test logic is split between the task or workunit and respective snippet(s) under qa/suites.

Other files under qa are less used, but still related to nothing but testing, so just add the label on all of it.