### PR TITLE
rbd-wnbd: wait for the disk cleanup to complete

### DIFF
--- a/src/common/win32/service.cc
+++ b/src/common/win32/service.cc
@@ -86,6 +86,8 @@ void ServiceBase::shutdown(bool ignore_errors)
   DWORD original_state = status.dwCurrentState;
   set_status(SERVICE_STOP_PENDING);
 
+  dout(0) << "Shutdown requested." << dendl;
+
   int err = shutdown_hook();
   if (err) {
     derr << "Shutdown service hook failed. Error code: " << err << dendl;
@@ -107,6 +109,8 @@ void ServiceBase::stop()
 {
   DWORD original_state = status.dwCurrentState;
   set_status(SERVICE_STOP_PENDING);
+
+  dout(0) << "Service stop requested." << dendl;
 
   int err = stop_hook();
   if (err) {

--- a/src/tools/rbd_wnbd/rbd_mapping.h
+++ b/src/tools/rbd_wnbd/rbd_mapping.h
@@ -107,7 +107,12 @@ private:
   std::map<std::string, std::shared_ptr<RbdMapping>> mappings;
   ceph::mutex map_mutex = ceph::make_mutex("RbdMappingDispatcher::MapMutex");
 
+  std::atomic<bool> stop_requested = false;
+
   void disconnect_cbk(std::string devpath, int ret);
+  int wait_for_mappings_removal(int timeout_ms);
+  std::vector<std::string> get_mapped_devpaths();
+  int get_mappings_count();
 
 public:
   RbdMappingDispatcher(RadosClientCache& _client_cache)
@@ -116,4 +121,7 @@ public:
 
   int create(Config& cfg);
   std::shared_ptr<RbdMapping> get_mapping(std::string& devpath);
+  int stop(bool hard_disconnect,
+           int soft_disconnect_timeout,
+           int worker_count);
 };

--- a/src/tools/rbd_wnbd/rbd_wnbd.h
+++ b/src/tools/rbd_wnbd/rbd_wnbd.h
@@ -55,11 +55,6 @@ typedef struct {
 bool is_process_running(DWORD pid);
 void unmap_at_exit();
 
-int disconnect_all_mappings(
-  bool unregister,
-  bool hard_disconnect,
-  int soft_disconnect_timeout,
-  int worker_count);
 int restart_registered_mappings(
   int worker_count, int total_timeout, int image_map_timeout);
 int map_device_using_same_process(std::string command_line);


### PR DESCRIPTION
The WNBD disk removal workflow is asynchronous, which is why we'll need to wait for the cleanup to complete when stopping the service.

Before https://github.com/ceph/ceph/pull/52540, each mapping was running in a separate process, which allowed the cleanup to complete even if the management service stopped.

Fixes: https://tracker.ceph.com/issues/66220


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
