### PR TITLE
rgw/curl: async curl client

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -62,6 +62,7 @@ set(librgw_common_srcs
   rgw_es_query.cc
   rgw_formats.cc
   rgw_http_client.cc
+  curl/client.cc
   rgw_keystone.cc
   rgw_keystone_scope.cc
   rgw_ldap.cc

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -31,6 +31,8 @@ function(gperf_generate input output)
     )
 endfunction()
 
+add_subdirectory(curl)
+
 find_package(ICU 52.0 COMPONENTS uc REQUIRED)
 
 set(librgw_common_srcs
@@ -62,7 +64,6 @@ set(librgw_common_srcs
   rgw_es_query.cc
   rgw_formats.cc
   rgw_http_client.cc
-  curl/client.cc
   rgw_keystone.cc
   rgw_keystone_scope.cc
   rgw_ldap.cc
@@ -320,7 +321,7 @@ target_link_libraries(rgw_common
     ICU::uc
     OATH::OATH
     dmclock::dmclock
-    ${CURL_LIBRARIES}
+    rgw_curl
     ${EXPAT_LIBRARIES}
     ${ARROW_LIBRARIES}
     ${ARROW_FLIGHT_LIBRARIES}

--- a/src/rgw/curl/CMakeLists.txt
+++ b/src/rgw/curl/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(rgw_curl STATIC client.cc)
+target_link_libraries(rgw_curl PUBLIC ${CURL_LIBRARIES})
+target_include_directories(rgw_curl PUBLIC ..)
+#target_compile_definitions(rgw_curl PUBLIC BOOST_ASIO_ENABLE_HANDLER_TRACKING)

--- a/src/rgw/curl/async_perform.h
+++ b/src/rgw/curl/async_perform.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <concepts>
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/compose.hpp>
+#include <boost/asio/execution_context.hpp>
+#include <boost/asio/execution/executor.hpp>
+#include <boost/system/error_code.hpp>
+
+#include "shared_client.h"
+
+namespace rgw::curl {
+
+/// \brief Perform an asynchronous http request with libcurl.
+///
+/// Send the http request asynchronously, as if by curl_easy_perform(), and
+/// invoke the handler on completion. The caller must keep the easy handle
+/// alive in the meantime.
+///
+/// The operation can be canceled by binding a cancellation slot to the
+/// given CompletionToken.
+///
+/// This function uses a shared Client instance associated with the given
+/// execution context. This Client is wrapped by a strand executor, making it
+/// safe to call async_perform() from any thread.
+template <boost::asio::execution::executor Executor,
+          boost::asio::completion_token_for<void(error_code)> CompletionToken>
+auto async_perform(const Executor& ex, void* easy, CompletionToken&& token);
+
+/// \overload
+template <typename ExecutionContext,
+          boost::asio::completion_token_for<void(error_code)> CompletionToken>
+    requires std::convertible_to<ExecutionContext&, boost::asio::execution_context&>
+auto async_perform(ExecutionContext& ctx, void* easy, CompletionToken&& token)
+{
+  return async_perform(ctx.get_executor(), easy,
+                       std::forward<CompletionToken>(token));
+}
+
+namespace detail {
+
+struct async_perform_impl {
+  void* easy = nullptr;
+  Client& client;
+  enum class State {
+    dispatch,
+    perform,
+    complete
+  } state = State::dispatch;
+
+  void operator()(auto& self, error_code ec = {})
+  {
+    BOOST_ASIO_HANDLER_LOCATION((__FILE__, __LINE__, "async_perform_impl"));
+
+    // handle cancellation at any state
+    if (self.cancelled() != boost::asio::cancellation_type::none) {
+      self.complete(boost::asio::error::operation_aborted);
+      return;
+    }
+
+    switch (state) {
+      case State::dispatch:
+        state = State::perform;
+        // switch to the client's strand executor before calling async_perform()
+        boost::asio::dispatch(client.get_executor(), std::move(self));
+        break;
+
+      case State::perform:
+        state = State::complete;
+        client.async_perform(easy, std::move(self));
+        break;
+
+      case State::complete:
+        self.complete(ec);
+        break;
+    }
+  }
+};
+
+} // namespace detail
+
+template <boost::asio::execution::executor Executor,
+          boost::asio::completion_token_for<void(error_code)> CompletionToken>
+auto async_perform(const Executor& ex, void* easy, CompletionToken&& token)
+{
+  return boost::asio::async_compose<CompletionToken, void(error_code)>(
+      detail::async_perform_impl{easy, detail::get_shared_client(ex)},
+      token, ex);
+}
+
+} // namespace rgw::curl

--- a/src/rgw/curl/client.cc
+++ b/src/rgw/curl/client.cc
@@ -1,0 +1,483 @@
+#include "client.h"
+
+#include <string>
+#include <unordered_map>
+#include <variant>
+
+#include <boost/asio/append.hpp>
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/ip/udp.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+#include <boost/system/system_error.hpp>
+
+#include <curl/curl.h>
+
+#include "common/async/service.h"
+
+#if !CURL_AT_LEAST_VERSION(7, 17, 1)
+#error "requires libcurl >= 7.17.1 for CURLOPT_OPENSOCKETFUNCTION"
+#endif
+
+namespace rgw::curl {
+
+boost::system::error_category& easy_category()
+{
+  static struct category : boost::system::error_category {
+    virtual ~category() {}
+    const char* name() const noexcept override { return "curl easy"; }
+    std::string message(int code) const override {
+      return ::curl_easy_strerror(static_cast<CURLcode>(code));
+    }
+  } instance;
+  return instance;
+}
+
+boost::system::error_category& multi_category()
+{
+  static struct category : boost::system::error_category {
+    virtual ~category() {}
+    const char* name() const noexcept override { return "curl multi"; }
+    std::string message(int code) const override {
+      return ::curl_multi_strerror(static_cast<CURLMcode>(code));
+    }
+  } instance;
+  return instance;
+}
+
+
+void easy_deleter::operator()(CURL* p) { ::curl_easy_cleanup(p); }
+
+easy_ptr easy_init(error_code& ec)
+{
+  auto easy = easy_ptr{::curl_easy_init()};
+  if (!easy) {
+    ec.assign(CURLE_OUT_OF_MEMORY, easy_category());
+  }
+  return easy;
+}
+
+easy_ptr easy_init()
+{
+  error_code ec;
+  auto easy = easy_init(ec);
+  if (ec) {
+    throw boost::system::system_error(ec, "curl_easy_init");
+  }
+  return easy;
+}
+
+template <typename T>
+void easy_setopt(CURL* easy, CURLoption option, T&& value, error_code& ec)
+{
+  CURLcode code = ::curl_easy_setopt(easy, option, std::forward<T>(value));
+  if (code != CURLE_OK) {
+    ec.assign(code, easy_category());
+  }
+}
+
+template <typename T>
+void easy_setopt(CURL* easy, CURLoption option, T&& value)
+{
+  error_code ec;
+  easy_setopt(easy, option, std::forward<T>(value), ec);
+  if (ec) {
+    throw boost::system::system_error(ec, "curl_easy_setopt");
+  }
+}
+
+
+void multi_deleter::operator()(CURLM* p) { ::curl_multi_cleanup(p); }
+
+multi_ptr multi_init(error_code& ec)
+{
+  auto multi = multi_ptr{::curl_multi_init()};
+  if (!multi) {
+    ec.assign(CURLE_OUT_OF_MEMORY, multi_category());
+  }
+  return multi;
+}
+
+multi_ptr multi_init()
+{
+  error_code ec;
+  auto multi = multi_init(ec);
+  if (ec) {
+    throw boost::system::system_error(ec, "curl_multi_init");
+  }
+  return multi;
+}
+
+template <typename T>
+void multi_setopt(CURLM* multi, CURLMoption option, T&& value, error_code& ec)
+{
+  CURLMcode mcode = ::curl_multi_setopt(multi, option, std::forward<T>(value));
+  if (mcode != CURLM_OK) {
+    ec.assign(mcode, multi_category());
+  }
+}
+
+template <typename T>
+void multi_setopt(CURLM* multi, CURLMoption option, T&& value)
+{
+  error_code ec;
+  multi_setopt(multi, option, std::forward<T>(value), ec);
+  if (ec) {
+    throw boost::system::system_error(ec, "curl_multi_setopt");
+  }
+}
+
+
+void slist_deleter::operator()(curl_slist* p) { ::curl_slist_free_all(p); }
+
+void slist_append(slist_ptr& p, const char* str, error_code& ec)
+{
+  if (curl_slist* tmp = ::curl_slist_append(p.get(), str); tmp) {
+    (void) p.release(); // will be freed by curl_slist_free_all(tmp)
+    p.reset(tmp);
+  } else {
+    ec.assign(CURLE_OUT_OF_MEMORY, easy_category());
+  }
+}
+
+void slist_append(slist_ptr& p, const char* str)
+{
+  error_code ec;
+  slist_append(p, str, ec);
+  if (ec) {
+    throw boost::system::system_error(ec, "curl_slist_append");
+  }
+}
+
+
+// libcurl callback functions
+static curl_socket_t opensocket_callback(void* user, curlsocktype purpose,
+                                         curl_sockaddr* address);
+static int closesocket_callback(void* user, curl_socket_t fd);
+static int socket_callback(CURL* easy, curl_socket_t fd, int what,
+                           void* user, void* socket);
+static int timer_callback(CURLM* multi, long timeout_ms, void* user);
+
+
+namespace ip = boost::asio::ip;
+
+// This implementation uses the 'multi_socket' flavor of the libcurl multi API:
+// https://curl.se/libcurl/c/libcurl-multi.html
+//
+// By providing our own CURLMOPT_TIMERFUNCTION AND CURLMOPT_SOCKETFUNCTION, we
+// can do all necessary polling and waiting on the given asio executor. As we
+// get wakeups from asio, we call curl_multi_socket_action() to do its
+// non-blocking socket i/o from within that executor.
+//
+// This also overrides CURLOPT_OPENSOCKETFUNCTION on each request to manage the
+// pool of asio sockets.
+class Client::Impl :
+    public boost::intrusive_ref_counter<Impl, boost::thread_unsafe_counter>,
+    public ceph::async::service_list_base_hook
+{
+ public:
+  explicit Impl(executor_type ex)
+    : svc(boost::asio::use_service<ceph::async::service<Impl>>(
+          boost::asio::query(ex, boost::asio::execution::context))),
+      ex(ex),
+      timer(ex),
+      multi(multi_init())
+  {
+    multi_setopt(multi.get(), CURLMOPT_TIMERFUNCTION, timer_callback);
+    multi_setopt(multi.get(), CURLMOPT_TIMERDATA, this);
+    multi_setopt(multi.get(), CURLMOPT_SOCKETFUNCTION, socket_callback);
+    multi_setopt(multi.get(), CURLMOPT_SOCKETDATA, this);
+
+    // register for service_shutdown() notifications
+    svc.add(*this);
+  }
+  ~Impl()
+  {
+    svc.remove(*this);
+  }
+
+  executor_type get_executor() const noexcept { return ex; }
+
+  void async_perform_impl(handler_type handler, CURL* easy)
+  {
+    // configure the easy handle and add it to the multi handle
+    error_code ec;
+    add_handle(easy, ec);
+    if (ec) {
+      boost::asio::post(boost::asio::bind_executor(get_executor(),
+          boost::asio::append(std::move(handler), ec)));
+      return;
+    }
+
+    // arrange for per-op cancellation
+    auto slot = boost::asio::get_associated_cancellation_slot(handler);
+    if (slot.is_connected()) {
+      slot.template emplace<op_cancellation>(this, easy);
+    }
+
+    // register the completion handler
+    handlers.emplace(easy, std::move(handler));
+
+    // kick things off if they haven't started yet
+    socket_action(CURL_SOCKET_TIMEOUT, 0);
+  }
+
+  void cancel(error_code ec)
+  {
+    auto h = handlers.begin();
+    while (h != handlers.end()) {
+      auto handler = std::move(h->second);
+      ::curl_multi_remove_handle(multi.get(), h->first);
+      h = handlers.erase(h);
+      boost::asio::dispatch(boost::asio::append(std::move(handler), ec));
+    }
+    timer.cancel();
+  }
+
+  void service_shutdown()
+  {
+    auto h = handlers.begin();
+    while (h != handlers.end()) {
+      auto handler = std::move(h->second);
+      ::curl_multi_remove_handle(multi.get(), h->first);
+      h = handlers.erase(h);
+    }
+  }
+
+ private:
+  ceph::async::service<Impl>& svc;
+  executor_type ex;
+  boost::asio::steady_timer timer;
+
+  using client_socket = std::variant<ip::tcp::socket, ip::udp::socket>;
+  using client_socket_map = std::unordered_map<curl_socket_t, client_socket>;
+  client_socket_map sockets;
+
+  using handler_map = std::unordered_map<CURL*, handler_type>;
+  handler_map handlers;
+
+  multi_ptr multi;
+
+  // handler for per-op cancellation
+  struct op_cancellation {
+    Impl* impl;
+    CURL* easy;
+
+    op_cancellation(Impl* impl, CURL* easy)
+      : impl(impl), easy(easy) {}
+
+    void operator()(boost::asio::cancellation_type_t type) {
+      if (type == boost::asio::cancellation_type::none) {
+        return;
+      }
+      auto h = impl->handlers.find(easy);
+      if (h == impl->handlers.end()) {
+        return;
+      }
+      auto ec = make_error_code(boost::asio::error::operation_aborted);
+      auto handler = std::move(h->second);
+      ::curl_multi_remove_handle(impl->multi.get(), easy);
+      impl->handlers.erase(h);
+      boost::asio::dispatch(boost::asio::append(std::move(handler), ec));
+    }
+  };
+
+  void add_handle(CURL* easy, error_code& ec)
+  {
+    // attach socket callbacks to the easy handle
+    easy_setopt(easy, CURLOPT_OPENSOCKETFUNCTION, opensocket_callback, ec);
+    if (ec) {
+      return;
+    }
+    easy_setopt(easy, CURLOPT_OPENSOCKETDATA, this, ec);
+    if (ec) {
+      return;
+    }
+    easy_setopt(easy, CURLOPT_CLOSESOCKETFUNCTION, closesocket_callback, ec);
+    if (ec) {
+      return;
+    }
+    easy_setopt(easy, CURLOPT_CLOSESOCKETDATA, this, ec);
+    if (ec) {
+      return;
+    }
+
+    // register the easy handle with the multi handle
+    CURLMcode mcode = ::curl_multi_add_handle(multi.get(), easy);
+    if (mcode != CURLM_OK) {
+      ec.assign(mcode, multi_category());
+      return;
+    }
+  }
+
+  void socket_action(curl_socket_t fd, int events)
+  {
+    // process the socket action as many times as necessary
+    CURLMcode mcode = CURLM_OK;
+    int count = 0;
+    do {
+      mcode = ::curl_multi_socket_action(multi.get(), fd, events, &count);
+    } while (mcode == CURLM_CALL_MULTI_PERFORM);
+
+    if (mcode != CURLM_OK) {
+      // on error, all transfers must be aborted
+      cancel(error_code{mcode, multi_category()});
+      return;
+    }
+
+    // handle any completions
+    while (CURLMsg* msg = ::curl_multi_info_read(multi.get(), &count)) {
+      if (msg->msg == CURLMSG_DONE) {
+        error_code ec;
+        if (msg->data.result != CURLE_OK) {
+          ec.assign(msg->data.result, easy_category());
+        }
+        auto h = handlers.find(msg->easy_handle);
+        if (h != handlers.end()) {
+          auto handler = std::move(h->second);
+          ::curl_multi_remove_handle(multi.get(), h->first);
+          handlers.erase(h);
+          boost::asio::dispatch(boost::asio::append(std::move(handler), ec));
+        }
+      }
+    }
+  }
+
+  // construct and open a tcp or udp socket
+  template <typename Protocol>
+  curl_socket_t open_socket(const Protocol& proto)
+  {
+    auto socket = typename Protocol::socket{get_executor()};
+    error_code ec;
+    socket.open(proto, ec);
+    if (ec) {
+      return CURL_SOCKET_BAD;
+    }
+    curl_socket_t fd = socket.native_handle();
+    sockets.emplace(std::piecewise_construct, std::forward_as_tuple(fd),
+                    std::forward_as_tuple(std::move(socket)));
+    return fd;
+  }
+
+  friend curl_socket_t opensocket_callback(void* user, curlsocktype purpose,
+                                           curl_sockaddr* address)
+  {
+    auto impl = static_cast<Impl*>(user);
+
+    if (address->socktype == SOCK_STREAM) {
+      auto proto = address->family == AF_INET ? ip::tcp::v4() : ip::tcp::v6();
+      return impl->open_socket(proto);
+    }
+    if (address->socktype == SOCK_DGRAM) {
+      auto proto = address->family == AF_INET ? ip::udp::v4() : ip::udp::v6();
+      return impl->open_socket(proto);
+    }
+    return CURL_SOCKET_BAD;
+  }
+
+  friend int closesocket_callback(void* user, curl_socket_t fd)
+  {
+    auto impl = static_cast<Impl*>(user);
+
+    impl->sockets.erase(fd);
+    return 0;
+  }
+
+  struct socket_wait_handler {
+    boost::intrusive_ptr<Impl> impl;
+    curl_socket_t fd;
+    int mask;
+
+    socket_wait_handler(boost::intrusive_ptr<Impl> impl,
+                        curl_socket_t fd, int mask)
+      : impl(std::move(impl)), fd(fd), mask(mask) {}
+
+    // callback for async_wait()
+    void operator()(error_code ec)
+    {
+      if (ec) {
+        mask |= CURL_CSELECT_ERR;
+      }
+      impl->socket_action(fd, mask);
+    }
+
+    // variant visitor for udp/tcp sockets
+    void operator()(auto& socket)
+    {
+      auto wait_flag = (mask == CURL_CSELECT_IN)
+          ? socket.wait_read : socket.wait_write;
+      socket.async_wait(wait_flag, std::move(*this));
+    }
+  };
+
+  friend int socket_callback(CURL* easy, curl_socket_t fd, int what,
+                             void* user, void* socket)
+  {
+    auto impl = static_cast<Impl*>(user);
+
+    if (what == CURL_POLL_REMOVE) {
+      return 0;
+    }
+
+    auto i = impl->sockets.find(fd);
+    if (i == impl->sockets.end()) {
+      return -1;
+    }
+
+    if (what & CURL_POLL_IN) {
+      std::visit(socket_wait_handler{impl, fd, CURL_CSELECT_IN}, i->second);
+    }
+    if (what & CURL_POLL_OUT) {
+      std::visit(socket_wait_handler{impl, fd, CURL_CSELECT_OUT}, i->second);
+    }
+    return 0;
+  }
+
+  friend int timer_callback(CURLM* multi, long timeout_ms, void* user)
+  {
+    boost::intrusive_ptr impl = static_cast<Impl*>(user);
+    if (timeout_ms == -1) {
+      impl->timer.cancel();
+      return 0;
+    }
+    impl->timer.expires_after(std::chrono::milliseconds(timeout_ms));
+    impl->timer.async_wait([impl] (error_code ec) {
+          if (!ec) {
+            impl->socket_action(CURL_SOCKET_TIMEOUT, 0);
+          }
+        });
+    return 0;
+  }
+};
+
+
+Client::Client(executor_type ex)
+  : impl(new Impl(ex))
+{
+}
+
+Client::~Client()
+{
+  cancel();
+}
+
+auto Client::get_executor() const noexcept -> executor_type
+{
+  return impl->get_executor();
+}
+
+void Client::async_perform_impl(handler_type handler, CURL* easy)
+{
+  impl->async_perform_impl(std::move(handler), easy);
+}
+
+void Client::cancel()
+{
+  impl->cancel(boost::asio::error::operation_aborted);
+}
+
+} // namespace rgw::curl

--- a/src/rgw/curl/client.cc
+++ b/src/rgw/curl/client.cc
@@ -7,8 +7,8 @@
 #include <boost/asio/append.hpp>
 #include <boost/asio/bind_executor.hpp>
 #include <boost/asio/dispatch.hpp>
-#include <boost/asio/ip/tcp.hpp>
-#include <boost/asio/ip/udp.hpp>
+#include <boost/asio/generic/datagram_protocol.hpp>
+#include <boost/asio/generic/stream_protocol.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/intrusive_ptr.hpp>
@@ -163,8 +163,6 @@ static int socket_callback(CURL* easy, curl_socket_t fd, int what,
 static int timer_callback(CURLM* multi, long timeout_ms, void* user);
 
 
-namespace ip = boost::asio::ip;
-
 // This implementation uses the 'multi_socket' flavor of the libcurl multi API:
 // https://curl.se/libcurl/c/libcurl-multi.html
 //
@@ -253,7 +251,10 @@ class Client::Impl :
   executor_type ex;
   boost::asio::steady_timer timer;
 
-  using client_socket = std::variant<ip::tcp::socket, ip::udp::socket>;
+  // holds either a tcp or udp socket
+  using client_socket = std::variant<
+      boost::asio::generic::stream_protocol::socket,
+      boost::asio::generic::datagram_protocol::socket>;
   using client_socket_map = std::unordered_map<curl_socket_t, client_socket>;
   client_socket_map sockets;
 
@@ -369,12 +370,14 @@ class Client::Impl :
     auto impl = static_cast<Impl*>(user);
 
     if (address->socktype == SOCK_STREAM) {
-      auto proto = address->family == AF_INET ? ip::tcp::v4() : ip::tcp::v6();
-      return impl->open_socket(proto);
+      using protocol_type = boost::asio::generic::stream_protocol;
+      return impl->open_socket(protocol_type{address->family,
+                                             address->protocol});
     }
     if (address->socktype == SOCK_DGRAM) {
-      auto proto = address->family == AF_INET ? ip::udp::v4() : ip::udp::v6();
-      return impl->open_socket(proto);
+      using protocol_type = boost::asio::generic::datagram_protocol;
+      return impl->open_socket(protocol_type{address->family,
+                                             address->protocol});
     }
     return CURL_SOCKET_BAD;
   }

--- a/src/rgw/curl/client.cc
+++ b/src/rgw/curl/client.cc
@@ -10,6 +10,7 @@
 #include <boost/asio/generic/datagram_protocol.hpp>
 #include <boost/asio/generic/stream_protocol.hpp>
 #include <boost/asio/post.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
@@ -258,6 +259,9 @@ class Client::Impl :
   using client_socket_map = std::unordered_map<curl_socket_t, client_socket>;
   client_socket_map sockets;
 
+  // libcurl-internal fds we wait on but never close
+  std::unordered_map<curl_socket_t, boost::asio::posix::stream_descriptor> ext_sockets;
+
   using handler_map = std::unordered_map<CURL*, handler_type>;
   handler_map handlers;
 
@@ -348,6 +352,36 @@ class Client::Impl :
     }
   }
 
+  int ext_socket_action(curl_socket_t fd, int what)
+  {
+    if (what == CURL_POLL_REMOVE) {
+      if (auto e = ext_sockets.find(fd); e != ext_sockets.end()) {
+        e->second.release();   // libcurl owns this fd; don't close it
+        ext_sockets.erase(e);
+      }
+      return 0;
+    }
+    auto e = ext_sockets.find(fd);
+    if (e == ext_sockets.end()) {
+      boost::system::error_code ec;
+      boost::asio::posix::stream_descriptor desc{get_executor()};
+      desc.assign(fd, ec);
+      if (ec) {
+        return -1;
+      }
+      e = ext_sockets.emplace(fd, std::move(desc)).first;
+    }
+    if (what & CURL_POLL_IN) {
+      e->second.async_wait(boost::asio::posix::stream_descriptor::wait_read,
+                           socket_wait_handler{this, fd, CURL_CSELECT_IN});
+    }
+    if (what & CURL_POLL_OUT) {
+      e->second.async_wait(boost::asio::posix::stream_descriptor::wait_write,
+                           socket_wait_handler{this, fd, CURL_CSELECT_OUT});
+    }
+    return 0;
+  }
+
   // construct and open a tcp or udp socket
   template <typename Protocol>
   curl_socket_t open_socket(const Protocol& proto)
@@ -369,12 +403,21 @@ class Client::Impl :
   {
     auto impl = static_cast<Impl*>(user);
 
-    if (address->socktype == SOCK_STREAM) {
+    // libcurl may OR SOCK_CLOEXEC/SOCK_NONBLOCK into socktype
+    int socktype = address->socktype;
+#ifdef SOCK_CLOEXEC
+    socktype &= ~SOCK_CLOEXEC;
+#endif
+#ifdef SOCK_NONBLOCK
+    socktype &= ~SOCK_NONBLOCK;
+#endif
+
+    if (socktype == SOCK_STREAM) {
       using protocol_type = boost::asio::generic::stream_protocol;
       return impl->open_socket(protocol_type{address->family,
                                              address->protocol});
     }
-    if (address->socktype == SOCK_DGRAM) {
+    if (socktype == SOCK_DGRAM) {
       using protocol_type = boost::asio::generic::datagram_protocol;
       return impl->open_socket(protocol_type{address->family,
                                              address->protocol});
@@ -422,13 +465,13 @@ class Client::Impl :
   {
     auto impl = static_cast<Impl*>(user);
 
-    if (what == CURL_POLL_REMOVE) {
-      return 0;
-    }
-
     auto i = impl->sockets.find(fd);
     if (i == impl->sockets.end()) {
-      return -1;
+      // libcurl opened this fd itself (e.g. resolver socketpair); wait, don't own
+      return impl->ext_socket_action(fd, what);
+    }
+    if (what == CURL_POLL_REMOVE) {
+      return 0;
     }
 
     if (what & CURL_POLL_IN) {

--- a/src/rgw/curl/client.cc
+++ b/src/rgw/curl/client.cc
@@ -10,8 +10,8 @@
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/generic/datagram_protocol.hpp>
 #include <boost/asio/generic/stream_protocol.hpp>
+#include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/post.hpp>
-#include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/intrusive_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
@@ -270,14 +270,14 @@ class Client::Impl :
   boost::asio::steady_timer timer;
 
   // holds either a tcp or udp socket
-  using client_socket = std::variant<
-      boost::asio::generic::stream_protocol::socket,
-      boost::asio::generic::datagram_protocol::socket>;
+  using stream_socket = boost::asio::generic::stream_protocol::socket;
+  using datagram_socket = boost::asio::generic::datagram_protocol::socket;
+  using client_socket = std::variant<stream_socket, datagram_socket>;
   using client_socket_map = std::unordered_map<curl_socket_t, client_socket>;
   client_socket_map sockets;
 
   // libcurl-internal fds we wait on but never close
-  std::unordered_map<curl_socket_t, boost::asio::posix::stream_descriptor> ext_sockets;
+  std::unordered_map<curl_socket_t, stream_socket> ext_sockets;
 
   using handler_map = std::unordered_map<CURL*, handler_type>;
   handler_map handlers;
@@ -482,12 +482,12 @@ class Client::Impl :
 
     if (i == impl->ext_sockets.end()) {
       boost::system::error_code ec;
-      boost::asio::posix::stream_descriptor desc{impl->get_executor()};
-      desc.assign(fd, ec);
+      auto socket = stream_socket{impl->get_executor()};
+      socket.assign(boost::asio::ip::tcp::v4(), fd, ec);
       if (ec) {
         return -1;
       }
-      i = impl->ext_sockets.emplace(fd, std::move(desc)).first;
+      i = impl->ext_sockets.emplace(fd, std::move(socket)).first;
     }
     if (what & CURL_POLL_IN) {
       std::invoke(socket_wait_handler{impl, fd, CURL_CSELECT_IN}, i->second);

--- a/src/rgw/curl/client.cc
+++ b/src/rgw/curl/client.cc
@@ -20,7 +20,6 @@
 #include <curl/curl.h>
 
 #include "common/async/service.h"
-#include "common/dout.h"
 
 #if !CURL_AT_LEAST_VERSION(7, 17, 1)
 #error "requires libcurl >= 7.17.1 for CURLOPT_OPENSOCKETFUNCTION"
@@ -165,21 +164,6 @@ static int socket_callback(CURL* easy, curl_socket_t fd, int what,
                            void* user, void* socket);
 static int timer_callback(CURLM* multi, long timeout_ms, void* user);
 
-// route libcurl's own connection trace into the rgw log
-static int debug_callback(CURL*, curl_infotype type, char* data,
-                          size_t size, void*)
-{
-  if (type == CURLINFO_TEXT) {
-    size_t len = size;
-    while (len > 0 && (data[len-1] == '\n' || data[len-1] == '\r')) {
-      --len;
-    }
-    lsubdout(g_ceph_context, rgw, 20) << "curl: "
-        << std::string_view{data, len} << dendl;
-  }
-  return 0;
-}
-
 
 // This implementation uses the 'multi_socket' flavor of the libcurl multi API:
 // https://curl.se/libcurl/c/libcurl-multi.html
@@ -310,19 +294,6 @@ class Client::Impl :
 
   void add_handle(CURL* easy, error_code& ec)
   {
-    // capture libcurl's connection trace when rgw logging is verbose
-    if (g_ceph_context &&
-        g_ceph_context->_conf->subsys.should_gather<ceph_subsys_rgw, 20>()) {
-      easy_setopt(easy, CURLOPT_VERBOSE, 1L, ec);
-      if (ec) {
-        return;
-      }
-      easy_setopt(easy, CURLOPT_DEBUGFUNCTION, debug_callback, ec);
-      if (ec) {
-        return;
-      }
-    }
-
     // attach socket callbacks to the easy handle
     easy_setopt(easy, CURLOPT_OPENSOCKETFUNCTION, opensocket_callback, ec);
     if (ec) {

--- a/src/rgw/curl/client.cc
+++ b/src/rgw/curl/client.cc
@@ -382,36 +382,6 @@ class Client::Impl :
     }
   }
 
-  int ext_socket_action(curl_socket_t fd, int what)
-  {
-    if (what == CURL_POLL_REMOVE) {
-      if (auto e = ext_sockets.find(fd); e != ext_sockets.end()) {
-        e->second.release();   // libcurl owns this fd; don't close it
-        ext_sockets.erase(e);
-      }
-      return 0;
-    }
-    auto e = ext_sockets.find(fd);
-    if (e == ext_sockets.end()) {
-      boost::system::error_code ec;
-      boost::asio::posix::stream_descriptor desc{get_executor()};
-      desc.assign(fd, ec);
-      if (ec) {
-        return -1;
-      }
-      e = ext_sockets.emplace(fd, std::move(desc)).first;
-    }
-    if (what & CURL_POLL_IN) {
-      e->second.async_wait(boost::asio::posix::stream_descriptor::wait_read,
-                           socket_wait_handler{this, fd, CURL_CSELECT_IN});
-    }
-    if (what & CURL_POLL_OUT) {
-      e->second.async_wait(boost::asio::posix::stream_descriptor::wait_write,
-                           socket_wait_handler{this, fd, CURL_CSELECT_OUT});
-    }
-    return 0;
-  }
-
   // construct and open a tcp or udp socket
   template <typename Protocol>
   curl_socket_t open_socket(const Protocol& proto)
@@ -487,20 +457,43 @@ class Client::Impl :
   {
     auto impl = static_cast<Impl*>(user);
 
-    auto i = impl->sockets.find(fd);
-    if (i == impl->sockets.end()) {
-      // libcurl opened this fd itself (e.g. resolver socketpair); wait, don't own
-      return impl->ext_socket_action(fd, what);
-    }
-    if (what == CURL_POLL_REMOVE) {
+    // callback on client-managed socket
+    if (auto i = impl->sockets.find(fd); i != impl->sockets.end()) {
+      if (what & CURL_POLL_IN) {
+        std::visit(socket_wait_handler{impl, fd, CURL_CSELECT_IN}, i->second);
+      }
+      if (what & CURL_POLL_OUT) {
+        std::visit(socket_wait_handler{impl, fd, CURL_CSELECT_OUT}, i->second);
+      }
       return 0;
     }
 
+    // callback on curl-managed socket
+    auto i = impl->ext_sockets.find(fd);
+
+    if (what == CURL_POLL_REMOVE) {
+      if (i == impl->ext_sockets.end()) {
+        return -1;
+      }
+      i->second.release(); // libcurl owns this fd; don't close it
+      impl->ext_sockets.erase(i);
+      return 0;
+    }
+
+    if (i == impl->ext_sockets.end()) {
+      boost::system::error_code ec;
+      boost::asio::posix::stream_descriptor desc{impl->get_executor()};
+      desc.assign(fd, ec);
+      if (ec) {
+        return -1;
+      }
+      i = impl->ext_sockets.emplace(fd, std::move(desc)).first;
+    }
     if (what & CURL_POLL_IN) {
-      std::visit(socket_wait_handler{impl, fd, CURL_CSELECT_IN}, i->second);
+      std::invoke(socket_wait_handler{impl, fd, CURL_CSELECT_IN}, i->second);
     }
     if (what & CURL_POLL_OUT) {
-      std::visit(socket_wait_handler{impl, fd, CURL_CSELECT_OUT}, i->second);
+      std::invoke(socket_wait_handler{impl, fd, CURL_CSELECT_OUT}, i->second);
     }
     return 0;
   }

--- a/src/rgw/curl/client.cc
+++ b/src/rgw/curl/client.cc
@@ -434,20 +434,12 @@ class Client::Impl :
     auto impl = static_cast<Impl*>(user);
 
     // libcurl may OR SOCK_CLOEXEC/SOCK_NONBLOCK into socktype
-    int socktype = address->socktype;
-#ifdef SOCK_CLOEXEC
-    socktype &= ~SOCK_CLOEXEC;
-#endif
-#ifdef SOCK_NONBLOCK
-    socktype &= ~SOCK_NONBLOCK;
-#endif
-
-    if (socktype == SOCK_STREAM) {
+    if (address->socktype & SOCK_STREAM) {
       using protocol_type = boost::asio::generic::stream_protocol;
       return impl->open_socket(protocol_type{address->family,
                                              address->protocol});
     }
-    if (socktype == SOCK_DGRAM) {
+    if (address->socktype & SOCK_DGRAM) {
       using protocol_type = boost::asio::generic::datagram_protocol;
       return impl->open_socket(protocol_type{address->family,
                                              address->protocol});

--- a/src/rgw/curl/client.cc
+++ b/src/rgw/curl/client.cc
@@ -1,6 +1,7 @@
 #include "client.h"
 
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <variant>
 
@@ -19,6 +20,7 @@
 #include <curl/curl.h>
 
 #include "common/async/service.h"
+#include "common/dout.h"
 
 #if !CURL_AT_LEAST_VERSION(7, 17, 1)
 #error "requires libcurl >= 7.17.1 for CURLOPT_OPENSOCKETFUNCTION"
@@ -163,6 +165,21 @@ static int socket_callback(CURL* easy, curl_socket_t fd, int what,
                            void* user, void* socket);
 static int timer_callback(CURLM* multi, long timeout_ms, void* user);
 
+// route libcurl's own connection trace into the rgw log
+static int debug_callback(CURL*, curl_infotype type, char* data,
+                          size_t size, void*)
+{
+  if (type == CURLINFO_TEXT) {
+    size_t len = size;
+    while (len > 0 && (data[len-1] == '\n' || data[len-1] == '\r')) {
+      --len;
+    }
+    lsubdout(g_ceph_context, rgw, 20) << "curl: "
+        << std::string_view{data, len} << dendl;
+  }
+  return 0;
+}
+
 
 // This implementation uses the 'multi_socket' flavor of the libcurl multi API:
 // https://curl.se/libcurl/c/libcurl-multi.html
@@ -293,6 +310,19 @@ class Client::Impl :
 
   void add_handle(CURL* easy, error_code& ec)
   {
+    // capture libcurl's connection trace when rgw logging is verbose
+    if (g_ceph_context &&
+        g_ceph_context->_conf->subsys.should_gather<ceph_subsys_rgw, 20>()) {
+      easy_setopt(easy, CURLOPT_VERBOSE, 1L, ec);
+      if (ec) {
+        return;
+      }
+      easy_setopt(easy, CURLOPT_DEBUGFUNCTION, debug_callback, ec);
+      if (ec) {
+        return;
+      }
+    }
+
     // attach socket callbacks to the easy handle
     easy_setopt(easy, CURLOPT_OPENSOCKETFUNCTION, opensocket_callback, ec);
     if (ec) {

--- a/src/rgw/curl/client.h
+++ b/src/rgw/curl/client.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <boost/asio/any_completion_handler.hpp>
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/system/error_category.hpp>
+#include <boost/system/error_code.hpp>
+
+struct curl_slist;
+
+namespace rgw::curl {
+
+using error_code = boost::system::error_code;
+
+/// Error category corresponding to CURLcode.
+boost::system::error_category& easy_category();
+
+/// Error category corresponding to CURLMcode.
+boost::system::error_category& multi_category();
+
+
+struct easy_deleter { void operator()(void* p); };
+/// A unique_ptr wrapper for CURL easy handles.
+using easy_ptr = std::unique_ptr<void, easy_deleter>;
+
+/// Create an easy handle with curl_easy_init(). May fail with
+/// CURLE_OUT_OF_MEMORY.
+easy_ptr easy_init(error_code& ec);
+/// \overload
+easy_ptr easy_init(); // throws on error
+
+
+struct multi_deleter { void operator()(void* p); };
+/// A unique_ptr wrapper for CURLM multi handles.
+using multi_ptr = std::unique_ptr<void, multi_deleter>;
+
+/// Create a multi handle with curl_multi_init(). May fail with
+/// CURLE_OUT_OF_MEMORY.
+multi_ptr multi_init(error_code& ec);
+/// \overload
+multi_ptr multi_init(); // throws on error
+
+
+struct slist_deleter { void operator()(curl_slist* p); };
+/// A unique_ptr wrapper for curl string lists.
+using slist_ptr = std::unique_ptr<curl_slist, slist_deleter>;
+
+/// Allocate a new slist entry to hold a copy of the given string and update
+/// the slist_ptr to point at the new head. May fail with CURLE_OUT_OF_MEMORY.
+void slist_append(slist_ptr& p, const char* str, error_code& ec);
+/// \overload
+void slist_append(slist_ptr& p, const char* str); // throws on error
+
+
+/// \brief Asynchronous libcurl HTTP client.
+///
+/// An asynchronous multiplexing libcurl client that runs exclusively on the
+/// given asio io executor. Each instance of Client manages its own curl multi
+/// handle and connection pool.
+///
+/// This class is not thread-safe, so a strand executor should be used in
+/// multi-threaded contexts, and all member functions must be called within
+/// that strand.
+class Client {
+ public:
+  using executor_type = boost::asio::any_io_executor;
+
+  /// Create and configure a curl multi handle.
+  explicit Client(executor_type ex);
+
+  /// Cancel any pending requests and close the curl handles.
+  ~Client();
+
+  /// Return the io executor.
+  executor_type get_executor() const noexcept;
+
+  /// \brief Perform an asynchronous http request with libcurl.
+  ///
+  /// Send the http request asynchronously, as if by curl_easy_perform(), and
+  /// invoke the handler on completion. The caller must keep the easy handle
+  /// alive in the meantime.
+  ///
+  /// The operation can be canceled by binding a cancellation slot to the
+  /// given CompletionToken.
+  template <boost::asio::completion_token_for<void(error_code)> CompletionToken>
+  auto async_perform(void* easy, CompletionToken&& token)
+  {
+    return boost::asio::async_initiate<CompletionToken, void(error_code)>(
+        [this, easy] (handler_type handler) {
+          async_perform_impl(std::move(handler), easy);
+        }, token);
+  }
+
+  /// Cancel all pending requests with boost::asio::error::operation_aborted.
+  void cancel();
+
+ private:
+  class Impl;
+  boost::intrusive_ptr<Impl> impl;
+
+  using handler_type = boost::asio::any_completion_handler<void(error_code)>;
+  void async_perform_impl(handler_type handler, void* easy);
+};
+
+} // namespace rgw::curl

--- a/src/rgw/curl/shared_client.h
+++ b/src/rgw/curl/shared_client.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "client.h"
+
+#include <mutex>
+#include <optional>
+
+#include <boost/asio/execution/context.hpp>
+#include <boost/asio/query.hpp>
+#include <boost/asio/strand.hpp>
+
+namespace rgw::curl::detail {
+
+// a service that owns the shared Client instance over the lifetime of its
+// execution context
+class shared_client_service : public boost::asio::execution_context::service {
+  std::once_flag init_flag;
+  std::optional<Client> client;
+
+  void shutdown() override
+  {
+    client.reset();
+  }
+
+ public:
+  using key_type = service;
+  static inline boost::asio::execution_context::id id;
+
+  explicit shared_client_service(boost::asio::execution_context& ctx)
+      : boost::asio::execution_context::service(ctx) {}
+
+  Client& get_client(const boost::asio::execution::executor auto& ex)
+  {
+    std::call_once(init_flag, [this, &ex] {
+      client.emplace(boost::asio::make_strand(ex));
+    });
+    return *client;
+  }
+};
+
+// get or create a shared Client instance from the underlying execution context
+Client& get_shared_client(const boost::asio::execution::executor auto& ex)
+{
+  auto& ctx = boost::asio::query(ex, boost::asio::execution::context);
+  auto& svc = boost::asio::use_service<shared_client_service>(ctx);
+  return svc.get_client(ex);
+}
+
+} // namespace rgw::curl::detail

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -147,6 +147,11 @@ add_executable(unittest_http_manager test_http_manager.cc)
 add_ceph_unittest(unittest_http_manager)
 target_link_libraries(unittest_http_manager ${rgw_libs})
 
+# unittest_rgw_curl_client
+add_executable(unittest_rgw_curl_client test_rgw_curl_client.cc)
+add_ceph_unittest(unittest_rgw_curl_client)
+target_link_libraries(unittest_rgw_curl_client ${rgw_libs})
+
 if(WITH_RADOSGW_RADOS)
 # unittest_rgw_reshard_wait
 add_executable(unittest_rgw_reshard_wait test_rgw_reshard_wait.cc)

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -150,7 +150,7 @@ target_link_libraries(unittest_http_manager ${rgw_libs})
 # unittest_rgw_curl_client
 add_executable(unittest_rgw_curl_client test_rgw_curl_client.cc)
 add_ceph_unittest(unittest_rgw_curl_client)
-target_link_libraries(unittest_rgw_curl_client ${rgw_libs})
+target_link_libraries(unittest_rgw_curl_client rgw_curl global unit-main)
 
 if(WITH_RADOSGW_RADOS)
 # unittest_rgw_reshard_wait

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -150,7 +150,7 @@ target_link_libraries(unittest_http_manager ${rgw_libs})
 # unittest_rgw_curl_client
 add_executable(unittest_rgw_curl_client test_rgw_curl_client.cc)
 add_ceph_unittest(unittest_rgw_curl_client)
-target_link_libraries(unittest_rgw_curl_client rgw_curl global unit-main)
+target_link_libraries(unittest_rgw_curl_client rgw_curl fmt::fmt)
 
 if(WITH_RADOSGW_RADOS)
 # unittest_rgw_reshard_wait

--- a/src/test/rgw/test_rgw_curl_client.cc
+++ b/src/test/rgw/test_rgw_curl_client.cc
@@ -1,0 +1,458 @@
+#include "curl/client.h"
+#include <gtest/gtest.h>
+#include <chrono>
+#include <exception>
+#include <optional>
+#include <string>
+#include <boost/asio.hpp>
+#include <curl/curl.h>
+#include <fmt/format.h>
+
+namespace rgw::curl {
+
+namespace asio = boost::asio;
+namespace ip = asio::ip;
+
+using namespace std::chrono_literals;
+
+template <typename T>
+auto capture(std::optional<T>& opt)
+{
+  return [&opt] (T value) { opt = std::move(value); };
+}
+
+template <typename T>
+auto capture(asio::cancellation_signal& signal, std::optional<T>& opt)
+{
+  return asio::bind_cancellation_slot(signal.slot(), capture(opt));
+}
+
+void rethrow(std::exception_ptr eptr)
+{
+  if (eptr) std::rethrow_exception(eptr);
+}
+
+auto accept_connection(ip::tcp::acceptor& acceptor, size_t keepalive_count)
+    -> asio::awaitable<void>
+{
+  auto socket = co_await acceptor.async_accept(asio::use_awaitable);
+
+  for (size_t i = 0; i < keepalive_count; i++) {
+    std::string request;
+    co_await asio::async_read_until(socket, asio::dynamic_buffer(request),
+                                    "\r\n\r\n", asio::use_awaitable);
+
+    static constexpr std::string_view response =
+        "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+    co_await asio::async_write(socket, asio::buffer(response),
+                               asio::use_awaitable);
+  }
+}
+
+auto perform(Client& client, const char* url)
+    -> asio::awaitable<void>
+{
+  auto easy = easy_init();
+  ::curl_easy_setopt(easy.get(), CURLOPT_URL, url);
+
+  co_await client.async_perform(easy.get(), asio::use_awaitable);
+}
+
+TEST(Client, one)
+{
+  asio::io_context sctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{sctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(1);
+
+  std::optional<std::exception_ptr> septr;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr));
+
+  sctx.poll(); // server spawn, block on accept
+  ASSERT_FALSE(sctx.stopped());
+  EXPECT_FALSE(septr);
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  // step through the client on a separate io_context
+  asio::io_context cctx;
+  auto client = Client{cctx.get_executor()};
+
+  std::optional<std::exception_ptr> ceptr;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr));
+
+  cctx.poll(); // client spawn + write, block on wait_read
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr);
+
+  sctx.poll(); // server accept + read + write
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr);
+  EXPECT_FALSE(*septr);
+
+  cctx.poll(); // client wait_read completes, timer is canceled
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr);
+  EXPECT_FALSE(*ceptr);
+}
+
+TEST(Client, cancel_destroy)
+{
+  asio::io_context sctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{sctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(1);
+
+  std::optional<std::exception_ptr> septr;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr));
+
+  sctx.poll();
+  ASSERT_FALSE(sctx.stopped());
+  EXPECT_FALSE(septr);
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  // step through the client on a separate io_context
+  asio::io_context cctx;
+  auto cr = [&cctx] (const char* url) -> asio::awaitable<void> {
+    auto client = Client{cctx.get_executor()};
+    co_await perform(client, url);
+  };
+
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> ceptr;
+  asio::co_spawn(cctx, cr(url.c_str()), capture(signal, ceptr));
+
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr);
+
+  // cancel before the server runs
+  signal.emit(asio::cancellation_type::terminal);
+
+  sctx.poll();
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr);
+  EXPECT_FALSE(*septr);
+
+  cctx.poll();
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr);
+  ASSERT_TRUE(*ceptr);
+  try {
+    std::rethrow_exception(*ceptr);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(Client, two)
+{
+  asio::io_context sctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{sctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(2);
+
+  // accept a single request then close the connection
+  std::optional<std::exception_ptr> septr1;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr1));
+
+  EXPECT_EQ(1, sctx.poll()); // server spawn, block on accept
+  ASSERT_FALSE(sctx.stopped());
+  EXPECT_FALSE(septr1);
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  // step through the client on a separate io_context
+  asio::io_context cctx;
+  auto client = Client{cctx.get_executor()};
+
+  std::optional<std::exception_ptr> ceptr1;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr1));
+
+  std::optional<std::exception_ptr> ceptr2;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr2));
+
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr1);
+  EXPECT_FALSE(ceptr2);
+
+  sctx.poll();
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr1);
+  EXPECT_FALSE(*septr1);
+
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  ASSERT_TRUE(ceptr1);
+  EXPECT_FALSE(*ceptr1);
+
+  // accept a second connection
+  std::optional<std::exception_ptr> septr2;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr2));
+
+  sctx.restart();
+  sctx.poll();
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr2);
+  EXPECT_FALSE(*septr2);
+
+  cctx.poll();
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr2);
+  EXPECT_FALSE(*ceptr2);
+}
+
+TEST(Client, two_keepalive)
+{
+  asio::io_context sctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{sctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(1);
+
+  // accept two requests on the same connection
+  std::optional<std::exception_ptr> septr;
+  asio::co_spawn(sctx, accept_connection(acceptor, 2), capture(septr));
+
+  EXPECT_EQ(1, sctx.poll()); // server spawn, block on accept
+  ASSERT_FALSE(sctx.stopped());
+  EXPECT_FALSE(septr);
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  // step through the client on a separate io_context
+  asio::io_context cctx;
+  auto client = Client{cctx.get_executor()};
+
+  std::optional<std::exception_ptr> ceptr1;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr1));
+
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr1);
+
+  sctx.poll();
+  ASSERT_FALSE(sctx.stopped());
+  ASSERT_FALSE(septr);
+
+  cctx.poll();
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr1);
+  EXPECT_FALSE(*ceptr1);
+
+  std::optional<std::exception_ptr> ceptr2;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr2));
+
+  cctx.restart();
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr2);
+
+  sctx.poll();
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr);
+  EXPECT_FALSE(*septr);
+
+  cctx.run_for(10ms);
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr2);
+  EXPECT_FALSE(*ceptr2);
+}
+
+TEST(Client, two_signal_one)
+{
+  asio::io_context sctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{sctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(2);
+
+  std::optional<std::exception_ptr> septr1;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr1));
+  std::optional<std::exception_ptr> septr2;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr2));
+
+  sctx.poll(); // server spawn, block on accept
+  ASSERT_FALSE(sctx.stopped());
+  EXPECT_FALSE(septr1);
+  EXPECT_FALSE(septr2);
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  // step through the client on a separate io_context
+  asio::io_context cctx;
+  auto client = Client{cctx.get_executor()};
+
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> ceptr1;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(signal, ceptr1));
+
+  std::optional<std::exception_ptr> ceptr2;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr2));
+
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr1);
+  EXPECT_FALSE(ceptr2);
+
+  // cancel before server runs
+  signal.emit(asio::cancellation_type::terminal);
+
+  sctx.poll();
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr1);
+  EXPECT_FALSE(*septr1);
+  ASSERT_TRUE(septr2);
+  EXPECT_FALSE(*septr2);
+
+  cctx.poll();
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr1);
+  ASSERT_TRUE(*ceptr1);
+  try {
+    std::rethrow_exception(*ceptr1);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+  ASSERT_TRUE(ceptr2);
+  EXPECT_FALSE(*ceptr2);
+}
+
+TEST(Client, two_cancel)
+{
+  asio::io_context sctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{sctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(2);
+
+  std::optional<std::exception_ptr> septr1;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr1));
+  std::optional<std::exception_ptr> septr2;
+  asio::co_spawn(sctx, accept_connection(acceptor, 1), capture(septr2));
+
+  sctx.poll(); // server spawn, block on accept
+  ASSERT_FALSE(sctx.stopped());
+  EXPECT_FALSE(septr1);
+  EXPECT_FALSE(septr2);
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  // step through the client on a separate io_context
+  asio::io_context cctx;
+  auto client = Client{cctx.get_executor()};
+
+  std::optional<std::exception_ptr> ceptr1;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr1));
+
+  std::optional<std::exception_ptr> ceptr2;
+  asio::co_spawn(cctx, perform(client, url.c_str()), capture(ceptr2));
+
+  cctx.poll();
+  ASSERT_FALSE(cctx.stopped());
+  EXPECT_FALSE(ceptr1);
+  EXPECT_FALSE(ceptr2);
+
+  // cancel before server runs
+  client.cancel();
+
+  sctx.poll();
+  ASSERT_TRUE(sctx.stopped());
+  ASSERT_TRUE(septr1);
+  EXPECT_FALSE(*septr1);
+  ASSERT_TRUE(septr2);
+  EXPECT_FALSE(*septr2);
+
+  cctx.poll();
+  ASSERT_TRUE(cctx.stopped());
+  ASSERT_TRUE(ceptr1);
+  ASSERT_TRUE(*ceptr1);
+  try {
+    std::rethrow_exception(*ceptr1);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+  ASSERT_TRUE(ceptr2);
+  ASSERT_TRUE(*ceptr2);
+  try {
+    std::rethrow_exception(*ceptr2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+auto client_load(Client& client, const char* url, size_t count)
+    -> asio::awaitable<void>
+{
+  for (size_t i = 0; i < count; i++) {
+    co_await perform(client, url);
+  }
+}
+
+TEST(ClientLoad, single_thread)
+{
+  constexpr size_t max_connections = 8;
+  constexpr size_t requests_per_connection = 256;
+
+  asio::io_context ctx;
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{ctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(max_connections);
+
+  auto client = Client{ctx.get_executor()};
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  for (size_t i = 0; i < max_connections; i++) {
+    asio::co_spawn(ctx, accept_connection(acceptor,
+        requests_per_connection), rethrow);
+    asio::co_spawn(ctx, client_load(client, url.c_str(),
+        requests_per_connection), rethrow);
+  }
+
+  ctx.run();
+}
+
+TEST(ClientLoad, multi_thread)
+{
+  constexpr size_t num_threads = 8;
+  constexpr size_t max_connections = 8;
+  constexpr size_t requests_per_connection = 256;
+
+  auto ctx = asio::static_thread_pool{num_threads};
+  const auto localhost = ip::make_address("127.0.0.1");
+  auto acceptor = ip::tcp::acceptor{ctx, ip::tcp::endpoint{localhost, 0}};
+  acceptor.listen(max_connections);
+
+  for (size_t i = 0; i < max_connections; i++) {
+    asio::co_spawn(ctx, accept_connection(acceptor,
+        requests_per_connection), rethrow);
+  }
+
+  const std::string url = fmt::format("http://127.0.0.1:{}",
+                                      acceptor.local_endpoint().port());
+
+  auto ex = asio::make_strand(ctx);
+  auto client = Client{ex};
+  for (size_t i = 0; i < max_connections; i++) {
+    asio::co_spawn(ex, client_load(client, url.c_str(),
+        requests_per_connection), rethrow);
+  }
+
+  ctx.join();
+}
+
+} // namespace rgw::curl

--- a/src/test/rgw/test_rgw_curl_client.cc
+++ b/src/test/rgw/test_rgw_curl_client.cc
@@ -173,6 +173,36 @@ TEST(SharedClient, one)
   EXPECT_FALSE(*ceptr);
 }
 
+TEST(Client, resolve_http)
+{
+  const std::string url = "http://ceph.io";
+
+  asio::io_context ctx;
+  auto client = Client{ctx.get_executor()};
+
+  std::optional<std::exception_ptr> ceptr;
+  asio::co_spawn(ctx, perform(client, url.c_str()), capture(ceptr));
+
+  ctx.run();
+  ASSERT_TRUE(ceptr);
+  EXPECT_FALSE(*ceptr);
+}
+
+TEST(Client, resolve_https)
+{
+  const std::string url = "https://ceph.io";
+
+  asio::io_context ctx;
+  auto client = Client{ctx.get_executor()};
+
+  std::optional<std::exception_ptr> ceptr;
+  asio::co_spawn(ctx, perform(client, url.c_str()), capture(ceptr));
+
+  ctx.run();
+  ASSERT_TRUE(ceptr);
+  EXPECT_FALSE(*ceptr);
+}
+
 TEST(Client, cancel_destroy)
 {
   asio::io_context sctx;

--- a/src/test/rgw/test_rgw_curl_client.cc
+++ b/src/test/rgw/test_rgw_curl_client.cc
@@ -50,11 +50,22 @@ auto accept_connection(ip::tcp::acceptor& acceptor, size_t keepalive_count)
   }
 }
 
+static int debug_callback(CURL*, curl_infotype type,
+                          char* data, size_t size, void*)
+{
+  if (type == CURLINFO_TEXT) {
+    std::cout.write(data, size);
+  }
+  return 0;
+}
+
 auto perform(Client& client, const char* url)
     -> asio::awaitable<void>
 {
   auto easy = easy_init();
   ::curl_easy_setopt(easy.get(), CURLOPT_URL, url);
+  ::curl_easy_setopt(easy.get(), CURLOPT_VERBOSE, 1L);
+  ::curl_easy_setopt(easy.get(), CURLOPT_DEBUGFUNCTION, debug_callback);
 
   co_await client.async_perform(easy.get(), asio::use_awaitable);
 }
@@ -64,6 +75,8 @@ auto perform(const char* url)
 {
   auto easy = easy_init();
   ::curl_easy_setopt(easy.get(), CURLOPT_URL, url);
+  ::curl_easy_setopt(easy.get(), CURLOPT_VERBOSE, 1L);
+  ::curl_easy_setopt(easy.get(), CURLOPT_DEBUGFUNCTION, debug_callback);
 
   co_await async_perform(co_await asio::this_coro::executor,
                          easy.get(), asio::use_awaitable);


### PR DESCRIPTION
adds class `rgw::curl::Client` that manages a curl multi handle and its associated connection pool. member function `async_perform()` executes an asynchronous http request as if by calling `curl_easy_perform()`. this function is not thread-safe, and must be called from the same executor that the Client was constructed with

also adds a free function `rgw::curl::async_perform()` that is thread-safe, and uses a hidden 'global' instance of Client that's wrapped in a strand executor. that global Client's lifetime is associated with the `asio::io_context` of its executor

the `Client` class is well-suited to single-threaded use cases like multisite sync. the free function is better suited to general use where you want to share a connection pool across several threads

```c++
// send a GET request for the resource specified by url
// errors are thrown as boost::system::system_error exceptions
void get_resource(const char* url, boost::asio::yield_context yield)
{
  auto easy = rgw::curl::easy_init();
  
  curl_easy_setopt(easy.get(), CURLOPT_URL, url);
  // set other options like CURLOPT_HEADERFUNCTION, CURLOPT_WRITEFUNCTION etc
  
  rgw::curl::async_perform(yield.get_executor(), easy.get(), yield);
}
```

---

unlike the existing `RGWHTTPManager` based on curl multi, `rgw::curl::Client` uses the 'multi-socket' api which avoids the need to dedicate a background thread to polling for curl completions. instead, it manages its own sockets and timer with asio that run in an existing event loop (asio::io_context):
```c++
// This implementation uses the 'multi_socket' flavor of the libcurl multi API:
// https://curl.se/libcurl/c/libcurl-multi.html
//
// By providing our own CURLMOPT_TIMERFUNCTION AND CURLMOPT_SOCKETFUNCTION, we
// can do all necessary polling and waiting on the given asio executor. As we
// get wakeups from asio, we call curl_multi_socket_action() to do its
// non-blocking socket i/o from within that executor.
//
// This also overrides CURLOPT_OPENSOCKETFUNCTION on each request to manage the
// pool of asio sockets.
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
