### PR TITLE
mgr/dashboard: Multi-cluster cleanup

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/multi_cluster.py
+++ b/src/pybind/mgr/dashboard/controllers/multi_cluster.py
@@ -267,12 +267,13 @@ class MultiCluster(RESTController):
     @Endpoint('PUT')
     @UpdatePermission
     # pylint: disable=unused-variable
-    def edit_cluster(self, url, cluster_alias, username, verify=False, ssl_certificate=None):
+    def edit_cluster(self, name, url, cluster_alias, username, verify=False, ssl_certificate=None):
         multicluster_config = self.load_multi_cluster_config()
         if "config" in multicluster_config:
             for key, cluster_details in multicluster_config["config"].items():
                 for cluster in cluster_details:
-                    if cluster["url"] == url and cluster["user"] == username:
+                    if cluster["name"] == name and cluster["user"] == username:
+                        cluster['url'] = url
                         cluster['cluster_alias'] = cluster_alias
                         cluster['ssl_verify'] = verify
                         cluster['ssl_certificate'] = ssl_certificate if verify else ''

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-form/multi-cluster-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-form/multi-cluster-form.component.html
@@ -117,7 +117,7 @@
                 </cd-copy-2-clipboard-button>
               </span>
               <span class="invalid-feedback"
-                    *ngIf="remoteClusterForm.showError('password', frm, 'required')"
+                    *ngIf="remoteClusterForm.showError('password', frm, 'requiredNotEdit')"
                     i18n>This field is required.
               </span>
             </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/multi-cluster.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/multi-cluster.service.ts
@@ -116,6 +116,7 @@ export class MultiClusterService {
   }
 
   editCluster(
+    name: string,
     url: any,
     clusterAlias: string,
     username: string,
@@ -123,6 +124,7 @@ export class MultiClusterService {
     ssl_certificate = ''
   ) {
     return this.http.put('api/multi-cluster/edit_cluster', {
+      name: name,
       url,
       cluster_alias: clusterAlias,
       username: username,

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -7244,6 +7244,8 @@ paths:
               properties:
                 cluster_alias:
                   type: string
+                name:
+                  type: string
                 ssl_certificate:
                   type: string
                 url:
@@ -7254,6 +7256,7 @@ paths:
                   default: false
                   type: boolean
               required:
+              - name
               - url
               - cluster_alias
               - username


### PR DESCRIPTION
After testing multi-cluster feature with new mgtm-gateway service, some workflows were not properly set to have the multi-cluster feature behind a proxy or could be improven, this PR cleans and fixes the following:

- Fix multi-cluster form password field as required
- Enable editing of Cluster API URL field on multi-cluster's edit form

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
