### PR TITLE
osd: fix mclock params cannot change when running

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -1126,6 +1126,15 @@ options:
   default: 21500
   flags:
   - runtime
+- name: osd_mclock_backfill_must_be_recovery
+  type: bool
+  level: advanced
+  desc: if enabled, osd_recovery_op_priority use backgroud_recovery
+    when pg is only backfilling
+  default: false
+  with_legacy: true
+  flags:
+  - runtime
 - name: osd_mclock_force_run_benchmark_on_init
   type: bool
   level: advanced

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1599,7 +1599,7 @@ public:
 	return recovery_msg_priority_t::FORCED;
       } else if (is_undersized()) {
 	return recovery_msg_priority_t::UNDERSIZED;
-      } else if (is_degraded()) {
+      } else if (cct->_conf->osd_mclock_backfill_must_be_recovery || is_degraded()) {
 	return recovery_msg_priority_t::DEGRADED;
       } else {
 	return recovery_msg_priority_t::BEST_EFFORT;

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -553,7 +553,8 @@ void mClockScheduler::handle_conf_change(
 
   if (auto key = get_changed_key(); key.has_value()) {
     auto mclock_profile = cct->_conf.get_val<std::string>("osd_mclock_profile");
-    if (mclock_profile == "custom") {
+    auto override_settings = cct->_conf.get_val<bool>("osd_mclock_override_recovery_settings");
+    if (override_settings || mclock_profile == "custom") {
       client_registry.update_from_config(
         conf, osd_bandwidth_capacity_per_shard);
     } else {
@@ -584,7 +585,7 @@ void mClockScheduler::handle_conf_change(
     }
     // Alternatively, the QoS parameter, if set ephemerally for this OSD via
     // the 'daemon' or 'tell' interfaces must be removed.
-    if (!cct->_conf.rm_val(*key)) {
+    if (override_settings || !cct->_conf.rm_val(*key)) {
       dout(10) << __func__ << " Restored " << *key << " to default" << dendl;
       cct->_conf.apply_changes(nullptr);
     }


### PR DESCRIPTION
Note: I hope to retain more freedom of control, otherwise debugging will be too difficult

```
Author: zhangjianwei2 <zhangjianwei2_yewu@cmss.chinamobile.com>
Date:   Thu Jun 20 15:17:52 2024 +0800

    osd: osd_mclock params cannot set by daemon/config set or tell

    due to 83883174bab70e43aac441230575d56a01172016
    the QoS parameter, if set ephemerally for this OSD via
    the 'daemon' or 'tell' interfaces must be removed.

    re-used param osd_mclock_override_recovery_settings,
    control the osd_mclock parameters by cli command.

    Signed-off-by: zhangjianwei2 <zhangjianwei2@cmss.chinamobile.com>
```

```
commit f330df87c294d134558d02553f9c84aee3f89c64
Author: zhangjianwei2 <zhangjianwei2_yewu@cmss.chinamobile.com>
Date:   Thu Jun 20 15:13:41 2024 +0800

    osd: fix backfill speed too slow when pg backfilling

    due to 3a87ddd6f150a2c22551f83af7f147ae38601650,

    When using mclock_scheduler, we usually set very low lim/res
    for background_best_effort.

    At this time, if pg is backfilling,
    the backfill speed will be very slow.
    In order to make the backfill speed faster,

    add osd_mclock_backfill_must_be_recovery option,
    If true, recovery_msg_priority_t::DEGRADED is forced to
    be used as the priority of recovery_op,
    and background_recovery is used in priority_to_scheduler_class.

    Signed-off-by: zhangjianwei2 <zhangjianwei2@cmss.chinamobile.com>
```