### PR TITLE
squid: qa: disable mon_warn_on_pool_no_app in fs suite

### DIFF
--- a/qa/cephfs/conf/mon.yaml
+++ b/qa/cephfs/conf/mon.yaml
@@ -5,3 +5,4 @@ overrides:
         mon op complaint time: 120
         # cephadm can take up to 5 minutes to bring up remaining mons
         mon down mkfs grace: 300
+        mon warn on pool no app: false

--- a/qa/suites/fs/cephadm/renamevolume/conf
+++ b/qa/suites/fs/cephadm/renamevolume/conf
@@ -1,0 +1,1 @@
+.qa/cephfs/conf

--- a/qa/suites/fs/mirror-ha/conf
+++ b/qa/suites/fs/mirror-ha/conf
@@ -1,0 +1,1 @@
+.qa/cephfs/conf

--- a/qa/suites/fs/mirror/conf
+++ b/qa/suites/fs/mirror/conf
@@ -1,0 +1,1 @@
+.qa/cephfs/conf

--- a/qa/suites/fs/top/conf
+++ b/qa/suites/fs/top/conf
@@ -1,0 +1,1 @@
+.qa/cephfs/conf


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66386

---

backport of https://github.com/ceph/ceph/pull/57879
parent tracker: https://tracker.ceph.com/issues/65976

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh