### PR TITLE
os/transaction: page align write data buffers to improve performance - version 1

### DIFF
--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -117,7 +117,18 @@ inline void decode(bool &v, bufferlist::const_iterator& p) {
     ceph_##etype e;							\
     ::ceph::decode_raw(e, p);						\
     v = e;								\
-  }
+  }									\
+  inline void encode(type v, ::ceph::bufferlist& p_bl, ::ceph::bufferlist& d_bl,uint64_t features=0) { \
+    ceph_##etype e;					                \
+    e = v;                                                              \
+    ::ceph::encode_raw(e, p_bl);					\
+  }									\
+  inline void decode(type &v, ::ceph::bufferlist::const_iterator& p, ::ceph::bufferlist::const_iterator& d) { \
+    ceph_##etype e;							\
+    ::ceph::decode_raw(e, p);						\
+    v = e;								\
+  }									\
+
 
 WRITE_INTTYPE_ENCODER(uint64_t, le64)
 WRITE_INTTYPE_ENCODER(int64_t, le64)
@@ -195,6 +206,11 @@ WRITE_FLTTYPE_ENCODER(double, uint64_t, le64)
   inline void encode(const cl &c, ::ceph::bufferlist &bl) const {	\
     ENCODE_DUMP_PRE(); c.encode(bl); ENCODE_DUMP_POST(cl); }		\
   inline void decode(cl &c, ::ceph::bufferlist::const_iterator &p) { c.decode(p); }
+
+#define WRITE_CLASS_ENCODER_WITH_DATA(cl)				\
+  inline void encode(const cl& c, ::ceph::buffer::list &p_bl, ::ceph::buffer::list &d_bl) { \
+    ENCODE_DUMP_PRE(); c.encode(p_bl,d_bl); ENCODE_DUMP_POST(cl); }	\
+  inline void decode(cl &c, ::ceph::bufferlist::const_iterator &p, ::ceph::bufferlist::const_iterator &d) { c.decode(p,d); }
 
 #define WRITE_CLASS_ENCODER_FEATURES(cl)				\
   inline void encode(const cl &c, ::ceph::bufferlist &bl, uint64_t features) { \
@@ -276,6 +292,13 @@ inline void encode(const buffer::ptr& bp, bufferlist& bl)
   if (len)
     bl.append(bp);
 }
+inline void encode(const buffer::ptr& bp, bufferlist& p_bl, bufferlist& d_bl)
+{
+  __u32 len = bp.length();
+  encode(len, p_bl);
+  if (len)
+    d_bl.append(bp);
+}
 inline void decode(buffer::ptr& bp, bufferlist::const_iterator& p)
 {
   __u32 len;
@@ -283,6 +306,21 @@ inline void decode(buffer::ptr& bp, bufferlist::const_iterator& p)
 
   bufferlist s;
   p.copy(len, s);
+
+  if (len) {
+    if (s.get_num_buffers() == 1)
+      bp = s.front();
+    else
+      bp = buffer::copy(s.c_str(), s.length());
+  }
+}
+inline void decode(buffer::ptr& bp, bufferlist::const_iterator& p_bl,bufferlist::const_iterator& d_bl)
+{
+  __u32 len;
+  decode(len, p_bl);
+
+  bufferlist s;
+  d_bl.copy(len, s);
 
   if (len) {
     if (s.get_num_buffers() == 1)
@@ -299,6 +337,12 @@ inline void encode(const bufferlist& s, bufferlist& bl)
   encode(len, bl);
   bl.append(s);
 }
+inline void encode(const bufferlist& s, bufferlist& p_bl, bufferlist& d_bl)
+{
+  __u32 len = s.length();
+  encode(len, p_bl);
+  d_bl.append(s);
+}
 inline void encode_destructively(bufferlist& s, bufferlist& bl) 
 {
   __u32 len = s.length();
@@ -311,6 +355,13 @@ inline void decode(bufferlist& s, bufferlist::const_iterator& p)
   decode(len, p);
   s.clear();
   p.copy(len, s);
+}
+inline void decode(bufferlist& s, bufferlist::const_iterator& p_bl,bufferlist::const_iterator& d_bl)
+{
+  __u32 len;
+  decode(len, p_bl);
+  s.clear();
+  d_bl.copy(len, s);
 }
 
 inline void encode_nohead(const bufferlist& s, bufferlist& bl) 
@@ -425,32 +476,62 @@ inline std::enable_if_t<!a_traits::supported || !b_traits::supported>
 encode(const std::pair<A,B> &p, bufferlist &bl, uint64_t features);
 template<class A, class B,
 	 typename a_traits=denc_traits<A>, typename b_traits=denc_traits<B>>
+inline void
+encode(const std::pair<A,B> &p, bufferlist &p_bl, bufferlist &d_bl, uint64_t features);
+template<class A, class B,
+	 typename a_traits=denc_traits<A>, typename b_traits=denc_traits<B>>
 inline std::enable_if_t<!a_traits::supported ||
 			!b_traits::supported>
 encode(const std::pair<A,B> &p, bufferlist &bl);
 template<class A, class B,
 	 typename a_traits=denc_traits<A>, typename b_traits=denc_traits<B>>
+inline void
+encode(const std::pair<A,B> &p, bufferlist &p_bl, bufferlist &d_bl);
+template<class A, class B,
+	 typename a_traits=denc_traits<A>, typename b_traits=denc_traits<B>>
 inline std::enable_if_t<!a_traits::supported ||
 			!b_traits::supported>
 decode(std::pair<A,B> &pa, bufferlist::const_iterator &p);
+template<class A, class B,
+	 typename a_traits=denc_traits<A>, typename b_traits=denc_traits<B>>
+inline void
+decode(std::pair<A,B> &pa, bufferlist::const_iterator &p, bufferlist::const_iterator &d);
 template<class T, class Alloc, typename traits=denc_traits<T>>
 inline std::enable_if_t<!traits::supported>
 encode(const std::list<T, Alloc>& ls, bufferlist& bl);
 template<class T, class Alloc, typename traits=denc_traits<T>>
+inline void
+encode(const std::list<T, Alloc>& ls, bufferlist& p_bl, bufferlist& d_bl);
+template<class T, class Alloc, typename traits=denc_traits<T>>
 inline std::enable_if_t<!traits::supported>
 encode(const std::list<T,Alloc>& ls, bufferlist& bl, uint64_t features);
 template<class T, class Alloc, typename traits=denc_traits<T>>
+inline void
+encode(const std::list<T,Alloc>& ls, bufferlist& p_bl, bufferlist& d_bl, uint64_t features);
+template<class T, class Alloc, typename traits=denc_traits<T>>
 inline std::enable_if_t<!traits::supported>
 decode(std::list<T,Alloc>& ls, bufferlist::const_iterator& p);
+template<class T, class Alloc, typename traits=denc_traits<T>>
+inline void
+decode(std::list<T,Alloc>& ls, bufferlist::const_iterator& p, bufferlist::const_iterator& d);
 template<class T, class Alloc>
 inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
 		   bufferlist& bl);
 template<class T, class Alloc>
 inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
+		   bufferlist& p_bl, bufferlist& d_pl);
+template<class T, class Alloc>
+inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
 		   bufferlist& bl, uint64_t features);
+template<class T, class Alloc>
+inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
+		     bufferlist& p_bl, bufferlist& d_pl, uint64_t features);
 template<class T, class Alloc>
 inline void decode(std::list<std::shared_ptr<T>, Alloc>& ls,
 		   bufferlist::const_iterator& p);
+template<class T, class Alloc>
+inline void decode(std::list<std::shared_ptr<T>, Alloc>& ls,
+		   bufferlist::const_iterator& p, bufferlist::const_iterator& d);
 template<class T, class Comp, class Alloc, typename traits=denc_traits<T>>
 inline std::enable_if_t<!traits::supported>
 encode(const std::set<T,Comp,Alloc>& s, bufferlist& bl);
@@ -530,12 +611,24 @@ inline std::enable_if_t<!t_traits::supported ||
 encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl);
 template<class T, class U, class Comp, class Alloc,
 	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
+inline void
+encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& p_bl, bufferlist& d_bl);
+template<class T, class U, class Comp, class Alloc,
+	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
 inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
 encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl, uint64_t features);
 template<class T, class U, class Comp, class Alloc,
 	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
+inline void
+encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& p_bl, bufferlist& d_bl, uint64_t features);
+template<class T, class U, class Comp, class Alloc,
+	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
 inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
 decode(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p);
+template<class T, class U, class Comp, class Alloc,
+	 typename t_traits=denc_traits<T>, typename u_traits=denc_traits<U>>
+inline void
+decode(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p, bufferlist::const_iterator& d);
 template<class T, class U, class Comp, class Alloc>
 inline void decode_noclear(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p);
 template<class T, class U, class Comp, class Alloc,
@@ -718,12 +811,28 @@ inline std::enable_if_t<!a_traits::supported || !b_traits::supported>
 }
 template<class A, class B,
 	 typename a_traits, typename b_traits>
+inline void
+  encode(const std::pair<A,B> &p, bufferlist &p_bl, bufferlist &d_bl, uint64_t features)
+{
+  encode(p.first, p_bl, d_bl, features);
+  encode(p.second, p_bl, d_bl, features);
+}
+template<class A, class B,
+	 typename a_traits, typename b_traits>
 inline std::enable_if_t<!a_traits::supported ||
 			!b_traits::supported>
   encode(const std::pair<A,B> &p, bufferlist &bl)
 {
   encode(p.first, bl);
   encode(p.second, bl);
+}
+template<class A, class B,
+	 typename a_traits, typename b_traits>
+inline void
+  encode(const std::pair<A,B> &p, bufferlist &p_bl, bufferlist &d_bl)
+{
+  encode(p.first, p_bl, d_bl);
+  encode(p.second, p_bl, d_bl);
 }
 template<class A, class B, typename a_traits, typename b_traits>
 inline std::enable_if_t<!a_traits::supported ||
@@ -732,6 +841,13 @@ inline std::enable_if_t<!a_traits::supported ||
 {
   decode(pa.first, p);
   decode(pa.second, p);
+}
+template<class A, class B, typename a_traits, typename b_traits>
+inline void
+  decode(std::pair<A,B> &pa, bufferlist::const_iterator &p, bufferlist::const_iterator &d)
+{
+  decode(pa.first, p, d);
+  decode(pa.second, p, d);
 }
 
 // std::list<T>
@@ -743,6 +859,15 @@ inline std::enable_if_t<!traits::supported>
   encode(n, bl);
   for (auto p = ls.begin(); p != ls.end(); ++p)
     encode(*p, bl);
+}
+template<class T, class Alloc, typename traits=denc_traits<T>>
+inline void
+  encode(const std::list<T, Alloc>& ls, bufferlist& p_bl, bufferlist& d_bl)
+{
+  __u32 n = (__u32)(ls.size());  // c++11 std::list::size() is O(1)
+  encode(n, p_bl);
+  for (auto p = ls.begin(); p != ls.end(); ++p)
+    encode(*p, p_bl, d_bl);
 }
 template<class T, class Alloc, typename traits>
 inline std::enable_if_t<!traits::supported>
@@ -761,6 +886,23 @@ inline std::enable_if_t<!traits::supported>
   en = n;
   filler.copy_in(sizeof(en), reinterpret_cast<char*>(&en));
 }
+template<class T, class Alloc, typename traits>
+inline void
+  encode(const std::list<T,Alloc>& ls, bufferlist& p_bl, bufferlist& d_bl, uint64_t features)
+{
+  using counter_encode_t = ceph_le32;
+  unsigned n = 0;
+  auto filler = p_bl.append_hole(sizeof(counter_encode_t));
+  for (const auto& item : ls) {
+    // we count on our own because of buggy std::list::size() implementation
+    // which doesn't follow the O(1) complexity constraint C++11 has brought.
+    ++n;
+    encode(item, p_bl, d_bl, features);
+  }
+  counter_encode_t en;
+  en = n;
+  filler.copy_in(sizeof(en), reinterpret_cast<char*>(&en));
+}
 
 template<class T, class Alloc, typename traits>
 inline std::enable_if_t<!traits::supported>
@@ -772,6 +914,18 @@ inline std::enable_if_t<!traits::supported>
   while (n--) {
     ls.emplace_back();
     decode(ls.back(), p);
+  }
+}
+template<class T, class Alloc, typename traits>
+inline
+void decode(std::list<T,Alloc>& ls, bufferlist::const_iterator& p, bufferlist::const_iterator& d)
+{
+  __u32 n;
+  decode(n, p);
+  ls.clear();
+  while (n--) {
+    ls.emplace_back();
+    decode(ls.back(), p, d);
   }
 }
 
@@ -788,12 +942,32 @@ inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
 }
 template<class T, class Alloc>
 inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
+		   bufferlist& p_bl, bufferlist& d_bl)
+{
+  __u32 n = (__u32)(ls.size());  // c++11 std::list::size() is O(1)
+  encode(n, p_bl);
+  for (const auto& ref : ls) {
+    encode(*ref, p_bl, d_bl);
+  }
+}
+template<class T, class Alloc>
+inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
 		   bufferlist& bl, uint64_t features)
 {
   __u32 n = (__u32)(ls.size());  // c++11 std::list::size() is O(1)
   encode(n, bl);
   for (const auto& ref : ls) {
     encode(*ref, bl, features);
+  }
+}
+template<class T, class Alloc>
+inline void encode(const std::list<std::shared_ptr<T>, Alloc>& ls,
+		   bufferlist& p_bl, bufferlist& d_bl, uint64_t features)
+{
+  __u32 n = (__u32)(ls.size());  // c++11 std::list::size() is O(1)
+  encode(n, p_bl);
+  for (const auto& ref : ls) {
+    encode(*ref, p_bl, d_bl, features);
   }
 }
 template<class T, class Alloc>
@@ -806,6 +980,19 @@ inline void decode(std::list<std::shared_ptr<T>, Alloc>& ls,
   while (n--) {
     auto ref = std::make_shared<T>();
     decode(*ref, p);
+    ls.emplace_back(std::move(ref));
+  }
+}
+template<class T, class Alloc>
+inline void decode(std::list<std::shared_ptr<T>, Alloc>& ls,
+		   bufferlist::const_iterator& p, bufferlist::const_iterator& d)
+{
+  __u32 n;
+  decode(n, p);
+  ls.clear();
+  while (n--) {
+    auto ref = std::make_shared<T>();
+    decode(*ref, p, d);
     ls.emplace_back(std::move(ref));
   }
 }
@@ -1071,6 +1258,18 @@ inline std::enable_if_t<!t_traits::supported ||
 }
 template<class T, class U, class Comp, class Alloc,
 	 typename t_traits, typename u_traits>
+inline void
+  encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& p_bl, bufferlist& d_bl)
+{
+  __u32 n = (__u32)(m.size());
+  encode(n, p_bl);
+  for (auto p = m.begin(); p != m.end(); ++p) {
+    encode(p->first, p_bl);
+    encode(p->second, p_bl, d_bl);
+  }
+}
+template<class T, class U, class Comp, class Alloc,
+	 typename t_traits, typename u_traits>
 inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
   encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& bl, uint64_t features)
 {
@@ -1079,6 +1278,18 @@ inline std::enable_if_t<!t_traits::supported || !u_traits::supported>
   for (auto p = m.begin(); p != m.end(); ++p) {
     encode(p->first, bl, features);
     encode(p->second, bl, features);
+  }
+}
+template<class T, class U, class Comp, class Alloc,
+	 typename t_traits, typename u_traits>
+inline void
+  encode(const std::map<T,U,Comp,Alloc>& m, bufferlist& p_bl, bufferlist& d_bl, uint64_t features)
+{
+  __u32 n = (__u32)(m.size());
+  encode(n, p_bl);
+  for (auto p = m.begin(); p != m.end(); ++p) {
+    encode(p->first, p_bl, features);
+    encode(p->second, p_bl, d_bl, features);
   }
 }
 template<class T, class U, class Comp, class Alloc,
@@ -1109,6 +1320,20 @@ decode(std::map<T, U, Comp, Alloc>& m, bufferlist::const_iterator& p)
     decode(k, p);
     decode(v, p);
     m.emplace(std::move(k), std::move(v));
+  }
+}
+template<class T, class U, class Comp, class Alloc,
+	 typename t_traits, typename u_traits>
+inline void
+  decode(std::map<T,U,Comp,Alloc>& m, bufferlist::const_iterator& p, bufferlist::const_iterator& d)
+{
+  __u32 n;
+  decode(n, p);
+  m.clear();
+  while (n--) {
+    T k;
+    decode(k, p);
+    decode(m[k], p, d);
   }
 }
 template<class T, class U, class Comp, class Alloc>

--- a/src/messages/MOSDECSubOpReadReply.h
+++ b/src/messages/MOSDECSubOpReadReply.h
@@ -20,7 +20,7 @@
 
 class MOSDECSubOpReadReply : public MOSDFastDispatchOp {
 private:
-  static constexpr int HEAD_VERSION = 2;
+  static constexpr int HEAD_VERSION = 3;
   static constexpr int COMPAT_VERSION = 1;
 
 public:
@@ -29,7 +29,7 @@ public:
   ECSubReadReply op;
 
   int get_cost() const override {
-    return 0;
+    return data.length();
   }
   epoch_t get_map_epoch() const override {
     return map_epoch;
@@ -48,9 +48,14 @@ public:
   void decode_payload() override {
     using ceph::decode;
     auto p = payload.cbegin();
+    auto d = data.cbegin();
     decode(pgid, p);
     decode(map_epoch, p);
-    decode(op, p);
+    if (header.version >= 3) {
+      decode(op, p, d);
+    } else {
+      decode(op, p);
+    }
     if (header.version >= 2) {
       decode(min_epoch, p);
       decode_trace(p);
@@ -63,7 +68,12 @@ public:
     using ceph::encode;
     encode(pgid, payload);
     encode(map_epoch, payload);
-    encode(op, payload);
+    if (!HAVE_FEATURE(features, SERVER_SQUID)) {
+      header.version = 2;
+      encode(op, payload);
+    } else {
+      encode(op, payload, data);
+    }
     encode(min_epoch, payload);
     encode_trace(payload, features);
   }

--- a/src/messages/MOSDRepOp.h
+++ b/src/messages/MOSDRepOp.h
@@ -17,6 +17,7 @@
 #define CEPH_MOSDREPOP_H
 
 #include "MOSDFastDispatchOp.h"
+#include "os/ObjectStore.h"
 
 /*
  * OSD sub op - for internal ops on pobjects between primary and replicas(/stripes/whatever)
@@ -24,7 +25,7 @@
 
 class MOSDRepOp final : public MOSDFastDispatchOp {
 private:
-  static constexpr int HEAD_VERSION = 3;
+  static constexpr int HEAD_VERSION = 4;
   static constexpr int COMPAT_VERSION = 1;
 
 public:
@@ -34,6 +35,7 @@ public:
   osd_reqid_t reqid;
 
   spg_t pgid;
+  ObjectStore::Transaction op_t;
 
   ceph::buffer::list::const_iterator p;
   // Decoding flags. Decoding is only needed for messages caught by pipe reader.
@@ -118,6 +120,14 @@ public:
       eversion_t pg_roll_forward_to;
       decode(pg_roll_forward_to, p);
     }
+
+    auto d = data.cbegin();
+    if (header.version >= 4) {
+      decode(op_t, p, d);
+    }else{
+      decode(op_t, d, d);
+    }
+
     final_decode_needed = false;
   }
 
@@ -142,6 +152,13 @@ public:
     encode(from, payload);
     encode(updated_hit_set_history, payload);
     encode(min_last_complete_ondisk, payload);
+
+    if (!HAVE_FEATURE(features, SERVER_SQUID)) {
+      header.version = 3;
+      encode(op_t, data);
+    } else {
+      encode(op_t, payload, data);
+    }
   }
 
   MOSDRepOp()
@@ -150,12 +167,13 @@ public:
       final_decode_needed(true), acks_wanted (0) {}
   MOSDRepOp(osd_reqid_t r, pg_shard_t from,
 	    spg_t p, const hobject_t& po, int aw,
-	    epoch_t mape, epoch_t min_epoch, ceph_tid_t rtid, eversion_t v)
+	    epoch_t mape, epoch_t min_epoch, ceph_tid_t rtid, eversion_t v, ObjectStore::Transaction& op_t)
     : MOSDFastDispatchOp{MSG_OSD_REPOP, HEAD_VERSION, COMPAT_VERSION},
       map_epoch(mape),
       min_epoch(min_epoch),
       reqid(r),
       pgid(p),
+      op_t(op_t),
       final_decode_needed(false),
       from(from),
       poid(po),
@@ -187,6 +205,10 @@ public:
       }
     }
     out << ")";
+  }
+
+  void clear_buffers() override {
+    op_t = ObjectStore::Transaction();
   }
 private:
   template<class T, typename... Args>

--- a/src/osd/ECMsgTypes.cc
+++ b/src/osd/ECMsgTypes.cc
@@ -24,53 +24,72 @@ using ceph::Formatter;
 
 void ECSubWrite::encode(bufferlist &bl) const
 {
-  ENCODE_START(4, 1, bl);
-  encode(from, bl);
-  encode(tid, bl);
-  encode(reqid, bl);
-  encode(soid, bl);
-  encode(stats, bl);
-  encode(t, bl);
-  encode(at_version, bl);
-  encode(trim_to, bl);
-  encode(log_entries, bl);
-  encode(temp_added, bl);
-  encode(temp_removed, bl);
-  encode(updated_hit_set_history, bl);
-  encode(roll_forward_to, bl);
-  encode(backfill_or_async_recovery, bl);
-  ENCODE_FINISH(bl);
+  encode(bl,bl);
+}
+
+void ECSubWrite::encode(bufferlist &p_bl,bufferlist &d_bl) const
+{
+  uint8_t ver = (&p_bl == &d_bl)?4:5;
+  ENCODE_START(ver, 1, p_bl);
+  encode(from, p_bl);
+  encode(tid, p_bl);
+  encode(reqid, p_bl);
+  encode(soid, p_bl);
+  encode(stats, p_bl);
+  if (ver >= 5) {
+    encode(t, p_bl, d_bl);
+  } else {
+    encode(t, p_bl);
+  }
+  encode(at_version, p_bl);
+  encode(trim_to, p_bl);
+  encode(log_entries, p_bl);
+  encode(temp_added, p_bl);
+  encode(temp_removed, p_bl);
+  encode(updated_hit_set_history, p_bl);
+  encode(roll_forward_to, p_bl);
+  encode(backfill_or_async_recovery, p_bl);
+  ENCODE_FINISH(p_bl);
 }
 
 void ECSubWrite::decode(bufferlist::const_iterator &bl)
 {
-  DECODE_START(4, bl);
-  decode(from, bl);
-  decode(tid, bl);
-  decode(reqid, bl);
-  decode(soid, bl);
-  decode(stats, bl);
-  decode(t, bl);
-  decode(at_version, bl);
-  decode(trim_to, bl);
-  decode(log_entries, bl);
-  decode(temp_added, bl);
-  decode(temp_removed, bl);
+  decode(bl,bl);
+}
+
+void ECSubWrite::decode(bufferlist::const_iterator &p_bl,bufferlist::const_iterator &d_bl)
+{
+  DECODE_START(5, p_bl);
+  decode(from, p_bl);
+  decode(tid, p_bl);
+  decode(reqid, p_bl);
+  decode(soid, p_bl);
+  decode(stats, p_bl);
+  if (struct_v >= 5) {
+    decode(t, p_bl, d_bl);
+  } else {
+    decode(t, p_bl);
+  }
+  decode(at_version, p_bl);
+  decode(trim_to, p_bl);
+  decode(log_entries, p_bl);
+  decode(temp_added, p_bl);
+  decode(temp_removed, p_bl);
   if (struct_v >= 2) {
-    decode(updated_hit_set_history, bl);
+    decode(updated_hit_set_history, p_bl);
   }
   if (struct_v >= 3) {
-    decode(roll_forward_to, bl);
+    decode(roll_forward_to, p_bl);
   } else {
     roll_forward_to = trim_to;
   }
   if (struct_v >= 4) {
-    decode(backfill_or_async_recovery, bl);
+    decode(backfill_or_async_recovery, p_bl);
   } else {
     // The old protocol used an empty transaction to indicate backfill or async_recovery
     backfill_or_async_recovery = t.empty();
   }
-  DECODE_FINISH(bl);
+  DECODE_FINISH(p_bl);
 }
 
 std::ostream &operator<<(
@@ -292,24 +311,43 @@ void ECSubRead::generate_test_instances(list<ECSubRead*>& o)
 
 void ECSubReadReply::encode(bufferlist &bl) const
 {
-  ENCODE_START(1, 1, bl);
-  encode(from, bl);
-  encode(tid, bl);
-  encode(buffers_read, bl);
-  encode(attrs_read, bl);
-  encode(errors, bl);
-  ENCODE_FINISH(bl);
+  encode(bl,bl);
+}
+
+void ECSubReadReply::encode(bufferlist &p_bl,bufferlist &d_bl) const
+{
+  uint8_t ver = (&p_bl == &d_bl)?1:2;
+  ENCODE_START(ver, ver, p_bl);
+  encode(from, p_bl);
+  encode(tid, p_bl);
+  if (ver >= 2) {
+    encode(buffers_read, p_bl, d_bl);
+  } else {
+    encode(buffers_read, p_bl);
+  }
+  encode(attrs_read, p_bl);
+  encode(errors, p_bl);
+  ENCODE_FINISH(p_bl);
 }
 
 void ECSubReadReply::decode(bufferlist::const_iterator &bl)
 {
-  DECODE_START(1, bl);
-  decode(from, bl);
-  decode(tid, bl);
-  decode(buffers_read, bl);
-  decode(attrs_read, bl);
-  decode(errors, bl);
-  DECODE_FINISH(bl);
+  decode(bl,bl);
+}
+
+void ECSubReadReply::decode(bufferlist::const_iterator &p_bl,bufferlist::const_iterator &d_bl)
+{
+  DECODE_START(2, p_bl);
+  decode(from, p_bl);
+  decode(tid, p_bl);
+  if (struct_v < 2) {
+    decode(buffers_read, p_bl);
+  } else {
+    decode(buffers_read, p_bl, d_bl);
+  }
+  decode(attrs_read, p_bl);
+  decode(errors, p_bl);
+  DECODE_FINISH(p_bl);
 }
 
 std::ostream &operator<<(

--- a/src/osd/ECMsgTypes.h
+++ b/src/osd/ECMsgTypes.h
@@ -80,7 +80,9 @@ struct ECSubWrite {
     backfill_or_async_recovery = other.backfill_or_async_recovery;
   }
   void encode(ceph::buffer::list &bl) const;
+  void encode(ceph::buffer::list &bl,ceph::buffer::list &datal) const;
   void decode(ceph::buffer::list::const_iterator &bl);
+  void decode(ceph::buffer::list::const_iterator &bl,ceph::buffer::list::const_iterator &datal);
   void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<ECSubWrite*>& o);
 private:
@@ -88,7 +90,9 @@ private:
   ECSubWrite(ECSubWrite& other);
   const ECSubWrite& operator=(const ECSubWrite& other);
 };
+
 WRITE_CLASS_ENCODER(ECSubWrite)
+WRITE_CLASS_ENCODER_WITH_DATA(ECSubWrite)
 
 struct ECSubWriteReply {
   pg_shard_t from;
@@ -124,11 +128,14 @@ struct ECSubReadReply {
   std::map<hobject_t, std::map<std::string, ceph::buffer::list, std::less<>>> attrs_read;
   std::map<hobject_t, int> errors;
   void encode(ceph::buffer::list &bl) const;
+  void encode(ceph::buffer::list &bl,ceph::buffer::list &datal) const;
   void decode(ceph::buffer::list::const_iterator &bl);
+  void decode(ceph::buffer::list::const_iterator &bl,ceph::buffer::list::const_iterator &datal);
   void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<ECSubReadReply*>& o);
 };
 WRITE_CLASS_ENCODER(ECSubReadReply)
+WRITE_CLASS_ENCODER_WITH_DATA(ECSubReadReply)
 
 std::ostream &operator<<(
   std::ostream &lhs, const ECSubWrite &rhs);

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -404,7 +404,7 @@ private:
     eversion_t last_complete;
     epoch_t epoch_started;
 
-    ObjectStore::Transaction opt, localt;
+    ObjectStore::Transaction localt;
     
     RepModify() : committed(false), ackerosd(-1),
 		  epoch_started(0) {}

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -173,6 +173,7 @@
   usage: rbd bench [--pool <pool>] [--namespace <namespace>] [--image <image>] 
                    [--io-size <io-size>] [--io-threads <io-threads>] 
                    [--io-total <io-total>] [--io-pattern <io-pattern>] 
+                   [--io-start <io-start>] 
                    [--rw-mix-read <rw-mix-read>] --io-type <io-type> 
                    <image-spec> 
   
@@ -190,8 +191,10 @@
     --io-threads arg     ios in flight [default: 16]
     --io-total arg       total size for IO (in B/K/M/G/T) [default: 1G]
     --io-pattern arg     IO pattern (rand, seq, or full-seq) [default: seq]
+    --io-start arg       start offset for seq or full-seq IO [default: 0]
     --rw-mix-read arg    read proportion in readwrite (<= 100) [default: 50]
-    --io-type arg        IO type (read, write, or readwrite(rw))
+    --io-type arg        IO type (read, write, readwrite(rw), write_zeroes or
+                         discard)
   
   rbd help children
   usage: rbd children [--pool <pool>] [--namespace <namespace>] 

--- a/src/test/objectstore/test_transaction.cc
+++ b/src/test/objectstore/test_transaction.cc
@@ -211,3 +211,867 @@ TEST(Transaction, GetNumBytesBenchCurrent)
 {
    bench_num_bytes(false);
 }
+
+/**
+ * create_pattern
+ *
+ * Fill bufferlist generating data from a seed value
+ */
+void create_pattern(bufferlist& bl, unsigned int seed, unsigned int length)
+{
+  ASSERT_TRUE(length%sizeof(int)==0);
+  for (unsigned int i=0;i<length/sizeof(int);i++) {
+    encode(seed, bl);
+    seed=(seed<<1)^seed;
+  }
+}
+
+/**
+ * check_pattern
+ *
+ * Validate bufferlist contents matches seed value
+ */
+void check_pattern(bufferlist& bl, unsigned int seed, unsigned int length)
+{
+  ceph::buffer::list::const_iterator p;
+  ASSERT_TRUE(length%sizeof(int)==0);
+  p = bl.cbegin();
+  for (unsigned int i=0;i<length/sizeof(int);i++) {
+    unsigned int j;
+    decode(j, p);
+    ASSERT_TRUE(j==seed);
+    seed=(seed<<1)^seed;
+  }
+}
+void check_pattern(bufferptr& bptr, unsigned int seed, unsigned int length)
+{
+  bufferlist bl;
+  bl.append(bptr);
+  check_pattern(bl, seed, length);
+}
+
+/**
+ * create_check_transaction1
+ *
+ * Construct/validate an instance of every type of Op in an ObjectStore:Transaction
+ */
+void create_check_transaction1(ObjectStore::Transaction& t, bool create)
+{
+  coll_t c1 = coll_t(spg_t(pg_t(0,111), shard_id_t::NO_SHARD));
+  coll_t c2 = coll_t(spg_t(pg_t(0,111), shard_id_t::NO_SHARD));
+  ghobject_t o1 = ghobject_t(hobject_t(sobject_t("testobject1", CEPH_NOSNAP)));
+  ghobject_t o2 = ghobject_t(hobject_t(sobject_t("testobject2", CEPH_NOSNAP)));
+  bufferlist bl1;
+  bufferlist bl2;
+
+  const unsigned int bl1_seed = 1234;
+  const unsigned int bl1_len = 1024;
+  const unsigned int bl2_seed = 6666;
+  const unsigned int bl2_len = 128;
+
+  create_pattern(bl1, bl1_seed, bl1_len);
+  create_pattern(bl2, bl2_seed, bl2_len);
+
+  ObjectStore::Transaction::iterator i = t.begin();
+  ObjectStore::Transaction::Op *op = nullptr;
+
+  for (int pos = 0; ; ++pos) {
+    if (!create) {
+      ASSERT_TRUE(i.have_op());
+      op = i.decode_op();
+      cout << " Checking pos " << pos << " op " << op->op << std::endl;
+    }
+    switch (pos) {
+    case 0:
+      // NOP
+      if (create) {
+        t.nop();
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_NOP);
+      }
+      break;
+    case 1:
+      // CREATE
+      if (create) {
+        t.create(c1, o1);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_CREATE);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->oid));
+      }
+      break;
+    case 2:
+      // TOUCH
+      if (create) {
+        t.touch(c2, o2);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_TOUCH);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+      }
+      break;
+    case 3:
+      // WRITE
+      if (create) {
+        t.write(c1, o1, 0, bl1_len, bl1);
+      }else{
+        bufferlist bl;
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_WRITE);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->oid));
+        ASSERT_TRUE(op->off == 0);
+        ASSERT_TRUE(op->len == 1024);
+        i.decode_bl(bl);
+	ASSERT_TRUE(bl.length() == op->len);
+        check_pattern(bl, bl1_seed, bl1_len);
+      }
+      break;
+    case 4:
+      // ZERO
+      if (create) {
+        t.zero(c2, o2, 1111, 2222);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_ZERO);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+        ASSERT_TRUE(op->off == 1111);
+        ASSERT_TRUE(op->len == 2222);
+      }
+      break;
+    case 5:
+      // TRUNCATE
+      if (create) {
+        t.truncate(c1, o1, 3333);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_TRUNCATE);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->oid));
+        ASSERT_TRUE(op->off = 3333);
+      }
+      break;
+    case 6:
+      // REMOVE
+      if (create) {
+        t.remove(c2, o2);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_REMOVE);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+      }
+      break;
+    case 7:
+      // SETATTR (1)
+      if (create) {
+        t.setattr(c1, o1, "attr1", bl2);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_SETATTR);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->oid));
+        string name = i.decode_string();
+        bufferptr bp;
+        i.decode_bp(bp);
+        ASSERT_TRUE(name == "attr1");
+	check_pattern(bp, bl2_seed, bl2_len);
+      }
+      break;
+    case 8:
+      // SETATTR (2)
+      if (create) {
+        t.setattr(c2, o2, std::string("attr2"), bl2);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_SETATTR);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+        string name = i.decode_string();
+        bufferptr bp;
+        i.decode_bp(bp);
+        ASSERT_TRUE(name == "attr2");
+	check_pattern(bp, bl2_seed, bl2_len);
+      }
+      break;
+    case 9:
+      // SETATTRS (1)
+      if (create) {
+        map<string,bufferptr,less<>> m;
+        m["a"] = buffer::copy("this", 4);
+        m["b"] = buffer::copy("that", 4);
+        t.setattrs(c1, o1, m);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_SETATTRS);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->oid));
+        map<string, bufferptr> aset;
+        i.decode_attrset(aset);
+	ASSERT_TRUE(aset.size()==2);
+	auto a = aset.find("a");
+	ASSERT_TRUE(a != aset.end());
+	ASSERT_TRUE(!a->second.cmp(buffer::copy("this",4)));
+	auto b = aset.find("b");
+	ASSERT_TRUE(b != aset.end());
+	ASSERT_TRUE(!b->second.cmp(buffer::copy("that",4)));
+      }
+      break;
+    case 10:
+      // SETATTRS (2)
+      if (create) {
+        map<string,bufferlist,less<>> m;
+        bufferlist bflip, bflop;
+        bflip.append(buffer::copy("flip",4));
+        bflop.append(buffer::copy("flop",4));
+        m["a"] = bflip;
+        m["b"] = bflop;
+        t.setattrs(c2, o2, m);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_SETATTRS);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+        map<string, bufferptr> aset;
+        i.decode_attrset(aset);
+	ASSERT_TRUE(aset.size()==2);
+	auto a = aset.find("a");
+	ASSERT_TRUE(a != aset.end());
+	ASSERT_TRUE(!a->second.cmp(buffer::copy("flip",4)));
+	auto b = aset.find("b");
+	ASSERT_TRUE(b != aset.end());
+	ASSERT_TRUE(!b->second.cmp(buffer::copy("flop",4)));
+      }
+      break;
+    case 11:
+      // RMATTR (1)
+      if (create) {
+        t.rmattr(c1, o1, "attr3");
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_RMATTR);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->oid));
+        string name = i.decode_string();
+        ASSERT_TRUE(name == "attr3");
+      }
+      break;
+    case 12:
+      // RMATTR (2)
+      if (create) {
+        t.rmattr(c2, o2, std::string("attr4"));
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_RMATTR);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+        string name = i.decode_string();
+        ASSERT_TRUE(name == "attr4");
+      }
+      break;
+    case 13:
+      // RMATTRS
+      if (create) {
+        t.rmattrs(c1, o1);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_RMATTRS);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->oid));
+      }
+      break;
+    case 14:
+      // CLONE
+      if (create) {
+        t.clone(c2, o2, o1);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_CLONE);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+	ASSERT_TRUE(o1 == i.get_oid(op->dest_oid));
+      }
+      break;
+    case 15:
+      // CLONERANGE2
+      if (create) {
+        t.clone_range(c1, o2, o1, 4444, 5555, 6666);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_CLONERANGE2);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+	ASSERT_TRUE(o1 == i.get_oid(op->dest_oid));
+        ASSERT_TRUE(op->off == 4444);
+        ASSERT_TRUE(op->len == 5555);
+        ASSERT_TRUE(op->dest_off == 6666);
+      }
+      break;
+    case 16:
+      // MKCOLL
+      if (create) {
+        t.create_collection(c2, 7777);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_MKCOLL);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+        ASSERT_TRUE(op->split_bits == 7777);
+      }
+      break;
+    case 17:
+      // COLL_HINT
+      if (create) {
+        t.collection_hint(c1, 8888, bl2);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_COLL_HINT);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+        ASSERT_TRUE(op->hint == 8888);
+        bufferlist bl;
+        i.decode_bl(bl);
+	check_pattern(bl, bl2_seed, bl2_len);
+      }
+      break;
+    case 18:
+      // RMCOLL
+      if (create) {
+        t.remove_collection(c1);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_RMCOLL);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+      }
+      break;
+    case 19:
+      // COLL_MOVE_RENAME
+      if (create) {
+        t.collection_move_rename(c2, o2, c1, o1);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_COLL_MOVE_RENAME);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+        ASSERT_TRUE(c1 == i.get_cid(op->dest_cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->dest_oid));
+      }
+      break;
+    case 20:
+      // TRY_RENAME
+      if (create) {
+        t.try_rename(c2, o2, o1);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_TRY_RENAME);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+	ASSERT_TRUE(o1 == i.get_oid(op->dest_oid));
+      }
+      break;
+    case 21:
+      // OMAP_CLEAR
+      if (create) {
+        t.omap_clear(c1, o1);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_OMAP_CLEAR);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->oid));
+      }
+      break;
+    case 22:
+      // OMAP_SETKEYS (1)
+      if (create) {
+        map<string,bufferlist> m;
+        bufferlist bthis, bthat;
+        bthis.append(buffer::copy("this",4));
+        bthat.append(buffer::copy("that",4));
+        m["a"] = bthis;
+        m["b"] = bthat;
+        t.omap_setkeys(c2, o2, m);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_OMAP_SETKEYS);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+	map<string,bufferlist> aset;
+        i.decode_attrset(aset);
+	ASSERT_TRUE(aset.size()==2);
+	auto a = aset.find("a");
+	ASSERT_TRUE(a != aset.end());
+	ASSERT_TRUE(a->second.contents_equal("this",4));
+	auto b = aset.find("b");
+	ASSERT_TRUE(b != aset.end());
+	ASSERT_TRUE(b->second.contents_equal("that",4));
+      }
+      break;
+    case 23:
+      // OMAP_SETKEYS (2)
+      if (create) {
+        map<string,bufferlist> m;
+        bufferlist bthis, bthat;
+        bthis.append(buffer::copy("this",4));
+        bthat.append(buffer::copy("that",4));
+        m["a"] = bthis;
+        m["b"] = bthat;
+        bufferlist bkeys;
+        encode(m,bkeys);
+        t.omap_setkeys(c1, o1, bkeys);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_OMAP_SETKEYS);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->oid));
+	map<string,bufferlist> aset;
+        i.decode_attrset(aset);
+	ASSERT_TRUE(aset.size()==2);
+	auto a = aset.find("a");
+	ASSERT_TRUE(a != aset.end());
+	ASSERT_TRUE(a->second.contents_equal("this",4));
+	auto b = aset.find("b");
+	ASSERT_TRUE(b != aset.end());
+	ASSERT_TRUE(b->second.contents_equal("that",4));
+      }
+      break;
+    case 24:
+      // OMAP_RMKEYS (1)
+      if (create) {
+        std::set<std::string> keys;
+        keys.insert(std::string("attr7"));
+        t.omap_rmkeys(c2, o2, keys);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_OMAP_RMKEYS);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+	bufferlist keys_bl;
+	i.decode_keyset_bl(&keys_bl);
+        std::set<std::string> keys;
+	decode(keys,keys_bl);
+	ASSERT_TRUE(keys.size() == 1);
+	for(auto& str: keys) {
+	  ASSERT_TRUE(str == "attr7");
+	}
+      }
+      break;
+    case 25:
+      // OMAP_RMKEYS (2)
+      if (create) {
+        t.omap_rmkey(c1, o1, std::string("attr8"));
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_OMAP_RMKEYS);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->oid));
+	bufferlist keys_bl;
+	i.decode_keyset_bl(&keys_bl);
+        std::set<std::string> keys;
+	decode(keys,keys_bl);
+	ASSERT_TRUE(keys.size() == 1);
+	for(auto& str: keys) {
+	  ASSERT_TRUE(str == "attr8");
+	}
+      }
+      break;
+    case 26:
+      // OMAP_RMKEYS (3)
+      if (create) {
+        std::set<std::string> keys;
+        keys.insert(std::string("attr9"));
+        bufferlist bkeys;
+        encode(keys,bkeys);
+        t.omap_rmkeys(c2, o2, bkeys);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_OMAP_RMKEYS);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+	bufferlist keys_bl;
+	i.decode_keyset_bl(&keys_bl);
+        std::set<std::string> keys;
+	decode(keys,keys_bl);
+	ASSERT_TRUE(keys.size() == 1);
+	for(auto& str: keys) {
+	  ASSERT_TRUE(str == "attr9");
+	}
+      }
+      break;
+    case 27:
+      // OMAP_RMKEYRANGE (1)
+      if (create) {
+        t.omap_rmkeyrange(c1, o1, std::string("attr1"), std::string("attr2"));
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_OMAP_RMKEYRANGE);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->oid));
+        string first, last;
+        first = i.decode_string();
+        last = i.decode_string();
+        ASSERT_TRUE(first == "attr1");
+        ASSERT_TRUE(last == "attr2");
+      }
+      break;
+    case 28:
+      // OMAP_RMKEYRANGE (2)
+      if (create) {
+        bufferlist brange;
+        encode(std::string("attr3"),brange);
+        encode(std::string("attr4"),brange);
+        t.omap_rmkeyrange(c2, o2, brange);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_OMAP_RMKEYRANGE);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+	ASSERT_TRUE(o2 == i.get_oid(op->oid));
+        string first, last;
+        first = i.decode_string();
+        last = i.decode_string();
+        ASSERT_TRUE(first == "attr3");
+        ASSERT_TRUE(last == "attr4");
+      }
+      break;
+    case 29:
+      // OMAP_SETHEADER
+      if (create) {
+        t.omap_setheader(c1, o1, bl1);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_OMAP_SETHEADER);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->oid));
+      }
+      break;
+    case 30:
+      // SPLIT_COLLECTION
+      if (create) {
+        t.split_collection(c2, 9999, 1000, c1);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_SPLIT_COLLECTION2);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+        ASSERT_TRUE(c1 == i.get_cid(op->dest_cid));
+        ASSERT_TRUE(op->split_bits == 9999);
+        ASSERT_TRUE(op->split_rem == 1000);
+      }
+      break;
+    case 31:
+      // MERGE_COLLECTION
+      if (create) {
+        t.merge_collection(c2, c1, 1100);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_MERGE_COLLECTION);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+        ASSERT_TRUE(c1 == i.get_cid(op->dest_cid));
+        ASSERT_TRUE(op->split_bits == 1100);
+      }
+      break;
+    case 32:
+      // SET_BITS
+      if (create) {
+        t.collection_set_bits(c2, 1200);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_COLL_SET_BITS);
+        ASSERT_TRUE(c2 == i.get_cid(op->cid));
+        ASSERT_TRUE(op->split_bits == 1200);
+      }
+      break;
+    case 33:
+      // SET_ALLOCHINT
+      if (create) {
+        t.set_alloc_hint(c1, o1, 1300, 1400, 1500);
+      }else{
+        ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_SETALLOCHINT);
+        ASSERT_TRUE(c1 == i.get_cid(op->cid));
+	ASSERT_TRUE(o1 == i.get_oid(op->oid));
+        ASSERT_TRUE(op->expected_object_size == 1300);
+        ASSERT_TRUE(op->expected_write_size == 1400);
+        ASSERT_TRUE(op->hint == 1500);
+      }
+      // Last op
+      if (!create) {
+        ASSERT_TRUE(!i.have_op());
+      }
+      return;
+    }
+  }
+}
+
+void create_transaction1(ObjectStore::Transaction& t)
+{
+  create_check_transaction1(t, true);
+}
+
+void check_content_transaction1(ObjectStore::Transaction& t)
+{
+  create_check_transaction1(t, false);
+}
+
+/**
+ * create_check_transaction2
+ *
+ * Construct/validate write Ops with different lengths and alignements
+ * in an ObejctStore::Transaction
+ */
+void create_check_transaction2(ObjectStore::Transaction& t,bool create)
+{
+  coll_t c = coll_t();
+  ghobject_t o1 = ghobject_t(hobject_t(sobject_t("testobject", CEPH_NOSNAP)));
+
+  bufferlist blshort;
+  bufferlist blpage;
+  bufferlist blfewpages;
+  bufferlist bllong;
+
+  // Less than 1 page
+  const unsigned int blshort_seed = 4567;
+  const unsigned int blshort_len = CEPH_PAGE_SIZE/4;
+  // 1 page
+  const unsigned int blpage_seed = 7654;
+  const unsigned int blpage_len = CEPH_PAGE_SIZE;
+  // Whole number of pages
+  const unsigned int blfewpages_seed = 1357;
+  const unsigned int blfewpages_len = CEPH_PAGE_SIZE*3;
+  // 1.5 pages
+  const unsigned int bllong_seed = 9876;
+  const unsigned int bllong_len = (CEPH_PAGE_SIZE*3)/2;
+
+  create_pattern(blshort,blshort_seed,blshort_len);
+  create_pattern(blpage,blpage_seed,blpage_len);
+  create_pattern(blfewpages,blfewpages_seed,blfewpages_len);
+  create_pattern(bllong,bllong_seed,bllong_len);
+
+  ObjectStore::Transaction::iterator i = t.begin();
+  ObjectStore::Transaction::Op *op = nullptr;
+
+  for (int pos = 0; ; ++pos) {
+    bufferlist bl;
+    if (!create) {
+      ASSERT_TRUE(i.have_op());
+      op = i.decode_op();
+      cout << " Checking pos " << pos << " off " << op->off << " len " << op->len << std::endl;
+      ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_WRITE);
+      i.decode_bl(bl);
+      ASSERT_TRUE(bl.length() == op->len);
+    }
+    switch (pos) {
+    case 0:
+      // Short buffer, PAGE aligned offset
+      if (create) {
+        t.write(c, o1, 0, blshort_len, blshort);
+      }else{
+        ASSERT_TRUE(op->off == 0);
+        ASSERT_TRUE(op->len == blshort_len);
+        check_pattern(bl, blshort_seed, blshort_len);
+      }
+      break;
+    case 1:
+      // Short buffer, straddle PAGE offset
+      if (create) {
+        t.write(c, o1, CEPH_PAGE_SIZE-10, blshort_len, blshort);
+      }else{
+        ASSERT_TRUE(op->off == CEPH_PAGE_SIZE-10);
+        ASSERT_TRUE(op->len == blshort_len);
+        check_pattern(bl, blshort_seed, blshort_len);
+      }
+      break;
+    case 2:
+      // Short buffer, end of buffer PAGE aligned
+      if (create) {
+        t.write(c, o1, CEPH_PAGE_SIZE-blshort_len, blshort_len, blshort);
+      }else{
+        ASSERT_TRUE(op->off == CEPH_PAGE_SIZE-blshort_len);
+        ASSERT_TRUE(op->len == blshort_len);
+        check_pattern(bl, blshort_seed, blshort_len);
+      }
+      break;
+    case 3:
+      // Page buffer, PAGE aligned offset
+      if (create) {
+        t.write(c, o1, CEPH_PAGE_SIZE*3, blpage_len, blpage);
+      }else{
+        ASSERT_TRUE(op->off == CEPH_PAGE_SIZE*3);
+        ASSERT_TRUE(op->len == blpage_len);
+        check_pattern(bl, blpage_seed, blpage_len);
+      }
+      break;
+    case 4:
+      // Page buffer, misaligned offset
+      if (create) {
+        t.write(c, o1, CEPH_PAGE_SIZE-10, blpage_len, blpage);
+      }else{
+        ASSERT_TRUE(op->off == CEPH_PAGE_SIZE-10);
+        ASSERT_TRUE(op->len == blpage_len);
+        check_pattern(bl, blpage_seed, blpage_len);
+      }
+      break;
+    case 5:
+      // Multiple page buffer, PAGE aligned offset
+      if (create) {
+        t.write(c, o1, CEPH_PAGE_SIZE*7, blfewpages_len, blfewpages);
+      }else{
+        ASSERT_TRUE(op->off == CEPH_PAGE_SIZE*7);
+        ASSERT_TRUE(op->len == blfewpages_len);
+        check_pattern(bl, blfewpages_seed, blfewpages_len);
+      }
+      break;
+    case 6:
+      // Multiple page buffer, misaligned offset
+      if (create) {
+        t.write(c, o1, CEPH_PAGE_SIZE-10, blfewpages_len, blfewpages);
+      }else{
+        ASSERT_TRUE(op->off == CEPH_PAGE_SIZE-10);
+        ASSERT_TRUE(op->len == blfewpages_len);
+        check_pattern(bl, blfewpages_seed, blfewpages_len);
+      }
+      break;
+    case 7:
+      // Long buffer, PAGE aligned offset
+      if (create) {
+        t.write(c, o1, 0, bllong_len, bllong);
+      }else{
+        ASSERT_TRUE(op->off == 0);
+        ASSERT_TRUE(op->len == bllong_len);
+        check_pattern(bl, bllong_seed, bllong_len);
+      }
+      break;
+    case 8:
+      // Long buffer, misaligned offset
+      if (create) {
+        t.write(c, o1, CEPH_PAGE_SIZE-10, bllong_len, bllong);
+      }else{
+        ASSERT_TRUE(op->off == CEPH_PAGE_SIZE-10);
+        ASSERT_TRUE(op->len == bllong_len);
+        check_pattern(bl, bllong_seed, bllong_len);
+      }
+      break;
+    case 9:
+      // Long buffer, end of buffer PAGE aligned
+      if (create) {
+        t.write(c, o1, 100*CEPH_PAGE_SIZE-bllong_len, bllong_len, bllong);
+      }else{
+        ASSERT_TRUE(op->off == 100*CEPH_PAGE_SIZE-bllong_len);
+        ASSERT_TRUE(op->len == bllong_len);
+        check_pattern(bl, bllong_seed, bllong_len);
+      }
+      // Last op
+      if (!create) {
+        ASSERT_TRUE(!i.have_op());
+      }
+      return;
+    }
+  }
+}
+
+void create_transaction2(ObjectStore::Transaction& t)
+{
+  create_check_transaction2(t, true);
+}
+
+void check_content_transaction2(ObjectStore::Transaction& t)
+{
+  create_check_transaction2(t, false);
+}
+
+/**
+ * check_alignment_transaction2
+ *
+ * Validate alignment of write Op data buffers in an ObjectStore::Transaction
+ */
+void check_alignment_transaction2(ObjectStore::Transaction& t)
+{
+  ObjectStore::Transaction::iterator i = t.begin();
+  unsigned int longest_aligned = 0;
+  unsigned int longest_misaligned = 0;
+  unsigned int quantity_aligned = 0;
+  unsigned int quantity_misaligned = 0;
+  for (int pos = 0; i.have_op(); ++pos) {
+    ObjectStore::Transaction::Op *op = i.decode_op();
+    ASSERT_TRUE(op->op == ObjectStore::Transaction::OP_WRITE);
+    bufferlist bl;
+    i.decode_bl(bl);
+    auto off = op->off;
+    auto len = bl.length();
+    for (const auto& bptr : bl.buffers()) {
+      cout << " Checking off " << off << " len " << bptr.length() << " ptr " << (void*)bptr.c_str() << std::endl;
+      if (off % CEPH_PAGE_SIZE) {
+        unsigned int align = (0-off) & ~CEPH_PAGE_MASK;
+        if (bptr.length() >= CEPH_PAGE_SIZE+align) {
+	  cout << "  Ideally should have been split" << std::endl;
+	  if (longest_misaligned < bptr.length()-align) {
+	    longest_misaligned = bptr.length()-align;
+	  }
+	}else{
+	  cout << "  OK - Sub PAGE misaligned offset" << std::endl;
+	}
+	quantity_misaligned += bptr.length();
+      }else{
+	if (bptr.length() >= CEPH_PAGE_SIZE) {
+	  if (!bptr.is_aligned(CEPH_PAGE_SIZE)) {
+	    cout << "  Ideally should have been aligned" << std::endl;
+            if (longest_misaligned < bptr.length()) {
+              longest_misaligned = bptr.length();
+	    }
+            quantity_misaligned += bptr.length();
+	  }else{
+	    cout << "  Good alignment" << std::endl;
+            if (longest_aligned < bptr.length()) {
+              longest_aligned = bptr.length();
+	    }
+            quantity_aligned += bptr.length();
+	  }
+	}else{
+	  cout << "  OK - Sub PAGE aligned offset" << std::endl;
+          quantity_misaligned += bptr.length();
+	}
+      }
+      off = off + bptr.length();
+      len = len - bptr.length();
+    }
+  }
+  ASSERT_TRUE(longest_aligned>=longest_misaligned);
+  cout << " Longest segment is aligned" << std::endl;
+  cout << " Bytes aligned "<< quantity_aligned << " Bytes misaligned " << quantity_misaligned << std::endl;
+}
+
+TEST(Transaction, EncodeDecode)
+{
+  ObjectStore::Transaction source;
+  bufferlist encoded1;
+  bufferlist encoded2p;
+  bufferlist encoded2d;
+  ObjectStore::Transaction decode1;
+  ObjectStore::Transaction decode2;
+  ceph::buffer::list::const_iterator p;
+  ceph::buffer::list::const_iterator d;
+
+  cout << "Creating transaction1" << std::endl;
+  create_transaction1(source);
+  cout << "Checking transaction1" << std::endl;
+  check_content_transaction1(source);
+
+  encode(source, encoded1);
+  p = encoded1.cbegin();
+  decode(decode1, p);
+  cout << "Checking encoded/decoded with 1 buffer transaction1" << std::endl;
+  check_content_transaction1(decode1);
+  encode(source, encoded2p, encoded2d);
+  p = encoded2p.cbegin();
+  d = encoded2d.cbegin();
+  decode(decode2, p, d);
+  cout << "Checking encoded/decoded with 2 buffers transaction1" << std::endl;
+  check_content_transaction1(decode2);
+}
+
+TEST(Transaction, WriteBufferAlignment)
+{
+  ObjectStore::Transaction source;
+  bufferlist encoded1;
+  bufferlist encoded2p;
+  bufferlist encoded2d;
+  ObjectStore::Transaction decode1;
+  ObjectStore::Transaction decode2;
+  ObjectStore::Transaction decode3;
+  ceph::buffer::list::const_iterator p;
+  ceph::buffer::list::const_iterator d;
+
+  cout << "Creating transaction2" << std::endl;
+  create_transaction2(source);
+  cout << "Checking transaction2" << std::endl;
+  check_content_transaction2(source);
+  encode(source, encoded1);
+  p = encoded1.cbegin();
+  decode(decode1, p);
+  cout << "Checking encoded/decoded with 1 buffer transaction2" << std::endl;
+  check_content_transaction2(decode1);
+
+  encode(source, encoded2p, encoded2d);
+  p = encoded2p.cbegin();
+  d = encoded2d.cbegin();
+  decode(decode2, p, d);
+  cout << "Checking encoded/decoded with 2 buffers transaction2" << std::endl;
+  check_content_transaction2(decode2);
+
+  ceph::buffer::list alignedbuf;
+  ceph::bufferptr ptr(ceph::buffer::create_aligned(encoded2d.length(), CEPH_PAGE_SIZE));
+
+  alignedbuf.push_back(ptr);
+  encoded2d.begin().copy(encoded2d.length(), ptr.c_str());
+  p = encoded2p.cbegin();
+  d = alignedbuf.cbegin();
+  decode(decode3, p, d);
+  cout << "Checking alignment of transaction2" << std::endl;
+  check_alignment_transaction2(decode3);
+}


### PR DESCRIPTION
Align write data in Objectstore::Transaction encoded buffers so that RepOp and ECSubOpWrite messages align data on the receiving OSD to avoid a later memmove.  Also fix ECSubOpReadReply messages in a similar way so that read data is aligned on the receiving OSD.

Version 1 - Minimal change, fixes alignment for RepOp and ECSubOpReadReply. ECSubOpWrite is only partially fixed - it splits long writes into multiple stripes, only the longest write will be aligned.

## More detail

Profiling showed that bluestore was spending a lot of time realigning data buffers for write I/Os. The flamegraph below (64K sequential writes to a 2+2 erasure code pool) has a plateau on the right where memmove is being used to realign buffers. In this profile 8% CPU time was spent realigning data.

![Screenshot 2024-05-28 at 08 12 13](https://github.com/ceph/ceph/assets/156200352/32ad42a2-98ec-4006-9106-1bdc6bc32ae4)

Investigation found:

1. Client to OSD messages will usually keep page aligned writes to RADOS objects in page aligned buffers - so nothing needs fixing here
2. Inter-OSD messages for Erasure Code pools have never tried to align data buffers to avoid memcpy’s
3. Inter-OSD messages for Replicated pools try to get the data buffer aligned on the receiving OSD using data_off field in the Message header, however this is ignored by ProtocolV2 and newer so has been broken for some time

Trying to fix ProtocolV2 is problematic, especially when considering newer features such as compression and encryption for data in flight (which benefit from page aligning the start of the buffer), this is probably why the data offset feature wasn’t implemented.

This pull request implements a new technique for ensuring that the majority of data is aligned (performance optimizations don’t have to be perfect - if 99% of the data is aligned you get 99% of the performance benefit). Instead of encoding/decoding a data structure such as ObjectStore::Transaction into a single buffer, a new style encode/decode interface is implemented which encodes/decodes data into a pair of buffers - the payload buffer is used for data structures, strings, etc. the second buffer is used only for data. Aligned data is placed in the data buffer first, followed by any misaligned data. Decoding uses information in the payload buffer to work out how to reassemble the data. Messages between Ceph clients/daemons already have a payload buffer and a data buffer and already guarantee that the data buffer will be page aligned on the receiver so its easy to use these two buffers with the new encode/decode methods. Long write buffers at misaligned offsets can even be efficiently encoded by splitting the data into three fragments - a misaligned prefix and suffix and an aligned middle part.

Backwards compatibility is a concern and therefore it must be possible to encode/decode objects in both a new style format using two buffers and an old style format that is backwards compatible with older code.

This is version 1 of the pull request - the merits of this version is a minimal set of changes, the changes to ObjectStore::Transaction are contained to the encoding/decoding functions. Only the largest data buffer in the transaction will be aligned (using the existing code in Transaction.h that tracks this). This is inconsequential for Replicated pools as most transactions will only have one data buffer. It is a problem for Erasure coded pools where long writes get broken into a series of chunk sized writes (defaults to 4K) in the transaction and will be encoded as <4 byte length><chunk of data><4 byte length><chunk of data>… so only one chunk will be properly aligned.

The decode function will create the same transaction regardless of whether an old or new style encoding was used, the only difference being the buffer fragments and their alignment in the data buffer list. As only the encode/decode functions are modified there is no changes needed to the iterator or other operations on transactions such as appends.

New unit tests are added to fully exercise building, encoding and decoding ObjectStore transactions and to validate the improvement in aligning buffers. The rbd bench utility is extended with extra options to provide more flexibility in generating I/O requests.  The RepOp, ECSubWriteOp and ECSubReadReplyOp messages have been modified to align the write data buffers they send. Manual testing has confirmed that these buffers are correctly page aligned on the receiving OSD.

 The performance benchmark ceph_perf_objectstore was run on old and new code and shows negligible difference in performance for the typical set of operations performed on ObjectStore::Transaction’s.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
