### PR TITLE
squid: test/crimson/seastore/transaction_manager_test_state: fix compilation…

### DIFF
--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -284,6 +284,7 @@ protected:
     auto sec_devices = devices->get_secondary_devices();
     auto p_dev = devices->get_primary_device();
     auto fut = seastar::now();
+#ifdef UNIT_TESTS_BUILT
     if (std::get<1>(GetParam()) == integrity_check_t::FULL_CHECK) {
       fut = crimson::common::local_conf().set_val(
 	"seastore_full_integrity_check", "true");
@@ -291,6 +292,7 @@ protected:
       fut = crimson::common::local_conf().set_val(
 	"seastore_full_integrity_check", "false");
     }
+#endif
     tm = make_transaction_manager(p_dev, sec_devices, true);
     epm = tm->get_epm();
     lba_manager = tm->get_lba_manager();
@@ -436,6 +438,7 @@ protected:
 
   virtual seastar::future<> _init() final {
     auto fut = seastar::now();
+#ifdef UNIT_TESTS_BUILT
     if (std::get<1>(GetParam()) == integrity_check_t::FULL_CHECK) {
       fut = crimson::common::local_conf().set_val(
 	"seastore_full_integrity_check", "true");
@@ -443,6 +446,7 @@ protected:
       fut = crimson::common::local_conf().set_val(
 	"seastore_full_integrity_check", "false");
     }
+#endif
     seastore = make_test_seastore(
       std::make_unique<TestMDStoreState::Store>(mdstore_state.get_mdstore()));
     return fut.then([this] {


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57656

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh