### PR TITLE
mgr/dashboard: Configure NVMe/TCP

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -75,7 +75,7 @@
                       i18n>Loading...</option>
               <option *ngIf="pools !== null && pools.length === 0"
                       [ngValue]="null"
-                      i18n>-- No rbd pools available --</option>
+                      i18n>-- No block pools available --</option>
               <option *ngIf="pools !== null && pools.length > 0"
                       [ngValue]="null"
                       i18n>-- Select a pool --</option>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -15,6 +15,7 @@
              (click)="createMultisiteSetup()">
              Click here</a> to create a new Realm/Zone Group/Zone
         </cd-alert-panel>
+
         <!-- Service type -->
         <div class="form-group row">
           <label class="cd-col-form-label required"
@@ -25,7 +26,7 @@
                     name="service_type"
                     class="form-select"
                     formControlName="service_type"
-                    (change)="getServiceIds($event.target.value)">
+                    (change)="onServiceTypeChange($event.target.value)">
               <option i18n
                       [ngValue]="null">-- Select a service type --</option>
               <option *ngFor="let serviceType of serviceTypes"
@@ -40,50 +41,90 @@
         </div>
 
         <!-- backend_service -->
-          <div *ngIf="serviceForm.controls.service_type.value === 'ingress'"
-               class="form-group row">
-            <label i18n
-                   class="cd-col-form-label"
-                   [ngClass]="{'required': ['ingress'].includes(serviceForm.controls.service_type.value)}"
-                   for="backend_service">Backend Service</label>
-            <div class="cd-col-form-input">
-              <select id="backend_service"
-                      name="backend_service"
-                      class="form-select"
-                      formControlName="backend_service"
-                      (change)="prePopulateId()">
-                <option *ngIf="services === null"
-                        [ngValue]="null"
-                        i18n>Loading...</option>
-                <option *ngIf="services !== null && services.length === 0"
-                        [ngValue]="null"
-                        i18n>-- No service available --</option>
-                <option *ngIf="services !== null && services.length > 0"
-                        [ngValue]="null"
-                        i18n>-- Select an existing service --</option>
-                <option *ngFor="let service of services"
-                        [value]="service.service_name">{{ service.service_name }}</option>
-              </select>
-              <span class="invalid-feedback"
-                    *ngIf="serviceForm.showError('backend_service', frm, 'required')"
-                    i18n>This field is required.</span>
-            </div>
+        <div *ngIf="serviceForm.controls.service_type.value === 'ingress'"
+             class="form-group row">
+          <label i18n
+                 class="cd-col-form-label"
+                 [ngClass]="{'required': ['ingress'].includes(serviceForm.controls.service_type.value)}"
+                 for="backend_service">Backend Service</label>
+          <div class="cd-col-form-input">
+            <select id="backend_service"
+                    name="backend_service"
+                    class="form-select"
+                    formControlName="backend_service"
+                    (change)="prePopulateId()">
+              <option *ngIf="services === null"
+                      [ngValue]="null"
+                      i18n>Loading...</option>
+              <option *ngIf="services !== null && services.length === 0"
+                      [ngValue]="null"
+                      i18n>-- No service available --</option>
+              <option *ngIf="services !== null && services.length > 0"
+                      [ngValue]="null"
+                      i18n>-- Select an existing service --</option>
+              <option *ngFor="let service of services"
+                      [value]="service.service_name">{{ service.service_name }}</option>
+            </select>
+            <span class="invalid-feedback"
+                  *ngIf="serviceForm.showError('backend_service', frm, 'required')"
+                  i18n>This field is required.</span>
           </div>
+        </div>
+
+        <!-- NVMe/TCP -->
+        <!-- Block Pool -->
+        <div class="form-group row"
+             *ngIf="serviceForm.controls.service_type.value === 'nvmeof'">
+          <label i18n
+                 class="cd-col-form-label required"
+                 for="pool">Block Pool</label>
+          <div class="cd-col-form-input">
+            <select id="pool"
+                    name="pool"
+                    class="form-select"
+                    formControlName="pool"
+                    (change)="onBlockPoolChange()">
+              <option *ngIf="rbdPools === null"
+                      [ngValue]="null"
+                      i18n>Loading...</option>
+              <option *ngIf="rbdPools && rbdPools.length === 0"
+                      [ngValue]="null"
+                      i18n>-- No block pools available --</option>
+              <option *ngIf="rbdPools && rbdPools.length > 0"
+                      [ngValue]="null"
+                      i18n>-- Select a pool --</option>
+              <option *ngFor="let pool of rbdPools"
+                      [value]="pool.pool_name">{{ pool.pool_name }}</option>
+            </select>
+            <cd-help-text i18n>
+              A pool in which the gateway configuration can be managed.
+            </cd-help-text>
+            <span class="invalid-feedback"
+                  *ngIf="serviceForm.showError('pool', frm, 'required')"
+                  i18n>This field is required.</span>
+          </div>
+        </div>
 
         <!-- Service id -->
         <div class="form-group row"
              *ngIf="serviceForm.controls.service_type.value !== 'snmp-gateway'">
           <label class="cd-col-form-label"
-                 [ngClass]="{'required': ['mds', 'rgw', 'nfs', 'iscsi', 'smb', 'ingress'].includes(serviceForm.controls.service_type.value)}"
+                 [ngClass]="{'required': ['mds', 'rgw', 'nfs', 'iscsi', 'nvmeof', 'smb', 'ingress'].includes(serviceForm.controls.service_type.value)}"
                  for="service_id">
-            <span i18n>Id</span>
-            <cd-helper i18n>Used in the service name which is &lt;service_type.service_id&gt;</cd-helper>
+            <span i18n>Service Name</span>
           </label>
           <div class="cd-col-form-input">
-            <input id="service_id"
-                   class="form-control"
-                   type="text"
-                   formControlName="service_id">
+            <div class="input-group">
+              <span class="input-group-text"
+                    *ngIf="serviceForm.controls.service_type.value && ['mds', 'rgw', 'nfs', 'iscsi', 'nvmeof', 'smb', 'ingress'].includes(serviceForm.controls.service_type.value)"
+                    for="userId"
+                    i18n>{{serviceForm.controls.service_type.value}}.
+              </span>
+              <input id="service_id"
+                     class="form-control"
+                     type="text"
+                     formControlName="service_id">
+            </div>
             <span class="invalid-feedback"
                   *ngIf="serviceForm.showError('service_id', frm, 'required')"
                   i18n>This field is required.</span>
@@ -164,11 +205,10 @@
                      id="unmanaged"
                      type="checkbox"
                      formControlName="unmanaged">
-              <label class="custom-control-label"
+              <label class="custom-control-label m-0"
                      for="unmanaged"
                      i18n>Unmanaged</label>
-              <cd-helper i18n>If set to true, the orchestrator will not start nor stop any daemon associated with this service.
-                 Placement and all other properties will be ignored.</cd-helper>
+              <cd-help-text i18n>If Unmanaged is selected, the orchestrator will not stop or stop any daemons associated with this service. Placement and all other properties will be ignored.</cd-help-text>
             </div>
           </div>
         </div>
@@ -226,13 +266,12 @@
           </div>
         </div>
 
-        <!-- count -->
+        <!-- Count -->
         <div *ngIf="!serviceForm.controls.unmanaged.value"
              class="form-group row">
           <label class="cd-col-form-label"
                  for="count">
             <span i18n>Count</span>
-            <cd-helper i18n>Only that number of daemons will be created.</cd-helper>
           </label>
           <div class="cd-col-form-input">
             <input id="count"
@@ -240,6 +279,7 @@
                    type="number"
                    formControlName="count"
                    min="1">
+            <cd-help-text i18n>Number of deamons that will be deployed</cd-help-text>
             <span class="invalid-feedback"
                   *ngIf="serviceForm.showError('count', frm, 'min')"
                   i18n>The value must be at least 1.</span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
@@ -387,6 +387,33 @@ x4Ea7kGVgx9kWh5XjWz9wjZvY49UKIT5ppIAWPMbLl3UpfckiuNhTA==
       });
     });
 
+    describe('should test service nvmeof', () => {
+      beforeEach(() => {
+        formHelper.setValue('service_type', 'nvmeof');
+        formHelper.setValue('service_id', 'svc');
+        formHelper.setValue('pool', 'xyz');
+      });
+
+      it('should submit nvmeof', () => {
+        component.onSubmit();
+        expect(cephServiceService.create).toHaveBeenCalledWith({
+          service_type: 'nvmeof',
+          service_id: 'svc',
+          placement: {},
+          unmanaged: false,
+          pool: 'xyz'
+        });
+      });
+
+      it('should throw error when there is no service id', () => {
+        formHelper.expectErrorChange('service_id', '', 'required');
+      });
+
+      it('should throw error when there is no pool', () => {
+        formHelper.expectErrorChange('pool', '', 'required');
+      });
+    });
+
     describe('should test service smb', () => {
       beforeEach(() => {
         formHelper.setValue('service_type', 'smb');
@@ -607,6 +634,15 @@ x4Ea7kGVgx9kWh5XjWz9wjZvY49UKIT5ppIAWPMbLl3UpfckiuNhTA==
         const serviceId = fixture.debugElement.query(By.css('#service_id')).nativeElement;
         expect(serviceType.disabled).toBeTruthy();
         expect(serviceId.disabled).toBeTruthy();
+      });
+
+      it('should not edit pools for nvmeof service', () => {
+        component.serviceType = 'nvmeof';
+        formHelper.setValue('service_type', 'nvmeof');
+        component.ngOnInit();
+        fixture.detectChanges();
+        const poolId = fixture.debugElement.query(By.css('#pool')).nativeElement;
+        expect(poolId.disabled).toBeTruthy();
       });
     });
   });


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/63686

- creation of NVMe/TCP service
- deletion of NVMe/TCP service
- edit/update NVMe/TCP service
- added unit tests for NVMe/TCP service
- changed Id -> Service Name
- added prefix of service type in service name (similar to <client.> in
  fs access)
- service name and pool are required fields for nvmeof
- placement count now takes default value as mentioned in cephadm

![image](https://github.com/ceph/ceph/assets/25664409/bf0a521b-9859-4372-9249-d8ef1d1be25e)
![image](https://github.com/ceph/ceph/assets/25664409/4886c816-83a3-4b9a-95e9-c4e23e34b70a)

[Screencast from 2024-06-11 14-42-21.webm](https://github.com/ceph/ceph/assets/25664409/6e4a68f3-9f66-4839-8954-639fc8e05dee)




## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>