### PR TITLE
rgw/auth: Refactor Keystone EC2Engine to not use admin token

### DIFF
--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -422,17 +422,6 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
     keystone_url.append("v2.0/s3tokens");
   }
 
-  /* get authentication token for Keystone. */
-  std::string admin_token;
-  bool admin_token_cached = false;
-  int ret = rgw::keystone::Service::get_admin_token(dpp, token_cache, config,
-                                                    y, admin_token, admin_token_cached);
-  if (ret < 0) {
-    ldpp_dout(dpp, 2) << "s3 keystone: cannot get token for keystone access"
-                  << dendl;
-    throw ret;
-  }
-
   using RGWValidateKeystoneToken
     = rgw::keystone::Service::RGWValidateKeystoneToken;
 
@@ -441,8 +430,7 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
   ceph::bufferlist token_body_bl;
   RGWValidateKeystoneToken validate(cct, "POST", keystone_url, &token_body_bl);
 
-  /* set required headers for keystone request */
-  validate.append_header("X-Auth-Token", admin_token);
+  /* set required header for keystone request */
   validate.append_header("Content-Type", "application/json");
 
   /* check if we want to verify keystone's ssl certs */
@@ -494,7 +482,7 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
 }
 
 auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
-                                         const std::string& user_id,
+                                         const rgw::keystone::TokenEnvelope& token_env,
                                          const std::string_view& access_key_id,
                                          optional_yield y) const
     -> std::pair<boost::optional<std::string>, int>
@@ -519,17 +507,6 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
   keystone_url.append("/credentials/OS-EC2/");
   keystone_url.append(std::string(access_key_id));
 
-  /* get authentication token for Keystone. */
-  std::string admin_token;
-  bool admin_token_cached = false;
-  int ret = rgw::keystone::Service::get_admin_token(dpp, token_cache, config,
-                                                    y, admin_token, admin_token_cached);
-  if (ret < 0) {
-    ldpp_dout(dpp, 2) << "s3 keystone: cannot get token for keystone access"
-                  << dendl;
-    return make_pair(boost::none, ret);
-  }
-
   using RGWGetAccessSecret
     = rgw::keystone::Service::RGWKeystoneHTTPTransceiver;
 
@@ -537,8 +514,8 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
   ceph::bufferlist token_body_bl;
   RGWGetAccessSecret secret(cct, "GET", keystone_url, &token_body_bl);
 
-  /* set required headers for keystone request */
-  secret.append_header("X-Auth-Token", admin_token);
+  /* set required header for keystone request */
+  secret.append_header("X-Auth-Token", token_env.token.id);
 
   /* check if we want to verify keystone's ssl certs */
   secret.set_verify_ssl(cct->_conf->rgw_keystone_verify_ssl);
@@ -632,7 +609,7 @@ auto EC2Engine::get_access_token(const DoutPrefixProvider* dpp,
   if (token) {
     /* Fetch secret from keystone for the access_key_id */
     std::tie(secret, failure_reason) =
-        get_secret_from_keystone(dpp, token->get_user_id(), access_key_id, y);
+        get_secret_from_keystone(dpp, token, access_key_id, y);
 
     if (secret) {
       /* Add token, secret pair to cache, and set timeout */

--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -176,7 +176,7 @@ class EC2Engine : public rgw::auth::s3::AWSEngine {
                         const req_state* s,
 			optional_yield y) const override;
   auto get_secret_from_keystone(const DoutPrefixProvider* dpp,
-                                const std::string& user_id,
+                                const rgw::keystone::TokenEnvelope& token_env,
                                 const std::string_view& access_key_id,
                                 optional_yield y) const
       -> std::pair<boost::optional<std::string>, int>;


### PR DESCRIPTION
The EC2Engine::get_from_keystone() function makes a HTTP POST request to /v3/s3tokens that is a public API [1] that does not require authentication to use, so we can drop the admin token in the header in that request.

The EC2Engine::get_secret_from_keystone() function makes the following HTTP GET request to get the secret key for that credential using the token we retrieved in the get_from_keystone function [2].

  /v3/users/{user_id}/credentials/OS-EC2/{credential_id}

This HTTP GET request in Keystone is validated by the identity:ec2_get_credential policy that before required an admin token but today can be retrieved by the
identity that created the credential [3].

That means we can drop the usage of admin token in the Keystone EC2Engine if we bump the minimum Keystone version required to >=16.0.0 (Train release) [4] that has been considered Extended Maintenance (EM) for a long time [5] and has since had it's git branch stable/train EOL'd into a train-eol git tag.

[1] https://github.com/openstack/keystone/blob/master/keystone/api/s3tokens.py#L94
[2] https://github.com/openstack/keystone/blob/master/keystone/api/users.py#L420
[3] https://bugs.launchpad.net/keystone/+bug/1750678
[4] https://releases.openstack.org/train/index.html
[5] https://review.opendev.org/c/openstack/releases/+/790750





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
