### PR TITLE
squid: mds: add missing policylock to test F_QUIESCE_BLOCK

### DIFF
--- a/qa/tasks/cephfs/test_quiesce.py
+++ b/qa/tasks/cephfs/test_quiesce.py
@@ -228,6 +228,7 @@ class QuiesceTestCase(CephFSTestCase):
         visited = set()
         locks_expected = set([
           "iquiesce",
+          "ipolicy",
         ])
         if not splitauth:
             locks_expected.add('iauth')
@@ -263,6 +264,9 @@ class QuiesceTestCase(CephFSTestCase):
                             self.assertEqual(lock['flags'], 4)
                             self.assertEqual(lock['lock']['state'], 'lock')
                             self.assertEqual(lock['lock']['num_xlocks'], 1)
+                        elif lock_type == "ipolicy":
+                            self.assertEqual(lock['flags'], 1)
+                            self.assertEqual(lock['lock']['state'][:4], 'sync')
                         elif lock_type in ("ifile", "iauth", "ilink", "ixattr"):
                             self.assertFalse(splitauth)
                             self.assertEqual(lock['flags'], 1)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65740

---

backport of https://github.com/ceph/ceph/pull/57010
parent tracker: https://tracker.ceph.com/issues/65595

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh