### PR TITLE
squid: qa/rados: don't pass --max_attr_len to ceph_test_rados unconditionally

### DIFF
--- a/qa/tasks/rados.py
+++ b/qa/tasks/rados.py
@@ -162,6 +162,8 @@ def task(ctx, config):
         args.extend(['--balance-reads'])
     if config.get('localize_reads', False):
         args.extend(['--localize-reads'])
+    if config.get('max_attr_len', None):
+        args.extend(['--max-attr-len', str(config.get('max_attr_len'))])
     args.extend([
         '--max-ops', str(config.get('ops', 10000)),
         '--objects', str(config.get('objects', 500)),
@@ -169,8 +171,7 @@ def task(ctx, config):
         '--size', str(object_size),
         '--min-stride-size', str(config.get('min_stride_size', object_size // 10)),
         '--max-stride-size', str(config.get('max_stride_size', object_size // 5)),
-        '--max-seconds', str(config.get('max_seconds', 0)),
-        '--max-attr-len', str(config.get('max_attr_len', 20000))
+        '--max-seconds', str(config.get('max_seconds', 0))
         ])
 
     weights = {}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66554

---

backport of https://github.com/ceph/ceph/pull/57855
parent tracker: https://tracker.ceph.com/issues/66321

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh