### PR TITLE
rgw/auth: Remove Keystone v2.0 API support

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -202,7 +202,6 @@ Keystone Settings
 =================
 
 .. confval:: rgw_keystone_url
-.. confval:: rgw_keystone_api_version
 .. confval:: rgw_keystone_admin_domain
 .. confval:: rgw_keystone_admin_project
 .. confval:: rgw_keystone_admin_token

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -783,16 +783,6 @@ options:
   services:
   - rgw
   with_legacy: true
-- name: rgw_keystone_api_version
-  type: int
-  level: advanced
-  desc: Version of Keystone API to use (2 or 3).
-  fmt_desc: The version (2 or 3) of OpenStack Identity API that should be
-    used for communication with the Keystone server.
-  default: 2
-  services:
-  - rgw
-  with_legacy: true
 - name: rgw_keystone_accepted_roles
   type: str
   level: advanced

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -62,18 +62,13 @@ admin_token_retry:
     throw -EINVAL;
   }
 
-  const auto keystone_version = config.get_api_version();
-  if (keystone_version == rgw::keystone::ApiVersion::VER_2) {
-    url.append("v2.0/tokens/" + token);
-  } else if (keystone_version == rgw::keystone::ApiVersion::VER_3) {
-    url.append("v3/auth/tokens");
+  url.append("v3/auth/tokens");
 
-    if (allow_expired) {
-      url.append("?allow_expired=1");
-    }
-
-    validate.append_header("X-Subject-Token", token);
+  if (allow_expired) {
+    url.append("?allow_expired=1");
   }
+
+  validate.append_header("X-Subject-Token", token);
 
   std::string admin_token;
   bool admin_token_cached = false;
@@ -130,7 +125,7 @@ admin_token_retry:
                  << ", body=" << token_body_bl.c_str() << dendl;
 
   TokenEngine::token_envelope_t token_body;
-  ret = token_body.parse(dpp, token, token_body_bl, config.get_api_version());
+  ret = token_body.parse(dpp, token, token_body_bl);
   if (ret < 0) {
     throw ret;
   }
@@ -415,12 +410,7 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
     throw -EINVAL;
   }
 
-  const auto api_version = config.get_api_version();
-  if (api_version == rgw::keystone::ApiVersion::VER_3) {
-    keystone_url.append("v3/s3tokens");
-  } else {
-    keystone_url.append("v2.0/s3tokens");
-  }
+  keystone_url.append("v3/s3tokens");
 
   /* get authentication token for Keystone. */
   std::string admin_token;
@@ -483,7 +473,7 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
 
   /* now parse response */
   rgw::keystone::TokenEnvelope token_envelope;
-  ret = token_envelope.parse(dpp, std::string(), token_body_bl, api_version);
+  ret = token_envelope.parse(dpp, std::string(), token_body_bl);
   if (ret < 0) {
     ldpp_dout(dpp, 2) << "s3 keystone: token parsing failed, ret=0" << ret
                   << dendl;
@@ -508,12 +498,7 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
     return make_pair(boost::none, -EINVAL);
   }
 
-  const auto api_version = config.get_api_version();
-  if (api_version == rgw::keystone::ApiVersion::VER_3) {
-    keystone_url.append("v3/");
-  } else {
-    keystone_url.append("v2.0/");
-  }
+  keystone_url.append("v3/");
   keystone_url.append("users/");
   keystone_url.append(user_id);
   keystone_url.append("/credentials/OS-EC2/");

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -54,21 +54,6 @@ void rgw_get_token_id(const string& token, string& token_id)
 namespace rgw {
 namespace keystone {
 
-ApiVersion CephCtxConfig::get_api_version() const noexcept
-{
-  switch (g_ceph_context->_conf->rgw_keystone_api_version) {
-  case 3:
-    return ApiVersion::VER_3;
-  case 2:
-    return ApiVersion::VER_2;
-  default:
-    dout(0) << "ERROR: wrong Keystone API version: "
-            << g_ceph_context->_conf->rgw_keystone_api_version
-            << "; falling back to v2" <<  dendl;
-    return ApiVersion::VER_2;
-  }
-}
-
 std::string CephCtxConfig::get_endpoint_url() const noexcept
 {
   static const std::string url = g_ceph_context->_conf->rgw_keystone_url;
@@ -186,33 +171,18 @@ int Service::issue_admin_token_request(const DoutPrefixProvider *dpp,
   token_req.append_header("Content-Type", "application/json");
   JSONFormatter jf;
 
-  const auto keystone_version = config.get_api_version();
-  if (keystone_version == ApiVersion::VER_2) {
-    AdminTokenRequestVer2 req_serializer(config);
-    req_serializer.dump(&jf);
+  AdminTokenRequest req_serializer(config);
+  req_serializer.dump(&jf);
 
-    std::stringstream ss;
-    jf.flush(ss);
-    token_req.set_post_data(ss.str());
-    token_req.set_send_length(ss.str().length());
-    token_url.append("v2.0/tokens");
-
-  } else if (keystone_version == ApiVersion::VER_3) {
-    AdminTokenRequestVer3 req_serializer(config);
-    req_serializer.dump(&jf);
-
-    std::stringstream ss;
-    jf.flush(ss);
-    token_req.set_post_data(ss.str());
-    token_req.set_send_length(ss.str().length());
-    token_url.append("v3/auth/tokens");
-  } else {
-    return -ENOTSUP;
-  }
+  std::stringstream ss;
+  jf.flush(ss);
+  token_req.set_post_data(ss.str());
+  token_req.set_send_length(ss.str().length());
+  token_url.append("v3/auth/tokens");
 
   token_req.set_url(token_url);
 
-  const int ret = token_req.process(dpp, y);
+  int ret = token_req.process(dpp, y);
 
   /* Detect rejection earlier than during the token parsing step. */
   if (token_req.get_http_status() ==
@@ -225,8 +195,8 @@ int Service::issue_admin_token_request(const DoutPrefixProvider *dpp,
     return ret;
   }
 
-  if (t.parse(dpp, token_req.get_subject_token(), token_bl,
-              keystone_version) != 0) {
+  ret = t.parse(dpp, token_req.get_subject_token(), token_bl);
+  if (ret != 0) {
     return -EINVAL;
   }
 
@@ -263,34 +233,19 @@ int Service::get_keystone_barbican_token(const DoutPrefixProvider *dpp,
   token_req.append_header("Content-Type", "application/json");
   JSONFormatter jf;
 
-  const auto keystone_version = config.get_api_version();
-  if (keystone_version == ApiVersion::VER_2) {
-    rgw::keystone::BarbicanTokenRequestVer2 req_serializer(cct);
-    req_serializer.dump(&jf);
+  BarbicanTokenRequest req_serializer(cct);
+  req_serializer.dump(&jf);
 
-    std::stringstream ss;
-    jf.flush(ss);
-    token_req.set_post_data(ss.str());
-    token_req.set_send_length(ss.str().length());
-    token_url.append("v2.0/tokens");
-
-  } else if (keystone_version == ApiVersion::VER_3) {
-    BarbicanTokenRequestVer3 req_serializer(cct);
-    req_serializer.dump(&jf);
-
-    std::stringstream ss;
-    jf.flush(ss);
-    token_req.set_post_data(ss.str());
-    token_req.set_send_length(ss.str().length());
-    token_url.append("v3/auth/tokens");
-  } else {
-    return -ENOTSUP;
-  }
+  std::stringstream ss;
+  jf.flush(ss);
+  token_req.set_post_data(ss.str());
+  token_req.set_send_length(ss.str().length());
+  token_url.append("v3/auth/tokens");
 
   token_req.set_url(token_url);
 
   ldpp_dout(dpp, 20) << "Requesting secret from barbican url=" << token_url << dendl;
-  const int ret = token_req.process(dpp, y);
+  int ret = token_req.process(dpp, y);
   if (ret < 0) {
     ldpp_dout(dpp, 20) << "Barbican process error:" << token_bl.c_str() << dendl;
     return ret;
@@ -302,8 +257,8 @@ int Service::get_keystone_barbican_token(const DoutPrefixProvider *dpp,
     return -EACCES;
   }
 
-  if (t.parse(dpp, token_req.get_subject_token(), token_bl,
-              keystone_version) != 0) {
+  ret = t.parse(dpp, token_req.get_subject_token(), token_bl);
+  if (ret != 0) {
     return -EINVAL;
   }
 
@@ -326,8 +281,7 @@ bool TokenEnvelope::has_role(const std::string& r) const
 
 int TokenEnvelope::parse(const DoutPrefixProvider *dpp,
                          const std::string& token_str,
-                         ceph::bufferlist& bl,
-                         const ApiVersion version)
+                         ceph::bufferlist& bl)
 {
   JSONParser parser;
   if (! parser.parse(bl.c_str(), bl.length())) {
@@ -336,40 +290,13 @@ int TokenEnvelope::parse(const DoutPrefixProvider *dpp,
   }
 
   JSONObjIter token_iter = parser.find_first("token");
-  JSONObjIter access_iter = parser.find_first("access");
 
   try {
-    if (version == rgw::keystone::ApiVersion::VER_2) {
-      if (! access_iter.end()) {
-        decode_v2(*access_iter);
-      } else if (! token_iter.end()) {
-        /* TokenEnvelope structure doesn't follow Identity API v2, so let's
-         * fallback to v3. Otherwise we can assume it's wrongly formatted.
-         * The whole mechanism is a workaround for s3_token middleware that
-         * speaks in v2 disregarding the promise to go with v3. */
-        decode_v3(*token_iter);
-
-        /* Identity v3 conveys the token information not as a part of JSON but
-         * in the X-Subject-Token HTTP header we're getting from caller. */
-        token.id = token_str;
-      } else {
-        return -EINVAL;
-      }
-    } else if (version == rgw::keystone::ApiVersion::VER_3) {
-      if (! token_iter.end()) {
-        decode_v3(*token_iter);
-        /* v3 succeeded. We have to fill token.id from external input as it
-         * isn't a part of the JSON response anymore. It has been moved
-         * to X-Subject-Token HTTP header instead. */
-        token.id = token_str;
-      } else if (! access_iter.end()) {
-        /* If the token cannot be parsed according to V3, try V2. */
-        decode_v2(*access_iter);
-      } else {
-        return -EINVAL;
-      }
+    if (! token_iter.end()) {
+      decode(*token_iter);
+      token.id = token_str;
     } else {
-      return -ENOTSUP;
+      return -EINVAL;
     }
   } catch (const JSONDecoder::err& err) {
     ldpp_dout(dpp, 0) << "Keystone token parse error: " << err.what() << dendl;
@@ -544,7 +471,6 @@ void rgw::keystone::TokenEnvelope::Token::decode_json(JSONObj *obj)
   struct tm t;
 
   JSONDecoder::decode_json("id", id, obj, true);
-  JSONDecoder::decode_json("tenant", tenant_v2, obj, true);
   JSONDecoder::decode_json("expires", expires_iso8601, obj, true);
 
   if (parse_iso8601(expires_iso8601.c_str(), &t)) {
@@ -579,10 +505,9 @@ void rgw::keystone::TokenEnvelope::User::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("id", id, obj, true);
   JSONDecoder::decode_json("name", name, obj, true);
   JSONDecoder::decode_json("domain", domain, obj);
-  JSONDecoder::decode_json("roles", roles_v2, obj);
 }
 
-void rgw::keystone::TokenEnvelope::decode_v3(JSONObj* const root_obj)
+void rgw::keystone::TokenEnvelope::decode(JSONObj* const root_obj)
 {
   std::string expires_iso8601;
 
@@ -601,15 +526,6 @@ void rgw::keystone::TokenEnvelope::decode_v3(JSONObj* const root_obj)
   }
 }
 
-void rgw::keystone::TokenEnvelope::decode_v2(JSONObj* const root_obj)
-{
-  JSONDecoder::decode_json("user", user, root_obj, true);
-  JSONDecoder::decode_json("token", token, root_obj, true);
-
-  roles = user.roles_v2;
-  project = token.tenant_v2;
-}
-
 /* This utility function shouldn't conflict with the overload of std::to_string
  * provided by string_ref since Boost 1.54 as it's defined outside of the std
  * namespace. I hope we'll remove it soon - just after merging the Matt's PR
@@ -619,20 +535,7 @@ static inline std::string to_string(const std::string_view& s)
   return std::string(s.data(), s.length());
 }
 
-void rgw::keystone::AdminTokenRequestVer2::dump(Formatter* const f) const
-{
-  f->open_object_section("token_request");
-    f->open_object_section("auth");
-      f->open_object_section("passwordCredentials");
-        encode_json("username", ::to_string(conf.get_admin_user()), f);
-        encode_json("password", ::to_string(conf.get_admin_password()), f);
-      f->close_section();
-      encode_json("tenantName", ::to_string(conf.get_admin_tenant()), f);
-    f->close_section();
-  f->close_section();
-}
-
-void rgw::keystone::AdminTokenRequestVer3::dump(Formatter* const f) const
+void rgw::keystone::AdminTokenRequest::dump(Formatter* const f) const
 {
   f->open_object_section("token_request");
     f->open_object_section("auth");
@@ -666,20 +569,7 @@ void rgw::keystone::AdminTokenRequestVer3::dump(Formatter* const f) const
   f->close_section();
 }
 
-void rgw::keystone::BarbicanTokenRequestVer2::dump(Formatter* const f) const
-{
-  f->open_object_section("token_request");
-    f->open_object_section("auth");
-      f->open_object_section("passwordCredentials");
-        encode_json("username", cct->_conf->rgw_keystone_barbican_user, f);
-        encode_json("password", cct->_conf->rgw_keystone_barbican_password, f);
-      f->close_section();
-      encode_json("tenantName", cct->_conf->rgw_keystone_barbican_tenant, f);
-    f->close_section();
-  f->close_section();
-}
-
-void rgw::keystone::BarbicanTokenRequestVer3::dump(Formatter* const f) const
+void rgw::keystone::BarbicanTokenRequest::dump(Formatter* const f) const
 {
   f->open_object_section("token_request");
     f->open_object_section("auth");
@@ -712,5 +602,3 @@ void rgw::keystone::BarbicanTokenRequestVer3::dump(Formatter* const f) const
     f->close_section();
   f->close_section();
 }
-
-


### PR DESCRIPTION
The v2.0 API was removed from Keystone [1] in
the Queens release back in 2018 so we can
safely remove it for the next release.

This helps cleanup a lot of code and removes
the need for the rgw_keystone_api_version
configuration option.

[1] https://docs.openstack.org/keystone/latest/contributor/http-api.html





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
