### PR TITLE
squid: crimson/common/errorator: disallow void-returning error handlers

### DIFF
--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -933,14 +933,6 @@ public:
     }
   };
 
-  struct discard_all {
-    template <class ErrorT, EnableIf<ErrorT>...>
-    void operator()(ErrorT&&) {
-      static_assert(contains_once_v<std::decay_t<ErrorT>>,
-                    "discarding disallowed ErrorT");
-    }
-  };
-
   template <typename T>
   static future<T> make_errorator_future(seastar::future<T>&& fut) {
     return std::move(fut);
@@ -1312,12 +1304,6 @@ namespace ct_error {
     template <class ErrorT>
     decltype(auto) operator()(ErrorT&& e) {
       return std::forward<ErrorT>(e);
-    }
-  };
-
-  struct discard_all {
-    template <class ErrorT>
-    void operator()(ErrorT&&) {
     }
   };
 

--- a/src/crimson/common/interruptible_future.h
+++ b/src/crimson/common/interruptible_future.h
@@ -821,13 +821,17 @@ public:
       }, [func=std::move(errfunc),
 	  interrupt_condition=interrupt_cond<InterruptCond>.interrupt_cond]
 	  (auto&& err) mutable -> decltype(auto) {
-	  constexpr bool return_void = std::is_void_v<
+	  static_assert(!std::is_void_v<
 	    std::invoke_result_t<ErrorVisitorT,
-	      std::decay_t<decltype(err)>>>;
+	      std::decay_t<decltype(err)>>>);
+	  constexpr bool is_assert = std::is_same_v<
+	    std::decay_t<std::invoke_result_t<ErrorVisitorT,
+	      std::decay_t<decltype(err)>>>,
+	    ::crimson::no_touch_error_marker>;
 	  constexpr bool return_err = ::crimson::is_error_v<
 	    std::decay_t<std::invoke_result_t<ErrorVisitorT,
 	      std::decay_t<decltype(err)>>>>;
-	  if constexpr (return_err || return_void) {
+	  if constexpr (return_err || is_assert) {
 	    return non_futurized_call_with_interruption(
 		      interrupt_condition,
 		      std::move(func),
@@ -857,13 +861,17 @@ public:
       }, [func=std::move(errfunc),
 	  interrupt_condition=interrupt_cond<InterruptCond>.interrupt_cond]
 	  (auto&& err) mutable -> decltype(auto) {
-	  constexpr bool return_void = std::is_void_v<
+	  static_assert(!std::is_void_v<
 	    std::invoke_result_t<ErrorVisitorT,
-	      std::decay_t<decltype(err)>>>;
+	      std::decay_t<decltype(err)>>>);
+	  constexpr bool is_assert = std::is_same_v<
+	    std::decay_t<std::invoke_result_t<ErrorVisitorT,
+	      std::decay_t<decltype(err)>>>,
+	    ::crimson::no_touch_error_marker>;
 	  constexpr bool return_err = ::crimson::is_error_v<
 	    std::decay_t<std::invoke_result_t<ErrorVisitorT,
 	      std::decay_t<decltype(err)>>>>;
-	  if constexpr (return_err || return_void) {
+	  if constexpr (return_err || is_assert) {
 	    return non_futurized_call_with_interruption(
 		      interrupt_condition,
 		      std::move(func),
@@ -985,13 +993,17 @@ public:
 	[errfunc=std::move(errfunc),
 	 interrupt_condition=interrupt_cond<InterruptCond>.interrupt_cond]
 	(auto&& err) mutable -> decltype(auto) {
-	  constexpr bool return_void = std::is_void_v<
+	  static_assert(!std::is_void_v<
 	    std::invoke_result_t<ErrorFunc,
-	      std::decay_t<decltype(err)>>>;
+	      std::decay_t<decltype(err)>>>);
+	  constexpr bool is_assert = std::is_same_v<
+	    std::decay_t<std::invoke_result_t<ErrorFunc,
+	      std::decay_t<decltype(err)>>>,
+	    ::crimson::no_touch_error_marker>;
 	  constexpr bool return_err = ::crimson::is_error_v<
 	    std::decay_t<std::invoke_result_t<ErrorFunc,
 	      std::decay_t<decltype(err)>>>>;
-	  if constexpr (return_err || return_void) {
+	  if constexpr (return_err || is_assert) {
 	    return non_futurized_call_with_interruption(
 		      interrupt_condition,
 		      std::move(errfunc),

--- a/src/crimson/os/cyanstore/cyan_store.h
+++ b/src/crimson/os/cyanstore/cyan_store.h
@@ -185,11 +185,10 @@ public:
     return shard_stores.invoke_on_all(
       [](auto &local_store) {
       return local_store.mount().handle_error(
-      crimson::stateful_ec::handle([](const auto& ec) {
+      crimson::stateful_ec::assert_failure([](const auto& ec) {
         crimson::get_logger(ceph_subsys_cyanstore).error(
 	    "error mounting cyanstore: ({}) {}",
             ec.value(), ec.message());
-        std::exit(EXIT_FAILURE);
       }));
     });
   }

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -299,9 +299,7 @@ public:
     return do_with_transaction_intr<Func, true>(
         Transaction::src_t::READ, name, std::forward<Func>(f)
     ).handle_error(
-      crimson::ct_error::eagain::handle([] {
-        ceph_assert(0 == "eagain impossible");
-      }),
+      crimson::ct_error::eagain::assert_failure{"unexpected eagain"},
       crimson::ct_error::pass_further_all{}
     );
   }

--- a/src/crimson/os/seastore/journal/record_submitter.cc
+++ b/src/crimson/os/seastore/journal/record_submitter.cc
@@ -255,6 +255,7 @@ RecordSubmitter::roll_segment()
           has_io_error = true;
           wait_available_promise->set_value();
           wait_available_promise.reset();
+          return seastar::now();
         })
       ).handle_exception([FNAME, this](auto e) {
         ERROR("{} got exception {}, available", get_name(), e);
@@ -522,6 +523,7 @@ void RecordSubmitter::flush_current_batch()
       ERROR("{} {} records, {}, got error {}",
             get_name(), num, sizes, e);
       finish_submit_batch(p_batch, std::nullopt);
+      return seastar::now();
     })
   ).handle_exception([this, p_batch, FNAME, num, sizes=sizes](auto e) {
     ERROR("{} {} records, {}, got exception {}",

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -428,9 +428,8 @@ eagain_ifuture<Ref<Node>> Node::load_root(context_t c, RootNodeTracker& root_tra
   return c.nm.get_super(c.t, root_tracker
   ).handle_error_interruptible(
     eagain_iertr::pass_further{},
-    crimson::ct_error::input_output_error::handle([FNAME, c] {
+    crimson::ct_error::input_output_error::assert_failure([FNAME, c] {
       ERRORT("EIO during get_super()", c.t);
-      ceph_abort("fatal error");
     })
   ).si_then([c, &root_tracker, FNAME](auto&& _super) {
     assert(_super);
@@ -692,29 +691,25 @@ eagain_ifuture<Ref<Node>> Node::load(
   return c.nm.read_extent(c.t, addr
   ).handle_error_interruptible(
     eagain_iertr::pass_further{},
-    crimson::ct_error::input_output_error::handle(
+    crimson::ct_error::input_output_error::assert_failure(
         [FNAME, c, addr, expect_is_level_tail] {
       ERRORT("EIO -- addr={:x}, is_level_tail={}",
              c.t, addr, expect_is_level_tail);
-      ceph_abort("fatal error");
     }),
-    crimson::ct_error::invarg::handle(
+    crimson::ct_error::invarg::assert_failure(
         [FNAME, c, addr, expect_is_level_tail] {
       ERRORT("EINVAL -- addr={:x}, is_level_tail={}",
              c.t, addr, expect_is_level_tail);
-      ceph_abort("fatal error");
     }),
-    crimson::ct_error::enoent::handle(
+    crimson::ct_error::enoent::assert_failure(
         [FNAME, c, addr, expect_is_level_tail] {
       ERRORT("ENOENT -- addr={:x}, is_level_tail={}",
              c.t, addr, expect_is_level_tail);
-      ceph_abort("fatal error");
     }),
-    crimson::ct_error::erange::handle(
+    crimson::ct_error::erange::assert_failure(
         [FNAME, c, addr, expect_is_level_tail] {
       ERRORT("ERANGE -- addr={:x}, is_level_tail={}",
              c.t, addr, expect_is_level_tail);
-      ceph_abort("fatal error");
     })
   ).si_then([FNAME, c, addr, expect_is_level_tail](auto extent)
 	      -> eagain_ifuture<Ref<Node>> {
@@ -2150,9 +2145,8 @@ eagain_ifuture<Ref<LeafNode>> LeafNode::allocate_root(
     return c.nm.get_super(c.t, root_tracker
     ).handle_error_interruptible(
       eagain_iertr::pass_further{},
-      crimson::ct_error::input_output_error::handle([FNAME, c] {
+      crimson::ct_error::input_output_error::assert_failure([FNAME, c] {
         ERRORT("EIO during get_super()", c.t);
-        ceph_abort("fatal error");
       })
     ).si_then([c, root](auto&& super) {
       assert(super);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -523,12 +523,11 @@ class NodeExtentAccessorT {
     return c.nm.alloc_extent(c.t, hint, alloc_size
     ).handle_error_interruptible(
       eagain_iertr::pass_further{},
-      crimson::ct_error::input_output_error::handle(
+      crimson::ct_error::input_output_error::assert_failure(
           [FNAME, c, alloc_size, l_to_discard = extent->get_laddr()] {
         SUBERRORT(seastore_onode,
             "EIO during allocate -- node_size={}, to_discard={:x}",
             c.t, alloc_size, l_to_discard);
-        ceph_abort("fatal error");
       })
     ).si_then([this, c, FNAME] (auto fresh_extent) {
       SUBDEBUGT(seastore_onode,
@@ -552,21 +551,19 @@ class NodeExtentAccessorT {
       return c.nm.retire_extent(c.t, to_discard
       ).handle_error_interruptible(
         eagain_iertr::pass_further{},
-        crimson::ct_error::input_output_error::handle(
+        crimson::ct_error::input_output_error::assert_failure(
             [FNAME, c, l_to_discard = to_discard->get_laddr(),
              l_fresh = fresh_extent->get_laddr()] {
           SUBERRORT(seastore_onode,
               "EIO during retire -- to_disgard={:x}, fresh={:x}",
               c.t, l_to_discard, l_fresh);
-          ceph_abort("fatal error");
         }),
-        crimson::ct_error::enoent::handle(
+        crimson::ct_error::enoent::assert_failure(
             [FNAME, c, l_to_discard = to_discard->get_laddr(),
              l_fresh = fresh_extent->get_laddr()] {
           SUBERRORT(seastore_onode,
               "ENOENT during retire -- to_disgard={:x}, fresh={:x}",
               c.t, l_to_discard, l_fresh);
-          ceph_abort("fatal error");
         })
       );
     }).si_then([this, c] {
@@ -583,15 +580,13 @@ class NodeExtentAccessorT {
     return c.nm.retire_extent(c.t, std::move(extent)
     ).handle_error_interruptible(
       eagain_iertr::pass_further{},
-      crimson::ct_error::input_output_error::handle(
+      crimson::ct_error::input_output_error::assert_failure(
           [FNAME, c, addr] {
         SUBERRORT(seastore_onode, "EIO -- addr={:x}", c.t, addr);
-        ceph_abort("fatal error");
       }),
-      crimson::ct_error::enoent::handle(
+      crimson::ct_error::enoent::assert_failure(
           [FNAME, c, addr] {
         SUBERRORT(seastore_onode, "ENOENT -- addr={:x}", c.t, addr);
-        ceph_abort("fatal error");
       })
 #ifndef NDEBUG
     ).si_then([c] {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -78,12 +78,11 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     return c.nm.alloc_extent(c.t, hint, extent_size
     ).handle_error_interruptible(
       eagain_iertr::pass_further{},
-      crimson::ct_error::input_output_error::handle(
+      crimson::ct_error::input_output_error::assert_failure(
           [FNAME, c, extent_size, is_level_tail, level] {
         SUBERRORT(seastore_onode,
             "EIO -- extent_size={}, is_level_tail={}, level={}",
             c.t, extent_size, is_level_tail, level);
-        ceph_abort("fatal error");
       })
     ).si_then([is_level_tail, level](auto extent) {
       assert(extent);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -327,9 +327,7 @@ class TreeBuilder {
       return eagain_iertr::make_ready_future<BtreeCursor>(cursor);
 #endif
     }).handle_error_interruptible(
-      [] (const crimson::ct_error::value_too_large& e) {
-        ceph_abort("impossible path");
-      },
+      crimson::ct_error::value_too_large::assert_failure{"impossible path"},
       crimson::ct_error::pass_further_all{}
     );
   }

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -951,10 +951,10 @@ SeaStore::Shard::get_attr(
           onode.get_metadata_hint(device->get_block_size())),
         name);
     }
-  ).handle_error(crimson::ct_error::input_output_error::handle([FNAME] {
-    ERROR("EIO when getting attrs");
-    abort();
-  }), crimson::ct_error::pass_further_all{});
+  ).handle_error(
+    crimson::ct_error::input_output_error::assert_failure{
+      "EIO when getting attrs"},
+    crimson::ct_error::pass_further_all{});
 }
 
 SeaStore::Shard::get_attrs_ertr::future<SeaStore::Shard::attrs_t>
@@ -994,10 +994,10 @@ SeaStore::Shard::get_attrs(
         return seastar::make_ready_future<omap_values_t>(std::move(attrs));
       });
     }
-  ).handle_error(crimson::ct_error::input_output_error::handle([FNAME] {
-    ERROR("EIO when getting attrs");
-    abort();
-  }), crimson::ct_error::pass_further_all{});
+  ).handle_error(
+    crimson::ct_error::input_output_error::assert_failure{
+      "EIO when getting attrs"},
+    crimson::ct_error::pass_further_all{});
 }
 
 seastar::future<struct stat> SeaStore::Shard::stat(

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -257,6 +257,7 @@ public:
 	  }).handle_error(
 	    crimson::ct_error::all_same_way([&ctx](auto e) {
 	      on_error(ctx.ext_transaction);
+	      return seastar::now();
 	    })
 	  );
 	}).then([this, op_type, &ctx] {

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -157,10 +157,7 @@ TransactionManager::mount_ertr::future<> TransactionManager::mount()
     INFO("completed");
   }).handle_error(
     mount_ertr::pass_further{},
-    crimson::ct_error::all_same_way([] {
-      ceph_assert(0 == "unhandled error");
-      return mount_ertr::now();
-    })
+    crimson::ct_error::assert_all{"unhandled error"}
   );
 }
 
@@ -195,9 +192,7 @@ TransactionManager::ref_ret TransactionManager::inc_ref(
     return result.refcount;
   }).handle_error_interruptible(
     ref_iertr::pass_further{},
-    ct_error::all_same_way([](auto e) {
-      ceph_assert(0 == "unhandled error, TODO");
-    }));
+    ct_error::assert_all{"unhandled error, TODO"});
 }
 
 TransactionManager::ref_ret TransactionManager::inc_ref(
@@ -457,9 +452,7 @@ TransactionManager::do_submit_transaction(
       });
     }).handle_error(
       submit_transaction_iertr::pass_further{},
-      crimson::ct_error::all_same_way([](auto e) {
-	ceph_assert(0 == "Hit error submitting to journal");
-      })
+      crimson::ct_error::assert_all{"Hit error submitting to journal"}
     );
   });
 }

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -78,10 +78,9 @@ Heartbeat::start_messenger(crimson::net::Messenger& msgr,
 {
   return msgr.bind(addrs).safe_then([this, &msgr]() mutable {
     return msgr.start({this});
-  }, crimson::net::Messenger::bind_ertr::all_same_way(
+  }, crimson::net::Messenger::bind_ertr::assert_all_func(
       [addrs] (const std::error_code& e) {
     logger().error("heartbeat messenger bind({}): {}", addrs, e);
-    ceph_abort();
   }));
 }
 

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -199,19 +199,17 @@ seastar::future<> OSD::mkfs(
   LOG_PREFIX(OSD::mkfs);
   return store.start().then([&store, FNAME, osd_uuid] {
     return store.mkfs(osd_uuid).handle_error(
-      crimson::stateful_ec::handle([FNAME] (const auto& ec) {
+      crimson::stateful_ec::assert_failure([FNAME] (const auto& ec) {
         ERROR("error creating empty object store in {}: ({}) {}",
 	      local_conf().get_val<std::string>("osd_data"),
 	      ec.value(), ec.message());
-        std::exit(EXIT_FAILURE);
       }));
   }).then([&store, FNAME] {
     return store.mount().handle_error(
-      crimson::stateful_ec::handle([FNAME](const auto& ec) {
+      crimson::stateful_ec::assert_failure([FNAME](const auto& ec) {
         ERROR("error mounting object store in {}: ({}) {}",
 	      local_conf().get_val<std::string>("osd_data"),
 	      ec.value(), ec.message());
-        std::exit(EXIT_FAILURE);
       }));
   }).then([&store] {
     return open_or_create_meta_coll(store);
@@ -411,11 +409,10 @@ seastar::future<> OSD::start()
 	whoami, get_shard_services(),
 	*monc, *hb_front_msgr, *hb_back_msgr});
     return store.mount().handle_error(
-      crimson::stateful_ec::handle([FNAME] (const auto& ec) {
+      crimson::stateful_ec::assert_failure([FNAME] (const auto& ec) {
         ERROR("error mounting object store in {}: ({}) {}",
 	      local_conf().get_val<std::string>("osd_data"),
 	      ec.value(), ec.message());
-        std::exit(EXIT_FAILURE);
       }));
   }).then([this] {
     return open_meta_coll();
@@ -470,18 +467,16 @@ seastar::future<> OSD::start()
       cluster_msgr->bind(pick_addresses(CEPH_PICK_ADDRESS_CLUSTER))
         .safe_then([this, dispatchers]() mutable {
 	  return cluster_msgr->start(dispatchers);
-        }, crimson::net::Messenger::bind_ertr::all_same_way(
+        }, crimson::net::Messenger::bind_ertr::assert_all_func(
             [FNAME] (const std::error_code& e) {
           ERROR("cluster messenger bind(): {}", e);
-          ceph_abort();
         })),
       public_msgr->bind(pick_addresses(CEPH_PICK_ADDRESS_PUBLIC))
         .safe_then([this, dispatchers]() mutable {
 	  return public_msgr->start(dispatchers);
-        }, crimson::net::Messenger::bind_ertr::all_same_way(
+        }, crimson::net::Messenger::bind_ertr::assert_all_func(
             [FNAME] (const std::error_code& e) {
           ERROR("public messenger bind(): {}", e);
-          ceph_abort();
         })));
   }).then_unpack([this] {
     return seastar::when_all_succeed(monc->start(),

--- a/src/crimson/osd/osd_meta.cc
+++ b/src/crimson/osd/osd_meta.cc
@@ -45,7 +45,7 @@ seastar::future<bufferlist> OSDMeta::load_map(epoch_t e)
   return store.read(coll,
                     osdmap_oid(e), 0, 0,
                     CEPH_OSD_OP_FLAG_FADVISE_WILLNEED).handle_error(
-    read_errorator::all_same_way([e] {
+    read_errorator::assert_all_func([e](const auto&) {
       ceph_abort_msg(fmt::format("{} read gave enoent on {}",
                                  __func__, osdmap_oid(e)));
     }));
@@ -97,7 +97,7 @@ OSDMeta::load_final_pool_info(int64_t pool) {
       std::make_tuple(std::move(pi),
 		      std::move(name),
 		      std::move(ec_profile)));
-  },read_errorator::all_same_way([pool] {
+  },read_errorator::assert_all_func([pool](const auto&) {
     throw std::runtime_error(fmt::format("read gave enoent on {}",
                                          final_pool_info_oid(pool)));
   }));

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -45,6 +45,7 @@ ReplicatedRecoveryBackend::recover_object(
       // TODO: may need eio handling?
       logger().error("recover_object saw error code {}, ignoring object {}",
                      code, soid);
+      return seastar::now();
     }));
   });
 }

--- a/src/crimson/tools/perf_crimson_msgr.cc
+++ b/src/crimson/tools/perf_crimson_msgr.cc
@@ -257,11 +257,10 @@ static seastar::future<> run(
           return server.msgr->bind(entity_addrvec_t{addr}
           ).safe_then([&server] {
             return server.msgr->start({&server});
-          }, crimson::net::Messenger::bind_ertr::all_same_way(
+          }, crimson::net::Messenger::bind_ertr::assert_all_func(
               [addr] (const std::error_code& e) {
             logger().error("Server: "
                            "there is another instance running at {}", addr);
-            ceph_abort();
           }));
         });
       }

--- a/src/crimson/tools/store_nbd/fs_driver.cc
+++ b/src/crimson/tools/store_nbd/fs_driver.cc
@@ -185,12 +185,11 @@ seastar::future<> FSDriver::mkfs()
     uuid_d uuid;
     uuid.generate_random();
     return fs->mkfs(uuid).handle_error(
-      crimson::stateful_ec::handle([] (const auto& ec) {
+      crimson::stateful_ec::assert_failure([] (const auto& ec) {
         crimson::get_logger(ceph_subsys_test)
           .error("error creating empty object store in {}: ({}) {}",
           crimson::common::local_conf().get_val<std::string>("osd_data"),
           ec.value(), ec.message());
-        std::exit(EXIT_FAILURE);
       }));
   }).then([this] {
     return fs->stop();
@@ -199,7 +198,7 @@ seastar::future<> FSDriver::mkfs()
   }).then([this] {
     return fs->mount(
     ).handle_error(
-      crimson::stateful_ec::handle([] (const auto& ec) {
+      crimson::stateful_ec::assert_failure([] (const auto& ec) {
         crimson::get_logger(
 	  ceph_subsys_test
 	).error(
@@ -207,7 +206,6 @@ seastar::future<> FSDriver::mkfs()
 	  crimson::common::local_conf().get_val<std::string>("osd_data"),
 	  ec.value(),
 	  ec.message());
-	std::exit(EXIT_FAILURE);
       }));
   }).then([this] {
     return seastar::do_for_each(
@@ -241,7 +239,7 @@ seastar::future<> FSDriver::mount()
   }).then([this] {
     return fs->mount(
     ).handle_error(
-      crimson::stateful_ec::handle([] (const auto& ec) {
+      crimson::stateful_ec::assert_failure([] (const auto& ec) {
         crimson::get_logger(
 	  ceph_subsys_test
 	).error(
@@ -249,7 +247,6 @@ seastar::future<> FSDriver::mount()
 	  crimson::common::local_conf().get_val<std::string>("osd_data"),
 	  ec.value(),
 	  ec.message());
-        std::exit(EXIT_FAILURE);
       }));
   }).then([this] {
     return seastar::do_for_each(

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -1279,7 +1279,7 @@ seastar::future<> PGLog::rebuild_missing_set_with_deletes_crimson(
 	  log_entry.is_delete());
 	return seastar::now();
       }),
-      crimson::ct_error::enodata::handle([] { ceph_abort("unexpected enodata"); })
+      crimson::ct_error::enodata::assert_failure{"unexpected enodata"}
       ).then([] {
 	return seastar::stop_iteration::no;
       });

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -209,9 +209,7 @@ struct b_dummy_tree_test_t : public seastar_test_suite_t {
       new UnboundedBtree(NodeExtentManager::create_dummy(IS_DUMMY_SYNC))
     );
     return INTR(tree->mkfs, *ref_t).handle_error(
-      crimson::ct_error::all_same_way([] {
-        ASSERT_FALSE("Unable to mkfs");
-      })
+      crimson::ct_error::assert_all{"Unable to mkfs"}
     );
   }
 

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -176,9 +176,7 @@ struct btree_test_base :
 	  });
 	});
     }).handle_error(
-      crimson::ct_error::all_same_way([] {
-	ceph_assert(0 == "error");
-      })
+      crimson::ct_error::assert_all{"error"}
     );
   }
 
@@ -197,9 +195,7 @@ struct btree_test_base :
       epm.reset();
       cache.reset();
     }).handle_error(
-      crimson::ct_error::all_same_way([] {
-	ASSERT_FALSE("Unable to close");
-      })
+      crimson::ct_error::assert_all{"Unable to close"}
     );
   }
 };

--- a/src/test/crimson/seastore/test_seastore.cc
+++ b/src/test/crimson/seastore/test_seastore.cc
@@ -394,17 +394,18 @@ struct seastore_test_t :
     SeaStoreShard::attrs_t get_attrs(
       SeaStoreShard &sharded_seastore) {
       return sharded_seastore.get_attrs(coll, oid)
-		     .handle_error(SeaStoreShard::get_attrs_ertr::discard_all{})
-		     .get();
+	.handle_error(
+	  SeaStoreShard::get_attrs_ertr::assert_all{"unexpected error"})
+	.get();
     }
 
     ceph::bufferlist get_attr(
       SeaStoreShard& sharded_seastore,
       std::string_view name) {
       return sharded_seastore.get_attr(coll, oid, name)
-		      .handle_error(
-			SeaStoreShard::get_attr_errorator::discard_all{})
-		      .get();
+	.handle_error(
+	  SeaStoreShard::get_attr_errorator::assert_all{"unexpected error"})
+	.get();
     }
 
     void check_omap_key(

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -81,9 +81,7 @@ struct cache_test_t : public seastar_test_suite_t {
 	cache->complete_commit(*t, prev, seq /* TODO */);
         return prev;
       },
-      crimson::ct_error::all_same_way([](auto e) {
-	ASSERT_FALSE("failed to submit");
-      })
+      crimson::ct_error::assert_all{"failed to submit"}
      );
   }
 
@@ -125,9 +123,7 @@ struct cache_test_t : public seastar_test_suite_t {
         });
       });
     }).handle_error(
-      crimson::ct_error::all_same_way([](auto e) {
-        ASSERT_FALSE("failed to submit");
-      })
+      crimson::ct_error::assert_all{"failed to submit"}
     );
   }
 

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -158,9 +158,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider, JournalTrimmer {
     }).safe_then([this](auto) {
       dummy_tail = journal_seq_t{0,
         paddr_t::make_seg_paddr(segment_id_t(segment_manager->get_device_id(), 0), 0)};
-    }, crimson::ct_error::all_same_way([] {
-      ASSERT_FALSE("Unable to mount");
-    }));
+    }, crimson::ct_error::assert_all{"Unable to mount"});
   }
 
   seastar::future<> tear_down_fut() final {
@@ -170,9 +168,7 @@ struct journal_test_t : seastar_test_suite_t, SegmentProvider, JournalTrimmer {
       sms.reset();
       journal.reset();
     }).handle_error(
-      crimson::ct_error::all_same_way([](auto e) {
-        ASSERT_FALSE("Unable to close");
-      })
+      crimson::ct_error::assert_all{"Unable to close"}
     );
   }
 

--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -179,9 +179,8 @@ seastar_echo(const entity_addr_t addr, echo_role role, unsigned count)
       return server.msgr->bind(entity_addrvec_t{addr}
       ).safe_then([&server] {
         return server.msgr->start({&server.dispatcher});
-      }, crimson::net::Messenger::bind_ertr::all_same_way([](auto& e) {
-        ceph_abort_msg("bind failed");
-      })).then([&dispatcher=server.dispatcher, count] {
+      }, crimson::net::Messenger::bind_ertr::assert_all{"bind failed"}
+      ).then([&dispatcher=server.dispatcher, count] {
         return dispatcher.on_reply.wait([&dispatcher, count] {
           return dispatcher.count >= count;
         });

--- a/src/test/crimson/test_interruptible_future.cc
+++ b/src/test/crimson/test_interruptible_future.cc
@@ -64,6 +64,7 @@ TEST_F(seastar_test_suite_t, basic)
 	  return seastar::now();
 	}, errorator<ct_error::enoent>::all_same_way([] {
 	  ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
+	  return seastar::now();
 	  })
 	);
       }, [](std::exception_ptr) {}, false).get0();
