### PR TITLE
quincy: common,ceph: add output file switch to dump json to

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -74,6 +74,13 @@
 --------
 >=19.0.0
 
+* ceph: a new --daemon-output-file switch is available for `ceph tell` commands
+  to dump output to a file local to the daemon. For commands which produce
+  large amounts of output, this avoids a potential spike in memory usage on the
+  daemon, allows for faster streaming writes to a file local to the daemon, and
+  reduces time holding any locks required to execute the command. For analysis,
+  it is necessary to retrieve the file from the host running the daemon
+  manually. Currently, only --format=json|json-pretty are supported.
 * RGW: S3 multipart uploads using Server-Side Encryption now replicate correctly in
   multi-site. Previously, the replicas of such objects were corrupted on decryption.
   A new tool, ``radosgw-admin bucket resync encrypted multipart``, can be used to

--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -1617,7 +1617,25 @@ Options
 
 .. option:: -f {json,json-pretty,xml,xml-pretty,plain,yaml}, --format
 
-	Format of output. Note: yaml is only valid for orch commands. 
+	Format of output.
+
+    Note: yaml is only valid for orch commands.
+
+.. option:: --daemon-output-file OUTPUT_FILE
+
+    When using --format=json|json-pretty, you may specify a file name on the
+    host running the daemon to stream output to. Be mindful this is probably
+    not the same machine running the ceph command. So to analyze the output, it
+    will be necessary to fetch the file once the command completes.
+
+    OUTPUT_FILE may also be ``:tmp:``, indicating that the daemon should create
+    a temporary file (subject to configurations tmp_dir and tmp_file_template).
+
+    The ``tell`` command will output json with the path to the output file
+    written to, the size of the file, the result code of the command, and any
+    output produced by the command.
+
+    Note: this option is only used for ``ceph tell`` commands.
 
 .. option:: --connect-timeout CLUSTER_TIMEOUT
 

--- a/doc/rados/configuration/common.rst
+++ b/doc/rados/configuration/common.rst
@@ -44,6 +44,27 @@ For more about configuring a network for use with Ceph, see the `Network
 Configuration Reference`_ .
 
 
+Temporary Directory
+===================
+
+Some operations will cause a daemon to write to a temporary file. These files
+are located according to the ``tmp_dir`` config.
+
+.. confval:: tmp_dir
+
+The ``$TMPDIR`` environment variable is used to initialize the config, if
+present, but may be overriden on the command-line. A default may also
+be set for the cluster using the usual ``ceph config`` API.
+
+The template for the temporary files created by daemons is controlled
+by the ``tmp_file_template`` config.
+
+.. confval:: tmp_file_template
+
+One example where temporary files are created by daemons is the use of the
+``--daemon-output-file=:tmp:`` argument to the ``ceph tell`` command.
+
+
 Monitors
 ========
 

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -854,6 +854,47 @@ function without_test_dup_command()
   fi
 }
 
+function test_tell_output_file()
+{
+  name="$1"
+  shift
+
+  # Test --daemon-output-file
+  # N.B.: note this only works if $name is on the same node as this script!
+  J=$(ceph tell --format=json --daemon-output-file=/tmp/foo "$name" version)
+  expect_true jq -e '.path == "/tmp/foo"' <<<"$J"
+  expect_true test -e /tmp/foo
+  # only one line of json
+  expect_true sed '2q1' < /tmp/foo > /dev/null
+  expect_true jq -e '.version | length > 0' < /tmp/foo
+  rm -f /tmp/foo
+
+  J=$(ceph tell --format=json-pretty --daemon-output-file=/tmp/foo "$name" version)
+  expect_true jq -e '.path == "/tmp/foo"' <<<"$J"
+  expect_true test -e /tmp/foo
+  # more than one line of json
+  expect_false sed '2q1' < /tmp/foo > /dev/null
+  expect_true jq -e '.version | length > 0' < /tmp/foo
+  rm -f /tmp/foo
+
+  # Test --daemon-output-file=:tmp:
+  J=$(ceph tell --format=json --daemon-output-file=":tmp:" "$name" version)
+  path=$(jq -r .path <<<"$J")
+  expect_true test -e "$path"
+  # only one line of json
+  expect_true sed '2q1' < "$path" > /dev/null
+  expect_true jq -e '.version | length > 0' < "$path"
+  rm -f "$path"
+
+  J=$(ceph tell --format=json-pretty --daemon-output-file=":tmp:" "$name" version)
+  path=$(jq -r .path <<<"$J")
+  expect_true test -e "$path"
+  # only one line of json
+  expect_false sed '2q1' < "$path" > /dev/null
+  expect_true jq -e '.version | length > 0' < "$path"
+  rm -f "$path"
+}
+
 function test_mds_tell()
 {
   local FS_NAME=cephfs
@@ -894,6 +935,8 @@ function test_mds_tell()
       new_mds_gids=$(get_mds_gids $FS_NAME)
   done
   echo New GIDs: $new_mds_gids
+
+  test_tell_output_file mds."$FS_NAME":0
 
   remove_all_fs
   ceph osd pool delete fs_data fs_data --yes-i-really-really-mean-it
@@ -2619,6 +2662,8 @@ function test_mon_tell()
     ceph_watch_wait "${m} \[DBG\] from.*cmd='sessions' args=\[\]: dispatch"
   done
   expect_false ceph tell mon.foo version
+
+  test_tell_output_file mon.0
 }
 
 function test_mon_ping()

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -335,6 +335,8 @@ def parse_cmdargs(args=None, target='') -> Tuple[argparse.ArgumentParser,
     parser.add_argument('--concise', dest='verbose', action="store_false",
                         help="make less verbose")
 
+    parser.add_argument('--daemon-output-file', dest='daemon_output_file',
+                        help="output file location local to the daemon for JSON produced by tell commands")
     parser.add_argument('-f', '--format', choices=['json', 'json-pretty',
                         'xml', 'xml-pretty', 'plain', 'yaml'],
                         help="Note: yaml is only valid for orch commands", dest='output_format')
@@ -579,6 +581,8 @@ def do_command(parsed_args, target, cmdargs, sigdict, inbuf, verbose):
     if valid_dict:
         if parsed_args.output_format:
             valid_dict['format'] = parsed_args.output_format
+        if parsed_args.daemon_output_file:
+            valid_dict['output-file'] = parsed_args.daemon_output_file
         if verbose:
             print("Submitting command: ", valid_dict, file=sys.stderr)
     else:

--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -148,12 +148,6 @@ void Formatter::dump_format_unquoted(std::string_view name, const char *fmt, ...
 
 // -----------------------
 
-JSONFormatter::JSONFormatter(bool p)
-: m_pretty(p), m_is_pending_string(false)
-{
-  reset();
-}
-
 void JSONFormatter::flush(std::ostream& os)
 {
   finish_pending_string();
@@ -175,30 +169,33 @@ void JSONFormatter::reset()
 
 void JSONFormatter::print_comma(json_formatter_stack_entry_d& entry)
 {
+  auto& ss = get_ss();
   if (entry.size) {
     if (m_pretty) {
-      m_ss << ",\n";
+      ss << ",\n";
       for (unsigned i = 1; i < m_stack.size(); i++)
-        m_ss << "    ";
+        ss << "    ";
     } else {
-      m_ss << ",";
+      ss << ",";
     }
   } else if (m_pretty) {
-    m_ss << "\n";
+    ss << "\n";
     for (unsigned i = 1; i < m_stack.size(); i++)
-      m_ss << "    ";
+      ss << "    ";
   }
   if (m_pretty && entry.is_array)
-    m_ss << "    ";
+    ss << "    ";
 }
 
 void JSONFormatter::print_quoted_string(std::string_view s)
 {
-  m_ss << '\"' << json_stream_escaper(s) << '\"';
+  auto& ss = get_ss();
+  ss << '\"' << json_stream_escaper(s) << '\"';
 }
 
 void JSONFormatter::print_name(std::string_view name)
 {
+  auto& ss = get_ss();
   finish_pending_string();
   if (m_stack.empty())
     return;
@@ -206,19 +203,20 @@ void JSONFormatter::print_name(std::string_view name)
   print_comma(entry);
   if (!entry.is_array) {
     if (m_pretty) {
-      m_ss << "    ";
+      ss << "    ";
     }
-    m_ss << "\"" << name << "\"";
+    ss << "\"" << name << "\"";
     if (m_pretty)
-      m_ss << ": ";
+      ss << ": ";
     else
-      m_ss << ':';
+      ss << ':';
   }
   ++entry.size;
 }
 
 void JSONFormatter::open_section(std::string_view name, const char *ns, bool is_array)
 {
+  auto& ss = get_ss();
   if (handle_open_section(name, ns, is_array)) {
     return;
   }
@@ -230,9 +228,9 @@ void JSONFormatter::open_section(std::string_view name, const char *ns, bool is_
     print_name(name);
   }
   if (is_array)
-    m_ss << '[';
+    ss << '[';
   else
-    m_ss << '{';
+    ss << '{';
 
   json_formatter_stack_entry_d n;
   n.is_array = is_array;
@@ -261,7 +259,7 @@ void JSONFormatter::open_object_section_in_ns(std::string_view name, const char 
 
 void JSONFormatter::close_section()
 {
-
+  auto& ss = get_ss();
   if (handle_close_section()) {
     return;
   }
@@ -270,14 +268,14 @@ void JSONFormatter::close_section()
 
   struct json_formatter_stack_entry_d& entry = m_stack.back();
   if (m_pretty && entry.size) {
-    m_ss << "\n";
+    ss << "\n";
     for (unsigned i = 1; i < m_stack.size(); i++)
-      m_ss << "    ";
+      ss << "    ";
   }
-  m_ss << (entry.is_array ? ']' : '}');
+  ss << (entry.is_array ? ']' : '}');
   m_stack.pop_back();
   if (m_pretty && m_stack.empty())
-    m_ss << "\n";
+    ss << "\n";
 }
 
 void JSONFormatter::finish_pending_string()
@@ -300,12 +298,13 @@ void JSONFormatter::add_value(std::string_view name, T val)
 
 void JSONFormatter::add_value(std::string_view name, std::string_view val, bool quoted)
 {
+  auto& ss = get_ss();
   if (handle_value(name, val, quoted)) {
     return;
   }
   print_name(name);
   if (!quoted) {
-    m_ss << val;
+    ss << val;
   } else {
     print_quoted_string(val);
   }
@@ -354,12 +353,12 @@ void JSONFormatter::dump_format_va(std::string_view name, const char *ns, bool q
 
 int JSONFormatter::get_len() const
 {
-  return m_ss.str().size();
+  return m_ss.tellp();
 }
 
 void JSONFormatter::write_raw_data(const char *data)
 {
-  m_ss << data;
+  get_ss() << data;
 }
 
 const char *XMLFormatter::XML_1_DTD =

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -265,6 +265,9 @@ public:
     int get_len() const override {
       return file.tellp();
     }
+    std::ofstream const& get_ofstream() const {
+      return file;
+    }
 
 protected:
     std::ostream& get_ss() override {

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -12,6 +12,7 @@
 #include <stdarg.h>
 #include <sstream>
 #include <map>
+#include <vector>
 
 namespace ceph {
 
@@ -197,7 +198,7 @@ namespace ceph {
     copyable_sstream m_ss;
     copyable_sstream m_pending_string;
     std::string m_pending_name;
-    std::list<json_formatter_stack_entry_d> m_stack;
+    std::vector<json_formatter_stack_entry_d> m_stack;
     bool m_is_pending_string;
     bool m_line_break_enabled = false;
   };

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -193,7 +193,7 @@ namespace ceph {
     int get_len() const override;
     void write_raw_data(const char *data) override;
 
-  protected:
+protected:
     virtual bool handle_value(std::string_view name, std::string_view s, bool quoted) {
       return false; /* is handling done? */
     }
@@ -212,8 +212,9 @@ namespace ceph {
       return m_ss;
     }
 
-  private:
+    void finish_pending_string();
 
+private:
     struct json_formatter_stack_entry_d {
       int size = 0;
       bool is_array = false;
@@ -224,7 +225,6 @@ namespace ceph {
     void print_quoted_string(std::string_view s);
     void print_name(std::string_view name);
     void print_comma(json_formatter_stack_entry_d& entry);
-    void finish_pending_string();
 
     template <class T>
     void add_value(std::string_view name, T val);
@@ -247,6 +247,14 @@ public:
     {
     }
     ~JSONFormatterFile() {
+      flush();
+    }
+
+    void flush(std::ostream& os) override {
+      flush();
+    }
+    void flush() {
+      JSONFormatter::finish_pending_string();
       file.flush();
     }
 

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -7,6 +7,7 @@
 #include "include/buffer_fwd.h"
 
 #include <deque>
+#include <fstream>
 #include <list>
 #include <vector>
 #include <stdarg.h>
@@ -123,21 +124,52 @@ namespace ceph {
     virtual void write_bin_data(const char* buff, int buf_len);
   };
 
-  class copyable_sstream : public std::stringstream {
-  public:
-    copyable_sstream() {}
-    copyable_sstream(const copyable_sstream& rhs) {
-      str(rhs.str());
-    }
-    copyable_sstream& operator=(const copyable_sstream& rhs) {
-      str(rhs.str());
-      return *this;
-    }
-  };
-
   class JSONFormatter : public Formatter {
   public:
-    explicit JSONFormatter(bool p = false);
+    explicit JSONFormatter(bool p = false) : m_pretty(p) {}
+    JSONFormatter(const JSONFormatter& f) :
+      m_pretty(f.m_pretty),
+      m_pending_name(f.m_pending_name),
+      m_stack(f.m_stack),
+      m_is_pending_string(f.m_is_pending_string),
+      m_line_break_enabled(f.m_line_break_enabled)
+    {
+      m_ss.str(f.m_ss.str());
+      m_pending_string.str(f.m_pending_string.str());
+    }
+    JSONFormatter(JSONFormatter&& f) :
+      m_pretty(f.m_pretty),
+      m_ss(std::move(f.m_ss)),
+      m_pending_string(std::move(f.m_pending_string)),
+      m_pending_name(f.m_pending_name),
+      m_stack(std::move(f.m_stack)),
+      m_is_pending_string(f.m_is_pending_string),
+      m_line_break_enabled(f.m_line_break_enabled)
+    {
+    }
+    JSONFormatter& operator=(const JSONFormatter& f)
+    {
+      m_pretty = f.m_pretty;
+      m_ss.str(f.m_ss.str());
+      m_pending_string.str(f.m_pending_string.str());
+      m_pending_name = f.m_pending_name;
+      m_stack = f.m_stack;
+      m_is_pending_string = f.m_is_pending_string;
+      m_line_break_enabled = f.m_line_break_enabled;
+      return *this;
+    }
+
+    JSONFormatter& operator=(JSONFormatter&& f)
+    {
+      m_pretty = f.m_pretty;
+      m_ss = std::move(f.m_ss);
+      m_pending_string = std::move(f.m_pending_string);
+      m_pending_name = f.m_pending_name;
+      m_stack = std::move(f.m_stack);
+      m_is_pending_string = f.m_is_pending_string;
+      m_line_break_enabled = f.m_line_break_enabled;
+      return *this;
+    }
 
     void set_status(int status, const char* status_name) override {};
     void output_header() override {};
@@ -176,15 +208,18 @@ namespace ceph {
 
     int stack_size() { return m_stack.size(); }
 
+    virtual std::ostream& get_ss() {
+      return m_ss;
+    }
+
   private:
 
     struct json_formatter_stack_entry_d {
-      int size;
-      bool is_array;
-      json_formatter_stack_entry_d() : size(0), is_array(false) { }
+      int size = 0;
+      bool is_array = false;
     };
 
-    bool m_pretty;
+    bool m_pretty = false;
     void open_section(std::string_view name, const char *ns, bool is_array);
     void print_quoted_string(std::string_view s);
     void print_name(std::string_view name);
@@ -195,12 +230,42 @@ namespace ceph {
     void add_value(std::string_view name, T val);
     void add_value(std::string_view name, std::string_view val, bool quoted);
 
-    copyable_sstream m_ss;
-    copyable_sstream m_pending_string;
+    mutable std::stringstream m_ss; // mutable for get_len
+    std::stringstream m_pending_string;
     std::string m_pending_name;
     std::vector<json_formatter_stack_entry_d> m_stack;
-    bool m_is_pending_string;
+    bool m_is_pending_string = false;
     bool m_line_break_enabled = false;
+  };
+
+  class JSONFormatterFile : public JSONFormatter {
+public:
+    JSONFormatterFile(const std::string& path, bool pretty=false) :
+      JSONFormatter(pretty),
+      path(path),
+      file(path, std::ios::out | std::ios::trunc)
+    {
+    }
+    ~JSONFormatterFile() {
+      file.flush();
+    }
+
+    void reset() override {
+      JSONFormatter::reset();
+      file = std::ofstream(path, std::ios::out | std::ios::trunc);
+    }
+    int get_len() const override {
+      return file.tellp();
+    }
+
+protected:
+    std::ostream& get_ss() override {
+      return file;
+    }
+
+private:
+    std::string path;
+    mutable std::ofstream file; // mutable for get_len
   };
 
   template <class T>

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -14,6 +14,8 @@
 #include <poll.h>
 #include <sys/un.h>
 
+#include <stdlib.h>
+
 #include "common/admin_socket.h"
 #include "common/admin_socket_client.h"
 #include "common/dout.h"
@@ -504,7 +506,46 @@ void AdminSocket::execute_command(
 		     empty);
   }
 
-  auto f = Formatter::create(format, "json-pretty", "json-pretty");
+  ldout(m_cct, 20) << __func__ << ": format is " << format << " prefix is " << prefix << dendl;
+
+  string output;
+  try {
+    cmd_getval(cmdmap, "output-file", output);
+    if (!output.empty()) {
+      ldout(m_cct, 20) << __func__ << ": output file is " << output << dendl;
+    }
+  } catch (const bad_cmd_get& e) {
+    output = "";
+  }
+
+  if (output == ":tmp:") {
+    auto path = m_cct->_conf.get_val<std::string>("tmp_file_template");
+    if (int fd = mkstemp(path.data()); fd >= 0) {
+      close(fd);
+      output = path;
+      ldout(m_cct, 20) << __func__ << ": output file created in tmp_dir is " << output << dendl;
+    } else {
+      return on_finish(-errno, "temporary output file could not be opened", empty);
+    }
+  }
+
+  Formatter* f;
+  if (!output.empty()) {
+    if (!(format == "json" || format == "json-pretty")) {
+      return on_finish(-EINVAL, "unsupported format for --output-file", empty);
+    }
+    ldout(m_cct, 10) << __func__ << ": opening file for json output: " << output << dendl;
+    bool pretty = (format == "json-pretty");
+    auto* jff = new JSONFormatterFile(output, pretty);
+    auto&& of = jff->get_ofstream();
+    if (!of.is_open()) {
+      delete jff;
+      return on_finish(-EIO, "output file could not be opened", empty);
+    }
+    f = jff;
+  } else {
+    f = Formatter::create(format, "json-pretty", "json-pretty");
+  }
 
   auto [retval, hook] = find_matched_hook(prefix, cmdmap);
   switch (retval) {
@@ -522,10 +563,27 @@ void AdminSocket::execute_command(
 
   hook->call_async(
     prefix, cmdmap, f, inbl,
-    [f, on_finish](int r, const std::string& err, bufferlist& out) {
+    [f, output, on_finish, m_cct=m_cct](int r, const std::string& err, bufferlist& out) {
       // handle either existing output in bufferlist *or* via formatter
-      if (r >= 0 && out.length() == 0) {
-	f->flush(out);
+      ldout(m_cct, 10) << __func__ << ": command completed with result " << r << dendl;
+      if (auto* jff = dynamic_cast<JSONFormatterFile*>(f); jff != nullptr) {
+        ldout(m_cct, 25) << __func__ << ": flushing file" << dendl;
+        jff->flush();
+        auto* outf = new JSONFormatter(true);
+        outf->open_object_section("result");
+        outf->dump_string("path", output);
+        outf->dump_int("result", r);
+        outf->dump_string("output", out.to_str());
+        outf->dump_int("len", jff->get_len());
+        outf->close_section();
+        CachedStackStringStream css;
+        outf->flush(*css);
+        delete outf;
+        out.clear();
+        out.append(css->strv());
+      } else if (r >= 0 && out.length() == 0) {
+        ldout(m_cct, 25) << __func__ << ": out is empty, dumping formatter" << dendl;
+        f->flush(out);
       }
       delete f;
       on_finish(r, err, out);

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -493,6 +493,11 @@ void md_config_t::parse_env(unsigned entity_type,
     }
   }
 
+  if (auto s = getenv("TMPDIR"); s) {
+    string err;
+    _set_val(values, tracker, s, *find_option("tmp_dir"), CONF_ENV, &err);
+  }
+
   // Apply pod memory limits:
   //
   // There are two types of resource requests: `limits` and `requests`.

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -250,6 +250,29 @@ options:
   flags:
   - startup
   with_legacy: true
+- name: tmp_dir
+  type: str
+  level: advanced
+  desc: path for the 'tmp' directory
+  default: /tmp
+  services:
+  - common
+  see_also:
+  - admin_socket
+  flags:
+  - runtime
+- name: tmp_file_template
+  type: str
+  level: advanced
+  desc: Template for temporary files created by daemons for ceph tell commands
+  long_desc: The template file name prefix for temporary files. For example, temporary files may be created by `ceph tell` commands using the --daemon-output-file switch.
+  daemon_default: $tmp_dir/$cluster-$name.XXXXXX
+  services:
+  - osd
+  - mds
+  - mon
+  flags:
+  - runtime
 - name: admin_socket
   type: str
   level: advanced

--- a/src/test/cli/ceph-conf/show-config.t
+++ b/src/test/cli/ceph-conf/show-config.t
@@ -1,4 +1,4 @@
-  $ ceph-conf -n osd.0 --show-config -c /dev/null | grep ceph-osd
+  $ ceph-conf -n osd.0 --show-config -c /dev/null | grep ceph-osd | grep -v tmp_file_template
   admin_socket = /var/run/ceph/ceph-osd.0.asok
   log_file = /var/log/ceph/ceph-osd.0.log
   mon_debug_dump_location = /var/log/ceph/ceph-osd.0.tdump


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66186

---

backport of https://github.com/ceph/ceph/pull/57215
parent tracker: https://tracker.ceph.com/issues/65747

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh