### PR TITLE
reef: mds: use regular dispatch for processing metrics

### DIFF
--- a/src/mds/MetricAggregator.cc
+++ b/src/mds/MetricAggregator.cc
@@ -126,15 +126,6 @@ void MetricAggregator::shutdown() {
   }
 }
 
-bool MetricAggregator::ms_can_fast_dispatch2(const cref_t<Message> &m) const {
-  return m->get_type() == MSG_MDS_METRICS;
-}
-
-void MetricAggregator::ms_fast_dispatch2(const ref_t<Message> &m) {
-  bool handled = ms_dispatch2(m);
-  ceph_assert(handled);
-}
-
 bool MetricAggregator::ms_dispatch2(const ref_t<Message> &m) {
   if (m->get_type() == MSG_MDS_METRICS &&
       m->get_connection()->get_peer_type() == CEPH_ENTITY_TYPE_MDS) {

--- a/src/mds/MetricAggregator.h
+++ b/src/mds/MetricAggregator.h
@@ -34,11 +34,6 @@ public:
 
   void notify_mdsmap(const MDSMap &mdsmap);
 
-  bool ms_can_fast_dispatch_any() const override {
-    return true;
-  }
-  bool ms_can_fast_dispatch2(const cref_t<Message> &m) const override;
-  void ms_fast_dispatch2(const ref_t<Message> &m) override;
   bool ms_dispatch2(const ref_t<Message> &m) override;
 
   void ms_handle_connect(Connection *c) override {

--- a/src/messages/MClientMetrics.h
+++ b/src/messages/MClientMetrics.h
@@ -13,13 +13,18 @@ class MClientMetrics final : public SafeMessage {
 private:
   static constexpr int HEAD_VERSION = 1;
   static constexpr int COMPAT_VERSION = 1;
+  static constexpr int PRIORITY = CEPH_MSG_PRIO_HIGH-1;
+
 public:
   std::vector<ClientMetricMessage> updates;
 
 protected:
-  MClientMetrics() : MClientMetrics(std::vector<ClientMetricMessage>{}) { }
+  MClientMetrics() : MClientMetrics(std::vector<ClientMetricMessage>{}) {
+    set_priority(PRIORITY);
+  }
   MClientMetrics(std::vector<ClientMetricMessage> updates)
     : SafeMessage(CEPH_MSG_CLIENT_METRICS, HEAD_VERSION, COMPAT_VERSION), updates(updates) {
+    set_priority(PRIORITY);
   }
   ~MClientMetrics() final {}
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66190

---

backport of https://github.com/ceph/ceph/pull/57081
parent tracker: https://tracker.ceph.com/issues/65658

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh