### PR TITLE
crimson/os/seastore: avoid getting wrong logical extents through "parent-invalid" lba mappings

### DIFF
--- a/src/crimson/os/seastore/btree/btree_range_pin.cc
+++ b/src/crimson/os/seastore/btree/btree_range_pin.cc
@@ -28,7 +28,7 @@ BtreeNodeMapping<key_t, val_t>::get_logical_extent(
 template <typename key_t, typename val_t>
 bool BtreeNodeMapping<key_t, val_t>::is_stable() const
 {
-  assert(is_parent_valid());
+  assert(!this->parent_modified());
   assert(pos != std::numeric_limits<uint16_t>::max());
   auto &p = (FixedKVNode<key_t>&)*parent;
   return p.is_child_stable(ctx, pos);
@@ -37,7 +37,7 @@ bool BtreeNodeMapping<key_t, val_t>::is_stable() const
 template <typename key_t, typename val_t>
 bool BtreeNodeMapping<key_t, val_t>::is_data_stable() const
 {
-  assert(is_parent_valid());
+  assert(!this->parent_modified());
   assert(pos != std::numeric_limits<uint16_t>::max());
   auto &p = (FixedKVNode<key_t>&)*parent;
   return p.is_child_data_stable(ctx, pos);

--- a/src/crimson/os/seastore/btree/btree_range_pin.cc
+++ b/src/crimson/os/seastore/btree/btree_range_pin.cc
@@ -31,7 +31,10 @@ bool BtreeNodeMapping<key_t, val_t>::is_stable() const
   assert(!this->parent_modified());
   assert(pos != std::numeric_limits<uint16_t>::max());
   auto &p = (FixedKVNode<key_t>&)*parent;
-  return p.is_child_stable(ctx, pos);
+  auto k = this->is_indirect()
+    ? this->get_intermediate_base()
+    : get_key();
+  return p.is_child_stable(ctx, pos, k);
 }
 
 template <typename key_t, typename val_t>
@@ -40,7 +43,10 @@ bool BtreeNodeMapping<key_t, val_t>::is_data_stable() const
   assert(!this->parent_modified());
   assert(pos != std::numeric_limits<uint16_t>::max());
   auto &p = (FixedKVNode<key_t>&)*parent;
-  return p.is_child_data_stable(ctx, pos);
+  auto k = this->is_indirect()
+    ? this->get_intermediate_base()
+    : get_key();
+  return p.is_child_data_stable(ctx, pos, k);
 }
 
 template class BtreeNodeMapping<laddr_t, paddr_t>;

--- a/src/crimson/os/seastore/btree/btree_range_pin.cc
+++ b/src/crimson/os/seastore/btree/btree_range_pin.cc
@@ -11,8 +11,7 @@ get_child_ret_t<LogicalCachedExtent>
 BtreeNodeMapping<key_t, val_t>::get_logical_extent(
   Transaction &t)
 {
-  assert(parent);
-  assert(parent->is_valid());
+  ceph_assert(is_parent_valid());
   assert(pos != std::numeric_limits<uint16_t>::max());
   ceph_assert(t.get_trans_id() == ctx.trans.get_trans_id());
   auto &p = (FixedKVNode<key_t>&)*parent;
@@ -29,8 +28,7 @@ BtreeNodeMapping<key_t, val_t>::get_logical_extent(
 template <typename key_t, typename val_t>
 bool BtreeNodeMapping<key_t, val_t>::is_stable() const
 {
-  assert(parent);
-  assert(parent->is_valid());
+  assert(is_parent_valid());
   assert(pos != std::numeric_limits<uint16_t>::max());
   auto &p = (FixedKVNode<key_t>&)*parent;
   return p.is_child_stable(ctx, pos);
@@ -39,8 +37,7 @@ bool BtreeNodeMapping<key_t, val_t>::is_stable() const
 template <typename key_t, typename val_t>
 bool BtreeNodeMapping<key_t, val_t>::is_data_stable() const
 {
-  assert(parent);
-  assert(parent->is_valid());
+  assert(is_parent_valid());
   assert(pos != std::numeric_limits<uint16_t>::max());
   auto &p = (FixedKVNode<key_t>&)*parent;
   return p.is_child_data_stable(ctx, pos);

--- a/src/crimson/os/seastore/btree/btree_range_pin.h
+++ b/src/crimson/os/seastore/btree/btree_range_pin.h
@@ -194,6 +194,27 @@ public:
     return parent->has_been_invalidated();
   }
 
+  bool is_unviewable_by_trans(CachedExtent& extent, Transaction &t) const {
+    if (!extent.is_valid()) {
+      return true;
+    }
+    if (extent.is_pending()) {
+      assert(extent.is_pending_in_trans(t.get_trans_id()));
+      return false;
+    }
+    auto &pendings = extent.mutation_pendings;
+    auto trans_id = t.get_trans_id();
+    bool unviewable = (pendings.find(trans_id, trans_spec_view_t::cmp_t()) !=
+		       pendings.end());
+    if (!unviewable) {
+      auto &trans = extent.retired_transactions;
+      unviewable = (trans.find(trans_id, trans_spec_view_t::cmp_t()) !=
+		 trans.end());
+      assert(unviewable == t.is_retired(extent.get_paddr(), extent.get_length()));
+    }
+    return unviewable;
+  }
+
   get_child_ret_t<LogicalCachedExtent> get_logical_extent(Transaction&) final;
   bool is_stable() const final;
   bool is_data_stable() const final;

--- a/src/crimson/os/seastore/btree/btree_range_pin.h
+++ b/src/crimson/os/seastore/btree/btree_range_pin.h
@@ -218,6 +218,13 @@ public:
   get_child_ret_t<LogicalCachedExtent> get_logical_extent(Transaction&) final;
   bool is_stable() const final;
   bool is_data_stable() const final;
+  bool is_parent_valid() const final {
+    ceph_assert(parent);
+    if (!parent->is_valid()) {
+      return false;
+    }
+    return !is_unviewable_by_trans(*parent, ctx.trans);
+  }
 };
 
 }

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -884,7 +884,7 @@ void Cache::mark_transaction_conflicted(
   if (t.get_src() != Transaction::src_t::READ) {
     io_stat_t retire_stat;
     for (auto &i: t.retired_set) {
-      retire_stat.increment(i->get_length());
+      retire_stat.increment(i.extent->get_length());
     }
     efforts.retire.increment_stat(retire_stat);
 
@@ -1249,18 +1249,19 @@ record_t Cache::prepare_record(
   alloc_delta_t rel_delta;
   rel_delta.op = alloc_delta_t::op_types_t::CLEAR;
   for (auto &i: t.retired_set) {
+    auto &extent = i.extent;
     get_by_ext(efforts.retire_by_ext,
-               i->get_type()).increment(i->get_length());
-    retire_stat.increment(i->get_length());
-    DEBUGT("retired and remove extent -- {}", t, *i);
-    commit_retire_extent(t, i);
-    if (is_backref_mapped_extent_node(i)
-	  || is_retired_placeholder(i->get_type())) {
+               extent->get_type()).increment(extent->get_length());
+    retire_stat.increment(extent->get_length());
+    DEBUGT("retired and remove extent -- {}", t, *extent);
+    commit_retire_extent(t, extent);
+    if (is_backref_mapped_extent_node(extent)
+	  || is_retired_placeholder(extent->get_type())) {
       rel_delta.alloc_blk_ranges.emplace_back(
-	i->get_paddr(),
+	extent->get_paddr(),
 	L_ADDR_NULL,
-	i->get_length(),
-	i->get_type());
+	extent->get_length(),
+	extent->get_type());
     }
   }
   alloc_deltas.emplace_back(std::move(rel_delta));
@@ -1621,7 +1622,8 @@ void Cache::complete_commit(
   }
 
   for (auto &i: t.retired_set) {
-    epm.mark_space_free(i->get_paddr(), i->get_length());
+    auto &extent = i.extent;
+    epm.mark_space_free(extent->get_paddr(), extent->get_length());
   }
   for (auto &i: t.existing_block_list) {
     if (i->is_valid()) {
@@ -1638,24 +1640,25 @@ void Cache::complete_commit(
 
   last_commit = start_seq;
   for (auto &i: t.retired_set) {
-    i->dirty_from_or_retired_at = start_seq;
-    if (is_backref_mapped_extent_node(i)
-	  || is_retired_placeholder(i->get_type())) {
+    auto &extent = i.extent;
+    extent->dirty_from_or_retired_at = start_seq;
+    if (is_backref_mapped_extent_node(extent)
+	  || is_retired_placeholder(extent->get_type())) {
       DEBUGT("backref_list free {} len {}",
 	     t,
-	     i->get_paddr(),
-	     i->get_length());
+	     extent->get_paddr(),
+	     extent->get_length());
       backref_list.emplace_back(
 	std::make_unique<backref_entry_t>(
-	  i->get_paddr(),
+	  extent->get_paddr(),
 	  L_ADDR_NULL,
-	  i->get_length(),
-	  i->get_type(),
+	  extent->get_length(),
+	  extent->get_type(),
 	  start_seq));
-    } else if (is_backref_node(i->get_type())) {
-      remove_backref_extent(i->get_paddr());
+    } else if (is_backref_node(extent->get_type())) {
+      remove_backref_extent(extent->get_paddr());
     } else {
-      ERRORT("{}", t, *i);
+      ERRORT("{}", t, *extent);
       ceph_abort("not possible");
     }
   }

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1151,6 +1151,7 @@ public:
   bool is_zero_reserved() const {
     return !get_val().is_real();
   }
+  virtual bool is_parent_valid() const = 0;
 
   virtual ~PhysicalNodeMapping() {}
 protected:

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -651,6 +651,7 @@ private:
   friend struct paddr_cmp;
   friend struct ref_paddr_cmp;
   friend class ExtentIndex;
+  friend struct trans_retired_extent_link_t;
 
   /// Pointer to containing index (or null)
   ExtentIndex *parent_index = nullptr;
@@ -735,6 +736,7 @@ private:
 
 protected:
   trans_view_set_t mutation_pendings;
+  trans_view_set_t retired_transactions;
 
   CachedExtent(CachedExtent &&other) = delete;
   CachedExtent(ceph::bufferptr &&_ptr) : ptr(std::move(_ptr)) {
@@ -884,17 +886,54 @@ struct paddr_cmp {
   }
 };
 
+// trans_retired_extent_link_t is used to link stable extents with
+// the transactions that retired them. With this link, we can find
+// out whether an extent has been retired by a specific transaction
+// in a way that's more efficient than searching through the transaction's
+// retired_set (Transaction::is_retired())
+struct trans_retired_extent_link_t {
+  CachedExtentRef extent;
+  // We use trans_spec_view_t instead of transaction_id_t, so that,
+  // when a transaction is deleted or reset, we can efficiently remove
+  // that transaction from the extents' extent-transaction link set.
+  // Otherwise, we have to search through each extent's "retired_transactions"
+  // to remove the transaction
+  trans_spec_view_t trans_view;
+  trans_retired_extent_link_t(CachedExtentRef extent, transaction_id_t id)
+    : extent(extent), trans_view{id}
+  {
+    assert(extent->is_stable());
+    extent->retired_transactions.insert(trans_view);
+  }
+};
+
 /// Compare extent refs by paddr
 struct ref_paddr_cmp {
   using is_transparent = paddr_t;
-  bool operator()(const CachedExtentRef &lhs, const CachedExtentRef &rhs) const {
-    return lhs->poffset < rhs->poffset;
+  bool operator()(
+    const trans_retired_extent_link_t &lhs,
+    const trans_retired_extent_link_t &rhs) const {
+    return lhs.extent->poffset < rhs.extent->poffset;
   }
-  bool operator()(const paddr_t &lhs, const CachedExtentRef &rhs) const {
-    return lhs < rhs->poffset;
+  bool operator()(
+    const paddr_t &lhs,
+    const trans_retired_extent_link_t &rhs) const {
+    return lhs < rhs.extent->poffset;
   }
-  bool operator()(const CachedExtentRef &lhs, const paddr_t &rhs) const {
-    return lhs->poffset < rhs;
+  bool operator()(
+    const trans_retired_extent_link_t &lhs,
+    const paddr_t &rhs) const {
+    return lhs.extent->poffset < rhs;
+  }
+  bool operator()(
+    const CachedExtentRef &lhs,
+    const trans_retired_extent_link_t &rhs) const {
+    return lhs->poffset < rhs.extent->poffset;
+  }
+  bool operator()(
+    const trans_retired_extent_link_t &lhs,
+    const CachedExtentRef &rhs) const {
+    return lhs.extent->poffset < rhs->poffset;
   }
 };
 
@@ -910,7 +949,7 @@ class addr_extent_set_base_t
 
 using pextent_set_t = addr_extent_set_base_t<
   paddr_t,
-  CachedExtentRef,
+  trans_retired_extent_link_t,
   ref_paddr_cmp
   >;
 

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1152,6 +1152,10 @@ public:
     return !get_val().is_real();
   }
   virtual bool is_parent_valid() const = 0;
+  virtual bool parent_modified() const {
+    ceph_abort("impossible");
+    return false;
+  };
 
   virtual ~PhysicalNodeMapping() {}
 protected:

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1157,6 +1157,10 @@ public:
     return false;
   };
 
+  virtual void maybe_fix_pos() {
+    ceph_abort("impossible");
+  }
+
   virtual ~PhysicalNodeMapping() {}
 protected:
   std::optional<child_pos_t> child_pos = std::nullopt;

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
@@ -31,6 +31,7 @@ std::ostream &LBALeafNode::_print_detail(std::ostream &out) const
 {
   out << ", size=" << this->get_size()
       << ", meta=" << this->get_meta()
+      << ", modifications=" << this->modifications
       << ", my_tracker=" << (void*)this->my_tracker;
   if (this->my_tracker) {
     out << ", my_tracker->parent=" << (void*)this->my_tracker->get_parent().get();

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -26,6 +26,8 @@ namespace crimson::os::seastore::lba_manager::btree {
 using base_iertr = LBAManager::base_iertr;
 using LBANode = FixedKVNode<laddr_t>;
 
+class BtreeLBAMapping;
+
 /**
  * lba_map_val_t
  *
@@ -290,6 +292,8 @@ struct LBALeafNode
   }
 
   std::ostream &_print_detail(std::ostream &out) const final;
+
+  void maybe_fix_mapping_pos(BtreeLBAMapping &mapping);
 };
 using LBALeafNodeRef = TCachedExtentRef<LBALeafNode>;
 

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -202,6 +202,7 @@ struct LBALeafNode
       assert(nextent->has_parent_tracker()
 	&& nextent->get_parent_node<LBALeafNode>().get() == this);
     }
+    this->on_modify();
     if (val.pladdr.is_paddr()) {
       val.pladdr = maybe_generate_relative(val.pladdr.get_paddr());
     }
@@ -222,6 +223,7 @@ struct LBALeafNode
       iter.get_offset(),
       addr,
       (void*)nextent);
+    this->on_modify();
     this->insert_child_ptr(iter, nextent);
     if (val.pladdr.is_paddr()) {
       val.pladdr = maybe_generate_relative(val.pladdr.get_paddr());
@@ -241,6 +243,7 @@ struct LBALeafNode
       iter.get_offset(),
       iter.get_key());
     assert(iter != this->end());
+    this->on_modify();
     this->remove_child_ptr(iter);
     return this->journal_remove(
       iter,

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -92,7 +92,7 @@ public:
 	*out = CachedExtentRef(&*iter);
       SUBTRACET(seastore_cache, "{} is present in write_set -- {}",
                 *this, addr, *iter);
-      assert((*out)->is_valid());
+      assert(!out || (*out)->is_valid());
       return get_extent_ret::PRESENT;
     } else if (retired_set.count(addr)) {
       return get_extent_ret::RETIRED;

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -317,19 +317,14 @@ public:
   }
 
   bool is_retired(paddr_t paddr, extent_len_t len) {
-    if (retired_set.empty()) {
-      return false;
-    }
     auto iter = retired_set.lower_bound(paddr);
     if (iter == retired_set.end() ||
-	(*iter)->get_paddr() > paddr) {
-      assert(iter != retired_set.begin());
-      --iter;
+	(*iter)->get_paddr() != paddr) {
+      return false;
+    } else {
+      assert(len == (*iter)->get_length());
+      return true;
     }
-    auto retired_paddr = (*iter)->get_paddr();
-    auto retired_length = (*iter)->get_length();
-    return retired_paddr <= paddr &&
-      retired_paddr.add_offset(retired_length) >= paddr.add_offset(len);
   }
 
   template <typename F>

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -221,7 +221,7 @@ public:
     LBAMappingRef pin,
     extent_types_t type)
   {
-    ceph_assert(pin->is_parent_valid());
+    ceph_assert(!pin->parent_modified());
     auto v = pin->get_logical_extent(t);
     // checking the lba child must be atomic with creating
     // and linking the absent child

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -181,14 +181,27 @@ public:
     Transaction &t,
     LBAMappingRef pin)
   {
-    // checking the lba child must be atomic with creating
-    // and linking the absent child
-    auto ret = get_extent_if_linked<T>(t, std::move(pin));
-    if (ret.index() == 1) {
-      return std::move(std::get<1>(ret));
+    auto fut = base_iertr::make_ready_future<LBAMappingRef>();
+    if (!pin->is_parent_valid()) {
+      fut = get_pin(t, pin->get_key()
+      ).handle_error_interruptible(
+	crimson::ct_error::enoent::assert_failure{"unexpected enoent"},
+	crimson::ct_error::input_output_error::pass_further{}
+      );
     } else {
-      return this->pin_to_extent<T>(t, std::move(std::get<0>(ret)));
+      pin->maybe_fix_pos();
+      fut = base_iertr::make_ready_future<LBAMappingRef>(std::move(pin));
     }
+    return fut.si_then([&t, this](auto npin) mutable {
+      // checking the lba child must be atomic with creating
+      // and linking the absent child
+      auto ret = get_extent_if_linked<T>(t, std::move(npin));
+      if (ret.index() == 1) {
+	return std::move(std::get<1>(ret));
+      } else {
+	return this->pin_to_extent<T>(t, std::move(std::get<0>(ret)));
+      }
+    });
   }
 
   template <typename T>
@@ -198,6 +211,8 @@ public:
     LBAMappingRef pin)
   {
     ceph_assert(pin->is_parent_valid());
+    // checking the lba child must be atomic with creating
+    // and linking the absent child
     auto v = pin->get_logical_extent(t);
     if (v.has_child()) {
       return v.get_child_fut().safe_then([pin=std::move(pin)](auto extent) {
@@ -459,16 +474,31 @@ public:
       // The according extent might be stable or pending.
       auto fut = base_iertr::now();
       if (!pin->is_indirect()) {
-	auto fut2 = base_iertr::make_ready_future<TCachedExtentRef<T>>();
-	if (full_extent_integrity_check) {
-	  fut2 = read_pin<T>(t, pin->duplicate());
+	if (!pin->is_parent_valid()) {
+	  fut = get_pin(t, pin->get_key()
+	  ).si_then([&pin](auto npin) {
+	    assert(npin);
+	    pin = std::move(npin);
+	    return seastar::now();
+	  }).handle_error_interruptible(
+	    crimson::ct_error::enoent::assert_failure{"unexpected enoent"},
+	    crimson::ct_error::input_output_error::pass_further{}
+	  );
 	} else {
-	  auto ret = get_extent_if_linked<T>(t, pin->duplicate());
-	  if (ret.index() == 1) {
-	    fut2 = std::move(std::get<1>(ret));
-	  }
+	  pin->maybe_fix_pos();
 	}
-	fut = fut2.si_then([this, &t, &remaps, original_paddr,
+
+	fut = fut.si_then([this, &t, &pin] {
+	  if (full_extent_integrity_check) {
+	    return read_pin<T>(t, pin->duplicate());
+	  } else {
+	    auto ret = get_extent_if_linked<T>(t, pin->duplicate());
+	    if (ret.index() == 1) {
+	      return std::move(std::get<1>(ret));
+	    }
+	  }
+	  return base_iertr::make_ready_future<TCachedExtentRef<T>>();
+	}).si_then([this, &t, &remaps, original_paddr,
 			    original_laddr, original_len,
 			    &extents, FNAME](auto ext) mutable {
 	  ceph_assert(full_extent_integrity_check

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -197,6 +197,7 @@ public:
     Transaction &t,
     LBAMappingRef pin)
   {
+    ceph_assert(pin->is_parent_valid());
     auto v = pin->get_logical_extent(t);
     if (v.has_child()) {
       return v.get_child_fut().safe_then([pin=std::move(pin)](auto extent) {
@@ -220,6 +221,7 @@ public:
     LBAMappingRef pin,
     extent_types_t type)
   {
+    ceph_assert(pin->is_parent_valid());
     auto v = pin->get_logical_extent(t);
     // checking the lba child must be atomic with creating
     // and linking the absent child


### PR DESCRIPTION
The parent of an lba mapping may be modified after the mapping's retrieval, so we need to avoid getting extents through the mapping with an outdated view.

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
