### PR TITLE
crimson/osd/osd_operations: make the "recover_missing" phase concurrent

### DIFF
--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -33,6 +33,8 @@ struct LttngBackend
     PGActivationBlocker::BlockingEvent::Backend,
     scrub::PGScrubber::BlockingEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::RecoverMissing::
+      BlockingEvent::ExitBarrierEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissingLockOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissingLockOBC::
       BlockingEvent::ExitBarrierEvent::Backend,
@@ -107,6 +109,10 @@ struct LttngBackend
   void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent& ev,
               const Operation& op,
               const ClientRequest::PGPipeline::RecoverMissing& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::ExitBarrierEvent& ev,
+	      const Operation& op) override {
   }
 
   void handle(ClientRequest::PGPipeline::RecoverMissingLockOBC::BlockingEvent& ev,
@@ -175,6 +181,8 @@ struct HistoricBackend
     PGActivationBlocker::BlockingEvent::Backend,
     scrub::PGScrubber::BlockingEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::Backend,
+    ClientRequest::PGPipeline::RecoverMissing::
+      BlockingEvent::ExitBarrierEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissingLockOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissingLockOBC::
       BlockingEvent::ExitBarrierEvent::Backend,
@@ -249,6 +257,10 @@ struct HistoricBackend
   void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent& ev,
               const Operation& op,
               const ClientRequest::PGPipeline::RecoverMissing& blocker) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::ExitBarrierEvent& ev,
+              const Operation& op) override {
   }
 
   void handle(ClientRequest::PGPipeline::RecoverMissingLockOBC::BlockingEvent& ev,

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -35,10 +35,6 @@ struct LttngBackend
     ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissing::
       BlockingEvent::ExitBarrierEvent::Backend,
-    ClientRequest::PGPipeline::RecoverMissingLockOBC::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::RecoverMissingLockOBC::
-      BlockingEvent::ExitBarrierEvent::Backend,
-    ClientRequest::PGPipeline::RecoverMissingSnaps::BlockingEvent::Backend,
     ClientRequest::PGPipeline::GetOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::LockOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::LockOBC::BlockingEvent::ExitBarrierEvent::Backend,
@@ -115,21 +111,6 @@ struct LttngBackend
 	      const Operation& op) override {
   }
 
-  void handle(ClientRequest::PGPipeline::RecoverMissingLockOBC::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::RecoverMissingLockOBC& blocker) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::RecoverMissingLockOBC::
-                BlockingEvent::ExitBarrierEvent& ev,
-              const Operation& op) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::RecoverMissingSnaps::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::RecoverMissingSnaps& blocker) override {
-  }
-
   void handle(ClientRequest::PGPipeline::GetOBC::BlockingEvent& ev,
               const Operation& op,
               const ClientRequest::PGPipeline::GetOBC& blocker) override {
@@ -183,10 +164,6 @@ struct HistoricBackend
     ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissing::
       BlockingEvent::ExitBarrierEvent::Backend,
-    ClientRequest::PGPipeline::RecoverMissingLockOBC::BlockingEvent::Backend,
-    ClientRequest::PGPipeline::RecoverMissingLockOBC::
-      BlockingEvent::ExitBarrierEvent::Backend,
-    ClientRequest::PGPipeline::RecoverMissingSnaps::BlockingEvent::Backend,
     ClientRequest::PGPipeline::GetOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::LockOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::LockOBC::BlockingEvent::ExitBarrierEvent::Backend,
@@ -261,21 +238,6 @@ struct HistoricBackend
 
   void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::ExitBarrierEvent& ev,
               const Operation& op) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::RecoverMissingLockOBC::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::RecoverMissingLockOBC& blocker) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::RecoverMissingLockOBC::
-                BlockingEvent::ExitBarrierEvent& ev,
-              const Operation& op) override {
-  }
-
-  void handle(ClientRequest::PGPipeline::RecoverMissingSnaps::BlockingEvent& ev,
-              const Operation& op,
-              const ClientRequest::PGPipeline::RecoverMissingSnaps& blocker) override {
   }
 
   void handle(ClientRequest::PGPipeline::GetOBC::BlockingEvent& ev,

--- a/src/crimson/osd/osd_operation_external_tracking.h
+++ b/src/crimson/osd/osd_operation_external_tracking.h
@@ -35,6 +35,7 @@ struct LttngBackend
     ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissing::
       BlockingEvent::ExitBarrierEvent::Backend,
+    ClientRequest::PGPipeline::CheckAlreadyCompleteGetObc::BlockingEvent::Backend,
     ClientRequest::PGPipeline::GetOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::LockOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::LockOBC::BlockingEvent::ExitBarrierEvent::Backend,
@@ -111,6 +112,11 @@ struct LttngBackend
 	      const Operation& op) override {
   }
 
