### PR TITLE
quincy: ceph_test_rados_api_misc: adjust LibRadosMiscConnectFailure.ConnectTimeout timeout

### DIFF
--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -76,15 +76,15 @@ TEST(LibRadosMiscConnectFailure, ConnectTimeout) {
   ASSERT_EQ(0, rados_conf_set(cluster, "mon_host", "255.0.1.2:3456"));
   ASSERT_EQ(0, rados_conf_set(cluster, "key",
                               "AQAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAA=="));
-  ASSERT_EQ(0, rados_conf_set(cluster, "client_mount_timeout", "2s"));
+  ASSERT_EQ(0, rados_conf_set(cluster, "client_mount_timeout", "5s"));
 
   utime_t start = ceph_clock_now();
   ASSERT_EQ(-ETIMEDOUT, rados_connect(cluster));
   utime_t end = ceph_clock_now();
 
   utime_t dur = end - start;
-  ASSERT_GE(dur, utime_t(2, 0));
-  ASSERT_LT(dur, utime_t(4, 0));
+  ASSERT_GE(dur, utime_t(5, 0));
+  ASSERT_LT(dur, utime_t(15, 0));
 
   rados_shutdown(cluster);
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66548

---

backport of https://github.com/ceph/ceph/pull/58100
parent tracker: https://tracker.ceph.com/issues/66534

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh