### PR TITLE
squid: crimson/common/operation: detach blockers from blocking events when they are destroyed

### DIFF
--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -73,6 +73,9 @@ void ClientRequest::dump_detail(Formatter *f) const
   std::apply([f] (auto... event) {
     (..., event.dump(f));
   }, tracking_events);
+  std::apply([f] (auto... event) {
+    (..., event.dump(f));
+  }, get_instance_handle()->pg_tracking_events);
 }
 
 ConnectionPipeline &ClientRequest::get_connection_pipeline()

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -162,6 +162,7 @@ public:
     instance_handle = new instance_handle_t;
   }
   auto get_instance_handle() { return instance_handle; }
+  auto get_instance_handle() const { return instance_handle; }
 
   std::set<snapid_t> snaps_need_to_recover() {
     std::set<snapid_t> ret;


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57069

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh