### PR TITLE
squid: qa/tasks/cephadm: fix pulling containers from private registries

### DIFF
--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -316,28 +316,8 @@ def _fetch_cephadm_from_chachra(ctx, config, cluster_name):
             sha1=sha1,
     )
     log.info("Discovered cachra url: %s", url)
-    ctx.cluster.run(
-        args=[
-            'curl', '--silent', '-L', url,
-            run.Raw('>'),
-            ctx.cephadm,
-            run.Raw('&&'),
-            'ls', '-l',
-            ctx.cephadm,
-        ],
-    )
+    _download_cephadm(ctx, url)
 
-    # sanity-check the resulting file and set executable bit
-    cephadm_file_size = '$(stat -c%s {})'.format(ctx.cephadm)
-    ctx.cluster.run(
-        args=[
-            'test', '-s', ctx.cephadm,
-            run.Raw('&&'),
-            'test', run.Raw(cephadm_file_size), "-gt", run.Raw('1000'),
-            run.Raw('&&'),
-            'chmod', '+x', ctx.cephadm,
-        ],
-    )
 
 def _fetch_stable_branch_cephadm_from_chacra(ctx, config, cluster_name):
     branch = config.get('compiled_cephadm_branch', 'reef')
@@ -365,6 +345,11 @@ def _fetch_stable_branch_cephadm_from_chacra(ctx, config, cluster_name):
             branch=branch,
     )
     log.info("Discovered cachra url: %s", url)
+    _download_cephadm(ctx, url)
+
+
+def _download_cephadm(ctx, url):
+    log.info("Downloading cephadm from url: %s", url)
     ctx.cluster.run(
         args=[
             'curl', '--silent', '-L', url,

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -208,7 +208,10 @@ def normalize_hostnames(ctx):
 def download_cephadm(ctx, config, ref):
     cluster_name = config['cluster']
 
-    if config.get('cephadm_mode') != 'cephadm-package':
+    if 'cephadm_binary_url' in config:
+        url = config['cephadm_binary_url']
+        _download_cephadm(ctx, url)
+    elif config.get('cephadm_mode') != 'cephadm-package':
         if ctx.config.get('redhat'):
             _fetch_cephadm_from_rpm(ctx)
         # TODO: come up with a sensible way to detect if we need an "old, uncompiled"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65953

---

backport of https://github.com/ceph/ceph/pull/57080
parent tracker: https://tracker.ceph.com/issues/65398

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh