### PR TITLE
squid: inf and NaN are invalid in JSON

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -287,7 +287,18 @@ void JSONFormatter::finish_pending_string()
   }
 }
 
-template <class T>
+void JSONFormatter::add_value(std::string_view name, double val) {
+  std::stringstream ss;
+  if (std::isinf(val) || std::isnan(val)) {
+    ss << "null";
+  } else {
+    ss.precision(std::numeric_limits<double>::max_digits10);
+    ss << val;
+  }
+  add_value(name, ss.str(), false);
+}
+
+template <typename T>
 void JSONFormatter::add_value(std::string_view name, T val)
 {
   std::stringstream ss;

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -232,8 +232,9 @@ namespace ceph {
     void print_name(std::string_view name);
     void print_comma(json_formatter_stack_entry_d& entry);
     void finish_pending_string();
+    void add_value(std::string_view name, double val);
 
-    template <class T>
+    template <typename T>
     void add_value(std::string_view name, T val);
     void add_value(std::string_view name, std::string_view val, bool quoted);
 

--- a/src/test/common/test_json_formatter.cc
+++ b/src/test/common/test_json_formatter.cc
@@ -79,3 +79,22 @@ TEST(formatter, utime)
   EXPECT_EQ(input.sec(), output.sec());
   EXPECT_EQ(input.nsec(), output.nsec());
 }
+
+TEST(formatter, dump_inf_or_nan)
+{
+  JSONFormatter formatter;
+  formatter.open_object_section("inf_and_nan");
+  double inf = std::numeric_limits<double>::infinity();
+  formatter.dump_float("positive_infinity", inf);
+  formatter.dump_float("negative_infinity", -inf);
+  formatter.dump_float("nan_val", std::numeric_limits<double>::quiet_NaN());
+  formatter.dump_float("nan_val_alt", std::nan(""));
+  formatter.dump_float("double_max", std::numeric_limits<double>::max());
+  formatter.dump_float("double_min", std::numeric_limits<double>::min());
+  formatter.close_section();
+  bufferlist bl;
+  formatter.flush(bl);
+  JSONParser parser;
+  cout << std::string(bl.c_str(), bl.length()) << endl;
+  EXPECT_TRUE(parser.parse(bl.c_str(), bl.length()));
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66290

--------
backport of #57695
parent tracker: https://tracker.ceph.com/issues/66215
