### PR TITLE
doc/start: format squash procedure

### DIFF
--- a/doc/start/documenting-ceph.rst
+++ b/doc/start/documenting-ceph.rst
@@ -546,7 +546,7 @@ commits will be squashed into a single commit.
 
 #. Make the commits that you will later squash.
 
-   #. Make the first commit.
+   A. Make the first commit.
 
       ::
 
@@ -564,7 +564,7 @@ commits will be squashed into a single commit.
          #       modified:   glossary.rst
          #
 
-   #. Make the second commit.
+   B. Make the second commit.
 
       ::
 
@@ -584,7 +584,7 @@ commits will be squashed into a single commit.
             # Changes to be committed:
             #       modified:   architecture.rst
 
-   #. Make the third commit.
+   C. Make the third commit.
 
       ::
 
@@ -607,14 +607,14 @@ commits will be squashed into a single commit.
 #. There are now three commits in the feature branch. We will now begin the
    process of squashing them into a single commit.
 
-   #. Run the command ``git rebase -i main``, which rebases the current branch
+   A. Run the command ``git rebase -i main``, which rebases the current branch
       (the feature branch) against the ``main`` branch:
 
       .. prompt:: bash
 
          git rebase -i main
 
-   #. A list of the commits that have been made to the feature branch now
+   B. A list of the commits that have been made to the feature branch now
       appear, and looks like this:
 
       ::
@@ -695,7 +695,7 @@ commits will be squashed into a single commit.
 #. Now we create a commit message that applies to all the commits that have
    been squashed together:
 
-   #. When you save and close the list of commits that you have designated for
+   A. When you save and close the list of commits that you have designated for
       squashing, a list of all three commit messages appears, and it looks
       like this:
 
@@ -744,7 +744,7 @@ commits will be squashed into a single commit.
          #       modified:   doc/architecture.rst
          #       modified:   doc/glossary.rst
 
-   #. The commit messages have been revised into the simpler form presented here:
+   B. The commit messages have been revised into the simpler form presented here:
 
       ::
 


### PR DESCRIPTION
Add letters to substeps in a procedure so that readers won't get too confused by having numbered steps nested inside numbered steps.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
