### PR TITLE
squid: crimson/osd/osdop_params:Unify OpsExecuter::user_modify and osd_op_params_t::user_modify

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -466,9 +466,8 @@ auto OpsExecuter::do_write_op(Func&& f, OpsExecuter::modified_by m) {
   ++num_write;
   if (!osd_op_params) {
     osd_op_params.emplace();
-    fill_op_params_bump_pg_version();
+    fill_op_params_bump_pg_version(m);
   }
-  user_modify = (m == modified_by::user);
   return std::forward<Func>(f)(pg->get_backend(), obc->obs, txn);
 }
 OpsExecuter::call_errorator::future<> OpsExecuter::do_assert_ver(
@@ -802,7 +801,7 @@ OpsExecuter::do_execute_op(OSDOp& osd_op)
   }
 }
 
-void OpsExecuter::fill_op_params_bump_pg_version()
+void OpsExecuter::fill_op_params_bump_pg_version(OpsExecuter::modified_by m)
 {
   osd_op_params->req_id = msg->get_reqid();
   osd_op_params->mtime = msg->get_mtime();
@@ -810,6 +809,7 @@ void OpsExecuter::fill_op_params_bump_pg_version()
   osd_op_params->pg_trim_to = pg->get_pg_trim_to();
   osd_op_params->min_last_complete_ondisk = pg->get_min_last_complete_ondisk();
   osd_op_params->last_complete = pg->get_info().last_complete;
+  osd_op_params->user_modify = (m == modified_by::user);
 }
 
 std::vector<pg_log_entry_t> OpsExecuter::prepare_transaction(

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -187,7 +187,6 @@ private:
   abstracted_msg_t msg;
   crimson::net::ConnectionXcoreRef conn;
   std::optional<osd_op_params_t> osd_op_params;
-  bool user_modify = false;
   ceph::os::Transaction txn;
 
   size_t num_read = 0;    ///< count read ops
@@ -424,7 +423,7 @@ public:
     MutFunc&& mut_func) &&;
   std::vector<pg_log_entry_t> prepare_transaction(
     const std::vector<OSDOp>& ops);
-  void fill_op_params_bump_pg_version();
+  void fill_op_params_bump_pg_version(modified_by m);
 
   ObjectContextRef get_obc() const {
     return obc;
@@ -520,7 +519,7 @@ OpsExecuter::flush_changes_n_do_ops_effects(
     ceph_assert(want_mutate);
   }
   if (want_mutate) {
-    if (user_modify) {
+    if (osd_op_params->user_modify) {
       osd_op_params->user_at_version = osd_op_params->at_version.version;
     }
     maybe_mutated = flush_clone_metadata(


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57102

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh