### PR TITLE
mgr/dashboard: adapt kcli plan to improve multi-cluster deployment

### DIFF
--- a/src/pybind/mgr/dashboard/.gitignore
+++ b/src/pybind/mgr/dashboard/.gitignore
@@ -5,6 +5,7 @@ coverage.xml
 junit*xml
 .cache
 ceph.conf
+ceph_image.tar
 
 # IDE
 .vscode

--- a/src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml
+++ b/src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml
@@ -1,11 +1,8 @@
 parameters:
- nodes: 4
- node_ip_offset: 100
  pool: ceph-dashboard
  network: ceph-dashboard
  gateway: 192.168.100.1
  netmask: 255.255.255.0
- prefix: ceph
  numcpus: 1
  memory: 2048
  image: fedora40
@@ -15,6 +12,10 @@ parameters:
  - 15
  - 5
  - 5
+
+{% set nodes = (nodes | default(4)) | int %}
+{% set node_ip_offset = node_ip_offset | default(100) %}
+{% set prefix = prefix | default('ceph') %}
 
 {% for number in range(0, nodes) %}
 {{ prefix }}-node-0{{ number }}:
@@ -49,6 +50,7 @@ parameters:
  - sed -i "s/SELINUX=enforcing/SELINUX=permissive/" /etc/selinux/config
  - setenforce 0
  {% if number == 0 %}
+ - export NODES={{nodes}} && export NODE_IP_OFFSET={{node_ip_offset}}
  - bash /root/bootstrap-cluster.sh
  {% endif %}
 {% endfor %}

--- a/src/pybind/mgr/dashboard/ci/cephadm/load-podman-image.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/load-podman-image.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
+PODMAN_IMG_LOC="/mnt/{{ ceph_dev_folder }}/src/pybind/mgr/dashboard/ci/cephadm/ceph_image.tar"
 echo -e "[registries.insecure]\n\
 registries = ['localhost:5000']" | sudo tee /etc/containers/registries.conf
 
 podman run -d -p 5000:5000 --name my-registry registry:2
 # Load the image and capture the output
-output=$(podman load -i /root/ceph_image.tar)
+output=$(podman load -i "${PODMAN_IMG_LOC}")
 
 # Extract image name from output
 image_name=$(echo "$output" | grep -oP '(?<=^Loaded image: ).*')
@@ -20,4 +21,3 @@ else
 fi
 
 podman push localhost:5000/ceph
-rm -f /root/ceph_image.tar

--- a/src/pybind/mgr/dashboard/ci/cephadm/quick-bootstrap.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/quick-bootstrap.sh
@@ -11,14 +11,21 @@ show_help() {
   echo "  -u, --use-cached-image     Uses the existing podman image in local. Only use this if there is such an image present."
   echo "  -dir, --ceph-dir             Use this to provide the local ceph directory. eg. --ceph-dir=/path/to/ceph"
   echo "  -e, --expanded-cluster     To add all the hosts and deploy OSDs on top of it."
+  echo "  -c, --clusters          Number of clusters to be created. Default is 1."
+  echo "  -n, --nodes           Number of nodes to be created per cluster. Default is 3."
   echo "  -h, --help             Display this help message."
   echo ""
   echo "Example:"
   echo "  ./quick-bootstrap.sh --use-cached-image"
 }
 
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
 use_cached_image=false
 extra_args="-P quick_install=True"
+CLUSTERS=1
+NODES=3
 
 for arg in "$@"; do
   case "$arg" in
@@ -30,6 +37,12 @@ for arg in "$@"; do
       ;;
     -e|--expanded-cluster)
       extra_args+=" -P expanded_cluster=True"
+      ;;
+    -n=*|--nodes=*)
+      NODES="${arg#*=}"
+      ;;
+    -c=*|--clusters=*)
+      CLUSTERS="${arg#*=}"
       ;;
     -h|--help)
       show_help
@@ -44,8 +57,8 @@ for arg in "$@"; do
 done
 
 image_name=$(echo "$CEPHADM_IMAGE")
-ceph_cluster_yml='ceph_cluster.yml'
-node_count=$(awk '/nodes:/ {print $2}' "${ceph_cluster_yml}")
+
+extra_args+=" -P nodes=${NODES}"
 
 if [[ ${use_cached_image} == false ]]; then
     printf "Pulling the image: %s\n" "$image_name"
@@ -57,30 +70,44 @@ rm -f ceph_image.tar
 printf "Saving the image: %s\n" "$image_name"
 podman save -o ceph_image.tar quay.ceph.io/ceph-ci/ceph:main
 
-printf "Creating the plan\n"
-kcli create plan -f ceph_cluster.yml ${extra_args} ceph
+NODE_IP_OFFSET=100
+PREFIX="ceph"
+for cluster in $(seq 1 $CLUSTERS); do
+    if [[ $cluster -gt 1 ]]; then
+        PREFIX="ceph${cluster}"
+    fi
+    printf "\nCreating cluster: %s\n" "${PREFIX}"
+    kcli create plan -f ceph_cluster.yml ${extra_args} -P node_ip_offset=${NODE_IP_OFFSET} \
+      -P prefix=${PREFIX} ${PREFIX}
+    NODE_IP_OFFSET=$((NODE_IP_OFFSET + 10))
+done
 
 attempt=0
 
 MAX_ATTEMPTS=10
 SLEEP_INTERVAL=5
 
-printf "Waiting for the host to be reachable\n"
-while [[ ${attempt} -lt ${MAX_ATTEMPTS} ]]; do
-    if ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10 root@192.168.100.100 exit; then
-        break
-    else
-        echo "Waiting for ssh connection to be available..., attempt: ${attempt}"
-        ((attempt++))
-        sleep ${SLEEP_INTERVAL}
-    fi
+NODE_IP_OFFSET=100
+PREFIX="ceph"
+for cluster in $(seq 1 $CLUSTERS); do
+  if [[ $cluster -gt 1 ]]; then
+      PREFIX="ceph${cluster}"
+  fi
+  printf "\nWaiting for the host to be reachable on cluster ${PREFIX}...\n"
+
+  while [[ ${attempt} -lt ${MAX_ATTEMPTS} ]]; do
+      if ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10 root@192.168.100."${NODE_IP_OFFSET}" exit; then
+          printf "\n${GREEN}Host is reachable on cluster %s\n${RESET}" "${PREFIX}"
+          break
+      else
+          echo "Waiting for ssh connection to be available..., attempt: ${attempt}"
+          ((attempt++))
+          sleep ${SLEEP_INTERVAL}
+      fi
+  done
+
+  NODE_IP_OFFSET=$((NODE_IP_OFFSET + 10))
 done
 
-printf "Copying the image to the hosts\n"
-
-for node in $(seq 0 $((node_count - 1))); do
-    scp -o StrictHostKeyChecking=no ceph_image.tar root@192.168.100.10"${node}":/root/
-done
-
-rm -f ceph_image.tar
+printf "\nOpening logs for first cluster"
 kcli ssh -u root -- ceph-node-00 'journalctl -n all -ft cloud-init'


### PR DESCRIPTION
a new `clusters` and `nodes` parameters, which can be used to provide how many clusters you want and how many nodes you want in each clusters.

```
./quick-bootstrap.sh -dir=/home/nia/projects/ceph -u -n=2 -c=2
```

the above will create 2 clusters with 2 nodes each so total 4 vms





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
