### PR TITLE
osd/ECBackend.cc: Fix double increment of num_shards_repaired stat

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -229,28 +229,20 @@ void ECBackend::handle_recovery_push(
 
   recovery_backend.handle_recovery_push(op, m, is_repair);
 
-  if (op.after_progress.data_complete) {
-    if ((get_parent()->pgb_is_primary())) {
-      if (get_parent()->pg_is_repair() || is_repair)
-        get_parent()->inc_osd_stat_repaired();
-    } else {
-      // If primary told us this is a repair, bump osd_stat_t::num_objects_repaired
-      if (is_repair)
-        get_parent()->inc_osd_stat_repaired();
-      if (get_parent()->pg_is_remote_backfilling()) {
-        struct stat st;
-        int r = store->stat(ch, ghobject_t(op.soid, ghobject_t::NO_GEN,
-                            get_parent()->whoami_shard().shard), &st);
-        if (r == 0) {
-          get_parent()->pg_sub_local_num_bytes(st.st_size);
-         // XXX: This can be way overestimated for small objects
-         get_parent()->pg_sub_num_bytes(st.st_size * get_ec_data_chunk_count());
-         dout(10) << __func__ << " " << op.soid
-                  << " sub actual data by " << st.st_size
-                  << " sub num_bytes by " << st.st_size * get_ec_data_chunk_count()
-                  << dendl;
-        }
-      }
+  if (op.after_progress.data_complete &&
+     !(get_parent()->pgb_is_primary()) &&
+     get_parent()->pg_is_remote_backfilling()) {
+    struct stat st;
+    int r = store->stat(ch, ghobject_t(op.soid, ghobject_t::NO_GEN,
+                        get_parent()->whoami_shard().shard), &st);
+    if (r == 0) {
+      get_parent()->pg_sub_local_num_bytes(st.st_size);
+      // XXX: This can be way overestimated for small objects
+      get_parent()->pg_sub_num_bytes(st.st_size * get_ec_data_chunk_count());
+      dout(10) << __func__ << " " << op.soid
+               << " sub actual data by " << st.st_size
+               << " sub num_bytes by " << st.st_size * get_ec_data_chunk_count()
+               << dendl;
     }
   }
 }


### PR DESCRIPTION
Commit https://github.com/ceph/ceph/commit/deffa8209f9c0bd300cfdb54d358402bfc6e41c6 refactored ECBackend::handle_recovery_push for Crimson but accidentally duplicated the code that increments the num_shards_repaired OSD statistic.

This caused one of the QA tests to fail because the stat reported twice as much repair work had been completed than expected:

qa/standalone/scrub/osd-scrub-repair.sh: TEST_repair_stats_ec: test 26 = 13

Running the standalone test without the fix reproduces the error every time. Running the standalone test with this fix passes.

It is clear from reviewing the commit above that the intent was to keep the code the same and just split the function ECBackend::handle_recovery_push into two functions - one that has code that will be common with Crimson and one that has the remainder of the code, however the increment of the statistic was left in both functions.

Fixes: https://tracker.ceph.com/issues/64437
Signed-off-by: Bill Scales <bill_scales@uk.ibm.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
