### PR TITLE
quincy: qa/tasks/qemu: Fix OS version comparison

### DIFF
--- a/qa/tasks/qemu.py
+++ b/qa/tasks/qemu.py
@@ -8,6 +8,8 @@ import os
 import yaml
 import time
 
+from packaging.version import Version
+
 from tasks import rbd
 from tasks.util.workunit import get_refspec_after_overrides
 from teuthology import contextutil
@@ -477,7 +479,10 @@ def run_qemu(ctx, config):
             )
 
         nfs_service_name = 'nfs'
-        if remote.os.name in ['rhel', 'centos'] and float(remote.os.version) >= 8:
+        if (
+            remote.os.name in ['rhel', 'centos'] and
+            Version(remote.os.version.lower().removesuffix(".stream")) >= Version("8")
+        ):
             nfs_service_name = 'nfs-server'
 
         # make an nfs mount to use for logging and to


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/58055 to quincy to fix `could not convert string to float: '9.stream' ` errors in qemu task.