### PR TITLE
ptl-tool.py: replace regular strings with raw string literal for regular expressions

### DIFF
--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -178,9 +178,9 @@ except FileNotFoundError:
     pass
 GITHUB_TOKEN = os.getenv("PTL_TOOL_GITHUB_TOKEN", GITHUB_TOKEN)
 INDICATIONS = [
-    re.compile("(Reviewed-by: .+ <[\w@.-]+>)", re.IGNORECASE),
-    re.compile("(Acked-by: .+ <[\w@.-]+>)", re.IGNORECASE),
-    re.compile("(Tested-by: .+ <[\w@.-]+>)", re.IGNORECASE),
+    re.compile(r"(Reviewed-by: .+ <[\w@.-]+>)", re.IGNORECASE),
+    re.compile(r"(Acked-by: .+ <[\w@.-]+>)", re.IGNORECASE),
+    re.compile(r"(Tested-by: .+ <[\w@.-]+>)", re.IGNORECASE),
 ]
 REDMINE_CUSTOM_FIELD_ID_SHAMAN_BUILD = 26
 REDMINE_CUSTOM_FIELD_ID_QA_RUNS = 27
@@ -218,8 +218,8 @@ while not os.path.exists(git_dir + '/.git'):
 CONTRIBUTORS = {}
 NEW_CONTRIBUTORS = {}
 with codecs.open(git_dir + "/.githubmap", encoding='utf-8') as f:
-    comment = re.compile("\s*#")
-    patt = re.compile("([\w-]+)\s+(.*)")
+    comment = re.compile(r"\s*#")
+    patt = re.compile(r"([\w-]+)\s+(.*)")
     for line in f:
         if comment.match(line):
             continue


### PR DESCRIPTION
Using ptl-tool.py on Fedora 40 with Python 3.12.3 produces the following:
```
mchangir:ORIG-mchangir-ceph.git$ ./src/script/ptl-tool.py --help
/home/mchangir/work/ORIG-mchangir-ceph.git/./src/script/ptl-tool.py:181: SyntaxWarning: invalid escape sequence '\w'
  re.compile("(Reviewed-by: .+ <[\w@.-]+>)", re.IGNORECASE),
/home/mchangir/work/ORIG-mchangir-ceph.git/./src/script/ptl-tool.py:182: SyntaxWarning: invalid escape sequence '\w'
  re.compile("(Acked-by: .+ <[\w@.-]+>)", re.IGNORECASE),
/home/mchangir/work/ORIG-mchangir-ceph.git/./src/script/ptl-tool.py:183: SyntaxWarning: invalid escape sequence '\w'
  re.compile("(Tested-by: .+ <[\w@.-]+>)", re.IGNORECASE),
/home/mchangir/work/ORIG-mchangir-ceph.git/./src/script/ptl-tool.py:221: SyntaxWarning: invalid escape sequence '\s'
  comment = re.compile("\s*#")
/home/mchangir/work/ORIG-mchangir-ceph.git/./src/script/ptl-tool.py:222: SyntaxWarning: invalid escape sequence '\w'
  patt = re.compile("([\w-]+)\s+(.*)")
usage: ptl-tool.py [-h] [--base BASE] [--branch BRANCH] [--branch-release BRANCH_RELEASE] [--create-qa] [--debug] [--debug-build] [--git-dir GIT]
                   [--label LABEL] [--merge-branch-name MERGE_BRANCH_NAME] [--no-credits] [--pr-label PR_LABEL] [--qa-release QA_RELEASE] [--qa-tags QA_TAGS]
                   [--stop-at-built] [--update-qa UPDATE_QA] [--no-push-ci]
                   [PR ...]

Ceph PTL tool
```

This PR fixes the above warnings.

Signed-off-by: Milind Changire <mchangir@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
