### PR TITLE
rgw: rgw_log_backing: Lock is not being re-instantiated 

### DIFF
--- a/src/rgw/driver/rados/rgw_log_backing.cc
+++ b/src/rgw/driver/rados/rgw_log_backing.cc
@@ -609,7 +609,6 @@ bs::error_code logback_generations::remove_empty(const DoutPrefixProvider *dpp, 
     if (ec) return ec;
     auto tries = 0;
     entries_t new_entries;
-    std::unique_lock l(m);
     ceph_assert(!entries_.empty());
     {
       auto i = lowest_nomempty(entries_);
@@ -619,8 +618,8 @@ bs::error_code logback_generations::remove_empty(const DoutPrefixProvider *dpp, 
     }
     entries_t es;
     auto now = ceph::real_clock::now();
-    l.unlock();
     do {
+      std::unique_lock l(m);
       std::copy_if(entries_.cbegin(), entries_.cend(),
 		   std::inserter(es, es.end()),
 		   [now](const auto& e) {
@@ -646,7 +645,6 @@ bs::error_code logback_generations::remove_empty(const DoutPrefixProvider *dpp, 
 	  es2.erase(i);
 	}
       }
-      l.lock();
       es.clear();
       ec = write(dpp, std::move(es2), std::move(l), y);
       ++tries;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/66481

The lock is not being re-instantiated in the loop. I have taken reference from [here](https://github.com/ceph/ceph/blob/fab66be49ffed7b42a2c4b93db7f38c23334d925/src/rgw/driver/rados/rgw_log_backing.cc#L574), here the same `write` function is being called but in the calling function the lock is being re-declared. 

A use-after-move warning was also being generated.


clang-tidy original warning:
```
/home/suyash/ceph/src/rgw/driver/rados/rgw_log_backing.cc:649:7: warning: 'l' used after it was moved [bugprone-use-after-move]
  	l.lock();
  	^
/home/suyash/ceph/src/rgw/driver/rados/rgw_log_backing.cc:651:12: note: move occurred here
  	ec = write(dpp, std::move(es2), std::move(l), y);
       	^
/home/suyash/ceph/src/rgw/driver/rados/rgw_log_backing.cc:649:7: note: the use happens in a later loop iteration than the move
  	l.lock();
  	^
```


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
