### PR TITLE
mgr/alerts: suppress muted alerts emails

### DIFF
--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -124,21 +124,23 @@ class Alerts(MgrModule):
         d: Dict[str, Any] = {}
         for code, alert in new.get('checks', {}).items():
             self.log.debug('new code %s alert %s' % (code, alert))
-            if code not in last.get('checks', {}):
-                if 'new' not in d:
-                    d['new'] = {}
-                d['new'][code] = alert
-            elif (alert['summary'].get('count', 0)
-                  > last['checks'][code]['summary'].get('count', 0)):
-                if 'updated' not in d:
-                    d['updated'] = {}
-                d['updated'][code] = alert
+            if not ('muted' in alert and alert['muted']):
+                if code not in last.get('checks', {}):
+                    if 'new' not in d:
+                        d['new'] = {}
+                    d['new'][code] = alert
+                elif (alert['summary'].get('count', 0)
+                      > last['checks'][code]['summary'].get('count', 0)):
+                    if 'updated' not in d:
+                        d['updated'] = {}
+                    d['updated'][code] = alert
         for code, alert in last.get('checks', {}).items():
             self.log.debug('old code %s alert %s' % (code, alert))
-            if code not in new.get('checks', {}):
-                if 'cleared' not in d:
-                    d['cleared'] = {}
-                d['cleared'][code] = alert
+            if not ('muted' in alert and alert['muted']):
+                if code not in new.get('checks', {}):
+                    if 'cleared' not in d:
+                        d['cleared'] = {}
+                    d['cleared'][code] = alert
         return d
 
     def _send_alert(self, status: Dict[str, Any], diff: Dict[str, Any]) -> None:


### PR DESCRIPTION
takes into account 'ceph health mute' command results

Fixes: https://tracker.ceph.com/issues/66222
Backport: quincy, reef
Signed-off-by: Konstantin Sakhinov <sakhinov@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
