### PR TITLE
squid: crimson/os/seastore: lba pointer consolidation

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -533,7 +533,7 @@ public:
           }
         } else if (child_node->is_pending()) {
           if (child_node->is_mutation_pending()) {
-            auto &prior = (child_node_t &)*child_node->prior_instance;
+            auto &prior = (child_node_t &)*child_node->get_prior_instance();
             assert(prior.is_valid());
             assert(prior.is_parent_valid());
             if (node->is_mutation_pending()) {

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -592,6 +592,15 @@ public:
                 : true);
             }
           }
+        } else if (child == get_reserved_ptr()) {
+          if constexpr(
+            !std::is_base_of_v<typename internal_node_t::base_t,
+                               child_node_t>) {
+            assert(i->get_val().pladdr.is_paddr());
+            assert(i->get_val().pladdr.get_paddr() == P_ADDR_ZERO);
+          } else {
+            ceph_abort();
+          }
         }
       } else {
         ceph_abort("impossible");

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -59,7 +59,7 @@ struct FixedKVNode : ChildableCachedExtent {
    * 	b. prior_instance is empty
    * 	c. child pointers point at stable children. Child resolution is done
    * 	   directly via this array.
-   * 	c. copy_sources is empty
+   * 	d. copy_sources is empty
    * 2. if nodes are mutation_pending:
    * 	a. parent is empty and needs to be fixed upon commit
    * 	b. prior_instance points to its stable version
@@ -67,7 +67,7 @@ struct FixedKVNode : ChildableCachedExtent {
    * 	   this transaction. Child resolution is done by first checking this
    * 	   array, and then recursively resolving via the parent. We copy child
    * 	   pointers from parent on commit.
-   * 	c. copy_sources is empty
+   * 	d. copy_sources is empty
    * 3. if nodes are initial_pending
    * 	a. parent points at its pending parent on this transaction (must exist)
    * 	b. prior_instance is empty or, if it's the result of rewrite, points to
@@ -80,6 +80,8 @@ struct FixedKVNode : ChildableCachedExtent {
    * 	d. copy_sources contains the set of stable nodes at the same tree-level(only
    * 	   its "prior_instance" if the node is the result of a rewrite), with which
    * 	   the lba range of this node overlaps.
+   * 4. EXIST_CLEAN and EXIST_MUTATION_PENDING belong to 3 above (except that they
+   * 	cannot be rewritten) because their parents must be mutated upon remapping.
    */
   std::vector<ChildableCachedExtent*> children;
   std::set<FixedKVNodeRef, copy_source_cmp_t> copy_sources;

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -727,7 +727,7 @@ struct FixedKVInternalNode
     return CachedExtentRef(new node_type_t(*this));
   };
 
-  void on_replace_prior(Transaction&) final {
+  void on_replace_prior() final {
     ceph_assert(!this->is_rewrite());
     this->set_children_from_prior_instance();
     auto &prior = (this_type_t&)(*this->get_prior_instance());
@@ -1119,7 +1119,7 @@ struct FixedKVLeafNode
       true);
   }
 
-  void on_replace_prior(Transaction&) final {
+  void on_replace_prior() final {
     ceph_assert(!this->is_rewrite());
     if constexpr (has_children) {
       this->set_children_from_prior_instance();

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1566,6 +1566,7 @@ void Cache::complete_commit(
     i->on_initial_write();
 
     i->state = CachedExtent::extent_state_t::CLEAN;
+    i->prior_instance.reset();
     DEBUGT("add extent as fresh, inline={} -- {}",
 	   t, is_inline, *i);
     const auto t_src = t.get_src();

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -829,7 +829,7 @@ void Cache::commit_replace_extent(
     add_to_dirty(next);
   }
 
-  next->on_replace_prior(t);
+  next->on_replace_prior();
   invalidate_extent(t, *prev);
 }
 

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -137,7 +137,7 @@ LogicalCachedExtent::~LogicalCachedExtent() {
   }
 }
 
-void LogicalCachedExtent::on_replace_prior(Transaction &t) {
+void LogicalCachedExtent::on_replace_prior() {
   assert(is_mutation_pending());
   take_prior_parent_tracker();
   assert(get_parent_node());

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -453,7 +453,8 @@ public:
 
   /// Returns true if extent has a pending delta
   bool is_mutation_pending() const {
-    return state == extent_state_t::MUTATION_PENDING;
+    return state == extent_state_t::MUTATION_PENDING
+      || state == extent_state_t::EXIST_MUTATION_PENDING;
   }
 
   /// Returns true if extent is a fresh extent

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -30,15 +30,6 @@ class SegmentedAllocator;
 class TransactionManager;
 class ExtentPlacementManager;
 
-template <
-  typename node_key_t,
-  typename node_val_t,
-  typename internal_node_t,
-  typename leaf_node_t,
-  typename pin_t,
-  size_t node_size,
-  bool leaf_has_children>
-class FixedKVBtree;
 template <typename, typename>
 class BtreeNodeMapping;
 
@@ -192,15 +183,6 @@ class CachedExtent
   friend class onode::DummyNodeExtent;
   friend class onode::TestReplayExtent;
 
-  template <
-    typename node_key_t,
-    typename node_val_t,
-    typename internal_node_t,
-    typename leaf_node_t,
-    typename pin_t,
-    size_t node_size,
-    bool leaf_has_children>
-  friend class FixedKVBtree;
   uint32_t last_committed_crc = 0;
 
   // Points at current version while in state MUTATION_PENDING

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -281,7 +281,7 @@ public:
    * with the states of Cache and can't wait till transaction
    * completes.
    */
-  virtual void on_replace_prior(Transaction &t) {}
+  virtual void on_replace_prior() {}
 
   /**
    * on_invalidated
@@ -1309,7 +1309,7 @@ public:
   virtual ~LogicalCachedExtent();
 
 protected:
-  void on_replace_prior(Transaction &t) final;
+  void on_replace_prior() final;
 
   virtual void apply_delta(const ceph::bufferlist &bl) = 0;
 

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -194,7 +194,11 @@ struct LBALeafNode
 	iter.get_offset(),
 	*nextent);
       // child-ptr may already be correct, see LBAManager::update_mappings()
-      this->update_child_ptr(iter, nextent);
+      if (!nextent->has_parent_tracker()) {
+	this->update_child_ptr(iter, nextent);
+      }
+      assert(nextent->has_parent_tracker()
+	&& nextent->get_parent_node<LBALeafNode>().get() == this);
     }
     if (val.pladdr.is_paddr()) {
       val.pladdr = maybe_generate_relative(val.pladdr.get_paddr());

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -171,6 +171,8 @@ struct LBALeafNode
 
     for (auto i : *this) {
       auto child = (LogicalCachedExtent*)this->children[i.get_offset()];
+      // Children may not be marked as stable yet,
+      // the specific order is undefined in the transaction prepare record phase.
       if (is_valid_child_ptr(child) && child->get_laddr() != i.get_key()) {
 	SUBERROR(seastore_fixedkv_tree,
 	  "stable child not valid: child {}, key {}",

--- a/src/crimson/os/seastore/root_block.cc
+++ b/src/crimson/os/seastore/root_block.cc
@@ -7,7 +7,7 @@
 
 namespace crimson::os::seastore {
 
-void RootBlock::on_replace_prior(Transaction &t) {
+void RootBlock::on_replace_prior() {
   if (!lba_root_node) {
     auto &prior = static_cast<RootBlock&>(*get_prior_instance());
     if (prior.lba_root_node) {

--- a/src/crimson/os/seastore/root_block.h
+++ b/src/crimson/os/seastore/root_block.h
@@ -61,7 +61,7 @@ struct RootBlock : CachedExtent {
     return extent_types_t::ROOT;
   }
 
-  void on_replace_prior(Transaction &t) final;
+  void on_replace_prior() final;
 
   /// dumps root as delta
   ceph::bufferlist get_delta() final {

--- a/src/crimson/os/seastore/root_block.h
+++ b/src/crimson/os/seastore/root_block.h
@@ -50,6 +50,8 @@ struct RootBlock : CachedExtent {
       backref_root_node(nullptr)
   {}
 
+  void on_rewrite(CachedExtent&, extent_len_t) final {}
+
   CachedExtentRef duplicate_for_write(Transaction&) final {
     return CachedExtentRef(new RootBlock(*this));
   };

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -494,12 +494,7 @@ TransactionManager::rewrite_logical_extent(
       lextent->get_user_hint(),
       // get target rewrite generation
       lextent->get_rewrite_generation())->cast<LogicalCachedExtent>();
-    lextent->get_bptr().copy_out(
-      0,
-      lextent->get_length(),
-      nlextent->get_bptr().c_str());
-    nlextent->set_laddr(lextent->get_laddr());
-    nlextent->set_modify_time(lextent->get_modify_time());
+    nlextent->rewrite(*lextent, 0);
 
     DEBUGT("rewriting logical extent -- {} to {}", t, *lextent, *nlextent);
 
@@ -540,13 +535,7 @@ TransactionManager::rewrite_logical_extent(
         bool first_extent = (off == 0);
         ceph_assert(left >= nextent->get_length());
         auto nlextent = nextent->template cast<LogicalCachedExtent>();
-        lextent->get_bptr().copy_out(
-          off,
-          nlextent->get_length(),
-          nlextent->get_bptr().c_str());
-        nlextent->set_laddr(lextent->get_laddr() + off);
-        nlextent->set_modify_time(lextent->get_modify_time());
-        nlextent->set_last_committed_crc(lextent->get_last_committed_crc());
+        nlextent->rewrite(*lextent, off);
         DEBUGT("rewriting logical extent -- {} to {}", t, *lextent, *nlextent);
 
         /* This update_mapping is, strictly speaking, unnecessary for delayed_alloc

--- a/src/test/crimson/seastore/test_block.h
+++ b/src/test/crimson/seastore/test_block.h
@@ -111,6 +111,8 @@ struct TestBlockPhysical : crimson::os::seastore::CachedExtent{
 
   std::vector<test_block_delta_t> delta = {};
 
+  void on_rewrite(CachedExtent&, extent_len_t) final {}
+
   TestBlockPhysical(ceph::bufferptr &&ptr)
     : CachedExtent(std::move(ptr)) {}
   TestBlockPhysical(const TestBlockPhysical &other)


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/55831

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh