### PR TITLE
mgr: stop sending beacon with all modules information if nothing changed

### DIFF
--- a/src/messages/MMgrBeacon.h
+++ b/src/messages/MMgrBeacon.h
@@ -95,6 +95,16 @@ public:
     command_descs = cmds;
   }
 
+  void clear_command_descs()
+  {
+    command_descs.clear();
+  }
+
+  void clear_modules()
+  {
+    modules.clear();
+  }
+
   const std::vector<MonCommand> &get_command_descs()
   {
     return command_descs;

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -274,6 +274,10 @@ void MgrStandby::send_beacon()
       m->set_command_descs(commands);
       dout(4) << "going active, including " << m->get_command_descs().size()
               << " commands in beacon" << dendl;
+    } else {
+      dout(10) << "already available in map, not sending command descs" << dendl;
+      m->clear_command_descs();
+      m->clear_modules();
     }
 
     m->set_services(active_mgr->get_services());

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -546,7 +546,8 @@ bool MgrMonitor::prepare_beacon(MonOpRequestRef op)
       pending_map.available = m->get_available();
       updated = true;
     }
-    if (pending_map.available_modules != m->get_available_modules()) {
+    if (pending_map.available_modules != m->get_available_modules() &&
+        m->get_available_modules().size() > 0) {
       dout(4) << "available_modules " << m->get_available_modules()
 	      << " (was " << pending_map.available_modules << ")" << dendl;
       pending_map.available_modules = m->get_available_modules();

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -370,7 +370,19 @@ Message *decode_message(CephContext *cct,
       }
     }
   }
-
+  // hexdump all in that message
+  if (cct) {
+    ldout(cct, DEBUGLVL) << "decode_message " << header.version << dendl;
+    ldout(cct, DEBUGLVL) << "front:\n";
+    front.hexdump(*_dout);
+    *_dout << dendl;
+    ldout(cct, DEBUGLVL) << "middle:\n";
+    middle.hexdump(*_dout);
+    *_dout << dendl;
+    ldout(cct, DEBUGLVL) << "data:\n";
+    data.hexdump(*_dout);
+    *_dout << dendl;
+  }
   // make message
   ceph::ref_t<Message> m;
   int type = header.type;


### PR DESCRIPTION
mgr is sending to the monitors beacon more information than it should send, if the active module list or modules commands didn't change, there is no need to resend them and let the monitor ignore them. we shouldn't send them in the first place.

Fixes: https://tracker.ceph.com/issues/66320





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
