### PR TITLE
reef: ceph-volume: use importlib from stdlib on Python 3.8 and up

### DIFF
--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -1,9 +1,14 @@
 from __future__ import print_function
 import argparse
 import os
-import pkg_resources
 import sys
 import logging
+
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from pkg_resources import iter_entry_points as entry_points
+
 
 from ceph_volume.decorators import catches
 from ceph_volume import log, devices, configuration, conf, exceptions, terminal, inventory, drive_group, activate
@@ -170,9 +175,9 @@ def _load_library_extensions():
     """
     logger = logging.getLogger('ceph_volume.plugins')
     group = 'ceph_volume_handlers'
-    entry_points = pkg_resources.iter_entry_points(group=group)
+
     plugins = []
-    for ep in entry_points:
+    for ep in entry_points(group=group):
         try:
             logger.debug('loading %s' % ep.name)
             plugin = ep.load()

--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -4,11 +4,19 @@ import os
 import sys
 import logging
 
+
+# `iter_entry_points` from `pkg_resources` takes one argument whereas
+# `entry_points` from `importlib.metadata` does not.
 try:
     from importlib.metadata import entry_points
-except ImportError:
-    from pkg_resources import iter_entry_points as entry_points
 
+    def get_entry_points(group: str):  # type: ignore
+        return entry_points().get(group, [])  # type: ignore
+except ImportError:
+    from pkg_resources import iter_entry_points as entry_points  # type: ignore
+
+    def get_entry_points(group: str):  # type: ignore
+        return entry_points(group=group)  # type: ignore
 
 from ceph_volume.decorators import catches
 from ceph_volume import log, devices, configuration, conf, exceptions, terminal, inventory, drive_group, activate
@@ -177,7 +185,7 @@ def _load_library_extensions():
     group = 'ceph_volume_handlers'
 
     plugins = []
-    for ep in entry_points(group=group):
+    for ep in get_entry_points(group=group):
         try:
             logger.debug('loading %s' % ep.name)
             plugin = ep.load()


### PR DESCRIPTION
since packaging was apparently removed from pkg_resources, let's use importlib.metadata when it is available and pkg_resources on older Python versions.

Refs https://tracker.ceph.com/issues/66201
Signed-off-by: Kefu Chai <tchaikov@gmail.com>
(cherry picked from commit 24f8e5c61b19deab7397b0237f8376c6c03a5dcb)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
