### PR TITLE
mds: dump formatter even for errors

### DIFF
--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -1,7 +1,6 @@
 """
 MDS admin socket scrubbing-related tests.
 """
-import json
 import logging
 import errno
 import time
@@ -227,7 +226,7 @@ class TestScrubChecks(CephFSTestCase):
         success_validator = lambda j, r: self.json_validator(j, r, "return_code", 0)
 
         nep = "{test_path}/i/dont/exist".format(test_path=abs_test_path)
-        self.asok_command(mds_rank, "flush_path {nep}".format(nep=nep),
+        self.tell_command(mds_rank, "flush_path {nep}".format(nep=nep),
                           lambda j, r: self.json_validator(j, r, "return_code", -errno.ENOENT))
         self.tell_command(mds_rank, "scrub start {nep}".format(nep=nep),
                           lambda j, r: self.json_validator(j, r, "return_code", -errno.ENOENT))
@@ -238,7 +237,7 @@ class TestScrubChecks(CephFSTestCase):
         if run_seq == 0:
             log.info("First run: flushing {dirpath}".format(dirpath=dirpath))
             command = "flush_path {dirpath}".format(dirpath=dirpath)
-            self.asok_command(mds_rank, command, success_validator)
+            self.tell_command(mds_rank, command, success_validator)
         command = "scrub start {dirpath}".format(dirpath=dirpath)
         self.tell_command(mds_rank, command, success_validator)
 
@@ -247,14 +246,14 @@ class TestScrubChecks(CephFSTestCase):
         if run_seq == 0:
             log.info("First run: flushing {filepath}".format(filepath=filepath))
             command = "flush_path {filepath}".format(filepath=filepath)
-            self.asok_command(mds_rank, command, success_validator)
+            self.tell_command(mds_rank, command, success_validator)
         command = "scrub start {filepath}".format(filepath=filepath)
         self.tell_command(mds_rank, command, success_validator)
 
         if run_seq == 0:
             log.info("First run: flushing base dir /")
             command = "flush_path /"
-            self.asok_command(mds_rank, command, success_validator)
+            self.tell_command(mds_rank, command, success_validator)
         command = "scrub start /"
         self.tell_command(mds_rank, command, success_validator)
 
@@ -263,7 +262,7 @@ class TestScrubChecks(CephFSTestCase):
                                                         i=run_seq)
         self.mount_a.run_shell(["mkdir", new_dir])
         command = "flush_path {dir}".format(dir=test_new_dir)
-        self.asok_command(mds_rank, command, success_validator)
+        self.tell_command(mds_rank, command, success_validator)
 
         new_file = "{repo_path}/new_file_{i}".format(repo_path=repo_path,
                                                      i=run_seq)
@@ -272,7 +271,7 @@ class TestScrubChecks(CephFSTestCase):
         self.mount_a.write_n_mb(new_file, 1)
 
         command = "flush_path {file}".format(file=test_new_file)
-        self.asok_command(mds_rank, command, success_validator)
+        self.tell_command(mds_rank, command, success_validator)
 
         # check that scrub fails on errors
         ino = self.mount_a.path_to_ino(new_file)
@@ -296,7 +295,7 @@ class TestScrubChecks(CephFSTestCase):
         self.assertTrue(_check_and_clear_damage(ino, "backtrace"));
 
         command = "flush_path /"
-        self.asok_command(mds_rank, command, success_validator)
+        self.tell_command(mds_rank, command, success_validator)
 
     def scrub_with_stray_evaluation(self, fs, mnt, path, flag, files=2000,
                                     _hard_links=3):
@@ -472,7 +471,7 @@ class TestScrubChecks(CephFSTestCase):
         log.info("Running command '{command}'".format(command=command))
 
         command_list = command.split()
-        jout = self.fs.rank_tell(command_list, rank=mds_rank)
+        jout = self.fs.rank_tell(command_list, rank=mds_rank, check_status=False)
 
         log.info("command '{command}' returned '{jout}'".format(
                      command=command, jout=jout))
@@ -480,33 +479,6 @@ class TestScrubChecks(CephFSTestCase):
         success, errstring = validator(jout, 0)
         if not success:
             raise AsokCommandFailedError(command, 0, jout, errstring)
