### PR TITLE
reef: qa/upgrade: convert reef-p2p upgrade tests to use cephadm

### DIFF
--- a/qa/suites/upgrade/reef-p2p/reef-p2p-parallel/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/reef-p2p/reef-p2p-parallel/point-to-point-upgrade.yaml
@@ -60,9 +60,11 @@ roles:
   - mgr.x
 - - mon.b
   - mon.c
+  - mds.b
   - osd.3
   - osd.4
   - osd.5
+  - mgr.y
   - client.0
 - - client.1
 openstack:
@@ -76,10 +78,9 @@ tasks:
     # line below can be removed its from jewel test
     #exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev', 'librgw2']
 - print: "**** done v18.2.0 install"
-- ceph:
-   fs: xfs
-   add_osds_to_crush: true
-- print: "**** done ceph xfs"
+- cephadm:
+    image: quay.io/ceph/ceph:v18.2.0
+    compiled_cephadm_branch: reef
 - sequential:
    - workload
 - print: "**** done workload v18.2.0"
@@ -92,6 +93,14 @@ tasks:
       tag: v18.2.1
     mon.b:
       tag: v18.2.1
+- cephadm.shell:
+    mon.a:
+      - ceph orch upgrade start --image quay.io/ceph/ceph:v18.2.1
+      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; ceph health detail ; sleep 30 ; done
+      - ceph orch ps
+      - ceph versions
+      - ceph versions | jq -e '.overall | length == 1'
+      - ceph versions | jq -e '.overall | keys' | grep 18.2.1
 - parallel:
    - workload_reef
    - upgrade-sequence_reef
@@ -101,6 +110,15 @@ tasks:
 - install.upgrade:
     mon.a:
     mon.b:
+- cephadm.shell:
+    env: [sha1]
+    mon.a:
+      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
+      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; ceph health detail ; sleep 30 ; done
+      - ceph orch ps
+      - ceph versions
+      - ceph versions | jq -e '.overall | length == 1'
+      - ceph versions | jq -e '.overall | keys' | grep $sha1
 - parallel:
    - workload_reef
    - upgrade-sequence_reef
@@ -136,38 +154,70 @@ workload_reef:
 
 upgrade-sequence_reef:
    sequential:
-   - print: "**** done branch: reef install.upgrade"
-   - ceph.restart: [mds.a]
+   - print: "**** done branch: reef upgrade"
+   - cephadm.shell:
+       mon.a:
+         - ceph orch daemon restart mds.a
    - sleep:
        duration: 60
-   - ceph.restart: [osd.0]
+   - cephadm.shell:
+       mon.a:
+         - ceph orch daemon restart mds.b
+   - sleep:
+       duration: 60
+   - cephadm.shell:
+       mon.a:
+         - ceph orch daemon restart osd.0
    - sleep:
        duration: 30
-   - ceph.restart: [osd.1]
+   - cephadm.shell:
+       mon.a:
+         - ceph orch daemon restart osd.1
    - sleep:
        duration: 30
-   - ceph.restart: [osd.2]
+   - cephadm.shell:
+       mon.a:
+         - ceph orch daemon restart osd.2
    - sleep:
        duration: 30
-   - ceph.restart: [osd.3]
+   - cephadm.shell:
+       mon.a:
+         - ceph orch daemon restart osd.3
    - sleep:
        duration: 30
-   - ceph.restart: [osd.4]
+   - cephadm.shell:
+       mon.a:
+         - ceph orch daemon restart osd.4
    - sleep:
        duration: 30
-   - ceph.restart: [osd.5]
+   - cephadm.shell:
+       mon.a:
+         - ceph orch daemon restart osd.5
    - sleep:
        duration: 60
-   - ceph.restart: [mgr.x]
+   - cephadm.shell:
+       mon.a:
+         - ceph orch daemon restart mgr.x
    - sleep:
        duration: 60
-   - ceph.restart: [mon.a]
+   - cephadm.shell:
+       mon.a:
+         - ceph orch daemon restart mgr.y
    - sleep:
        duration: 60
-   - ceph.restart: [mon.b]
+   - cephadm.shell:
+       mon.a:
+         - ceph orch daemon restart mon.a
    - sleep:
        duration: 60
-   - ceph.restart: [mon.c]
+   - cephadm.shell:
+       mon.a:
+         - ceph orch daemon restart mon.b
    - sleep:
        duration: 60
-   - print: "**** done ceph.restart all reef branch mds/osd/mon"
+   - cephadm.shell:
+       mon.a:
+         - ceph orch daemon restart mon.c
+   - sleep:
+       duration: 60
+   - print: "**** done restart all reef branch mds/osd/mon"

--- a/qa/suites/upgrade/reef-p2p/reef-p2p-stress-split/0-cluster/start.yaml
+++ b/qa/suites/upgrade/reef-p2p/reef-p2p-stress-split/0-cluster/start.yaml
@@ -30,4 +30,5 @@ roles:
   - osd.5
   - osd.6
   - osd.7
+  - mgr.y
 - - client.0

--- a/qa/suites/upgrade/reef-p2p/reef-p2p-stress-split/1-ceph-install/reef.yaml
+++ b/qa/suites/upgrade/reef-p2p/reef-p2p-stress-split/1-ceph-install/reef.yaml
@@ -8,7 +8,9 @@ tasks:
     exclude_packages: ['librados3']
     extra_packages: ['librados2']
 - print: "**** done install reef v18.2.0"
-- ceph:
+- cephadm:
+    image: quay.io/ceph/ceph:v18.2.0
+    compiled_cephadm_branch: reef
 - exec:
     osd.0:
       - ceph osd require-osd-release reef

--- a/qa/suites/upgrade/reef-p2p/reef-p2p-stress-split/2-partial-upgrade/firsthalf.yaml
+++ b/qa/suites/upgrade/reef-p2p/reef-p2p-stress-split/2-partial-upgrade/firsthalf.yaml
@@ -1,13 +1,38 @@
 meta:
 - desc: |
-   install upgrade ceph/-x on one node only
+   install upgrade ceph/-x on one node only (with the exception of the mgr on the other host)
    1st half
    restart : osd.0,1,2,3
 tasks:
+- cephadm.shell:
+    env: [sha1]
+    mon.a:
+      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types mgr
+      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; ceph health detail ; sleep 30 ; done
+      - ceph orch ps
+      - ceph versions
+      - ceph versions | jq -e '.mgr | length == 1'
+      - ceph versions | jq -e '.mgr | keys' | grep $sha1
+- cephadm.shell:
+    env: [sha1]
+    mon.a:
+      - HOSTNAME=$(ceph orch ps --format json | jq -r '.[] | select( .daemon_name == "mon.vm-00" ) | .hostname')
+      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --hosts $HOSTNAME
+      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; ceph health detail ; sleep 30 ; done
+      - ceph orch ps
+      - ceph versions
+      - ceph versions | jq -e '.mon | length == 1'
+      - ceph versions | jq -e '.mon | keys' | grep $sha1
+      - ceph versions | jq -e '.osd | length == 2'
 - install.upgrade:
     osd.0:
 - print: "**** done install.upgrade osd.0"
-- ceph.restart:
-    daemons: [mon.a,mon.b,mon.c,mgr.x,osd.0,osd.1,osd.2,osd.3]
-    mon-health-to-clog: false
+- cephadm.shell:
+    mon.a:
+      - ceph orch restart mon
+      - ceph orch restart mgr
+      - ceph orch daemon restart osd.0
+      - ceph orch daemon restart osd.1
+      - ceph orch daemon restart osd.2
+      - ceph orch daemon restart osd.3
 - print: "**** done ceph.restart 1st half"

--- a/qa/suites/upgrade/reef-p2p/reef-p2p-stress-split/5-finish-upgrade.yaml
+++ b/qa/suites/upgrade/reef-p2p/reef-p2p-stress-split/5-finish-upgrade.yaml
@@ -1,8 +1,19 @@
 tasks:
+- cephadm.shell:
+    env: [sha1]
+    mon.a:
+      - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1
+      - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; ceph health detail ; sleep 30 ; done
+      - ceph orch ps
+      - ceph versions
+      - ceph versions | jq -e '.overall | length == 1'
+      - ceph versions | jq -e '.overall | keys' | grep $sha1
 - install.upgrade:
     osd.4:
     client.0:
-- ceph.restart:
-    daemons: [osd.4, osd.5, osd.6, osd.7]
-    wait-for-healthy: false
-    wait-for-osds-up: true
+- cephadm.shell:
+    mon.a:
+      - ceph orch daemon restart osd.4
+      - ceph orch daemon restart osd.5
+      - ceph orch daemon restart osd.6
+      - ceph orch daemon restart osd.7

--- a/qa/tasks/util/chacra.py
+++ b/qa/tasks/util/chacra.py
@@ -71,7 +71,15 @@ def get_binary_url(
     if len(result) == 0:
         raise RuntimeError(f'no results found at {resp.url}')
 
-    # TODO: filter the result down to the correct arch etc.?
+    # if arch was supplied, filter down to only results
+    # that include the desired arch
+    if arch:
+        result = [r for r in result if ('archs' in r and arch in r['archs'])]
+
+    # TODO: Is there any further filtering we should do beyond arch?
+    # We already use flavor, ref, etc. in our search.
+
+    # TODO: After filtering, does it matter which result we take?
     result = result[0]
 
     status = result['status']


### PR DESCRIPTION

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
