### PR TITLE
osd/scrub: allow new scrubs while reserving

### DIFF
--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -171,12 +171,6 @@ Scrub::OSDRestrictions OsdScrub::restrictions_on_scrubbing(
 	       << dendl;
       env_conditions.high_priority_only = true;
 
-  } else if (m_queue.is_reserving_now()) {
-    // if there is a PG that is just now trying to reserve scrub replica
-    // resources - we should wait and not initiate a new scrub
-    dout(10) << "scrub resources reservation in progress" << dendl;
-    env_conditions.high_priority_only = true;
-
   } else if (is_recovery_active && !conf->osd_scrub_during_recovery) {
     if (conf->osd_repair_during_recovery) {
       dout(15)

--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -476,13 +476,3 @@ int OsdScrub::get_blocked_pgs_count() const
 {
   return m_queue.get_blocked_pgs_count();
 }
-
-bool OsdScrub::set_reserving_now(spg_t reserving_id, utime_t now_is)
-{
-  return m_queue.set_reserving_now(reserving_id, now_is);
-}
-
-void OsdScrub::clear_reserving_now(spg_t reserving_id)
-{
-  m_queue.clear_reserving_now(reserving_id);
-}

--- a/src/osd/scrubber/osd_scrub.h
+++ b/src/osd/scrubber/osd_scrub.h
@@ -135,15 +135,6 @@ class OsdScrub {
       bool high_priority_scrub) const;
 
   /**
-   * No new scrub session will start while a scrub was initiated on a PG,
-   * and that PG is trying to acquire replica resources.
-   * \retval false if the flag was already set (due to a race)
-   */
-  bool set_reserving_now(spg_t reserving_id, utime_t now_is);
-
-  void clear_reserving_now(spg_t reserving_id);
-
-  /**
    * push the 'not_before' time out by 'delay' seconds, so that this scrub target
    * would not be retried before 'delay' seconds have passed.
    */

--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -361,28 +361,3 @@ int ScrubQueue::get_blocked_pgs_count() const
 {
   return blocked_scrubs_cnt;
 }
-
-// ////////////////////////////////////////////////////////////////////////// //
-// ScrubQueue - maintaining the 'some PG is reserving' flag
-
-bool ScrubQueue::set_reserving_now(spg_t reserving_id, utime_t now_is)
-{
-  std::unique_lock l{reserving_lock};
-
-  if (!reserving_pg.has_value()) {
-    reserving_pg = reserving_id;
-    reserving_since = now_is;
-    return true;
-  }
-  ceph_assert(reserving_id != *reserving_pg);
-  return false;
-}
-
-void ScrubQueue::clear_reserving_now(spg_t was_reserving_id)
-{
-  std::unique_lock l{reserving_lock};
-  if (reserving_pg && (*reserving_pg == was_reserving_id)) {
-    reserving_pg.reset();
-  }
-  // otherwise - ignore silently
-}

--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -386,9 +386,3 @@ void ScrubQueue::clear_reserving_now(spg_t was_reserving_id)
   }
   // otherwise - ignore silently
 }
-
-bool ScrubQueue::is_reserving_now() const
-{
-  // no lock needed, as set_reserving_now() will recheck
-  return reserving_pg.has_value();
-}

--- a/src/osd/scrubber/osd_scrub_sched.h
+++ b/src/osd/scrubber/osd_scrub_sched.h
@@ -84,7 +84,6 @@ ScrubQueue interfaces (main functions):
   - can_inc_scrubs()
   - {inc/dec}_scrubs_{local/remote}()
   - dump_scrub_reservations()
-  - {set/clear/is}_reserving_now()
 
 <2> - environment conditions:
 
@@ -238,30 +237,6 @@ class ScrubQueue {
  public:
   void dump_scrubs(ceph::Formatter* f) const;
 
-  /**
-   * No new scrub session will start while a scrub was initiated on a PG,
-   * and that PG is trying to acquire replica resources.
-   *
-   * \todo replace the atomic bool with a regular bool protected by a
-   * common OSD-service lock. Or better still - once PR#53263 is merged,
-   * remove this flag altogether.
-   */
-
-  /**
-   * set_reserving_now()
-   * \returns 'false' if the flag was already set
-   * (which is a possible result of a race between the check in OsdScrub and
-   * the initiation of a scrub by some other PG)
-   */
-  bool set_reserving_now(spg_t reserving_id, utime_t now_is);
-
-  /**
-   * silently ignore attempts to clear the flag if it was not set by
-   * the named pg.
-   */
-  void clear_reserving_now(spg_t reserving_id);
-  bool is_reserving_now() const;
-
   /// counting the number of PGs stuck while scrubbing, waiting for objects
   void mark_pg_scrub_blocked(spg_t blocked_pg);
   void clear_pg_scrub_blocked(spg_t blocked_pg);
@@ -330,17 +305,6 @@ class ScrubQueue {
    * existence of such a situation in the scrub-queue log messages.
    */
   std::atomic_int_fast16_t blocked_scrubs_cnt{0};
-
-  /**
-   * One of the OSD's primary PGs is in the initial phase of a scrub,
-   * trying to secure its replicas' resources. We will refrain from initiating
-   * any other scrub sessions until this one is done.
-   *
-   * \todo replace the local lock with regular osd-service locking
-   */
-  ceph::mutex reserving_lock = ceph::make_mutex("ScrubQueue::reserving_lock");
-  std::optional<spg_t> reserving_pg;
-  utime_t reserving_since;
 
   /**
    * If the scrub job was not explicitly requested, we postpone it by some

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -1773,17 +1773,6 @@ void PgScrubber::handle_scrub_reserve_msgs(OpRequestRef op)
   }
 }
 
-
-bool PgScrubber::set_reserving_now() {
-  return m_osds->get_scrub_services().set_reserving_now(m_pg_id,
-                                                        ceph_clock_now());
-}
-
-void PgScrubber::clear_reserving_now()
-{
-  m_osds->get_scrub_services().clear_reserving_now(m_pg_id);
-}
-
 void PgScrubber::set_queued_or_active()
 {
   m_queued_or_active = true;

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -456,9 +456,6 @@ class PgScrubber : public ScrubPgIF,
 
   int build_replica_map_chunk() final;
 
-  bool set_reserving_now() final;
-  void clear_reserving_now() final;
-
   [[nodiscard]] bool was_epoch_changed() const final;
 
   void set_queued_or_active() final;

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -564,7 +564,7 @@ struct Session : sc::state<Session, PrimaryActive, ReservingReplicas>,
 
 struct ReservingReplicas : sc::state<ReservingReplicas, Session>, NamedSimply {
   explicit ReservingReplicas(my_context ctx);
-  ~ReservingReplicas();
+  ~ReservingReplicas() = default;
   using reactions = mpl::list<
       sc::custom_reaction<ReplicaGrant>,
       sc::custom_reaction<ReplicaReject>,

--- a/src/osd/scrubber/scrub_machine_lstnr.h
+++ b/src/osd/scrubber/scrub_machine_lstnr.h
@@ -206,18 +206,6 @@ struct ScrubMachineListener {
   virtual void set_scrub_duration(std::chrono::milliseconds duration) = 0;
 
   /**
-   * No new scrub session will start while a scrub was initiate on a PG,
-   * and that PG is trying to acquire replica resources.
-   * set_reserving_now()/clear_reserving_now() let's the OSD scrub-queue know
-   * we are busy reserving.
-   *
-   * set_reserving_now() returns 'false' if there already is a PG in the
-   * reserving stage of the scrub session.
-   */
-  virtual bool set_reserving_now() = 0;
-  virtual void clear_reserving_now() = 0;
-
-  /**
    * Manipulate the 'I am being scrubbed now' Scrubber's flag
    */
   virtual void set_queued_or_active() = 0;


### PR DESCRIPTION
allow new scrub sessions to be initiated by an OSD even while a PG is
in the process of reserving scrub resources.

The existing restriction made sense when the replica reservation process
was expected to succeed or fail within a few milliseconds. It makes less
sense now that the reservation process is queue-based (Reserver based)
and can take unlimited time (hours, days, ...) to complete.

Fixes: https://tracker.ceph.com/issues/66351
