### PR TITLE
reef: librbd: diff-iterate shouldn't crash on an empty byte range

### DIFF
--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -312,12 +312,12 @@ int DiffIterate<I>::execute() {
   if (from_snap_id == CEPH_NOSNAP) {
     return -ENOENT;
   }
-  if (from_snap_id == end_snap_id) {
+  if (from_snap_id > end_snap_id) {
+    return -EINVAL;
+  }
+  if (from_snap_id == end_snap_id || m_length == 0) {
     // no diff.
     return 0;
-  }
-  if (from_snap_id >= end_snap_id) {
-    return -EINVAL;
   }
 
   int r;

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -266,6 +266,7 @@ int DiffIterate<I>::diff_iterate(I *ictx,
 
 template <typename I>
 std::pair<uint64_t, uint64_t> DiffIterate<I>::calc_object_diff_range() {
+  ceph_assert(m_length > 0);
   uint64_t period = m_image_ctx.get_stripe_period();
   uint64_t first_period_off = round_down_to(m_offset, period);
   uint64_t last_period_off = round_down_to(m_offset + m_length - 1, period);

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -7480,6 +7480,10 @@ TYPED_TEST(DiffIterateTest, DiffIterateDeterministic)
                                  vector_iterate_cb, &extents));
   ASSERT_EQ(0u, extents.size());
 
+  ASSERT_EQ(-ENOENT, rbd_diff_iterate2(image, "snap1", 0, size, true,
+                                       this->whole_object, vector_iterate_cb,
+                                       &extents));
+
   ASSERT_EQ(0, rbd_snap_create(image, "snap1"));
 
   std::string buf(256, '1');
@@ -7556,30 +7560,60 @@ TYPED_TEST(DiffIterateTest, DiffIterateDeterministic)
   ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[0]);
   extents.clear();
 
+  // 8. snap3 -> snap3
+  ASSERT_EQ(0, rbd_diff_iterate2(image, "snap3", 0, size, true, this->whole_object,
+                                 vector_iterate_cb, &extents));
+  ASSERT_EQ(0u, extents.size());
+
   ASSERT_PASSED(this->validate_object_map, image);
   ASSERT_EQ(0, rbd_snap_set(image, "snap2"));
 
-  // 8. beginning of time -> snap2
+  // 9. beginning of time -> snap2
   ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, this->whole_object,
                                  vector_iterate_cb, &extents));
   ASSERT_EQ(1u, extents.size());
   ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
   extents.clear();
 
-  // 9. snap1 -> snap2
+  // 10. snap1 -> snap2
   ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, this->whole_object,
                                  vector_iterate_cb, &extents));
   ASSERT_EQ(1u, extents.size());
   ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
   extents.clear();
 
+  // 11. snap2 -> snap2
+  ASSERT_EQ(0, rbd_diff_iterate2(image, "snap2", 0, size, true, this->whole_object,
+                                 vector_iterate_cb, &extents));
+  ASSERT_EQ(0u, extents.size());
+
+  // 12. snap3 -> snap2
+  ASSERT_EQ(-EINVAL, rbd_diff_iterate2(image, "snap3", 0, size, true,
+                                       this->whole_object, vector_iterate_cb,
+                                       &extents));
+
   ASSERT_PASSED(this->validate_object_map, image);
   ASSERT_EQ(0, rbd_snap_set(image, "snap1"));
 
-  // 10. beginning of time -> snap1
+  // 13. beginning of time -> snap1
   ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, this->whole_object,
                                  vector_iterate_cb, &extents));
   ASSERT_EQ(0u, extents.size());
+
+  // 14. snap1 -> snap1
+  ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, this->whole_object,
+                                 vector_iterate_cb, &extents));
+  ASSERT_EQ(0u, extents.size());
+
+  // 15. snap2 -> snap1
+  ASSERT_EQ(-EINVAL, rbd_diff_iterate2(image, "snap2", 0, size, true,
+                                       this->whole_object, vector_iterate_cb,
+                                       &extents));
+
+  // 16. snap3 -> snap1
+  ASSERT_EQ(-EINVAL, rbd_diff_iterate2(image, "snap3", 0, size, true,
+                                       this->whole_object, vector_iterate_cb,
+                                       &extents));
 
   ASSERT_PASSED(this->validate_object_map, image);
 
@@ -7612,6 +7646,10 @@ TYPED_TEST(DiffIterateTest, DiffIterateDeterministicPP)
   ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
                                    vector_iterate_cb, &extents));
   ASSERT_EQ(0u, extents.size());
+
+  ASSERT_EQ(-ENOENT, image.diff_iterate2("snap1", 0, size, true,
+                                         this->whole_object, vector_iterate_cb,
+                                         &extents));
 
   ASSERT_EQ(0, image.snap_create("snap1"));
 
@@ -7690,30 +7728,60 @@ TYPED_TEST(DiffIterateTest, DiffIterateDeterministicPP)
   ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[0]);
   extents.clear();
 
+  // 8. snap3 -> snap3
+  ASSERT_EQ(0, image.diff_iterate2("snap3", 0, size, true, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(0u, extents.size());
+
   ASSERT_PASSED(this->validate_object_map, image);
   ASSERT_EQ(0, image.snap_set("snap2"));
 
-  // 8. beginning of time -> snap2
+  // 9. beginning of time -> snap2
   ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
                                    vector_iterate_cb, &extents));
   ASSERT_EQ(1u, extents.size());
   ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
   extents.clear();
 
-  // 9. snap1 -> snap2
+  // 10. snap1 -> snap2
   ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, this->whole_object,
                                    vector_iterate_cb, &extents));
   ASSERT_EQ(1u, extents.size());
   ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
   extents.clear();
 
+  // 11. snap2 -> snap2
+  ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(0u, extents.size());
+
+  // 12. snap3 -> snap2
+  ASSERT_EQ(-EINVAL, image.diff_iterate2("snap3", 0, size, true,
+                                         this->whole_object, vector_iterate_cb,
+                                         &extents));
+
   ASSERT_PASSED(this->validate_object_map, image);
   ASSERT_EQ(0, image.snap_set("snap1"));
 
-  // 10. beginning of time -> snap1
+  // 13. beginning of time -> snap1
   ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
                                    vector_iterate_cb, &extents));
   ASSERT_EQ(0u, extents.size());
+
+  // 14. snap1 -> snap1
+  ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, this->whole_object,
+                                   vector_iterate_cb, &extents));
+  ASSERT_EQ(0u, extents.size());
+
+  // 15. snap2 -> snap1
+  ASSERT_EQ(-EINVAL, image.diff_iterate2("snap2", 0, size, true,
+                                         this->whole_object, vector_iterate_cb,
+                                         &extents));
+
+  // 16. snap3 -> snap1
+  ASSERT_EQ(-EINVAL, image.diff_iterate2("snap3", 0, size, true,
+                                         this->whole_object, vector_iterate_cb,
+                                         &extents));
 
   ASSERT_PASSED(this->validate_object_map, image);
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66583

---

backport of https://github.com/ceph/ceph/pull/57973
parent tracker: https://tracker.ceph.com/issues/66418