### PR TITLE
src/cephadm/box: remove unused imports

### DIFF
--- a/src/cephadm/box/box.py
+++ b/src/cephadm/box/box.py
@@ -6,9 +6,8 @@ import json
 import sys
 import host
 import osd
-from multiprocessing import Process, Pool
+from multiprocessing import Pool
 from util import (
-    BoxType,
     Config,
     Target,
     ensure_inside_container,
@@ -19,12 +18,9 @@ from util import (
     run_dc_shell_commands,
     get_container_engine,
     run_shell_command,
-    run_shell_commands,
-    ContainerEngine,
     DockerEngine,
     PodmanEngine,
     colored,
-    engine,
     engine_compose,
     Colors,
     get_seed_name

--- a/src/cephadm/box/host.py
+++ b/src/cephadm/box/host.py
@@ -12,7 +12,6 @@ from util import (
     run_dc_shell_command,
     run_shell_command,
     engine,
-    BoxType
 )
 
 

--- a/src/cephadm/box/osd.py
+++ b/src/cephadm/box/osd.py
@@ -5,7 +5,6 @@ import re
 from typing import Dict
 
 from util import (
-    BoxType,
     Config,
     Target,
     ensure_inside_container,

--- a/src/cephadm/box/util.py
+++ b/src/cephadm/box/util.py
@@ -417,5 +417,4 @@ class PodmanEngine(ContainerEngine):
 def get_container_engine() -> ContainerEngine:
     if engine() == 'docker':
         return DockerEngine()
-    else:
-        return PodmanEngine()
+    return PodmanEngine()


### PR DESCRIPTION
Removed unused imports from cephadm/box module.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
