### PR TITLE
squid: crimson/osd/ops_executer: LIST_SNAPS only on CEPH_SNAPDIR

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -490,6 +490,11 @@ OpsExecuter::list_snaps_iertr::future<> OpsExecuter::do_list_snaps(
   const ObjectState& os,
   const SnapSet& ss)
 {
+  if (msg->get_snapid() != CEPH_SNAPDIR) {
+    logger().debug("LIST_SNAPS with incorrect context");
+    return crimson::ct_error::invarg::make();
+  }
+
   obj_list_snap_response_t resp;
   resp.clones.reserve(ss.clones.size() + 1);
   for (auto &clone: ss.clones) {

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -107,6 +107,7 @@ public:
     virtual uint64_t get_features() const = 0;
     virtual bool has_flag(uint32_t flag) const = 0;
     virtual entity_name_t get_source() const = 0;
+    virtual snapid_t get_snapid() const = 0;
   };
 
   template <class ImplT>
@@ -143,6 +144,9 @@ public:
     }
     uint64_t get_features() const final {
       return pimpl->get_features();
+    }
+    snapid_t get_snapid() const final {
+      return pimpl->get_snapid();
     }
   };
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -831,12 +831,17 @@ struct PG::do_osd_ops_params_t {
     return orig_source_inst.name;
   }
 
+  snapid_t get_snapid() const {
+    return snapid;
+  }
+
   crimson::net::ConnectionXcoreRef &conn;
   osd_reqid_t reqid;
   utime_t mtime;
   epoch_t map_epoch;
   entity_inst_t orig_source_inst;
   uint64_t features;
+  snapid_t snapid;
 };
 
 std::ostream& operator<<(std::ostream&, const PG& pg);

--- a/src/test/librados/snapshots_cxx.cc
+++ b/src/test/librados/snapshots_cxx.cc
@@ -153,7 +153,6 @@ TEST_F(LibRadosSnapshotsSelfManagedPP, SnapPP) {
 }
 
 TEST_F(LibRadosSnapshotsSelfManagedPP, RollbackPP) {
-  SKIP_IF_CRIMSON();
   std::vector<uint64_t> my_snaps;
   IoCtx readioctx;
   ASSERT_EQ(0, cluster.ioctx_create(pool_name.c_str(), readioctx));


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57561

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh