### PR TITLE
squid: cephfs-shell: prints warning, hangs and aborts when launched

### DIFF
--- a/src/tools/cephfs/shell/cephfs-shell
+++ b/src/tools/cephfs/shell/cephfs-shell
@@ -16,13 +16,12 @@ import shlex
 import stat
 import errno
 
-from pkg_resources import packaging  # type: ignore
-
 from cmd2 import Cmd
 from cmd2 import __version__ as cmd2_version
+from packaging.version import Version
+
 # XXX: In cmd2 versions < 1.0.1, we'll get SystemExit(2) instead of
 # Cmd2ArgparseError
-Version = packaging.version.Version
 if Version(cmd2_version) >= Version("1.0.1"):
     from cmd2.exceptions import Cmd2ArgparseError
 else:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66500

---

backport of https://github.com/ceph/ceph/pull/55711
parent tracker: https://tracker.ceph.com/issues/64538

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh