### PR TITLE
squid: src/test/TestRados: add max-attr-len to control the max length of attributes sent to OSDs

### DIFF
--- a/qa/suites/crimson-rados-experimental/seastore/basic/tasks/readwrite.yaml
+++ b/qa/suites/crimson-rados-experimental/seastore/basic/tasks/readwrite.yaml
@@ -11,6 +11,7 @@ tasks:
     clients: [client.0]
     ops: 4000
     objects: 500
+    max_attr_len: 8192
     op_weights:
       read: 45
       write: 45

--- a/qa/suites/crimson-rados/thrash/workloads/small-objects-balanced.yaml
+++ b/qa/suites/crimson-rados/thrash/workloads/small-objects-balanced.yaml
@@ -10,6 +10,7 @@ tasks:
     objects: 1024
     size: 16384
     balance_reads: true
+    max_attr_len: 8192
     op_weights:
       read: 100
       write: 100

--- a/qa/suites/crimson-rados/thrash/workloads/small-objects-localized.yaml
+++ b/qa/suites/crimson-rados/thrash/workloads/small-objects-localized.yaml
@@ -10,6 +10,7 @@ tasks:
     objects: 1024
     size: 16384
     localize_reads: true
+    max_attr_len: 8192
     op_weights:
       read: 100
       write: 100

--- a/qa/suites/crimson-rados/thrash/workloads/small-objects.yaml
+++ b/qa/suites/crimson-rados/thrash/workloads/small-objects.yaml
@@ -9,6 +9,7 @@ tasks:
     max_in_flight: 64
     objects: 1024
     size: 16384
+    max_attr_len: 8192
     op_weights:
       read: 100
       write: 100

--- a/qa/tasks/rados.py
+++ b/qa/tasks/rados.py
@@ -169,7 +169,8 @@ def task(ctx, config):
         '--size', str(object_size),
         '--min-stride-size', str(config.get('min_stride_size', object_size // 10)),
         '--max-stride-size', str(config.get('max_stride_size', object_size // 5)),
-        '--max-seconds', str(config.get('max_seconds', 0))
+        '--max-seconds', str(config.get('max_seconds', 0)),
+        '--max-attr-len', str(config.get('max_attr_len', 20000))
         ])
 
     weights = {}

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -215,6 +215,7 @@ public:
 		   bool enable_dedup,
 		   std::string chunk_algo,
 		   std::string chunk_size,
+		   size_t max_attr_len,
 		   const char *id = 0) :
     pool_obj_cont(),
     current_snap(0),
@@ -226,7 +227,7 @@ public:
     rados_id(id), initialized(false),
     max_size(max_size), 
     min_stride_size(min_stride_size), max_stride_size(max_stride_size),
-    attr_gen(2000, 20000),
+    attr_gen(2000, max_attr_len),
     no_omap(no_omap),
     no_sparse(no_sparse),
     pool_snaps(pool_snaps),

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -523,6 +523,7 @@ int main(int argc, char **argv)
   bool enable_dedup = false;
   string chunk_algo = "";
   string chunk_size = "";
+  size_t max_attr_len = 20000;
 
 
   for (int i = 1; i < argc; ++i) {
@@ -554,6 +555,8 @@ int main(int argc, char **argv)
       pool_snaps = true;
     else if (strcmp(argv[i], "--write-fadvise-dontneed") == 0)
       write_fadvise_dontneed = true;
+    else if (strcmp(argv[i], "--max-attr-len") == 0)
+      max_attr_len = atoi(argv[++i]);
     else if (strcmp(argv[i], "--ec-pool") == 0) {
       if (!op_weights.empty()) {
 	cerr << "--ec-pool must be specified prior to any ops" << std::endl;
@@ -700,6 +703,7 @@ int main(int argc, char **argv)
     enable_dedup,
     chunk_algo,
     chunk_size,
+    max_attr_len,
     id);
 
   TestOpStat stats;


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/56114

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh