### PR TITLE
mgr/dashboard: disable telemetry notification in e2e 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/block/images.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/block/images.e2e-spec.ts
@@ -11,7 +11,7 @@ describe('Images page', () => {
     cy.login();
     // Need pool for image testing
     pools.navigateTo('create');
-    pools.create(poolName, 8, 'rbd');
+    pools.create(poolName, 8, ['rbd']);
     pools.existTableCell(poolName);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/block/mirroring.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/block/mirroring.e2e-spec.ts
@@ -32,7 +32,7 @@ describe('Mirroring page', () => {
       cy.ceph2Login();
       cy.login();
       pools.navigateTo('create');
-      pools.create(poolName, 8, 'rbd');
+      pools.create(poolName, 8, ['rbd']);
       pools.navigateTo();
       pools.existTableCell(poolName, true);
       mirroring.navigateTo();
@@ -49,16 +49,17 @@ describe('Mirroring page', () => {
         // so writing the code to copy the token inside the origin manually
         // rather than using a function call
         // @ts-ignore
+        cy.ceph2Login();
         cy.origin(url, { args }, ({ name, bootstrapToken }) => {
           // Create an rbd pool in the second cluster
+          cy.visit('#/pool/create').wait(100);
 
           // Login to the second cluster
           // Somehow its not working with the cypress login function
-          cy.visit('#/pool/create').wait(100);
-
           cy.get('[name=username]').type('admin');
           cy.get('#password').type('admin');
           cy.get('[type=submit]').click();
+
           cy.get('input[name=name]').clear().type(name);
           cy.get(`select[name=poolType]`).select('replicated');
           cy.get(`select[name=poolType] option:checked`).contains('replicated');
@@ -93,7 +94,7 @@ describe('Mirroring page', () => {
 
     beforeEach(() => {
       pools.navigateTo('create'); // Need pool for mirroring testing
-      pools.create(poolName, 8, 'rbd');
+      pools.create(poolName, 8, ['rbd']);
       pools.navigateTo();
       pools.existTableCell(poolName, true);
     });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/logs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/logs.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('Logs page', () => {
   describe('audit logs respond to pool creation and deletion test', () => {
     it('should create pool and check audit logs reacted', () => {
       pools.navigateTo('create');
-      pools.create(poolname, 8, 'rbd');
+      pools.create(poolname, 8, ['rbd']);
       pools.navigateTo();
       pools.existTableCell(poolname, true);
       logs.checkAuditForPoolFunction(poolname, 'create', hour, minute);

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/services.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/services.po.ts
@@ -49,7 +49,9 @@ export class ServicesPageHelper extends PageHelper {
       switch (serviceType) {
         case 'rgw':
           cy.get('#service_id').type('foo');
-          unmanaged ? cy.get('label[for=unmanaged]').click() : cy.get('#count').type(String(count));
+          unmanaged
+            ? cy.get('label[for=unmanaged]').click()
+            : cy.get('#count').clear().type(String(count));
           break;
 
         case 'ingress':
@@ -65,12 +67,16 @@ export class ServicesPageHelper extends PageHelper {
 
         case 'nfs':
           cy.get('#service_id').type('testnfs');
-          unmanaged ? cy.get('label[for=unmanaged]').click() : cy.get('#count').type(String(count));
+          unmanaged
+            ? cy.get('label[for=unmanaged]').click()
+            : cy.get('#count').clear().type(String(count));
           break;
 
         case 'smb':
           cy.get('#service_id').type('testsmb');
-          unmanaged ? cy.get('label[for=unmanaged]').click() : cy.get('#count').type(String(count));
+          unmanaged
+            ? cy.get('label[for=unmanaged]').click()
+            : cy.get('#count').clear().type(String(count));
           cy.get('#cluster_id').type('cluster_foo');
           cy.get('#config_uri').type('rados://.smb/foo/scc.toml');
           break;
@@ -96,7 +102,9 @@ export class ServicesPageHelper extends PageHelper {
 
         default:
           cy.get('#service_id').type('test');
-          unmanaged ? cy.get('label[for=unmanaged]').click() : cy.get('#count').type(String(count));
+          unmanaged
+            ? cy.get('label[for=unmanaged]').click()
+            : cy.get('#count').clear().type(String(count));
           break;
       }
       if (serviceType === 'snmp-gateway') {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.e2e-spec.ts
@@ -67,5 +67,5 @@ describe('Pools page', () => {
     it('should delete the pool', () => {
       pools.delete(poolName);
     });
-  })
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.e2e-spec.ts
@@ -28,14 +28,14 @@ describe('Pools page', () => {
   });
 
   describe('Create, update and destroy', () => {
-    it('should create a pool with mirroring enabled', () => {
+    it('should create a pool', () => {
       pools.existTableCell(poolName, false);
       pools.navigateTo('create');
-      pools.create(poolName, 8, 'rbd');
+      pools.create(poolName, 8, ['rbd']);
       pools.existTableCell(poolName);
     });
 
-    it('should edit a pools placement group and check if mirroring is enabled', () => {
+    it('should edit a pools placement group', () => {
       pools.existTableCell(poolName);
       pools.edit_pool_pg(poolName, 32);
     });
@@ -50,4 +50,22 @@ describe('Pools page', () => {
       pools.delete(poolName);
     });
   });
+
+  describe('Pool with mirroring', () => {
+    it('should create a pool with mirroring enabled', () => {
+      pools.existTableCell(poolName, false);
+      pools.navigateTo('create');
+      pools.create(poolName, 8, ['rbd'], true);
+      pools.existTableCell(poolName);
+    });
+
+    it('should edit a pools placement group with mirroring enabled', () => {
+      pools.existTableCell(poolName);
+      pools.edit_pool_pg(poolName, 32, true, true);
+    });
+
+    it('should delete the pool', () => {
+      pools.delete(poolName);
+    });
+  })
 });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.po.ts
@@ -14,7 +14,7 @@ export class PoolPageHelper extends PageHelper {
   }
 
   @PageHelper.restrictTo(pages.create.url)
-  create(name: string, placement_groups: number, ...apps: string[]) {
+  create(name: string, placement_groups: number, apps: string[], mirroring = false) {
     cy.get('input[name=name]').clear().type(name);
 
     this.isPowerOf2(placement_groups);
@@ -25,15 +25,19 @@ export class PoolPageHelper extends PageHelper {
     this.selectOption('pgAutoscaleMode', 'off'); // To show pgNum field
     cy.get('input[name=pgNum]').clear().type(`${placement_groups}`);
     this.setApplications(apps);
-    cy.get('#rbdMirroring').check({ force: true });
+    if (mirroring) {
+      cy.get('#rbdMirroring').check({ force: true });
+    }
     cy.get('cd-submit-button').click();
   }
 
-  edit_pool_pg(name: string, new_pg: number, wait = true) {
+  edit_pool_pg(name: string, new_pg: number, wait = true, mirroring=false) {
     this.isPowerOf2(new_pg);
     this.navigateEdit(name);
 
-    cy.get('#rbdMirroring').should('be.checked');
+    if (mirroring) {
+      cy.get('#rbdMirroring').should('be.checked');
+    }
 
     cy.get('input[name=pgNum]').clear().type(`${new_pg}`);
     cy.get('cd-submit-button').click();

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.po.ts
@@ -31,7 +31,7 @@ export class PoolPageHelper extends PageHelper {
     cy.get('cd-submit-button').click();
   }
 
-  edit_pool_pg(name: string, new_pg: number, wait = true, mirroring=false) {
+  edit_pool_pg(name: string, new_pg: number, wait = true, mirroring = false) {
     this.isPowerOf2(new_pg);
     this.navigateEdit(name);
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/language.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/language.po.ts
@@ -10,6 +10,6 @@ export class LanguagePageHelper extends PageHelper {
   }
 
   getAllLanguages() {
-    return cy.get('cd-language-selector cds-header-menu');
+    return cy.get('cd-language-selector cds-header-menu cds-header-item');
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/notification.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/notification.e2e-spec.ts
@@ -9,7 +9,7 @@ describe('Notification page', () => {
   before(() => {
     cy.login();
     pools.navigateTo('create');
-    pools.create(poolName, 8, 'rbd');
+    pools.create(poolName, 8, ['rbd']);
     pools.edit_pool_pg(poolName, 4, false);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/support/commands.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/support/commands.ts
@@ -27,6 +27,7 @@ const fillAuth = () => {
   window.localStorage.setItem('user_pwd_expiration_date', auth.pwdExpirationDate);
   window.localStorage.setItem('user_pwd_update_required', auth.pwdUpdateRequired);
   window.localStorage.setItem('sso', auth.sso);
+  window.localStorage.setItem('telemetry_notification_hidden', 'true'); // disable telemetry notification in e2e
 };
 
 Cypress.Commands.add('login', (username, password) => {
@@ -68,6 +69,7 @@ Cypress.Commands.add('ceph2Login', (username, password) => {
           window.localStorage.setItem('user_pwd_expiration_date', pwdExpirationDate);
           window.localStorage.setItem('user_pwd_update_required', pwdUpdateRequired);
           window.localStorage.setItem('sso', sso);
+          window.localStorage.setItem('telemetry_notification_hidden', 'true'); // disable telemetry notification in e2e
         }
       );
     });


### PR DESCRIPTION
After the new UI shell, the telemetry notifications are displayed on the bottom side, which kind of exists on top of some buttons and that causes some cypress failures while clicking Submit button in the form.

I am disabling the notification itself in e2e because its not checked in the e2e at all so we can afford to disable it. Incase we decide to add an e2e for the notification, we can just toggle it on later on and we can check it

Below image shows how it hides the button
![image](https://github.com/ceph/ceph/assets/71764184/388744e4-ac64-4463-ae82-65d101dd0023)

- Also fixing the language selector in e2e
- Mirroring checkbox in e2e is flaky. So conditionally making sure that its run only when it is needed





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
