### PR TITLE
librbd: Modify locks and atomics in AioCompletion to improve performance

### DIFF
--- a/src/librbd/io/AioCompletion.h
+++ b/src/librbd/io/AioCompletion.h
@@ -38,20 +38,13 @@ namespace io {
  * context or via a thread pool context for cache read hits).
  */
 struct AioCompletion {
-  typedef enum {
-    AIO_STATE_PENDING = 0,
-    AIO_STATE_COMPLETE,
-  } aio_state_t;
-
   mutable std::mutex lock;
-  std::condition_variable cond;
 
   callback_t complete_cb = nullptr;
   void *complete_arg = nullptr;
   rbd_completion_t rbd_comp = nullptr;
 
-  /// note: only using atomic for built-in memory barrier
-  std::atomic<aio_state_t> state{AIO_STATE_PENDING};
+  std::atomic<bool> completed{false};
 
   std::atomic<ssize_t> rval{0};
   std::atomic<int> error_rval{0};


### PR DESCRIPTION
This PR proposes the following performance improvements to AioCompletion:

1. Replace the conditional variable with the atomic wait/notify functions introduced in C++20.
2. Remove the mutex lock which was previously required to update the conditional variable.
3. Relax the memory order of the atomic operations to update the AioCompletion state.

Flame graph analysis of `rbd bench` indicates an almost 1% performance improvement on average in the function AioCompletion::notify_callbacks_complete().

Before:
<img width="601" alt="AioCompletion_before" src="https://github.com/user-attachments/assets/64cd89b7-2268-4ba9-80a8-0de649b2a181">

After:
<img width="601" alt="AioCompletion_after" src="https://github.com/user-attachments/assets/af8f7647-ac0b-422b-863f-f288c7e6b17e">

This data was captured by running a workload of 4K sequential writes to a 200G volume.

I have ran `bin/ceph_test_librbd `to validate that the code reliant on the conditional variable still works and specifically ran -`-gtest_filter=TestLibRBD.TestIO` with valgrind to validate that there are no memory leaks.

This is my first pull request for ceph so I'm open to feedback, please let me know if you think there's anything I've missed.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
