### PR TITLE
quincy: qa/suites/rbd: override extra_system_packages directly on install task

### DIFF
--- a/qa/suites/rbd/basic/tasks/rbd_python_api_tests_old_format.yaml
+++ b/qa/suites/rbd/basic/tasks/rbd_python_api_tests_old_format.yaml
@@ -4,8 +4,7 @@ overrides:
       - \(SLOW_OPS\)
       - slow request
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:

--- a/qa/suites/rbd/device/workloads/diff-continuous-krbd.yaml
+++ b/qa/suites/rbd/device/workloads/diff-continuous-krbd.yaml
@@ -1,8 +1,7 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
-        - pv
+    extra_system_packages:
+      - pv
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/device/workloads/diff-continuous-nbd.yaml
+++ b/qa/suites/rbd/device/workloads/diff-continuous-nbd.yaml
@@ -3,8 +3,8 @@ overrides:
     ceph:
       extra_packages:
         - rbd-nbd
-      extra_system_packages:
-        - pv
+    extra_system_packages:
+      - pv
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/librbd/workloads/python_api_tests.yaml
+++ b/qa/suites/rbd/librbd/workloads/python_api_tests.yaml
@@ -1,7 +1,6 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:

--- a/qa/suites/rbd/librbd/workloads/python_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/librbd/workloads/python_api_tests_with_defaults.yaml
@@ -1,7 +1,6 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:

--- a/qa/suites/rbd/librbd/workloads/python_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/librbd/workloads/python_api_tests_with_journaling.yaml
@@ -1,7 +1,6 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:

--- a/qa/suites/rbd/mirror/workloads/compare-mirror-image-alternate-primary-krbd.yaml
+++ b/qa/suites/rbd/mirror/workloads/compare-mirror-image-alternate-primary-krbd.yaml
@@ -1,8 +1,7 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
-        - pv
+    extra_system_packages:
+      - pv
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/mirror/workloads/compare-mirror-image-alternate-primary-nbd.yaml
+++ b/qa/suites/rbd/mirror/workloads/compare-mirror-image-alternate-primary-nbd.yaml
@@ -3,8 +3,8 @@ overrides:
     ceph:
       extra_packages:
         - rbd-nbd
-      extra_system_packages:
-        - pv
+    extra_system_packages:
+      - pv
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/mirror/workloads/compare-mirror-images-krbd.yaml
+++ b/qa/suites/rbd/mirror/workloads/compare-mirror-images-krbd.yaml
@@ -1,8 +1,7 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
-        - pv
+    extra_system_packages:
+      - pv
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/mirror/workloads/compare-mirror-images-nbd.yaml
+++ b/qa/suites/rbd/mirror/workloads/compare-mirror-images-nbd.yaml
@@ -3,8 +3,8 @@ overrides:
     ceph:
       extra_packages:
         - rbd-nbd
-      extra_system_packages:
-        - pv
+    extra_system_packages:
+      - pv
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests.yaml
@@ -1,7 +1,6 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests_with_defaults.yaml
@@ -1,7 +1,6 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests_with_journaling.yaml
@@ -1,7 +1,6 @@
 overrides:
   install:
-    ceph:
-      extra_system_packages:
+    extra_system_packages:
       - python3-pytest
 tasks:
 - workunit:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66264

---

backport of https://github.com/ceph/ceph/pull/57729
parent tracker: https://tracker.ceph.com/issues/66232