### PR TITLE
squid: crimson/os/seastore: fix compile error in release build

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -108,8 +108,8 @@ Cache::retire_extent_ret Cache::retire_extent_addr(
 void Cache::retire_absent_extent_addr(
   Transaction &t, paddr_t addr, extent_len_t length)
 {
-#ifndef NDEBUG
   CachedExtentRef ext;
+#ifndef NDEBUG
   auto result = t.get_extent(addr, &ext);
   assert(result != Transaction::get_extent_ret::PRESENT
     && result != Transaction::get_extent_ret::RETIRED);


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57654

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh