### PR TITLE
rgw/multipart: acquire a cls lock on meta_obj before adding multipart part info to it to avoid racing with multipart complete

### DIFF
--- a/src/rgw/driver/rados/rgw_putobj_processor.cc
+++ b/src/rgw/driver/rados/rgw_putobj_processor.cc
@@ -567,6 +567,37 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
     return r;
   }
 
+  /* take a cls lock on meta_obj to prevent writing to meta object deleted by completion */
+  auto mp_meta_obj = upload->get_meta_obj();
+  if (mp_meta_obj == nullptr) {
+    ldpp_dout(dpp, 5) << "the meta object dosen't exist: upload_id" << upload_id  << dendl;
+    return -ERR_NO_SUCH_UPLOAD;
+  }
+  mp_meta_obj->set_in_extra_data(true);
+  mp_meta_obj->set_hash_source(target_obj.get_oid());
+
+  int max_lock_secs_mp =
+    store->ctx()->_conf.get_val<int64_t>("rgw_mp_lock_max_time");
+  utime_t dur(max_lock_secs_mp, 0);
+
+  auto serializer = mp_meta_obj->get_serializer(dpp, "RGWCompleteMultipart");
+
+  /* retry in case another part upload holds the lock */
+  static constexpr int NUM_TRY_LOCK_RETRIES = 3;
+  for (int i = 0; i < NUM_TRY_LOCK_RETRIES; i++) {
+    r = serializer->try_lock(dpp, dur, rctx.y);
+    if (r < 0 && r != -ENOENT) {
+      ldpp_dout(dpp, 20) << "failed to acquire lock. ret = " << r << ", retry = " << i << dendl;
+      continue;
+    }
+    break;
+  }
+  if (r < 0) {
+    ldpp_dout(dpp, 5) << "failed to acquire lock. r = " << r << dendl;
+    r = -ERR_NO_SUCH_UPLOAD;
+    return r;
+  }
+
   librados::ObjectWriteOperation op;
   cls_rgw_mp_upload_part_info_update(op, p, info);
   r = rgw_rados_operate(rctx.dpp, meta_obj_ref.ioctx, meta_obj_ref.obj.oid, &op, rctx.y);
@@ -585,6 +616,8 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
     op.omap_set(m);
     r = rgw_rados_operate(rctx.dpp, meta_obj_ref.ioctx, meta_obj_ref.obj.oid, &op, rctx.y);
   }
+  serializer->unlock();
+
   if (r < 0) {
     return r == -ENOENT ? -ERR_NO_SUCH_UPLOAD : r;
   }

--- a/src/rgw/driver/rados/rgw_putobj_processor.h
+++ b/src/rgw/driver/rados/rgw_putobj_processor.h
@@ -209,6 +209,7 @@ class AtomicObjectProcessor : public ManifestObjectProcessor {
 class MultipartObjectProcessor : public ManifestObjectProcessor {
   const rgw_obj target_obj; // target multipart object
   const std::string upload_id;
+  rgw::sal::MultipartUpload* upload;
   const int part_num;
   const std::string part_num_str;
   RGWMPObj mp;
@@ -224,12 +225,14 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
                            const rgw_placement_rule *ptail_placement_rule,
                            const ACLOwner& owner, RGWObjectCtx& obj_ctx,
                            const rgw_obj& _head_obj,
-                           const std::string& upload_id, uint64_t part_num,
+                           const std::string& upload_id,
+                           rgw::sal::MultipartUpload* _upload,
+                           uint64_t part_num,
                            const std::string& part_num_str,
                            const DoutPrefixProvider *dpp, optional_yield y, jspan_context& trace)
     : ManifestObjectProcessor(aio, store, bucket_info, ptail_placement_rule,
                               owner, obj_ctx, _head_obj, dpp, y, trace),
-      target_obj(head_obj), upload_id(upload_id),
+      target_obj(head_obj), upload_id(upload_id), upload(_upload),
       part_num(part_num), part_num_str(part_num_str),
       mp(head_obj.key.name, upload_id)
   {}

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -3511,7 +3511,8 @@ std::unique_ptr<Writer> RadosMultipartUpload::get_writer(
   return std::make_unique<RadosMultipartWriter>(dpp, y, get_upload_id(),
 				 bucket_info, obj_ctx,
 				 obj->get_obj(), store, std::move(aio), owner,
-				 ptail_placement_rule, part_num, part_num_str, obj->get_trace());
+				 ptail_placement_rule, part_num, part_num_str,
+				 obj->get_trace(), this);
 }
 
 MPRadosSerializer::MPRadosSerializer(const DoutPrefixProvider *dpp, RadosStore* store, RadosObject* obj, const std::string& lock_name) :

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -1050,14 +1050,15 @@ public:
 		       RadosStore* _store, std::unique_ptr<Aio> _aio,
 		       const ACLOwner& owner,
 		       const rgw_placement_rule *ptail_placement_rule,
-		       uint64_t part_num, const std::string& part_num_str, jspan_context& trace) :
+		       uint64_t part_num, const std::string& part_num_str,
+		       jspan_context& trace, rgw::sal::MultipartUpload* _upload) :
 			StoreWriter(dpp, y),
 			store(_store),
 			aio(std::move(_aio)),
 			obj_ctx(obj_ctx),
 			processor(&*aio, store->getRados(), bucket_info,
 				  ptail_placement_rule, owner, obj_ctx,
-				  obj, upload_id,
+				  obj, upload_id, _upload,
 				  part_num, part_num_str, dpp, y, trace)
   {}
   ~RadosMultipartWriter() = default;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4198,8 +4198,8 @@ void RGWPutObj::execute(optional_yield y)
 
   s->object->set_trace(s->trace->GetContext());
 
+  std::unique_ptr<rgw::sal::MultipartUpload> upload;
   if (multipart) {
-    std::unique_ptr<rgw::sal::MultipartUpload> upload;
     upload = s->bucket->get_multipart_upload(s->object->get_name(),
 					 multipart_upload_id);
     op_ret = upload->get_info(this, s->yield, &pdest_placement);
@@ -6355,7 +6355,18 @@ void RGWCompleteMultipart::execute(optional_yield y)
   utime_t dur(max_lock_secs_mp, 0);
 
   serializer = meta_obj->get_serializer(this, "RGWCompleteMultipart");
-  op_ret = serializer->try_lock(this, dur, y);
+
+  /* retry in case a part upload holds the lock */
+  static constexpr int NUM_TRY_LOCK_RETRIES = 3;
+  for (int i = 0; i < NUM_TRY_LOCK_RETRIES; i++) {
+    op_ret = serializer->try_lock(this, dur, y);
+    if (op_ret < 0 && op_ret != -ENOENT) {
+      ldpp_dout(this, 20) << "failed to acquire lock. ret = " << op_ret << ", retry = " << i << dendl;
+      continue;
+    }
+    break;
+  }
+
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "failed to acquire lock" << dendl;
     if (op_ret == -ENOENT && check_previously_completed(parts)) {


### PR DESCRIPTION

      Fixes: https://tracker.ceph.com/issues/66516
      Signed-off-by: Jane Zhu [jzhu116@bloomberg.net](mailto:jzhu116@bloomberg.net)

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
