### PR TITLE
quincy: doc/developer_guide: update doc about installing teuthology

### DIFF
--- a/doc/dev/developer_guide/running-tests-locally.rst
+++ b/doc/dev/developer_guide/running-tests-locally.rst
@@ -52,10 +52,33 @@ Running your first test
 The Python tests in Ceph repository can be executed on your local machine
 using `vstart_runner.py`_. To do that, you'd need `teuthology`_ installed::
 
+    $ git clone https://github.com/ceph/teuthology
+    $ cd teuthology
+    $ ./bootstrap install
+
+This will create a virtual environment named ``virtualenv`` in root of the
+teuthology repository and install teuthology in it.
+
+You can also install teuthology via ``pip`` if you would like to install it
+in a custom virtual environment with clone `teuthology`_ repository using
+``git``::
+
     $ virtualenv --python=python3 venv
     $ source venv/bin/activate
     $ pip install 'setuptools >= 12'
     $ pip install teuthology[test]@git+https://github.com/ceph/teuthology
+    $ deactivate
+
+If for some unforeseen reason above approaches do no work (maybe boostrap
+script doesn't work due to a bug or you can't download tethology at the
+moment) teuthology can be installed manually manually from copy of
+teuthology repo already present on your machine::
+
+    $ cd teuthology
+    $ virtualenv -p python3 venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    $ pip install .
     $ deactivate
 
 The above steps installs teuthology in a virtual environment. Before running


### PR DESCRIPTION
There are 2 more ways to install teuthology. Approach with boostrap script is easier and more convenient while other approach is more elaborate but manual, document both of them. Don't delete the currently documented approach because it lets users install teuthology conveniently in a custom virtual environment. So, keep all three.

Signed-off-by: Rishabh Dave <ridave@redhat.com>
(cherry picked from commit 899c481d4006a1231354de6633fd2806aa4bd5d2)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
