### PR TITLE
squid: crimson/osd/replicated_backend: no need to set_rollback_to for repops

### DIFF
--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -70,7 +70,6 @@ ReplicatedBackend::_submit_transaction(std::set<pg_shard_t>&& pg_shards,
       encode(log_entries, m->logbl);
       m->pg_trim_to = osd_op_p.pg_trim_to;
       m->min_last_complete_ondisk = osd_op_p.min_last_complete_ondisk;
-      m->set_rollback_to(osd_op_p.at_version);
       // TODO: set more stuff. e.g., pg_states
       sends->emplace_back(
 	shard_services.send_to_osd(


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57455

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh