### PR TITLE
squid: crimson/osd/osd_operations/client_request: retrieve the correct version for objects to be recovered urgently

### DIFF
--- a/src/crimson/osd/osd_operations/client_request_common.cc
+++ b/src/crimson/osd/osd_operations/client_request_common.cc
@@ -73,12 +73,17 @@ CommonClientRequest::do_recover_missing(
   assert(pg->is_primary());
   logger().debug("{} reqid {} check for recovery, {}",
                  __func__, reqid, soid);
-  if (!pg->is_unreadable_object(soid, &ver) &&
+  auto &peering_state = pg->get_peering_state();
+  auto &missing_loc = peering_state.get_missing_loc();
+  bool needs_recovery = missing_loc.needs_recovery(soid, &ver);
+  if (!pg->is_unreadable_object(soid) &&
       !pg->is_degraded_or_backfilling_object(soid)) {
     logger().debug("{} reqid {} nothing to recover {}",
                    __func__, reqid, soid);
     return seastar::now();
   }
+  ceph_assert(needs_recovery);
+
   logger().debug("{} reqid {} need to wait for recovery, {} version {}",
                  __func__, reqid, soid, ver);
   if (pg->get_recovery_backend()->is_recovering(soid)) {

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -429,8 +429,12 @@ void ReplicatedRecoveryBackend::prepare_pull(
 
   pg_missing_tracker_t local_missing = pg.get_local_missing();
   const auto missing_iter = local_missing.get_items().find(soid);
-  auto m = pg.get_missing_loc_shards();
-  pg_shard_t fromshard = *(m[soid].begin());
+  auto &m = pg.get_missing_loc_shards();
+  assert(m.contains(soid));
+  auto &locs = m.at(soid);
+  auto iter = locs.begin();
+  assert(iter != locs.end());
+  pg_shard_t fromshard = *(iter);
 
   pull_op.recovery_info =
     set_recovery_info(soid, head_obc->ssc);


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56892

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh