### PR TITLE
nasm-wrapper: Ignore --coverage flag passed to nasm

### DIFF
--- a/src/nasm-wrapper
+++ b/src/nasm-wrapper
@@ -10,7 +10,7 @@ while [ -n "$*" ]; do
         refine_nasm_options+=" -f $1"
         shift
         ;;
-    -c | --param* | -m* | -pipe | -thread )
+    -c | --param* | --coverage | -m* | -pipe | -thread )
         # unknown options under nasm & yasm
         shift
         ;;


### PR DESCRIPTION
https://tracker.ceph.com/issues/66158 added a fix for compiling with gcov coverage enabled, but a tweak to the nasm-wrapper script which excludes the --coverage flag was erroneously left out of the pull request. Nasm does not recognise this flag, so this PR will stop it being passed to nasm.

Fixes: https://tracker.ceph.com/issues/66601
Signed-off-by: Connor Fawcett <connorfa@uk.ibm.com>

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
