### PR TITLE
common: MemoryModel: performance improvements and API changes

### DIFF
--- a/src/common/MemoryModel.cc
+++ b/src/common/MemoryModel.cc
@@ -17,8 +17,6 @@
 using namespace std;
 using mem_snap_t = MemoryModel::mem_snap_t;
 
-MemoryModel::MemoryModel(CephContext *cct_) : cct(cct_) {}
-
 inline bool MemoryModel::cmp_against(
     const std::string &ln,
     std::string_view param,
@@ -41,14 +39,10 @@ inline bool MemoryModel::cmp_against(
 }
 
 
-std::optional<int64_t> MemoryModel::get_mapped_heap()
+tl::expected<int64_t, std::string> MemoryModel::get_mapped_heap()
 {
   if (!proc_maps.is_open()) {
-    ldout(cct, 0) << fmt::format(
-			 "MemoryModel::get_mapped_heap() unable to open {}",
-			 proc_maps_fn)
-		  << dendl;
-    return std::nullopt;
+    return tl::unexpected("unable to open proc/maps");
   }
   // always rewind before reading
   proc_maps.clear();
@@ -99,14 +93,10 @@ std::optional<int64_t> MemoryModel::get_mapped_heap()
 }
 
 
-std::optional<mem_snap_t> MemoryModel::full_sample()
+tl::expected<mem_snap_t, std::string> MemoryModel::full_sample()
 {
   if (!proc_status.is_open()) {
-    ldout(cct, 0) << fmt::format(
-			 "MemoryModel::sample() unable to open {}",
-			 proc_stat_fn)
-		  << dendl;
-    return std::nullopt;
+    return tl::unexpected("unable to open proc/status");
   }
   // always rewind before reading
   proc_status.clear();

--- a/src/common/MemoryModel.cc
+++ b/src/common/MemoryModel.cc
@@ -10,13 +10,14 @@
 #define dout_subsys ceph_subsys_
 
 using namespace std;
+using mem_snap_t = MemoryModel::mem_snap_t;
 
 MemoryModel::MemoryModel(CephContext *cct_)
   : cct(cct_)
 {
 }
 
-void MemoryModel::_sample(snap *psnap)
+void MemoryModel::_sample(mem_snap_t *psnap)
 {
   ifstream f;
 

--- a/src/common/MemoryModel.cc
+++ b/src/common/MemoryModel.cc
@@ -1,6 +1,8 @@
-#include "MemoryModel.h"
-#include "include/compat.h"
 #include "debug.h"
+
+#include "include/compat.h"
+
+#include "MemoryModel.h"
 #if defined(__linux__)
 #include <malloc.h>
 #endif
@@ -15,15 +17,37 @@
 using namespace std;
 using mem_snap_t = MemoryModel::mem_snap_t;
 
-MemoryModel::MemoryModel(CephContext *cct_)
-  : cct(cct_)
+MemoryModel::MemoryModel(CephContext *cct_) : cct(cct_) {}
+
+inline bool MemoryModel::cmp_against(
+    const std::string &ln,
+    std::string_view param,
+    long &v) const
 {
+  if (ln.size() < (param.size() + 10)) {
+    return false;
+  }
+  if (ln.starts_with(param)) {
+    auto p = ln.c_str();
+    auto s = p + param.size();
+    // charconv does not like leading spaces
+    while (*s && isblank(*s)) {
+      s++;
+    }
+    from_chars(s, p + ln.size(), v);
+    return true;
+  }
+  return false;
 }
+
 
 std::optional<int64_t> MemoryModel::get_mapped_heap()
 {
   if (!proc_maps.is_open()) {
-    ldout(cct, 0) <<  fmt::format("MemoryModel::get_mapped_heap() unable to open {}", proc_maps_fn) << dendl;
+    ldout(cct, 0) << fmt::format(
+			 "MemoryModel::get_mapped_heap() unable to open {}",
+			 proc_maps_fn)
+		  << dendl;
     return std::nullopt;
   }
   // always rewind before reading
@@ -38,15 +62,17 @@ std::optional<int64_t> MemoryModel::get_mapped_heap()
 
     const char *start = line.c_str();
     const char *dash = start;
-    while (*dash && *dash != '-') dash++;
+    while (*dash && *dash != '-')
+      dash++;
     if (!*dash)
       continue;
     const char *end = dash + 1;
-    while (*end && *end != ' ') end++;
+    while (*end && *end != ' ')
+      end++;
     if (!*end)
       continue;
     unsigned long long as = strtoll(start, 0, 16);
-    unsigned long long ae = strtoll(dash+1, 0, 16);
+    unsigned long long ae = strtoll(dash + 1, 0, 16);
 
     end++;
     const char *mode = end;
@@ -54,7 +80,8 @@ std::optional<int64_t> MemoryModel::get_mapped_heap()
     int skip = 4;
     while (skip--) {
       end++;
-      while (*end && *end != ' ') end++;
+      while (*end && *end != ' ')
+	end++;
     }
     if (*end)
       end++;
@@ -72,35 +99,47 @@ std::optional<int64_t> MemoryModel::get_mapped_heap()
 }
 
 
-
-void MemoryModel::_sample(mem_snap_t *psnap)
+std::optional<mem_snap_t> MemoryModel::full_sample()
 {
   if (!proc_status.is_open()) {
-    ldout(cct, 0) <<  fmt::format("MemoryModel::sample() unable to open {}", proc_stat_fn) << dendl;
-    return;
+    ldout(cct, 0) << fmt::format(
+			 "MemoryModel::sample() unable to open {}",
+			 proc_stat_fn)
+		  << dendl;
+    return std::nullopt;
   }
   // always rewind before reading
   proc_status.clear();
   proc_status.seekg(0);
 
-  while (!proc_status.eof()) {
-    string line;
-    getline(proc_status, line);
+  mem_snap_t s;
+  // we will be looking for 6 entries
+  int yet_to_find = 6;
 
-    if (strncmp(line.c_str(), "VmSize:", 7) == 0)
-      psnap->size = atol(line.c_str() + 7);
-    else if (strncmp(line.c_str(), "VmRSS:", 6) == 0)
-      psnap->rss = atol(line.c_str() + 7);
-    else if (strncmp(line.c_str(), "VmHWM:", 6) == 0)
-      psnap->hwm = atol(line.c_str() + 7);
-    else if (strncmp(line.c_str(), "VmLib:", 6) == 0)
-      psnap->lib = atol(line.c_str() + 7);
-    else if (strncmp(line.c_str(), "VmPeak:", 7) == 0)
-      psnap->peak = atol(line.c_str() + 7);
-    else if (strncmp(line.c_str(), "VmData:", 7) == 0)
-      psnap->data = atol(line.c_str() + 7);
+  while (!proc_status.eof() && yet_to_find > 0) {
+    string ln;
+    getline(proc_status, ln);
+
+    if (cmp_against(ln, "VmSize:", s.size) ||
+	cmp_against(ln, "VmRSS:", s.rss) || cmp_against(ln, "VmHWM:", s.hwm) ||
+	cmp_against(ln, "VmLib:", s.lib) ||
+	cmp_against(ln, "VmPeak:", s.peak) ||
+	cmp_against(ln, "VmData:", s.data)) {
+      yet_to_find--;
+    }
   }
 
   // get heap size
-  psnap->heap = static_cast<long>(get_mapped_heap().value_or(0));
+  s.heap = static_cast<long>(get_mapped_heap().value_or(0));
+  return s;
+}
+
+void MemoryModel::sample(mem_snap_t *p)
+{
+  auto s = full_sample();
+  if (s) {
+    last = *s;
+    if (p)
+      *p = last;
+  }
 }

--- a/src/common/MemoryModel.cc
+++ b/src/common/MemoryModel.cc
@@ -5,7 +5,10 @@
 #include <malloc.h>
 #endif
 
-#include <fstream>
+#include <charconv>
+
+#include "common/fmt_common.h"
+
 
 #define dout_subsys ceph_subsys_
 
@@ -17,45 +20,21 @@ MemoryModel::MemoryModel(CephContext *cct_)
 {
 }
 
-void MemoryModel::_sample(mem_snap_t *psnap)
+std::optional<int64_t> MemoryModel::get_mapped_heap()
 {
-  ifstream f;
-
-  f.open(PROCPREFIX "/proc/self/status");
-  if (!f.is_open()) {
-    ldout(cct, 0) << "check_memory_usage unable to open " PROCPREFIX "/proc/self/status" << dendl;
-    return;
+  if (!proc_maps.is_open()) {
+    ldout(cct, 0) <<  fmt::format("MemoryModel::get_mapped_heap() unable to open {}", proc_maps_fn) << dendl;
+    return std::nullopt;
   }
-  while (!f.eof()) {
+  // always rewind before reading
+  proc_maps.clear();
+  proc_maps.seekg(0);
+
+  int64_t heap = 0;
+
+  while (proc_maps.is_open() && !proc_maps.eof()) {
     string line;
-    getline(f, line);
-    
-    if (strncmp(line.c_str(), "VmSize:", 7) == 0)
-      psnap->size = atol(line.c_str() + 7);
-    else if (strncmp(line.c_str(), "VmRSS:", 6) == 0)
-      psnap->rss = atol(line.c_str() + 7);
-    else if (strncmp(line.c_str(), "VmHWM:", 6) == 0)
-      psnap->hwm = atol(line.c_str() + 7);
-    else if (strncmp(line.c_str(), "VmLib:", 6) == 0)
-      psnap->lib = atol(line.c_str() + 7);
-    else if (strncmp(line.c_str(), "VmPeak:", 7) == 0)
-      psnap->peak = atol(line.c_str() + 7);
-    else if (strncmp(line.c_str(), "VmData:", 7) == 0)
-      psnap->data = atol(line.c_str() + 7);
-  }
-  f.close();
-
-  f.open(PROCPREFIX "/proc/self/maps");
-  if (!f.is_open()) {
-    ldout(cct, 0) << "check_memory_usage unable to open " PROCPREFIX "/proc/self/maps" << dendl;
-    return;
-  }
-
-  long heap = 0;
-  while (f.is_open() && !f.eof()) {
-    string line;
-    getline(f, line);
-    //ldout(cct, 0) << "line is " << line << dendl;
+    getline(proc_maps, line);
 
     const char *start = line.c_str();
     const char *dash = start;
@@ -69,8 +48,6 @@ void MemoryModel::_sample(mem_snap_t *psnap)
     unsigned long long as = strtoll(start, 0, 16);
     unsigned long long ae = strtoll(dash+1, 0, 16);
 
-    //ldout(cct, 0) << std::hex << as << " to " << ae << std::dec << dendl;
-
     end++;
     const char *mode = end;
 
@@ -83,7 +60,6 @@ void MemoryModel::_sample(mem_snap_t *psnap)
       end++;
 
     long size = ae - as;
-    //ldout(cct, 0) << "size " << size << " mode is '" << mode << "' end is '" << end << "'" << dendl;
 
     /*
      * anything 'rw' and anon is assumed to be heap.
@@ -92,6 +68,39 @@ void MemoryModel::_sample(mem_snap_t *psnap)
       heap += size;
   }
 
-  psnap->heap = heap >> 10;
+  return heap;
+}
 
+
+
+void MemoryModel::_sample(mem_snap_t *psnap)
+{
+  if (!proc_status.is_open()) {
+    ldout(cct, 0) <<  fmt::format("MemoryModel::sample() unable to open {}", proc_stat_fn) << dendl;
+    return;
+  }
+  // always rewind before reading
+  proc_status.clear();
+  proc_status.seekg(0);
+
+  while (!proc_status.eof()) {
+    string line;
+    getline(proc_status, line);
+
+    if (strncmp(line.c_str(), "VmSize:", 7) == 0)
+      psnap->size = atol(line.c_str() + 7);
+    else if (strncmp(line.c_str(), "VmRSS:", 6) == 0)
+      psnap->rss = atol(line.c_str() + 7);
+    else if (strncmp(line.c_str(), "VmHWM:", 6) == 0)
+      psnap->hwm = atol(line.c_str() + 7);
+    else if (strncmp(line.c_str(), "VmLib:", 6) == 0)
+      psnap->lib = atol(line.c_str() + 7);
+    else if (strncmp(line.c_str(), "VmPeak:", 7) == 0)
+      psnap->peak = atol(line.c_str() + 7);
+    else if (strncmp(line.c_str(), "VmData:", 7) == 0)
+      psnap->data = atol(line.c_str() + 7);
+  }
+
+  // get heap size
+  psnap->heap = static_cast<long>(get_mapped_heap().value_or(0));
 }

--- a/src/common/MemoryModel.cc
+++ b/src/common/MemoryModel.cc
@@ -143,13 +143,3 @@ tl::expected<mem_snap_t, std::string> MemoryModel::full_sample()
   s.heap = static_cast<long>(get_mapped_heap().value_or(0));
   return s;
 }
-
-void MemoryModel::sample(mem_snap_t *p)
-{
-  auto s = full_sample();
-  if (s) {
-    last = *s;
-    if (p)
-      *p = last;
-  }
-}

--- a/src/common/MemoryModel.cc
+++ b/src/common/MemoryModel.cc
@@ -89,11 +89,6 @@ tl::expected<int64_t, std::string> MemoryModel::get_mapped_heap()
       continue;
     }
 
-    if (the_rest.ends_with("[stack]")) {
-      // should we really exclude the stack?
-      continue;
-    }
-
     std::string_view final_token{the_rest.begin() + sizeof("00000000 00:00 0") - 1,
                                  the_rest.end()};
     if (final_token.size() < 3 ||

--- a/src/common/MemoryModel.h
+++ b/src/common/MemoryModel.h
@@ -17,6 +17,7 @@
 
 #include <fstream>
 #include <optional>
+#include <string_view>
 #include "include/common_fwd.h"
 #include "include/compat.h"
 
@@ -50,16 +51,20 @@ private:
   std::ifstream proc_maps{proc_maps_fn};
 
   CephContext *cct;
-  void _sample(mem_snap_t *p);
   std::optional<int64_t> get_mapped_heap();
+
+  /**
+   * @brief Compare a line against an expected data label
+   *
+   * If the line starts with the expected label, extract the value and store it in v.
+   * \retval true if the line starts with the expected label
+   */
+  bool cmp_against(const std::string& ln, std::string_view param, long& v) const;
 
 public:
   explicit MemoryModel(CephContext *cct);
-  void sample(mem_snap_t *p = 0) {
-    _sample(&last);
-    if (p)
-      *p = last;
-  }
+  std::optional<mem_snap_t> full_sample();
+  void sample(mem_snap_t *p = nullptr);
 };
 
 #endif

--- a/src/common/MemoryModel.h
+++ b/src/common/MemoryModel.h
@@ -26,23 +26,18 @@
 class MemoryModel {
 public:
   struct mem_snap_t {
-    long peak;
-    long size;
-    long hwm;
-    long rss;
-    long data;
-    long lib;
-
-    long heap;
-
-    mem_snap_t() : peak(0), size(0), hwm(0), rss(0), data(0), lib(0),
-	     heap(0)
-    {}
+    long peak{0};
+    long size{0};
+    long hwm{0};
+    long rss{0};
+    long data{0};
+    long lib{0};
+    long heap{0};
 
     long get_total() const { return size; }
     long get_rss() const { return rss; }
     long get_heap() const { return heap; }
-  } last;
+  };
 
 private:
   static inline constexpr const char* proc_stat_fn = PROCPREFIX "/proc/self/status";
@@ -81,8 +76,6 @@ public:
    *    size will be reported as 0).
    */
   tl::expected<mem_snap_t, std::string> full_sample();
-
-  void sample(mem_snap_t *p = nullptr);
 };
 
 #endif

--- a/src/common/MemoryModel.h
+++ b/src/common/MemoryModel.h
@@ -19,17 +19,17 @@
 
 class MemoryModel {
 public:
-  struct snap {
+  struct mem_snap_t {
     long peak;
     long size;
     long hwm;
     long rss;
     long data;
     long lib;
-    
+
     long heap;
 
-    snap() : peak(0), size(0), hwm(0), rss(0), data(0), lib(0),
+    mem_snap_t() : peak(0), size(0), hwm(0), rss(0), data(0), lib(0),
 	     heap(0)
     {}
 
@@ -40,11 +40,11 @@ public:
 
 private:
   CephContext *cct;
-  void _sample(snap *p);
+  void _sample(mem_snap_t *p);
 
 public:
   explicit MemoryModel(CephContext *cct);
-  void sample(snap *p = 0) {
+  void sample(mem_snap_t *p = 0) {
     _sample(&last);
     if (p)
       *p = last;

--- a/src/common/MemoryModel.h
+++ b/src/common/MemoryModel.h
@@ -33,9 +33,9 @@ public:
 	     heap(0)
     {}
 
-    long get_total() { return size; }
-    long get_rss() { return rss; }
-    long get_heap() { return heap; }
+    long get_total() const { return size; }
+    long get_rss() const { return rss; }
+    long get_heap() const { return heap; }
   } last;
 
 private:

--- a/src/common/MemoryModel.h
+++ b/src/common/MemoryModel.h
@@ -15,7 +15,11 @@
 #ifndef CEPH_MEMORYMODEL_H
 #define CEPH_MEMORYMODEL_H
 
+#include <fstream>
+#include <optional>
 #include "include/common_fwd.h"
+#include "include/compat.h"
+
 
 class MemoryModel {
 public:
@@ -39,8 +43,15 @@ public:
   } last;
 
 private:
+  static inline constexpr const char* proc_stat_fn = PROCPREFIX "/proc/self/status";
+  static inline constexpr const char* proc_maps_fn = PROCPREFIX "/proc/self/maps";
+
+  std::ifstream proc_status{proc_stat_fn};
+  std::ifstream proc_maps{proc_maps_fn};
+
   CephContext *cct;
   void _sample(mem_snap_t *p);
+  std::optional<int64_t> get_mapped_heap();
 
 public:
   explicit MemoryModel(CephContext *cct);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -46,7 +46,6 @@
 #include "msg/Message.h"
 #include "msg/Messenger.h"
 
-#include "common/MemoryModel.h"
 #include "common/errno.h"
 #include "common/perf_counters.h"
 #include "common/safe_io.h"
@@ -7813,12 +7812,10 @@ void MDCache::trim_client_leases()
   }
 }
 
-void MDCache::check_memory_usage()
+void MDCache::check_memory_usage(const MemoryModel::mem_snap_t &baseline)
 {
-  static MemoryModel mm(g_ceph_context);
-  static MemoryModel::mem_snap_t last;
-  mm.sample(&last);
-  static MemoryModel::mem_snap_t baseline = last;
+  MemoryModel mm(g_ceph_context);
+  mm.sample();
 
   // check client caps
   ceph_assert(CInode::count() == inode_map.size() + snap_inode_map.size() + num_shadow_inodes);
@@ -7827,17 +7824,17 @@ void MDCache::check_memory_usage()
     caps_per_inode = (double)Capability::count() / (double)CInode::count();
 
   dout(2) << "Memory usage: "
-	   << " total " << last.get_total()
-	   << ", rss " << last.get_rss()
-	   << ", heap " << last.get_heap()
+	   << " total " << mm.last.get_total()
+	   << ", rss " << mm.last.get_rss()
+	   << ", heap " << mm.last.get_heap()
 	   << ", baseline " << baseline.get_heap()
 	   << ", " << num_inodes_with_caps << " / " << CInode::count() << " inodes have caps"
 	   << ", " << Capability::count() << " caps, " << caps_per_inode << " caps per inode"
 	   << dendl;
 
   mds->update_mlogger();
-  mds->mlogger->set(l_mdm_rss, last.get_rss());
-  mds->mlogger->set(l_mdm_heap, last.get_heap());
+  mds->mlogger->set(l_mdm_rss, mm.last.get_rss());
+  mds->mlogger->set(l_mdm_heap, mm.last.get_heap());
 }
 
 
@@ -14173,6 +14170,14 @@ bool MDCache::is_ready_to_trim_cache(void)
 void MDCache::upkeep_main(void)
 {
   std::unique_lock lock(upkeep_mutex);
+
+  // get initial sample upon thread creation
+  MemoryModel::mem_snap_t baseline;
+  {
+    MemoryModel mm(g_ceph_context);
+    mm.sample(&baseline);
+  }
+
   while (!upkeep_trim_shutdown.load()) {
     auto now = clock::now();
     auto since = now-upkeep_last_trim;
@@ -14183,7 +14188,7 @@ void MDCache::upkeep_main(void)
       lock.lock();
       if (upkeep_trim_shutdown.load())
         return;
-      check_memory_usage();
+      check_memory_usage(baseline);
       if (mds->is_cache_trimmable()) {
         dout(20) << "upkeep thread trimming cache; last trim " << since << " ago" << dendl;
         bool active_with_clients = mds->is_active() || mds->is_clientreplay() || mds->is_stopping();

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7816,9 +7816,9 @@ void MDCache::trim_client_leases()
 void MDCache::check_memory_usage()
 {
   static MemoryModel mm(g_ceph_context);
-  static MemoryModel::snap last;
+  static MemoryModel::mem_snap_t last;
   mm.sample(&last);
-  static MemoryModel::snap baseline = last;
+  static MemoryModel::mem_snap_t baseline = last;
 
   // check client caps
   ceph_assert(CInode::count() == inode_map.size() + snap_inode_map.size() + num_shadow_inodes);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -20,6 +20,7 @@
 #include <thread>
 
 #include "common/DecayCounter.h"
+#include "common/MemoryModel.h"
 #include "include/common_fwd.h"
 #include "include/types.h"
 #include "include/filepath.h"
@@ -775,7 +776,7 @@ private:
   bool expire_recursive(CInode *in, expiremap& expiremap);
 
   void trim_client_leases();
-  void check_memory_usage();
+  void check_memory_usage(const MemoryModel::mem_snap_t &baseline);
 
   void shutdown_start();
   void shutdown_check();

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -776,7 +776,7 @@ private:
   bool expire_recursive(CInode *in, expiremap& expiremap);
 
   void trim_client_leases();
-  void check_memory_usage(const MemoryModel::mem_snap_t &baseline);
+  void check_memory_usage();
 
   void shutdown_start();
   void shutdown_check();
@@ -1540,6 +1540,8 @@ private:
   time upkeep_last_trim = clock::zero();
   time upkeep_last_release = clock::zero();
   std::atomic<bool> upkeep_trim_shutdown{false};
+  std::optional<MemoryModel> upkeep_memory_stats;
+  MemoryModel::mem_snap_t upkeep_mem_baseline;
 
   uint64_t kill_shutdown_at = 0;
 


### PR DESCRIPTION
**Performance:** per my off-line (code snippets) benchmarks
(see [benchtest](https://github.com/ronen-fr/memorymodel)):

- the parsing of /proc/status improved by 
1. only opening the proc file once (saves almost 40%)
2. using charconv

- for /proc/maps:
1. opening once (most of the improvement);
2. faster discarding of lines;
3. using charconv

**The API changes:**
- no output parameters;
- no internally-maintained samples;
- not issuing warning messages to the log directly;

The PR includes work by @athanatos & @shreekarSS,
picked from https://github.com/ceph/ceph/pull/54698