### PR TITLE
squid: crimson: fix user_version handling

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -963,10 +963,10 @@ std::unique_ptr<OpsExecuter::CloningContext> OpsExecuter::execute_clone(
     pg_log_entry_t::CLONE,
     coid,
     clone_obc->obs.oi.version,
-    initial_obs.oi.version,
-    initial_obs.oi.user_version,
+    clone_obc->obs.oi.prior_version,
+    clone_obc->obs.oi.user_version,
     osd_reqid_t(),
-    initial_obs.oi.mtime, // will be replaced in `apply_to()`
+    clone_obc->obs.oi.mtime, // will be replaced in `apply_to()`
     0
   };
   encode(cloned_snaps, cloning_ctx->log_entry.snaps);

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -819,7 +819,6 @@ std::vector<pg_log_entry_t> OpsExecuter::prepare_transaction(
   // entry.
   assert(obc->obs.oi.soid.snap >= CEPH_MAXSNAP);
   std::vector<pg_log_entry_t> log_entries;
-  osd_op_params->at_version.version++;
   log_entries.emplace_back(
     obc->obs.exists ?
       pg_log_entry_t::MODIFY : pg_log_entry_t::DELETE,
@@ -931,8 +930,8 @@ std::unique_ptr<OpsExecuter::CloningContext> OpsExecuter::execute_clone(
     return std::vector<snapid_t>{std::begin(snapc.snaps), last};
   }();
 
-  osd_op_params->at_version.version++;
   auto clone_obc = prepare_clone(coid, osd_op_params->at_version);
+  osd_op_params->at_version.version++;
 
   // make clone
   backend.clone(clone_obc->obs.oi, initial_obs, clone_obc->obs, txn);

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -931,7 +931,9 @@ std::unique_ptr<OpsExecuter::CloningContext> OpsExecuter::execute_clone(
     return std::vector<snapid_t>{std::begin(snapc.snaps), last};
   }();
 
-  auto clone_obc = prepare_clone(coid);
+  osd_op_params->at_version.version++;
+  auto clone_obc = prepare_clone(coid, osd_op_params->at_version);
+
   // make clone
   backend.clone(clone_obc->obs.oi, initial_obs, clone_obc->obs, txn);
 
@@ -1038,13 +1040,13 @@ OpsExecuter::flush_clone_metadata(
 }
 
 ObjectContextRef OpsExecuter::prepare_clone(
-  const hobject_t& coid)
+  const hobject_t& coid,
+  eversion_t version)
 {
   ceph_assert(pg->is_primary());
-  osd_op_params->at_version.version++;
   ObjectState clone_obs{coid};
   clone_obs.exists = true;
-  clone_obs.oi.version = osd_op_params->at_version;
+  clone_obs.oi.version = version;
   clone_obs.oi.prior_version = obc->obs.oi.version;
   clone_obs.oi.copy_user_bits(obc->obs.oi);
   clone_obs.oi.clear_flag(object_info_t::FLAG_WHITEOUT);

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -457,7 +457,8 @@ public:
   version_t get_last_user_version() const;
 
   ObjectContextRef prepare_clone(
-    const hobject_t& coid);
+    const hobject_t& coid,
+    eversion_t version);
 
   void apply_stats();
 };

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -520,9 +520,6 @@ OpsExecuter::flush_changes_n_do_ops_effects(
     ceph_assert(want_mutate);
   }
   if (want_mutate) {
-    if (osd_op_params->user_modify) {
-      osd_op_params->user_at_version = osd_op_params->at_version.version;
-    }
     maybe_mutated = flush_clone_metadata(
       prepare_transaction(ops),
       snap_mapper,

--- a/src/crimson/osd/osd_operations/osdop_params.h
+++ b/src/crimson/osd/osd_operations/osdop_params.h
@@ -14,7 +14,6 @@ struct osd_op_params_t {
   eversion_t pg_trim_to;
   eversion_t min_last_complete_ondisk;
   eversion_t last_complete;
-  version_t user_at_version = 0;
   bool user_modify = false;
   ObjectCleanRegions clean_regions;
   interval_set<uint64_t> modified_ranges;

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -813,7 +813,6 @@ PG::submit_transaction(
   }
 
   epoch_t map_epoch = get_osdmap_epoch();
-  ceph_assert(!has_reset_since(osd_op_p.at_version.epoch));
 
   peering_state.pre_submit_op(obc->obs.oi.soid, log_entries, osd_op_p.at_version);
   peering_state.update_trim_to();

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -163,11 +163,6 @@ PGBackend::mutate_object(
 {
   logger().trace("mutate_object: num_ops={}", txn.get_num_ops());
   if (obc->obs.exists) {
-#if 0
-    obc->obs.oi.version = ctx->at_version;
-    obc->obs.oi.prior_version = ctx->obs->oi.version;
-#endif
-
     obc->obs.oi.prior_version = obc->obs.oi.version;
     obc->obs.oi.version = osd_op_p.at_version;
     if (osd_op_p.user_at_version > obc->obs.oi.user_version)

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -165,8 +165,8 @@ PGBackend::mutate_object(
   if (obc->obs.exists) {
     obc->obs.oi.prior_version = obc->obs.oi.version;
     obc->obs.oi.version = osd_op_p.at_version;
-    if (osd_op_p.user_at_version > obc->obs.oi.user_version)
-      obc->obs.oi.user_version = osd_op_p.user_at_version;
+    if (osd_op_p.user_modify)
+      obc->obs.oi.user_version = osd_op_p.at_version.version;
     obc->obs.oi.last_reqid = osd_op_p.req_id;
     obc->obs.oi.mtime = osd_op_p.mtime;
     obc->obs.oi.local_mtime = ceph_clock_now();


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57383

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh