### PR TITLE
squid: osd/scrub: Change scrub cost to average object size

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1798,17 +1798,6 @@ void OSDService::queue_scrub_event_msg_default_cost(PG* pg,
   queue_scrub_event_msg<MSG_TYPE>(pg, with_priority, cost);
 }
 
-int64_t OSDService::get_scrub_cost()
-{
-
-  int64_t cost_for_queue = cct->_conf->osd_scrub_cost;
-  if (op_queue_type_t::mClockScheduler == osd->osd_op_queue_type()) {
-    cost_for_queue = cct->_conf->osd_scrub_event_cost *
-                     cct->_conf->osd_shallow_scrub_chunk_max;
-  }
-  return cost_for_queue;
-}
-
 void OSDService::queue_for_scrub(PG* pg, Scrub::scrub_prio_t with_priority)
 {
   queue_scrub_event_msg_default_cost<PGScrub>(pg, with_priority);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1822,9 +1822,10 @@ void OSDService::queue_scrub_after_repair(PG* pg, Scrub::scrub_prio_t with_prior
 void OSDService::queue_for_rep_scrub(PG* pg,
 				     Scrub::scrub_prio_t with_priority,
 				     unsigned int qu_priority,
-				     Scrub::act_token_t act_token)
+				     Scrub::act_token_t act_token,
+				     uint64_t cost)
 {
-  queue_scrub_event_msg<PGRepScrub>(pg, with_priority, qu_priority, act_token, get_scrub_cost());
+  queue_scrub_event_msg<PGRepScrub>(pg, with_priority, qu_priority, act_token, cost);
 }
 
 void OSDService::queue_for_rep_scrub_resched(PG* pg,
@@ -1849,10 +1850,10 @@ void OSDService::queue_scrub_pushes_update(PG* pg, Scrub::scrub_prio_t with_prio
   queue_scrub_event_msg_default_cost<PGScrubPushesUpdate>(pg, with_priority);
 }
 
-void OSDService::queue_scrub_chunk_free(PG* pg, Scrub::scrub_prio_t with_priority)
+void OSDService::queue_scrub_chunk_free(PG* pg, Scrub::scrub_prio_t with_priority, uint64_t cost)
 {
   // Resulting scrub event: 'SelectedChunkFree'
-  queue_scrub_event_msg<PGScrubChunkIsFree>(pg, with_priority, get_scrub_cost());
+  queue_scrub_event_msg<PGScrubChunkIsFree>(pg, with_priority, cost);
 }
 
 void OSDService::queue_scrub_chunk_busy(PG* pg, Scrub::scrub_prio_t with_priority)

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1682,6 +1682,11 @@ void OSDService::enqueue_front(OpSchedulerItem&& qi)
   osd->op_shardedwq.queue_front(std::move(qi));
 }
 
+double OSDService::get_cost_per_io() const
+{
+  return osd->op_shardedwq.get_cost_per_io();
+}
+
 void OSDService::queue_recovery_context(
   PG *pg,
   GenContext<ThreadPool::TPHandle&> *c,

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1755,27 +1755,47 @@ template <class MSG_TYPE>
 void OSDService::queue_scrub_event_msg(PG* pg,
 				       Scrub::scrub_prio_t with_priority,
 				       unsigned int qu_priority,
-				       Scrub::act_token_t act_token)
+				       Scrub::act_token_t act_token,
+				       uint64_t cost)
 {
   const auto epoch = pg->get_osdmap_epoch();
   auto msg = new MSG_TYPE(pg->get_pgid(), epoch, act_token);
   dout(15) << "queue a scrub event (" << *msg << ") for " << *pg
            << ". Epoch: " << epoch << " token: " << act_token << dendl;
   enqueue_back(OpSchedulerItem(
-    unique_ptr<OpSchedulerItem::OpQueueable>(msg), get_scrub_cost(),
+    unique_ptr<OpSchedulerItem::OpQueueable>(msg), cost,
     pg->scrub_requeue_priority(with_priority, qu_priority), ceph_clock_now(), 0, epoch));
 }
 
 template <class MSG_TYPE>
 void OSDService::queue_scrub_event_msg(PG* pg,
-                                       Scrub::scrub_prio_t with_priority)
+                                       Scrub::scrub_prio_t with_priority,
+				        uint64_t cost)
 {
   const auto epoch = pg->get_osdmap_epoch();
   auto msg = new MSG_TYPE(pg->get_pgid(), epoch);
   dout(15) << "queue a scrub event (" << *msg << ") for " << *pg << ". Epoch: " << epoch << dendl;
   enqueue_back(OpSchedulerItem(
-    unique_ptr<OpSchedulerItem::OpQueueable>(msg), get_scrub_cost(),
+    unique_ptr<OpSchedulerItem::OpQueueable>(msg), cost,
     pg->scrub_requeue_priority(with_priority), ceph_clock_now(), 0, epoch));
+}
+
+template <class MSG_TYPE>
+void OSDService::queue_scrub_event_msg_default_cost(PG* pg,
+		                                     Scrub::scrub_prio_t with_priority,
+						     unsigned int qu_priority,
+						     Scrub::act_token_t act_token)
+{
+  uint64_t cost = cct->_conf->osd_scrub_event_cost;
+  queue_scrub_event_msg<MSG_TYPE>(pg, with_priority, qu_priority, act_token, cost);
+}
+
+template <class MSG_TYPE>
+void OSDService::queue_scrub_event_msg_default_cost(PG* pg,
+		                                     Scrub::scrub_prio_t with_priority)
+{
+  uint64_t cost = cct->_conf->osd_scrub_event_cost;
+  queue_scrub_event_msg<MSG_TYPE>(pg, with_priority, cost);
 }
 
 int64_t OSDService::get_scrub_cost()
@@ -1791,12 +1811,12 @@ int64_t OSDService::get_scrub_cost()
 
 void OSDService::queue_for_scrub(PG* pg, Scrub::scrub_prio_t with_priority)
 {
-  queue_scrub_event_msg<PGScrub>(pg, with_priority);
+  queue_scrub_event_msg_default_cost<PGScrub>(pg, with_priority);
 }
 
 void OSDService::queue_scrub_after_repair(PG* pg, Scrub::scrub_prio_t with_priority)
 {
-  queue_scrub_event_msg<PGScrubAfterRepair>(pg, with_priority);
+  queue_scrub_event_msg_default_cost<PGScrubAfterRepair>(pg, with_priority);
 }
 
 void OSDService::queue_for_rep_scrub(PG* pg,
@@ -1804,7 +1824,7 @@ void OSDService::queue_for_rep_scrub(PG* pg,
 				     unsigned int qu_priority,
 				     Scrub::act_token_t act_token)
 {
-  queue_scrub_event_msg<PGRepScrub>(pg, with_priority, qu_priority, act_token);
+  queue_scrub_event_msg<PGRepScrub>(pg, with_priority, qu_priority, act_token, get_scrub_cost());
 }
 
 void OSDService::queue_for_rep_scrub_resched(PG* pg,
@@ -1813,73 +1833,73 @@ void OSDService::queue_for_rep_scrub_resched(PG* pg,
 					     Scrub::act_token_t act_token)
 {
   // Resulting scrub event: 'SchedReplica'
-  queue_scrub_event_msg<PGRepScrubResched>(pg, with_priority, qu_priority,
-					   act_token);
+  queue_scrub_event_msg_default_cost<PGRepScrubResched>(pg, with_priority, qu_priority,
+					                act_token);
 }
 
 void OSDService::queue_for_scrub_resched(PG* pg, Scrub::scrub_prio_t with_priority)
 {
   // Resulting scrub event: 'InternalSchedScrub'
-  queue_scrub_event_msg<PGScrubResched>(pg, with_priority);
+  queue_scrub_event_msg_default_cost<PGScrubResched>(pg, with_priority);
 }
 
 void OSDService::queue_scrub_pushes_update(PG* pg, Scrub::scrub_prio_t with_priority)
 {
   // Resulting scrub event: 'ActivePushesUpd'
-  queue_scrub_event_msg<PGScrubPushesUpdate>(pg, with_priority);
+  queue_scrub_event_msg_default_cost<PGScrubPushesUpdate>(pg, with_priority);
 }
 
 void OSDService::queue_scrub_chunk_free(PG* pg, Scrub::scrub_prio_t with_priority)
 {
   // Resulting scrub event: 'SelectedChunkFree'
-  queue_scrub_event_msg<PGScrubChunkIsFree>(pg, with_priority);
+  queue_scrub_event_msg<PGScrubChunkIsFree>(pg, with_priority, get_scrub_cost());
 }
 
 void OSDService::queue_scrub_chunk_busy(PG* pg, Scrub::scrub_prio_t with_priority)
 {
   // Resulting scrub event: 'ChunkIsBusy'
-  queue_scrub_event_msg<PGScrubChunkIsBusy>(pg, with_priority);
+  queue_scrub_event_msg_default_cost<PGScrubChunkIsBusy>(pg, with_priority);
 }
 
 void OSDService::queue_scrub_applied_update(PG* pg, Scrub::scrub_prio_t with_priority)
 {
-  queue_scrub_event_msg<PGScrubAppliedUpdate>(pg, with_priority);
+  queue_scrub_event_msg_default_cost<PGScrubAppliedUpdate>(pg, with_priority);
 }
 
 void OSDService::queue_scrub_unblocking(PG* pg, Scrub::scrub_prio_t with_priority)
 {
   // Resulting scrub event: 'Unblocked'
-  queue_scrub_event_msg<PGScrubUnblocked>(pg, with_priority);
+  queue_scrub_event_msg_default_cost<PGScrubUnblocked>(pg, with_priority);
 }
 
 void OSDService::queue_scrub_digest_update(PG* pg, Scrub::scrub_prio_t with_priority)
 {
   // Resulting scrub event: 'DigestUpdate'
-  queue_scrub_event_msg<PGScrubDigestUpdate>(pg, with_priority);
+  queue_scrub_event_msg_default_cost<PGScrubDigestUpdate>(pg, with_priority);
 }
 
 void OSDService::queue_scrub_got_repl_maps(PG* pg, Scrub::scrub_prio_t with_priority)
 {
   // Resulting scrub event: 'GotReplicas'
-  queue_scrub_event_msg<PGScrubGotReplMaps>(pg, with_priority);
+  queue_scrub_event_msg_default_cost<PGScrubGotReplMaps>(pg, with_priority);
 }
 
 void OSDService::queue_scrub_replica_pushes(PG *pg, Scrub::scrub_prio_t with_priority)
 {
   // Resulting scrub event: 'ReplicaPushesUpd'
-  queue_scrub_event_msg<PGScrubReplicaPushes>(pg, with_priority);
+  queue_scrub_event_msg_default_cost<PGScrubReplicaPushes>(pg, with_priority);
 }
 
 void OSDService::queue_scrub_is_finished(PG *pg)
 {
   // Resulting scrub event: 'ScrubFinished'
-  queue_scrub_event_msg<PGScrubScrubFinished>(pg, Scrub::scrub_prio_t::high_priority);
+  queue_scrub_event_msg_default_cost<PGScrubScrubFinished>(pg, Scrub::scrub_prio_t::high_priority);
 }
 
 void OSDService::queue_scrub_next_chunk(PG *pg, Scrub::scrub_prio_t with_priority)
 {
   // Resulting scrub event: 'NextChunk'
-  queue_scrub_event_msg<PGScrubGetNextChunk>(pg, with_priority);
+  queue_scrub_event_msg_default_cost<PGScrubGetNextChunk>(pg, with_priority);
 }
 
 void OSDService::queue_for_pg_delete(spg_t pgid, epoch_t e, int64_t num_objects)

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -600,8 +600,6 @@ private:
 		                          Scrub::scrub_prio_t with_priority,
 					  unsigned int qu_priority,
 					  Scrub::act_token_t act_token);
-  int64_t get_scrub_cost();
-
   utime_t defer_recovery_until;
   uint64_t recovery_ops_active;
   uint64_t recovery_ops_reserved;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -585,12 +585,20 @@ private:
   void queue_scrub_event_msg(PG* pg,
 			     Scrub::scrub_prio_t with_priority,
 			     unsigned int qu_priority,
-			     Scrub::act_token_t act_token);
+			     Scrub::act_token_t act_token,
+			     uint64_t cost);
 
   /// An alternative version of queue_scrub_event_msg(), in which the queuing priority is
   /// provided by the executing scrub (i.e. taken from PgScrubber::m_flags)
   template <class MSG_TYPE>
-  void queue_scrub_event_msg(PG* pg, Scrub::scrub_prio_t with_priority);
+  void queue_scrub_event_msg(PG* pg, Scrub::scrub_prio_t with_priority, uint64_t cost);
+  template <class MSG_TYPE>
+  void queue_scrub_event_msg_default_cost(PG* pg, Scrub::scrub_prio_t with_priority);
+  template <class MSG_TYPE>
+  void queue_scrub_event_msg_default_cost(PG* pg,
+		                          Scrub::scrub_prio_t with_priority,
+					  unsigned int qu_priority,
+					  Scrub::act_token_t act_token);
   int64_t get_scrub_cost();
 
   utime_t defer_recovery_until;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -118,6 +118,8 @@ public:
 
   void enqueue_back(OpSchedulerItem&& qi);
   void enqueue_front(OpSchedulerItem&& qi);
+  /// scheduler cost per io, only valid for mclock, asserts for wpq
+  double get_cost_per_io() const;
 
   void maybe_inject_dispatch_delay() {
     if (g_conf()->osd_debug_inject_dispatch_delay_probability > 0) {
@@ -1619,6 +1621,11 @@ protected:
       for (auto p : oncommits) {
 	p->complete(0);
       }
+    }
+
+    double get_cost_per_io() const {
+      auto &sdata = osd->shards[0];
+      return sdata->scheduler->get_cost_per_io();
     }
   } op_shardedwq;
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -526,7 +526,7 @@ public:
   void queue_scrub_applied_update(PG* pg, Scrub::scrub_prio_t with_priority);
 
   /// Signals that the selected chunk (objects range) is available for scrubbing
-  void queue_scrub_chunk_free(PG* pg, Scrub::scrub_prio_t with_priority);
+  void queue_scrub_chunk_free(PG* pg, Scrub::scrub_prio_t with_priority, uint64_t cost);
 
   /// The chunk selected is blocked by user operations, and cannot be scrubbed now
   void queue_scrub_chunk_busy(PG* pg, Scrub::scrub_prio_t with_priority);
@@ -552,7 +552,8 @@ public:
   void queue_for_rep_scrub(PG* pg,
 			   Scrub::scrub_prio_t with_high_priority,
 			   unsigned int qu_priority,
-			   Scrub::act_token_t act_token);
+			   Scrub::act_token_t act_token,
+			   uint64_t cost);
 
   /// Signals a change in the number of in-flight recovery writes
   void queue_scrub_replica_pushes(PG *pg, Scrub::scrub_prio_t with_priority);

--- a/src/osd/scheduler/OpScheduler.h
+++ b/src/osd/scheduler/OpScheduler.h
@@ -22,6 +22,8 @@
 #include "mon/MonClient.h"
 #include "osd/scheduler/OpSchedulerItem.h"
 
+#include "include/ceph_assert.h"
+
 namespace ceph::osd::scheduler {
 
 using client = uint64_t;
@@ -57,6 +59,11 @@ public:
 
   // Get the scheduler type set for the queue
   virtual op_queue_type_t get_type() const = 0;
+
+  virtual double get_cost_per_io() const {
+    ceph_assert(0 == "impossible for wpq");
+    return 0.0;
+  }
 
   // Destructor
   virtual ~OpScheduler() {};

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -261,6 +261,10 @@ public:
   const char** get_tracked_conf_keys() const final;
   void handle_conf_change(const ConfigProxy& conf,
 			  const std::set<std::string> &changed) final;
+
+  double get_cost_per_io() const {
+    return osd_bandwidth_cost_per_io;
+  }
 private:
   // Enqueue the op to the high priority queue
   void enqueue_high(unsigned prio, OpSchedulerItem &&item, bool front = false);

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -876,8 +876,11 @@ int PgScrubber::get_whoami() const
  * - m_max_end
  * - end
  * - start
+ * returns:
+ * - std::nullopt if the range is blocked
+ * - otherwise, the number of objects in the selected range
  */
-bool PgScrubber::select_range()
+std::optional<uint64_t> PgScrubber::select_range()
 {
   m_be->new_chunk();
 
@@ -959,7 +962,7 @@ bool PgScrubber::select_range()
     // we'll be requeued by whatever made us unavailable for scrub
     dout(10) << __func__ << ": scrub blocked somewhere in range "
 	     << "[" << m_start << ", " << candidate_end << ")" << dendl;
-    return false;
+    return std::nullopt;
   }
 
   m_end = candidate_end;
@@ -972,9 +975,9 @@ bool PgScrubber::select_range()
   // debug: be 'blocked' if told so by the 'pg scrub_debug block' asok command
   if (m_debug_blockrange > 0) {
     m_debug_blockrange--;
-    return false;
+    return std::nullopt;
   }
-  return true;
+  return objects.size();
 }
 
 void PgScrubber::select_range_n_notify()
@@ -985,12 +988,33 @@ void PgScrubber::select_range_n_notify()
     // the next chunk to handle is not blocked
     dout(20) << __func__ << ": selection OK" << dendl;
     m_osds->queue_scrub_chunk_free(m_pg, Scrub::scrub_prio_t::low_priority);
-
   } else {
     // we will wait for the objects range to become available for scrubbing
     dout(10) << __func__ << ": selected chunk is busy" << dendl;
     m_osds->queue_scrub_chunk_busy(m_pg, Scrub::scrub_prio_t::low_priority);
     get_counters_set().inc(scrbcnt_chunks_busy);
+  }
+}
+
+uint64_t PgScrubber::get_scrub_cost(uint64_t num_chunk_objects)
+{
+  const auto& conf = m_pg->get_cct()->_conf;
+  if (op_queue_type_t::WeightedPriorityQueue == m_osds->osd->osd_op_queue_type()) {
+    // if the osd_op_queue is WPQ, we will use the default osd_scrub_cost value
+    return conf->osd_scrub_cost;
+  }
+  uint64_t cost = 0;
+  double scrub_metadata_cost = m_osds->get_cost_per_io();
+  if (m_is_deep) {
+    auto pg_avg_object_size = m_pg->get_average_object_size();
+    cost = conf->osd_scrub_event_cost + (num_chunk_objects
+    * (scrub_metadata_cost + pg_avg_object_size));
+    dout(20) << fmt::format("{} : deep-scrub cost = {}", __func__, cost) << dendl;
+    return cost;
+  } else {
+    cost = conf->osd_scrub_event_cost + (num_chunk_objects *  scrub_metadata_cost);
+    dout(20) << fmt::format("{} : shallow-scrub cost = {}", __func__, cost) << dendl;
+    return cost;
   }
 }
 

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -983,11 +983,12 @@ std::optional<uint64_t> PgScrubber::select_range()
 void PgScrubber::select_range_n_notify()
 {
   get_counters_set().inc(scrbcnt_chunks_selected);
-
-  if (select_range()) {
+  auto num_chunk_objects = select_range();
+  if (num_chunk_objects.has_value()) {
     // the next chunk to handle is not blocked
     dout(20) << __func__ << ": selection OK" << dendl;
-    m_osds->queue_scrub_chunk_free(m_pg, Scrub::scrub_prio_t::low_priority);
+    auto cost = get_scrub_cost(num_chunk_objects.value());
+    m_osds->queue_scrub_chunk_free(m_pg, Scrub::scrub_prio_t::low_priority, cost);
   } else {
     // we will wait for the objects range to become available for scrubbing
     dout(10) << __func__ << ": selected chunk is busy" << dendl;
@@ -1598,10 +1599,15 @@ void PgScrubber::replica_scrub_op(OpRequestRef op)
 
   set_queued_or_active();
   advance_token();
+  const auto& conf = m_pg->get_cct()->_conf;
+  const int max_from_conf = size_from_conf(
+    m_is_deep, conf, "osd_scrub_chunk_max", "osd_shallow_scrub_chunk_max");
+  auto cost = get_scrub_cost(max_from_conf);
   m_osds->queue_for_rep_scrub(m_pg,
 			      m_replica_request_priority,
 			      m_flags.priority,
-			      m_current_token);
+			      m_current_token,
+			      cost);
 }
 
 void PgScrubber::set_op_parameters(const requested_scrub_t& request)

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -729,6 +729,8 @@ class PgScrubber : public ScrubPgIF,
   /// Returns epoch of current osdmap
   epoch_t get_osdmap_epoch() const { return get_osdmap()->get_epoch(); }
 
+  uint64_t get_scrub_cost(uint64_t num_chunk_objects);
+
   // collected statistics
   int m_shallow_errors{0};
   int m_deep_errors{0};
@@ -802,8 +804,11 @@ class PgScrubber : public ScrubPgIF,
    * - handling some head/clones issues
    *
    * The selected range is set directly into 'm_start' and 'm_end'
+   *
+   * Returns std::nullopt if the range is busy otherwise returns the
+   * number of objects in the range.
    */
-  bool select_range();
+  std::optional<uint64_t> select_range();
 
   std::list<Context*> m_callbacks;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66421

---

backport of https://github.com/ceph/ceph/pull/51171
parent tracker: https://tracker.ceph.com/issues/66420

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh