### PR TITLE
squid: crimson/osd/pg: trigger wait_for_active_blocker on replica osds when the activate event is committed

### DIFF
--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -323,7 +323,9 @@ public:
   }
   Context *on_clean() final;
   void on_activate_committed() final {
-    // Not needed yet (will be needed for IO unblocking)
+    if (!is_primary()) {
+      wait_for_active_blocker.unblock();
+    }
   }
   void on_active_exit() final {
     // Not needed yet


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57279

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh