### PR TITLE
ceph_test_rados_api_misc: adjust LibRadosMiscConnectFailure.ConnectTimeout timeout

### DIFF
--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -76,15 +76,15 @@ TEST(LibRadosMiscConnectFailure, ConnectTimeout) {
   ASSERT_EQ(0, rados_conf_set(cluster, "mon_host", "255.0.1.2:3456"));
   ASSERT_EQ(0, rados_conf_set(cluster, "key",
                               "AQAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAA=="));
-  ASSERT_EQ(0, rados_conf_set(cluster, "client_mount_timeout", "2s"));
+  ASSERT_EQ(0, rados_conf_set(cluster, "client_mount_timeout", "5s"));
 
   utime_t start = ceph_clock_now();
   ASSERT_EQ(-ETIMEDOUT, rados_connect(cluster));
   utime_t end = ceph_clock_now();
 
   utime_t dur = end - start;
-  ASSERT_GE(dur, utime_t(2, 0));
-  ASSERT_LT(dur, utime_t(4, 0));
+  ASSERT_GE(dur, utime_t(5, 0));
+  ASSERT_LT(dur, utime_t(15, 0));
 
   rados_shutdown(cluster);
 }


### PR DESCRIPTION
The test sets a 2 second connection timeout and asserts that the attempt takes less than 4 seconds.

Under load, the asserted timeout can be exceeded. In particular, this affects the Windows CI job, which uses a VM with a reduced amount of resources.

    [ RUN      ] LibRadosMiscConnectFailure.ConnectTimeout
    /home/ubuntu/ceph/src/test/librados/misc.cc:87: Failure
    Expected: (dur) < (utime_t(4, 0)), actual: 5.987712 vs 4.000000

We'll adjust the timeouts, using a 5s configured timeout, asserting that the connection attempt doesn't take more than 15s.

Fixes: https://tracker.ceph.com/issues/66534

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
