### PR TITLE
osd: suppressing two false clang-tidy detections

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4904,7 +4904,7 @@ int PrimaryLogPG::trim_object(
     encode(snapset, bl);
     attrs[SS_ATTR] = std::move(bl);
 
-    bl.clear();
+    bl.clear(); //NOLINT(bugprone-use-after-move)
     encode(head_obc->obs.oi, bl,
 	     get_osdmap()->get_features(CEPH_ENTITY_TYPE_OSD, nullptr));
     attrs[OI_ATTR] = std::move(bl);

--- a/src/osdc/Striper.cc
+++ b/src/osdc/Striper.cc
@@ -407,7 +407,7 @@ void Striper::StripedReadResult::add_partial_result(
 		 << " to " << buffer_extents << dendl;
   for (auto& be : buffer_extents) {
     auto& r = partial[be.first];
-    size_t actual = std::min<uint64_t>(bl.length(), be.second);
+    size_t actual = std::min<uint64_t>(bl.length(), be.second); //NOLINT(bugprone-use-after-move)
     if (buffer_extents.size() == 1) {
       r.first = std::move(bl);
     } else {


### PR DESCRIPTION
Suppressing two false 'use-after-move' detections.

1. src/osd/PrimaryLogPG.cc:

It's safe to use  clear() on operand that has been moved.

**reference:** https://github.com/ceph/ceph/pull/48839/files

2. src/osdc/Striper.cc:

This is a false-positive because in the loop the bufferlist is only being moved when the size of the buffer_extents is equal to 1 otherwise it will not move

**reference:** https://github.com/ceph/ceph/blob/e879ce83c084f1a96e5dd0ab2b57bf909cfa423d/src/osdc/Striper.cc#L411-L415

clang-tidy warning for `Striper.cc`:
```
home/suyash/ceph/src/osdc/Striper.cc:410:40: warning: 'bl' used after it was moved [bugprone-use-after-move]
	size_t actual = std::min<uint64_t>(bl.length(), be.second);
                                   	   ^
/home/suyash/ceph/src/osdc/Striper.cc:412:15: note: move occurred here
  	r.first = std::move(bl);
          	 ^
/home/suyash/ceph/src/osdc/Striper.cc:410:40: note: the use happens in a later loop iteration than the move
	size_t actual = std::min<uint64_t>(bl.length(), be.second);
                                   	    ^
```

clang-tidy warning for `PrimaryLogPG.cc`:
```
/home/suyash/ceph/src/osd/PrimaryLogPG.cc:4907:5: warning: 'bl' used after it was moved [bugprone-use-after-move]
	bl.clear();
	^
/home/suyash/ceph/src/osd/PrimaryLogPG.cc:4905:20: note: move occurred here
	attrs[SS_ATTR] = std::move(bl);
               	       ^
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
