### PR TITLE
squid: rgw: do not assert on thread name setting failures

### DIFF
--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -728,9 +728,11 @@ public:
           throw err;
         }
       });
-      const auto rc = ceph_pthread_setname(workers.back().native_handle(), 
-        (WORKER_THREAD_NAME+std::to_string(worker_id)).c_str());
-      ceph_assert(rc == 0);
+      const auto thread_name = WORKER_THREAD_NAME+std::to_string(worker_id);
+      if (const auto rc = ceph_pthread_setname(workers.back().native_handle(), thread_name.c_str()); rc != 0) {
+        ldpp_dout(this, 1) << "ERROR: failed to set notification manager thread name to: " << thread_name
+          << ". error: " << rc << dendl;
+      }
     }
     ldpp_dout(this, 10) << "INfO: started notification manager with: " << worker_count << " workers" << dendl;
   }

--- a/src/rgw/rgw_amqp.cc
+++ b/src/rgw/rgw_amqp.cc
@@ -836,8 +836,11 @@ public:
       // when a new connection is added.
       connections.max_load_factor(10.0);
       // give the runner thread a name for easier debugging
-      const auto rc = ceph_pthread_setname(runner.native_handle(), "amqp_manager");
-      ceph_assert(rc==0);
+      const char* thread_name = "amqp_manager";
+      if (const auto rc = ceph_pthread_setname(runner.native_handle(), thread_name); rc != 0) {
+        ldout(cct, 1) << "ERROR: failed to set amqp manager thread name to: " << thread_name
+          << ". error: " << rc << dendl;
+      }
   }
 
   // non copyable

--- a/src/rgw/rgw_kafka.cc
+++ b/src/rgw/rgw_kafka.cc
@@ -535,8 +535,11 @@ public:
       // when a new connection is added.
       connections.max_load_factor(10.0);
       // give the runner thread a name for easier debugging
-      const auto rc = ceph_pthread_setname(runner.native_handle(), "kafka_manager");
-      ceph_assert(rc==0);
+      const char* thread_name = "kafka_manager";
+      if (const auto rc = ceph_pthread_setname(runner.native_handle(), thread_name); rc != 0) {
+        ldout(cct, 1) << "ERROR: failed to set kafka manager thread name to: " << thread_name
+          << ". error: " << rc << dendl;
+      }
   }
 
   // non copyable

--- a/src/rgw/rgw_lua_background.cc
+++ b/src/rgw/rgw_lua_background.cc
@@ -83,9 +83,11 @@ void Background::start() {
   }
   started = true;
   runner = std::thread(&Background::run, this);
-  const auto rc = ceph_pthread_setname(runner.native_handle(),
-      "lua_background");
-  ceph_assert(rc == 0);
+  const char* thread_name = "lua_background";
+  if (const auto rc = ceph_pthread_setname(runner.native_handle(), thread_name); rc != 0) {
+    ldout(cct, 1) << "ERROR: failed to set lua background thread name to: " << thread_name
+      << ". error: " << rc << dendl;
+  }
 }
 
 void Background::pause() {

--- a/src/rgw/rgw_ratelimit.h
+++ b/src/rgw/rgw_ratelimit.h
@@ -286,7 +286,8 @@ class ActiveRateLimiter : public DoutPrefix  {
     void start() {
       ldpp_dout(this, 20) << "starting ratelimit_gc thread" << dendl;
       runner = std::thread(&ActiveRateLimiter::replace_active, this);
-      const auto rc = ceph_pthread_setname(runner.native_handle(), "ratelimit_gc");
-      ceph_assert(rc==0);
+      if (const auto rc = ceph_pthread_setname(runner.native_handle(), "ratelimit_gc"); rc != 0) {
+        ldpp_dout(this, 1) << "ERROR: failed to set ratelimit_gc thread name. error: " << rc << dendl;
+      }
     }
 };


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66499

---

backport of https://github.com/ceph/ceph/pull/57969
parent tracker: https://tracker.ceph.com/issues/64305

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh