### PR TITLE
squid: cephadm: use importlib.metadata for querying ceph_iscsi's version

### DIFF
--- a/src/cephadm/cephadmlib/daemons/iscsi.py
+++ b/src/cephadm/cephadmlib/daemons/iscsi.py
@@ -138,6 +138,11 @@ class CephIscsi(ContainerDaemonForm):
         )
         if code == 0:
             return out.strip()
+        out, _, code = python(
+            "import pkg_resources; print(pkg_resources.require('ceph_iscsi')[0].version)"
+        )
+        if code == 0:
+            return out.strip()
         return None
 
     def validate(self):

--- a/src/cephadm/cephadmlib/daemons/iscsi.py
+++ b/src/cephadm/cephadmlib/daemons/iscsi.py
@@ -119,22 +119,26 @@ class CephIscsi(ContainerDaemonForm):
     @staticmethod
     def get_version(ctx, container_id):
         # type: (CephadmContext, str) -> Optional[str]
-        version = None
-        out, err, code = call(
-            ctx,
-            [
-                ctx.container_engine.path,
-                'exec',
-                container_id,
-                '/usr/bin/python3',
-                '-c',
-                "import pkg_resources; print(pkg_resources.require('ceph_iscsi')[0].version)",
-            ],
-            verbosity=CallVerbosity.QUIET,
+        def python(s: str) -> Tuple[str, str, int]:
+            return call(
+                ctx,
+                [
+                    ctx.container_engine.path,
+                    'exec',
+                    container_id,
+                    '/usr/bin/python3',
+                    '-c',
+                    s,
+                ],
+                verbosity=CallVerbosity.QUIET,
+            )
+
+        out, _, code = python(
+            "from importlib.metadata import version; print(version('ceph_iscsi'))"
         )
         if code == 0:
-            version = out.strip()
-        return version
+            return out.strip()
+        return None
 
     def validate(self):
         # type: () -> None


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/57685

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
