### PR TITLE
mgr/cephadm: allow passing client/server cert/key in nvmeof spec

### DIFF
--- a/src/cephadm/cephadmlib/daemons/nvmeof.py
+++ b/src/cephadm/cephadmlib/daemons/nvmeof.py
@@ -80,7 +80,13 @@ class CephNvmeof(ContainerDaemonForm):
         self, data_dir: str, files: Dict[str, str]
     ) -> Dict[str, str]:
         mounts = dict()
-        for fn in ['server_cert', 'server_key', 'client_cert', 'client_key']:
+        for fn in [
+            'server_cert',
+            'server_key',
+            'client_cert',
+            'client_key',
+            'root_ca_cert',
+        ]:
             if fn in files:
                 mounts[
                     os.path.join(data_dir, fn)

--- a/src/cephadm/cephadmlib/daemons/nvmeof.py
+++ b/src/cephadm/cephadmlib/daemons/nvmeof.py
@@ -76,12 +76,24 @@ class CephNvmeof(ContainerDaemonForm):
         mounts[log_dir] = '/var/log/ceph:z'
         return mounts
 
+    def _get_tls_cert_key_mounts(
+        self, data_dir: str, files: Dict[str, str]
+    ) -> Dict[str, str]:
+        mounts = dict()
+        for fn in ['server_cert', 'server_key', 'client_cert', 'client_key']:
+            if fn in files:
+                mounts[
+                    os.path.join(data_dir, fn)
+                ] = f'/{fn.replace("_", ".")}'
+        return mounts
+
     def customize_container_mounts(
         self, ctx: CephadmContext, mounts: Dict[str, str]
     ) -> None:
         data_dir = self.identity.data_dir(ctx.data_dir)
         log_dir = os.path.join(ctx.log_dir, self.identity.fsid)
         mounts.update(self._get_container_mounts(data_dir, log_dir))
+        mounts.update(self._get_tls_cert_key_mounts(data_dir, self.files))
 
     def customize_container_binds(
         self, ctx: CephadmContext, binds: List[List[str]]

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -48,6 +48,26 @@ class HostCacheStatus(enum.Enum):
     devices = 'devices'
 
 
+class OrchSecretNotFound(OrchestratorError):
+    def __init__(
+        self,
+        message: Optional[str] = '',
+        entity: Optional[str] = '',
+        service_name: Optional[str] = '',
+        hostname: Optional[str] = ''
+    ):
+        if not message:
+            message = f'No secret found for entity {entity}'
+            if service_name:
+                message += f' with service name {service_name}'
+            if hostname:
+                message += f' with hostname {hostname}'
+        super().__init__(message)
+        self.entity = entity
+        self.service_name = service_name
+        self.hostname = hostname
+
+
 class Inventory:
     """
     The inventory stores a HostSpec for all hosts persistently.

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -87,6 +87,7 @@ from .inventory import (
     TunedProfileStore,
     NodeProxyCache,
     CertKeyStore,
+    OrchSecretNotFound,
 )
 from .upgrade import CephadmUpgrade
 from .template import TemplateMgr
@@ -3148,12 +3149,7 @@ Then run the following:
     ) -> str:
         cert = self.cert_key_store.get_cert(entity, service_name or '', hostname or '')
         if not cert:
-            err_msg = f'No cert found for entity {entity}'
-            if service_name:
-                err_msg += f' with service name {service_name}'
-            if hostname:
-                err_msg += f' with hostname {hostname}'
-            raise OrchestratorError(err_msg)
+            raise OrchSecretNotFound(entity=entity, service_name=service_name, hostname=hostname)
         return cert
 
     @handle_orch_error
@@ -3165,12 +3161,7 @@ Then run the following:
     ) -> str:
         key = self.cert_key_store.get_key(entity, service_name or '', hostname or '')
         if not key:
-            err_msg = f'No key found for entity {entity}'
-            if service_name:
-                err_msg += f' with service name {service_name}'
-            if hostname:
-                err_msg += f' with hostname {hostname}'
-            raise OrchestratorError(err_msg)
+            raise OrchSecretNotFound(entity=entity, service_name=service_name, hostname=hostname)
         return key
 
     @handle_orch_error

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3140,6 +3140,40 @@ Then run the following:
         return self.cert_key_store.key_ls()
 
     @handle_orch_error
+    def cert_store_get_cert(
+        self,
+        entity: str,
+        service_name: Optional[str] = None,
+        hostname: Optional[str] = None
+    ) -> str:
+        cert = self.cert_key_store.get_cert(entity, service_name or '', hostname or '')
+        if not cert:
+            err_msg = f'No cert found for entity {entity}'
+            if service_name:
+                err_msg += f' with service name {service_name}'
+            if hostname:
+                err_msg += f' with hostname {hostname}'
+            raise OrchestratorError(err_msg)
+        return cert
+
+    @handle_orch_error
+    def cert_store_get_key(
+        self,
+        entity: str,
+        service_name: Optional[str] = None,
+        hostname: Optional[str] = None
+    ) -> str:
+        key = self.cert_key_store.get_key(entity, service_name or '', hostname or '')
+        if not key:
+            err_msg = f'No key found for entity {entity}'
+            if service_name:
+                err_msg += f' with service name {service_name}'
+            if hostname:
+                err_msg += f' with hostname {hostname}'
+            raise OrchestratorError(err_msg)
+        return key
+
+    @handle_orch_error
     def apply_mon(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -60,15 +60,20 @@ class NvmeofService(CephService):
                 or not spec.client_key
                 or not spec.server_cert
                 or not spec.server_key
+                or not spec.root_ca_cert
             ):
-                self.mgr.log.error(f'enable_auth set for {spec.service_name()} spec, but at '
-                                   'least one of server/client cert/key fields missing. TLS '
-                                   f'not being set up for {daemon_spec.name()}')
+                err_msg = 'enable_auth is true but '
+                for cert_key_attr in ['server_key', 'server_cert', 'client_key', 'client_cert', 'root_ca_cert']:
+                    if not hasattr(spec, cert_key_attr):
+                        err_msg += f'{cert_key_attr}, '
+                err_msg += 'attribute(s) missing from nvmeof spec'
+                self.mgr.log.error(err_msg)
             else:
                 daemon_spec.extra_files['server_cert'] = spec.server_cert
                 daemon_spec.extra_files['client_cert'] = spec.client_cert
                 daemon_spec.extra_files['server_key'] = spec.server_key
                 daemon_spec.extra_files['client_key'] = spec.client_key
+                daemon_spec.extra_files['root_ca_cert'] = spec.root_ca_cert
 
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
         daemon_spec.deps = []

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -53,6 +53,23 @@ class NvmeofService(CephService):
 
         daemon_spec.keyring = keyring
         daemon_spec.extra_files = {'ceph-nvmeof.conf': gw_conf}
+
+        if spec.enable_auth:
+            if (
+                not spec.client_cert
+                or not spec.client_key
+                or not spec.server_cert
+                or not spec.server_key
+            ):
+                self.mgr.log.error(f'enable_auth set for {spec.service_name()} spec, but at '
+                                   'least one of server/client cert/key fields missing. TLS '
+                                   f'not being set up for {daemon_spec.name()}')
+            else:
+                daemon_spec.extra_files['server_cert'] = spec.server_cert
+                daemon_spec.extra_files['client_cert'] = spec.client_cert
+                daemon_spec.extra_files['server_key'] = spec.server_key
+                daemon_spec.extra_files['client_key'] = spec.client_key
+
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
         daemon_spec.deps = []
         return daemon_spec

--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -41,10 +41,10 @@ config_file = /etc/ceph/ceph.conf
 id = {{ rados_id }}
 
 [mtls]
-server_key = {{ spec.server_key }}
-client_key = {{ spec.client_key }}
-server_cert = {{ spec.server_cert }}
-client_cert = {{ spec.client_cert }}
+server_key = /server.key
+client_key = /client.key
+server_cert = /server.cert
+client_cert = /client.cert
 
 [spdk]
 tgt_path = {{ spec.tgt_path }}

--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -45,6 +45,7 @@ server_key = /server.key
 client_key = /client.key
 server_cert = /server.cert
 client_cert = /client.cert
+root_ca_cert = /root.ca.cert
 
 [spdk]
 tgt_path = {{ spec.tgt_path }}

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1704,14 +1704,23 @@ class TestCephadm(object):
         agent_endpoint_root_cert = 'fake-agent-cert'
         alertmanager_host1_cert = 'fake-alertm-host1-cert'
         rgw_frontend_rgw_foo_host2_cert = 'fake-rgw-cert'
+        nvmeof_client_cert = 'fake-nvmeof-client-cert'
+        nvmeof_server_cert = 'fake-nvmeof-server-cert'
+        nvmeof_root_ca_cert = 'fake-nvmeof-root-ca-cert'
         cephadm_module.cert_key_store.save_cert('agent_endpoint_root_cert', agent_endpoint_root_cert)
         cephadm_module.cert_key_store.save_cert('alertmanager_cert', alertmanager_host1_cert, host='host1')
         cephadm_module.cert_key_store.save_cert('rgw_frontend_ssl_cert', rgw_frontend_rgw_foo_host2_cert, service_name='rgw.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_server_cert', nvmeof_server_cert, service_name='nvmeof.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_client_cert', nvmeof_client_cert, service_name='nvmeof.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_root_ca_cert', nvmeof_root_ca_cert, service_name='nvmeof.foo', user_made=True)
 
         expected_calls = [
             mock.call(f'{CERT_STORE_CERT_PREFIX}agent_endpoint_root_cert', json.dumps(Cert(agent_endpoint_root_cert).to_json())),
             mock.call(f'{CERT_STORE_CERT_PREFIX}alertmanager_cert', json.dumps({'host1': Cert(alertmanager_host1_cert).to_json()})),
             mock.call(f'{CERT_STORE_CERT_PREFIX}rgw_frontend_ssl_cert', json.dumps({'rgw.foo': Cert(rgw_frontend_rgw_foo_host2_cert, True).to_json()})),
+            mock.call(f'{CERT_STORE_CERT_PREFIX}nvmeof_server_cert', json.dumps({'nvmeof.foo': Cert(nvmeof_server_cert, True).to_json()})),
+            mock.call(f'{CERT_STORE_CERT_PREFIX}nvmeof_client_cert', json.dumps({'nvmeof.foo': Cert(nvmeof_client_cert, True).to_json()})),
+            mock.call(f'{CERT_STORE_CERT_PREFIX}nvmeof_root_ca_cert', json.dumps({'nvmeof.foo': Cert(nvmeof_root_ca_cert, True).to_json()})),
         ]
         _set_store.assert_has_calls(expected_calls)
 
@@ -1729,6 +1738,9 @@ class TestCephadm(object):
             'alertmanager_cert': False,
             'prometheus_cert': False,
             'node_exporter_cert': False,
+            'nvmeof_client_cert': False,
+            'nvmeof_server_cert': False,
+            'nvmeof_root_ca_cert': False,
         }
         assert cephadm_module.cert_key_store.cert_ls() == expected_ls
 
@@ -1750,18 +1762,35 @@ class TestCephadm(object):
         expected_ls['rgw_frontend_ssl_cert']['rgw.bar'] = True
         assert cephadm_module.cert_key_store.cert_ls() == expected_ls
 
+        cephadm_module.cert_key_store.save_cert('nvmeof_client_cert', 'xxx', service_name='nvmeof.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_server_cert', 'xxx', service_name='nvmeof.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_root_ca_cert', 'xxx', service_name='nvmeof.foo', user_made=True)
+        expected_ls['nvmeof_client_cert'] = {}
+        expected_ls['nvmeof_client_cert']['nvmeof.foo'] = True
+        expected_ls['nvmeof_server_cert'] = {}
+        expected_ls['nvmeof_server_cert']['nvmeof.foo'] = True
+        expected_ls['nvmeof_root_ca_cert'] = {}
+        expected_ls['nvmeof_root_ca_cert']['nvmeof.foo'] = True
+        assert cephadm_module.cert_key_store.cert_ls() == expected_ls
+
     @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
     def test_cert_store_save_key(self, _set_store, cephadm_module: CephadmOrchestrator):
         cephadm_module.cert_key_store._init_known_cert_key_dicts()
 
         agent_endpoint_key = 'fake-agent-key'
-        grafana_host1_key = 'fake-grafana-host1-cert'
+        grafana_host1_key = 'fake-grafana-host1-key'
+        nvmeof_client_key = 'nvmeof-client-key'
+        nvmeof_server_key = 'nvmeof-server-key'
         cephadm_module.cert_key_store.save_key('agent_endpoint_key', agent_endpoint_key)
         cephadm_module.cert_key_store.save_key('grafana_key', grafana_host1_key, host='host1')
+        cephadm_module.cert_key_store.save_key('nvmeof_client_key', nvmeof_client_key, service_name='nvmeof.foo')
+        cephadm_module.cert_key_store.save_key('nvmeof_server_key', nvmeof_server_key, service_name='nvmeof.foo')
 
         expected_calls = [
             mock.call(f'{CERT_STORE_KEY_PREFIX}agent_endpoint_key', json.dumps(PrivKey(agent_endpoint_key).to_json())),
             mock.call(f'{CERT_STORE_KEY_PREFIX}grafana_key', json.dumps({'host1': PrivKey(grafana_host1_key).to_json()})),
+            mock.call(f'{CERT_STORE_KEY_PREFIX}nvmeof_client_key', json.dumps({'nvmeof.foo': PrivKey(nvmeof_client_key).to_json()})),
+            mock.call(f'{CERT_STORE_KEY_PREFIX}nvmeof_server_key', json.dumps({'nvmeof.foo': PrivKey(nvmeof_server_key).to_json()})),
         ]
         _set_store.assert_has_calls(expected_calls)
 
@@ -1778,6 +1807,8 @@ class TestCephadm(object):
             'node_exporter_key': False,
             'iscsi_ssl_key': False,
             'ingress_ssl_key': False,
+            'nvmeof_client_key': False,
+            'nvmeof_server_key': False,
         }
         assert cephadm_module.cert_key_store.key_ls() == expected_ls
 
@@ -1792,6 +1823,14 @@ class TestCephadm(object):
         expected_ls['alertmanager_key']['host2'] = True
         assert cephadm_module.cert_key_store.key_ls() == expected_ls
 
+        cephadm_module.cert_key_store.save_key('nvmeof_client_key', 'xxx', service_name='nvmeof.foo')
+        cephadm_module.cert_key_store.save_key('nvmeof_server_key', 'xxx', service_name='nvmeof.foo')
+        expected_ls['nvmeof_server_key'] = {}
+        expected_ls['nvmeof_server_key']['nvmeof.foo'] = True
+        expected_ls['nvmeof_client_key'] = {}
+        expected_ls['nvmeof_client_key']['nvmeof.foo'] = True
+        assert cephadm_module.cert_key_store.key_ls() == expected_ls
+
     @mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix")
     def test_cert_store_load(self, _get_store_prefix, cephadm_module: CephadmOrchestrator):
         cephadm_module.cert_key_store._init_known_cert_key_dicts()
@@ -1801,18 +1840,28 @@ class TestCephadm(object):
         rgw_frontend_rgw_foo_host2_cert = 'fake-rgw-cert'
         agent_endpoint_key = 'fake-agent-key'
         grafana_host1_key = 'fake-grafana-host1-cert'
+        nvmeof_server_cert = 'nvmeof-server-cert'
+        nvmeof_client_cert = 'nvmeof-client-cert'
+        nvmeof_root_ca_cert = 'nvmeof-root-ca-cert'
+        nvmeof_server_key = 'nvmeof-server-key'
+        nvmeof_client_key = 'nvmeof-client-key'
 
         def _fake_prefix_store(key):
             if key == 'cert_store.cert.':
                 return {
                     f'{CERT_STORE_CERT_PREFIX}agent_endpoint_root_cert': json.dumps(Cert(agent_endpoint_root_cert).to_json()),
                     f'{CERT_STORE_CERT_PREFIX}alertmanager_cert': json.dumps({'host1': Cert(alertmanager_host1_cert).to_json()}),
-                    f'{CERT_STORE_CERT_PREFIX}rgw_frontend_ssl_cert': json.dumps({'rgw.foo': Cert(rgw_frontend_rgw_foo_host2_cert, True).to_json()})
+                    f'{CERT_STORE_CERT_PREFIX}rgw_frontend_ssl_cert': json.dumps({'rgw.foo': Cert(rgw_frontend_rgw_foo_host2_cert, True).to_json()}),
+                    f'{CERT_STORE_CERT_PREFIX}nvmeof_server_cert': json.dumps({'nvmeof.foo': Cert(nvmeof_server_cert, True).to_json()}),
+                    f'{CERT_STORE_CERT_PREFIX}nvmeof_client_cert': json.dumps({'nvmeof.foo': Cert(nvmeof_client_cert, True).to_json()}),
+                    f'{CERT_STORE_CERT_PREFIX}nvmeof_root_ca_cert': json.dumps({'nvmeof.foo': Cert(nvmeof_root_ca_cert, True).to_json()}),
                 }
             elif key == 'cert_store.key.':
                 return {
                     f'{CERT_STORE_KEY_PREFIX}agent_endpoint_key': json.dumps(PrivKey(agent_endpoint_key).to_json()),
                     f'{CERT_STORE_KEY_PREFIX}grafana_key': json.dumps({'host1': PrivKey(grafana_host1_key).to_json()}),
+                    f'{CERT_STORE_KEY_PREFIX}nvmeof_server_key': json.dumps({'nvmeof.foo': PrivKey(nvmeof_server_key).to_json()}),
+                    f'{CERT_STORE_KEY_PREFIX}nvmeof_client_key': json.dumps({'nvmeof.foo': PrivKey(nvmeof_client_key).to_json()}),
                 }
             else:
                 raise Exception(f'Get store with unexpected value {key}')
@@ -1822,8 +1871,13 @@ class TestCephadm(object):
         assert cephadm_module.cert_key_store.known_certs['agent_endpoint_root_cert'] == Cert(agent_endpoint_root_cert)
         assert cephadm_module.cert_key_store.known_certs['alertmanager_cert']['host1'] == Cert(alertmanager_host1_cert)
         assert cephadm_module.cert_key_store.known_certs['rgw_frontend_ssl_cert']['rgw.foo'] == Cert(rgw_frontend_rgw_foo_host2_cert, True)
+        assert cephadm_module.cert_key_store.known_certs['nvmeof_server_cert']['nvmeof.foo'] == Cert(nvmeof_server_cert, True)
+        assert cephadm_module.cert_key_store.known_certs['nvmeof_client_cert']['nvmeof.foo'] == Cert(nvmeof_client_cert, True)
+        assert cephadm_module.cert_key_store.known_certs['nvmeof_root_ca_cert']['nvmeof.foo'] == Cert(nvmeof_root_ca_cert, True)
         assert cephadm_module.cert_key_store.known_keys['agent_endpoint_key'] == PrivKey(agent_endpoint_key)
         assert cephadm_module.cert_key_store.known_keys['grafana_key']['host1'] == PrivKey(grafana_host1_key)
+        assert cephadm_module.cert_key_store.known_keys['nvmeof_server_key']['nvmeof.foo'] == PrivKey(nvmeof_server_key)
+        assert cephadm_module.cert_key_store.known_keys['nvmeof_client_key']['nvmeof.foo'] == PrivKey(nvmeof_client_key)
 
     def test_cert_store_get_cert_key(self, cephadm_module: CephadmOrchestrator):
         cephadm_module.cert_key_store._init_known_cert_key_dicts()
@@ -1831,16 +1885,23 @@ class TestCephadm(object):
         agent_endpoint_root_cert = 'fake-agent-cert'
         alertmanager_host1_cert = 'fake-alertm-host1-cert'
         rgw_frontend_rgw_foo_host2_cert = 'fake-rgw-cert'
+        nvmeof_client_cert = 'fake-nvmeof-client-cert'
+        nvmeof_server_cert = 'fake-nvmeof-server-cert'
         cephadm_module.cert_key_store.save_cert('agent_endpoint_root_cert', agent_endpoint_root_cert)
         cephadm_module.cert_key_store.save_cert('alertmanager_cert', alertmanager_host1_cert, host='host1')
         cephadm_module.cert_key_store.save_cert('rgw_frontend_ssl_cert', rgw_frontend_rgw_foo_host2_cert, service_name='rgw.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_server_cert', nvmeof_server_cert, service_name='nvmeof.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_client_cert', nvmeof_client_cert, service_name='nvmeof.foo', user_made=True)
 
         assert cephadm_module.cert_key_store.get_cert('agent_endpoint_root_cert') == agent_endpoint_root_cert
         assert cephadm_module.cert_key_store.get_cert('alertmanager_cert', host='host1') == alertmanager_host1_cert
         assert cephadm_module.cert_key_store.get_cert('rgw_frontend_ssl_cert', service_name='rgw.foo') == rgw_frontend_rgw_foo_host2_cert
+        assert cephadm_module.cert_key_store.get_cert('nvmeof_server_cert', service_name='nvmeof.foo') == nvmeof_server_cert
+        assert cephadm_module.cert_key_store.get_cert('nvmeof_client_cert', service_name='nvmeof.foo') == nvmeof_client_cert
         assert cephadm_module.cert_key_store.get_cert('service_discovery_root_cert') == ''
         assert cephadm_module.cert_key_store.get_cert('grafana_cert', host='host1') == ''
         assert cephadm_module.cert_key_store.get_cert('iscsi_ssl_cert', service_name='iscsi.foo') == ''
+        assert cephadm_module.cert_key_store.get_cert('nvmeof_root_ca_cert', service_name='nvmeof.foo') == ''
 
         with pytest.raises(OrchestratorError, match='Attempted to access cert for unknown entity'):
             cephadm_module.cert_key_store.get_cert('unknown_entity')
@@ -1851,11 +1912,17 @@ class TestCephadm(object):
 
         agent_endpoint_key = 'fake-agent-key'
         grafana_host1_key = 'fake-grafana-host1-cert'
+        nvmeof_server_key = 'nvmeof-server-key'
         cephadm_module.cert_key_store.save_key('agent_endpoint_key', agent_endpoint_key)
         cephadm_module.cert_key_store.save_key('grafana_key', grafana_host1_key, host='host1')
+        cephadm_module.cert_key_store.save_key('agent_endpoint_key', agent_endpoint_key)
+        cephadm_module.cert_key_store.save_key('grafana_key', grafana_host1_key, host='host1')
+        cephadm_module.cert_key_store.save_key('nvmeof_server_key', nvmeof_server_key, service_name='nvmeof.foo')
 
         assert cephadm_module.cert_key_store.get_key('agent_endpoint_key') == agent_endpoint_key
         assert cephadm_module.cert_key_store.get_key('grafana_key', host='host1') == grafana_host1_key
+        assert cephadm_module.cert_key_store.get_key('nvmeof_server_key', service_name='nvmeof.foo') == nvmeof_server_key
+        assert cephadm_module.cert_key_store.get_key('nvmeof_client_key', service_name='nvmeof.foo') == ''
         assert cephadm_module.cert_key_store.get_key('service_discovery_key') == ''
         assert cephadm_module.cert_key_store.get_key('alertmanager_key', host='host1') == ''
 

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -426,10 +426,11 @@ config_file = /etc/ceph/ceph.conf
 id = nvmeof.{nvmeof_daemon_id}
 
 [mtls]
-server_key = ./server.key
-client_key = ./client.key
-server_cert = ./server.crt
-client_cert = ./client.crt
+server_key = /server.key
+client_key = /client.key
+server_cert = /server.cert
+client_cert = /client.cert
+root_ca_cert = /root.ca.cert
 
 [spdk]
 tgt_path = /usr/local/bin/nvmf_tgt

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -563,6 +563,22 @@ class Orchestrator(object):
     def cert_store_key_ls(self) -> OrchResult[Dict[str, Any]]:
         raise NotImplementedError()
 
+    def cert_store_get_cert(
+        self,
+        entity: str,
+        service_name: Optional[str] = None,
+        hostname: Optional[str] = None
+    ) -> OrchResult[str]:
+        raise NotImplementedError()
+
+    def cert_store_get_key(
+        self,
+        entity: str,
+        service_name: Optional[str] = None,
+        hostname: Optional[str] = None
+    ) -> OrchResult[str]:
+        raise NotImplementedError()
+
     @handle_orch_error
     def apply(self, specs: Sequence["GenericSpec"], no_overwrite: bool = False) -> List[str]:
         """

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1167,6 +1167,30 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
             result_str = self._process_cert_store_json(key_ls, 0)
             return HandleCommandResult(stdout=result_str)
 
+    @_cli_read_command('orch cert-store get cert')
+    def _cert_store_get_cert(
+        self,
+        entity: str,
+        _end_positional_: int = 0,
+        service_name: Optional[str] = None,
+        hostname: Optional[str] = None
+    ) -> HandleCommandResult:
+        completion = self.cert_store_get_cert(entity, service_name, hostname)
+        cert = raise_if_exception(completion)
+        return HandleCommandResult(stdout=cert)
+
+    @_cli_read_command('orch cert-store get key')
+    def _cert_store_get_key(
+        self,
+        entity: str,
+        _end_positional_: int = 0,
+        service_name: Optional[str] = None,
+        hostname: Optional[str] = None
+    ) -> HandleCommandResult:
+        completion = self.cert_store_get_key(entity, service_name, hostname)
+        key = raise_if_exception(completion)
+        return HandleCommandResult(stdout=key)
+
     def _get_credentials(self, username: Optional[str] = None, password: Optional[str] = None, inbuf: Optional[str] = None) -> Tuple[str, str]:
 
         _username = username

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1331,6 +1331,7 @@ class NvmeofServiceSpec(ServiceSpec):
                  server_cert: Optional[str] = None,
                  client_key: Optional[str] = None,
                  client_cert: Optional[str] = None,
+                 root_ca_cert: Optional[str] = None,
                  spdk_path: Optional[str] = None,
                  tgt_path: Optional[str] = None,
                  spdk_timeout: Optional[float] = 60.0,
@@ -1415,6 +1416,8 @@ class NvmeofServiceSpec(ServiceSpec):
         self.client_key = client_key
         #: ``client_cert`` client certificate
         self.client_cert = client_cert
+        #: ``root_ca_cert`` CA cert for server/client certs
+        self.root_ca_cert = root_ca_cert
         #: ``spdk_path`` path to SPDK
         self.spdk_path = spdk_path or '/usr/local/bin/nvmf_tgt'
         #: ``tgt_path`` nvmeof target path
@@ -1469,9 +1472,13 @@ class NvmeofServiceSpec(ServiceSpec):
             raise SpecValidationError('Cannot add NVMEOF: No Pool specified')
 
         if self.enable_auth:
-            if not all([self.server_key, self.server_cert, self.client_key, self.client_cert]):
-                raise SpecValidationError(
-                    'enable_auth is true but client/server certificates are missing')
+            if not all([self.server_key, self.server_cert, self.client_key, self.client_cert, self.root_ca_cert]):
+                err_msg = 'enable_auth is true but '
+                for cert_key_attr in ['server_key', 'server_cert', 'client_key', 'client_cert', 'root_ca_cert']:
+                    if not hasattr(self, cert_key_attr):
+                        err_msg += f'{cert_key_attr}, '
+                err_msg += 'attribute(s) not set in the spec'
+                raise SpecValidationError(err_msg)
 
         if self.transports not in ['tcp']:
             raise SpecValidationError('Invalid transport. Valid values are tcp')

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1408,13 +1408,13 @@ class NvmeofServiceSpec(ServiceSpec):
         #: ``bdevs_per_cluster`` number of bdevs per cluster
         self.bdevs_per_cluster = bdevs_per_cluster
         #: ``server_key`` gateway server key
-        self.server_key = server_key or './server.key'
+        self.server_key = server_key
         #: ``server_cert`` gateway server certificate
-        self.server_cert = server_cert or './server.crt'
+        self.server_cert = server_cert
         #: ``client_key`` client key
-        self.client_key = client_key or './client.key'
+        self.client_key = client_key
         #: ``client_cert`` client certificate
-        self.client_cert = client_cert or './client.crt'
+        self.client_cert = client_cert
         #: ``spdk_path`` path to SPDK
         self.spdk_path = spdk_path or '/usr/local/bin/nvmf_tgt'
         #: ``tgt_path`` nvmeof target path
@@ -1469,7 +1469,7 @@ class NvmeofServiceSpec(ServiceSpec):
             raise SpecValidationError('Cannot add NVMEOF: No Pool specified')
 
         if self.enable_auth:
-            if not any([self.server_key, self.server_cert, self.client_key, self.client_cert]):
+            if not all([self.server_key, self.server_cert, self.client_key, self.client_cert]):
                 raise SpecValidationError(
                     'enable_auth is true but client/server certificates are missing')
 


### PR DESCRIPTION
Before this patch the client/server cert/key fields were just filepaths that told the nvmeof gw daemon where to look for the cert/key. There's not much reason why users would care where in the nvmeof gw container the cert goes. It's more useful to use these fields as a way to pass the certs/keys to the daemon and then just hardcode where in the container we'll place the certs/keys





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
