### PR TITLE
squid: mds: QuiesceDbRequest: update the internal encoding of ops

### DIFF
--- a/src/mds/MDSRankQuiesce.cc
+++ b/src/mds/MDSRankQuiesce.cc
@@ -197,9 +197,9 @@ void MDSRank::command_quiesce_db(const cmdmap_t& cmdmap, std::function<void(int,
     } else if (op_reset) {
       r.reset_roots(roots);
     } else if (op_release) {
-      r.release_roots();
+      r.release();
     } else if (op_cancel) {
-      r.cancel_roots();
+      r.cancel();
     }
 
     double timeout;
@@ -319,7 +319,7 @@ void MDSRank::quiesce_cluster_update() {
     struct CancelAll: public QuiesceDbManager::RequestContext {
       mds_rank_t whoami;
       CancelAll(mds_rank_t whoami) : whoami(whoami) {
-        request.cancel_roots();
+        request.cancel();
       }
       void finish(int rc) override {
         dout(rc == 0 ? 15 : 3) << "injected cancel all completed with rc: " << rc << dendl;

--- a/src/mds/QuiesceDb.h
+++ b/src/mds/QuiesceDb.h
@@ -340,8 +340,8 @@ struct QuiesceDbRequest {
   ///        for when `roots` is empty
   enum RootsOp: uint8_t {
     INCLUDE_OR_QUERY,
-    EXCLUDE_OR_RELEASE,
-    RESET_OR_CANCEL,
+    EXCLUDE_OR_CANCEL,
+    RESET_OR_RELEASE,
     __INVALID
   };
 
@@ -427,15 +427,15 @@ struct QuiesceDbRequest {
 
   bool is_mutating() const { return (control.roots_op != INCLUDE_OR_QUERY) || !roots.empty() || timeout || expiration; }
   bool is_cancel_all() const { return !set_id && is_cancel(); }
-  bool excludes_roots() const { return control.roots_op == RESET_OR_CANCEL || (control.roots_op == EXCLUDE_OR_RELEASE && !roots.empty()); }
-  bool includes_roots() const { return (control.roots_op == RESET_OR_CANCEL || control.roots_op == INCLUDE_OR_QUERY) && !roots.empty(); }
+  bool excludes_roots() const { return is_exclude() || is_reset(); }
+  bool includes_roots() const { return is_include() || is_reset(); }
 
   bool is_include() const { return control.roots_op == INCLUDE_OR_QUERY && !roots.empty(); }
   bool is_query() const { return control.roots_op == INCLUDE_OR_QUERY && roots.empty(); }
-  bool is_exclude() const { return control.roots_op == EXCLUDE_OR_RELEASE && !roots.empty(); }
-  bool is_release() const { return control.roots_op == EXCLUDE_OR_RELEASE && roots.empty(); }
-  bool is_reset() const { return control.roots_op == RESET_OR_CANCEL && !roots.empty(); }
-  bool is_cancel() const { return control.roots_op == RESET_OR_CANCEL && roots.empty(); }
+  bool is_exclude() const { return control.roots_op == EXCLUDE_OR_CANCEL && !roots.empty(); }
+  bool is_release() const { return control.roots_op == RESET_OR_RELEASE && roots.empty(); }
+  bool is_reset() const { return control.roots_op == RESET_OR_RELEASE && !roots.empty(); }
+  bool is_cancel() const { return control.roots_op == EXCLUDE_OR_CANCEL && roots.empty(); }
 
   bool is_verbose() const { return control.flags & Flags::VERBOSE; }
   bool is_exclusive() const { return control.flags & Flags::EXCLUSIVE; }
@@ -444,11 +444,11 @@ struct QuiesceDbRequest {
     switch (control.roots_op) {
     case INCLUDE_OR_QUERY:
       return false;
-    case EXCLUDE_OR_RELEASE:
-      return roots.contains(root);
-    case RESET_OR_CANCEL:
-      return !roots.contains(root);
-      default: ceph_abort("unknown roots_op"); return false;
+    case EXCLUDE_OR_CANCEL:
+      return roots.empty() || roots.contains(root);
+    case RESET_OR_RELEASE:
+      return !roots.empty() && !roots.contains(root);
+    default: ceph_abort("unknown roots_op"); return false;
     }
   }
 
@@ -493,22 +493,22 @@ struct QuiesceDbRequest {
   template <typename R = Roots>
   void exclude_roots(R&& roots)
   {
-    set_roots(EXCLUDE_OR_RELEASE, std::forward<R>(roots));
+    set_roots(EXCLUDE_OR_CANCEL, std::forward<R>(roots));
   }
 
-  void release_roots() {
-    set_roots(EXCLUDE_OR_RELEASE, {});
+  void release() {
+    set_roots(RESET_OR_RELEASE, {});
   }
 
   template <typename R = Roots>
   void reset_roots(R&& roots)
   {
-    set_roots(RESET_OR_CANCEL, std::forward<R>(roots));
+    set_roots(RESET_OR_RELEASE, std::forward<R>(roots));
   }
 
-  void cancel_roots()
+  void cancel()
   {
-    set_roots(RESET_OR_CANCEL, {});
+    set_roots(EXCLUDE_OR_CANCEL, {});
   }
 
   template <typename S = std::string>
@@ -522,10 +522,10 @@ struct QuiesceDbRequest {
     switch (control.roots_op) {
     case INCLUDE_OR_QUERY:
       return roots.empty() ? "query" : "include";
-    case EXCLUDE_OR_RELEASE:
-      return roots.empty() ? "release" : "exclude";
-    case RESET_OR_CANCEL:
-      return roots.empty() ? "cancel" : "reset";
+    case EXCLUDE_OR_CANCEL:
+      return roots.empty() ? "cancel" : "exclude";
+    case RESET_OR_RELEASE:
+      return roots.empty() ? "release" : "reset";
     default:
       return "<unknown>";
     }
@@ -547,11 +547,11 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const QuiesceDbRequest& req)
   os << "q-req[" << req.op_string();
 
   if (req.set_id) {
-    os << " \"" << req.set_id << "\"";
+    os << " \"" << *req.set_id << "\"";
   }
 
   if (req.if_version) {
-    os << " ?v:" << req.if_version;
+    os << " ?v:" << *req.if_version;
   }
 
   if (req.await) {

--- a/src/mds/QuiesceDbManager.cc
+++ b/src/mds/QuiesceDbManager.cc
@@ -447,7 +447,7 @@ void QuiesceDbManager::complete_requests() {
     }
 
     // non-zero result codes are all errors
-    dout(10) << "completing request '" << req->request << " with rc: " << -res << dendl;
+    dout(10) << "completing " << req->request << " with rc: " << -res << dendl;
     req->complete(-res);
   }
   done_requests.clear();
@@ -588,6 +588,8 @@ int QuiesceDbManager::leader_process_request(RequestContext* req_ctx)
     dout(2) << "failed to sanitize roots for a request" << dendl;
     return EINVAL;
   }
+
+  dout(20) << request << dendl;
 
   const auto db_age = db.get_age();
 


### PR DESCRIPTION
Backport: Excluding the last root from a set will automatically mark it as QS_CANCELED. Hence, it makes more sense if `exclude` and `cancel` share the same op code, rather than `exclude` and `release`.

Fixes: https://tracker.ceph.com/issues/66400
Signed-off-by: Leonid Usov <leonid.usov@ibm.com>
Original-issue: https://tracker.ceph.com/issues/66383
Original-PR: https://github.com/ceph/ceph/pull/57912
(cherry picked from commit dad52497817c372fd7c61a88a210b5a3613cb807)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
