### PR TITLE
squid: crimson/os/seastore/record_scanner: replace [=] capturing

### DIFF
--- a/src/crimson/os/seastore/record_scanner.cc
+++ b/src/crimson/os/seastore/record_scanner.cc
@@ -120,7 +120,7 @@ RecordScanner::read_validate_record_metadata(
   }
   TRACE("reading record group header block {}~4096", start);
   return read(start, block_size
-  ).safe_then([=](bufferptr bptr) mutable
+  ).safe_then([this, FNAME, nonce, block_size, &cursor](bufferptr bptr)
               -> read_validate_record_metadata_ret {
     bufferlist bl;
     bl.append(bptr);


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57434

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh