### PR TITLE
reef: mgr/k8sevents: update V1Events to CoreV1Events

### DIFF
--- a/src/pybind/mgr/k8sevents/module.py
+++ b/src/pybind/mgr/k8sevents/module.py
@@ -67,7 +67,11 @@ else:
     # which causes an exception in the generator. A workaround is discussed for a similar issue
     # in https://github.com/kubernetes-client/python/issues/376 which has been used here
     # pylint: disable=no-member
-    from kubernetes.client.models.v1_event import V1Event
+    try:
+        from kubernetes.client.models.core_v1_event import CoreV1Event as V1Event
+    except ImportError:
+        from kubernetes.client.models.v1_event import V1Event
+
     def local_involved_object(self, involved_object):
         if involved_object is None:
             involved_object = client.V1ObjectReference(api_version="1")
@@ -409,14 +413,14 @@ class KubernetesEvent(object):
 
         event_source = client.V1EventSource(component="ceph-mgr", 
                                             host=self.host)
-        return  client.V1Event(
-                    involved_object=obj_ref, 
-                    metadata=obj_meta, 
-                    message=self.message, 
-                    count=self.count, 
+        return V1Event(
+                    involved_object=obj_ref,
+                    metadata=obj_meta,
+                    message=self.message,
+                    count=self.count,
                     type=self.event_type,
                     reason=self.event_reason,
-                    source=event_source, 
+                    source=event_source,
                     first_timestamp=self.first_timestamp,
                     last_timestamp=self.last_timestamp
                 )

--- a/src/pybind/mgr/requirements.txt
+++ b/src/pybind/mgr/requirements.txt
@@ -1,5 +1,5 @@
 -rrequirements-required.txt
 asyncssh==2.9
-kubernetes==11.0.0
+kubernetes
 urllib3==1.26.15
 pytest==7.4.4


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66450

---

backport of https://github.com/ceph/ceph/pull/57253
parent tracker: https://tracker.ceph.com/issues/65627

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh