### PR TITLE
qa/suites/rbd: override extra_system_packages directly on install task

### DIFF
--- a/qa/suites/rbd/basic/tasks/rbd_python_api_tests_old_format.yaml
+++ b/qa/suites/rbd/basic/tasks/rbd_python_api_tests_old_format.yaml
@@ -4,8 +4,7 @@ overrides:
       - \(SLOW_OPS\)
       - slow request
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:

--- a/qa/suites/rbd/device/workloads/diff-continuous-krbd.yaml
+++ b/qa/suites/rbd/device/workloads/diff-continuous-krbd.yaml
@@ -1,8 +1,7 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
-        - pv
+    extra_system_packages:
+      - pv
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/device/workloads/diff-continuous-nbd.yaml
+++ b/qa/suites/rbd/device/workloads/diff-continuous-nbd.yaml
@@ -3,8 +3,8 @@ overrides:
     ceph:
       extra_packages:
         - rbd-nbd
-      extra_system_packages:
-        - pv
+    extra_system_packages:
+      - pv
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/librbd/workloads/python_api_tests.yaml
+++ b/qa/suites/rbd/librbd/workloads/python_api_tests.yaml
@@ -1,7 +1,6 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:

--- a/qa/suites/rbd/librbd/workloads/python_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/librbd/workloads/python_api_tests_with_defaults.yaml
@@ -1,7 +1,6 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:

--- a/qa/suites/rbd/librbd/workloads/python_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/librbd/workloads/python_api_tests_with_journaling.yaml
@@ -1,7 +1,6 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:

--- a/qa/suites/rbd/mirror/workloads/compare-mirror-image-alternate-primary-krbd.yaml
+++ b/qa/suites/rbd/mirror/workloads/compare-mirror-image-alternate-primary-krbd.yaml
@@ -1,8 +1,7 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
-        - pv
+    extra_system_packages:
+      - pv
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/mirror/workloads/compare-mirror-image-alternate-primary-nbd.yaml
+++ b/qa/suites/rbd/mirror/workloads/compare-mirror-image-alternate-primary-nbd.yaml
@@ -3,8 +3,8 @@ overrides:
     ceph:
       extra_packages:
         - rbd-nbd
-      extra_system_packages:
-        - pv
+    extra_system_packages:
+      - pv
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/mirror/workloads/compare-mirror-images-krbd.yaml
+++ b/qa/suites/rbd/mirror/workloads/compare-mirror-images-krbd.yaml
@@ -1,8 +1,7 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
-        - pv
+    extra_system_packages:
+      - pv
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/mirror/workloads/compare-mirror-images-nbd.yaml
+++ b/qa/suites/rbd/mirror/workloads/compare-mirror-images-nbd.yaml
@@ -3,8 +3,8 @@ overrides:
     ceph:
       extra_packages:
         - rbd-nbd
-      extra_system_packages:
-        - pv
+    extra_system_packages:
+      - pv
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests.yaml
@@ -1,7 +1,6 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests_with_defaults.yaml
@@ -1,7 +1,6 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests_with_journaling.yaml
@@ -1,7 +1,6 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:


### PR DESCRIPTION
[1] and [2] added support for applying extra_system_packages overrides directly on install task, but at the same time broke our long standing workaround where we sneaked extra_system_packages directive in through an override on ceph task.  This is likely getting addressed in [3], but it's better to not rely on this odd feature in the first place.

[1] https://github.com/ceph/teuthology/pull/1941
[2] https://github.com/ceph/teuthology/pull/1943
[3] https://github.com/ceph/teuthology/pull/1942

Fixes: https://tracker.ceph.com/issues/66232





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
