### PR TITLE
mds: just skip checking the replicated ancestor inodes

### DIFF
--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -522,7 +522,13 @@ class TestScrubChecks(CephFSTestCase):
         out_json = self.fs.run_scrub(["start", "/", "recursive"])
         self.assertNotEqual(out_json, None)
 
-        self.wait_for_health("MDS_DAMAGE", 60)
+        # There should no MDS_DAMAGE health error reported.
+        try:
+            self.wait_for_health("MDS_DAMAGE", 60)
+        except TestTimeoutError:
+            pass
+        else:
+            raise Exception("Scrub backtrace divergent test failed!")
 
     def test_stray_evaluation_with_scrub(self):
         """

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1323,7 +1323,7 @@ void CInode::build_backtrace(int64_t pool, inode_backtrace_t& bt)
   CDentry *pdn = get_parent_dn();
   while (pdn) {
     CInode *diri = pdn->get_dir()->get_inode();
-    bt.ancestors.push_back(inode_backpointer_t(diri->ino(), pdn->get_name(), in->get_inode()->version));
+    bt.ancestors.push_back(inode_backpointer_t(diri->ino(), pdn->get_name(), in->get_inode()->version, diri->is_auth()));
     in = diri;
     pdn = in->get_parent_dn();
   }

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4770,7 +4770,7 @@ void CInode::validate_disk_state(CInode::validated_data *results,
       const int64_t pool = in->get_backtrace_pool();
       inode_backtrace_t& memory_backtrace = results->backtrace.memory_value;
       in->build_backtrace(pool, memory_backtrace);
-      bool equivalent, divergent;
+      bool divergent;
       int memory_newer;
 
       MDCache *mdcache = in->mdcache;  // For the benefit of dout
@@ -4822,7 +4822,7 @@ void CInode::validate_disk_state(CInode::validated_data *results,
       }
 
       memory_newer = memory_backtrace.compare(results->backtrace.ondisk_value,
-					      &equivalent, &divergent);
+					      &divergent);
 
       if (divergent || memory_newer < 0) {
         // we're divergent, or on-disk version is newer

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1006,19 +1006,6 @@ bool CInode::is_ancestor_of(const CInode *other, std::unordered_map<CInode const
   return false;
 }
 
-bool CInode::is_any_ancestor_inode_a_replica() {
-  CDentry *pdn = get_parent_dn();
-  while (pdn) {
-    CInode *diri = pdn->get_dir()->get_inode();
-    if (!diri->is_auth()) {
-      return true;
-    }
-    pdn = diri->get_parent_dn();
-  }
-
-  return false;
-}
-
 bool CInode::is_projected_ancestor_of(const CInode *other) const
 {
   while (other) {
@@ -4849,11 +4836,7 @@ void CInode::validate_disk_state(CInode::validated_data *results,
           dout(20) << "divergent backtraces are acceptable when dn "
                       "is being purged or has been renamed or moved to a "
                       "different directory " << *in << dendl;
-        } else if (in->is_any_ancestor_inode_a_replica()) {
-          results->backtrace.passed = true;
-          dout(20) << "divergent backtraces are acceptable when some "
-	              "ancestor inodes are replicas " << *in << dendl;
-	}
+        }
       } else {
         results->backtrace.passed = true;
       }

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -707,8 +707,6 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   const CDir *get_projected_parent_dir() const;
   CDir *get_projected_parent_dir();
   CInode *get_parent_inode();
-
-  bool is_any_ancestor_inode_a_replica();
   
   bool is_lt(const MDSCacheObject *r) const override {
     const CInode *o = static_cast<const CInode*>(r);

--- a/src/mds/inode_backtrace.cc
+++ b/src/mds/inode_backtrace.cc
@@ -120,10 +120,9 @@ void inode_backtrace_t::generate_test_instances(std::list<inode_backtrace_t*>& l
 }
 
 int inode_backtrace_t::compare(const inode_backtrace_t& other,
-                               bool *equivalent, bool *divergent) const
+                               bool *divergent) const
 {
   int min_size = std::min(ancestors.size(),other.ancestors.size());
-  *equivalent = true;
   *divergent = false;
   if (min_size == 0)
     return 0;
@@ -145,7 +144,7 @@ int inode_backtrace_t::compare(const inode_backtrace_t& other,
     }
     if (ancestors[i].dirino != other.ancestors[i].dirino ||
         ancestors[i].dname != other.ancestors[i].dname) {
-      *equivalent = false;
+      *divergent = true;
       return comparator;
     } else if (ancestors[i].version > other.ancestors[i].version) {
       if (comparator < 0)
@@ -157,7 +156,5 @@ int inode_backtrace_t::compare(const inode_backtrace_t& other,
       comparator = -1;
     }
   }
-  if (*divergent)
-    *equivalent = false;
   return comparator;
 }

--- a/src/mds/inode_backtrace.h
+++ b/src/mds/inode_backtrace.h
@@ -63,15 +63,12 @@ struct inode_backtrace_t {
    * @pre The backtraces are for the same inode
    *
    * @param other The backtrace to compare ourselves with
-   * @param equivalent A bool pointer which will be set to true if
-   * the other backtrace is equivalent to our own (has the same dentries)
    * @param divergent A bool pointer which will be set to true if
    * the backtraces have differing entries without versions supporting them
    *
    * @returns 1 if we are newer than the other, 0 if equal, -1 if older
    */
-  int compare(const inode_backtrace_t& other,
-               bool *equivalent, bool *divergent) const;
+  int compare(const inode_backtrace_t& other, bool *divergent) const;
 
   void clear() {
     ancestors.clear();

--- a/src/mds/inode_backtrace.h
+++ b/src/mds/inode_backtrace.h
@@ -23,7 +23,8 @@ namespace ceph {
  */
 struct inode_backpointer_t {
   inode_backpointer_t() {}
-  inode_backpointer_t(inodeno_t i, std::string_view d, version_t v) : dirino(i), dname(d), version(v) {}
+  inode_backpointer_t(inodeno_t i, std::string_view d, version_t v, int a=-1) :
+    dirino(i), dname(d), version(v), is_auth(a) {}
 
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator &bl);
@@ -34,6 +35,9 @@ struct inode_backpointer_t {
   inodeno_t dirino;    // containing directory ino
   std::string dname;        // linking dentry name
   version_t version = 0;   // child's version at time of backpointer creation
+
+  // This won't be persisted to disk
+  int is_auth = -1;   // < 0: unknown, == 0: is replica, > 0: is auth
 };
 WRITE_CLASS_ENCODER(inode_backpointer_t)
 
@@ -42,7 +46,14 @@ inline bool operator==(const inode_backpointer_t& l, const inode_backpointer_t& 
 }
 
 inline std::ostream& operator<<(std::ostream& out, const inode_backpointer_t& ib) {
-  return out << "<" << ib.dirino << "/" << ib.dname << " v" << ib.version << ">";
+  out << "<" << ib.dirino << "/" << ib.dname << " v" << ib.version << " auth:";
+  if (ib.is_auth > 0)
+    out << " yes";
+  else if (ib.is_auth == 0)
+    out << " no";
+  else
+    out << " unknown";
+  return out << ">";
 }
 
 /*

--- a/src/test/fs/mds_types.cc
+++ b/src/test/fs/mds_types.cc
@@ -115,6 +115,7 @@ TEST(inode_backtrace_t, compare_equal)
   foo.old_pools.push_back(5);
 
   inode_backpointer_t foop;
+  foop.is_auth = 1;
   foop.dirino = 3;
   foop.dname = "l3";
   foop.version = 15;
@@ -153,6 +154,7 @@ TEST(inode_backtrace_t, compare_newer)
   bar.old_pools.push_back(10);
 
   inode_backpointer_t foop;
+  foop.is_auth = 1;
   foop.dirino = 3;
   foop.dname = "l3";
   foop.version = 15;
@@ -212,6 +214,7 @@ TEST(inode_backtrace_t, compare_divergent)
   bar.old_pools.push_back(10);
 
   inode_backpointer_t foop;
+  foop.is_auth = 1;
   foop.dirino = 3;
   foop.dname = "l3";
   foop.version = 15;

--- a/src/test/fs/mds_types.cc
+++ b/src/test/fs/mds_types.cc
@@ -131,12 +131,10 @@ TEST(inode_backtrace_t, compare_equal)
   bar = foo;
   
   int compare_r;
-  bool equivalent;
   bool divergent;
 
-  compare_r = foo.compare(bar, &equivalent, &divergent);
+  compare_r = foo.compare(bar, &divergent);
   EXPECT_EQ(0, compare_r);
-  EXPECT_TRUE(equivalent);
   EXPECT_FALSE(divergent);
 }
 
@@ -176,32 +174,27 @@ TEST(inode_backtrace_t, compare_newer)
   bar.ancestors.push_back(foop);
 
   int compare_r;
-  bool equivalent;
   bool divergent;
 
-  compare_r = foo.compare(bar, &equivalent, &divergent);
+  compare_r = foo.compare(bar, &divergent);
   EXPECT_EQ(1, compare_r);
-  EXPECT_TRUE(equivalent);
   EXPECT_FALSE(divergent);
 
-  compare_r = bar.compare(foo, &equivalent, &divergent);
+  compare_r = bar.compare(foo, &divergent);
   EXPECT_EQ(-1, compare_r);
-  EXPECT_TRUE(equivalent);
   EXPECT_FALSE(divergent);
 
   bar.ancestors.back().dirino = 75;
   bar.ancestors.back().dname = "l1-old";
   bar.ancestors.back().version = 70;
 
-  compare_r = foo.compare(bar, &equivalent, &divergent);
+  compare_r = foo.compare(bar, &divergent);
   EXPECT_EQ(1, compare_r);
-  EXPECT_FALSE(equivalent);
-  EXPECT_FALSE(divergent);
+  EXPECT_TRUE(divergent);
 
-  compare_r = bar.compare(foo, &equivalent, &divergent);
+  compare_r = bar.compare(foo, &divergent);
   EXPECT_EQ(-1, compare_r);
-  EXPECT_FALSE(equivalent);
-  EXPECT_FALSE(divergent);
+  EXPECT_TRUE(divergent);
 }
 
 TEST(inode_backtrace_t, compare_divergent)
@@ -240,13 +233,12 @@ TEST(inode_backtrace_t, compare_divergent)
   bar.ancestors.push_back(foop);
 
   int compare_r;
-  bool equivalent;
   bool divergent;
 
-  compare_r = foo.compare(bar, &equivalent, &divergent);
+  compare_r = foo.compare(bar, &divergent);
   EXPECT_EQ(1, compare_r);
   EXPECT_TRUE(divergent);
-  compare_r = bar.compare(foo, &equivalent, &divergent);
+  compare_r = bar.compare(foo, &divergent);
   EXPECT_EQ(-1, compare_r);
   EXPECT_TRUE(divergent);
 }


### PR DESCRIPTION
For the replicaed ancestor inodes the backtrace in disk maybe newer
than the one in replica MDS' memory. We should just ignore these
ancestor inodes and only compare the inodes whose author is local
MDS.

Fixes: https://tracker.ceph.com/issues/57656


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
