### PR TITLE
quincy: doc/rados: explain replaceable parts of command

### DIFF
--- a/doc/rados/troubleshooting/troubleshooting-mon.rst
+++ b/doc/rados/troubleshooting/troubleshooting-mon.rst
@@ -133,9 +133,13 @@ Understanding mon_status
 
 The status of a Monitor (as reported by the ``ceph tell mon.X mon_status``
 command) can be obtained via the admin socket. The ``ceph tell mon.X
-mon_status``  command outputs a great deal of information about the monitor
+mon_status`` command outputs a great deal of information about the monitor
 (including the information found in the output of the ``quorum_status``
 command).
+
+.. note:: The command ``ceph tell mon.X mon_status`` is not meant to be input
+   literally. The ``X`` portion of ``mon.X`` is meant to be replaced with a
+   value specific to your own Ceph cluster when you run the command.
 
 To understand this command's output, let us consider the following example, in
 which we see the output of ``ceph tell mon.c mon_status``::
@@ -165,24 +169,24 @@ which we see the output of ``ceph tell mon.c mon_status``::
                 "name": "c",
                 "addr": "127.0.0.1:6795\/0"}]}}
 
-This output reports that there are three monitors in the monmap (*a*, *b*, and
-*c*), that quorum is formed by only two monitors, and that *c* is in quorum as
-a *peon*.
+This output reports that there are three monitors in the monmap (``a``, ``b``,
+and ``c``), that quorum is formed by only two monitors, and that ``c`` is in
+quorum as a ``peon``.
 
 **Which monitor is out of quorum?**
 
-  The answer is **a** (that is, ``mon.a``). ``mon.a`` is out of quorum.
+  The answer is ``a`` (that is, ``mon.a``). ``mon.a`` is out of quorum.
 
 **How do we know, in this example, that mon.a is out of quorum?**
 
-  We know that ``mon.a`` is out of quorum because it has rank 0, and Monitors
-  with rank 0 are by definition out of quorum.
+  We know that ``mon.a`` is out of quorum because it has rank ``0``, and
+  Monitors with rank ``0`` are by definition out of quorum.
 
   If we examine the ``quorum`` set, we can see that there are clearly two
-  monitors in the set: *1* and *2*. But these are not monitor names. They are
-  monitor ranks, as established in the current ``monmap``. The ``quorum`` set
-  does not include the monitor that has rank 0, and according to the ``monmap``
-  that monitor is ``mon.a``.
+  monitors in the set: ``1`` and ``2``. But these are not monitor names. They
+  are monitor ranks, as established in the current ``monmap``. The ``quorum``
+  set does not include the monitor that has rank ``0``, and according to the
+  ``monmap`` that monitor is ``mon.a``.
 
 **How are monitor ranks determined?**
 
@@ -192,7 +196,7 @@ a *peon*.
   case, because ``127.0.0.1:6789`` (``mon.a``) is numerically less than the
   other two ``IP:PORT`` combinations (which are ``127.0.0.1:6790`` for "Monitor
   b" and ``127.0.0.1:6795`` for "Monitor c"), ``mon.a`` has the highest rank:
-  namely, rank 0.
+  namely, rank ``0``.
   
 
 Most Common Monitor Issues


### PR DESCRIPTION
Add an explanation that directs the reader to replace the "X" part of the command "ceph tell mon.X mon_status" with the value specific to the reader's Ceph cluster (which is (probably) not "X").

In the future, such replaceable strings in commands may be bounded by angle brackets ("<" and ">").

This improvement to the documentation was suggested on the [ceph-users] email list by Joel Davidow. This email, an absolute model of user engagement with an upstream project, can be reviewed here: https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/message/KF67F5TXFSSTPXV7EKL6JKLA5KZQDLDQ/

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit d071ad2575c86f300a9ba39df3c4949e5dc9c47d)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
