### PR TITLE
cmake: fix the bug of compiling with rdma

### DIFF
--- a/cmake/modules/BuildDPDK.cmake
+++ b/cmake/modules/BuildDPDK.cmake
@@ -181,7 +181,8 @@ function(do_export_dpdk dpdk_dir)
   set_target_properties(dpdk::dpdk PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES ${DPDK_INCLUDE_DIR}
     INTERFACE_LINK_LIBRARIES
-    "-Wl,--whole-archive $<JOIN:${DPDK_ARCHIVES}, > -Wl,--no-whole-archive ${dpdk_numa} -Wl,-lpthread,-ldl")
+    "-Wl,--whole-archive $<JOIN:${DPDK_ARCHIVES}, > -Wl,--no-whole-archive ${dpdk_numa} -Wl,-lpthread,-ldl,-lmlx5")
+  target_link_libraries(dpdk::dpdk INTERFACE IBVerbs::verbs RDMA::RDMAcm)
   if(dpdk_rte_CFLAGS)
     set_target_properties(dpdk::dpdk PROPERTIES
       INTERFACE_COMPILE_OPTIONS "${dpdk_rte_CFLAGS}")

--- a/cmake/modules/CheckCxxAtomic.cmake
+++ b/cmake/modules/CheckCxxAtomic.cmake
@@ -62,7 +62,7 @@ if(NOT HAVE_CXX11_ATOMIC)
   check_cxx_atomics(HAVE_LIBATOMIC)
   cmake_pop_check_state()
   if(HAVE_LIBATOMIC)
-    set(LIBATOMIC_LINK_FLAGS "-Wl,--as-needed -latomic")
+    set(LIBATOMIC_LINK_FLAGS "-Wl,--as-needed -latomic -lmlx5 -libverbs -lrdmacm")
   else()
     message(FATAL_ERROR
       "Host compiler ${CMAKE_CXX_COMPILER} requires libatomic, but it is not found")


### PR DESCRIPTION
When ceph needs to use the rdma function, the rdma compilation option needs to be turned on. However, once the rdma compilation option is turned on, ceph cannot be compiled. After analyzing the problem, it is found that there is a problem with a compilation file of ceph, this patch is for fix this bug.

Signed-off-by: Xiaobing Li <xiaobing.li@samsung.com>