### PR TITLE
squid: crimson/os/seastore/transaction_manager: correct the offset of the data copied from the original extents

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -1040,6 +1040,7 @@ public:
         n_fixed_kv_extent->get_bptr().c_str());
       n_fixed_kv_extent->set_modify_time(fixed_kv_extent.get_modify_time());
       n_fixed_kv_extent->range = n_fixed_kv_extent->get_node_meta();
+      n_fixed_kv_extent->set_last_committed_crc(fixed_kv_extent.get_last_committed_crc());
 
       if (fixed_kv_extent.get_type() == internal_node_t::TYPE ||
           leaf_node_t::do_has_children) {

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -561,7 +561,7 @@ TransactionManager::rewrite_logical_extent(
         ceph_assert(left >= nextent->get_length());
         auto nlextent = nextent->template cast<LogicalCachedExtent>();
         lextent->get_bptr().copy_out(
-          0,
+          off,
           nlextent->get_length(),
           nlextent->get_bptr().c_str());
         nlextent->set_laddr(lextent->get_laddr() + off);

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -566,7 +566,7 @@ TransactionManager::rewrite_logical_extent(
           nlextent->get_bptr().c_str());
         nlextent->set_laddr(lextent->get_laddr() + off);
         nlextent->set_modify_time(lextent->get_modify_time());
-        nlextent->set_last_committed_crc(nlextent->calc_crc32c());
+        nlextent->set_last_committed_crc(lextent->get_last_committed_crc());
         DEBUGT("rewriting logical extent -- {} to {}", t, *lextent, *nlextent);
 
         /* This update_mapping is, strictly speaking, unnecessary for delayed_alloc


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57474

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh