### PR TITLE
quincy: qa: enable debug logs for fs:cephadm:multivolume subsuite

### DIFF
--- a/qa/suites/fs/cephadm/multivolume/conf
+++ b/qa/suites/fs/cephadm/multivolume/conf
@@ -1,0 +1,1 @@
+.qa/cephfs/conf


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66323

---

backport of https://github.com/ceph/ceph/pull/57477
parent tracker: https://tracker.ceph.com/issues/66029

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh