### PR TITLE
cls: avoid reusing moved-from buffers in cls_queue_src.cc

### DIFF
--- a/src/cls/queue/cls_queue_src.cc
+++ b/src/cls/queue/cls_queue_src.cc
@@ -327,11 +327,11 @@ int queue_list_entries(cls_method_context_t hctx, const cls_queue_list_op& op, c
     }
 
     //If there is leftover data from previous iteration, append new data to leftover data
-    uint64_t entry_start_offset = start_offset - bl.length();
+    uint64_t entry_start_offset = start_offset - bl.length(); //NOLINT(bugprone-use-after-move)
     CLS_LOG(20, "INFO: queue_list_entries(): Entry start offset accounting for leftover data is %lu", entry_start_offset);
     bl.claim_append(bl_chunk);
     bl_chunk = std::move(bl);
-
+    bl.clear(); //NOLINT(bugprone-use-after-move)
     CLS_LOG(20, "INFO: queue_list_entries(): size of chunk %u", bl_chunk.length());
 
     //Process the chunk of data read


### PR DESCRIPTION
`bufferlist` must be declared in the top of the loop to avoid `use-after-move`

clang-tidy original warning:
```
/home/suyash/ceph/src/cls/queue/cls_queue_src.cc:330:50: warning: 'bl' used after it was moved [bugprone-use-after-move]
    uint64_t entry_start_offset = start_offset - bl.length();
                                                 ^
/home/suyash/ceph/src/cls/queue/cls_queue_src.cc:333:14: note: move occurred here
    bl_chunk = std::move(bl);
             ^
/home/suyash/ceph/src/cls/queue/cls_queue_src.cc:330:50: note: the use happens in a later loop iteration than the move
    uint64_t entry_start_offset = start_offset - bl.length();
                                                 ^

```
Fixes: https://tracker.ceph.com/issues/66356





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
