### PR TITLE
qa: check objecter flush when bufferheads exceed limit

### DIFF
--- a/qa/suites/rados/objectstore/backends/objectcacher-stress.yaml
+++ b/qa/suites/rados/objectstore/backends/objectcacher-stress.yaml
@@ -14,3 +14,4 @@ tasks:
     clients:
       all:
         - osdc/stress_objectcacher.sh
+        - osdc/object_cacher_misc.sh

--- a/qa/workunits/osdc/object_cacher_misc.sh
+++ b/qa/workunits/osdc/object_cacher_misc.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -ex
+
+ceph_test_objectcacher_misc --flush-test > /dev/null 2>&1
+
+echo OK

--- a/src/test/osdc/object_cacher_misc.cc
+++ b/src/test/osdc/object_cacher_misc.cc
@@ -1,0 +1,151 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <cstdlib>
+#include <ctime>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <boost/scoped_ptr.hpp>
+
+#include "common/ceph_argparse.h"
+#include "common/ceph_mutex.h"
+#include "common/common_init.h"
+#include "common/config.h"
+#include "common/snap_types.h"
+#include "global/global_init.h"
+#include "include/buffer.h"
+#include "include/Context.h"
+#include "include/stringify.h"
+#include "osdc/ObjectCacher.h"
+
+#include "FakeWriteback.h"
+#include "MemWriteback.h"
+
+#include <atomic>
+
+using namespace std;
+
+int flush_test()
+{
+  bool fail = false;
+  bool done = false;
+  uint64_t delay_ns = 0;
+  ceph::mutex lock = ceph::make_mutex("object_cacher_misc");
+  MemWriteback writeback(g_ceph_context, &lock, delay_ns);
+
+  int max_dirty_age = 1;
+  uint64_t max_cache = 1 << 20; // max cache size, 1MB
+  uint64_t max_dirty = 1 << 19; // max dirty, 512KB
+  uint64_t target_dirty = 1 << 18; // target dirty, 256KB
+
+  int bl_size = 1 << 12;
+  ceph::_page_shift = 16; // 64KB
+  int max_dirty_bhs = max_dirty / (1 << ceph::_page_shift); // 8
+
+  std::cout << "Test configuration:\n"
+      << setw(20) << "max_cache: " << max_cache << "\n"
+      << setw(20) << "max_dirty_age: " << max_dirty_age << "\n"
+      << setw(20) << "max_dirty: " << max_dirty << "\n"
+      << setw(20) << "ceph::_page_shift: " << ceph::_page_shift << "\n"
+      << setw(20) << "max_dirty_bh: " << max_dirty_bhs << "\n"
+      << setw(20) << "write extent size: " << bl_size << "\n\n";
+
+  ObjectCacher obc(g_ceph_context, "test", writeback, lock, NULL, NULL,
+		   max_cache, // max cache size, 1MB
+		   1, // max objects, just one
+		   max_dirty, // max dirty, 512KB
+		   target_dirty, // target dirty, 256KB
+		   max_dirty_age,
+		   true);
+  obc.start();
+
+  SnapContext snapc;
+  ceph_tid_t journal_tid = 0;
+  std::string oid("flush_test_obj");
+  ObjectCacher::ObjectSet object_set(NULL, 0, 0);
+  ceph::bufferlist zeroes_bl;
+  zeroes_bl.append_zero(bl_size);
+
+  std::map<int, C_SaferCond> create_finishers;
+
+  utime_t last_start;
+  for (int i = 0; i < max_dirty_bhs; ++i) {
+    if (i == (max_dirty_bhs - 1)) {
+      last_start = ceph_clock_now();
+    }
+    ObjectCacher::OSDWrite *wr = obc.prepare_write(snapc, zeroes_bl,
+						   ceph::real_clock::zero(), 0,
+						   ++journal_tid);
+    ObjectExtent extent(oid, 0, zeroes_bl.length()*i, zeroes_bl.length(), 0);
+    extent.oloc.pool = 0;
+    extent.buffer_extents.push_back(make_pair(0, bl_size));
+    wr->extents.push_back(extent);
+    lock.lock();
+    obc.writex(wr, &object_set, &create_finishers[i]);
+    lock.unlock();
+  }
+  utime_t last_end = ceph_clock_now();
+
+  std::cout << "Write " << max_dirty_bhs << " extents"
+      << ", total size " << zeroes_bl.length() * max_dirty_bhs
+      << ", attain max dirty bufferheads " << max_dirty_bhs
+      << ", but below max dirty " << max_dirty << std::endl;
+
+  if (last_end - last_start > utime_t(max_dirty_age, 0)) {
+    std::cout << "Error: the last writex took more than " << max_dirty_age
+        << "s(max_dirty_age), fail to trigger flush" << std::endl;
+    fail = true;;
+  } else {
+    std::cout << "Info: the last writex took " << last_end - last_start
+        << ", success to trigger flush" << std::endl;
+  }
+
+  for (int i = 0; i < max_dirty_bhs; ++i) {
+    create_finishers[i].wait();
+  }
+
+  lock.lock();
+  C_SaferCond flushcond;
+  obc.flush_all(&flushcond);
+  done = obc.flush_all(&flushcond);
+  if (!done) {
+    lock.unlock();
+    flushcond.wait();
+    lock.lock();
+  }
+
+  obc.release_set(&object_set);
+  lock.unlock();
+  obc.stop();
+
+  if (fail) {
+    std::cout << "Test ObjectCacher flush completed failed" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "Test ObjectCacher flush completed successfully" << std::endl;
+  return EXIT_SUCCESS;
+}
+
+int main(int argc, const char **argv)
+{
+  auto args = argv_to_vec(argc, argv);
+  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
+			 CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  bool flush = false;
+  std::vector<const char*>::iterator i;
+  for (i = args.begin(); i != args.end();) {
+    if (ceph_argparse_flag(args, i, "--flush-test", NULL)) {
+      flush = true;
+    } else {
+      cerr << "unknown option " << *i << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (flush) {
+    return flush_test();
+  }
+}


### PR DESCRIPTION
check if objectcacher flush is running properly




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
