### PR TITLE
mgr/dashboard: apply replication policy for a bucket 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -14,7 +14,7 @@ from ..rest_client import RequestException
 from ..security import Permission, Scope
 from ..services.auth import AuthManager, JwtManager
 from ..services.ceph_service import CephService
-from ..services.rgw_client import NoRgwDaemonsException, RgwClient, RgwMultisite
+from ..services.rgw_client import _SYNC_GROUP_ID, NoRgwDaemonsException, RgwClient, RgwMultisite
 from ..tools import json_str_to_object, str_to_bool
 from . import APIDoc, APIRouter, BaseController, CreatePermission, \
     CRUDCollectionMethod, CRUDEndpoint, DeletePermission, Endpoint, \
@@ -242,6 +242,7 @@ class RgwDaemon(RESTController):
                     'server_hostname': hostname,
                     'realm_name': metadata['realm_name'],
                     'zonegroup_name': metadata['zonegroup_name'],
+                    'zonegroup_id': metadata['zonegroup_id'],
                     'zone_name': metadata['zone_name'],
                     'default': instance.daemon.name == metadata['id'],
                     'port': int(port) if port else None
@@ -307,6 +308,8 @@ class RgwSite(RgwRESTController):
             return RgwClient.admin_instance(daemon_name=daemon_name).get_realms()
         if query == 'default-realm':
             return RgwClient.admin_instance(daemon_name=daemon_name).get_default_realm()
+        if query == 'default-zonegroup':
+            return RgwMultisite().get_all_zonegroups_info()['default_zonegroup']
 
         # @TODO: for multisite: by default, retrieve cluster topology/map.
         raise DashboardException(http_status_code=501, component='rgw', msg='Not Implemented')
@@ -396,6 +399,16 @@ class RgwBucket(RgwRESTController):
         rgw_client = RgwClient.instance(owner, daemon_name)
         return rgw_client.set_acl(bucket_name, acl)
 
+    def _set_replication(self, bucket_name: str, replication: bool, owner, daemon_name):
+        multisite = RgwMultisite()
+        rgw_client = RgwClient.instance(owner, daemon_name)
+        zonegroup_name = RgwClient.admin_instance(daemon_name=daemon_name).get_default_zonegroup()
+
+        policy_exists = multisite.policy_group_exists(_SYNC_GROUP_ID, zonegroup_name)
+        if replication and not policy_exists:
+            multisite.create_dashboard_admin_sync_group(zonegroup_name=zonegroup_name)
+        return rgw_client.set_bucket_replication(bucket_name, replication)
+
     @staticmethod
     def strip_tenant_from_bucket_name(bucket_name):
         # type (str) -> str
@@ -463,9 +476,11 @@ class RgwBucket(RgwRESTController):
                lock_retention_period_days=None,
                lock_retention_period_years=None, encryption_state='false',
                encryption_type=None, key_id=None, tags=None,
-               bucket_policy=None, canned_acl=None, daemon_name=None):
+               bucket_policy=None, canned_acl=None, replication='false',
+               daemon_name=None):
         lock_enabled = str_to_bool(lock_enabled)
         encryption_state = str_to_bool(encryption_state)
+        replication = str_to_bool(replication)
         try:
             rgw_client = RgwClient.instance(uid, daemon_name)
             result = rgw_client.create_bucket(bucket, zonegroup,
@@ -488,6 +503,8 @@ class RgwBucket(RgwRESTController):
             if canned_acl:
                 self._set_acl(bucket, canned_acl, uid, daemon_name)
 
+            if replication:
+                self._set_replication(bucket, replication, uid, daemon_name)
             return result
         except RequestException as e:  # pragma: no cover - handling is too obvious
             raise DashboardException(e, http_status_code=500, component='rgw')

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-daemon.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-daemon.ts
@@ -5,6 +5,7 @@ export class RgwDaemon {
   server_hostname: string;
   realm_name: string;
   zonegroup_name: string;
+  zonegroup_id: string;
   zone_name: string;
   default: boolean;
   port: number;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
@@ -387,6 +387,49 @@
           </div>
         </fieldset>
 
+        <!-- Replication -->
+        <fieldset>
+          <legend class="cd-header"
+                  i18n>Replication</legend>
+          <div class="form-group row">
+            <label class="cd-col-form-label pt-0"
+                   for="replication"
+                   i18n>
+                    Enable
+            </label>
+            <div class="cd-col-form-input"
+                 *ngIf="{status: multisiteStatus$, isDefaultZg: isDefaultZoneGroup$ | async} as multisiteStatus; else loadingTpl">
+              <input type="checkbox"
+                     class="form-check-input"
+                     id="replication"
+                     name="replication"
+                     formControlName="replication"
+                     [attr.disabled]="!multisiteStatus.isDefaultZg && !multisiteStatus.status.available ? true : null">
+              <cd-help-text>
+                <span i18n>Enables replication for the objects in the bucket.</span>
+              </cd-help-text>
+              <div class="mt-1">
+                <cd-alert-panel type="info"
+                                *ngIf="!multisiteStatus.status.available && !multisiteStatus.isDefaultZg"
+                                class="me-1"
+                                id="multisite-configured-info"
+                                i18n>
+                  Multi-site needs to be configured on the current realm or you need to be on
+                  the default zonegroup to enable replication.
+                </cd-alert-panel>
+                <cd-alert-panel type="info"
+                                *ngIf="bucketForm.getValue('replication')"
+                                class="me-1"
+                                id="replication-info"
+                                i18n>
+                  A bi-directional sync policy group will be created by the dashboard along with flows and pipes.
+                  The pipe id will then be used for applying the replication policy to the bucket.
+                </cd-alert-panel>
+              </div>
+            </div>
+          </div>
+        </fieldset>
+
         <!-- Tags -->
         <fieldset>
           <legend class="cd-header"
@@ -592,5 +635,11 @@
             (click)="deleteTag(index)">
       <i [ngClass]="[icons.trash]"></i>
     </button>
+  </div>
+</ng-template>
+
+<ng-template #loadingTpl>
+  <div class="cd-col-form-input">
+    <cd-loading-panel i18n>Checking multi-site status...</cd-loading-panel>
   </div>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
@@ -307,4 +307,12 @@ describe('RgwBucketFormComponent', () => {
       expectValidLockInputs(false, 'Compliance', '2');
     });
   });
+
+  describe('bucket replication', () => {
+    it('should validate replication input', () => {
+      formHelper.setValue('replication', true);
+      fixture.detectChanges();
+      formHelper.expectValid('replication');
+    });
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -10,7 +10,7 @@ import { AbstractControl, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import _ from 'lodash';
-import { forkJoin } from 'rxjs';
+import { Observable, forkJoin } from 'rxjs';
 import * as xml2js from 'xml2js';
 
 import { RgwBucketService } from '~/app/shared/api/rgw-bucket.service';
@@ -36,6 +36,9 @@ import { RgwBucketVersioning } from '../models/rgw-bucket-versioning';
 import { RgwConfigModalComponent } from '../rgw-config-modal/rgw-config-modal.component';
 import { BucketTagModalComponent } from '../bucket-tag-modal/bucket-tag-modal.component';
 import { TextAreaJsonFormatterService } from '~/app/shared/services/text-area-json-formatter.service';
+import { RgwMultisiteService } from '~/app/shared/api/rgw-multisite.service';
+import { RgwDaemonService } from '~/app/shared/api/rgw-daemon.service';
+import { map, switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'cd-rgw-bucket-form',
@@ -72,6 +75,8 @@ export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewC
   ];
   grantees: string[] = [Grantee.Owner, Grantee.Everyone, Grantee.AuthenticatedUsers];
   aclPermissions: AclPermissionsType[] = [aclPermission.FullControl];
+  multisiteStatus$: Observable<any>;
+  isDefaultZoneGroup$: Observable<boolean>;
 
   get isVersioningEnabled(): boolean {
     return this.bucketForm.getValue('versioning');
@@ -92,7 +97,9 @@ export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewC
     private rgwEncryptionModal: RgwBucketEncryptionModel,
     private textAreaJsonFormatterService: TextAreaJsonFormatterService,
     public actionLabels: ActionLabelsI18n,
-    private readonly changeDetectorRef: ChangeDetectorRef
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private rgwMultisiteService: RgwMultisiteService,
+    private rgwDaemonService: RgwDaemonService
   ) {
     super();
     this.editing = this.router.url.startsWith(`/rgw/bucket/${URLVerbs.EDIT}`);
@@ -154,7 +161,8 @@ export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewC
       lock_retention_period_days: [10, [CdValidators.number(false), lockDaysValidator]],
       bucket_policy: ['{}', CdValidators.json()],
       grantee: [Grantee.Owner, [Validators.required]],
-      aclPermission: [[aclPermission.FullControl], [Validators.required]]
+      aclPermission: [[aclPermission.FullControl], [Validators.required]],
+      replication: [false]
     });
   }
 
@@ -162,6 +170,16 @@ export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewC
     const promises = {
       owners: this.rgwUserService.enumerate()
     };
+    this.multisiteStatus$ = this.rgwMultisiteService.status();
+    this.isDefaultZoneGroup$ = this.rgwDaemonService.selectedDaemon$.pipe(
+      switchMap((daemon) =>
+        this.rgwSiteService.get('default-zonegroup').pipe(
+          map((defaultZoneGroup) => {
+            return daemon.zonegroup_id === defaultZoneGroup;
+          })
+        )
+      )
+    );
 
     this.kmsProviders = this.rgwEncryptionModal.kmsProviders;
     this.rgwBucketService.getEncryptionConfig().subscribe((data) => {
@@ -331,7 +349,8 @@ export class RgwBucketFormComponent extends CdForm implements OnInit, AfterViewC
           values['keyId'],
           xmlStrTags,
           bucketPolicy,
-          cannedAcl
+          cannedAcl,
+          values['replication']
         )
         .subscribe(
           () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.spec.ts
@@ -32,6 +32,7 @@ describe('RgwDaemonListComponent', () => {
     server_hostname: 'ceph',
     realm_name: 'realm1',
     zonegroup_name: 'zg1-realm1',
+    zonegroup_id: 'zg1-id',
     zone_name: 'zone1-zg1-realm1',
     default: true,
     port: 80

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.spec.ts
@@ -26,6 +26,7 @@ describe('RgwOverviewDashboardComponent', () => {
     server_hostname: 'ceph',
     realm_name: 'realm1',
     zonegroup_name: 'zg1-realm1',
+    zonegroup_id: 'zg1-id',
     zone_name: 'zone1-zg1-realm1',
     default: true,
     port: 80

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -51,7 +51,7 @@ import { BucketTagModalComponent } from './bucket-tag-modal/bucket-tag-modal.com
     CommonModule,
     SharedModule,
     FormsModule,
-    ReactiveFormsModule,
+    ReactiveFormsModule.withConfig({ callSetDisabledState: 'whenDisabledForLegacyCode' }),
     PerformanceCounterModule,
     NgbNavModule,
     RouterModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
@@ -62,11 +62,12 @@ describe('RgwBucketService', () => {
         'qwerty1',
         null,
         null,
-        'private'
+        'private',
+        'true'
       )
       .subscribe();
     const req = httpTesting.expectOne(
-      `api/rgw/bucket?bucket=foo&uid=bar&zonegroup=default&lock_enabled=false&lock_mode=COMPLIANCE&lock_retention_period_days=5&encryption_state=true&encryption_type=aws%253Akms&key_id=qwerty1&tags=null&bucket_policy=null&canned_acl=private&${RgwHelper.DAEMON_QUERY_PARAM}`
+      `api/rgw/bucket?bucket=foo&uid=bar&zonegroup=default&lock_enabled=false&lock_mode=COMPLIANCE&lock_retention_period_days=5&encryption_state=true&encryption_type=aws%253Akms&key_id=qwerty1&tags=null&bucket_policy=null&canned_acl=private&replication=true&${RgwHelper.DAEMON_QUERY_PARAM}`
     );
     expect(req.request.method).toBe('POST');
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
@@ -62,7 +62,8 @@ export class RgwBucketService extends ApiClient {
     key_id: string,
     tags: string,
     bucketPolicy: string,
-    cannedAcl: string
+    cannedAcl: string,
+    replication: string
   ) {
     return this.rgwDaemonService.request((params: HttpParams) => {
       const paramsObject = {
@@ -78,6 +79,7 @@ export class RgwBucketService extends ApiClient {
         tags: tags,
         bucket_policy: bucketPolicy,
         canned_acl: cannedAcl,
+        replication: replication,
         daemon_name: params.get('daemon_name')
       };
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-multisite.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-multisite.service.ts
@@ -30,4 +30,8 @@ export class RgwMultisiteService {
   getSyncStatus() {
     return this.http.get(`${this.url}/sync_status`);
   }
+
+  status() {
+    return this.http.get(`${this.uiUrl}/status`);
+  }
 }

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -10615,6 +10615,9 @@ paths:
                   type: string
                 placement_target:
                   type: string
+                replication:
+                  default: 'false'
+                  type: string
                 tags:
                   type: string
                 uid:

--- a/src/pybind/mgr/dashboard/tests/test_rgw.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw.py
@@ -93,6 +93,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
                 'id': 'daemon1',
                 'realm_name': 'realm1',
                 'zonegroup_name': 'zg1',
+                'zonegroup_id': 'zg1-id',
                 'zone_name': 'zone1',
                 'frontend_config#0': 'beast port=80'
             },
@@ -101,6 +102,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
                 'id': 'daemon2',
                 'realm_name': 'realm2',
                 'zonegroup_name': 'zg2',
+                'zonegroup_id': 'zg2-id',
                 'zone_name': 'zone2',
                 'frontend_config#0': 'beast ssl_port=443 ssl_certificate=config:/config'
             },
@@ -109,6 +111,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
                 'id': 'daemon3',
                 'realm_name': 'realm3',
                 'zonegroup_name': 'zg3',
+                'zonegroup_id': 'zg3-id',
                 'zone_name': 'zone3',
                 'frontend_config#0':
                     'beast ssl_endpoint=0.0.0.0:8080 ssl_certificate=config:/config'
@@ -118,6 +121,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
                 'id': 'daemon4',
                 'realm_name': 'realm4',
                 'zonegroup_name': 'zg4',
+                'zonegroup_id': 'zg4-id',
                 'zone_name': 'zone4',
                 'frontend_config#0': 'beast ssl_certificate=config:/config'
             },
@@ -126,6 +130,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
                 'id': 'daemon5',
                 'realm_name': 'realm5',
                 'zonegroup_name': 'zg5',
+                'zonegroup_id': 'zg5-id',
                 'zone_name': 'zone5',
                 'frontend_config#0':
                     'beast endpoint=0.0.0.0:8445 ssl_certificate=config:/config'
@@ -139,6 +144,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'server_hostname': 'host1',
             'realm_name': 'realm1',
             'zonegroup_name': 'zg1',
+            'zonegroup_id': 'zg1-id',
             'zone_name': 'zone1', 'default': True,
             'port': 80
         },
@@ -149,6 +155,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'server_hostname': 'host1',
             'realm_name': 'realm2',
             'zonegroup_name': 'zg2',
+            'zonegroup_id': 'zg2-id',
             'zone_name': 'zone2',
             'default': False,
             'port': 443,
@@ -160,6 +167,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'server_hostname': 'host1',
             'realm_name': 'realm3',
             'zonegroup_name': 'zg3',
+            'zonegroup_id': 'zg3-id',
             'zone_name': 'zone3',
             'default': False,
             'port': 8080,
@@ -171,6 +179,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'server_hostname': 'host1',
             'realm_name': 'realm4',
             'zonegroup_name': 'zg4',
+            'zonegroup_id': 'zg4-id',
             'zone_name': 'zone4',
             'default': False,
             'port': None,
@@ -182,6 +191,7 @@ class RgwDaemonControllerTestCase(ControllerTestCase):
             'server_hostname': 'host1',
             'realm_name': 'realm5',
             'zonegroup_name': 'zg5',
+            'zonegroup_id': 'zg5-id',
             'zone_name': 'zone5',
             'default': False,
             'port': 8445,


### PR DESCRIPTION
Depends on https://github.com/ceph/ceph/pull/57462

On a normal multisite configured cluster, you can create a bucket with
this replication enabled which will stop the normal syncing and starts
doing the granular bucket syncing; meaning only the bucket with the
replication enabled will be syncing to the secondary site.

To enable replication, there should be a group policy created in the
primary site. the dashboard will create
one with bidirectional rule and add all the zones in the zonegroup for
syncing.

![image](https://github.com/ceph/ceph/assets/71764184/c09f6f6c-14d9-4e95-bf5e-be9a775b3c03)

If multisite is not configured or not on the default zonegroup


![Screenshot from 2024-06-11 15-52-20](https://github.com/ceph/ceph/assets/71764184/7e9fe743-d94c-466f-b9d3-80ecf462a9a7)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
