### PR TITLE
crimson/os/seastore: add fine-grained cache

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -105,8 +105,8 @@ options:
 - name: seastore_max_data_allocation_size
   type: size
   level: advanced
-  desc: Max size in bytes that an extent can be
-  default: 32_K
+  desc: Max size in bytes that an extent can be, 0 to disable
+  default: 0
 - name: seastore_cache_lru_size
   type: size
   level: advanced

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1700,6 +1700,7 @@ private:
     assert(extent->state == CachedExtent::extent_state_t::CLEAN_PENDING ||
       extent->state == CachedExtent::extent_state_t::EXIST_CLEAN ||
       extent->state == CachedExtent::extent_state_t::CLEAN);
+    /// TODO: add fine-grained io check to support concurrent read
     extent->set_io_wait();
     region_list_t regions;
     if (extent->is_fully_loaded()) {

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -411,7 +411,10 @@ public:
       for (auto &ext : addrs) {
         auto left = ext.len;
         while (left > 0) {
-          auto len = std::min(max_data_allocation_size, left);
+          auto len = left;
+          if (max_data_allocation_size) {
+            len = std::min(max_data_allocation_size, len);
+          }
           auto bp = ceph::bufferptr(buffer::create_page_aligned(len));
           bp.zero();
           auto start = ext.start.is_delayed()

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -1535,9 +1535,12 @@ ObjectDataHandler::read_ret ObjectDataHandler::read(
               e_off = 0;
             }
             extent_len_t e_current_off = e_off + l_current - pin_key;
+            extent_len_t e_current_len = l_current_end - l_current;
             return ctx.tm.read_pin<ObjectDataBlock>(
               ctx.t,
-              std::move(pin)
+              std::move(pin),
+              e_current_off,
+              e_current_len
             ).si_then([&ret, &l_current, l_current_end,
 #ifndef NDEBUG
                        e_key, e_len, e_current_off](auto extent) {
@@ -1547,8 +1550,7 @@ ObjectDataHandler::read_ret ObjectDataHandler::read(
               assert(e_key == extent->get_laddr());
               assert(e_len == extent->get_length());
               ret.append(
-                bufferptr(
-                  extent->get_bptr(),
+                extent->get_range(
                   e_current_off,
                   l_current_end - l_current));
               l_current = l_current_end;

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -525,6 +525,7 @@ public:
 	      ? (ext && ext->is_fully_loaded())
 	      : true);
 	  std::optional<ceph::bufferptr> original_bptr;
+          // TODO: preserve the partially loaded buffer during remapping
 	  if (ext && ext->is_fully_loaded()) {
 	    ceph_assert(!ext->is_mutable());
 	    ceph_assert(ext->get_length() >= original_len);

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -858,6 +858,31 @@ TEST_P(object_data_handler_test_t, overwrite_then_read_within_transaction) {
   });
 }
 
+TEST_P(object_data_handler_test_t, parallel_partial_read) {
+  run_async([this] {
+    disable_max_extent_size();
+    enable_delta_based_overwrite();
+    auto t = create_mutate_transaction();
+    auto base = 0;
+    auto len = 4096 * 10;
+    write(*t, base, len, 'a');
+    submit_transaction(std::move(t));
+
+    restart();
+    epm->check_usage();
+    seastar::parallel_for_each(
+      boost::make_counting_iterator(0lu),
+      boost::make_counting_iterator(8lu),
+      [&](auto i) {
+        return seastar::async([&] {
+          read(i * 4096, 8192);
+        });
+      }).get0();
+    disable_delta_based_overwrite();
+    enable_max_extent_size();
+  });
+}
+
 INSTANTIATE_TEST_SUITE_P(
   object_data_handler_test,
   object_data_handler_test_t,


### PR DESCRIPTION
The fine-grained cache is introduced to improve the performance and reduce read amplification when reading small chunks of data from large extents. 
Overall, we add a structure named "BufferSpace" to control the small buffers in CachedExtent so that it can load the exact required data from disk. Now the ObjectDataBlock can be incomplete. Some paths are modified to adapt to this change.
Currently, we don't calculate the crc while the extent is not fully loaded.
This is a refreshed version of [PR50421](https://github.com/ceph/ceph/pull/50421).


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
