### PR TITLE
squid: qa/config/crimson_qa_overrides: adjust mgr_stats_period

### DIFF
--- a/qa/config/crimson_qa_overrides.yaml
+++ b/qa/config/crimson_qa_overrides.yaml
@@ -9,6 +9,8 @@ overrides:
         osd pool default crimson: true
       osd:
         crimson osd obc lru size: 10
+      mgr:
+        mgr stats period: 30
     flavor: crimson
   workunit:
     env:


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57245

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh