### PR TITLE
core: Change the default plugin for Ceph erasure coded pools from Jerasure to ISA-L

### DIFF
--- a/doc/dev/erasure-coded-pool.rst
+++ b/doc/dev/erasure-coded-pool.rst
@@ -63,7 +63,7 @@ Set the CRUSH failure domain to osd (instead of host, which is the default)::
  $ ceph osd erasure-code-profile get myprofile
  k=2
  m=2
- plugin=jerasure
+ plugin=isa
  technique=reed_sol_van
  crush-failure-domain=osd
  $ ceph osd pool create ecpool erasure myprofile
@@ -75,7 +75,7 @@ Control the parameters of the erasure code plugin::
  $ ceph osd erasure-code-profile get myprofile
  k=3
  m=2
- plugin=jerasure
+ plugin=isa
  technique=reed_sol_van
  $ ceph osd pool create ecpool erasure myprofile
 
@@ -98,7 +98,7 @@ Display the default erasure code profile::
   $ ceph osd erasure-code-profile get default
   k=2
   m=2
-  plugin=jerasure
+  plugin=isa
   technique=reed_sol_van
 
 Create a profile to set the data to be distributed on six OSDs (k+m=6) and sustain the loss of three OSDs (m=3) without losing data::
@@ -107,7 +107,7 @@ Create a profile to set the data to be distributed on six OSDs (k+m=6) and susta
   $ ceph osd erasure-code-profile get myprofile
   k=3
   m=3
-  plugin=jerasure
+  plugin=isa
   technique=reed_sol_van
   $ ceph osd erasure-code-profile ls
   default
@@ -129,7 +129,7 @@ Set the rule to ssd (instead of default)::
  $ ceph osd erasure-code-profile get myprofile
  k=2
  m=2
- plugin=jerasure
+ plugin=isa
  technique=reed_sol_van
  crush-root=ssd
 

--- a/doc/dev/osd_internals/erasure_coding/developer_notes.rst
+++ b/doc/dev/osd_internals/erasure_coding/developer_notes.rst
@@ -171,7 +171,7 @@ key=value pairs stored in an `erasure code profile`_.
  directory=/usr/lib/ceph/erasure-code
  k=2
  m=1
- plugin=jerasure
+ plugin=isa
  technique=reed_sol_van
  crush-failure-domain=osd
  $ ceph osd pool create ecpool erasure myprofile
@@ -206,7 +206,7 @@ set in the erasure code profile, before the pool was created.
  
   ceph osd erasure-code-profile set myprofile \
      directory=<dir>         \ # mandatory
-     plugin=jerasure         \ # mandatory
+     plugin=isa              \ # mandatory
      m=10                    \ # optional and plugin dependent
      k=3                     \ # optional and plugin dependent
      technique=reed_sol_van  \ # optional and plugin dependent

--- a/doc/rados/operations/erasure-code-isa.rst
+++ b/doc/rados/operations/erasure-code-isa.rst
@@ -2,6 +2,7 @@
 ISA erasure code plugin
 =======================
 
+The *isa* plugin is the default for Ceph erasure coded pools.
 The *isa* plugin encapsulates the `ISA
 <https://01.org/intel%C2%AE-storage-acceleration-library-open-source-version/>`_
 library.

--- a/doc/rados/operations/erasure-code-jerasure.rst
+++ b/doc/rados/operations/erasure-code-jerasure.rst
@@ -2,8 +2,10 @@
 Jerasure erasure code plugin
 ============================
 
-The *jerasure* plugin is the most generic and flexible plugin, it is
-also the default for Ceph erasure coded pools. 
+The *jerasure* plugin is a generic and flexible plugin. However,
+the *jerasure* library is no longer maintained and has not been
+updated to support modern CPU instructions that can improve
+performance when encoding and decoding data.
 
 The *jerasure* plugin encapsulates the `Jerasure
 <https://github.com/ceph/jerasure>`_ library. It is

--- a/doc/rados/operations/erasure-code-lrc.rst
+++ b/doc/rados/operations/erasure-code-lrc.rst
@@ -2,9 +2,9 @@
 Locally repairable erasure code plugin
 ======================================
 
-With the *jerasure* plugin, when an erasure coded object is stored on
+With the *isa* plugin, when an erasure coded object is stored on
 multiple OSDs, recovering from the loss of one OSD requires reading
-from *k* others. For instance if *jerasure* is configured with
+from *k* others. For instance if *isa* is configured with
 *k=8* and *m=4*, recovering from the loss of one OSD requires reading
 from eight others.
 
@@ -195,7 +195,7 @@ Minimal testing
 ---------------
 
 It is strictly equivalent to using a *K=2* *M=1* erasure code profile. The *DD*
-implies *K=2*, the *c* implies *M=1* and the *jerasure* plugin is used
+implies *K=2*, the *c* implies *M=1* and the *isa* plugin is used
 by default.:
 
 .. prompt:: bash $
@@ -253,11 +253,11 @@ the same rack as the lost chunk. **WARNING: PROMPTS ARE SELECTABLE**
 Testing with different Erasure Code backends
 --------------------------------------------
 
-LRC now uses jerasure as the default EC backend. It is possible to
+LRC now uses ISA as the default EC backend. It is possible to
 specify the EC backend/algorithm on a per layer basis using the low
 level configuration. The second argument in layers='[ [ "DDc", "" ] ]'
 is actually an erasure code profile to be used for this level. The
-example below specifies the ISA backend with the cauchy technique to
+example below specifies the Jerasure backend with the cauchy technique to
 be used in the lrcpool.:
 
 .. prompt:: bash $
@@ -265,7 +265,7 @@ be used in the lrcpool.:
    ceph osd erasure-code-profile set LRCprofile \
       plugin=lrc \
       mapping=DD_ \
-      layers='[ [ "DDc", "plugin=isa technique=cauchy" ] ]'
+      layers='[ [ "DDc", "plugin=jerasure technique=cauchy" ] ]'
    ceph osd pool create lrcpool erasure LRCprofile
 
 You could also use a different erasure code profile for each

--- a/doc/rados/operations/erasure-code-profile.rst
+++ b/doc/rados/operations/erasure-code-profile.rst
@@ -67,7 +67,7 @@ Where:
 
 :Type: String
 :Required: No.
-:Default: jerasure
+:Default: isa
 
 ``{stripe_unit=stripe_unit}``
 

--- a/doc/rados/operations/erasure-code.rst
+++ b/doc/rados/operations/erasure-code.rst
@@ -64,7 +64,7 @@ profile can be displayed with this command:
 
    k=2
    m=2
-   plugin=jerasure
+   plugin=isa
    crush-failure-domain=host
    technique=reed_sol_van
 

--- a/qa/standalone/erasure-code/test-erasure-code-plugins.sh
+++ b/qa/standalone/erasure-code/test-erasure-code-plugins.sh
@@ -14,7 +14,7 @@ case $arch in
     aarch64*|arm*)
         legacy_jerasure_plugins=(jerasure_generic jerasure_neon)
         legacy_shec_plugins=(shec_generic shec_neon)
-        plugins=(jerasure shec lrc)
+        plugins=(jerasure shec lrc isa)
         ;;
     *)
         echo "unsupported platform ${arch}."

--- a/qa/standalone/mon/osd-erasure-code-profile.sh
+++ b/qa/standalone/mon/osd-erasure-code-profile.sh
@@ -46,15 +46,15 @@ function TEST_set() {
     #
     ceph osd erasure-code-profile set $profile 2>&1 || return 1
     ceph osd erasure-code-profile get $profile | \
-        grep plugin=jerasure || return 1
+        grep plugin=isa || return 1
     ceph osd erasure-code-profile rm $profile
     #
     # key=value pairs override the default
     #
     ceph osd erasure-code-profile set $profile \
-        key=value plugin=isa || return 1
+        key=value plugin=jerasure || return 1
     ceph osd erasure-code-profile get $profile | \
-        grep -e key=value -e plugin=isa || return 1
+        grep -e key=value -e plugin=jerasure || return 1
     #
     # --force is required to override an existing profile
     #
@@ -115,9 +115,9 @@ function TEST_get() {
 
     local default_profile=default
     ceph osd erasure-code-profile get $default_profile | \
-        grep plugin=jerasure || return 1
+        grep plugin=isa || return 1
     ceph --format xml osd erasure-code-profile get $default_profile | \
-        grep '<plugin>jerasure</plugin>' || return 1
+        grep '<plugin>isa</plugin>' || return 1
     ! ceph osd erasure-code-profile get WRONG > $dir/out 2>&1 || return 1
     grep -q "unknown erasure code profile 'WRONG'" $dir/out || return 1
 }

--- a/qa/standalone/mon/osd-pool-create.sh
+++ b/qa/standalone/mon/osd-pool-create.sh
@@ -99,7 +99,7 @@ function TEST_erasure_crush_stripe_unit_padded() {
     local dir=$1
     # setting osd_pool_erasure_code_stripe_unit modifies the stripe_width
     # and it is padded as required by the default plugin
-    profile+=" plugin=jerasure"
+    profile+=" plugin=isa"
     profile+=" technique=reed_sol_van"
     k=4
     profile+=" k=$k"

--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -32,7 +32,7 @@
         mon_warn_on_pool_no_redundancy = false
 	mon_allow_pool_size_one = true
 
-        osd pool default erasure code profile = "plugin=jerasure technique=reed_sol_van k=2 m=1 crush-failure-domain=osd"
+        osd pool default erasure code profile = "plugin=isa technique=reed_sol_van k=2 m=1 crush-failure-domain=osd"
 
 	osd default data pool replay window = 5
 

--- a/qa/tasks/cephadm.conf
+++ b/qa/tasks/cephadm.conf
@@ -11,7 +11,7 @@ mon clock drift allowed = 1.000
 # replicate across OSDs, not hosts
 osd crush chooseleaf type = 0
 #osd pool default size = 2
-osd pool default erasure code profile = "plugin=jerasure technique=reed_sol_van k=2 m=1 crush-failure-domain=osd"
+osd pool default erasure code profile = "plugin=isa technique=reed_sol_van k=2 m=1 crush-failure-domain=osd"
 
 # enable some debugging
 auth debug = true

--- a/qa/tasks/mgr/dashboard/test_erasure_code_profile.py
+++ b/qa/tasks/mgr/dashboard/test_erasure_code_profile.py
@@ -41,7 +41,7 @@ class ECPTest(DashboardTestCase):
                 'technique': 'reed_sol_van',
                 'm': 1,
                 'name': 'default',
-                'plugin': 'jerasure'
+                'plugin': 'isa'
             }
             if 'crush-failure-domain' in default[0]:
                 default_ecp['crush-failure-domain'] = default[0]['crush-failure-domain']
@@ -59,11 +59,10 @@ class ECPTest(DashboardTestCase):
             'crush-device-class': '',
             'crush-failure-domain': 'osd',
             'crush-root': 'default',
-            'jerasure-per-chunk-alignment': 'false',
             'k': 3,
             'm': 2,
             'name': 'ecp32',
-            'plugin': 'jerasure',
+            'plugin': 'isa',
             'technique': 'reed_sol_van',
         })
 

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -2568,7 +2568,7 @@ options:
   type: str
   level: advanced
   desc: default erasure code profile for new erasure-coded pools
-  default: plugin=jerasure technique=reed_sol_van k=2 m=2
+  default: plugin=isa technique=reed_sol_van k=2 m=2
   services:
   - mon
   flags:

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -14,7 +14,6 @@
  *  version 2.1 of the License, or (at your option) any later version.
  *
  */
-
 #include <cerrno>
 #include <algorithm>
 
@@ -232,7 +231,7 @@ int ErasureCodeLrc::layers_init(ostream *ss)
     if (layer.profile.find("m") == layer.profile.end())
       layer.profile["m"] = stringify(layer.coding.size());
     if (layer.profile.find("plugin") == layer.profile.end())
-      layer.profile["plugin"] = "jerasure";
+      layer.profile["plugin"] = "isa";
     if (layer.profile.find("technique") == layer.profile.end())
       layer.profile["technique"] = "reed_sol_van";
     int err = registry.factory(layer.profile["plugin"],

--- a/src/test/ceph-erasure-code-tool/test_ceph-erasure-code-tool.sh
+++ b/src/test/ceph-erasure-code-tool/test_ceph-erasure-code-tool.sh
@@ -5,22 +5,22 @@ mkdir $TMPDIR
 trap "rm -fr $TMPDIR" 0
 
 ceph-erasure-code-tool test-plugin-exists INVALID_PLUGIN && exit 1
-ceph-erasure-code-tool test-plugin-exists jerasure
+ceph-erasure-code-tool test-plugin-exists isa
 
 ceph-erasure-code-tool validate-profile \
-                       plugin=jerasure,technique=reed_sol_van,k=2,m=1
+                       plugin=isa,technique=reed_sol_van,k=2,m=1
 
 test "$(ceph-erasure-code-tool validate-profile \
-          plugin=jerasure,technique=reed_sol_van,k=2,m=1 chunk_count)" = 3
+          plugin=isa,technique=reed_sol_van,k=2,m=1 chunk_count)" = 3
 
 test "$(ceph-erasure-code-tool calc-chunk-size \
-          plugin=jerasure,technique=reed_sol_van,k=2,m=1 4194304)" = 2097152
+          plugin=isa,technique=reed_sol_van,k=2,m=1 4194304)" = 2097152
 
 dd if="$(which ceph-erasure-code-tool)" of=$TMPDIR/data bs=770808 count=1
 cp $TMPDIR/data $TMPDIR/data.orig
 
 ceph-erasure-code-tool encode \
-                       plugin=jerasure,technique=reed_sol_van,k=2,m=1 \
+                       plugin=isa,technique=reed_sol_van,k=2,m=1 \
                        4096 \
                        0,1,2 \
                        $TMPDIR/data
@@ -31,7 +31,7 @@ test -f $TMPDIR/data.2
 rm $TMPDIR/data
 
 ceph-erasure-code-tool decode \
-                       plugin=jerasure,technique=reed_sol_van,k=2,m=1 \
+                       plugin=isa,technique=reed_sol_van,k=2,m=1 \
                        4096 \
                        0,2 \
                        $TMPDIR/data

--- a/src/test/erasure-code/TestErasureCodeLrc.cc
+++ b/src/test/erasure-code/TestErasureCodeLrc.cc
@@ -417,7 +417,7 @@ TEST(ErasureCodeLrc, layers_init)
     EXPECT_EQ(0, lrc.layers_init(&cerr));
     EXPECT_EQ("5", lrc.layers.front().profile["k"]);
     EXPECT_EQ("2", lrc.layers.front().profile["m"]);
-    EXPECT_EQ("jerasure", lrc.layers.front().profile["plugin"]);
+    EXPECT_EQ("isa", lrc.layers.front().profile["plugin"]);
     EXPECT_EQ("reed_sol_van", lrc.layers.front().profile["technique"]);
   }
 }

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -56,7 +56,7 @@ int ErasureCodeBench::setup(int argc, char** argv) {
      "size of the buffer to be encoded")
     ("iterations,i", po::value<int>()->default_value(1),
      "number of encode/decode runs")
-    ("plugin,p", po::value<string>()->default_value("jerasure"),
+    ("plugin,p", po::value<string>()->default_value("isa"),
      "erasure code plugin name")
     ("workload,w", po::value<string>()->default_value("encode"),
      "run either encode or decode")
@@ -343,7 +343,7 @@ int main(int argc, char** argv) {
  * compile-command: "cd ../../../build ; make -j4 ceph_erasure_code_benchmark &&
  *   valgrind --tool=memcheck --leak-check=full \
  *      ./bin/ceph_erasure_code_benchmark \
- *      --plugin jerasure \
+ *      --plugin isa \
  *      --parameter directory=lib \
  *      --parameter technique=reed_sol_van \
  *      --parameter k=2 \

--- a/src/test/erasure-code/ceph_erasure_code_non_regression.cc
+++ b/src/test/erasure-code/ceph_erasure_code_non_regression.cc
@@ -64,7 +64,7 @@ int ErasureCodeNonRegression::setup(int argc, char** argv) {
     ("help,h", "produce help message")
     ("stripe-width,s", po::value<int>()->default_value(4 * 1024),
      "stripe_width, i.e. the size of the buffer to be encoded")
-    ("plugin,p", po::value<string>()->default_value("jerasure"),
+    ("plugin,p", po::value<string>()->default_value("isa"),
      "erasure code plugin name")
     ("base", po::value<string>()->default_value("."),
      "prefix all paths with base")
@@ -314,7 +314,7 @@ int main(int argc, char** argv) {
  *   make ceph_erasure_code_non_regression &&
  *   libtool --mode=execute valgrind --tool=memcheck --leak-check=full \
  *      ./ceph_erasure_code_non_regression \
- *      --plugin jerasure \
+ *      --plugin isa \
  *      --parameter technique=reed_sol_van \
  *      --parameter k=2 \
  *      --parameter m=2 \

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -968,7 +968,7 @@ $DAEMONOPTS
 $CMONDEBUG
         $(format_conf "${extra_conf}")
         mon cluster log file = $CEPH_OUT_DIR/cluster.mon.\$id.log
-        osd pool default erasure code profile = plugin=jerasure technique=reed_sol_van k=2 m=1 crush-failure-domain=osd
+        osd pool default erasure code profile = plugin=isa technique=reed_sol_van k=2 m=1 crush-failure-domain=osd
         auth allow insecure global id reclaim = false
 EOF
 


### PR DESCRIPTION
This PR changes the default plugin for erasure coded pools from Jerasure to ISA-L. Until now, Jerasure has been Ceph's default plugin due to its flexibility and genericism. However, the jerasure and gf-complete libraries no longer appear to be maintained, and they have not been updated to use modern CPU instructions such as AVX2 and AVX512. Using these instructions for erasure coding can result in performance improvements. ISA-L on the other hand is still maintained and receives updates to take advantage of modern CPU features. ISA-L also offers comparable flexibility to Jerasure.

Testing with the ceph_erasure_code_benchmark tool shows the potential for performance improvements when using ISA-L instead of Jerasure.

This benchmark data was captured by compiling Ceph from source and then executing the benchmark tool using the versions of the EC libraries that are currently included in Ceph. The following command was used to run the tool.

`TOTAL_SIZE=$((4 * 1024 * 1024 * 1024)) qa/workunits/erasure-code/bench.sh fplot | tee qa/workunits/erasure-code/bench.js`

The first set of data was captured on an Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz to show the potential for improved performance on x86-64 architecture.

![image](https://github.com/ceph/ceph/assets/47678243/9d067197-1b7c-411a-a25a-5d6a6957e2d0)

![image](https://github.com/ceph/ceph/assets/47678243/a642db90-85ea-4de5-83ed-aec1acce0085)


The second set of data was captured on a Macbook Pro with an M1 Pro and 16GB RAM. Ceph is built in a CentOS 8 aarch64 container running with 8GB of RAM assigned to the podman machine VM. This is intended to show the potential for improved performance on ARM64/aarch64 architecture, as well as showing that ISA-L supports non-Intel platforms.

![image](https://github.com/ceph/ceph/assets/47678243/f534c785-34bd-4ac9-a249-d5fbc7f84802)

![image](https://github.com/ceph/ceph/assets/47678243/8c7e707f-00fa-4475-96e4-1c45735fe634)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
