### PR TITLE
mon: fix inconsistencies in class param

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -129,6 +129,10 @@
  * to any guidelines regarding deprecating commands.
  */
 
+#define DEFAULT_GOODCHARS "[A-Za-z0-9-_.]"
+#define FS_NAME_GOODCHARS DEFAULT_GOODCHARS
+#define CLASS_GOODCHARS DEFAULT_GOODCHARS
+
 COMMAND("pg map name=pgid,type=CephPgid", "show mapping of pg to osds", \
 	"pg", "r")
 COMMAND("pg repeer name=pgid,type=CephPgid", "force a PG to repeer",
@@ -292,7 +296,6 @@ COMMAND("versions",
  * MDS commands (MDSMonitor.cc)
  */
 
-#define FS_NAME_GOODCHARS "[A-Za-z0-9-_.]"
 COMMAND_WITH_FLAG("mds stat", "show MDS status", "mds", "r", FLAG(HIDDEN))
 COMMAND("fs dump "
 	"name=epoch,type=CephInt,req=false,range=0",
@@ -617,7 +620,7 @@ COMMAND_WITH_FLAG("osd crush rule list", "list crush rules", "osd", "r",
 		  FLAG(DEPRECATED))
 COMMAND("osd crush rule ls", "list crush rules", "osd", "r")
 COMMAND("osd crush rule ls-by-class "
-        "name=class,type=CephString,goodchars=[A-Za-z0-9-_.]",
+        "name=class,type=CephString,goodchars=" CLASS_GOODCHARS,
         "list all crush rules that reference the same <class>",
         "osd", "r")
 COMMAND("osd crush rule dump "
@@ -661,16 +664,16 @@ COMMAND("osd crush set-all-straw-buckets-to-straw2",
         "convert all CRUSH current straw buckets to use the straw2 algorithm",
 	"osd", "rw")
 COMMAND("osd crush class create "
-        "name=class,type=CephString,goodchars=[A-Za-z0-9-_]",
+        "name=class,type=CephString,goodchars=" CLASS_GOODCHARS,
         "create crush device class <class>",
         "osd", "rw")
 COMMAND("osd crush class rm "
-        "name=class,type=CephString,goodchars=[A-Za-z0-9-_]",
+        "name=class,type=CephString,goodchars=" CLASS_GOODCHARS,
         "remove crush device class <class>",
         "osd", "rw")
 COMMAND("osd crush set-device-class "
-        "name=class,type=CephString "
-	"name=ids,type=CephString,n=N",
+        "name=class,type=CephString,goodchars=" CLASS_GOODCHARS
+	" name=ids,type=CephString,n=N",
 	"set the <class> of the osd(s) <id> [<id>...],"
         "or use <all|any> to set all.",
 	"osd", "rw")
@@ -760,7 +763,7 @@ COMMAND("osd crush rule create-replicated "
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] "
 	"name=root,type=CephString,goodchars=[A-Za-z0-9-_.] "
 	"name=type,type=CephString,goodchars=[A-Za-z0-9-_.] "
-	"name=class,type=CephString,goodchars=[A-Za-z0-9-_.],req=false",
+	"name=class,type=CephString,goodchars=" CLASS_GOODCHARS ",req=false",
 	"create crush rule <name> for replicated pool to start from <root>, replicate across buckets of type <type>, use devices of type <class> (ssd or hdd)",
 	"osd", "rw")
 COMMAND("osd crush rule create-erasure "
@@ -787,7 +790,7 @@ COMMAND("osd crush class ls",
 	"list all crush device classes",
 	"osd", "r")
 COMMAND("osd crush class ls-osd "
-        "name=class,type=CephString,goodchars=[A-Za-z0-9-_]",
+        "name=class,type=CephString,goodchars=" CLASS_GOODCHARS,
         "list all osds belonging to the specific <class>",
         "osd", "r")
 COMMAND("osd crush get-device-class "


### PR DESCRIPTION
Consistently apply allowed set of goodchars across all uses of the 'class' param. This is my first Ceph bug fix; an exercise to learn about the delivery process and get used to navigating the code. For this fix I had to make a choice between two sets of goodchars which had been used for different commands. I went with the more generous one as I could find no documentation prohibiting the use of "." in a class. 

To test the fix I tried out all of the commands which take a class parameter, using several different characters, including "."

Fixes: https://tracker.ceph.com/issues/45253

Signed-off-by: Victoria Mackie <victoriam@uk.ibm.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
