### PR TITLE
mds: mark the scrub passed if dirfrag is dirty

### DIFF
--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -467,6 +467,16 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     return scrub_infop->queued_frags;
   }
 
+  bool has_dirty_remote_dirfrag_scrubbed() {
+    return dirty_remote_dirfrag_scrubbed;
+  }
+  void mark_dirty_remote_dirfrag_scrubbed() {
+    dirty_remote_dirfrag_scrubbed = true;
+  }
+  void clear_dirty_remote_dirfrag_scrubbed() {
+    dirty_remote_dirfrag_scrubbed = false;
+  }
+
   bool is_multiversion() const {
     return snaprealm ||  // other snaprealms will link to me
       get_inode()->is_dir() ||  // links to me in other snaps
@@ -1255,6 +1265,7 @@ private:
 
   int stickydir_ref = 0;
   std::unique_ptr<scrub_info_t> scrub_infop;
+  bool dirty_remote_dirfrag_scrubbed = false;
   /** @} Scrubbing and fsck */
 };
 

--- a/src/messages/MMDSScrub.h
+++ b/src/messages/MMDSScrub.h
@@ -51,6 +51,7 @@ public:
     if (is_force()) out << " force";
     if (is_recursive()) out << " recursive";
     if (is_repair()) out << " repair";
+    if (is_remote_dirfrag_dirty()) out << " dirty_remote_dirfrag";
     out << ")";
   }
   void encode_payload(uint64_t features) override {
@@ -99,23 +100,28 @@ public:
   bool is_repair() const {
     return flags & FLAG_REPAIR;
   }
+  bool is_remote_dirfrag_dirty() const {
+    return flags & FLAG_DIRTY_REMOTE_DIRFRAG;
+  }
 
 protected:
-  static constexpr int HEAD_VERSION = 1;
-  static constexpr int COMPAT_VERSION = 1;
+  static constexpr int HEAD_VERSION = 2;
+  static constexpr int COMPAT_VERSION = 2;
 
   MMDSScrub() : MMDSOp(MSG_MDS_SCRUB, HEAD_VERSION, COMPAT_VERSION) {}
   MMDSScrub(int o)
     : MMDSOp(MSG_MDS_SCRUB, HEAD_VERSION, COMPAT_VERSION), op(o) {}
   MMDSScrub(int o, inodeno_t i, fragset_t&& _frags, std::string_view _tag,
 	    inodeno_t _origin=inodeno_t(), bool internal_tag=false,
-	    bool force=false, bool recursive=false, bool repair=false)
+	    bool force=false, bool recursive=false, bool repair=false,
+	    bool remote_dirfrag_dirty=false)
     : MMDSOp(MSG_MDS_SCRUB, HEAD_VERSION, COMPAT_VERSION),
     op(o), ino(i), frags(std::move(_frags)), tag(_tag), origin(_origin) {
     if (internal_tag) flags |= FLAG_INTERNAL_TAG;
     if (force) flags |= FLAG_FORCE;
     if (recursive) flags |= FLAG_RECURSIVE;
     if (repair) flags |= FLAG_REPAIR;
+    if (remote_dirfrag_dirty) flags |= FLAG_DIRTY_REMOTE_DIRFRAG;
   }
 
   ~MMDSScrub() override {}
@@ -129,6 +135,7 @@ private:
   static constexpr unsigned FLAG_FORCE		= 1<<1;
   static constexpr unsigned FLAG_RECURSIVE	= 1<<2;
   static constexpr unsigned FLAG_REPAIR		= 1<<3;
+  static constexpr unsigned FLAG_DIRTY_REMOTE_DIRFRAG	= 1<<4;
 
   int32_t op;
   inodeno_t ino;


### PR DESCRIPTION
The in-memory and on-disk stats might not match on a directory inode if any of the dirfrag is dirty.
So don't fail the scrub  and mark it as passed if
the dirfrag is dirty.


Fixes: https://tracker.ceph.com/issues/65020





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
