### PR TITLE
quincy: qa/distros: add centos stream 9 as supported distro

### DIFF
--- a/qa/distros/all/centos_9.stream.yaml
+++ b/qa/distros/all/centos_9.stream.yaml
@@ -1,0 +1,2 @@
+os_type: centos
+os_version: "9.stream"

--- a/qa/distros/all/centos_9.stream.yaml
+++ b/qa/distros/all/centos_9.stream.yaml
@@ -1,2 +1,9 @@
 os_type: centos
 os_version: "9.stream"
+
+# enable the ceph/el9 copr for python packages that aren't in epel9 yet
+# see https://tracker.ceph.com/issues/58832
+overrides:
+  install:
+    ceph:
+      enable_coprs: [ceph/el9]

--- a/qa/distros/all/centos_latest.yaml
+++ b/qa/distros/all/centos_latest.yaml
@@ -1,0 +1,1 @@
+centos_9.stream.yaml

--- a/qa/distros/supported-random-distro$/centos_latest.yaml
+++ b/qa/distros/supported-random-distro$/centos_latest.yaml
@@ -1,0 +1,1 @@
+../all/centos_latest.yaml

--- a/qa/distros/supported/centos_8.stream.yaml
+++ b/qa/distros/supported/centos_8.stream.yaml
@@ -1,1 +1,0 @@
-../all/centos_8.stream.yaml

--- a/qa/distros/supported/centos_8.stream.yaml
+++ b/qa/distros/supported/centos_8.stream.yaml
@@ -1,0 +1,1 @@
+../all/centos_8.stream.yaml

--- a/qa/distros/supported/centos_latest.yaml
+++ b/qa/distros/supported/centos_latest.yaml
@@ -1,1 +1,1 @@
-../all/centos_8.yaml
+../all/centos_latest.yaml


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/50441 since centos 8 is EOL.

Fixes: https://tracker.ceph.com/issues/66334

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
