### PR TITLE
rgw/adminops: add option to provide storageclass adminops user apis

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -486,6 +486,19 @@ A tenant name may also specified as a part of ``uid``, by following the syntax
 :Example: tenant1
 :Required: No
 
+``default-placement``
+
+:Description: default placement for the user.
+:Type: string
+:Example: default-placement
+:Required: No
+
+``default-storage-class``
+:Description: default storage class for the user, default-placement must be defined when setting this option.
+:Type: string
+:Example: STANDARD-1A
+:Required: No
+
 Response Entities
 ~~~~~~~~~~~~~~~~~
 
@@ -681,6 +694,19 @@ Request Parameters
 :Description: The op-mask of the user to be modified.
 :Type: String
 :Example: ``read, write, delete, *``
+:Required: No
+
+``default-placement``
+
+:Description: default placement for the user.
+:Type: string
+:Example: default-placement
+:Required: No
+
+``default-storage-class``
+:Description: default storage class for the user, default-placement must be defined when setting this option.
+:Type: string
+:Example: STANDARD-1A
 :Required: No
 
 Response Entities

--- a/src/rgw/driver/rados/rgw_rest_user.cc
+++ b/src/rgw/driver/rados/rgw_rest_user.cc
@@ -157,6 +157,7 @@ void RGWOp_User_Create::execute(optional_yield y)
   std::string op_mask_str;
   std::string default_placement_str;
   std::string placement_tags_str;
+  std::string default_storage_class_str;
 
   bool gen_key;
   bool suspended;
@@ -188,6 +189,7 @@ void RGWOp_User_Create::execute(optional_yield y)
   RESTArgs::get_bool(s, "exclusive", false, &exclusive);
   RESTArgs::get_string(s, "op-mask", op_mask_str, &op_mask_str);
   RESTArgs::get_string(s, "default-placement", default_placement_str, &default_placement_str);
+  RESTArgs::get_string(s, "default-storage-class", default_storage_class_str, &default_storage_class_str);
   RESTArgs::get_string(s, "placement-tags", placement_tags_str, &placement_tags_str);
   RESTArgs::get_string(s, "account-id", "", &op_state.account_id);
   RESTArgs::get_string(s, "path", "", &op_state.path);
@@ -251,7 +253,10 @@ void RGWOp_User_Create::execute(optional_yield y)
 
   if (!default_placement_str.empty()) {
     rgw_placement_rule target_rule;
-    target_rule.from_str(default_placement_str);
+    target_rule.name = default_placement_str;
+    if (!default_storage_class_str.empty()){
+      target_rule.storage_class = default_storage_class_str;
+    }
     if (!driver->valid_placement(target_rule)) {
       ldpp_dout(this, 0) << "NOTICE: invalid dest placement: " << target_rule.to_str() << dendl;
       op_ret = -EINVAL;
@@ -309,6 +314,7 @@ void RGWOp_User_Modify::execute(optional_yield y)
   std::string op_mask_str;
   std::string default_placement_str;
   std::string placement_tags_str;
+  std::string default_storage_class_str;
 
   bool gen_key;
   bool suspended;
@@ -336,6 +342,7 @@ void RGWOp_User_Modify::execute(optional_yield y)
   RESTArgs::get_bool(s, "account-root", false, &account_root);
   RESTArgs::get_string(s, "op-mask", op_mask_str, &op_mask_str);
   RESTArgs::get_string(s, "default-placement", default_placement_str, &default_placement_str);
+  RESTArgs::get_string(s, "default-storage-class", default_storage_class_str, &default_storage_class_str);
   RESTArgs::get_string(s, "placement-tags", placement_tags_str, &placement_tags_str);
   RESTArgs::get_string(s, "account-id", "", &op_state.account_id);
   RESTArgs::get_string(s, "path", "", &op_state.path);
@@ -404,7 +411,10 @@ void RGWOp_User_Modify::execute(optional_yield y)
 
   if (!default_placement_str.empty()) {
     rgw_placement_rule target_rule;
-    target_rule.from_str(default_placement_str);
+    target_rule.name = default_placement_str;
+    if (!default_storage_class_str.empty()){
+      target_rule.storage_class = default_storage_class_str;
+    }
     if (!driver->valid_placement(target_rule)) {
       ldpp_dout(this, 0) << "NOTICE: invalid dest placement: " << target_rule.to_str() << dendl;
       op_ret = -EINVAL;


### PR DESCRIPTION
In the `radosgw-admin user` command, the default storage class can defined. This capability is missing in the adminops api.

Fixes https://tracker.ceph.com/issues/66439



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
