### PR TITLE
squid: mgr/pybind/object_format: fix json-pretty being marked invalid

### DIFF
--- a/src/pybind/mgr/object_format.py
+++ b/src/pybind/mgr/object_format.py
@@ -533,9 +533,9 @@ class Responder:
         formatter = self._formatter(obj)
         if format_req is None:
             format_req = self.default_format
-        if format_req not in formatter.valid_formats():
-            raise UnknownFormat(format_req)
         req = str(format_req).replace("-", "_")
+        if req not in formatter.valid_formats():
+            raise UnknownFormat(format_req)
         ffunc = getattr(formatter, f"format_{req}", None)
         if ffunc is None:
             raise UnsupportedFormat(format_req)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65948

---

backport of https://github.com/ceph/ceph/pull/56963
parent tracker: https://tracker.ceph.com/issues/65554

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh