### PR TITLE
squid: crimson/osd/ops_executor: calculation of clone_overlap shouldn't consider snap contexts

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -980,7 +980,6 @@ void OpsExecuter::update_clone_overlap() {
       &cloning_ctx->new_snapset.clone_overlap.rbegin()->second;
   } else if (op_info.may_write() 
     && obc->obs.exists 
-    && !snapc.snaps.empty() 
     && !obc->ssc->snapset.clones.empty()) {
     newest_overlap =
       &obc->ssc->snapset.clone_overlap.rbegin()->second;


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57313

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh