### PR TITLE
cmake: fix the bug of compiling with rdma

### DIFF
--- a/cmake/modules/BuildDPDK.cmake
+++ b/cmake/modules/BuildDPDK.cmake
@@ -181,7 +181,8 @@ function(do_export_dpdk dpdk_dir)
   set_target_properties(dpdk::dpdk PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES ${DPDK_INCLUDE_DIR}
     INTERFACE_LINK_LIBRARIES
-    "-Wl,--whole-archive $<JOIN:${DPDK_ARCHIVES}, > -Wl,--no-whole-archive ${dpdk_numa} -Wl,-lpthread,-ldl")
+    "-Wl,--whole-archive $<JOIN:${DPDK_ARCHIVES}, > -Wl,--no-whole-archive ${dpdk_numa} -Wl,-lpthread,-ldl,-lmlx5")
+  target_link_libraries(dpdk::dpdk INTERFACE IBVerbs::verbs RDMA::RDMAcm)
   if(dpdk_rte_CFLAGS)
     set_target_properties(dpdk::dpdk PROPERTIES
       INTERFACE_COMPILE_OPTIONS "${dpdk_rte_CFLAGS}")

--- a/cmake/modules/BuildDPDK.cmake
+++ b/cmake/modules/BuildDPDK.cmake
@@ -182,7 +182,11 @@ function(do_export_dpdk dpdk_dir)
     INTERFACE_INCLUDE_DIRECTORIES ${DPDK_INCLUDE_DIR}
     INTERFACE_LINK_LIBRARIES
     "-Wl,--whole-archive $<JOIN:${DPDK_ARCHIVES}, > -Wl,--no-whole-archive ${dpdk_numa} -Wl,-lpthread,-ldl,-lmlx5")
+<<<<<<< HEAD
   target_link_libraries(dpdk::dpdk INTERFACE IBVerbs::verbs RDMA::RDMAcm)
+=======
+  target_link_libraries(dpdk::dpdk INTERFACE RDMA::RDMAcm IBVerbs::verbs)
+>>>>>>> 86f9179ee0 (cmake: fix the bug of compiling with rdma)
   if(dpdk_rte_CFLAGS)
     set_target_properties(dpdk::dpdk PROPERTIES
       INTERFACE_COMPILE_OPTIONS "${dpdk_rte_CFLAGS}")

--- a/cmake/modules/BuildDPDK.cmake
+++ b/cmake/modules/BuildDPDK.cmake
@@ -182,11 +182,7 @@ function(do_export_dpdk dpdk_dir)
     INTERFACE_INCLUDE_DIRECTORIES ${DPDK_INCLUDE_DIR}
     INTERFACE_LINK_LIBRARIES
     "-Wl,--whole-archive $<JOIN:${DPDK_ARCHIVES}, > -Wl,--no-whole-archive ${dpdk_numa} -Wl,-lpthread,-ldl,-lmlx5")
-<<<<<<< HEAD
-  target_link_libraries(dpdk::dpdk INTERFACE IBVerbs::verbs RDMA::RDMAcm)
-=======
   target_link_libraries(dpdk::dpdk INTERFACE RDMA::RDMAcm IBVerbs::verbs)
->>>>>>> 86f9179ee0 (cmake: fix the bug of compiling with rdma)
   if(dpdk_rte_CFLAGS)
     set_target_properties(dpdk::dpdk PROPERTIES
       INTERFACE_COMPILE_OPTIONS "${dpdk_rte_CFLAGS}")


### PR DESCRIPTION
When ceph uses the rdma function, the rdma compilation option needs to be enabled, but once the rdma compilation option is enabled, a link error will occur in the ceph compilation. After analysis, it was found that when the rdma compilation option is enabled, the following three link libraries are required: lmlx5, libverbs, and lrdmacm.

Signed-off-by: Xiaobing Li <xiaobing.li@samsung.com>