### PR TITLE
quincy: cephfs-shell: prints warning, hangs and aborts when launched

### DIFF
--- a/src/tools/cephfs/shell/cephfs-shell
+++ b/src/tools/cephfs/shell/cephfs-shell
@@ -18,7 +18,17 @@ import errno
 
 from cmd2 import Cmd
 from cmd2 import __version__ as cmd2_version
-from distutils.version import LooseVersion
+from packaging.version import Version
+
+# XXX: In cmd2 versions < 1.0.1, we'll get SystemExit(2) instead of
+# Cmd2ArgparseError
+if Version(cmd2_version) >= Version("1.0.1"):
+    from cmd2.exceptions import Cmd2ArgparseError
+else:
+    # HACK: so that we don't have check for version everywhere
+    # Cmd2ArgparseError is used.
+    class Cmd2ArgparseError:
+        pass
 
 if sys.version_info.major < 3:
     raise RuntimeError("cephfs-shell is only compatible with python3")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66501

---

backport of https://github.com/ceph/ceph/pull/55711
parent tracker: https://tracker.ceph.com/issues/64538

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh