### PR TITLE
ceph-backport: fix 'is a backport to null which is not an active milestone

### DIFF
--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -1580,7 +1580,7 @@ else
 fi
 
 debug "Looking up release/milestone of $redmine_url"
-milestone="$(echo "$remote_api_output" | jq -r '.issue.custom_fields[0].value')"
+milestone="$(echo "$remote_api_output" | jq -r '.issue.custom_fields[] | select(.id | contains(16)) | .value')"
 if [ "$milestone" ] ; then
     debug "Release/milestone: $milestone"
 else


### PR DESCRIPTION
```
$ src/script/ceph-backport.sh 64399
ceph-backport.sh: my GitHub username is cbodley
grep: warning: stray \ before /
grep: warning: stray \ before /
ceph-backport.sh: my Redmine username is cbodley (ID 2735)
ceph-backport.sh: ERROR: https://tracker.ceph.com/issues/64399 is a backport to null which is not an active milestone
ceph-backport.sh: Cowardly refusing to work on a backport to an inactive release
```

in this case, the script was incorrectly choosing the value of the custom field "Tags" instead of "Release". use jq to select the correct field by id (16) as is done elsewhere in the script

Fixes: https://tracker.ceph.com/issues/66370

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