-        return jout
-
-    def asok_command(self, mds_rank, command, validator):
-        log.info("Running command '{command}'".format(command=command))
-
-        command_list = command.split()
-
-        # we just assume there's an active mds for every rank
-        mds_id = self.fs.get_active_names()[mds_rank]
-        proc = self.fs.mon_manager.admin_socket('mds', mds_id,
-                                                command_list, check_status=False)
-        rout = proc.exitstatus
-        sout = proc.stdout.getvalue()
-
-        if sout.strip():
-            jout = json.loads(sout)
-        else:
-            jout = None
-
-        log.info("command '{command}' got response code '{rout}' and stdout '{sout}'".format(
-            command=command, rout=rout, sout=sout))
-
-        success, errstring = validator(jout, rout)
-
-        if not success:
-            raise AsokCommandFailedError(command, rout, jout, errstring)
-
         return jout
 
     @staticmethod

--- a/src/common/admin_finisher.h
+++ b/src/common/admin_finisher.h
@@ -1,0 +1,21 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2024 IBM, Inc.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License version 2.1, as published by
+ * the Free Software Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include <functional>
+#include <string_view>
+
+#include "include/buffer.h"
+
+typedef std::function<void(int,std::string_view,ceph::buffer::list&)> asok_finisher;

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -425,7 +425,7 @@ void AdminSocket::do_tell_queue()
     execute_command(
       m->cmd,
       m->get_data(),
-      [m](int r, const std::string& err, bufferlist& outbl) {
+      [m](int r, std::string_view err, bufferlist& outbl) {
 	auto reply = new MCommandReply(r, err);
 	reply->set_tid(m->get_tid());
 	reply->set_data(outbl);
@@ -441,7 +441,7 @@ void AdminSocket::do_tell_queue()
     execute_command(
       m->cmd,
       m->get_data(),
-      [m](int r, const std::string& err, bufferlist& outbl) {
+      [m](int r, std::string_view err, bufferlist& outbl) {
 	auto reply = new MMonCommandAck(m->cmd, r, err, 0);
 	reply->set_tid(m->get_tid());
 	reply->set_data(outbl);
@@ -472,7 +472,7 @@ int AdminSocket::execute_command(
   execute_command(
     cmd,
     inbl,
-    [&errss, outbl, &fin](int r, const std::string& err, bufferlist& out) {
+    [&errss, outbl, &fin](int r, std::string_view err, bufferlist& out) {
       errss << err;
       *outbl = std::move(out);
       fin.finish(r);
@@ -488,7 +488,7 @@ int AdminSocket::execute_command(
 void AdminSocket::execute_command(
   const std::vector<std::string>& cmdvec,
   const bufferlist& inbl,
-  std::function<void(int,const std::string&,bufferlist&)> on_finish)
+  asok_finisher on_finish)
 {
   cmdmap_t cmdmap;
   string format;
@@ -565,7 +565,7 @@ void AdminSocket::execute_command(
 
   hook->call_async(
     prefix, cmdmap, f, inbl,
-    [f, output, on_finish, m_cct=m_cct](int r, const std::string& err, bufferlist& out) {
+    [f, output, on_finish, m_cct=m_cct](int r, std::string_view err, bufferlist& out) {
       // handle either existing output in bufferlist *or* via formatter
       ldout(m_cct, 10) << __func__ << ": command completed with result " << r << dendl;
       if (auto* jff = dynamic_cast<JSONFormatterFile*>(f); jff != nullptr) {

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -27,6 +27,7 @@
 
 #include "include/buffer.h"
 #include "include/common_fwd.h"
+#include "common/admin_finisher.h"
 #include "common/ref.h"
 #include "common/cmdparse.h"
 
@@ -34,6 +35,8 @@ class MCommand;
 class MMonCommand;
 
 inline constexpr auto CEPH_ADMIN_SOCK_VERSION = std::string_view("2");
+
+typedef std::function<void(int,std::string_view,ceph::buffer::list&)> asok_finisher;
 
 class AdminSocketHook {
 public:
@@ -93,7 +96,7 @@ public:
     const cmdmap_t& cmdmap,
     ceph::Formatter *f,
     const ceph::buffer::list& inbl,
-    std::function<void(int,const std::string&,ceph::buffer::list&)> on_finish) {
+    asok_finisher on_finish) {
     // by default, call the synchronous handler and then finish
     ceph::buffer::list out;
     std::ostringstream errss;
@@ -151,7 +154,7 @@ public:
   void execute_command(
     const std::vector<std::string>& cmd,
     const ceph::buffer::list& inbl,
-    std::function<void(int,const std::string&,ceph::buffer::list&)> on_fin);
+    asok_finisher on_fin);
 
   /// execute (blocking)
   int execute_command(

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -127,7 +127,7 @@ public:
     const cmdmap_t& cmdmap,
     Formatter *f,
     const bufferlist& inbl,
-    std::function<void(int,const std::string&,bufferlist&)> on_finish) override {
+    asok_finisher on_finish) override {
     mds->asok_command(command, cmdmap, f, inbl, on_finish);
   }
 };
@@ -137,7 +137,7 @@ void MDSDaemon::asok_command(
   const cmdmap_t& cmdmap,
   Formatter *f,
   const bufferlist& inbl,
-  std::function<void(int,const std::string&,bufferlist&)> on_finish)
+  asok_finisher on_finish)
 {
   dout(1) << "asok_command: " << command << " " << cmdmap
 	  << " (starting...)" << dendl;

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -101,7 +101,7 @@ class MDSDaemon : public Dispatcher {
     const cmdmap_t& cmdmap,
     Formatter *f,
     const bufferlist &inbl,
-    std::function<void(int,const std::string&,bufferlist&)> on_finish);
+    asok_finisher on_finish);
 
   void dump_status(Formatter *f);
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2651,7 +2651,7 @@ void MDSRankDispatcher::handle_asok_command(
   const cmdmap_t& cmdmap,
   Formatter *f,
   const bufferlist &inbl,
-  std::function<void(int,const std::string&,bufferlist&)> on_finish)
+  asok_finisher on_finish)
 {
   int r = 0;
   CachedStackStringStream css;
@@ -3090,7 +3090,7 @@ out:
  */
 void MDSRankDispatcher::evict_clients(
   const SessionFilter &filter,
-  std::function<void(int,const std::string&,bufferlist&)> on_finish)
+  asok_finisher on_finish)
 {
   bufferlist outbl;
   if (is_any_replay()) {
@@ -3473,7 +3473,7 @@ public:
   std::function<void(int, C_MDS_QuiescePathCommand const&)> finish_once;
 };
 
-void MDSRank::command_quiesce_path(Formatter* f, const cmdmap_t& cmdmap, std::function<void(int, const std::string&, bufferlist&)> on_finish)
+void MDSRank::command_quiesce_path(Formatter* f, const cmdmap_t& cmdmap, asok_finisher on_finish)
 {
   std::string path;
   if (!cmd_getval(cmdmap, "path", path)) {
@@ -3515,7 +3515,7 @@ void MDSRank::command_quiesce_path(Formatter* f, const cmdmap_t& cmdmap, std::fu
   }
 }
 
-void MDSRank::command_lock_path(Formatter* f, const cmdmap_t& cmdmap, std::function<void(int, const std::string&, bufferlist&)> on_finish)
+void MDSRank::command_lock_path(Formatter* f, const cmdmap_t& cmdmap, asok_finisher on_finish)
 {
   std::string path;
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2675,6 +2675,7 @@ void MDSRankDispatcher::handle_asok_command(
       f->close_section();
 
       bufferlist outbl;
+      f->flush(outbl); /* even for errors, dump f */
       do_respond(rc, {}, outbl);
     }
   };

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2661,16 +2661,15 @@ void MDSRankDispatcher::handle_asok_command(
   struct AsyncResponse : Context {
     Formatter* f;
     decltype(on_finish) do_respond;
-    std::basic_ostringstream<char> css;
+    std::basic_ostringstream<char> ss;
 
     AsyncResponse(Formatter* f, decltype(on_finish)&& respond_action)
       : f(f), do_respond(std::forward<decltype(on_finish)>(respond_action)) {}
 
     void finish(int rc) override {
       f->open_object_section("result");
-      if (!css.view().empty()) {
-        f->dump_string("message", css.view());
-      }
+      if (!ss.view().empty()) {
+        f->dump_string("message", ss.view());
       f->dump_int("return_code", rc);
       f->close_section();
 
@@ -2964,7 +2963,7 @@ void MDSRankDispatcher::handle_asok_command(
     return;
   } else if (command == "flush journal") {
     auto respond = new AsyncResponse(f, std::move(on_finish));
-    C_Flush_Journal* flush_journal = new C_Flush_Journal(mdcache, mdlog, this, &respond->css, respond);
+    C_Flush_Journal* flush_journal = new C_Flush_Journal(mdcache, mdlog, this, &respond->ss, respond);
 
     std::lock_guard locker(mds_lock);
     flush_journal->send();

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2674,7 +2674,7 @@ void MDSRankDispatcher::handle_asok_command(
 
       bufferlist outbl;
       f->flush(outbl); /* even for errors, dump f */
-      do_respond(rc, {}, outbl);
+      do_respond(rc, ss.view(), outbl);
     }
   };
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2668,8 +2668,7 @@ void MDSRankDispatcher::handle_asok_command(
 
     void finish(int rc) override {
       f->open_object_section("result");
-      if (!ss.view().empty()) {
-        f->dump_string("message", ss.view());
+      f->dump_string("message", ss.view());
       f->dump_int("return_code", rc);
       f->close_section();
 

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -526,12 +526,12 @@ class MDSRank {
         std::ostream &ss);
     void command_openfiles_ls(Formatter *f);
     void command_dump_tree(const cmdmap_t &cmdmap, std::ostream &ss, Formatter *f);
-    void command_quiesce_path(Formatter *f, const cmdmap_t &cmdmap, std::function<void(int, const std::string&, bufferlist&)> on_finish);
-    void command_lock_path(Formatter* f, const cmdmap_t& cmdmap, std::function<void(int, const std::string&, bufferlist&)> on_finish);
+    void command_quiesce_path(Formatter *f, const cmdmap_t &cmdmap, asok_finisher on_finish);
+    void command_lock_path(Formatter* f, const cmdmap_t& cmdmap, asok_finisher on_finish);
     void command_dump_inode(Formatter *f, const cmdmap_t &cmdmap, std::ostream &ss);
     void command_dump_dir(Formatter *f, const cmdmap_t &cmdmap, std::ostream &ss);
     void command_cache_drop(uint64_t timeout, Formatter *f, Context *on_finish);
-    void command_quiesce_db(const cmdmap_t& cmdmap, std::function<void(int, const std::string&, bufferlist&)> on_finish);
+    void command_quiesce_db(const cmdmap_t& cmdmap, asok_finisher on_finish);
 
     // FIXME the state machine logic should be separable from the dispatch
     // logic that calls it.
@@ -725,7 +725,7 @@ public:
     const cmdmap_t& cmdmap,
     Formatter *f,
     const bufferlist &inbl,
-    std::function<void(int,const std::string&,bufferlist&)> on_finish);
+    asok_finisher on_finish);
   void handle_mds_map(const cref_t<MMDSMap> &m, const MDSMap &oldmap);
   void handle_osd_map();
   void update_log_config();
@@ -735,7 +735,7 @@ public:
 
   void dump_sessions(const SessionFilter &filter, Formatter *f, bool cap_dump=false) const;
   void evict_clients(const SessionFilter &filter,
-		     std::function<void(int,const std::string&,bufferlist&)> on_finish);
+		     asok_finisher on_finish);
 
   // Call into me from MDS::ms_dispatch
   bool ms_dispatch(const cref_t<Message> &m);

--- a/src/mds/MDSRankQuiesce.cc
+++ b/src/mds/MDSRankQuiesce.cc
@@ -45,7 +45,7 @@
   }           \
   while (0)
 
-void MDSRank::command_quiesce_db(const cmdmap_t& cmdmap, std::function<void(int, const std::string&, bufferlist&)> on_finish)
+void MDSRank::command_quiesce_db(const cmdmap_t& cmdmap, asok_finisher on_finish)
 {
   // validate the command:
   using ceph::common::cmd_getval;
@@ -111,7 +111,7 @@ void MDSRank::command_quiesce_db(const cmdmap_t& cmdmap, std::function<void(int,
   }
 
   struct Ctx : public QuiesceDbManager::RequestContext {
-    std::function<void(int, const std::string&, bufferlist&)> on_finish;
+    asok_finisher on_finish;
     bool all = false;
     mds_gid_t me;
 

--- a/src/messages/MMonCommandAck.h
+++ b/src/messages/MMonCommandAck.h
@@ -27,9 +27,9 @@ public:
   std::string rs;
 
   MMonCommandAck() : PaxosServiceMessage{MSG_MON_COMMAND_ACK, 0} {}
-  MMonCommandAck(const std::vector<std::string>& c, int _r, std::string s, version_t v) :
+  MMonCommandAck(const std::vector<std::string>& c, int _r, auto&& s, version_t v) :
     PaxosServiceMessage{MSG_MON_COMMAND_ACK, v},
-    cmd(c), r(_r), rs(s) { }
+    cmd(c), r(_r), rs(std::forward<decltype(s)>(s)) { }
 private:
   ~MMonCommandAck() final {}
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2598,7 +2598,7 @@ public:
     const cmdmap_t& cmdmap,
     Formatter *f,
     const bufferlist& inbl,
-    std::function<void(int,const std::string&,bufferlist&)> on_finish) override {
+    asok_finisher on_finish) override {
     try {
       osd->asok_command(prefix, cmdmap, f, inbl, on_finish);
     } catch (const TOPNSPC::common::bad_cmd_get& e) {
@@ -2660,7 +2660,7 @@ int OSD::asok_route_to_pg(
   stringstream& ss,
   const bufferlist& inbl,
   bufferlist& outbl,
-  std::function<void(int, const std::string&, bufferlist&)> on_finish)
+  asok_finisher on_finish)
 {
   auto [target_pg, ret] = locate_asok_target(cmdmap, ss, only_primary);
 
@@ -2687,7 +2687,7 @@ void OSD::asok_command(
   std::string_view prefix, const cmdmap_t& cmdmap,
   Formatter *f,
   const bufferlist& inbl,
-  std::function<void(int,const std::string&,bufferlist&)> on_finish)
+  asok_finisher on_finish)
 {
   int ret = 0;
   stringstream ss;   // stderr error message stream

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -19,6 +19,7 @@
 
 #include "msg/Dispatcher.h"
 
+#include "common/admin_finisher.h"
 #include "common/async/context_pool.h"
 #include "common/Timer.h"
 #include "common/WorkQueue.h"
@@ -1124,13 +1125,13 @@ protected:
     std::stringstream& ss,
     const bufferlist& inbl,
     bufferlist& outbl,
-    std::function<void(int, const std::string&, bufferlist&)> on_finish);
+    asok_finisher on_finish);
   void asok_command(
     std::string_view prefix,
     const cmdmap_t& cmdmap,
     ceph::Formatter *f,
     const ceph::buffer::list& inbl,
-    std::function<void(int,const std::string&,ceph::buffer::list&)> on_finish);
+    asok_finisher on_finish);
 
 public:
   int get_nodeid() { return whoami; }

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -20,6 +20,7 @@
 #include "include/mempool.h"
 
 // re-include our assert to clobber boost's
+#include "common/admin_finisher.h"
 #include "include/ceph_assert.h" 
 #include "include/common_fwd.h"
 
@@ -764,7 +765,7 @@ public:
     std::string_view prefix,
     const cmdmap_t& cmdmap,
     const ceph::buffer::list& idata,
-    std::function<void(int,const std::string&,ceph::buffer::list&)> on_finish) = 0;
+    asok_finisher on_finish) = 0;
 
   virtual bool agent_work(int max) = 0;
   virtual bool agent_work(int max, int agent_flush_quota) = 0;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1015,7 +1015,7 @@ void PrimaryLogPG::do_command(
   string_view orig_prefix,
   const cmdmap_t& cmdmap,
   const bufferlist& idata,
-  std::function<void(int,const std::string&,bufferlist&)> on_finish)
+  asok_finisher on_finish)
 {
   string format;
   cmd_getval(cmdmap, "format", format);
@@ -12718,7 +12718,7 @@ void PrimaryLogPG::do_update_log_missing_reply(OpRequestRef &op)
  */
 void PrimaryLogPG::mark_all_unfound_lost(
   int what,
-  std::function<void(int,const std::string&,bufferlist&)> on_finish)
+  asok_finisher on_finish)
 {
   dout(3) << __func__ << " " << pg_log_entry_t::get_op_name(what) << dendl;
   list<hobject_t> oids;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -25,6 +25,7 @@
 #include "Watch.h"
 #include "TierAgentState.h"
 #include "messages/MOSDOpReply.h"
+#include "common/admin_finisher.h"
 #include "common/Checksummer.h"
 #include "common/sharedptr_registry.hpp"
 #include "common/shared_cache.hpp"
@@ -1500,7 +1501,7 @@ public:
     std::string_view prefix,
     const cmdmap_t& cmdmap,
     const ceph::buffer::list& idata,
-    std::function<void(int,const std::string&,ceph::buffer::list&)> on_finish) override;
+    asok_finisher on_finish) override;
 
   void clear_cache() override;
   int get_cache_obj_count() override {
@@ -1894,7 +1895,7 @@ public:
 
   void mark_all_unfound_lost(
     int what,
-    std::function<void(int,const std::string&,ceph::buffer::list&)> on_finish);
+    asok_finisher on_finish);
   eversion_t pick_newest_available(const hobject_t& oid);
 
   void do_update_log_missing(


### PR DESCRIPTION
The admin_socket framework only dumps the formatter by default if the command succeeds.

Fixes: a4dc88140071f9cdfe5654402067434728fee469
Fixes: https://tracker.ceph.com/issues/66184





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
