### PR TITLE
cephadm: disable ms_bind_ipv4 if we will enable ms_bind_ipv6

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2564,6 +2564,12 @@ def finish_bootstrap_config(
     if ipv6 or ipv6_cluster_network:
         logger.info('Enabling IPv6 (ms_bind_ipv6) binding')
         cli(['config', 'set', 'global', 'ms_bind_ipv6', 'true'])
+        # note: Ceph does not fully support dual stack.
+        # kernel clients: https://tracker.ceph.com/issues/49581
+        # if we do not disable ipv4 binding, daemons will bind
+        # to 0.0.0.0 and clients will misbehave.
+        logger.info('Disabling IPv4 (ms_bind_ipv4) binding')
+        cli(['config', 'set', 'global', 'ms_bind_ipv4', 'false'])
 
     with open(ctx.output_config, 'w') as f:
         f.write(config)


### PR DESCRIPTION
While bootstrapping an ipv6 cluster with an ipv6 initial mon, cephadm correctly enables ms_bind_ipv6=true. However it leaves ms_bind_ipv4 as it's default (true).

As a result, daemons (osd, mds, ...) will attempt to bind to both ipv6 and ipv4. Usually this results in an osdmap and fsmap like the following:

```
osd.2 up in weight 1 up_from 26 up_thru 909 down_at 0 last_clean_interval [0,0) [v2:[xxxx:4f8:d0:4401:3::29]:6800/3680761436,v1:[xxxx:4f8:d0:4401:3::29]:6801/3680761436,v2:0.0.0.0:6802/3680761436,v1:0.0.0.0:6803/3680761436] [v2:[xxxx:4f8:d0:4401:3::29]:6804/3680761436,v1:[xxxx:4f8:d0:4401:3::29]:6805/3680761436,v2:0.0.0.0:6806/3680761436,v1:0.0.0.0:6807/3680761436] exists,up 0978a571-cd00-4eba-b00b-f863603a9a70
```

```
[mds.cephfs.ceph-test-3.isityv{-1:793154} state up:standby seq 1 join_fscid=1 addr [v2:[xxxx:4f8:d0:4401:3::29]:6832/2213688825,v1:[xxxx:4f8:d0:4401:3::29]:6833/2213688825,v2:0.0.0.0:6834/2213688825,v1:0.0.0.0:6835/2213688825] compat {c=[1],r=[1],i=[7ff]}]
```

Dual stack is not support by kernels (https://tracker.ceph.com/issues/49581) which leads to hard to debug issues for the end users. (corrupt map messages in dmesg).

Fix by disabling ms_bind_ipv4 in the case ipv6 is desired.

Fixes: https://tracker.ceph.com/issues/66436





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
