### PR TITLE
squid:  rgw/notification: Store the value of `persistent_queue` for existing topics and continue commiting events for all topics subscribed to given bucket

### DIFF
--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -1086,7 +1086,7 @@ int publish_reserve(const DoutPrefixProvider* dpp,
           // either the topic is deleted but the corresponding notification
           // still exist or in v2 mode the notification could have synced first
           // but topic is not synced yet.
-          return 0;
+          continue;
         }
         ldpp_dout(res.dpp, 1)
             << "WARN: Using the stored topic from bucket notification struct."

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -402,6 +402,8 @@ void RGWPSCreateTopicOp::execute(optional_yield y) {
                          << op_ret << dendl;
       return;
     }
+  } else if (already_persistent) {  // redundant call to CreateTopic
+    dest.persistent_queue = topic->dest.persistent_queue;
   }
   const RGWPubSub ps(driver, get_account_or_tenant(s->owner.id), *s->penv.site);
   op_ret = ps.create_topic(this, topic_name, dest, topic_arn.to_string(),
@@ -861,7 +863,7 @@ void RGWPSSetTopicAttributesOp::execute(optional_yield y) {
           << op_ret << dendl;
       return;
     }
-  } else if (already_persistent) {
+  } else if (already_persistent && !topic_needs_queue(dest)) {
     // changing the persistent topic to non-persistent.
     op_ret = rgw::notify::remove_persistent_topic(result.dest.persistent_queue, s->yield);
     if (op_ret != -ENOENT && op_ret < 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66443

---

backport of https://github.com/ceph/ceph/pull/57536
parent tracker: https://tracker.ceph.com/issues/66097

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh