### PR TITLE
cls/rbd: add group_snap_list_order method to enable sorting snapshots in creation order

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -7566,7 +7566,10 @@ int group_snap_list(cls_method_context_t hctx,
     return -EINVAL;
   }
   std::vector<cls::rbd::GroupSnapshot> group_snaps;
-  group::snap_list(hctx, start_after, max_return, &group_snaps);
+  int r = group::snap_list(hctx, start_after, max_return, &group_snaps);
+  if (r < 0) {
+    return r;
+  }
 
   encode(group_snaps, *out);
 

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -2782,6 +2782,30 @@ int group_snap_list(librados::IoCtx *ioctx, const std::string &oid,
   return 0;
 }
 
+int group_snap_list_order(librados::IoCtx *ioctx, const std::string &oid,
+                          const std::string &start, uint64_t max_return,
+                          std::map<std::string, uint64_t> *snap_order)
+{
+  using ceph::encode;
+  using ceph::decode;
+  bufferlist inbl, outbl;
+  encode(start, inbl);
+  encode(max_return, inbl);
+
+  int r = ioctx->exec(oid, "rbd", "group_snap_list_order", inbl, outbl);
+  if (r < 0) {
+    return r;
+  }
+  auto iter = outbl.cbegin();
+  try {
+    decode(*snap_order, iter);
+  } catch (const ceph::buffer::error &err) {
+    return -EBADMSG;
+  }
+
+  return 0;
+}
+
 // rbd_trash functions
 void trash_add(librados::ObjectWriteOperation *op,
                const std::string &id,

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -584,7 +584,10 @@ int group_snap_list(librados::IoCtx *ioctx, const std::string &oid,
                     const cls::rbd::GroupSnapshot &start,
                     uint64_t max_return,
                     std::vector<cls::rbd::GroupSnapshot> *snapshots);
-
+int group_snap_list_order(librados::IoCtx *ioctx, const std::string &oid,
+                          const std::string &snap_id, uint64_t max_return,
+                          std::map<std::string, uint64_t> *snap_order);
+ 
 // operations on rbd_trash object
 void trash_add(librados::ObjectWriteOperation *op,
                const std::string &id,

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -2676,10 +2676,10 @@ TEST_F(TestClsRbd, group_snap_set) {
 
   set<string> keys;
   ASSERT_EQ(0, ioctx.omap_get_keys(group_id, "", 10, &keys));
+  ASSERT_EQ(3U, keys.size());
 
   auto it = keys.begin();
-  ASSERT_EQ(2U, keys.size());
-
+  ASSERT_EQ("snap_max_order", *it++);
   ASSERT_EQ("snap_order_" + snap.id, *it++);
   ASSERT_EQ("snapshot_" + snap.id, *it);
 }
@@ -2785,10 +2785,10 @@ TEST_F(TestClsRbd, group_snap_remove) {
 
   set<string> keys;
   ASSERT_EQ(0, ioctx.omap_get_keys(group_id, "", 10, &keys));
+  ASSERT_EQ(3U, keys.size());
 
   auto it = keys.begin();
-  ASSERT_EQ(2U, keys.size());
-
+  ASSERT_EQ("snap_max_order", *it++);
   ASSERT_EQ("snap_order_" + snap.id, *it++);
   ASSERT_EQ("snapshot_" + snap.id, *it);
 
@@ -2798,7 +2798,8 @@ TEST_F(TestClsRbd, group_snap_remove) {
 
   ASSERT_EQ(0, ioctx.omap_get_keys(group_id, "", 10, &keys));
 
-  ASSERT_EQ(0U, keys.size());
+  ASSERT_EQ(1U, keys.size());
+  ASSERT_EQ("snap_max_order", *keys.begin());
 }
 
 TEST_F(TestClsRbd, group_snap_remove_without_order) {
@@ -2818,13 +2819,19 @@ TEST_F(TestClsRbd, group_snap_remove_without_order) {
   ASSERT_EQ(0, ioctx.omap_rm_keys(group_id, keys));
 
   ASSERT_EQ(0, ioctx.omap_get_keys(group_id, "", 10, &keys));
-  ASSERT_EQ(1U, keys.size());
+  ASSERT_EQ(2U, keys.size());
 
   auto it = keys.begin();
+  ASSERT_EQ("snap_max_order", *it++);
   ASSERT_EQ("snapshot_" + snap.id, *it);
 
   // Remove the snapshot
   ASSERT_EQ(0, group_snap_remove(&ioctx, group_id, snap_id));
+
+  ASSERT_EQ(0, ioctx.omap_get_keys(group_id, "", 10, &keys));
+  ASSERT_EQ(1U, keys.size());
+
+  ASSERT_EQ("snap_max_order", *keys.begin());
 }
 
 TEST_F(TestClsRbd, group_snap_get_by_id) {

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -2692,18 +2692,56 @@ TEST_F(TestClsRbd, group_snap_list) {
   ASSERT_EQ(0, ioctx.create(group_id, true));
 
   string snap_id1 = "snap_id1";
-  cls::rbd::GroupSnapshot snap1 = {snap_id1, "test_snapshot1", cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE};
+  cls::rbd::GroupSnapshot snap1 = {snap_id1, "test_snapshot1",
+				   cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE};
   ASSERT_EQ(0, group_snap_set(&ioctx, group_id, snap1));
 
+  string snap_id0 = "snap_id0";
+  cls::rbd::GroupSnapshot snap0 = {snap_id0, "test_snapshot0",
+				   cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE};
+  ASSERT_EQ(0, group_snap_set(&ioctx, group_id, snap0));
+
   string snap_id2 = "snap_id2";
-  cls::rbd::GroupSnapshot snap2 = {snap_id2, "test_snapshot2", cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE};
+  cls::rbd::GroupSnapshot snap2 = {snap_id2, "test_snapshot2",
+				   cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE};
   ASSERT_EQ(0, group_snap_set(&ioctx, group_id, snap2));
 
   std::vector<cls::rbd::GroupSnapshot> snapshots;
-  ASSERT_EQ(0, group_snap_list(&ioctx, group_id, cls::rbd::GroupSnapshot(), 10, &snapshots));
-  ASSERT_EQ(2U, snapshots.size());
-  ASSERT_EQ(snap_id1, snapshots[0].id);
-  ASSERT_EQ(snap_id2, snapshots[1].id);
+  ASSERT_EQ(0, group_snap_list(&ioctx, group_id, cls::rbd::GroupSnapshot(),
+                               10, &snapshots));
+  ASSERT_EQ(3U, snapshots.size());
+
+  ASSERT_EQ(snap_id0, snapshots[0].id);
+  ASSERT_EQ(snap_id1, snapshots[1].id);
+  ASSERT_EQ(snap_id2, snapshots[2].id);
+
+  std::map<std::string, uint64_t> snap_orders;
+  ASSERT_EQ(0, group_snap_list_order(&ioctx, group_id, "", 10, &snap_orders));
+  ASSERT_EQ(3U, snap_orders.size());
+
+  ASSERT_EQ(1, snap_orders[snap_id1]);
+  ASSERT_EQ(2, snap_orders[snap_id0]);
+  ASSERT_EQ(3, snap_orders[snap_id2]);
+
+  ASSERT_EQ(0, group_snap_remove(&ioctx, group_id, snap_id2));
+
+  ASSERT_EQ(0, group_snap_list_order(&ioctx, group_id, "", 10, &snap_orders));
+  ASSERT_EQ(2U, snap_orders.size());
+
+  ASSERT_EQ(1, snap_orders[snap_id1]);
+  ASSERT_EQ(2, snap_orders[snap_id0]);
+
+  string snap_id4 = "snap_id4";
+  cls::rbd::GroupSnapshot snap4 = {snap_id4, "test_snapshot4",
+				   cls::rbd::GROUP_SNAPSHOT_STATE_INCOMPLETE};
+  ASSERT_EQ(0, group_snap_set(&ioctx, group_id, snap4));
+
+  ASSERT_EQ(0, group_snap_list_order(&ioctx, group_id, "", 10, &snap_orders));
+  ASSERT_EQ(3U, snap_orders.size());
+
+  ASSERT_EQ(1, snap_orders[snap_id1]);
+  ASSERT_EQ(2, snap_orders[snap_id0]);
+  ASSERT_EQ(4, snap_orders[snap_id4]);
 }
 
 static std::string hexify(int v) {


### PR DESCRIPTION
To make this possible the snapshot order is stored on a snapshot
creation and the shapshot list result is sorted using this order
before returning to the caller.

This change adds a restriction on start_after parameter: now it
may be either the empty string id (to start at the beginning) or
an existing snapshot id. Otherwise -ERESTART is returned to inform
the caller that the "start_after" snapshot is invalid/removed and
the listing should be restarted.

Fixes: https://tracker.ceph.com/issues/51686
Original Author:  Mykola Golub [mgolub@suse.com](mailto:mgolub@suse.com)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
