### PR TITLE
msg/mds: print more debug logs from protocol layer

### DIFF
--- a/qa/cephfs/conf/mds.yaml
+++ b/qa/cephfs/conf/mds.yaml
@@ -4,7 +4,7 @@ overrides:
       mds:
         debug mds: 20
         debug mds balancer: 20
-        debug ms: 1
+        debug ms: 2
         mds debug frag: true
         mds debug scatterstat: true
         mds op complaint time: 180

--- a/qa/suites/fs/full/tasks/mgr-osd-full.yaml
+++ b/qa/suites/fs/full/tasks/mgr-osd-full.yaml
@@ -8,7 +8,7 @@ overrides:
         debug ms: 1
         debug client: 20
       mds:
-        debug ms: 1
+        debug ms: 2
         debug mds: 20
       osd: # force bluestore since it's required for ec overwrites
         osd objectstore: bluestore

--- a/qa/suites/fs/libcephfs/tasks/client.yaml
+++ b/qa/suites/fs/libcephfs/tasks/client.yaml
@@ -5,7 +5,7 @@ overrides:
         debug ms: 1
         debug client: 20
       mds:
-        debug ms: 1
+        debug ms: 2
         debug mds: 20
 tasks:
 - workunit:

--- a/qa/suites/fs/libcephfs/tasks/ino_release_cb.yaml
+++ b/qa/suites/fs/libcephfs/tasks/ino_release_cb.yaml
@@ -5,7 +5,7 @@ overrides:
         debug ms: 1
         debug client: 20
       mds:
-        debug ms: 1
+        debug ms: 2
         debug mds: 20
 tasks:
 - exec:

--- a/qa/suites/fs/libcephfs/tasks/libcephfs/test.yaml
+++ b/qa/suites/fs/libcephfs/tasks/libcephfs/test.yaml
@@ -5,7 +5,7 @@ overrides:
         debug ms: 1
         debug client: 20
       mds:
-        debug ms: 1
+        debug ms: 2
         debug mds: 20
 tasks:
 - check-counter:

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -1173,8 +1173,8 @@ ssize_t ProtocolV1::write_message(Message *m, ceph::buffer::list &bl, bool more)
   }
 
   m->trace.event("async writing message");
-  ldout(cct, 20) << __func__ << " sending " << m->get_seq() << " " << m
-                 << dendl;
+  ldout(cct, 2) << __func__ << " sending message m=" << m
+                << " seq=" << m->get_seq() << " " << *m << dendl;
   ssize_t total_send_size = connection->outgoing_bl.length();
   ssize_t rc = connection->_try_send(more);
   if (rc < 0) {

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -551,7 +551,7 @@ ssize_t ProtocolV2::write_message(Message *m, bool more) {
     return -EILSEQ;
   }
 
-  ldout(cct, 5) << __func__ << " sending message m=" << m
+  ldout(cct, 2) << __func__ << " sending message m=" << m
                 << " seq=" << m->get_seq() << " " << *m << dendl;
 
   m->trace.event("async writing message");


### PR DESCRIPTION
The bug is for many time the MDS sent out the `beacon` msg to monitors,
and from the mds and msgr logs we can see that the `beacon` msg was
really sent out, more exactly is the msg had been enqueued to the protocol
sender queue. But we don't know whether this msg had been sent out or
stuck in the route, and the monitors received it after minutes.

We need to know whether it's a bug in protocol code and need more debug
logs from it.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
