### PR TITLE
mgr/dashboard: Fix login and notification e2e tests

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/logs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/logs.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('Logs page', () => {
   describe('audit logs respond to pool creation and deletion test', () => {
     it('should create pool and check audit logs reacted', () => {
       pools.navigateTo('create');
-      pools.create(poolname, 8);
+      pools.create(poolname, 8, 'rbd');
       pools.navigateTo();
       pools.existTableCell(poolname, true);
       logs.checkAuditForPoolFunction(poolname, 'create', hour, minute);

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/notification.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/notification.e2e-spec.ts
@@ -9,7 +9,7 @@ describe('Notification page', () => {
   before(() => {
     cy.login();
     pools.navigateTo('create');
-    pools.create(poolName, 8);
+    pools.create(poolName, 8, 'rbd');
     pools.edit_pool_pg(poolName, 4, false);
   });
 


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/66453

- `#rbdMirroring` checkbox is not found due to which both of these tests are failing on most of the Prs
- this is due to the pool helper function which checks for an existing app passed in parameter
- if app is not found, then mirroring checkbox remains hidden


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
