### PR TITLE
squid: crimson/osd/pg_backend: only create new onode when it doesn't exist

### DIFF
--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -993,8 +993,6 @@ PGBackend::create_iertr::future<> PGBackend::create(
     }
   }
   maybe_create_new_object(os, txn, delta_stats);
-  txn.create(coll->get_cid(),
-             ghobject_t{os.oi.soid, ghobject_t::NO_GEN, shard});
   return seastar::now();
 }
 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57251

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh