### PR TITLE
qa: avoid reusing CephManager object across tests

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1586,6 +1586,10 @@ class CephManager:
                     f'{self.testdir}/archive/coverage']
         self.RADOS_CMD = self.pre + ['rados', '--cluster', self.cluster]
 
+        self.init_pools()
+
+    def init_pools(self):
+        self.wait_for_active()
         pools = self.list_pools()
         self.pools = {}
         for pool in pools:

--- a/qa/tasks/ceph_test_case.py
+++ b/qa/tasks/ceph_test_case.py
@@ -148,6 +148,10 @@ class CephTestCase(unittest.TestCase, RunCephCmd):
             from tasks.ceph_manager import CephManager
             self.mon_manager = CephManager(self.ceph_cluster.admin_remote,
                 ctx=self.ctx, logger=log.getChild('ceph_manager'))
+        if not hasattr(self.ctx, 'managers'):
+            self.ctx.managers = {}
+        # set the manager for cluster 'ceph'
+        self.ctx.managers[self.mon_manager.cluster] = self.mon_manager
 
     def setUp(self):
         self._init_mon_manager()

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -242,6 +242,7 @@ class CephClusterBase(RunCephCmd):
             manager = CephManager(self.admin_remote, ctx=ctx,
                                   logger=log.getChild('ceph_manager'))
         self.mon_manager = manager
+        self.mon_manager.init_pools()
 
     def get_config(self, key, service_type=None):
         """

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -235,10 +235,16 @@ class CephClusterBase(RunCephCmd):
 
     def __init__(self, ctx, cluster_name='ceph') -> None:
         self._ctx = ctx
-        try:
-            manager = ctx.managers[cluster_name]
-        except Exception as e:
-            log.warn(f"Couldn't get a manager for cluster {cluster_name} from the context; exception: {e}")
+        #try:
+        #    manager = LocalCephManager(ctx=self._ctx)
+        #except Exception as e:
+        #    log.warn(f"Couldn't get a manager for cluster {cluster_name} from the context; exception: {e}")
+        #    manager = CephManager(self.admin_remote, ctx=ctx,
+        #                          logger=log.getChild('ceph_manager'))
+        if hasattr(ctx, 'environment') and ctx.environment == 'vstart':
+            from tasks.vstart_runner import LocalCephManager
+            manager = LocalCephManager(ctx=ctx)
+        else:
             manager = CephManager(self.admin_remote, ctx=ctx,
                                   logger=log.getChild('ceph_manager'))
         self.mon_manager = manager

--- a/qa/tasks/cephfs/test_snap_schedules.py
+++ b/qa/tasks/cephfs/test_snap_schedules.py
@@ -586,18 +586,31 @@ class TestSnapSchedules(TestSnapSchedulesHelper):
             self.fs_snap_schedule_cmd('add', path=test_dir, snap_schedule='')
 
         test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/minutes"
+        self.remove_snapshots(test_dir)
         self.mount_a.run_shell(['rmdir', test_dir])
+
         test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/hourly"
+        self.remove_snapshots(test_dir)
         self.mount_a.run_shell(['rmdir', test_dir])
+
         test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/daily"
+        self.remove_snapshots(test_dir)
         self.mount_a.run_shell(['rmdir', test_dir])
+
         test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/weekly"
+        self.remove_snapshots(test_dir)
         self.mount_a.run_shell(['rmdir', test_dir])
+
         test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/monthly"
+        self.remove_snapshots(test_dir)
         self.mount_a.run_shell(['rmdir', test_dir])
+
         test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/yearly"
+        self.remove_snapshots(test_dir)
         self.mount_a.run_shell(['rmdir', test_dir])
+
         test_dir = TestSnapSchedulesSnapdir.TEST_DIRECTORY + "/bad_period_spec"
+        self.remove_snapshots(test_dir)
         self.mount_a.run_shell(['rmdir', test_dir])
 
 
@@ -726,6 +739,7 @@ class TestSnapSchedulesSubvolAndGroupArguments(TestSnapSchedulesHelper):
         self.fs_snap_schedule_cmd('add', '--subvol', 'sv05', '--group', 'mygrp05', path='.', snap_schedule='1m', fs='cephfs')
 
         self._verify_snap_schedule(self.CREATE_VERSION, 'sv05', 'mygrp05')
+        self.fs_snap_schedule_cmd('remove', '--subvol', 'sv05', '--group', 'mygrp05', path='.', snap_schedule='1m', fs='cephfs')
         path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv05', 'mygrp05')
         self.remove_snapshots(path, self.get_snap_dir_name())
 
@@ -776,6 +790,8 @@ class TestSnapSchedulesSubvolAndGroupArguments(TestSnapSchedulesHelper):
         self.fs_snap_schedule_cmd('add', '--subvol', 'sv08', '--group', 'mygrp08', path='.', snap_schedule='1m', fs='cephfs')
         self.fs_snap_schedule_cmd('list', '--subvol', 'sv08', '--group', 'mygrp08', path='.', fs='cephfs')
         self.fs_snap_schedule_cmd('remove', '--subvol', 'sv08', '--group', 'mygrp08', path='.', snap_schedule='1m', fs='cephfs')
+        path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv08', 'mygrp08')
+        self.remove_snapshots(path, self.get_snap_dir_name())
 
         path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv08', 'mygrp08')
         self.remove_snapshots(path, self.get_snap_dir_name())
@@ -826,6 +842,8 @@ class TestSnapSchedulesSubvolAndGroupArguments(TestSnapSchedulesHelper):
         self.fs_snap_schedule_cmd('add', '--subvol', 'sv11', '--group', 'mygrp11', path='.', snap_schedule='1m', fs='cephfs')
         self.fs_snap_schedule_cmd('retention', 'add', '--subvol', 'sv11', '--group', 'mygrp11', path='.', retention_spec_or_period='h', retention_count=5, fs='cephfs')
         self.fs_snap_schedule_cmd('remove', '--subvol', 'sv11', '--group', 'mygrp11', path='.', snap_schedule='1m', fs='cephfs')
+        path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv11', 'mygrp11')
+        self.remove_snapshots(path, self.get_snap_dir_name())
 
         path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv11', 'mygrp11')
         self.remove_snapshots(path, self.get_snap_dir_name())
@@ -844,6 +862,8 @@ class TestSnapSchedulesSubvolAndGroupArguments(TestSnapSchedulesHelper):
         with self.assertRaises(CommandFailedError):
             self.fs_snap_schedule_cmd('activate', '--subvol', 'sv12', path='.', fs='cephfs')
         self.fs_snap_schedule_cmd('remove', '--subvol', 'sv12', '--group', 'mygrp12', path='.', snap_schedule='1m', fs='cephfs')
+        path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv12', 'mygrp12')
+        self.remove_snapshots(path, self.get_snap_dir_name())
 
         path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv12', 'mygrp12')
         self.remove_snapshots(path, self.get_snap_dir_name())
@@ -880,10 +900,11 @@ class TestSnapSchedulesSubvolAndGroupArguments(TestSnapSchedulesHelper):
         self.fs_snap_schedule_cmd('activate', '--subvol', 'sv14', '--group', 'mygrp14', path='.', fs='cephfs')
 
         self._verify_snap_schedule(self.CREATE_VERSION, 'sv14', 'mygrp14')
+        self.fs_snap_schedule_cmd('remove', '--subvol', 'sv14', '--group', 'mygrp14', path='.', snap_schedule='1m', fs='cephfs')
+
         path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv14', 'mygrp14')
         self.remove_snapshots(path, self.get_snap_dir_name())
 
-        self.fs_snap_schedule_cmd('remove', '--subvol', 'sv14', '--group', 'mygrp14', path='.', snap_schedule='1m', fs='cephfs')
         self._fs_cmd('subvolume', 'rm', 'cephfs', 'sv14', '--group_name', 'mygrp14')
         self._fs_cmd('subvolumegroup', 'rm', 'cephfs', 'mygrp14')
 
@@ -937,11 +958,11 @@ class TestSnapSchedulesSubvolAndGroupArguments(TestSnapSchedulesHelper):
         self.fs_snap_schedule_cmd('activate', '--subvol', 'sv17', '--group', 'mygrp17', path='.', fs='cephfs')
 
         self._verify_snap_schedule(self.CREATE_VERSION, 'sv17', 'mygrp17')
-        path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv17', 'mygrp17')
-        self.remove_snapshots(path, self.get_snap_dir_name())
 
         self.fs_snap_schedule_cmd('deactivate', '--subvol', 'sv17', '--group', 'mygrp17', path='.', fs='cephfs')
         self.fs_snap_schedule_cmd('remove', '--subvol', 'sv17', '--group', 'mygrp17', path='.', snap_schedule='1m', fs='cephfs')
+        path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv17', 'mygrp17')
+        self.remove_snapshots(path, self.get_snap_dir_name())
 
         self._fs_cmd('subvolume', 'rm', 'cephfs', 'sv17', '--group_name', 'mygrp17')
         self._fs_cmd('subvolumegroup', 'rm', 'cephfs', 'mygrp17')
@@ -999,6 +1020,8 @@ class TestSnapSchedulesSubvolAndGroupArguments(TestSnapSchedulesHelper):
         self.fs_snap_schedule_cmd('deactivate', '--subvol', 'sv20', '--group', 'mygrp20', path='.', fs='cephfs')
         self.fs_snap_schedule_cmd('retention', 'remove', '--subvol', 'sv20', '--group', 'mygrp20', path='.', retention_spec_or_period='h', retention_count='5', fs='cephfs')
         self.fs_snap_schedule_cmd('remove', '--subvol', 'sv20', '--group', 'mygrp20', path='.', snap_schedule='1m', fs='cephfs')
+        path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv20', 'mygrp20')
+        self.remove_snapshots(path, self.get_snap_dir_name())
 
         path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv20', 'mygrp20')
         self.remove_snapshots(path, self.get_snap_dir_name())
@@ -1060,6 +1083,8 @@ class TestSnapSchedulesSubvolAndGroupArguments(TestSnapSchedulesHelper):
         self.fs_snap_schedule_cmd('deactivate', '--subvol', 'sv23', '--group', 'mygrp23', path='.', fs='cephfs')
         self.fs_snap_schedule_cmd('retention', 'remove', '--subvol', 'sv23', '--group', 'mygrp23', path='.', retention_spec_or_period='h', retention_count='5', fs='cephfs')
         self.fs_snap_schedule_cmd('remove', '--subvol', 'sv23', '--group', 'mygrp23', path='.', snap_schedule='1m', fs='cephfs')
+        path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv23', 'mygrp23')
+        self.remove_snapshots(path, self.get_snap_dir_name())
 
         path = self._get_subvol_snapdir_path(self.CREATE_VERSION, 'sv23', 'mygrp23')
         self.remove_snapshots(path, self.get_snap_dir_name())
@@ -1131,5 +1156,6 @@ class TestSnapSchedulesMandatoryFSArgument(TestSnapSchedulesHelper):
         self.fs_snap_schedule_cmd('retention', 'remove', test_path, retention_spec_or_period='1M', fs='backup_fs')
         self.fs_snap_schedule_cmd('deactivate', test_path, snap_schedule='1M', fs='backup_fs')
         self.fs_snap_schedule_cmd('remove', test_path, snap_schedule='1M', fs='backup_fs')
+        self.remove_snapshots(test_path, self.get_snap_dir_name())
 
         self.mount_a.run_shell(['rmdir', test_path])

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -793,7 +793,7 @@ tasks.cephfs.fuse_mount.FuseMount = LocalFuseMount
 # XXX: this class has nothing to do with the Ceph daemon (ceph-mgr) of
 # the same name.
 class LocalCephManager(CephManager):
-    def __init__(self, ctx=None, cluster_name=None):
+    def __init__(self, ctx=None, cluster_name='ceph'):
         self.ctx = ctx
         self.cluster = cluster_name
 
@@ -821,6 +821,9 @@ class LocalCephManager(CephManager):
         self.RADOS_CMD = [RADOS_CMD]
 
         self.save_conf_epoch()
+
+    def init_pools(self):
+        self.wait_for_active()
 
     def get_ceph_cmd(self, **kwargs):
         return [CEPH_CMD]

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1031,6 +1031,7 @@ class LocalContext(object):
                           stdout=StringIO()).stdout.getvalue()
         from teuthology.run import get_summary
 
+        self.environment = 'vstart'
         cluster_name = 'ceph'
         self.archive = "./"
         self.config = {'cluster': cluster_name}


### PR DESCRIPTION
Since the ceph cluster is destroyed and recreated after every test case, it wasn't a good idea to reuse the same CephManager object.

Introduced-by: 329edd3c56baff81cb76c5008ac2eaf7c110f9e1
Fixes: https://tracker.ceph.com/issues/66009
Signed-off-by: Milind Changire <mchangir@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
