### PR TITLE
test/librados: fix LibRadosIoECPP.CrcZeroWrite

### DIFF
--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -879,7 +879,7 @@ TEST_F(LibRadosIoECPP, RmXattrPP) {
 
 TEST_F(LibRadosIoECPP, CrcZeroWrite) {
   SKIP_IF_CRIMSON();
-  set_allow_ec_overwrites(pool_name, true);
+  set_allow_ec_overwrites();
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl;
@@ -890,7 +890,6 @@ TEST_F(LibRadosIoECPP, CrcZeroWrite) {
   ObjectReadOperation read;
   read.read(0, bl.length(), NULL, NULL);
   ASSERT_EQ(0, ioctx.operate("foo", &read, &bl));
-  recreate_pool();
 }
 
 TEST_F(LibRadosIoECPP, XattrListPP) {

--- a/src/test/librados/io_cxx.cc
+++ b/src/test/librados/io_cxx.cc
@@ -883,6 +883,7 @@ TEST_F(LibRadosIoECPP, CrcZeroWrite) {
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));
   bufferlist bl;
+  bl.append(buf, sizeof(buf));
 
   ASSERT_EQ(0, ioctx.write("foo", bl, 0, 0));
   ASSERT_EQ(0, ioctx.write("foo", bl, 0, sizeof(buf)));

--- a/src/test/librados/testcase_cxx.cc
+++ b/src/test/librados/testcase_cxx.cc
@@ -401,18 +401,16 @@ void RadosTestECPP::TearDown()
     cleanup_default_namespace(ioctx);
     cleanup_namespace(ioctx, nspace);
   }
+  if (ec_overwrites_set) {
+    ASSERT_EQ(0, destroy_one_ec_pool_pp(pool_name, s_cluster));
+    ASSERT_EQ("", create_one_ec_pool_pp(pool_name, s_cluster));
+    ec_overwrites_set = false;
+  }
   ioctx.close();
 }
 
-void RadosTestECPP::recreate_pool()
+void RadosTestECPP::set_allow_ec_overwrites()
 {
-  SKIP_IF_CRIMSON();
-  ASSERT_EQ(0, destroy_one_ec_pool_pp(pool_name, s_cluster));
-  ASSERT_EQ("", create_one_ec_pool_pp(pool_name, s_cluster));
-  SetUp();
-}
-
-void RadosTestECPP::set_allow_ec_overwrites(std::string pool, bool allow)
-{
-  ASSERT_EQ("", set_allow_ec_overwrites_pp(pool, cluster, allow));
+  ASSERT_EQ("", set_allow_ec_overwrites_pp(pool_name, cluster, true));
+  ec_overwrites_set = true;
 }

--- a/src/test/librados/testcase_cxx.cc
+++ b/src/test/librados/testcase_cxx.cc
@@ -3,6 +3,9 @@
 
 #include "testcase_cxx.h"
 
+#include <chrono>
+#include <thread>
+
 #include <errno.h>
 #include <fmt/format.h>
 #include "test_cxx.h"
@@ -411,6 +414,22 @@ void RadosTestECPP::TearDown()
 
 void RadosTestECPP::set_allow_ec_overwrites()
 {
-  ASSERT_EQ("", set_allow_ec_overwrites_pp(pool_name, cluster, true));
   ec_overwrites_set = true;
+  ASSERT_EQ("", set_allow_ec_overwrites_pp(pool_name, cluster, true));
+
+  char buf[128];
+  memset(buf, 0xcc, sizeof(buf));
+  bufferlist bl;
+  bl.append(buf, sizeof(buf));
+
+  const std::string objname = "RadosTestECPP::set_allow_ec_overwrites:test_obj";
+  ASSERT_EQ(0, ioctx.write(objname, bl, sizeof(buf), 0));
+  const auto end = std::chrono::steady_clock::now() + std::chrono::seconds(120);
+  while (true) {
+    if (0 == ioctx.write(objname, bl, sizeof(buf), 0)) {
+      break;
+    }
+    ASSERT_LT(std::chrono::steady_clock::now(), end);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+  }
 }

--- a/src/test/librados/testcase_cxx.h
+++ b/src/test/librados/testcase_cxx.h
@@ -111,14 +111,14 @@ protected:
 };
 
 class RadosTestECPP : public RadosTestPP {
+  bool ec_overwrites_set = false;
 public:
   RadosTestECPP(bool c=false) : cluster(s_cluster), cleanup(c) {}
   ~RadosTestECPP() override {}
 protected:
   static void SetUpTestCase();
   static void TearDownTestCase();
-  void recreate_pool();
-  void set_allow_ec_overwrites(std::string pool, bool allow=true);
+  void set_allow_ec_overwrites();
   static librados::Rados s_cluster;
   static std::string pool_name;
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/66226

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
