### PR TITLE
squid: crimson/os/seastore: implement disk and writer level stats reporting

### DIFF
--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -186,6 +186,8 @@ public:
 
   virtual seastar::future<store_statfs_t> pool_statfs(int64_t pool_id) const = 0;
 
+  virtual seastar::future<> report_stats() { return seastar::now(); }
+
   virtual uuid_d get_fsid() const  = 0;
 
   virtual seastar::future<> write_meta(const std::string& key,

--- a/src/crimson/os/seastore/async_cleaner.cc
+++ b/src/crimson/os/seastore/async_cleaner.cc
@@ -349,18 +349,18 @@ void JournalTrimmerImpl::config_t::validate() const
 
 JournalTrimmerImpl::config_t
 JournalTrimmerImpl::config_t::get_default(
-  std::size_t roll_size, journal_type_t type)
+  std::size_t roll_size, backend_type_t type)
 {
   assert(roll_size);
   std::size_t target_dirty_bytes = 0;
   std::size_t target_alloc_bytes = 0;
   std::size_t max_journal_bytes = 0;
-  if (type == journal_type_t::SEGMENTED) {
+  if (type == backend_type_t::SEGMENTED) {
     target_dirty_bytes = 12 * roll_size;
     target_alloc_bytes = 2 * roll_size;
     max_journal_bytes = 16 * roll_size;
   } else {
-    assert(type == journal_type_t::RANDOM_BLOCK);
+    assert(type == backend_type_t::RANDOM_BLOCK);
     target_dirty_bytes = roll_size / 4;
     target_alloc_bytes = roll_size / 4;
     max_journal_bytes = roll_size / 2;
@@ -376,18 +376,18 @@ JournalTrimmerImpl::config_t::get_default(
 
 JournalTrimmerImpl::config_t
 JournalTrimmerImpl::config_t::get_test(
-  std::size_t roll_size, journal_type_t type)
+  std::size_t roll_size, backend_type_t type)
 {
   assert(roll_size);
   std::size_t target_dirty_bytes = 0;
   std::size_t target_alloc_bytes = 0;
   std::size_t max_journal_bytes = 0;
-  if (type == journal_type_t::SEGMENTED) {
+  if (type == backend_type_t::SEGMENTED) {
     target_dirty_bytes = 2 * roll_size;
     target_alloc_bytes = 2 * roll_size;
     max_journal_bytes = 4 * roll_size;
   } else {
-    assert(type == journal_type_t::RANDOM_BLOCK);
+    assert(type == backend_type_t::RANDOM_BLOCK);
     target_dirty_bytes = roll_size / 36;
     target_alloc_bytes = roll_size / 4;
     max_journal_bytes = roll_size / 2;
@@ -404,12 +404,12 @@ JournalTrimmerImpl::config_t::get_test(
 JournalTrimmerImpl::JournalTrimmerImpl(
   BackrefManager &backref_manager,
   config_t config,
-  journal_type_t type,
+  backend_type_t type,
   device_off_t roll_start,
   device_off_t roll_size)
   : backref_manager(backref_manager),
     config(config),
-    journal_type(type),
+    backend_type(type),
     roll_start(roll_start),
     roll_size(roll_size),
     reserved_usage(0)
@@ -507,7 +507,7 @@ journal_seq_t JournalTrimmerImpl::get_tail_limit() const
 {
   assert(background_callback->is_ready());
   auto ret = journal_head.add_offset(
-      journal_type,
+      backend_type,
       -static_cast<device_off_t>(config.max_journal_bytes),
       roll_start,
       roll_size);
@@ -518,7 +518,7 @@ journal_seq_t JournalTrimmerImpl::get_dirty_tail_target() const
 {
   assert(background_callback->is_ready());
   auto ret = journal_head.add_offset(
-      journal_type,
+      backend_type,
       -static_cast<device_off_t>(config.target_journal_dirty_bytes),
       roll_start,
       roll_size);
@@ -529,7 +529,7 @@ journal_seq_t JournalTrimmerImpl::get_alloc_tail_target() const
 {
   assert(background_callback->is_ready());
   auto ret = journal_head.add_offset(
-      journal_type,
+      backend_type,
       -static_cast<device_off_t>(config.target_journal_alloc_bytes),
       roll_start,
       roll_size);
@@ -542,7 +542,7 @@ std::size_t JournalTrimmerImpl::get_dirty_journal_size() const
     return 0;
   }
   auto ret = journal_head.relative_to(
-      journal_type,
+      backend_type,
       journal_dirty_tail,
       roll_start,
       roll_size);
@@ -556,7 +556,7 @@ std::size_t JournalTrimmerImpl::get_alloc_journal_size() const
     return 0;
   }
   auto ret = journal_head.relative_to(
-      journal_type,
+      backend_type,
       journal_alloc_tail,
       roll_start,
       roll_size);

--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -491,16 +491,16 @@ public:
     void validate() const;
 
     static config_t get_default(
-        std::size_t roll_size, journal_type_t type);
+        std::size_t roll_size, backend_type_t type);
 
     static config_t get_test(
-        std::size_t roll_size, journal_type_t type);
+        std::size_t roll_size, backend_type_t type);
   };
 
   JournalTrimmerImpl(
     BackrefManager &backref_manager,
     config_t config,
-    journal_type_t type,
+    backend_type_t type,
     device_off_t roll_start,
     device_off_t roll_size);
 
@@ -538,8 +538,8 @@ public:
       config.rewrite_dirty_bytes_per_cycle;
   }
 
-  journal_type_t get_journal_type() const {
-    return journal_type;
+  backend_type_t get_backend_type() const {
+    return backend_type;
   }
 
   void set_extent_callback(ExtentCallbackInterface *cb) {
@@ -564,7 +564,7 @@ public:
   bool should_block_io_on_trim() const {
     return get_tail_limit() >
       get_journal_tail().add_offset(
-        journal_type, reserved_usage, roll_start, roll_size);
+        backend_type, reserved_usage, roll_start, roll_size);
   }
 
   bool try_reserve_inline_usage(std::size_t usage) final {
@@ -587,7 +587,7 @@ public:
   static JournalTrimmerImplRef create(
       BackrefManager &backref_manager,
       config_t config,
-      journal_type_t type,
+      backend_type_t type,
       device_off_t roll_start,
       device_off_t roll_size) {
     return std::make_unique<JournalTrimmerImpl>(
@@ -627,7 +627,7 @@ private:
   BackrefManager &backref_manager;
 
   config_t config;
-  journal_type_t journal_type;
+  backend_type_t backend_type;
   device_off_t roll_start;
   device_off_t roll_size;
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1505,9 +1505,6 @@ private:
     }
   };
 
-  template <typename CounterT>
-  using counter_by_src_t = std::array<CounterT, TRANSACTION_TYPE_MAX>;
-
   static constexpr std::size_t NUM_SRC_COMB =
       TRANSACTION_TYPE_MAX * (TRANSACTION_TYPE_MAX + 1) / 2;
 
@@ -1545,14 +1542,6 @@ private:
     version_stat_t committed_dirty_version;
     version_stat_t committed_reclaim_version;
   } stats;
-
-  template <typename CounterT>
-  CounterT& get_by_src(
-      counter_by_src_t<CounterT>& counters_by_src,
-      Transaction::src_t src) {
-    assert(static_cast<std::size_t>(src) < counters_by_src.size());
-    return counters_by_src[static_cast<std::size_t>(src)];
-  }
 
   template <typename CounterT>
   CounterT& get_by_ext(

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -191,7 +191,7 @@ void ExtentPlacementManager::init(
     dynamic_max_rewrite_generation = MAX_REWRITE_GENERATION;
   }
 
-  if (trimmer->get_journal_type() == journal_type_t::SEGMENTED) {
+  if (trimmer->get_backend_type() == backend_type_t::SEGMENTED) {
     auto segment_cleaner = dynamic_cast<SegmentCleaner*>(cleaner.get());
     ceph_assert(segment_cleaner != nullptr);
     auto num_writers = generation_to_writer(dynamic_max_rewrite_generation + 1);
@@ -217,7 +217,7 @@ void ExtentPlacementManager::init(
       add_device(device);
     }
   } else {
-    assert(trimmer->get_journal_type() == journal_type_t::RANDOM_BLOCK);
+    assert(trimmer->get_backend_type() == backend_type_t::RANDOM_BLOCK);
     auto rb_cleaner = dynamic_cast<RBMCleaner*>(cleaner.get());
     ceph_assert(rb_cleaner != nullptr);
     auto num_writers = generation_to_writer(dynamic_max_rewrite_generation + 1);

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -196,7 +196,7 @@ void ExtentPlacementManager::init(
     ceph_assert(segment_cleaner != nullptr);
     auto num_writers = generation_to_writer(dynamic_max_rewrite_generation + 1);
 
-    data_writers_by_gen.resize(num_writers, {});
+    data_writers_by_gen.resize(num_writers, nullptr);
     for (rewrite_gen_t gen = OOL_GENERATION; gen < MIN_COLD_GENERATION; ++gen) {
       writer_refs.emplace_back(std::make_unique<SegmentedOolWriter>(
 	    data_category_t::DATA, gen, *segment_cleaner,
@@ -221,7 +221,7 @@ void ExtentPlacementManager::init(
     auto rb_cleaner = dynamic_cast<RBMCleaner*>(cleaner.get());
     ceph_assert(rb_cleaner != nullptr);
     auto num_writers = generation_to_writer(dynamic_max_rewrite_generation + 1);
-    data_writers_by_gen.resize(num_writers, {});
+    data_writers_by_gen.resize(num_writers, nullptr);
     md_writers_by_gen.resize(num_writers, {});
     writer_refs.emplace_back(std::make_unique<RandomBlockOolWriter>(
 	    rb_cleaner));

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -84,7 +84,7 @@ SegmentedOolWriter::do_write(
       return do_write(t, extents);
     });
   }
-  record_t record(TRANSACTION_TYPE_NULL);
+  record_t record(t.get_src());
   std::list<LogicalCachedExtentRef> pending_extents;
   auto commit_time = seastar::lowres_system_clock::now();
 

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -3,7 +3,8 @@
 
 #pragma once
 
-#include "seastar/core/gate.hh"
+#include <seastar/core/gate.hh>
+#include <seastar/core/lowres_clock.hh>
 
 #include "crimson/os/seastore/async_cleaner.h"
 #include "crimson/os/seastore/cached_extent.h"
@@ -29,6 +30,10 @@ class ExtentOolWriter {
       crimson::ct_error::input_output_error>;
 public:
   virtual ~ExtentOolWriter() {}
+
+  virtual backend_type_t get_type() const = 0;
+
+  virtual writer_stats_t get_stats() const = 0;
 
   using open_ertr = base_ertr;
   virtual open_ertr::future<> open() = 0;
@@ -67,6 +72,14 @@ public:
                      rewrite_gen_t gen,
                      SegmentProvider &sp,
                      SegmentSeqAllocator &ssa);
+
+  backend_type_t get_type() const final {
+    return backend_type_t::SEGMENTED;
+  }
+
+  writer_stats_t get_stats() const final {
+    return record_submitter.get_stats();
+  }
 
   open_ertr::future<> open() final {
     return record_submitter.open(false).discard_result();
@@ -118,6 +131,15 @@ class RandomBlockOolWriter : public ExtentOolWriter {
 public:
   RandomBlockOolWriter(RBMCleaner* rb_cleaner) :
     rb_cleaner(rb_cleaner) {}
+
+  backend_type_t get_type() const final {
+    return backend_type_t::RANDOM_BLOCK;
+  }
+
+  writer_stats_t get_stats() const final {
+    // TODO: collect stats
+    return {};
+  }
 
   using open_ertr = ExtentOolWriter::open_ertr;
   open_ertr::future<> open() final {
@@ -267,6 +289,10 @@ public:
   store_statfs_t get_stat() const {
     return background_process.get_stat();
   }
+
+  device_stats_t get_device_stats(
+    const writer_stats_t &journal_stats,
+    bool report_detail) const;
 
   using mount_ertr = crimson::errorator<
       crimson::ct_error::input_output_error>;
@@ -589,6 +615,27 @@ private:
                               rewrite_gen_t gen) {
     assert(hint < placement_hint_t::NUM_HINTS);
     // TODO: might worth considering the hint
+    return get_writer(category, gen);
+  }
+
+  ExtentOolWriter* get_writer(data_category_t category,
+                              rewrite_gen_t gen) {
+    assert(is_rewrite_generation(gen));
+    assert(gen != INLINE_GENERATION);
+    assert(gen <= dynamic_max_rewrite_generation);
+    ExtentOolWriter* ret = nullptr;
+    if (category == data_category_t::DATA) {
+      ret = data_writers_by_gen[generation_to_writer(gen)];
+    } else {
+      assert(category == data_category_t::METADATA);
+      ret = md_writers_by_gen[generation_to_writer(gen)];
+    }
+    assert(ret != nullptr);
+    return ret;
+  }
+
+  const ExtentOolWriter* get_writer(data_category_t category,
+                                    rewrite_gen_t gen) const {
     assert(is_rewrite_generation(gen));
     assert(gen != INLINE_GENERATION);
     assert(gen <= dynamic_max_rewrite_generation);
@@ -1029,6 +1076,9 @@ private:
   // TODO: drop once paddr->journal_seq_t is introduced
   SegmentSeqAllocatorRef ool_segment_seq_allocator;
   extent_len_t max_data_allocation_size = 0;
+
+  mutable seastar::lowres_clock::time_point last_tp =
+    seastar::lowres_clock::time_point::min();
 
   friend class ::transaction_manager_test_t;
 };

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -250,8 +250,8 @@ public:
     return writer->can_inplace_rewrite(t, extent);
   }
 
-  journal_type_t get_journal_type() const {
-    return background_process.get_journal_type();
+  backend_type_t get_backend_type() const {
+    return background_process.get_backend_type();
   }
 
   extent_len_t get_block_size() const {
@@ -644,8 +644,8 @@ private:
       }
     }
 
-    journal_type_t get_journal_type() const {
-      return trimmer->get_journal_type();
+    backend_type_t get_backend_type() const {
+      return trimmer->get_backend_type();
     }
 
     bool has_cold_tier() const {
@@ -764,7 +764,7 @@ private:
 
     seastar::future<> stop_background();
     backend_type_t get_main_backend_type() const {
-      return get_journal_type();
+      return get_backend_type();
     }
 
     // Testing interfaces

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -23,6 +23,9 @@ class JournalTrimmer;
 class Journal {
 public:
   virtual JournalTrimmer &get_trimmer() = 0;
+
+  virtual writer_stats_t get_writer_stats() const = 0;
+
   /**
    * initializes journal for mkfs writes -- must run prior to calls
    * to submit_record.

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -103,7 +103,7 @@ public:
 
   virtual ~Journal() {}
 
-  virtual journal_type_t get_type() = 0;
+  virtual backend_type_t get_type() = 0;
 };
 using JournalRef = std::unique_ptr<Journal>;
 

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.h
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.h
@@ -66,6 +66,10 @@ public:
     return trimmer;
   }
 
+  writer_stats_t get_writer_stats() const final {
+    return record_submitter.get_stats();
+  }
+
   open_for_mkfs_ret open_for_mkfs() final;
 
   open_for_mount_ret open_for_mount() final;

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.h
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.h
@@ -72,8 +72,8 @@ public:
 
   close_ertr::future<> close() final;
 
-  journal_type_t get_type() final {
-    return journal_type_t::RANDOM_BLOCK;
+  backend_type_t get_type() final {
+    return backend_type_t::RANDOM_BLOCK;
   }
 
   submit_record_ret submit_record(

--- a/src/crimson/os/seastore/journal/record_submitter.cc
+++ b/src/crimson/os/seastore/journal/record_submitter.cc
@@ -482,6 +482,15 @@ void RecordSubmitter::account_submission(
   stats.record_group_metadata_bytes += rg.size.get_raw_mdlength();
   stats.record_group_data_bytes += rg.size.dlength;
   stats.record_batch_stats.increment(rg.get_size());
+
+  for (const record_t& r : rg.records) {
+    auto src = r.type;
+    assert(is_modify_transaction(src));
+    auto& trans_stats = get_by_src(stats.stats_by_src, src);
+    ++(trans_stats.num_records);
+    trans_stats.metadata_bytes += r.size.get_raw_mdlength();
+    trans_stats.data_bytes += r.size.dlength;
+  }
 }
 
 void RecordSubmitter::finish_submit_batch(

--- a/src/crimson/os/seastore/journal/record_submitter.cc
+++ b/src/crimson/os/seastore/journal/record_submitter.cc
@@ -61,8 +61,7 @@ RecordBatch::add_pending(
   });
 }
 
-std::pair<ceph::bufferlist, record_group_size_t>
-RecordBatch::encode_batch(
+ceph::bufferlist RecordBatch::encode_batch(
   const journal_seq_t& committed_to,
   segment_nonce_t segment_nonce)
 {
@@ -72,13 +71,12 @@ RecordBatch::encode_batch(
 
   state = state_t::SUBMITTING;
   submitting_size = pending.get_size();
-  auto gsize = pending.size;
-  submitting_length = gsize.get_encoded_length();
-  submitting_mdlength = gsize.get_mdlength();
+  submitting_length = pending.size.get_encoded_length();
+  submitting_mdlength = pending.size.get_mdlength();
   auto bl = encode_records(pending, committed_to, segment_nonce);
   // Note: pending is cleared here
   assert(bl.length() == submitting_length);
-  return std::make_pair(bl, gsize);
+  return bl;
 }
 
 void RecordBatch::set_result(
@@ -103,24 +101,24 @@ void RecordBatch::set_result(
   io_promise.reset();
 }
 
-std::pair<ceph::bufferlist, record_group_size_t>
+ceph::bufferlist
 RecordBatch::submit_pending_fast(
-  record_t&& record,
+  record_group_t&& group,
   extent_len_t block_size,
   const journal_seq_t& committed_to,
   segment_nonce_t segment_nonce)
 {
+  assert(group.get_size() == 1);
+  auto& record = group.records[0];
   auto new_size = get_encoded_length_after(record, block_size);
   std::ignore = new_size;
   assert(state == state_t::EMPTY);
   assert(evaluate_submit(record.size, block_size).submit_size == new_size);
-
-  auto group = record_group_t(std::move(record), block_size);
-  auto size = group.size;
-  assert(size == new_size);
+  assert(group.size == new_size);
   auto bl = encode_records(group, committed_to, segment_nonce);
-  assert(bl.length() == size.get_encoded_length());
-  return std::make_pair(std::move(bl), size);
+  // Note: group is cleared here
+  assert(bl.length() == new_size.get_encoded_length());
+  return bl;
 }
 
 RecordSubmitter::RecordSubmitter(
@@ -292,14 +290,17 @@ RecordSubmitter::submit(
       state != state_t::FULL) {
     // fast path with direct write
     increment_io();
-    auto [to_write, sizes] = p_current_batch->submit_pending_fast(
-      std::move(record),
-      journal_allocator.get_block_size(),
+    auto block_size = journal_allocator.get_block_size();
+    auto rg = record_group_t(std::move(record), block_size);
+    account_submission(rg);
+    record_group_size_t sizes = rg.size;
+    auto to_write = p_current_batch->submit_pending_fast(
+      std::move(rg),
+      block_size,
       get_committed_to(),
       journal_allocator.get_nonce());
     DEBUG("{} fast submit {}, committed_to={}, outstanding_io={} ...",
           get_name(), sizes, get_committed_to(), num_outstanding_io);
-    account_submission(1, sizes);
     return journal_allocator.write(std::move(to_write)
     ).safe_then([mdlength = sizes.get_mdlength()](auto write_result) {
       return record_locator_t{
@@ -478,14 +479,13 @@ void RecordSubmitter::decrement_io_with_flush()
 }
 
 void RecordSubmitter::account_submission(
-  std::size_t num,
-  const record_group_size_t& size)
+  const record_group_t& rg)
 {
   stats.record_group_padding_bytes +=
-    (size.get_mdlength() - size.get_raw_mdlength());
-  stats.record_group_metadata_bytes += size.get_raw_mdlength();
-  stats.record_group_data_bytes += size.dlength;
-  stats.record_batch_stats.increment(num);
+    (rg.size.get_mdlength() - rg.size.get_raw_mdlength());
+  stats.record_group_metadata_bytes += rg.size.get_raw_mdlength();
+  stats.record_group_data_bytes += rg.size.dlength;
+  stats.record_batch_stats.increment(rg.get_size());
 }
 
 void RecordSubmitter::finish_submit_batch(
@@ -508,24 +508,28 @@ void RecordSubmitter::flush_current_batch()
 
   increment_io();
   auto num = p_batch->get_num_records();
-  auto [to_write, sizes] = p_batch->encode_batch(
+  const auto& rg = p_batch->get_record_group();
+  assert(rg.get_size() == num);
+  record_group_size_t sizes = rg.size;
+  account_submission(rg);
+  auto to_write = p_batch->encode_batch(
     get_committed_to(), journal_allocator.get_nonce());
+  // Note: rg is cleared
   DEBUG("{} {} records, {}, committed_to={}, outstanding_io={} ...",
         get_name(), num, sizes, get_committed_to(), num_outstanding_io);
-  account_submission(num, sizes);
   std::ignore = journal_allocator.write(std::move(to_write)
-  ).safe_then([this, p_batch, FNAME, num, sizes=sizes](auto write_result) {
+  ).safe_then([this, p_batch, FNAME, num, sizes](auto write_result) {
     TRACE("{} {} records, {}, write done with {}",
           get_name(), num, sizes, write_result);
     finish_submit_batch(p_batch, write_result);
   }).handle_error(
-    crimson::ct_error::all_same_way([this, p_batch, FNAME, num, sizes=sizes](auto e) {
+    crimson::ct_error::all_same_way([this, p_batch, FNAME, num, sizes](auto e) {
       ERROR("{} {} records, {}, got error {}",
             get_name(), num, sizes, e);
       finish_submit_batch(p_batch, std::nullopt);
       return seastar::now();
     })
-  ).handle_exception([this, p_batch, FNAME, num, sizes=sizes](auto e) {
+  ).handle_exception([this, p_batch, FNAME, num, sizes](auto e) {
     ERROR("{} {} records, {}, got exception {}",
           get_name(), num, sizes, e);
     finish_submit_batch(p_batch, std::nullopt);

--- a/src/crimson/os/seastore/journal/record_submitter.cc
+++ b/src/crimson/os/seastore/journal/record_submitter.cc
@@ -172,6 +172,14 @@ bool RecordSubmitter::is_available() const
   return ret;
 }
 
+writer_stats_t RecordSubmitter::get_stats() const
+{
+  writer_stats_t ret = stats;
+  ret.minus(last_stats);
+  last_stats = stats;
+  return ret;
+}
+
 RecordSubmitter::wa_ertr::future<>
 RecordSubmitter::wait_available()
 {
@@ -364,6 +372,7 @@ RecordSubmitter::open(bool is_mkfs)
     LOG_PREFIX(RecordSubmitter::open);
     DEBUG("{} register metrics", get_name());
     stats = {};
+    last_stats = {};
     namespace sm = seastar::metrics;
     std::vector<sm::label_instance> label_instances;
     label_instances.push_back(sm::label_instance("submitter", get_name()));

--- a/src/crimson/os/seastore/journal/record_submitter.h
+++ b/src/crimson/os/seastore/journal/record_submitter.h
@@ -217,16 +217,6 @@ class RecordSubmitter {
     // OVERFLOW: outstanding_io >  io_depth_limit is impossible
   };
 
-  struct grouped_io_stats {
-    uint64_t num_io = 0;
-    uint64_t num_io_grouped = 0;
-
-    void increment(uint64_t num_grouped_io) {
-      ++num_io;
-      num_io_grouped += num_grouped_io;
-    }
-  };
-
   using base_ertr = crimson::errorator<
       crimson::ct_error::input_output_error>;
 
@@ -334,13 +324,8 @@ private:
   // wait for decrement_io_with_flush()
   std::optional<seastar::promise<> > wait_unfull_flush_promise;
 
-  struct {
-    grouped_io_stats record_batch_stats;
-    grouped_io_stats io_depth_stats;
-    uint64_t record_group_padding_bytes = 0;
-    uint64_t record_group_metadata_bytes = 0;
-    uint64_t record_group_data_bytes = 0;
-  } stats;
+  writer_stats_t stats;
+
   seastar::metrics::metric_group metrics;
 };
 

--- a/src/crimson/os/seastore/journal/record_submitter.h
+++ b/src/crimson/os/seastore/journal/record_submitter.h
@@ -242,6 +242,9 @@ public:
   // whether is available to submit a record
   bool is_available() const;
 
+  // get the stats since last_stats
+  writer_stats_t get_stats() const;
+
   // wait for available if cannot submit, should check is_available() again
   // when the future is resolved.
   using wa_ertr = base_ertr;
@@ -329,6 +332,7 @@ private:
   std::optional<seastar::promise<> > wait_unfull_flush_promise;
 
   writer_stats_t stats;
+  mutable writer_stats_t last_stats;
 
   seastar::metrics::metric_group metrics;
 };

--- a/src/crimson/os/seastore/journal/record_submitter.h
+++ b/src/crimson/os/seastore/journal/record_submitter.h
@@ -113,6 +113,10 @@ public:
     }
   }
 
+  const record_group_t& get_record_group() const {
+    return pending;
+  }
+
   struct evaluation_t {
     record_group_size_t submit_size;
     bool is_full;
@@ -150,7 +154,7 @@ public:
       extent_len_t block_size);
 
   // Encode the batched records for write.
-  std::pair<ceph::bufferlist, record_group_size_t> encode_batch(
+  ceph::bufferlist encode_batch(
       const journal_seq_t& committed_to,
       segment_nonce_t segment_nonce);
 
@@ -165,8 +169,8 @@ public:
   // the intervention of the shared io_promise.
   //
   // Note the current RecordBatch can be reused afterwards.
-  std::pair<ceph::bufferlist, record_group_size_t> submit_pending_fast(
-      record_t&&,
+  ceph::bufferlist submit_pending_fast(
+      record_group_t&&,
       extent_len_t block_size,
       const journal_seq_t& committed_to,
       segment_nonce_t segment_nonce);
@@ -296,7 +300,7 @@ private:
     free_batch_ptrs.pop_front();
   }
 
-  void account_submission(std::size_t, const record_group_size_t&);
+  void account_submission(const record_group_t&);
 
   using maybe_result_t = RecordBatch::maybe_result_t;
   void finish_submit_batch(RecordBatch*, maybe_result_t);

--- a/src/crimson/os/seastore/journal/segmented_journal.h
+++ b/src/crimson/os/seastore/journal/segmented_journal.h
@@ -52,8 +52,8 @@ public:
     write_pipeline = _write_pipeline;
   }
 
-  journal_type_t get_type() final {
-    return journal_type_t::SEGMENTED;
+  backend_type_t get_type() final {
+    return backend_type_t::SEGMENTED;
   }
   seastar::future<> finish_commit(transaction_type_t type) {
     return seastar::now();

--- a/src/crimson/os/seastore/journal/segmented_journal.h
+++ b/src/crimson/os/seastore/journal/segmented_journal.h
@@ -34,6 +34,10 @@ public:
     return trimmer;
   }
 
+  writer_stats_t get_writer_stats() const final {
+    return record_submitter.get_stats();
+  }
+
   open_for_mkfs_ret open_for_mkfs() final;
 
   open_for_mount_ret open_for_mount() final;

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -2,6 +2,9 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "crimson/os/seastore/seastore_types.h"
+
+#include <utility>
+
 #include "crimson/common/log.h"
 
 namespace {
@@ -160,7 +163,7 @@ journal_seq_t journal_seq_t::add_offset(
       ++new_jseq;
       joff -= roll_size;
     }
-    assert(new_jseq < MAX_SEG_SEQ);
+    assert(std::cmp_less(new_jseq, MAX_SEG_SEQ));
     jseq = static_cast<segment_seq_t>(new_jseq);
   } else {
     device_off_t mod = (-off) / roll_size;
@@ -169,7 +172,7 @@ journal_seq_t journal_seq_t::add_offset(
       ++mod;
       joff += roll_size;
     }
-    if (jseq >= mod) {
+    if (std::cmp_greater_equal(jseq, mod)) {
       jseq -= mod;
     } else {
       return JOURNAL_SEQ_MIN;

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -878,4 +878,46 @@ std::ostream& operator<<(std::ostream& out, const scan_valid_records_cursor& c)
              << ")";
 }
 
+std::ostream& operator<<(std::ostream& out, const tw_stats_printer_t& p)
+{
+  constexpr const char* dfmt = "{:.2f}";
+  double d_num_records = static_cast<double>(p.stats.num_records);
+  out << "rps="
+      << fmt::format(dfmt, d_num_records/p.seconds)
+      << ",bwMiB="
+      << fmt::format(dfmt, p.stats.get_total_bytes()/p.seconds/(1<<20))
+      << ",sizeB="
+      << fmt::format(dfmt, p.stats.get_total_bytes()/d_num_records)
+      << "("
+      << fmt::format(dfmt, p.stats.data_bytes/d_num_records)
+      << ","
+      << fmt::format(dfmt, p.stats.metadata_bytes/d_num_records)
+      << ")";
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const writer_stats_printer_t& p)
+{
+  constexpr const char* dfmt = "{:.2f}";
+  auto d_num_io = static_cast<double>(p.stats.io_depth_stats.num_io);
+  out << "iops="
+      << fmt::format(dfmt, d_num_io/p.seconds)
+      << ",depth="
+      << fmt::format(dfmt, p.stats.io_depth_stats.average())
+      << ",batch="
+      << fmt::format(dfmt, p.stats.record_batch_stats.average())
+      << ",bwMiB="
+      << fmt::format(dfmt, p.stats.get_total_bytes()/p.seconds/(1<<20))
+      << ",sizeB="
+      << fmt::format(dfmt, p.stats.get_total_bytes()/d_num_io)
+      << "("
+      << fmt::format(dfmt, p.stats.record_group_data_bytes/d_num_io)
+      << ","
+      << fmt::format(dfmt, p.stats.record_group_metadata_bytes/d_num_io)
+      << ","
+      << fmt::format(dfmt, p.stats.record_group_padding_bytes/d_num_io)
+      << ")";
+  return out;
+}
+
 }

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -133,7 +133,7 @@ std::ostream &operator<<(std::ostream &out, const paddr_t &rhs)
 }
 
 journal_seq_t journal_seq_t::add_offset(
-      journal_type_t type,
+      backend_type_t type,
       device_off_t off,
       device_off_t roll_start,
       device_off_t roll_size) const
@@ -145,10 +145,10 @@ journal_seq_t journal_seq_t::add_offset(
 
   segment_seq_t jseq = segment_seq;
   device_off_t joff;
-  if (type == journal_type_t::SEGMENTED) {
+  if (type == backend_type_t::SEGMENTED) {
     joff = offset.as_seg_paddr().get_segment_off();
   } else {
-    assert(type == journal_type_t::RANDOM_BLOCK);
+    assert(type == backend_type_t::RANDOM_BLOCK);
     auto boff = offset.as_blk_paddr().get_device_off();
     joff = boff;
   }
@@ -184,7 +184,7 @@ journal_seq_t journal_seq_t::add_offset(
 }
 
 device_off_t journal_seq_t::relative_to(
-      journal_type_t type,
+      backend_type_t type,
       const journal_seq_t& r,
       device_off_t roll_start,
       device_off_t roll_size) const
@@ -196,11 +196,11 @@ device_off_t journal_seq_t::relative_to(
 
   device_off_t ret = static_cast<device_off_t>(segment_seq) - r.segment_seq;
   ret *= roll_size;
-  if (type == journal_type_t::SEGMENTED) {
+  if (type == backend_type_t::SEGMENTED) {
     ret += (static_cast<device_off_t>(offset.as_seg_paddr().get_segment_off()) -
             static_cast<device_off_t>(r.offset.as_seg_paddr().get_segment_off()));
   } else {
-    assert(type == journal_type_t::RANDOM_BLOCK);
+    assert(type == backend_type_t::RANDOM_BLOCK);
     ret += offset.as_blk_paddr().get_device_off() -
            r.offset.as_blk_paddr().get_device_off();
   }

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2211,6 +2211,43 @@ struct scan_valid_records_cursor {
 };
 std::ostream& operator<<(std::ostream&, const scan_valid_records_cursor&);
 
+template <typename CounterT>
+using counter_by_src_t = std::array<CounterT, TRANSACTION_TYPE_MAX>;
+
+template <typename CounterT>
+CounterT& get_by_src(
+    counter_by_src_t<CounterT>& counters_by_src,
+    transaction_type_t src) {
+  assert(static_cast<std::size_t>(src) < counters_by_src.size());
+  return counters_by_src[static_cast<std::size_t>(src)];
+}
+
+template <typename CounterT>
+const CounterT& get_by_src(
+    const counter_by_src_t<CounterT>& counters_by_src,
+    transaction_type_t src) {
+  assert(static_cast<std::size_t>(src) < counters_by_src.size());
+  return counters_by_src[static_cast<std::size_t>(src)];
+}
+
+struct grouped_io_stats {
+  uint64_t num_io = 0;
+  uint64_t num_io_grouped = 0;
+
+  void increment(uint64_t num_grouped_io) {
+    ++num_io;
+    num_io_grouped += num_grouped_io;
+  }
+};
+
+struct writer_stats_t {
+  grouped_io_stats record_batch_stats;
+  grouped_io_stats io_depth_stats;
+  uint64_t record_group_padding_bytes = 0;
+  uint64_t record_group_metadata_bytes = 0;
+  uint64_t record_group_data_bytes = 0;
+};
+
 }
 
 WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::seastore_meta_t)

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1888,6 +1888,11 @@ constexpr bool is_trim_transaction(transaction_type_t type) {
       type == transaction_type_t::TRIM_ALLOC);
 }
 
+constexpr bool is_modify_transaction(transaction_type_t type) {
+  return (type == transaction_type_t::MUTATE ||
+      is_background_transaction(type));
+}
+
 struct record_size_t {
   extent_len_t plain_mdlength = 0; // mdlength without the record header
   extent_len_t dlength = 0;
@@ -2240,12 +2245,19 @@ struct grouped_io_stats {
   }
 };
 
+struct trans_writer_stats_t {
+  uint64_t num_records = 0;
+  uint64_t metadata_bytes = 0;
+  uint64_t data_bytes = 0;
+};
+
 struct writer_stats_t {
   grouped_io_stats record_batch_stats;
   grouped_io_stats io_depth_stats;
   uint64_t record_group_padding_bytes = 0;
   uint64_t record_group_metadata_bytes = 0;
   uint64_t record_group_data_bytes = 0;
+  counter_by_src_t<trans_writer_stats_t> stats_by_src;
 };
 
 }

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2235,13 +2235,58 @@ const CounterT& get_by_src(
   return counters_by_src[static_cast<std::size_t>(src)];
 }
 
+template <typename CounterT>
+void add_srcs(counter_by_src_t<CounterT>& base,
+              const counter_by_src_t<CounterT>& by) {
+  for (std::size_t i=0; i<TRANSACTION_TYPE_MAX; ++i) {
+    base[i] += by[i];
+  }
+}
+
+template <typename CounterT>
+void minus_srcs(counter_by_src_t<CounterT>& base,
+                const counter_by_src_t<CounterT>& by) {
+  for (std::size_t i=0; i<TRANSACTION_TYPE_MAX; ++i) {
+    base[i] -= by[i];
+  }
+}
+
 struct grouped_io_stats {
   uint64_t num_io = 0;
   uint64_t num_io_grouped = 0;
 
+  double average() const {
+    return static_cast<double>(num_io_grouped)/num_io;
+  }
+
+  bool is_empty() const {
+    return num_io == 0;
+  }
+
+  void add(const grouped_io_stats &o) {
+    num_io += o.num_io;
+    num_io_grouped += o.num_io_grouped;
+  }
+
+  void minus(const grouped_io_stats &o) {
+    num_io -= o.num_io;
+    num_io_grouped -= o.num_io_grouped;
+  }
+
   void increment(uint64_t num_grouped_io) {
-    ++num_io;
-    num_io_grouped += num_grouped_io;
+    add({1, num_grouped_io});
+  }
+};
+
+struct device_stats_t {
+  uint64_t num_io = 0;
+  uint64_t total_depth = 0;
+  uint64_t total_bytes = 0;
+
+  void add(const device_stats_t& other) {
+    num_io += other.num_io;
+    total_depth += other.total_depth;
+    total_bytes += other.total_bytes;
   }
 };
 
@@ -2249,7 +2294,36 @@ struct trans_writer_stats_t {
   uint64_t num_records = 0;
   uint64_t metadata_bytes = 0;
   uint64_t data_bytes = 0;
+
+  bool is_empty() const {
+    return num_records == 0;
+  }
+
+  uint64_t get_total_bytes() const {
+    return metadata_bytes + data_bytes;
+  }
+
+  trans_writer_stats_t&
+  operator+=(const trans_writer_stats_t& o) {
+    num_records += o.num_records;
+    metadata_bytes += o.metadata_bytes;
+    data_bytes += o.data_bytes;
+    return *this;
+  }
+
+  trans_writer_stats_t&
+  operator-=(const trans_writer_stats_t& o) {
+    num_records -= o.num_records;
+    metadata_bytes -= o.metadata_bytes;
+    data_bytes -= o.data_bytes;
+    return *this;
+  }
 };
+struct tw_stats_printer_t {
+  double seconds;
+  const trans_writer_stats_t &stats;
+};
+std::ostream& operator<<(std::ostream&, const tw_stats_printer_t&);
 
 struct writer_stats_t {
   grouped_io_stats record_batch_stats;
@@ -2258,7 +2332,40 @@ struct writer_stats_t {
   uint64_t record_group_metadata_bytes = 0;
   uint64_t record_group_data_bytes = 0;
   counter_by_src_t<trans_writer_stats_t> stats_by_src;
+
+  bool is_empty() const {
+    return io_depth_stats.is_empty();
+  }
+
+  uint64_t get_total_bytes() const {
+    return record_group_padding_bytes +
+           record_group_metadata_bytes +
+           record_group_data_bytes;
+  }
+
+  void add(const writer_stats_t &o) {
+    record_batch_stats.add(o.record_batch_stats);
+    io_depth_stats.add(o.io_depth_stats);
+    record_group_padding_bytes += o.record_group_padding_bytes;
+    record_group_metadata_bytes += o.record_group_metadata_bytes;
+    record_group_data_bytes += o.record_group_data_bytes;
+    add_srcs(stats_by_src, o.stats_by_src);
+  }
+
+  void minus(const writer_stats_t &o) {
+    record_batch_stats.minus(o.record_batch_stats);
+    io_depth_stats.minus(o.io_depth_stats);
+    record_group_padding_bytes -= o.record_group_padding_bytes;
+    record_group_metadata_bytes -= o.record_group_metadata_bytes;
+    record_group_data_bytes -= o.record_group_data_bytes;
+    minus_srcs(stats_by_src, o.stats_by_src);
+  }
 };
+struct writer_stats_printer_t {
+  double seconds;
+  const writer_stats_t &stats;
+};
+std::ostream& operator<<(std::ostream&, const writer_stats_printer_t&);
 
 }
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -904,7 +904,6 @@ enum class backend_type_t {
 };
 
 std::ostream& operator<<(std::ostream& out, backend_type_t);
-using journal_type_t = backend_type_t;
 
 constexpr backend_type_t get_default_backend_of_device(device_type_t dtype) {
   assert(dtype != device_type_t::NONE &&
@@ -933,13 +932,13 @@ struct journal_seq_t {
 
   // produces a pseudo journal_seq_t relative to this by offset
   journal_seq_t add_offset(
-      journal_type_t type,
+      backend_type_t type,
       device_off_t off,
       device_off_t roll_start,
       device_off_t roll_size) const;
 
   device_off_t relative_to(
-      journal_type_t type,
+      backend_type_t type,
       const journal_seq_t& r,
       device_off_t roll_start,
       device_off_t roll_size) const;

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -786,10 +786,10 @@ TransactionManagerRef make_transaction_manager(
     }
   }
 
-  auto journal_type = p_backend_type;
+  auto backend_type = p_backend_type;
   device_off_t roll_size;
   device_off_t roll_start;
-  if (journal_type == journal_type_t::SEGMENTED) {
+  if (backend_type == backend_type_t::SEGMENTED) {
     roll_size = static_cast<SegmentManager*>(primary_device)->get_segment_size();
     roll_start = 0;
   } else {
@@ -812,17 +812,17 @@ TransactionManagerRef make_transaction_manager(
     cleaner_is_detailed = true;
     cleaner_config = SegmentCleaner::config_t::get_test();
     trimmer_config = JournalTrimmerImpl::config_t::get_test(
-        roll_size, journal_type);
+        roll_size, backend_type);
   } else {
     cleaner_is_detailed = false;
     cleaner_config = SegmentCleaner::config_t::get_default();
     trimmer_config = JournalTrimmerImpl::config_t::get_default(
-        roll_size, journal_type);
+        roll_size, backend_type);
   }
 
   auto journal_trimmer = JournalTrimmerImpl::create(
       *backref_manager, trimmer_config,
-      journal_type, roll_start, roll_size);
+      backend_type, roll_start, roll_size);
 
   AsyncCleanerRef cleaner;
   JournalRef journal;
@@ -837,7 +837,7 @@ TransactionManagerRef make_transaction_manager(
       epm->get_ool_segment_seq_allocator(),
       cleaner_is_detailed,
       /* is_cold = */ true);
-    if (journal_type == journal_type_t::SEGMENTED) {
+    if (backend_type == backend_type_t::SEGMENTED) {
       for (auto id : cold_segment_cleaner->get_device_ids()) {
         segment_providers_by_id[id] =
           static_cast<SegmentProvider*>(cold_segment_cleaner.get());
@@ -845,7 +845,7 @@ TransactionManagerRef make_transaction_manager(
     }
   }
 
-  if (journal_type == journal_type_t::SEGMENTED) {
+  if (backend_type == backend_type_t::SEGMENTED) {
     cleaner = SegmentCleaner::create(
       cleaner_config,
       std::move(sms),

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -79,6 +79,11 @@ public:
   using close_ertr = base_ertr;
   close_ertr::future<> close();
 
+  device_stats_t get_device_stats(bool report_detail) const {
+    writer_stats_t journal_stats = journal->get_writer_stats();
+    return epm->get_device_stats(journal_stats, report_detail);
+  }
+
   /// Resets transaction
   void reset_transaction_preserve_handle(Transaction &t) {
     return cache->reset_transaction_preserve_handle(t);

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -413,6 +413,9 @@ seastar::future<> OSD::start()
             INFO("reactor_utilizations: {}", oss.str());
           });
         });
+        gate.dispatch_in_background("stats_store", *this, [this] {
+          return store.report_stats();
+        });
       });
       stats_timer.arm_periodic(std::chrono::seconds(stats_seconds));
     }

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -183,7 +183,6 @@ class EphemeralTestState
   {
 #endif
 protected:
-  journal_type_t journal_type;
   size_t num_main_device_managers = 0;
   size_t num_cold_device_managers = 0;
   EphemeralDevicesRef devices;


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57788

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh