### PR TITLE
rgw/reshard: with new bucket info for index completion after reshard

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -919,7 +919,16 @@ void RGWIndexCompletionManager::process()
       RGWRados::BucketShard bs(store);
       RGWBucketInfo bucket_info;
 
-      int r = bs.init(c->obj.bucket, c->obj, &bucket_info, &dpp);
+      std::map<std::string, bufferlist> bucket_attrs;
+      int r = store->get_bucket_info(&store->svc, c->obj.bucket.tenant, c->obj.bucket.name,
+                              bucket_info, nullptr, null_yield, &dpp, &bucket_attrs);
+      if (r < 0) {
+        ldpp_dout(&dpp, 0) << "ERROR: " << __func__ << "(): failed to get_bucket_info, obj=" << c->obj << " r=" << r << dendl;
+        /* not much to do */
+        continue;
+      }
+      c->obj.bucket = bucket_info.bucket;
+      r = bs.init(c->obj.bucket, c->obj, &bucket_info, &dpp);
       if (r < 0) {
         ldpp_dout(&dpp, 0) << "ERROR: " << __func__ << "(): failed to initialize BucketShard, obj=" << c->obj << " r=" << r << dendl;
         /* not much to do */


### PR DESCRIPTION
rgw/reshard: with new bucket info for index completion after reshard

A reshard usually be successfully executed before index completion manager, so it is better to use latest bucket info to index complete.
The instance may not exists with old bucket info, so bs.init() will return ENOENT and index complete for the entry is ignored.

What is more, I do not know if there is such a condition, there are still entries not been executed in queue of IndexCompletionManager after a reshard, then a another reshard is executed manually to this bucket. In this way, the reshard_lock is created with the bucket_id before second reshard, the bucket_id of entries stored in IndexCompletionManger is older. So if old bucket info is used, even a reshard is executing, a reshard_lock with old bucket_id will be held in block_while_resharding(), and it mistakenly call clear_resharding(). The client can write to the bucket util reshard process renew reshard_lock after 60s maximum.

Signed-off-by: Mingyuan Liang <liangmingyuan@baidu.com>