### PR TITLE
paxos: skip logm op while trim reached max

### DIFF
--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -401,6 +401,7 @@ void PaxosService::maybe_trim()
   const version_t trim_min = g_conf().get_val<version_t>("paxos_service_trim_min");
   if (trim_min > 0 &&
       to_remove < trim_min) {
+    last_to_remove = to_remove;
     dout(10) << __func__ << " trim_to " << trim_to << " would only trim " << to_remove
 	     << " < paxos_service_trim_min " << trim_min << dendl;
     return;
@@ -432,6 +433,7 @@ void PaxosService::maybe_trim()
   trim(t, first_committed, trim_to);
   put_first_committed(t, trim_to);
   cached_first_committed = trim_to;
+  last_to_remove = to_remove;
 
   // let the service add any extra stuff
   encode_trim_extra(t, trim_to);

--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -152,7 +152,8 @@ public:
       last_committed_name("last_committed"),
       first_committed_name("first_committed"),
       full_prefix_name("full"), full_latest_name("latest"),
-      cached_first_committed(0), cached_last_committed(0)
+      cached_first_committed(0), cached_last_committed(0),
+      last_to_remove(0)
   {
   }
 
@@ -477,6 +478,8 @@ public:
   /**
    * @}
    */
+
+  version_t last_to_remove;
 
   /**
    * Callback list to be used for waiting for the next proposal to commit.
@@ -850,6 +853,15 @@ public:
    */
   version_t get_last_committed() const{
     return cached_last_committed;
+  }
+
+  /**
+   * Get the quantity of last to remove
+   *
+   * @returns Our last to remove quantity
+   */
+  const version_t& get_last_to_remove() const {
+    return last_to_remove;
   }
 
   /**


### PR DESCRIPTION
A large number of logm op will lead to continuous increase in mon store.db capacity. If the speed of trim cannot keep up with the speed of mon accepting logm op, mon db will write to full disk space.

Fixes: https://tracker.ceph.com/issues/66562





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
