### PR TITLE
mgr/smb: add sqlite internal store backend for smb mgr module

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_basic.yaml
@@ -17,6 +17,7 @@ tasks:
 - cephadm.configure_samba_client_container:
     role: host.b
 - cephadm:
+    single_host_defaults: true
 
 - cephadm.shell:
     host.a:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_domain.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_domain.yaml
@@ -17,6 +17,7 @@ tasks:
 - cephadm.deploy_samba_ad_dc:
     role: host.b
 - cephadm:
+    single_host_defaults: true
 
 - cephadm.shell:
     host.a:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_basic.yaml
@@ -17,6 +17,7 @@ tasks:
 - cephadm.configure_samba_client_container:
     role: host.b
 - cephadm:
+    single_host_defaults: true
 
 - cephadm.shell:
     host.a:

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_dom.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_res_dom.yaml
@@ -17,6 +17,7 @@ tasks:
 - cephadm.deploy_samba_ad_dc:
     role: host.b
 - cephadm:
+    single_host_defaults: true
 
 - cephadm.shell:
     host.a:

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -191,6 +191,13 @@ class MgrDBNotReady(RuntimeError):
     pass
 
 
+class MgrDBNotAllowed(MgrDBNotReady):
+    """A more specific subclass of MgrDBNotReady raised when mgr_pool option
+    disabled.
+    """
+    pass
+
+
 class OSDMap(ceph_module.BasePyOSDMap):
     def get_epoch(self) -> int:
         return self._get_epoch()
@@ -1357,7 +1364,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
             return self._db
         db_allowed = self.get_ceph_option("mgr_pool")
         if not db_allowed:
-            raise MgrDBNotReady()
+            raise MgrDBNotAllowed()
         self._db = self.open_db()
         if self._db is None:
             raise MgrDBNotReady()

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1323,6 +1323,7 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
     def open_db(self) -> Optional[sqlite3.Connection]:
         if not self.pool_exists(self.MGR_POOL_NAME):
             if not self.have_enough_osds():
+                self.log.warning('not enough osds to create mgr pool')
                 return None
             self.create_mgr_pool()
         uri = f"file:///{self.MGR_POOL_NAME}:{self.module_name}/main.db?vfs=ceph"

--- a/src/pybind/mgr/smb/config_store.py
+++ b/src/pybind/mgr/smb/config_store.py
@@ -1,6 +1,6 @@
 from typing import Collection, Dict, Iterator, Optional
 
-from .proto import ConfigEntry, EntryKey, Simplified
+from .proto import ConfigEntry, ConfigStore, EntryKey, FindParams, Simplified
 
 
 class MemConfigEntry:
@@ -140,3 +140,40 @@ class ObjectCachingEntry:
     @property
     def full_key(self) -> EntryKey:
         return self._base.full_key
+
+
+def find_in_store(
+    store: ConfigStore, ns: str, params: FindParams
+) -> Collection[ConfigEntry]:
+    """Given a ConfigStore and namespace within that store, search the stored
+    objects for matching parameters. Params is a dict that will be compared to
+    the same keys/attributes of the objects being searched. Only exact matches
+    will be returned.
+    If the store implements the FindingConfigStore protocol the operation
+    of finding
+    """
+    # is it a FindingConfigStore?
+    _find_entries = getattr(store, 'find_entries', None)
+    if _find_entries:
+        try:
+            return _find_entries(ns, params)
+        except NotImplementedError:
+            # Allow the store to reject any of the ns/params/whatnot with a
+            # NotImplementedError even if it implements the find_entries
+            # function. This will fall back to the simple-but-slow approach of
+            # deserializing and examining every object.
+            pass
+    return _find_in_store(store, ns, params)
+
+
+def _find_in_store(
+    store: ConfigStore, ns: str, params: FindParams
+) -> Collection[ConfigEntry]:
+    """Fallback mode for find_in_store."""
+    found = []
+    for sub_key in store.contents(ns):
+        entry = store[(ns, sub_key)]
+        obj = entry.get()
+        if all(obj[pkey] == pval for pkey, pval in params.items()):
+            found.append(ObjectCachingEntry(entry, obj=obj))
+    return found

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -402,13 +402,15 @@ class ClusterConfigHandler:
         return list(UsersAndGroupsEntry.ids(self.internal_store))
 
     def all_resources(self) -> List[SMBResource]:
-        return self._search_resources(_Matcher())
+        with _store_transaction(self.internal_store):
+            return self._search_resources(_Matcher())
 
     def matching_resources(self, names: List[str]) -> List[SMBResource]:
         matcher = _Matcher()
         for name in names:
             matcher.parse(name)
-        return self._search_resources(matcher)
+        with _store_transaction(self.internal_store):
+            return self._search_resources(matcher)
 
     def _search_resources(self, matcher: _Matcher) -> List[SMBResource]:
         log.debug("performing search with matcher: %s", matcher)

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -369,7 +369,11 @@ class ClusterConfigHandler:
             results.append(err)
         except Exception as err:
             log.exception("error updating resource")
-            result = ErrorResult(resource, msg=str(err))
+            msg = str(err)
+            if not msg:
+                # handle the case where the exception has no text
+                msg = f"error updating resource: {type(err)} (see logs for details)"
+            result = ErrorResult(resource, msg=msg)
             results.append(result)
         if results.success:
             log.debug(

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -84,14 +84,20 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         # Store conf is meant for devs, maybe testers to experiment with
         # certain backend options at run time. This is not meant to be
         # a formal or friendly interface.
+        name = 'default'
+        opts = {}
         if store_conf:
             parts = [v.strip() for v in store_conf.split(';')]
             assert parts
             name = parts[0]
             opts = dict(p.split('=', 1) for p in parts[1:])
-        else:
-            name = 'db'
-            opts = {}
+        if name == 'default':
+            log.info('Using default backend: sqlite3 with mirroring')
+            mc_store = mon_store.ModuleConfigStore(self)
+            db_store = sqlite_store.mgr_sqlite3_db_with_mirroring(
+                self, mc_store, opts
+            )
+            return db_store
         if name == 'mon':
             log.info('Using specified backend: module config internal store')
             return mon_store.ModuleConfigStore(self)

--- a/src/pybind/mgr/smb/proto.py
+++ b/src/pybind/mgr/smb/proto.py
@@ -48,6 +48,7 @@ class Simplifiable(Protocol):
 
 
 EntryKey = Tuple[str, str]
+FindParams = Dict[str, Any]
 
 
 class ConfigEntry(Protocol):
@@ -99,6 +100,21 @@ class ConfigStore(ConfigStoreListing, Protocol):
         ...  # pragma: no cover
 
     def remove(self, ns: EntryKey) -> bool:
+        ...  # pragma: no cover
+
+
+class FindingConfigStore(ConfigStore, Protocol):
+    """A protocol for a config store that can more efficiently find
+    items within the the store.
+    """
+
+    def find_entries(
+        self, ns: str, params: FindParams
+    ) -> Collection[ConfigEntry]:
+        """Find entries in the store matching the given params.
+        Params is a dict that will be compared to the same keys/attributes of
+        the objects being searched. Only exact matches will be returned.
+        """
         ...  # pragma: no cover
 
 

--- a/src/pybind/mgr/smb/proto.py
+++ b/src/pybind/mgr/smb/proto.py
@@ -4,6 +4,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Collection,
+    ContextManager,
     Dict,
     Iterator,
     List,
@@ -114,6 +115,20 @@ class FindingConfigStore(ConfigStore, Protocol):
         """Find entries in the store matching the given params.
         Params is a dict that will be compared to the same keys/attributes of
         the objects being searched. Only exact matches will be returned.
+        """
+        ...  # pragma: no cover
+
+
+class TransactingConfigStore(ConfigStore, Protocol):
+    """A protocol for a config store that supports transactions.
+    Using the transactions can make using the store more robust or
+    efficient.
+    """
+
+    def transaction(self) -> ContextManager[None]:
+        """Return a context manager that wraps a transaction. What exactly
+        this means depends on the store. Typically this would wrap a database
+        transaction.
         """
         ...  # pragma: no cover
 

--- a/src/pybind/mgr/smb/sqlite_store.py
+++ b/src/pybind/mgr/smb/sqlite_store.py
@@ -1,0 +1,447 @@
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    ContextManager,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
+
+if TYPE_CHECKING:
+    from sqlite3 import Connection, Cursor
+else:
+    Cursor = Connection = Any
+
+import contextlib
+import json
+import logging
+
+from .config_store import ObjectCachingEntry
+from .proto import ConfigEntry, EntryKey, FindParams, Protocol, Simplified
+
+log = logging.getLogger(__name__)
+
+
+class DirectDBAcessor(Protocol):
+    """A simple protocol describing the minimal per-mgr-module (mon) store interface
+    provided by the fairly giganto MgrModule class.
+    """
+
+    @property
+    def db(self) -> Connection:
+        ...
+
+
+class ExclusiveCursorAccessor(Protocol):
+    """A wrapper protocol for describing a method for getting exclusive
+    access to the db via a cursor.
+    """
+
+    def exclusive_db_cursor(self) -> ContextManager[Cursor]:
+        ...
+
+
+DBAcessor = Union[DirectDBAcessor, ExclusiveCursorAccessor]
+
+
+def _execute(
+    dbc: Cursor, query: str, *args: Any, params: Optional[FindParams] = None
+) -> None:
+    log.debug(
+        "executing sql query: %s, args: %r, params: %r", query, args, params
+    )
+    if params and args:
+        raise ValueError('got args and params')
+    if params:
+        dbc.execute(query, params)
+        return
+    dbc.execute(query, args)
+
+
+class Table:
+    """Abstract table for holding store entries."""
+
+    def __init__(self, namespace: str, table_name: str) -> None:
+        self.namespace = namespace
+        self.table_name = table_name
+
+    def create_table(self, dbc: Cursor) -> None:
+        """Create a new db table."""
+        raise NotImplementedError()
+
+    def keys(self, dbc: Cursor) -> Collection[EntryKey]:
+        """Return all (primary) keys in the table."""
+        raise NotImplementedError()
+
+    def fetch(self, dbc: Cursor, key: str) -> str:
+        """Fetch a serialized object from the table."""
+        raise NotImplementedError()
+
+    def delete(self, dbc: Cursor, key: str) -> int:
+        """Delete an item from the table."""
+        raise NotImplementedError()
+
+    def find(
+        self, dbc: Cursor, params: FindParams
+    ) -> Iterable[Tuple[EntryKey, str]]:
+        """Find a matching object in the table."""
+        raise NotImplementedError()
+
+    def replace(self, dbc: Cursor, key: str, data: str) -> None:
+        """Create or replace a serialized object in the table."""
+        raise NotImplementedError()
+
+
+class SimpleTable(Table):
+    """A simple table that is capable of storing JSON serialized objects
+    with a simple primary key. A SimpleTable ought to be capable of
+    representing any kind of store entry but without any optimizations.
+    """
+
+    def create_table(self, dbc: Cursor) -> None:
+        _execute(
+            dbc,
+            f"CREATE TABLE IF NOT EXISTS {self.table_name} ("
+            "  key TEXT PRIMARY KEY NOT NULL,"
+            "  obj JSON"
+            ");",
+        )
+
+    def keys(self, dbc: Cursor) -> Collection[EntryKey]:
+        """Return all (primary) keys in the table."""
+        query = f"SELECT key FROM {self.table_name} ORDER BY rowid;"
+        _execute(dbc, query)
+        return set((self.namespace, r[0]) for r in dbc.fetchall())
+
+    def fetch(self, dbc: Cursor, key: str) -> str:
+        """Fetch a serialized object from the table."""
+        query = f"SELECT obj FROM {self.table_name} WHERE key=?;"
+        _execute(dbc, query, key)
+        row = dbc.fetchone()
+        if row is None:
+            raise KeyError(key)
+        return row[0]
+
+    def delete(self, dbc: Cursor, key: str) -> int:
+        """Delete an item from the table."""
+        query = f"DELETE FROM {self.table_name} WHERE key=?;"
+        _execute(dbc, query, key)
+        return dbc.rowcount
+
+    def replace(self, dbc: Cursor, key: str, data: str) -> None:
+        """Create or replace a serialized object in the table."""
+        query = (
+            f"INSERT OR REPLACE INTO {self.table_name}"
+            " (key, obj) VALUES (?, ?);"
+        )
+        _execute(dbc, query, key, data)
+
+
+class ShareResourceTable(SimpleTable):
+    """A table tuned for storing share resources.
+    This table supports finding shares with particular names
+    faster than walking over every share in the table, deserializing it,
+    and comparing the values in python.
+
+    Some calls making use of the find function can complete in approx. 0.0004s
+    vs 0.008s on average for non-specialized versions when using around 500
+    shares in a single cluster.
+
+    This is a bit of a leaky abstraction because this table "knows"
+    about the structure of a serialized Share resource implicitly.
+    If the Share resource changes this may need to be kept in sync
+    manually.
+    """
+
+    def create_table(self, dbc: Cursor) -> None:
+        """Create a table for shares with indexes."""
+        super().create_table(dbc)
+        _execute(
+            dbc,
+            f"CREATE INDEX IF NOT EXISTS idx_{self.table_name}_cn"
+            f" ON {self.table_name} ("
+            "  json_extract(obj, '$.cluster_id'),"
+            "  json_extract(obj, '$.name')"
+            ");",
+        )
+
+    def find(
+        self, dbc: Cursor, params: FindParams
+    ) -> Iterable[Tuple[EntryKey, str]]:
+        """Find a matching object in the table using json field matching on a
+        limited set of Share fields.
+        """
+        query = f"SELECT key, obj FROM {self.table_name} WHERE"
+        valid_columns = {'key', 'cluster_id', 'share_id', 'name'}
+        where = []
+        for param in params:
+            if param not in valid_columns:
+                log.error('can not find obj using param: %r', param)
+                raise NotImplementedError('invalid parameter')
+            if param == 'key':
+                # a tad redundant, but why not
+                where.append('key=:key')
+            else:
+                # the version of sqlite currently in use by ceph does not support
+                # the ->> operator. use `json_extract` instead.
+                where.append(f"json_extract(obj, '$.{param}') = :{param}")
+        query += ' ' + ' AND '.join(where)
+
+        _execute(dbc, query, params=params)
+        for row in dbc:
+            yield ((self.namespace, row[0]), row[1])
+
+
+class SqliteStoreEntry:
+    """A store entry for the SqliteStore."""
+
+    def __init__(self, store: 'SqliteStore', full_key: EntryKey) -> None:
+        self._store = store
+        self._full_key = full_key
+
+    def set(self, obj: Simplified) -> None:
+        """Set the store entry value to that of the serialized value of obj."""
+        self._store.set_object(self._full_key, obj)
+
+    def get(self) -> Simplified:
+        """Get the deserialized store entry value."""
+        return self._store.get_object(self._full_key)
+
+    def remove(self) -> bool:
+        """Remove the current entry from the store."""
+        return self._store.remove(self._full_key)
+
+    def exists(self) -> bool:
+        """Returns true if the entry currently exists within the store."""
+        return self._full_key in self._store
+
+    @property
+    def uri(self) -> str:
+        """Returns an identifier for the entry within the store."""
+        ns, name = self._full_key
+        return f'ceph-internal-sqlite-resource:{ns}/{name}'
+
+    @property
+    def full_key(self) -> EntryKey:
+        """Return a namespaced key for the entry."""
+        return self._full_key
+
+
+class SqliteStore:
+    """A store wrapping a sqlite3 database.
+
+    A SqliteStore maps each store namespace to a particular db table. This means
+    that unlike some stores arbitrary namespace values are not supported. The
+    namespaces are fixed ahead of time and well known.
+
+    This store is mainly aimed at providing a fast internal store suitable for
+    tracking the internal module resources, in particular shares, because these
+    are expected to be more numerous than the other resource types.
+    """
+
+    def __init__(self, backend: DBAcessor, tables: Iterable[Table]) -> None:
+        self._backend = backend
+        self._tables: Dict[str, Table] = {t.namespace: t for t in tables}
+        self._prepared = False
+        self._cursor: Optional[Cursor] = None
+
+    def _prepare_tables(self) -> None:
+        """Automatic/internal table preparation."""
+        if self._prepared:
+            return
+        with self._db() as dbc:
+            self.prepare(dbc)
+
+    def prepare(self, dbc: Cursor) -> None:
+        """Prepare db tables for use."""
+        if self._prepared:
+            return
+        log.info('Preparing db tables for store')
+        for tbl in self._tables.values():
+            tbl.create_table(dbc)
+        self._prepared = True
+
+    def _table(self, key: Union[str, EntryKey]) -> Table:
+        ns = key if isinstance(key, str) else key[0]
+        return self._tables[ns]
+
+    @contextlib.contextmanager
+    def transaction(self) -> Iterator[None]:
+        """Explicitly start a DB transaction."""
+        with self._db():
+            assert self._cursor
+            self._cursor.execute('BEGIN;')
+            yield None
+
+    @contextlib.contextmanager
+    def _db(self) -> Iterator[Cursor]:
+        if self._cursor is not None:
+            log.debug('fetching cached cursor')
+            yield self._cursor
+            return
+        if hasattr(self._backend, 'exclusive_db_cursor'):
+            log.debug('fetching exclusive db cursor')
+            with self._backend.exclusive_db_cursor() as cursor:
+                try:
+                    self._cursor = cursor
+                    yield cursor
+                finally:
+                    self._cursor = None
+            return
+        log.debug('fetching default db cursor')
+        with self._backend.db:
+            try:
+                self._cursor = self._backend.db.cursor()
+                yield self._cursor
+            finally:
+                self._cursor = None
+
+    def __getitem__(self, key: EntryKey) -> SqliteStoreEntry:
+        """Return an entry object given a namespaced entry key. This entry does
+        not have to exist in the store.
+        """
+        self._prepare_tables()
+        return SqliteStoreEntry(self, key)
+
+    def remove(self, key: EntryKey) -> bool:
+        """Remove an entry from the store. Returns true if an entry was
+        present.
+        """
+        self._prepare_tables()
+        with self._db() as dbc:
+            _, tkey = key
+            rcount = self._table(key).delete(dbc, tkey)
+        return rcount > 0
+
+    def set_object(self, key: EntryKey, obj: Simplified) -> None:
+        """Create or update a simplified object in the store."""
+        self._prepare_tables()
+        obj_data = json.dumps(obj)
+        with self._db() as dbc:
+            _, tkey = key
+            self._table(key).replace(dbc, tkey, obj_data)
+
+    def get_object(self, key: EntryKey) -> Simplified:
+        """Fetch a simplified object from the store."""
+        self._prepare_tables()
+        with self._db() as dbc:
+            _, tkey = key
+            obj = json.loads(self._table(key).fetch(dbc, tkey))
+        return obj
+
+    def namespaces(self) -> Collection[str]:
+        """Return all namespaces currently in the store."""
+        self._prepare_tables()
+        return set(self._tables.keys())
+
+    def contents(self, ns: str) -> Collection[str]:
+        """Return all subkeys currently in the namespace."""
+        self._prepare_tables()
+        with self._db() as dbc:
+            return {k for _, k in self._table(ns).keys(dbc)}
+
+    def __iter__(self) -> Iterator[EntryKey]:
+        """Iterate over all namespaced keys currently in the store."""
+        self._prepare_tables()
+        with self._db() as dbc:
+            for ns, tbl in self._tables.items():
+                for key in tbl.keys(dbc):
+                    yield key
+
+    def find_entries(
+        self, ns: str, params: FindParams
+    ) -> Collection[ConfigEntry]:
+        """Find matching entries in the store, belonging to the specified namespace."""
+        self._prepare_tables()
+        with self._db() as dbc:
+            return [
+                ObjectCachingEntry(
+                    SqliteStoreEntry(self, ekey), obj=json.loads(obj)
+                )
+                for ekey, obj in self._table(ns).find(dbc, params)
+            ]
+
+    @property
+    def data(self) -> Dict[EntryKey, Simplified]:
+        """Debugging/testing helper for dumping contents of the store."""
+        out = {}
+        for k in self:
+            assert isinstance(k, tuple)
+            out[k] = self.get_object(k)
+        return out
+
+    def overwrite(self, nd: Dict[EntryKey, Simplified]) -> None:
+        """Debugging/testing helper for changing contents of the store."""
+        for key, obj in nd.items():
+            if isinstance(key, str):
+                keyns, keyname = key.split('.', 1)
+            else:
+                keyns, keyname = key
+            self.set_object((keyns, keyname), obj)
+
+
+def _tables(
+    *,
+    specialize: bool = True,
+) -> List[Table]:
+    """Create tables for the current smb resources.
+    This function implicitly knows what resources will be needed and so
+    must be manually kept in sync with the resources.py objects.
+    """
+    srt: Table
+    if specialize:
+        log.debug('using specialized shares table')
+        srt = ShareResourceTable('shares', 'shares')
+    else:
+        log.warning('using non-specialized shares table')
+        srt = SimpleTable('shares', 'shares')
+    return [
+        SimpleTable('clusters', 'clusters'),
+        srt,
+        SimpleTable('join_auths', 'join_auths'),
+        SimpleTable('users_and_groups', 'users_and_groups'),
+    ]
+
+
+def mgr_sqlite3_db(
+    mgr: Any, opts: Optional[Dict[str, str]] = None
+) -> SqliteStore:
+    """Set up a store for use in the real ceph mgr."""
+    specialize = (opts or {}).get('specialize') != 'no'
+    return SqliteStore(
+        mgr,
+        _tables(specialize=specialize),
+    )
+
+
+def memory_db(
+    *,
+    specialize: bool = True,
+) -> SqliteStore:
+    """A hack to set up the store to use an in memory sqlite db for unit
+    testing.
+    """
+    import sqlite3
+
+    uri = ':memory:'
+    try:
+        conn = sqlite3.connect(
+            uri, check_same_thread=False, uri=True, autocommit=False
+        )  # type: ignore[call-arg]
+    except TypeError:
+        conn = sqlite3.connect(
+            uri, check_same_thread=False, uri=True, isolation_level=None
+        )
+
+    class InMemoryDB:
+        db = conn
+
+    return SqliteStore(
+        InMemoryDB(),
+        _tables(specialize=specialize),
+    )

--- a/src/pybind/mgr/smb/sqlite_store.py
+++ b/src/pybind/mgr/smb/sqlite_store.py
@@ -479,12 +479,29 @@ class MirrorJoinAuths(Mirror):
     def __init__(self, store: ConfigStore) -> None:
         super().__init__('join_auths', store)
 
+    def filter_object(self, obj: Simplified) -> Simplified:
+        """Filter join auth data for sqlite3 store."""
+        filtered = copy.deepcopy(obj)
+        if 'auth' in filtered:
+            filtered['auth'].pop('password', None)
+        return filtered
+
 
 class MirrorUsersAndGroups(Mirror):
     """Mirroring configuration for objects in the users_and_groups namespace."""
 
     def __init__(self, store: ConfigStore) -> None:
         super().__init__('users_and_groups', store)
+
+    def filter_object(self, obj: Simplified) -> Simplified:
+        """Filter join users and groups data for sqlite3 store."""
+        filtered = copy.deepcopy(obj)
+        for user in filtered.get('values', {}).get('users', []):
+            # retain the key, to have the capability of knowing it was part of
+            # this row, but remove the value from this object
+            if 'password' in user:
+                user['password'] = ''
+        return filtered
 
 
 def _tables(


### PR DESCRIPTION
Add a new store backend for internal smb module configuration resources. This layer is based on the Ceph MGR's sqlite3 db stored in RADOS. The aim is to improve the performance with regards to searching certain fields of the resources for duplicate values, mainly to prevent the same cluster + share name pair being used for different share resources. This uses sqlite3's JSON support and indexes to achieve the performance improvement.

In order to to significantly change the module's stance with regards to potentially sensitive information the db store provides a subclass that can mirror objects in a different store. We use this to keep all the possibly sensitive info in the mon config key store (like how cephadm stores certs etc).



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
