### PR TITLE
squid: debian: package mgr/rgw in ceph-mgr-modules-core

### DIFF
--- a/debian/ceph-mgr-modules-core.install
+++ b/debian/ceph-mgr-modules-core.install
@@ -15,6 +15,7 @@ usr/share/ceph/mgr/pg_autoscaler
 usr/share/ceph/mgr/progress
 usr/share/ceph/mgr/prometheus
 usr/share/ceph/mgr/rbd_support
+usr/share/ceph/mgr/rgw
 usr/share/ceph/mgr/restful
 usr/share/ceph/mgr/selftest
 usr/share/ceph/mgr/snap_schedule


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66352

---

backport of https://github.com/ceph/ceph/pull/57811
parent tracker: https://tracker.ceph.com/issues/66326

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh