### PR TITLE
squid: crimson/os/seastore/lba_manager: don't increase intermediate mappings' refcount if LBAManager::clone_mapping() is called to remap mappings

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -1515,6 +1515,8 @@ private:
     };
 
     auto v = parent->template get_child<internal_node_t>(c, node_iter);
+    // checking the lba child must be atomic with creating
+    // and linking the absent child
     if (v.has_child()) {
       return v.get_child_fut().safe_then(
         [on_found=std::move(on_found), node_iter, c,
@@ -1583,6 +1585,8 @@ private:
     };
 
     auto v = parent->template get_child<leaf_node_t>(c, node_iter);
+    // checking the lba child must be atomic with creating
+    // and linking the absent child
     if (v.has_child()) {
       return v.get_child_fut().safe_then(
         [on_found=std::move(on_found), node_iter, c,
@@ -2136,6 +2140,8 @@ private:
     };
 
     auto v = parent_pos.node->template get_child<NodeType>(c, donor_iter);
+    // checking the lba child must be atomic with creating
+    // and linking the absent child
     if (v.has_child()) {
       return v.get_child_fut().safe_then(
         [do_merge=std::move(do_merge), &pos,

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -104,6 +104,33 @@ Cache::retire_extent_ret Cache::retire_extent_addr(
   return retire_extent_iertr::now();
 }
 
+void Cache::retire_absent_extent_addr(
+  Transaction &t, paddr_t addr, extent_len_t length)
+{
+#ifndef NDEBUG
+  CachedExtentRef ext;
+  auto result = t.get_extent(addr, &ext);
+  assert(result != Transaction::get_extent_ret::PRESENT
+    && result != Transaction::get_extent_ret::RETIRED);
+  assert(!query_cache(addr, nullptr));
+#endif
+  LOG_PREFIX(Cache::retire_absent_extent_addr);
+  // add a new placeholder to Cache
+  ext = CachedExtent::make_cached_extent_ref<
+    RetiredExtentPlaceholder>(length);
+  ext->init(CachedExtent::extent_state_t::CLEAN,
+	    addr,
+	    PLACEMENT_HINT_NULL,
+	    NULL_GENERATION,
+	    TRANS_ID_NULL);
+  DEBUGT("retire {}~{} as placeholder, add extent -- {}",
+	 t, addr, length, *ext);
+  const auto t_src = t.get_src();
+  add_extent(ext, &t_src);
+  t.add_to_read_set(ext);
+  t.add_to_retired_set(ext);
+}
+
 void Cache::dump_contents()
 {
   LOG_PREFIX(Cache::dump_contents);

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -58,6 +58,7 @@ Cache::~Cache()
   ceph_assert(extents.empty());
 }
 
+// TODO: this method can probably be removed in the future
 Cache::retire_extent_ret Cache::retire_extent_addr(
   Transaction &t, paddr_t addr, extent_len_t length)
 {

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -246,6 +246,9 @@ public:
   retire_extent_ret retire_extent_addr(
     Transaction &t, paddr_t addr, extent_len_t length);
 
+  void retire_absent_extent_addr(
+    Transaction &t, paddr_t addr, extent_len_t length);
+
   /**
    * get_root
    *

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -921,7 +921,7 @@ public:
     paddr_t remap_paddr,
     extent_len_t remap_length,
     laddr_t original_laddr,
-    std::optional<ceph::bufferptr> &&original_bptr) {
+    std::optional<ceph::bufferptr> &original_bptr) {
     LOG_PREFIX(Cache::alloc_remapped_extent);
     assert(remap_laddr >= original_laddr);
     TCachedExtentRef<T> ext;

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -101,8 +101,7 @@ public:
     laddr_t hint,
     extent_len_t len,
     laddr_t intermediate_key,
-    laddr_t intermediate_base,
-    bool inc_ref) = 0;
+    laddr_t intermediate_base) = 0;
 
   virtual alloc_extent_ret reserve_region(
     Transaction &t,
@@ -146,6 +145,35 @@ public:
     Transaction &t,
     laddr_t addr,
     int delta) = 0;
+
+  struct remap_entry {
+    extent_len_t offset;
+    extent_len_t len;
+    remap_entry(extent_len_t _offset, extent_len_t _len) {
+      offset = _offset;
+      len = _len;
+    }
+  };
+  struct lba_remap_ret_t {
+    ref_update_result_t ruret;
+    std::vector<LBAMappingRef> remapped_mappings;
+  };
+  using remap_iertr = ref_iertr;
+  using remap_ret = remap_iertr::future<lba_remap_ret_t>;
+
+  /**
+   * remap_mappings
+   *
+   * Remap an original mapping into new ones
+   * Return the old mapping's info and new mappings
+   */
+  virtual remap_ret remap_mappings(
+    Transaction &t,
+    LBAMappingRef orig_mapping,
+    std::vector<remap_entry> remaps,
+    std::vector<LogicalCachedExtentRef> extents  // Required if and only
+						 // if pin isn't indirect
+    ) = 0;
 
   /**
    * Should be called after replay on each cached extent.

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -101,7 +101,8 @@ public:
     laddr_t hint,
     extent_len_t len,
     laddr_t intermediate_key,
-    laddr_t intermediate_base) = 0;
+    laddr_t intermediate_base,
+    bool inc_ref) = 0;
 
   virtual alloc_extent_ret reserve_region(
     Transaction &t,

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -124,8 +124,7 @@ public:
    */
   virtual ref_ret decref_extent(
     Transaction &t,
-    laddr_t addr,
-    bool cascade_remove) = 0;
+    laddr_t addr) = 0;
 
   /**
    * Increments ref count on extent

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -135,16 +135,6 @@ public:
     Transaction &t,
     laddr_t addr) = 0;
 
-  /**
-   * Increments ref count on extent
-   *
-   * @return returns resulting refcount
-   */
-  virtual ref_ret incref_extent(
-    Transaction &t,
-    laddr_t addr,
-    int delta) = 0;
-
   struct remap_entry {
     extent_len_t offset;
     extent_len_t len;

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -95,13 +95,10 @@ public:
     laddr_t interkey = L_ADDR_NULL)
   {
     assert(!indirect);
-    assert(value.is_paddr());
-    intermediate_base = key;
-    intermediate_key = (interkey == L_ADDR_NULL ? key : interkey);
     indirect = true;
-    key = new_key;
+    intermediate_base = key;
     intermediate_length = len;
-    len = length;
+    adjust_mutable_indirect_attrs(new_key, length, interkey);
   }
 
   laddr_t get_key() const final {
@@ -143,6 +140,18 @@ public:
 
   uint32_t get_checksum() const final {
     return get_map_val().checksum;
+  }
+
+  void adjust_mutable_indirect_attrs(
+    laddr_t new_key,
+    extent_len_t length,
+    laddr_t interkey = L_ADDR_NULL)
+  {
+    assert(indirect);
+    assert(value.is_paddr());
+    intermediate_key = (interkey == L_ADDR_NULL ? key : interkey);
+    key = new_key;
+    len = length;
   }
 
 protected:
@@ -247,63 +256,33 @@ public:
 
   alloc_extent_ret clone_mapping(
     Transaction &t,
-    laddr_t hint,
+    laddr_t laddr,
     extent_len_t len,
     laddr_t intermediate_key,
-    laddr_t intermediate_base,
-    bool inc_ref) final
+    laddr_t intermediate_base) final
   {
-    assert(intermediate_key != L_ADDR_NULL);
-    assert(intermediate_base != L_ADDR_NULL);
-    std::vector<alloc_mapping_info_t> alloc_infos = {
-      alloc_mapping_info_t{
-	len,
-	intermediate_key,
-	0,	// crc will only be used and checked with LBA direct mappings
-		// also see pin_to_extent(_by_type)
-	nullptr}};
-    return seastar::do_with(
-      std::move(alloc_infos),
-      [this, &t, intermediate_base, hint, inc_ref](auto &alloc_infos) {
-      return _alloc_extents(
-	t,
-	hint,
-	alloc_infos,
-	EXTENT_DEFAULT_REF_COUNT
-      ).si_then([&t, this, intermediate_base, inc_ref](auto mappings) {
-	assert(mappings.size() == 1);
-	auto indirect_mapping = std::move(mappings.front());
-	assert(indirect_mapping->is_indirect());
-	auto to_indirect = [](auto &mapping, const auto &imapping) mutable {
-	  ceph_assert(mapping->is_stable());
-	  mapping->make_indirect(
-	    imapping->get_key(),
-	    imapping->get_length(),
-	    imapping->get_intermediate_key());
-	};
-	if (inc_ref) {
-	  return update_refcount(t, intermediate_base, 1, false
-	  ).si_then([imapping=std::move(indirect_mapping),
-		     to_indirect=std::move(to_indirect)](auto p) mutable {
-	    auto mapping = std::move(p.mapping);
-	    to_indirect(mapping, imapping);
-	    return seastar::make_ready_future<
-	      LBAMappingRef>(std::move(mapping));
-	  });
-	} else {
-	  return _get_mapping(t, intermediate_base
-	  ).si_then([imapping=std::move(indirect_mapping),
-		     to_indirect=std::move(to_indirect)](auto mapping) mutable {
-	    to_indirect(mapping, imapping);
-	    return seastar::make_ready_future<
-	      LBAMappingRef>(std::move(mapping));
-	  });
-	}
-      }).handle_error_interruptible(
-	crimson::ct_error::input_output_error::pass_further{},
-	crimson::ct_error::assert_all{"unexpect enoent"}
-      );
-    });
+    return alloc_cloned_mapping(
+      t,
+      laddr,
+      len,
+      intermediate_key
+    ).si_then([&t, this, intermediate_base](auto imapping) {
+      return update_refcount(t, intermediate_base, 1, false
+      ).si_then([imapping=std::move(imapping)](auto p) mutable {
+	auto mapping = std::move(p.mapping);
+	ceph_assert(mapping->is_stable());
+	ceph_assert(imapping->is_indirect());
+	mapping->make_indirect(
+	  imapping->get_key(),
+	  imapping->get_length(),
+	  imapping->get_intermediate_key());
+	return seastar::make_ready_future<
+	  LBAMappingRef>(std::move(mapping));
+      });
+    }).handle_error_interruptible(
+      crimson::ct_error::input_output_error::pass_further{},
+      crimson::ct_error::assert_all{"unexpect enoent"}
+    );
   }
 
   alloc_extent_ret alloc_extent(
@@ -380,6 +359,109 @@ public:
     return update_refcount(t, addr, delta, false
     ).si_then([](auto res) {
       return std::move(res.ref_update_res);
+    });
+  }
+
+  remap_ret remap_mappings(
+    Transaction &t,
+    LBAMappingRef orig_mapping,
+    std::vector<remap_entry> remaps,
+    std::vector<LogicalCachedExtentRef> extents) final {
+    LOG_PREFIX(BtreeLBAManager::remap_mappings);
+    assert((orig_mapping->is_indirect())
+      == (remaps.size() != extents.size()));
+    return seastar::do_with(
+      lba_remap_ret_t{},
+      std::move(remaps),
+      std::move(extents),
+      std::move(orig_mapping),
+      [&t, FNAME, this](auto &ret, auto &remaps,
+			auto &extents, auto &orig_mapping) {
+      return update_refcount(t, orig_mapping->get_key(), -1, false
+      ).si_then([&ret, this, &extents, &remaps,
+		&t, &orig_mapping, FNAME](auto r) {
+	ret.ruret = std::move(r.ref_update_res);
+	if (!orig_mapping->is_indirect()) {
+	  ceph_assert(ret.ruret.refcount == 0 &&
+	    ret.ruret.addr.is_paddr() &&
+	    !ret.ruret.addr.get_paddr().is_zero());
+	}
+	return trans_intr::do_for_each(
+	  boost::make_counting_iterator(size_t(0)),
+	  boost::make_counting_iterator(remaps.size()),
+	  [&remaps, &t, this, &orig_mapping, &extents, FNAME, &ret](auto i) {
+	  laddr_t orig_laddr = orig_mapping->get_key();
+	  extent_len_t orig_len = orig_mapping->get_length();
+	  paddr_t orig_paddr = orig_mapping->get_val();
+	  laddr_t intermediate_base = orig_mapping->is_indirect()
+	    ? orig_mapping->get_intermediate_base()
+	    : L_ADDR_NULL;
+	  laddr_t intermediate_key = orig_mapping->is_indirect()
+	    ? orig_mapping->get_intermediate_key()
+	    : L_ADDR_NULL;
+	  auto &remap = remaps[i];
+	  auto remap_offset = remap.offset;
+	  auto remap_len = remap.len;
+	  auto remap_laddr = orig_laddr + remap_offset;
+	  auto remap_paddr = orig_paddr.add_offset(remap_offset);
+	  if (orig_mapping->is_indirect()) {
+	    ceph_assert(intermediate_base != L_ADDR_NULL);
+	    ceph_assert(intermediate_key != L_ADDR_NULL);
+	    remap_paddr = orig_paddr;
+	  }
+	  ceph_assert(remap_len < orig_len);
+	  ceph_assert(remap_offset + remap_len <= orig_len);
+	  ceph_assert(remap_len != 0);
+	  SUBDEBUGT(seastore_lba,
+	    "remap laddr: {}, remap paddr: {}, remap length: {},"
+	    " intermediate_base: {}, intermediate_key: {}", t,
+	    remap_laddr, remap_paddr, remap_len,
+	    intermediate_base, intermediate_key);
+	  auto fut = alloc_extent_iertr::make_ready_future<LBAMappingRef>();
+	  if (orig_mapping->is_indirect()) {
+	    assert(intermediate_base != L_ADDR_NULL
+	      && intermediate_key != L_ADDR_NULL);
+	    auto remapped_intermediate_key = intermediate_key + remap_offset;
+	    fut = alloc_cloned_mapping(
+	      t,
+	      remap_laddr,
+	      remap_len,
+	      remapped_intermediate_key
+	    ).si_then([&orig_mapping](auto imapping) mutable {
+	      auto mapping = orig_mapping->duplicate();
+	      auto bmapping = static_cast<BtreeLBAMapping*>(mapping.get());
+	      bmapping->adjust_mutable_indirect_attrs(
+		imapping->get_key(),
+		imapping->get_length(),
+		imapping->get_intermediate_key());
+	      return seastar::make_ready_future<LBAMappingRef>(
+		std::move(mapping));
+	    });
+	  } else {
+	    fut = alloc_extent(t, remap_laddr, *extents[i]);
+	  }
+	  return fut.si_then([remap_laddr, remap_len, &ret,
+			      remap_paddr](auto &&ref) {
+	    assert(ref->get_key() == remap_laddr);
+	    assert(ref->get_val() == remap_paddr);
+	    assert(ref->get_length() == remap_len);
+	    ret.remapped_mappings.emplace_back(std::move(ref));
+	    return seastar::now();
+	  });
+	});
+      }).si_then([&remaps, &t, &orig_mapping, this] {
+	if (remaps.size() > 1 && orig_mapping->is_indirect()) {
+	  auto intermediate_base = orig_mapping->get_intermediate_base();
+	  return incref_extent(t, intermediate_base, remaps.size() - 1
+	  ).si_then([](auto) {
+	    return seastar::now();
+	  });
+	}
+	return ref_iertr::now();
+      }).si_then([&ret, &remaps] {
+	assert(ret.remapped_mappings.size() == remaps.size());
+	return seastar::make_ready_future<lba_remap_ret_t>(std::move(ret));
+      });
     });
   }
 
@@ -483,6 +565,38 @@ private:
     laddr_t hint,
     std::vector<alloc_mapping_info_t> &alloc_infos,
     extent_ref_count_t refcount);
+
+  alloc_extent_iertr::future<BtreeLBAMappingRef> alloc_cloned_mapping(
+    Transaction &t,
+    laddr_t laddr,
+    extent_len_t len,
+    laddr_t intermediate_key)
+  {
+    assert(intermediate_key != L_ADDR_NULL);
+    std::vector<alloc_mapping_info_t> alloc_infos = {
+      alloc_mapping_info_t{
+	len,
+	intermediate_key,
+	0,	// crc will only be used and checked with LBA direct mappings
+		// also see pin_to_extent(_by_type)
+	nullptr}};
+    return seastar::do_with(
+      std::move(alloc_infos),
+      [this, &t, laddr](auto &alloc_infos) {
+      return _alloc_extents(
+	t,
+	laddr,
+	alloc_infos,
+	EXTENT_DEFAULT_REF_COUNT
+      ).si_then([laddr](auto mappings) {
+	ceph_assert(mappings.size() == 1);
+	auto mapping = std::move(mappings.front());
+	ceph_assert(mapping->get_key() == laddr);
+	return std::unique_ptr<BtreeLBAMapping>(
+	    static_cast<BtreeLBAMapping*>(mapping.release()));
+      });
+    });
+  }
 
   using _get_mapping_ret = get_mapping_iertr::future<BtreeLBAMappingRef>;
   _get_mapping_ret _get_mapping(

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -334,9 +334,8 @@ public:
 
   ref_ret decref_extent(
     Transaction &t,
-    laddr_t addr,
-    bool cascade_remove) final {
-    return update_refcount(t, addr, -1, cascade_remove
+    laddr_t addr) final {
+    return update_refcount(t, addr, -1, true
     ).si_then([](auto res) {
       return std::move(res.ref_update_res);
     });

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -465,6 +465,7 @@ ObjectDataHandler::write_ret do_remappings(
 	  return ObjectDataHandler::write_iertr::now();
 	});
       } else if (region.is_remap2()) {
+	auto pin_key = region.pin->get_key();
         return ctx.tm.remap_pin<ObjectDataBlock, 2>(
           ctx.t,
           std::move(region.pin),
@@ -472,10 +473,10 @@ ObjectDataHandler::write_ret do_remappings(
             region.create_left_remap_entry(),
             region.create_right_remap_entry()
           }
-        ).si_then([&region](auto pins) {
+        ).si_then([&region, pin_key](auto pins) {
           ceph_assert(pins.size() == 2);
-          ceph_assert(region.pin->get_key() == pins[0]->get_key());
-          ceph_assert(region.pin->get_key() + pins[0]->get_length() +
+          ceph_assert(pin_key == pins[0]->get_key());
+          ceph_assert(pin_key + pins[0]->get_length() +
             region.new_len == pins[1]->get_key());
           return ObjectDataHandler::write_iertr::now();
         });

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -221,7 +221,7 @@ TransactionManager::ref_ret TransactionManager::remove(
 {
   LOG_PREFIX(TransactionManager::remove);
   TRACET("{}", t, *ref);
-  return lba_manager->decref_extent(t, ref->get_laddr(), true
+  return lba_manager->decref_extent(t, ref->get_laddr()
   ).si_then([this, FNAME, &t, ref](auto result) {
     DEBUGT("extent refcount is decremented to {} -- {}",
            t, result.refcount, *ref);
@@ -234,12 +234,11 @@ TransactionManager::ref_ret TransactionManager::remove(
 
 TransactionManager::ref_ret TransactionManager::_dec_ref(
   Transaction &t,
-  laddr_t offset,
-  bool cascade_remove)
+  laddr_t offset)
 {
   LOG_PREFIX(TransactionManager::_dec_ref);
   TRACET("{}", t, offset);
-  return lba_manager->decref_extent(t, offset, cascade_remove
+  return lba_manager->decref_extent(t, offset
   ).si_then([this, FNAME, offset, &t](auto result) -> ref_ret {
     DEBUGT("extent refcount is decremented to {} -- {}~{}, {}",
            t, result.refcount, offset, result.length, result.addr);

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -176,6 +176,20 @@ public:
     Transaction &t,
     LBAMappingRef pin)
   {
+    auto ret = get_extent_if_linked<T>(t, std::move(pin));
+    if (ret.index() == 1) {
+      return std::move(std::get<1>(ret));
+    } else {
+      return this->pin_to_extent<T>(t, std::move(std::get<0>(ret)));
+    }
+  }
+
+  template <typename T>
+  std::variant<LBAMappingRef, base_iertr::future<TCachedExtentRef<T>>>
+  get_extent_if_linked(
+    Transaction &t,
+    LBAMappingRef pin)
+  {
     auto v = pin->get_logical_extent(t);
     if (v.has_child()) {
       return v.get_child_fut().safe_then([pin=std::move(pin)](auto extent) {
@@ -190,7 +204,7 @@ public:
 	return extent->template cast<T>();
       });
     } else {
-      return pin_to_extent<T>(t, std::move(pin));
+      return pin;
     }
   }
 

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -593,7 +593,8 @@ public:
       hint,
       mapping.get_length(),
       intermediate_key,
-      intermediate_base
+      intermediate_base,
+      true
     );
   }
 
@@ -1023,7 +1024,8 @@ private:
 	remap_laddr,
 	remap_length,
 	intermediate_key,
-	intermediate_base);
+	intermediate_base,
+	false);
     }
     return fut.si_then([remap_laddr, remap_length, remap_paddr](auto &&ref) {
       assert(ref->get_key() == remap_laddr);

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -283,7 +283,7 @@ public:
   ref_ret remove(
     Transaction &t,
     laddr_t offset) {
-    return _dec_ref(t, offset, true);
+    return _dec_ref(t, offset);
   }
 
   /// remove refcount for list of offset
@@ -803,8 +803,7 @@ private:
   /// Remove refcount for offset
   ref_ret _dec_ref(
     Transaction &t,
-    laddr_t offset,
-    bool cascade_remove);
+    laddr_t offset);
 
   using update_lba_mappings_ret = LBAManager::update_mappings_ret;
   update_lba_mappings_ret update_lba_mappings(

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -176,6 +176,8 @@ public:
     Transaction &t,
     LBAMappingRef pin)
   {
+    // checking the lba child must be atomic with creating
+    // and linking the absent child
     auto ret = get_extent_if_linked<T>(t, std::move(pin));
     if (ret.index() == 1) {
       return std::move(std::get<1>(ret));
@@ -214,6 +216,8 @@ public:
     extent_types_t type)
   {
     auto v = pin->get_logical_extent(t);
+    // checking the lba child must be atomic with creating
+    // and linking the absent child
     if (v.has_child()) {
       return std::move(v.get_child_fut());
     } else {

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -567,8 +567,7 @@ struct btree_lba_manager_test : btree_test_base {
       [=, this](auto &t) {
 	return lba_manager->decref_extent(
 	  t,
-	  target->first,
-	  true
+	  target->first
 	).si_then([this, &t, target](auto result) {
 	  EXPECT_EQ(result.refcount, target->second.refcount);
 	  if (result.refcount == 0) {

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -1111,7 +1111,8 @@ struct transaction_manager_test_t :
       return nullptr;
     }
     auto o_laddr = opin->get_key();
-    auto data_laddr = opin->is_indirect()
+    bool indirect_opin = opin->is_indirect();
+    auto data_laddr = indirect_opin
       ? opin->get_intermediate_base()
       : o_laddr;
     auto pin = with_trans_intr(*(t.t), [&](auto& trans) {
@@ -1128,7 +1129,7 @@ struct transaction_manager_test_t :
     if (t.t->is_conflicted()) {
       return nullptr;
     }
-    if (opin->is_indirect()) {
+    if (indirect_opin) {
       test_mappings.inc_ref(data_laddr, t.mapping_delta);
     } else {
       test_mappings.dec_ref(data_laddr, t.mapping_delta);


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57262

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh