### PR TITLE
ceph-volume: fix regression

### DIFF
--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -4,11 +4,19 @@ import os
 import sys
 import logging
 
+
+# `iter_entry_points` from `pkg_resources` takes one argument whereas
+# `entry_points` from `importlib.metadata` does not.
 try:
     from importlib.metadata import entry_points
-except ImportError:
-    from pkg_resources import iter_entry_points as entry_points
 
+    def get_entry_points(group: str):  # type: ignore
+        return entry_points().get(group, [])  # type: ignore
+except ImportError:
+    from pkg_resources import iter_entry_points as entry_points  # type: ignore
+
+    def get_entry_points(group: str):  # type: ignore
+        return entry_points(group=group)  # type: ignore
 
 from ceph_volume.decorators import catches
 from ceph_volume import log, devices, configuration, conf, exceptions, terminal, inventory, drive_group, activate
@@ -177,7 +185,7 @@ def _load_library_extensions():
     group = 'ceph_volume_handlers'
 
     plugins = []
-    for ep in entry_points(group=group):
+    for ep in get_entry_points(group=group):
         try:
             logger.debug('loading %s' % ep.name)
             plugin = ep.load()


### PR DESCRIPTION
This fixes a regression introduced by: 24f8e5c61b19deab7397b0237f8376c6c03a5dcb

`iter_entry_points` from `pkg_resources` takes one argument whereas `entry_points` from `importlib.metadata` does not.

The call to `entry_points(group=group)` makes ceph-volume fail.

Fixes: https://tracker.ceph.com/issues/66328