@@ -146,6 +147,7 @@ TEST_F(seastar_test_suite_t, loops)
 		return seastar::now();
 	      }, errorator<ct_error::enoent>::all_same_way([] {
 		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
+		return seastar::now();
 	      }));
 	    });
 	  });
@@ -167,6 +169,7 @@ TEST_F(seastar_test_suite_t, loops)
 		return seastar::now();
 	      }, errorator<ct_error::enoent>::all_same_way([] {
 		ceph_assert(interruptible::interrupt_cond<TestInterruptCondition>.interrupt_cond);
+		return seastar::now();
 	      }));
 	    });
 	  });

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -153,11 +153,10 @@ static seastar::future<> test_echo(unsigned rounds,
         msgr->set_auth_server(&dummy_auth);
         return msgr->bind(entity_addrvec_t{addr}).safe_then([this] {
           return msgr->start({this});
-        }, crimson::net::Messenger::bind_ertr::all_same_way(
+        }, crimson::net::Messenger::bind_ertr::assert_all_func(
             [addr] (const std::error_code& e) {
           logger().error("test_echo(): "
                          "there is another instance running at {}", addr);
-          ceph_abort();
         }));
       }
       seastar::future<> shutdown() {
@@ -422,11 +421,10 @@ seastar::future<> test_preemptive_shutdown() {
         msgr->set_auth_server(&dummy_auth);
         return msgr->bind(entity_addrvec_t{addr}).safe_then([this] {
           return msgr->start({this});
-        }, crimson::net::Messenger::bind_ertr::all_same_way(
+        }, crimson::net::Messenger::bind_ertr::assert_all_func(
             [addr] (const std::error_code& e) {
           logger().error("test_preemptive_shutdown(): "
                          "there is another instance running at {}", addr);
-          ceph_abort();
         }));
       }
       entity_addr_t get_addr() const {
@@ -1044,10 +1042,10 @@ class FailoverSuite : public Dispatcher {
     test_msgr->set_interceptor(&interceptor);
     return test_msgr->bind(entity_addrvec_t{test_addr}).safe_then([this] {
       return test_msgr->start({this});
-    }, Messenger::bind_ertr::all_same_way([test_addr] (const std::error_code& e) {
+    }, Messenger::bind_ertr::assert_all_func(
+      [test_addr] (const std::error_code& e) {
       logger().error("FailoverSuite: "
                      "there is another instance running at {}", test_addr);
-      ceph_abort();
     }));
   }
 
@@ -1607,10 +1605,10 @@ class FailoverSuitePeer : public Dispatcher {
     peer_msgr->set_auth_server(&dummy_auth);
     return peer_msgr->bind(entity_addrvec_t{test_peer_addr}).safe_then([this] {
       return peer_msgr->start({this});
-    }, Messenger::bind_ertr::all_same_way([test_peer_addr] (const std::error_code& e) {
+    }, Messenger::bind_ertr::assert_all_func(
+      [test_peer_addr] (const std::error_code& e) {
       logger().error("FailoverSuitePeer: "
                      "there is another instance running at {}", test_peer_addr);
-      ceph_abort();
     }));
   }
 
@@ -1811,10 +1809,10 @@ class FailoverTestPeer : public Dispatcher {
     cmd_msgr->set_auth_server(&dummy_auth);
     return cmd_msgr->bind(entity_addrvec_t{cmd_peer_addr}).safe_then([this] {
       return cmd_msgr->start({this});
-    }, Messenger::bind_ertr::all_same_way([cmd_peer_addr] (const std::error_code& e) {
+    }, Messenger::bind_ertr::assert_all_func(
+      [cmd_peer_addr] (const std::error_code& e) {
       logger().error("FailoverTestPeer: "
                      "there is another instance running at {}", cmd_peer_addr);
-      ceph_abort();
     }));
   }
 

--- a/src/test/crimson/test_messenger_thrash.cc
+++ b/src/test/crimson/test_messenger_thrash.cc
@@ -365,12 +365,11 @@ class SyntheticWorkload {
      return msgr->bind(entity_addrvec_t{addr}).safe_then(
          [this, msgr] {
        return msgr->start({&dispatcher});
-     }, crimson::net::Messenger::bind_ertr::all_same_way(
+     }, crimson::net::Messenger::bind_ertr::assert_all_func(
          [addr] (const std::error_code& e) {
        logger().error("{} test_messenger_thrash(): "
                       "there is another instance running at {}",
                        __func__, addr);
-       ceph_abort();
      }));
    }
 

--- a/src/test/crimson/test_socket.cc
+++ b/src/test/crimson/test_socket.cc
@@ -99,11 +99,10 @@ future<> test_bind_same(bool is_fixed_cpu) {
           return pss2->shutdown_destroy();
         });
       });
-    }, listen_ertr::all_same_way(
+    }, listen_ertr::assert_all_func(
         [saddr](const std::error_code& e) {
       logger().error("test_bind_same(): there is another instance running at {}",
                      saddr);
-      ceph_abort();
     })).then([pss1] {
       return pss1->shutdown_destroy();
     }).handle_exception([](auto eptr) {
@@ -129,11 +128,10 @@ future<> test_accept(bool is_fixed_cpu) {
           ).finally([cleanup = std::move(socket)] {});
         });
       });
-    }, listen_ertr::all_same_way(
+    }, listen_ertr::assert_all_func(
         [saddr](const std::error_code& e) {
       logger().error("test_accept(): there is another instance running at {}",
                      saddr);
-      ceph_abort();
     })).then([saddr] {
       return seastar::when_all(
         socket_connect(saddr).then([](auto socket) {
@@ -184,10 +182,10 @@ class SocketFactory {
         psf->pss = pss;
         return pss->listen(saddr
         ).safe_then([] {
-        }, listen_ertr::all_same_way([saddr](const std::error_code& e) {
+        }, listen_ertr::assert_all_func(
+	  [saddr](const std::error_code& e) {
           logger().error("dispatch_sockets(): there is another instance running at {}",
                          saddr);
-          ceph_abort();
         }));
       });
     }).then([psf, saddr] {


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55735

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh