### PR TITLE
qa/standalone: bugfix for latecy repair after scrub

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1856,6 +1856,7 @@ function repair() {
     local last_scrub=$(get_last_scrub_stamp $pgid)
     ceph pg repair $pgid
     wait_for_scrub $pgid "$last_scrub"
+    sleep 2
 }
 
 function test_repair() {


### PR DESCRIPTION
When pg repair is called manully, a deep-scrub will be executed firstly, and requeue DoRecovery() if there are inconsistent objects. But in repair() of ceph-helpers.sh, it use scrub_stamp to determine repair completing time. This will leads to the repair is not completed before another test case.

https://tracker.ceph.com/issues/66360

Signed-off-by: Mingyuan Liang <liangmingyuan@baidu.com>