+  void handle(ClientRequest::PGPipeline::CheckAlreadyCompleteGetObc::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::CheckAlreadyCompleteGetObc& blocker) override {
+  }
+
   void handle(ClientRequest::PGPipeline::GetOBC::BlockingEvent& ev,
               const Operation& op,
               const ClientRequest::PGPipeline::GetOBC& blocker) override {
@@ -164,6 +170,7 @@ struct HistoricBackend
     ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::Backend,
     ClientRequest::PGPipeline::RecoverMissing::
       BlockingEvent::ExitBarrierEvent::Backend,
+    ClientRequest::PGPipeline::CheckAlreadyCompleteGetObc::BlockingEvent::Backend,
     ClientRequest::PGPipeline::GetOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::LockOBC::BlockingEvent::Backend,
     ClientRequest::PGPipeline::LockOBC::BlockingEvent::ExitBarrierEvent::Backend,
@@ -238,6 +245,11 @@ struct HistoricBackend
 
   void handle(ClientRequest::PGPipeline::RecoverMissing::BlockingEvent::ExitBarrierEvent& ev,
               const Operation& op) override {
+  }
+
+  void handle(ClientRequest::PGPipeline::CheckAlreadyCompleteGetObc::BlockingEvent& ev,
+              const Operation& op,
+              const ClientRequest::PGPipeline::CheckAlreadyCompleteGetObc& blocker) override {
   }
 
   void handle(ClientRequest::PGPipeline::GetOBC::BlockingEvent& ev,

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -337,7 +337,6 @@ ClientRequest::process_op(
 
     std::set<snapid_t> snaps = snaps_need_to_recover();
     if (!snaps.empty()) {
-      // call with_obc() in order, but wait concurrently for loading.
       auto with_obc = pg->obc_loader.with_obc<RWState::RWREAD>(
         m->get_hobj().get_head(),
         [&snaps, &ihref, pg, this](auto head, auto) {
@@ -350,6 +349,16 @@ ClientRequest::process_op(
     }
   }
 
+  /**
+   * The previous stage of recover_missing is a concurrent phase.
+   * Checking for already_complete requests must done exclusively.
+   * Since get_obc is also an exclusive stage, we can merge both stages into
+   * a single stage and avoid stage switching overhead.
+   */
+  DEBUGDPP("{}.{}: entering check_already_complete_get_obc",
+	   *pg, *this, this_instance_id);
+  co_await ihref.enter_stage<interruptor>(
+    client_pp(*pg).check_already_complete_get_obc, *this);
   DEBUGDPP("{}.{}: checking already_complete",
 	   *pg, *this, this_instance_id);
   auto completed = co_await pg->already_complete(m->get_reqid());
@@ -368,11 +377,7 @@ ClientRequest::process_op(
     co_return;
   }
 
-  DEBUGDPP("{}.{}: not completed, entering get_obc stage",
-	   *pg, *this, this_instance_id);
-  co_await ihref.enter_stage<interruptor>(client_pp(*pg).get_obc, *this);
-
-  DEBUGDPP("{}.{}: entered get_obc stage, about to wait_scrub",
+  DEBUGDPP("{}.{}: not completed, about to wait_scrub",
 	   *pg, *this, this_instance_id);
   co_await ihref.enter_blocker(
     *this, pg->scrubber, &decltype(pg->scrubber)::wait_scrub,

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -294,9 +294,7 @@ ClientRequest::recover_missing_snaps(
   ObjectContextRef head,
   std::set<snapid_t> &snaps)
 {
-  LOG_PREFIX(ClientRequest::process_op);
-  co_await ihref.enter_stage<interruptor>(
-    client_pp(*pg).recover_missing_snaps, *this);
+  LOG_PREFIX(ClientRequest::recover_missing_snaps);
   for (auto &snap : snaps) {
     auto coid = head->obs.oi.soid;
     coid.snap = snap;
@@ -323,9 +321,7 @@ ClientRequest::process_op(
   instance_handle_t &ihref, Ref<PG> pg, unsigned this_instance_id)
 {
   LOG_PREFIX(ClientRequest::process_op);
-  co_await ihref.enter_stage<interruptor>(
-    client_pp(*pg).recover_missing, *this
-  );
+  ihref.enter_stage_sync(client_pp(*pg).recover_missing, *this);
   if (!pg->is_primary()) {
     DEBUGDPP(
       "Skipping recover_missings on non primary pg for soid {}",
@@ -342,8 +338,6 @@ ClientRequest::process_op(
     std::set<snapid_t> snaps = snaps_need_to_recover();
     if (!snaps.empty()) {
       // call with_obc() in order, but wait concurrently for loading.
-      ihref.enter_stage_sync(
-          client_pp(*pg).recover_missing_lock_obc, *this);
       auto with_obc = pg->obc_loader.with_obc<RWState::RWREAD>(
         m->get_hobj().get_head(),
         [&snaps, &ihref, pg, this](auto head, auto) {

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -44,12 +44,6 @@ class ClientRequest final : public PhasedOperationT<ClientRequest>,
 public:
   class PGPipeline : public CommonPGPipeline {
     public:
-    struct RecoverMissingLockOBC : OrderedConcurrentPhaseT<RecoverMissingLockOBC> {
-      static constexpr auto type_name = "ClientRequest::PGPipeline::recover_missing_lock_obc";
-    } recover_missing_lock_obc;
-    struct RecoverMissingSnaps : OrderedExclusivePhaseT<RecoverMissingSnaps> {
-      static constexpr auto type_name = "ClientRequest::PGPipeline::recover_missing_snaps";
-    } recover_missing_snaps;
     struct AwaitMap : OrderedExclusivePhaseT<AwaitMap> {
       static constexpr auto type_name = "ClientRequest::PGPipeline::await_map";
     } await_map;
@@ -108,8 +102,6 @@ public:
       PGPipeline::WaitForActive::BlockingEvent,
       PGActivationBlocker::BlockingEvent,
       PGPipeline::RecoverMissing::BlockingEvent,
-      PGPipeline::RecoverMissingLockOBC::BlockingEvent,
-      PGPipeline::RecoverMissingSnaps::BlockingEvent,
       scrub::PGScrubber::BlockingEvent,
       PGPipeline::GetOBC::BlockingEvent,
       PGPipeline::LockOBC::BlockingEvent,

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -103,6 +103,7 @@ public:
       PGActivationBlocker::BlockingEvent,
       PGPipeline::RecoverMissing::BlockingEvent,
       scrub::PGScrubber::BlockingEvent,
+      PGPipeline::CheckAlreadyCompleteGetObc::BlockingEvent,
       PGPipeline::GetOBC::BlockingEvent,
       PGPipeline::LockOBC::BlockingEvent,
       PGPipeline::Process::BlockingEvent,

--- a/src/crimson/osd/osd_operations/common/pg_pipeline.h
+++ b/src/crimson/osd/osd_operations/common/pg_pipeline.h
@@ -17,7 +17,7 @@ protected:
   struct WaitForActive : OrderedExclusivePhaseT<WaitForActive> {
     static constexpr auto type_name = "CommonPGPipeline:::wait_for_active";
   } wait_for_active;
-  struct RecoverMissing : OrderedExclusivePhaseT<RecoverMissing> {
+  struct RecoverMissing : OrderedConcurrentPhaseT<RecoverMissing> {
     static constexpr auto type_name = "CommonPGPipeline::recover_missing";
   } recover_missing;
   struct GetOBC : OrderedExclusivePhaseT<GetOBC> {

--- a/src/crimson/osd/osd_operations/common/pg_pipeline.h
+++ b/src/crimson/osd/osd_operations/common/pg_pipeline.h
@@ -20,6 +20,9 @@ protected:
   struct RecoverMissing : OrderedConcurrentPhaseT<RecoverMissing> {
     static constexpr auto type_name = "CommonPGPipeline::recover_missing";
   } recover_missing;
+  struct CheckAlreadyCompleteGetObc : OrderedExclusivePhaseT<CheckAlreadyCompleteGetObc> {
+    static constexpr auto type_name = "CommonPGPipeline::check_already_complete_get_obc";
+  } check_already_complete_get_obc;
   struct GetOBC : OrderedExclusivePhaseT<GetOBC> {
     static constexpr auto type_name = "CommonPGPipeline::get_obc";
   } get_obc;


### PR DESCRIPTION
Otherwise, UrgentRecovery requests within the same pg can only be processed sequentially

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
