### PR TITLE
rgw: test that no asio threads are blocked on null_yield

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2230,6 +2230,14 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_asio_assert_yielding
+  type: bool
+  level: dev
+  desc: Trigger an assertion failure if an operation would block an asio thread
+  default: false
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_user_quota_bucket_sync_interval
   type: int
   level: advanced

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -63,6 +63,7 @@ set(librgw_common_srcs
   rgw_acl_swift.cc
   rgw_aio.cc
   rgw_aio_throttle.cc
+  rgw_asio_thread.cc
   rgw_auth.cc
   rgw_auth_s3.cc
   rgw_arn.cc

--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -277,7 +277,7 @@ public:
           return io_block(0);
         }
         yield {
-          op_ret = http_op->wait(shard_info, null_yield);
+          op_ret = http_op->wait(dpp, shard_info, null_yield);
           http_op->put();
         }
 
@@ -377,7 +377,7 @@ public:
         }
         yield {
           timer.reset();
-          op_ret = http_op->wait(&response, null_yield);
+          op_ret = http_op->wait(dpp, &response, null_yield);
           http_op->put();
         }
 
@@ -495,7 +495,7 @@ public:
   }
 
   int request_complete() override {
-    int ret = http_op->wait(result, null_yield);
+    int ret = http_op->wait(sync_env->dpp, result, null_yield);
     http_op->put();
     if (ret < 0 && ret != -ENOENT) {
       ldpp_dout(sync_env->dpp, 5) << "ERROR: failed to list remote datalog shard, ret=" << ret << dendl;

--- a/src/rgw/driver/rados/rgw_lc_tier.cc
+++ b/src/rgw/driver/rados/rgw_lc_tier.cc
@@ -269,7 +269,7 @@ static int cloud_tier_get_object(RGWLCCloudTierCtx& tier_ctx, bool head,
   }
 
   /* fetch headers */
-  ret = tier_ctx.conn.complete_request(in_req, nullptr, nullptr, nullptr, nullptr, &headers, null_yield);
+  ret = tier_ctx.conn.complete_request(tier_ctx.dpp, in_req, nullptr, nullptr, nullptr, nullptr, &headers, null_yield);
   if (ret < 0 && ret != -ENOENT) {
     ldpp_dout(tier_ctx.dpp, 20) << "ERROR: " << __func__ << "(): conn.complete_request() returned ret=" << ret << dendl;
     return ret;
@@ -704,8 +704,7 @@ RGWGetDataCB *RGWLCCloudStreamPut::get_cb() {
 }
 
 int RGWLCCloudStreamPut::complete_request() {
-  int ret = conn.complete_request(out_req, etag, &obj_properties.mtime, null_yield);
-  return ret;
+  return conn.complete_request(dpp, out_req, etag, &obj_properties.mtime, null_yield);
 }
 
 /* Read local copy and write to Cloud endpoint */

--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -248,7 +248,7 @@ private:
                         << " retry_number: "
                         << entry_persistency_tracker.retires_num
                         << " current time: " << time_now << dendl;
-    const auto ret = push_endpoint->send(event_entry.event, yield);
+    const auto ret = push_endpoint->send(this, event_entry.event, yield);
     if (ret < 0) {
       ldpp_dout(this, 5) << "WARNING: push entry marker: " << entry.marker
                          << " failed. error: " << ret
@@ -1266,7 +1266,7 @@ int publish_commit(rgw::sal::Object* obj,
 	  dpp->get_cct());
         ldpp_dout(res.dpp, 20) << "INFO: push endpoint created: "
 			       << topic.cfg.dest.push_endpoint << dendl;
-        const auto ret = push_endpoint->send(event_entry.event, res.yield);
+        const auto ret = push_endpoint->send(dpp, event_entry.event, res.yield);
         if (ret < 0) {
           ldpp_dout(dpp, 1)
               << "ERROR: failed to push sync notification event with error: "

--- a/src/rgw/driver/rados/rgw_pubsub_push.cc
+++ b/src/rgw/driver/rados/rgw_pubsub_push.cc
@@ -9,6 +9,7 @@
 #include "common/Formatter.h"
 #include "common/iso_8601.h"
 #include "common/async/completion.h"
+#include "rgw_asio_thread.h"
 #include "rgw_common.h"
 #include "rgw_data_sync.h"
 #include "rgw_pubsub.h"
@@ -161,6 +162,8 @@ public:
           }, token, yield.get_executor());
       return -ec.value();
     }
+    maybe_warn_about_blocking(dpp);
+
     cond.wait(l, [this]{return (done==true);});
     return ret;
   }

--- a/src/rgw/driver/rados/rgw_pubsub_push.h
+++ b/src/rgw/driver/rados/rgw_pubsub_push.h
@@ -8,6 +8,7 @@
 #include "include/common_fwd.h"
 #include "common/async/yield_context.h"
 
+class DoutPrefixProvider;
 class RGWHTTPArgs;
 struct rgw_pubsub_s3_event;
 
@@ -28,7 +29,9 @@ public:
  
   // this method is used in order to send notification and wait for completion 
   // in async manner via a coroutine when invoked in the frontend environment
-  virtual int send(const rgw_pubsub_s3_event& event, optional_yield y) = 0;
+  virtual int send(const DoutPrefixProvider* dpp,
+                   const rgw_pubsub_s3_event& event,
+                   optional_yield y) = 0;
 
   // present as string
   virtual std::string to_str() const = 0;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -4083,7 +4083,7 @@ int RGWRados::stat_remote_obj(const DoutPrefixProvider *dpp,
       return ret;
     }
 
-    ret = conn->complete_request(in_stream_req, nullptr, &set_mtime, psize,
+    ret = conn->complete_request(dpp, in_stream_req, nullptr, &set_mtime, psize,
                                  nullptr, pheaders, y);
     if (ret < 0) {
       if (ret == -EIO && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
@@ -4318,7 +4318,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
       goto set_err_state;
     }
 
-    ret = conn->complete_request(in_stream_req, &etag, &set_mtime,
+    ret = conn->complete_request(rctx.dpp, in_stream_req, &etag, &set_mtime,
                                  &accounted_size, nullptr, nullptr, rctx.y);
     if (ret < 0) {
       if (ret == -EIO && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
@@ -4578,7 +4578,7 @@ int RGWRados::copy_obj_to_remote_dest(const DoutPrefixProvider *dpp,
       return ret;
     }
 
-    ret = rest_master_conn->complete_request(out_stream_req, etag, mtime, y);
+    ret = rest_master_conn->complete_request(dpp, out_stream_req, etag, mtime, y);
     if (ret < 0) {
       if (ret == -EIO && tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
         ldpp_dout(dpp, 20) << __func__  << "(): failed to put_obj_async_init. retries=" << tries << dendl;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -7776,7 +7776,7 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
       } // if taking of lock succeeded
     } // block to encapsulate recovery from incomplete reshard
 
-    ret = reshard_wait->wait(y);
+    ret = reshard_wait->wait(dpp, y);
     if (ret < 0) {
       ldpp_dout(dpp, 0) << __func__ <<
 	" ERROR: bucket is still resharding, please retry" << dendl;

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -7,6 +7,7 @@
 
 #include "rgw_zone.h"
 #include "driver/rados/rgw_bucket.h"
+#include "rgw_asio_thread.h"
 #include "rgw_reshard.h"
 #include "rgw_sal.h"
 #include "rgw_sal_rados.h"
@@ -1261,7 +1262,7 @@ int RGWReshard::clear_bucket_resharding(const DoutPrefixProvider *dpp, const str
   return 0;
 }
 
-int RGWReshardWait::wait(optional_yield y)
+int RGWReshardWait::wait(const DoutPrefixProvider* dpp, optional_yield y)
 {
   std::unique_lock lock(mutex);
 
@@ -1285,6 +1286,7 @@ int RGWReshardWait::wait(optional_yield y)
     waiters.erase(waiters.iterator_to(waiter));
     return -ec.value();
   }
+  maybe_warn_about_blocking(dpp);
 
   cond.wait_for(lock, duration);
 

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -266,7 +266,7 @@ public:
   ~RGWReshardWait() {
     ceph_assert(going_down);
   }
-  int wait(optional_yield y);
+  int wait(const DoutPrefixProvider* dpp, optional_yield y);
   // unblock any threads waiting on reshard
   void stop();
 };

--- a/src/rgw/driver/rados/rgw_sync.cc
+++ b/src/rgw/driver/rados/rgw_sync.cc
@@ -505,7 +505,7 @@ public:
           return io_block(0);
         }
         yield {
-          op_ret = http_op->wait(shard_info, null_yield);
+          op_ret = http_op->wait(dpp, shard_info, null_yield);
           http_op->put();
         }
 
@@ -586,7 +586,7 @@ public:
   }
 
   int request_complete() override {
-    int ret = http_op->wait(result, null_yield);
+    int ret = http_op->wait(sync_env->dpp, result, null_yield);
     http_op->put();
     if (ret < 0 && ret != -ENOENT) {
       ldpp_dout(sync_env->dpp, 5) << "ERROR: failed to list remote mdlog shard, ret=" << ret << dendl;
@@ -1089,7 +1089,7 @@ public:
           return io_block(0);
         }
         yield {
-          op_ret = http_op->wait(pbl, null_yield);
+          op_ret = http_op->wait(dpp, pbl, null_yield);
           http_op->put();
         }
 
@@ -2547,7 +2547,7 @@ int RGWCloneMetaLogCoroutine::state_send_rest_request(const DoutPrefixProvider *
 
 int RGWCloneMetaLogCoroutine::state_receive_rest_response()
 {
-  op_ret = http_op->wait(&data, null_yield);
+  op_ret = http_op->wait(sync_env->dpp, &data, null_yield);
   if (op_ret < 0 && op_ret != -EIO) {
     error_stream << "http operation failed: " << http_op->to_str() << " status=" << http_op->get_http_status() << std::endl;
     ldpp_dout(sync_env->dpp, 5) << "failed to wait for op, ret=" << op_ret << dendl;

--- a/src/rgw/driver/rados/rgw_tools.h
+++ b/src/rgw/driver/rados/rgw_tools.h
@@ -90,10 +90,6 @@ const char *rgw_find_mime_by_ext(std::string& ext);
 void rgw_filter_attrset(std::map<std::string, bufferlist>& unfiltered_attrset, const std::string& check_prefix,
                         std::map<std::string, bufferlist> *attrset);
 
-/// indicates whether the current thread is in boost::asio::io_context::run(),
-/// used to log warnings if synchronous librados calls are made
-extern thread_local bool is_asio_thread;
-
 /// perform the rados operation, using the yield context when given
 int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, const std::string& oid,
                       librados::ObjectReadOperation *op, bufferlist* pbl,

--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -26,6 +26,7 @@
 #include "include/str_list.h"
 #include "include/stringify.h"
 #include "rgw_main.h"
+#include "rgw_asio_thread.h"
 #include "rgw_common.h"
 #include "rgw_sal.h"
 #include "rgw_sal_config.h"

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -25,6 +25,7 @@
 
 #include "rgw_asio_client.h"
 #include "rgw_asio_frontend.h"
+#include "rgw_asio_thread.h"
 
 #ifdef WITH_RADOSGW_BEAST_OPENSSL
 #include <boost/asio/ssl.hpp>

--- a/src/rgw/rgw_asio_thread.cc
+++ b/src/rgw/rgw_asio_thread.cc
@@ -1,0 +1,34 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "rgw_asio_thread.h"
+
+#include "common/BackTrace.h"
+#include "common/dout.h"
+
+thread_local bool is_asio_thread = false;
+
+void maybe_warn_about_blocking(const DoutPrefixProvider* dpp)
+{
+  // work on asio threads should be asynchronous, so warn when they block
+  if (!is_asio_thread) {
+    return;
+  }
+
+  ldpp_dout(dpp, 20) << "WARNING: blocking librados call" << dendl;
+#ifdef _BACKTRACE_LOGGING
+  ldpp_dout(dpp, 20) << "BACKTRACE: " << ClibBackTrace(0) << dendl;
+#endif
+}

--- a/src/rgw/rgw_asio_thread.cc
+++ b/src/rgw/rgw_asio_thread.cc
@@ -17,6 +17,7 @@
 
 #include "common/BackTrace.h"
 #include "common/dout.h"
+#include "include/ceph_assert.h"
 
 thread_local bool is_asio_thread = false;
 
@@ -27,6 +28,11 @@ void maybe_warn_about_blocking(const DoutPrefixProvider* dpp)
     return;
   }
 
+  // for validation, tests can assert that no requests block
+  const auto& conf = dpp->get_cct()->_conf;
+  ceph_assert_always(!conf->rgw_asio_assert_yielding);
+
+  // otherwise just log the warning and optional backtrace
   ldpp_dout(dpp, 20) << "WARNING: blocking librados call" << dendl;
 #ifdef _BACKTRACE_LOGGING
   ldpp_dout(dpp, 20) << "BACKTRACE: " << ClibBackTrace(0) << dendl;

--- a/src/rgw/rgw_asio_thread.h
+++ b/src/rgw/rgw_asio_thread.h
@@ -1,0 +1,26 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+class DoutPrefixProvider;
+
+/// indicates whether the current thread is in boost::asio::io_context::run(),
+/// used to log warnings if synchronous librados calls are made
+extern thread_local bool is_asio_thread;
+
+/// call when an operation will block the calling thread due to an empty
+/// optional_yield. a warning is logged when is_asio_thread is true
+void maybe_warn_about_blocking(const DoutPrefixProvider* dpp);

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -88,7 +88,7 @@ admin_token_retry:
 
   validate.set_url(url);
 
-  ret = validate.process(y);
+  ret = validate.process(dpp, y);
 
   /* NULL terminate for debug output. */
   token_body_bl.append(static_cast<char>(0));
@@ -464,7 +464,7 @@ EC2Engine::get_from_keystone(const DoutPrefixProvider* dpp, const std::string_vi
   validate.set_send_length(os.str().length());
 
   /* send request */
-  ret = validate.process(y);
+  ret = validate.process(dpp, y);
 
   /* if the supplied signature is wrong, we will get 401 from Keystone */
   if (validate.get_http_status() ==
@@ -544,7 +544,7 @@ auto EC2Engine::get_secret_from_keystone(const DoutPrefixProvider* dpp,
   secret.set_verify_ssl(cct->_conf->rgw_keystone_verify_ssl);
 
   /* send request */
-  ret = secret.process(y);
+  ret = secret.process(dpp, y);
 
   /* if the supplied access key isn't found, we will get 404 from Keystone */
   if (secret.get_http_status() ==

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -175,8 +175,6 @@ rgw_http_errors rgw_http_iam_errors({
 using namespace std;
 using namespace ceph::crypto;
 
-thread_local bool is_asio_thread = false;
-
 rgw_err::
 rgw_err()
 {

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -4,6 +4,7 @@
 #include "include/Context.h"
 #include "common/ceph_json.h"
 #include "rgw_coroutine.h"
+#include "rgw_asio_thread.h"
 
 // re-include our assert to clobber the system one; fix dout:
 #include "include/ceph_assert.h"
@@ -615,6 +616,8 @@ void RGWCoroutinesManager::io_complete(RGWCoroutine *cr, const rgw_io_id& io_id)
 
 int RGWCoroutinesManager::run(const DoutPrefixProvider *dpp, list<RGWCoroutinesStack *>& stacks)
 {
+  maybe_warn_about_blocking(dpp);
+
   int ret = 0;
   int blocked_count = 0;
   int interval_wait_count = 0;

--- a/src/rgw/rgw_cr_rest.cc
+++ b/src/rgw/rgw_cr_rest.cc
@@ -84,7 +84,8 @@ RGWStreamReadHTTPResourceCRF::~RGWStreamReadHTTPResourceCRF()
 {
   if (req) {
     req->cancel();
-    req->wait(null_yield);
+    auto dpp = NoDoutPrefix{cct, ceph_subsys_rgw};
+    req->wait(&dpp, null_yield);
     delete req;
   }
 }
@@ -188,7 +189,8 @@ RGWStreamWriteHTTPResourceCRF::~RGWStreamWriteHTTPResourceCRF()
 {
   if (req) {
     req->cancel();
-    req->wait(null_yield);
+    auto dpp = NoDoutPrefix{cct, ceph_subsys_rgw};
+    req->wait(&dpp, null_yield);
     delete req;
   }
 }

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -9,6 +9,7 @@
 #include <curl/easy.h>
 #include <curl/multi.h>
 
+#include "rgw_asio_thread.h"
 #include "rgw_common.h"
 #include "rgw_http_client.h"
 #include "rgw_http_errors.h"
@@ -82,10 +83,8 @@ struct rgw_http_req_data : public RefCountedObject {
       async_wait(yield.get_executor(), l, yield[ec]);
       return -ec.value();
     }
-    // work on asio threads should be asynchronous, so warn when they block
-    if (is_asio_thread) {
-      dout(20) << "WARNING: blocking http request" << dendl;
-    }
+    maybe_warn_about_blocking(dpp);
+
     cond.wait(l, [this]{return done==true;});
     return ret;
   }

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -71,7 +71,7 @@ struct rgw_http_req_data : public RefCountedObject {
         }, token, ex);
   }
 
-  int wait(optional_yield y) {
+  int wait(const DoutPrefixProvider* dpp, optional_yield y) {
     std::unique_lock l{lock};
     if (done) {
       return ret;
@@ -534,9 +534,9 @@ static bool is_upload_request(const string& method)
 /*
  * process a single simple one off request
  */
-int RGWHTTPClient::process(optional_yield y)
+int RGWHTTPClient::process(const DoutPrefixProvider* dpp, optional_yield y)
 {
-  return RGWHTTP::process(this, y);
+  return RGWHTTP::process(dpp, this, y);
 }
 
 string RGWHTTPClient::to_str()
@@ -648,9 +648,9 @@ bool RGWHTTPClient::is_done()
 /*
  * wait for async request to complete
  */
-int RGWHTTPClient::wait(optional_yield y)
+int RGWHTTPClient::wait(const DoutPrefixProvider* dpp, optional_yield y)
 {
-  return req_data->wait(y);
+  return req_data->wait(dpp, y);
 }
 
 void RGWHTTPClient::cancel()
@@ -1214,7 +1214,7 @@ int RGWHTTP::send(RGWHTTPClient *req) {
   return 0;
 }
 
-int RGWHTTP::process(RGWHTTPClient *req, optional_yield y) {
+int RGWHTTP::process(const DoutPrefixProvider* dpp, RGWHTTPClient *req, optional_yield y) {
   if (!req) {
     return 0;
   }
@@ -1223,6 +1223,6 @@ int RGWHTTP::process(RGWHTTPClient *req, optional_yield y) {
     return r;
   }
 
-  return req->wait(y);
+  return req->wait(dpp, y);
 }
 

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -151,9 +151,9 @@ public:
     req_timeout = timeout;
   }
 
-  int process(optional_yield y);
+  int process(const DoutPrefixProvider* dpp, optional_yield y);
 
-  int wait(optional_yield y);
+  int wait(const DoutPrefixProvider* dpp, optional_yield y);
   void cancel();
   bool is_done();
 
@@ -349,5 +349,6 @@ class RGWHTTP
 {
 public:
   static int send(RGWHTTPClient *req);
-  static int process(RGWHTTPClient *req, optional_yield y);
+  static int process(const DoutPrefixProvider* dpp, RGWHTTPClient *req,
+                     optional_yield y);
 };

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -212,7 +212,7 @@ int Service::issue_admin_token_request(const DoutPrefixProvider *dpp,
 
   token_req.set_url(token_url);
 
-  const int ret = token_req.process(y);
+  const int ret = token_req.process(dpp, y);
 
   /* Detect rejection earlier than during the token parsing step. */
   if (token_req.get_http_status() ==
@@ -290,7 +290,7 @@ int Service::get_keystone_barbican_token(const DoutPrefixProvider *dpp,
   token_req.set_url(token_url);
 
   ldpp_dout(dpp, 20) << "Requesting secret from barbican url=" << token_url << dendl;
-  const int ret = token_req.process(y);
+  const int ret = token_req.process(dpp, y);
   if (ret < 0) {
     ldpp_dout(dpp, 20) << "Barbican process error:" << token_bl.c_str() << dendl;
     return ret;

--- a/src/rgw/rgw_kmip_client.h
+++ b/src/rgw/rgw_kmip_client.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+class DoutPrefixProvider;
 class RGWKMIPManager;
 
 class RGWKMIPTransceiver {
@@ -35,7 +36,7 @@ public:
   ceph::mutex lock = ceph::make_mutex("rgw_kmip_req::lock");
   ceph::condition_variable cond;
 
-  int wait(optional_yield y);
+  int wait(const DoutPrefixProvider* dpp, optional_yield y);
   RGWKMIPTransceiver(CephContext * const cct,
     kmip_operation operation)
   : cct(cct),
@@ -46,7 +47,7 @@ public:
   ~RGWKMIPTransceiver();
 
   int send();
-  int process(optional_yield y);
+  int process(const DoutPrefixProvider* dpp, optional_yield y);
 };
 
 class RGWKMIPManager {

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -306,7 +306,7 @@ protected:
       secret_req.set_client_key(kctx.ssl_clientkey());
     }
 
-    res = secret_req.process(y);
+    res = secret_req.process(dpp, y);
 
     // map 401 to EACCES instead of EPERM
     if (secret_req.get_http_status() ==
@@ -782,8 +782,8 @@ private:
 protected:
 	KmipGetTheKey(CephContext *cct) : cct(cct) {}
 	KmipGetTheKey& keyid_to_keyname(std::string_view key_id);
-	KmipGetTheKey& get_uniqueid_for_keyname(optional_yield y);
-	int get_key_for_uniqueid(optional_yield y, std::string &);
+	KmipGetTheKey& get_uniqueid_for_keyname(const DoutPrefixProvider* dpp, optional_yield y);
+	int get_key_for_uniqueid(const DoutPrefixProvider* dpp, optional_yield y, std::string &);
 	friend KmipSecretEngine;
 };
 
@@ -808,7 +808,8 @@ KmipGetTheKey::keyid_to_keyname(std::string_view key_id)
 }
 
 KmipGetTheKey&
-KmipGetTheKey::get_uniqueid_for_keyname(optional_yield y)
+KmipGetTheKey::get_uniqueid_for_keyname(const DoutPrefixProvider* dpp,
+                                        optional_yield y)
 {
 	RGWKMIPTransceiver secret_req(cct, RGWKMIPTransceiver::LOCATE);
 
@@ -834,7 +835,8 @@ KmipGetTheKey::get_uniqueid_for_keyname(optional_yield y)
 }
 
 int
-KmipGetTheKey::get_key_for_uniqueid(optional_yield y, std::string& actual_key)
+KmipGetTheKey::get_key_for_uniqueid(const DoutPrefixProvider* dpp,
+                                    optional_yield y, std::string& actual_key)
 {
 	if (failed) return ret;
 	RGWKMIPTransceiver secret_req(cct, RGWKMIPTransceiver::GET);
@@ -866,8 +868,8 @@ public:
 	int r;
 	r = KmipGetTheKey{cct}
 		.keyid_to_keyname(key_id)
-		.get_uniqueid_for_keyname(y)
-		.get_key_for_uniqueid(y, actual_key);
+		.get_uniqueid_for_keyname(dpp, y)
+		.get_key_for_uniqueid(dpp, y, actual_key);
 	return r;
   }
 };
@@ -937,7 +939,7 @@ static int request_key_from_barbican(const DoutPrefixProvider *dpp,
   secret_req.append_header("Accept", "application/octet-stream");
   secret_req.append_header("X-Auth-Token", barbican_token);
 
-  res = secret_req.process(y);
+  res = secret_req.process(dpp, y);
   // map 401 to EACCES instead of EPERM
   if (secret_req.get_http_status() ==
       RGWHTTPTransceiver::HTTP_STATUS_UNAUTHORIZED) {

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -814,7 +814,7 @@ KmipGetTheKey::get_uniqueid_for_keyname(const DoutPrefixProvider* dpp,
 	RGWKMIPTransceiver secret_req(cct, RGWKMIPTransceiver::LOCATE);
 
 	secret_req.name = work.data();
-	ret = secret_req.process(y);
+	ret = secret_req.process(dpp, y);
 	if (ret < 0) {
 		failed = true;
 	} else if (!secret_req.outlist->string_count) {
@@ -841,7 +841,7 @@ KmipGetTheKey::get_key_for_uniqueid(const DoutPrefixProvider* dpp,
 	if (failed) return ret;
 	RGWKMIPTransceiver secret_req(cct, RGWKMIPTransceiver::GET);
 	secret_req.unique_id = work.data();
-	ret = secret_req.process(y);
+	ret = secret_req.process(dpp, y);
 	if (ret < 0) {
 		failed = true;
 	} else {

--- a/src/rgw/rgw_opa.cc
+++ b/src/rgw/rgw_opa.cc
@@ -71,7 +71,7 @@ int rgw_opa_authorize(RGWOp *& op,
   req.set_send_length(ss.str().length());
 
   /* send request */
-  ret = req.process(null_yield);
+  ret = req.process(op, s->yield);
   if (ret < 0) {
     ldpp_dout(op, 2) << "OPA process error:" << bl.c_str() << dendl;
     return ret;

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -452,7 +452,7 @@ int RGWRESTSimpleRequest::forward_request(const DoutPrefixProvider *dpp, const R
   method = new_info.method;
   url = new_url;
 
-  int r = process(y);
+  int r = process(dpp, y);
   if (r < 0){
     if (r == -EINVAL){
       // curl_easy has errored, generally means the service is not available
@@ -922,14 +922,15 @@ int RGWRESTStreamRWRequest::send(RGWHTTPManager *mgr)
   return RGWHTTPStreamRWRequest::send(mgr);
 }
 
-int RGWHTTPStreamRWRequest::complete_request(optional_yield y,
+int RGWHTTPStreamRWRequest::complete_request(const DoutPrefixProvider* dpp,
+                                             optional_yield y,
                                              string *etag,
                                              real_time *mtime,
                                              uint64_t *psize,
                                              map<string, string> *pattrs,
                                              map<string, string> *pheaders)
 {
-  int ret = wait(y);
+  int ret = wait(dpp, y);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -168,7 +168,7 @@ public:
 
   virtual int send(RGWHTTPManager *mgr);
 
-  int complete_request(optional_yield y,
+  int complete_request(const DoutPrefixProvider* dpp, optional_yield y,
                        std::string *etag = nullptr,
                        real_time *mtime = nullptr,
                        uint64_t *psize = nullptr,

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -257,10 +257,11 @@ int RGWRESTConn::put_obj_async_init(const DoutPrefixProvider *dpp, const rgw_own
   return 0;
 }
 
-int RGWRESTConn::complete_request(RGWRESTStreamS3PutObj *req, string& etag,
+int RGWRESTConn::complete_request(const DoutPrefixProvider* dpp,
+                                  RGWRESTStreamS3PutObj *req, string& etag,
                                   real_time *mtime, optional_yield y)
 {
-  int ret = req->complete_request(y, &etag, mtime);
+  int ret = req->complete_request(dpp, y, &etag, mtime);
   if (ret == -EIO) {
     ldout(cct, 5) << __func__ << ": complete_request() returned ret=" << ret << dendl;
     set_url_unconnectable(req->get_url_orig());
@@ -408,7 +409,8 @@ done_err:
   return r;
 }
 
-int RGWRESTConn::complete_request(RGWRESTStreamRWRequest *req,
+int RGWRESTConn::complete_request(const DoutPrefixProvider* dpp,
+                                  RGWRESTStreamRWRequest *req,
                                   string *etag,
                                   real_time *mtime,
                                   uint64_t *psize,
@@ -416,7 +418,7 @@ int RGWRESTConn::complete_request(RGWRESTStreamRWRequest *req,
                                   map<string, string> *pheaders,
                                   optional_yield y)
 {
-  int ret = req->complete_request(y, etag, mtime, psize, pattrs, pheaders);
+  int ret = req->complete_request(dpp, y, etag, mtime, psize, pattrs, pheaders);
   if (ret == -EIO) {
     ldout(cct, 5) << __func__ << ": complete_request() returned ret=" << ret << dendl;
     set_url_unconnectable(req->get_url_orig());
@@ -467,7 +469,7 @@ int RGWRESTConn::get_resource(const DoutPrefixProvider *dpp,
       return ret;
     }
 
-    ret = req.complete_request(y);
+    ret = req.complete_request(dpp, y);
     if (ret == -EIO) {
       set_url_unconnectable(url);
       if (tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
@@ -521,7 +523,7 @@ int RGWRESTConn::send_resource(const DoutPrefixProvider *dpp, const std::string&
       return ret;
     }
 
-    ret = req.complete_request(y);
+    ret = req.complete_request(dpp, y);
     if (ret == -EIO) {
       set_url_unconnectable(url);
       if (tries < NUM_ENPOINT_IOERROR_RETRIES - 1) {
@@ -580,7 +582,7 @@ int RGWRESTReadResource::read(const DoutPrefixProvider *dpp, optional_yield y)
     return ret;
   }
 
-  ret = req.complete_request(y);
+  ret = req.complete_request(dpp, y);
   if (ret == -EIO) {
     conn->set_url_unconnectable(req.get_url_orig());
     ldpp_dout(dpp, 20) << __func__ << ": complete_request() returned ret=" << ret << dendl;
@@ -647,7 +649,7 @@ int RGWRESTSendResource::send(const DoutPrefixProvider *dpp, bufferlist& outbl, 
     return ret;
   }
 
-  ret = req.complete_request(y);
+  ret = req.complete_request(dpp, y);
   if (ret == -EIO) {
     conn->set_url_unconnectable(req.get_url_orig());
     ldpp_dout(dpp, 20) << __func__ << ": complete_request() returned ret=" << ret << dendl;

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -315,7 +315,7 @@ WebTokenEngine::get_cert_url(const string& iss, const DoutPrefixProvider *dpp, o
   //Headers
   openidc_req.append_header("Content-Type", "application/x-www-form-urlencoded");
 
-  int res = openidc_req.process(y);
+  int res = openidc_req.process(dpp, y);
   if (res < 0) {
     ldpp_dout(dpp, 10) << "HTTP request res: " << res << dendl;
     throw -EINVAL;
@@ -353,7 +353,7 @@ WebTokenEngine::validate_signature(const DoutPrefixProvider* dpp, const jwt::dec
     //Headers
     cert_req.append_header("Content-Type", "application/x-www-form-urlencoded");
 
-    int res = cert_req.process(y);
+    int res = cert_req.process(dpp, y);
     if (res < 0) {
       ldpp_dout(dpp, 10) << "HTTP request res: " << res << dendl;
       throw -EINVAL;

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -479,7 +479,7 @@ ExternalTokenEngine::authenticate(const DoutPrefixProvider* dpp,
 
   ldpp_dout(dpp, 10) << "rgw_swift_validate_token url=" << url_buf << dendl;
 
-  int ret = validator.process(y);
+  int ret = validator.process(dpp, y);
   if (ret < 0) {
     throw ret;
   }

--- a/src/test/rgw/test_http_manager.cc
+++ b/src/test/rgw/test_http_manager.cc
@@ -76,7 +76,8 @@ TEST(HTTPManager, ReadTruncated)
   const auto url = std::string{"http://127.0.0.1:"} + std::to_string(acceptor.local_endpoint().port());
 
   RGWHTTPClient client{g_ceph_context, "GET", url};
-  EXPECT_EQ(-EAGAIN, RGWHTTP::process(&client, null_yield));
+  const auto dpp = NoDoutPrefix{g_ceph_context, ceph_subsys_rgw};
+  EXPECT_EQ(-EAGAIN, RGWHTTP::process(&dpp, &client, null_yield));
 
   server.join();
 }
@@ -100,7 +101,8 @@ TEST(HTTPManager, Head)
   const auto url = std::string{"http://127.0.0.1:"} + std::to_string(acceptor.local_endpoint().port());
 
   RGWHTTPClient client{g_ceph_context, "HEAD", url};
-  EXPECT_EQ(0, RGWHTTP::process(&client, null_yield));
+  const auto dpp = NoDoutPrefix{g_ceph_context, ceph_subsys_rgw};
+  EXPECT_EQ(0, RGWHTTP::process(&dpp, &client, null_yield));
 
   server.join();
 }

--- a/src/test/rgw/test_rgw_reshard_wait.cc
+++ b/src/test/rgw/test_rgw_reshard_wait.cc
@@ -23,10 +23,11 @@ using Clock = RGWReshardWait::Clock;
 TEST(ReshardWait, wait_block)
 {
   constexpr ceph::timespan wait_duration = 10ms;
+  const auto dpp = NoDoutPrefix{g_ceph_context, ceph_subsys_rgw};
   RGWReshardWait waiter(wait_duration);
 
   const auto start = Clock::now();
-  EXPECT_EQ(0, waiter.wait(null_yield));
+  EXPECT_EQ(0, waiter.wait(&dpp, null_yield));
   const ceph::timespan elapsed = Clock::now() - start;
 
   EXPECT_LE(wait_duration, elapsed); // waited at least 10ms
@@ -37,16 +38,17 @@ TEST(ReshardWait, stop_block)
 {
   constexpr ceph::timespan short_duration = 10ms;
   constexpr ceph::timespan long_duration = 10s;
+  const auto dpp = NoDoutPrefix{g_ceph_context, ceph_subsys_rgw};
 
   RGWReshardWait long_waiter(long_duration);
   RGWReshardWait short_waiter(short_duration);
 
   const auto start = Clock::now();
-  std::thread thread([&long_waiter] {
-    EXPECT_EQ(-ECANCELED, long_waiter.wait(null_yield));
+  std::thread thread([&dpp, &long_waiter] {
+    EXPECT_EQ(-ECANCELED, long_waiter.wait(&dpp, null_yield));
   });
 
-  EXPECT_EQ(0, short_waiter.wait(null_yield));
+  EXPECT_EQ(0, short_waiter.wait(&dpp, null_yield));
 
   long_waiter.stop(); // cancel long waiter
 
@@ -65,11 +67,12 @@ void rethrow(std::exception_ptr eptr) {
 TEST(ReshardWait, wait_yield)
 {
   constexpr ceph::timespan wait_duration = 50ms;
+  const auto dpp = NoDoutPrefix{g_ceph_context, ceph_subsys_rgw};
   RGWReshardWait waiter(wait_duration);
 
   boost::asio::io_context context;
   boost::asio::spawn(context, [&] (boost::asio::yield_context yield) {
-      EXPECT_EQ(0, waiter.wait(yield));
+      EXPECT_EQ(0, waiter.wait(&dpp, yield));
     }, rethrow);
 
   const auto start = Clock::now();
@@ -88,6 +91,7 @@ TEST(ReshardWait, stop_yield)
 {
   constexpr ceph::timespan short_duration = 50ms;
   constexpr ceph::timespan long_duration = 10s;
+  const auto dpp = NoDoutPrefix{g_ceph_context, ceph_subsys_rgw};
 
   RGWReshardWait long_waiter(long_duration);
   RGWReshardWait short_waiter(short_duration);
@@ -95,14 +99,14 @@ TEST(ReshardWait, stop_yield)
   boost::asio::io_context context;
   boost::asio::spawn(context,
     [&] (boost::asio::yield_context yield) {
-      EXPECT_EQ(-ECANCELED, long_waiter.wait(yield));
+      EXPECT_EQ(-ECANCELED, long_waiter.wait(&dpp, yield));
     }, rethrow);
 
   const auto start = Clock::now();
   EXPECT_EQ(1u, context.poll()); // spawn
   EXPECT_FALSE(context.stopped());
 
-  EXPECT_EQ(0, short_waiter.wait(null_yield));
+  EXPECT_EQ(0, short_waiter.wait(&dpp, null_yield));
 
   long_waiter.stop(); // cancel long waiter
 
@@ -119,6 +123,7 @@ TEST(ReshardWait, stop_multiple)
 {
   constexpr ceph::timespan short_duration = 50ms;
   constexpr ceph::timespan long_duration = 10s;
+  const auto dpp = NoDoutPrefix{g_ceph_context, ceph_subsys_rgw};
 
   RGWReshardWait long_waiter(long_duration);
   RGWReshardWait short_waiter(short_duration);
@@ -126,8 +131,8 @@ TEST(ReshardWait, stop_multiple)
   // spawn 4 threads
   std::vector<std::thread> threads;
   {
-    auto sync_waiter([&long_waiter] {
-      EXPECT_EQ(-ECANCELED, long_waiter.wait(null_yield));
+    auto sync_waiter([&dpp, &long_waiter] {
+      EXPECT_EQ(-ECANCELED, long_waiter.wait(&dpp, null_yield));
     });
     threads.emplace_back(sync_waiter);
     threads.emplace_back(sync_waiter);
@@ -138,7 +143,7 @@ TEST(ReshardWait, stop_multiple)
   boost::asio::io_context context;
   {
     auto async_waiter = [&] (boost::asio::yield_context yield) {
-        EXPECT_EQ(-ECANCELED, long_waiter.wait(yield));
+        EXPECT_EQ(-ECANCELED, long_waiter.wait(&dpp, yield));
       };
     boost::asio::spawn(context, async_waiter, rethrow);
     boost::asio::spawn(context, async_waiter, rethrow);
@@ -150,7 +155,7 @@ TEST(ReshardWait, stop_multiple)
   EXPECT_EQ(4u, context.poll()); // spawn
   EXPECT_FALSE(context.stopped());
 
-  EXPECT_EQ(0, short_waiter.wait(null_yield));
+  EXPECT_EQ(0, short_waiter.wait(&dpp, null_yield));
 
   long_waiter.stop(); // cancel long waiter
 


### PR DESCRIPTION
continuation of the async refactoring project to eliminate the use of null_yield in frontend request coroutines

* moves the existing warnings into new function `maybe_warn_about_blocking()` in rgw_asio_thread.*
* adds config option `rgw_asio_assert_yielding` that teuthology tests can enable to crash on assertion failure instead of logging a warning message
* adds `maybe_warn_about_blocking()` coverage to some other blocking functions

as we make progress eliminating these null_yields, we can enable `rgw_asio_assert_yielding` in teuthology jobs to catch any regressions

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
