### PR TITLE
squid: qa: correct json lookup for new `lock path` output

### DIFF
--- a/qa/tasks/cephfs/test_subvolume.py
+++ b/qa/tasks/cephfs/test_subvolume.py
@@ -193,7 +193,7 @@ class TestSubvolumeReplicated(CephFSTestCase):
         op = self.fs.rank_tell("lock", "path", "/dir1/dir2", "snap:r", rank=1)
         p = self.mount_a.setfattr("dir1/dir2", "ceph.dir.subvolume", "1", wait=False)
         sleep(2)
-        reqid = self._reqid_tostr(op['op']['reqid'])
+        reqid = self._reqid_tostr(op['reqid'])
         self.fs.kill_op(reqid, rank=1)
         p.wait()
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66385

---

backport of https://github.com/ceph/ceph/pull/57877
parent tracker: https://tracker.ceph.com/issues/66355

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh