### PR TITLE
squid: mgr/dashboard: fix readonly landingpage

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/health.py
+++ b/src/pybind/mgr/dashboard/controllers/health.py
@@ -300,3 +300,7 @@ class Health(BaseController):
     @Endpoint()
     def get_cluster_fsid(self):
         return mgr.get('config')['fsid']
+
+    @Endpoint()
+    def get_telemetry_status(self):
+        return mgr.get_module_option_ex('telemetry', 'enabled', False)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.ts
@@ -22,7 +22,6 @@ import { SummaryService } from '~/app/shared/services/summary.service';
 import { PrometheusListHelper } from '~/app/shared/helpers/prometheus-list-helper';
 import { PrometheusAlertService } from '~/app/shared/services/prometheus-alert.service';
 import { OrchestratorService } from '~/app/shared/api/orchestrator.service';
-import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 import { AlertClass } from '~/app/shared/enum/health-icon.enum';
 
 @Component({
@@ -78,7 +77,6 @@ export class DashboardV3Component extends PrometheusListHelper implements OnInit
     private featureToggles: FeatureTogglesService,
     private healthService: HealthService,
     public prometheusService: PrometheusService,
-    private mgrModuleService: MgrModuleService,
     private refreshIntervalService: RefreshIntervalService,
     public prometheusAlertService: PrometheusAlertService
   ) {
@@ -155,8 +153,8 @@ export class DashboardV3Component extends PrometheusListHelper implements OnInit
   }
 
   private getTelemetryReport() {
-    this.mgrModuleService.getConfig('telemetry').subscribe((resp: any) => {
-      this.telemetryEnabled = resp?.enabled;
+    this.healthService.getTelemetryStatus().subscribe((enabled: boolean) => {
+      this.telemetryEnabled = enabled;
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/health.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/health.service.ts
@@ -26,4 +26,8 @@ export class HealthService {
   getOrchestratorName() {
     return this.http.get('api/health/get_orchestrator_name');
   }
+
+  getTelemetryStatus() {
+    return this.http.get('api/health/get_telemetry_status');
+  }
 }

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -4838,6 +4838,28 @@ paths:
       - jwt: []
       tags:
       - Health
+  /api/health/get_telemetry_status:
+    get:
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - Health
   /api/health/minimal:
     get:
       parameters: []


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66247

Conflicts:
	mgr/dashboard/frontend/src/app/core/layouts/workbench-layout/workbench-layout.component.ts
	mgr/dashboard/frontend/src/app/ceph/dashboard-v3/dashboard/dashboard-v3.component.ts
- Hardware status and multi-cluster features are not included in squid, therefore this only affects the telemetry status

---

backport of https://github.com/ceph/ceph/pull/57070
parent tracker: https://tracker.ceph.com/issues/65643

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh