### PR TITLE
crimson/os/seastore/async_cleaner: fix incorrect get_num_rolls()

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -414,6 +414,12 @@ public:
   // set the committed journal head
   virtual void set_journal_head(journal_seq_t) = 0;
 
+  // get the opened journal head sequence
+  virtual segment_seq_t get_journal_head_sequence() const = 0;
+
+  // set the opened journal head sequence
+  virtual void set_journal_head_sequence(segment_seq_t) = 0;
+
   // get the committed journal dirty tail
   virtual journal_seq_t get_dirty_tail() const = 0;
 
@@ -453,7 +459,9 @@ public:
     }
     assert(get_journal_head().segment_seq >=
            get_journal_tail().segment_seq);
-    return get_journal_head().segment_seq + 1 -
+    assert(get_journal_head_sequence() >=
+           get_journal_head().segment_seq);
+    return get_journal_head_sequence() + 1 -
            get_journal_tail().segment_seq;
   }
 };
@@ -508,6 +516,12 @@ public:
 
   void set_journal_head(journal_seq_t) final;
 
+  segment_seq_t get_journal_head_sequence() const final {
+    return journal_head_seq;
+  }
+
+  void set_journal_head_sequence(segment_seq_t) final;
+
   journal_seq_t get_dirty_tail() const final {
     return journal_dirty_tail;
   }
@@ -537,6 +551,7 @@ public:
   }
 
   void reset() {
+    journal_head_seq = NULL_SEG_SEQ;
     journal_head = JOURNAL_SEQ_NULL;
     journal_dirty_tail = JOURNAL_SEQ_NULL;
     journal_alloc_tail = JOURNAL_SEQ_NULL;
@@ -616,6 +631,7 @@ private:
   device_off_t roll_start;
   device_off_t roll_size;
 
+  segment_seq_t journal_head_seq = NULL_SEG_SEQ;
   journal_seq_t journal_head;
   journal_seq_t journal_dirty_tail;
   journal_seq_t journal_alloc_tail;

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -55,6 +55,12 @@ struct btree_test_base :
 
   void set_journal_head(journal_seq_t) final {}
 
+  segment_seq_t get_journal_head_sequence() const final {
+    return NULL_SEG_SEQ;
+  }
+
+  void set_journal_head_sequence(segment_seq_t) final {}
+
   journal_seq_t get_dirty_tail() const final { return dummy_tail; }
 
   journal_seq_t get_alloc_tail() const final { return dummy_tail; }

--- a/src/test/crimson/seastore/test_cbjournal.cc
+++ b/src/test/crimson/seastore/test_cbjournal.cc
@@ -147,8 +147,12 @@ struct cbjournal_test_t : public seastar_test_suite_t, JournalTrimmer
   /*
    * JournalTrimmer interfaces
    */
-  journal_seq_t get_journal_head() const {
+  journal_seq_t get_journal_head() const final {
     return JOURNAL_SEQ_NULL;
+  }
+
+  segment_seq_t get_journal_head_sequence() const final {
+    return NULL_SEG_SEQ;
   }
 
   journal_seq_t get_dirty_tail() const final {
@@ -160,6 +164,8 @@ struct cbjournal_test_t : public seastar_test_suite_t, JournalTrimmer
   }
 
   void set_journal_head(journal_seq_t head) final {}
+
+  void set_journal_head_sequence(segment_seq_t) final {}
 
   void update_journal_tails(
     journal_seq_t dirty_tail,

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -94,6 +94,12 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider, JournalTrimmer {
 
   void set_journal_head(journal_seq_t) final {}
 
+  segment_seq_t get_journal_head_sequence() const final {
+    return NULL_SEG_SEQ;
+  }
+
+  void set_journal_head_sequence(segment_seq_t) final {}
+
   journal_seq_t get_dirty_tail() const final { return dummy_tail; }
 
   journal_seq_t get_alloc_tail() const final { return dummy_tail; }


### PR DESCRIPTION
The number of journal segments should not be based on the committed journal_head. Otherwise, if a new journal segment is just opened and the committed journal_head hasn't been updated, the result will be wrong.

This causes `ceph_assert(get_segments_reclaimable() == 0)` in `SegmentCleaner::get_next_reclaim_segment()`.

I can reproduce it locally with debug build (which enables aggressive cleaning), the assert can happen as below:
```c++
...
INFO  2024-05-24 16:45:01,793 [shard 0:main] seastore_cleaner - segments_info_t::mark_open: opening Seg[Dev(0),0] JOURNAL sseq(4) MD GEN_INL, seg_info_t(state=EMPTY, Seg[Dev(0),0]), num_segments(empty=191, opened=6, closed=2)
INFO  2024-05-24 16:45:01,793 [shard 0:main] seastore_cleaner - SegmentCleaner::allocate_segment: opened, SegmentCleaner(should_block_io_on_clean=0, should_clean=1, projected_avail_ratio=0.985887, reclaim_ratio=0.676983, alive_ratio=0.00455862)
INFO  2024-05-24 16:45:01,793 [shard 0:main] seastore_device - BlockSegmentManager::open: Seg[Dev(0),0] ...
ERROR 2024-05-24 16:45:01,793 [shard 0:main] seastore_cleaner - SegmentCleaner::get_next_reclaim_segment: reclaimable=1
ERROR 2024-05-24 16:45:01,793 [shard 0:main] seastore_cleaner - SegmentCleaner::get_next_reclaim_segment: closed=2, in_journal(closed=1, open=1, total=2), head=jseq(sseq(3), paddr<Seg[Dev(0),3],67100672>), tail=jseq(sseq(2), paddr<Seg[Dev(0),1],483328>)
ERROR 2024-05-24 16:45:01,794 [shard 0:main] seastore_cleaner - SegmentCleaner::get_next_reclaim_segment: closed: seg_info_t(state=CLOSED, Seg[Dev(0),1] JOURNAL sseq(2) MD GEN_INL, modify_time=tp(NULL), num_extents=0, written_to=67108864), in_journal=true
ERROR 2024-05-24 16:45:01,794 [shard 0:main] seastore_cleaner - SegmentCleaner::get_next_reclaim_segment: closed: seg_info_t(state=CLOSED, Seg[Dev(0),3] JOURNAL sseq(3) MD GEN_INL, modify_time=tp(2024-05-24 16:44:23), num_extents=834, written_to=67104768), in_journal=true
ERROR 2024-05-24 16:45:01,794 [shard 0:main] none - /root/ceph/src/crimson/os/seastore/async_cleaner.cc:1588 : In function 'crimson::os::seastore::segment_id_t crimson::os::seastore::SegmentCleaner::get_next_reclaim_segment() const', ceph_assert(%s)
get_segments_reclaimable() == 0
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
