### PR TITLE
squid: cephadm: CephExporter doesn't bind to IPv6 in dual stack

### DIFF
--- a/src/cephadm/cephadmlib/daemons/ceph.py
+++ b/src/cephadm/cephadmlib/daemons/ceph.py
@@ -292,8 +292,8 @@ class CephExporter(ContainerDaemonForm):
         self.image = image
 
         self.sock_dir = config_json.get('sock-dir', '/var/run/ceph/')
-        ipv4_addrs, _ = get_ip_addresses(get_hostname())
-        addrs = '0.0.0.0' if ipv4_addrs else '::'
+        _, ipv6_addrs = get_ip_addresses(get_hostname())
+        addrs = '::' if ipv6_addrs else '0.0.0.0'
         self.addrs = config_json.get('addrs', addrs)
         self.port = config_json.get('port', self.DEFAULT_PORT)
         self.prio_limit = config_json.get('prio-limit', 5)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66427

---

backport of https://github.com/ceph/ceph/pull/57389
parent tracker: https://tracker.ceph.com/issues/65896

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh