### PR TITLE
squid: crimson/osd/pg_shard_manager: remove the unnecessary "std::move" call

### DIFF
--- a/src/crimson/osd/pg_shard_manager.h
+++ b/src/crimson/osd/pg_shard_manager.h
@@ -232,7 +232,7 @@ public:
       return target_shard_services.get_or_create_pg(
         std::move(trigger),
         opref.get_pgid(),
-        std::move(opref.get_create_info())
+        opref.get_create_info()
       );
     }).safe_then([&logger, &target_shard_services, &opref](Ref<PG> pgref) {
       logger.debug("{}: have_pg", opref);


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57692

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh