### PR TITLE
crimson/osd/object_context_loader: Fix obc cache existence usage

### DIFF
--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -1230,6 +1230,17 @@ public:
 	    };
   }
 
+  template <typename Lock, typename Func>
+  [[gnu::always_inline]]
+  static auto with_lock(Lock& lock, Func&& func) {
+    return seastar::with_lock(
+      lock,
+      [func=std::move(func),
+       interrupt_condition=interrupt_cond<InterruptCond>.interrupt_cond]() mutable {
+      return call_with_interruption(interrupt_condition, func);
+    });
+  }
+
   template <typename Iterator,
 	    InvokeReturnsInterruptibleFuture<typename Iterator::reference> AsyncAction>
   [[gnu::always_inline]]

--- a/src/crimson/common/tri_mutex.cc
+++ b/src/crimson/common/tri_mutex.cc
@@ -5,6 +5,9 @@
 
 #include <seastar/util/later.hh>
 
+SET_SUBSYS(osd);
+//TODO: SET_SUBSYS(crimson_tri_mutex);
+
 seastar::future<> read_lock::lock()
 {
   return static_cast<tri_mutex*>(this)->lock_for_read();
@@ -57,20 +60,28 @@ void excl_lock_from_write::unlock()
 
 tri_mutex::~tri_mutex()
 {
+  LOG_PREFIX(tri_mutex::~tri_mutex());
+  DEBUGDPP("", *this);
   assert(!is_acquired());
 }
 
 seastar::future<> tri_mutex::lock_for_read()
 {
+  LOG_PREFIX(tri_mutex::lock_for_read());
+  DEBUGDPP("", *this);
   if (try_lock_for_read()) {
+    DEBUGDPP("lock_for_read successfully", *this);
     return seastar::now();
   }
+  DEBUGDPP("can't lock_for_read, adding to waiters", *this);
   waiters.emplace_back(seastar::promise<>(), type_t::read);
   return waiters.back().pr.get_future();
 }
 
 bool tri_mutex::try_lock_for_read() noexcept
 {
+  LOG_PREFIX(tri_mutex::try_lock_for_read());
+  DEBUGDPP("", *this);
   if (!writers && !exclusively_used && waiters.empty()) {
     ++readers;
     return true;
@@ -81,6 +92,8 @@ bool tri_mutex::try_lock_for_read() noexcept
 
 void tri_mutex::unlock_for_read()
 {
+  LOG_PREFIX(tri_mutex::unlock_for_read());
+  DEBUGDPP("", *this);
   assert(readers > 0);
   if (--readers == 0) {
     wake();
@@ -89,6 +102,8 @@ void tri_mutex::unlock_for_read()
 
 void tri_mutex::promote_from_read()
 {
+  LOG_PREFIX(tri_mutex::promote_from_read());
+  DEBUGDPP("", *this);
   assert(readers == 1);
   --readers;
   exclusively_used = true;
@@ -96,6 +111,8 @@ void tri_mutex::promote_from_read()
 
 void tri_mutex::demote_to_read()
 {
+  LOG_PREFIX(tri_mutex::demote_to_read());
+  DEBUGDPP("", *this);
   assert(exclusively_used);
   exclusively_used = false;
   ++readers;
@@ -103,15 +120,21 @@ void tri_mutex::demote_to_read()
 
 seastar::future<> tri_mutex::lock_for_write()
 {
+  LOG_PREFIX(tri_mutex::lock_for_write());
+  DEBUGDPP("", *this);
   if (try_lock_for_write()) {
+    DEBUGDPP("lock_for_write successfully", *this);
     return seastar::now();
   }
+  DEBUGDPP("can't lock_for_write, adding to waiters", *this);
   waiters.emplace_back(seastar::promise<>(), type_t::write);
   return waiters.back().pr.get_future();
 }
 
 bool tri_mutex::try_lock_for_write() noexcept
 {
+  LOG_PREFIX(tri_mutex::try_lock_for_write());
+  DEBUGDPP("", *this);
   if (!readers && !exclusively_used) {
     if (waiters.empty()) {
       ++writers;
@@ -123,6 +146,8 @@ bool tri_mutex::try_lock_for_write() noexcept
 
 void tri_mutex::unlock_for_write()
 {
+  LOG_PREFIX(tri_mutex::unlock_for_write());
+  DEBUGDPP("", *this);
   assert(writers > 0);
   if (--writers == 0) {
     wake();
@@ -131,6 +156,8 @@ void tri_mutex::unlock_for_write()
 
 void tri_mutex::promote_from_write()
 {
+  LOG_PREFIX(tri_mutex::promote_from_write());
+  DEBUGDPP("", *this);
   assert(writers == 1);
   --writers;
   exclusively_used = true;
@@ -138,6 +165,8 @@ void tri_mutex::promote_from_write()
 
 void tri_mutex::demote_to_write()
 {
+  LOG_PREFIX(tri_mutex::demote_to_write());
+  DEBUGDPP("", *this);
   assert(exclusively_used);
   exclusively_used = false;
   ++writers;
@@ -146,15 +175,21 @@ void tri_mutex::demote_to_write()
 // for exclusive users
 seastar::future<> tri_mutex::lock_for_excl()
 {
+  LOG_PREFIX(tri_mutex::lock_for_excl());
+  DEBUGDPP("", *this);
   if (try_lock_for_excl()) {
+    DEBUGDPP("lock_for_excl, successfully", *this);
     return seastar::now();
   }
+  DEBUGDPP("can't lock_for_excl, adding to waiters", *this);
   waiters.emplace_back(seastar::promise<>(), type_t::exclusive);
   return waiters.back().pr.get_future();
 }
 
 bool tri_mutex::try_lock_for_excl() noexcept
 {
+  LOG_PREFIX(tri_mutex::try_lock_for_excl());
+  DEBUGDPP("", *this);
   if (readers == 0u && writers == 0u && !exclusively_used) {
     exclusively_used = true;
     return true;
@@ -165,6 +200,8 @@ bool tri_mutex::try_lock_for_excl() noexcept
 
 void tri_mutex::unlock_for_excl()
 {
+  LOG_PREFIX(tri_mutex::unlock_for_excl());
+  DEBUGDPP("", *this);
   assert(exclusively_used);
   exclusively_used = false;
   wake();
@@ -172,6 +209,8 @@ void tri_mutex::unlock_for_excl()
 
 bool tri_mutex::is_acquired() const
 {
+  LOG_PREFIX(tri_mutex::is_acquired());
+  DEBUGDPP("", *this);
   if (readers != 0u) {
     return true;
   } else if (writers != 0u) {
@@ -185,6 +224,8 @@ bool tri_mutex::is_acquired() const
 
 void tri_mutex::wake()
 {
+  LOG_PREFIX(tri_mutex::wake());
+  DEBUGDPP("", *this);
   assert(!readers && !writers && !exclusively_used);
   type_t type = type_t::none;
   while (!waiters.empty()) {
@@ -210,7 +251,9 @@ void tri_mutex::wake()
     default:
       assert(0);
     }
+    // TODO: DEBUGDPP("waking up {} ", *this);
     waiter.pr.set_value();
     waiters.pop_front();
   }
+  DEBUGDPP("no waiters", *this);
 }

--- a/src/crimson/common/tri_mutex.cc
+++ b/src/crimson/common/tri_mutex.cc
@@ -85,9 +85,8 @@ bool tri_mutex::try_lock_for_read() noexcept
   if (!writers && !exclusively_used && waiters.empty()) {
     ++readers;
     return true;
-  } else {
-    return false;
   }
+  return false;
 }
 
 void tri_mutex::unlock_for_read()
@@ -135,11 +134,9 @@ bool tri_mutex::try_lock_for_write() noexcept
 {
   LOG_PREFIX(tri_mutex::try_lock_for_write());
   DEBUGDPP("", *this);
-  if (!readers && !exclusively_used) {
-    if (waiters.empty()) {
-      ++writers;
-      return true;
-    }
+  if (!readers && !exclusively_used && waiters.empty()) {
+    ++writers;
+    return true;
   }
   return false;
 }

--- a/src/crimson/common/tri_mutex.cc
+++ b/src/crimson/common/tri_mutex.cc
@@ -74,7 +74,7 @@ seastar::future<> tri_mutex::lock_for_read()
     return seastar::now();
   }
   DEBUGDPP("can't lock_for_read, adding to waiters", *this);
-  waiters.emplace_back(seastar::promise<>(), type_t::read);
+  waiters.emplace_back(seastar::promise<>(), type_t::read, name);
   return waiters.back().pr.get_future();
 }
 
@@ -127,7 +127,7 @@ seastar::future<> tri_mutex::lock_for_write()
     return seastar::now();
   }
   DEBUGDPP("can't lock_for_write, adding to waiters", *this);
-  waiters.emplace_back(seastar::promise<>(), type_t::write);
+  waiters.emplace_back(seastar::promise<>(), type_t::write, name);
   return waiters.back().pr.get_future();
 }
 
@@ -182,7 +182,7 @@ seastar::future<> tri_mutex::lock_for_excl()
     return seastar::now();
   }
   DEBUGDPP("can't lock_for_excl, adding to waiters", *this);
-  waiters.emplace_back(seastar::promise<>(), type_t::exclusive);
+  waiters.emplace_back(seastar::promise<>(), type_t::exclusive, name);
   return waiters.back().pr.get_future();
 }
 
@@ -251,7 +251,7 @@ void tri_mutex::wake()
     default:
       assert(0);
     }
-    // TODO: DEBUGDPP("waking up {} ", *this);
+    DEBUGDPP("waking up {}", *this, waiter.waiter_name);
     waiter.pr.set_value();
     waiters.pop_front();
   }

--- a/src/crimson/common/tri_mutex.h
+++ b/src/crimson/common/tri_mutex.h
@@ -3,25 +3,27 @@
 
 #pragma once
 
+#include <optional>
+
 #include <seastar/core/future.hh>
 #include <seastar/core/circular_buffer.hh>
 #include "crimson/common/log.h"
 
 class read_lock {
 public:
-  seastar::future<> lock();
+  std::optional<seastar::future<>> lock();
   void unlock();
 };
 
 class write_lock {
 public:
-  seastar::future<> lock();
+  std::optional<seastar::future<>> lock();
   void unlock();
 };
 
 class excl_lock {
 public:
-  seastar::future<> lock();
+  std::optional<seastar::future<>> lock();
   void unlock();
 };
 
@@ -87,7 +89,7 @@ public:
   }
 
   // for shared readers
-  seastar::future<> lock_for_read();
+  std::optional<seastar::future<>> lock_for_read();
   bool try_lock_for_read() noexcept;
   void unlock_for_read();
   void promote_from_read();
@@ -97,7 +99,7 @@ public:
   }
 
   // for shared writers
-  seastar::future<> lock_for_write();
+  std::optional<seastar::future<>> lock_for_write();
   bool try_lock_for_write() noexcept;
   void unlock_for_write();
   void promote_from_write();
@@ -107,7 +109,7 @@ public:
   }
 
   // for exclusive users
-  seastar::future<> lock_for_excl();
+  std::optional<seastar::future<>> lock_for_excl();
   bool try_lock_for_excl() noexcept;
   void unlock_for_excl();
   bool is_excl_acquired() const {

--- a/src/crimson/common/tri_mutex.h
+++ b/src/crimson/common/tri_mutex.h
@@ -142,11 +142,12 @@ private:
     none,
   };
   struct waiter_t {
-    waiter_t(seastar::promise<>&& pr, type_t type)
+    waiter_t(seastar::promise<>&& pr, type_t type, std::string_view waiter_name)
       : pr(std::move(pr)), type(type)
     {}
     seastar::promise<> pr;
     type_t type;
+    std::string_view waiter_name;
   };
   seastar::circular_buffer<waiter_t> waiters;
   const std::string name;

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -70,6 +70,10 @@ public:
   using watch_key_t = std::pair<uint64_t, entity_name_t>;
   std::map<watch_key_t, seastar::shared_ptr<crimson::osd::Watch>> watchers;
 
+  // obc loading is a concurrent phase. In case this obc is being loaded,
+  // make other users of this obc to await for the loading to complete.
+  seastar::shared_mutex loading_mutex;
+
   ObjectContext(hobject_t hoid) : obs(std::move(hoid)) {}
 
   const hobject_t &get_oid() const {

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -125,10 +125,6 @@ public:
     return !invalidated_by_interval_change;
   }
 
-  bool is_loaded_and_valid() const {
-    return is_loaded() && is_valid();
-  }
-
 private:
   tri_mutex lock;
   bool recovery_read_marker = false;

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -117,8 +117,16 @@ public:
     }
   }
 
+  bool is_loaded() const {
+    return fully_loaded;
+  }
+
+  bool is_valid() const {
+    return !invalidated_by_interval_change;
+  }
+
   bool is_loaded_and_valid() const {
-    return fully_loaded && !invalidated_by_interval_change;
+    return is_loaded() && is_valid();
   }
 
 private:

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -14,7 +14,8 @@ using crimson::common::local_conf;
   {
     LOG_PREFIX(ObjectContextLoader::with_head_obc);
     auto [obc, existed] = obc_registry.get_cached_obc(oid);
-    DEBUGDPP("object {}", dpp, obc->get_oid());
+    DEBUGDPP("object {} existed {}",
+             dpp, obc->get_oid(), existed);
     assert(obc->is_head());
     obc->append_to(obc_set_accessing);
     return obc->with_lock<State, IOInterruptCondition>(

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -144,18 +144,15 @@ using crimson::common::local_conf;
                                        bool existed)
   {
     LOG_PREFIX(ObjectContextLoader::get_or_load_obc);
+    DEBUGDPP("{} -- fully_loaded={}, "
+             "invalidated_by_interval_change={}",
+             dpp, obc->get_oid(),
+             obc->fully_loaded,
+             obc->invalidated_by_interval_change);
     auto loaded =
       load_obc_iertr::make_ready_future<ObjectContextRef>(obc);
     if (existed && obc->is_loaded()) {
-      if (!obc->is_loaded_and_valid()) {
-	ERRORDPP(
-	  "obc for {} invalid -- fully_loaded={}, "
-	  "invalidated_by_interval_change={}",
-	  dpp, obc->get_oid(),
-	  obc->fully_loaded, obc->invalidated_by_interval_change
-	);
-      }
-      ceph_assert(obc->is_loaded_and_valid());
+      ceph_assert(obc->is_valid());
       DEBUGDPP("cache hit on {}", dpp, obc->get_oid());
     } else {
       DEBUGDPP("cache miss on {}", dpp, obc->get_oid());

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -146,7 +146,7 @@ using crimson::common::local_conf;
     LOG_PREFIX(ObjectContextLoader::get_or_load_obc);
     auto loaded =
       load_obc_iertr::make_ready_future<ObjectContextRef>(obc);
-    if (existed) {
+    if (existed && obc->is_loaded()) {
       if (!obc->is_loaded_and_valid()) {
 	ERRORDPP(
 	  "obc for {} invalid -- fully_loaded={}, "

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -80,6 +80,18 @@ private:
   get_or_load_obc(ObjectContextRef obc,
                   bool existed);
 
+  template<RWState::State State>
+  load_obc_iertr::future<ObjectContextRef>
+  _get_or_load_obc(ObjectContextRef obc,
+                  bool existed);
+
+  static inline load_obc_iertr::future<ObjectContextRef>
+  get_obc(ObjectContextRef obc,
+          bool existed) {
+    ceph_assert(existed && obc->is_valid() && obc->is_loaded());
+    return load_obc_iertr::make_ready_future<ObjectContextRef>(obc);
+  }
+
   load_obc_iertr::future<ObjectContextRef>
   load_obc(ObjectContextRef obc);
 };

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -29,6 +29,9 @@ public:
       ::crimson::osd::IOInterruptCondition,
       load_obc_ertr>;
 
+  using interruptor = ::crimson::interruptible::interruptor<
+    ::crimson::osd::IOInterruptCondition>;
+
   using with_obc_func_t =
     std::function<load_obc_iertr::future<> (ObjectContextRef, ObjectContextRef)>;
 


### PR DESCRIPTION
with_head_obc() uses get_cached_obc() to get_or_create obc instances.

If the obc exists in cache, get_or_load_obc is called with `existed`=true.
The assumption above is wrong.
Cache existence (`existed`) only guarantees that the obc instance was created (and inserted) in the obc_registery. However, it does **not** assure that the obc was actually loaded.

As obc-loading is now concurrent, it's possible for the first user to only create the obc in cache (without loading yet) and the second concurrent user to assume it was already loaded.

With this patch, we verify that the obc was loaded for get_or_load_obc usage.

* make loading-obc concurrent PR: https://github.com/ceph/ceph/pull/55488

Fixes: https://tracker.ceph.com/issues/64206
Fixes: https://tracker.ceph.com/issues/66214

---

```
  // obc loading is a concurrent phase. In case this obc is being loaded,
  // make other useres of this obc to await for the loading to complete.
```

Since we now await for loading to finish (in-case in progress), we can
also assert is_loaded().

Fixes: https://tracker.ceph.com/issues/65451

--- 
Fixes: https://tracker.ceph.com/issues/66308





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
