### PR TITLE
squid: mgr/cephadm: make setting --cgroups=split configurable for adopted daemons

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -5014,6 +5014,11 @@ def _get_parser():
         action='store_true',
         default=CONTAINER_INIT,
         help=argparse.SUPPRESS)
+    parser_adopt.add_argument(
+        '--no-cgroups-split',
+        action='store_true',
+        default=False,
+        help='Do not run containers with --cgroups=split (currently only relevant when using podman)')
 
     parser_rm_daemon = subparsers.add_parser(
         'rm-daemon', help='remove daemon instance')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65968

---

backport of https://github.com/ceph/ceph/pull/57205
parent tracker: https://tracker.ceph.com/issues/65739

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh