### PR TITLE
common: CephContext avoids deprecated atomic_load/store_explicit() for shared_ptr

### DIFF
--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -282,11 +282,10 @@ public:
   void set_mon_addrs(const MonMap& mm);
   void set_mon_addrs(const std::vector<entity_addrvec_t>& in) {
     auto ptr = std::make_shared<std::vector<entity_addrvec_t>>(in);
-    atomic_store_explicit(&_mon_addrs, std::move(ptr), std::memory_order_relaxed);
+    _mon_addrs.store(std::move(ptr), std::memory_order_relaxed);
   }
   std::shared_ptr<std::vector<entity_addrvec_t>> get_mon_addrs() const {
-    auto ptr = atomic_load_explicit(&_mon_addrs, std::memory_order_relaxed);
-    return ptr;
+    return _mon_addrs.load(std::memory_order_relaxed);
   }
 
 private:
@@ -306,7 +305,7 @@ private:
 
   int _crypto_inited;
 
-  std::shared_ptr<std::vector<entity_addrvec_t>> _mon_addrs;
+  std::atomic<std::shared_ptr<std::vector<entity_addrvec_t>>> _mon_addrs;
 
   /* libcommon service thread.
    * SIGHUP wakes this thread, which then reopens logfiles */


### PR DESCRIPTION
addresses compiler warnings with gcc 14.1.1:
```
ceph/src/common/ceph_context.h: In member function ‘void ceph::common::CephContext::set_mon_addrs(const std::vector<entity_addrvec_t>&)’: ceph/src/common/ceph_context.h:285:26: warning: ‘void std::atomic_store_explicit(shared_ptr<_Tp>*, shared_ptr<_Tp>, memory_order) [with _Tp = vector<entity_addrvec_t>]’ is deprecated: use 'std::atomic<std::shared_ptr<T>>' instead [-Wdeprecated-declarations]
  285 |     atomic_store_explicit(&_mon_addrs, std::move(ptr), std::memory_order_relaxed);
      |     ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/14/memory:81,
                 from ceph/src/fmt/include/fmt/format.h:40,
                 from ceph/src/rgw/rgw_op.cc:15:
/usr/include/c++/14/bits/shared_ptr_atomic.h:173:5: note: declared here
  173 |     atomic_store_explicit(shared_ptr<_Tp>* __p, shared_ptr<_Tp> __r,
      |     ^~~~~~~~~~~~~~~~~~~~~
ceph/src/common/ceph_context.h: In member function ‘std::shared_ptr<std::vector<entity_addrvec_t> > ceph::common::CephContext::get_mon_addrs() const’:
ceph/src/common/ceph_context.h:288:36: warning: ‘std::shared_ptr<_Tp> std::atomic_load_explicit(const shared_ptr<_Tp>*, memory_order) [with _Tp = vector<entity_addrvec_t>]’ is deprecated: use 'std::atomic<std::shared_ptr<T>>' instead [-Wdeprecated-declarations]
  288 |     auto ptr = atomic_load_explicit(&_mon_addrs, std::memory_order_relaxed);
      |                ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr_atomic.h:133:5: note: declared here
  133 |     atomic_load_explicit(const shared_ptr<_Tp>* __p, memory_order)
      |     ^~~~~~~~~~~~~~~~~~~~
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
