### PR TITLE
rgw/rgw_rados: fix server side-copy orphans tail-objects

### DIFF
--- a/qa/workunits/rgw/test_rgw_orphan_list.sh
+++ b/qa/workunits/rgw/test_rgw_orphan_list.sh
@@ -376,6 +376,95 @@ done
 
 mys3cmd rb --recursive s3://$o_bkt
 
+############################################################
+# copy multipart objects and delete destination
+
+o_bkt="orig-mp-bkt-5"
+d_bkt="copy-mp-bkt-5"
+
+mys3cmd mb s3://$o_bkt
+
+for f in $(seq 2) ;do
+    dest_obj="orig-multipart-obj-$f"
+    mys3cmd put -q $huge_obj s3://${o_bkt}/$dest_obj
+done
+
+mys3cmd mb s3://$d_bkt
+
+mys3cmd cp s3://${o_bkt}/orig-multipart-obj-1 \
+	s3://${d_bkt}/copied-multipart-obj-1
+
+for f in $(seq 5 5) ;do
+    dest_obj="orig-multipart-obj-$f"
+    mys3cmd put -q $huge_obj s3://${d_bkt}/$dest_obj
+done
+
+mys3cmd rb --recursive s3://$d_bkt
+
+#####################################################################
+# FORCE GARBAGE COLLECTION
+sleep 6 # since for testing age at which gc can happen is 5 secs
+radosgw-admin gc process --include-all
+#####################################################################
+
+############################################################
+# copy multipart objects and delete original then destination
+
+o_bkt="orig-mp-bkt-6"
+d_bkt="copy-mp-bkt-6"
+
+mys3cmd mb s3://$o_bkt
+
+for f in $(seq 2) ;do
+    dest_obj="orig-multipart-obj-$f"
+    mys3cmd put -q $huge_obj s3://${o_bkt}/$dest_obj
+done
+
+mys3cmd mb s3://$d_bkt
+
+mys3cmd cp s3://${o_bkt}/orig-multipart-obj-1 \
+	s3://${d_bkt}/copied-multipart-obj-1
+
+for f in $(seq 5 5) ;do
+    dest_obj="orig-multipart-obj-$f"
+    mys3cmd put -q $huge_obj s3://${d_bkt}/$dest_obj
+done
+
+mys3cmd rb --recursive s3://$o_bkt
+mys3cmd rb --recursive s3://$d_bkt
+
+############################################################
+# copy multipart objects and delete destination then original
+
+o_bkt="orig-mp-bkt-7"
+d_bkt="copy-mp-bkt-7"
+
+mys3cmd mb s3://$o_bkt
+
+for f in $(seq 2) ;do
+    dest_obj="orig-multipart-obj-$f"
+    mys3cmd put -q $huge_obj s3://${o_bkt}/$dest_obj
+done
+
+mys3cmd mb s3://$d_bkt
+
+mys3cmd cp s3://${o_bkt}/orig-multipart-obj-1 \
+	s3://${d_bkt}/copied-multipart-obj-1
+
+for f in $(seq 5 5) ;do
+    dest_obj="orig-multipart-obj-$f"
+    mys3cmd put -q $huge_obj s3://${d_bkt}/$dest_obj
+done
+
+mys3cmd rb --recursive s3://$d_bkt
+mys3cmd rb --recursive s3://$o_bkt
+
+#####################################################################
+# FORCE GARBAGE COLLECTION
+sleep 6 # since for testing age at which gc can happen is 5 secs
+radosgw-admin gc process --include-all
+#####################################################################
+
 ########################################################################
 # SWIFT TESTS
 

--- a/qa/workunits/rgw/test_rgw_orphan_list.sh
+++ b/qa/workunits/rgw/test_rgw_orphan_list.sh
@@ -6,7 +6,8 @@ set -e
 # if defined, debug messages will be displayed and prepended with the string
 # debug="DEBUG"
 
-huge_size=5100 # in megabytes
+#huge_size=5100 # in megabytes
+huge_size=51 # in megabytes
 big_size=7 # in megabytes
 
 huge_obj=/tmp/huge_obj.temp.$$

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -2915,6 +2915,7 @@ int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
   jspan_context no_trace{false, false};
 
   r = copy_obj(obj_ctx,
+               obj_ctx,  /* src and dest share an obj_ctx */
                owner,
                remote_user,
                NULL, /* req_info *info */
@@ -3014,6 +3015,7 @@ int RGWRados::swift_versioning_restore(RGWObjectCtx& obj_ctx,
     jspan_context no_trace{false, false};
 
     int ret = copy_obj(obj_ctx,
+                       obj_ctx,  /* src and dest share an obj_ctx */
                        owner,
                        remote_user,
                        nullptr,       /* req_info *info */
@@ -4154,7 +4156,7 @@ int RGWFetchObjFilter_Default::filter(CephContext *cct,
   return 0;
 }
 
-int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
+int RGWRados::fetch_remote_obj(RGWObjectCtx& dest_obj_ctx,
                const rgw_user& user_id,
                req_info *info,
                const rgw_zone_id& source_zone,
@@ -4206,7 +4208,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   using namespace rgw::putobj;
   jspan_context no_trace{false, false};
   AtomicObjectProcessor processor(&aio, this, dest_bucket_info, nullptr,
-                                  owner, obj_ctx, dest_obj, olh_epoch,
+                                  owner, dest_obj_ctx, dest_obj, olh_epoch,
 				  tag, rctx.dpp, rctx.y, no_trace);
   RGWRESTConn *conn;
   auto& zone_conn_map = svc.zone->get_zone_conn_map();
@@ -4290,7 +4292,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
 
   if (copy_if_newer) {
     /* need to get mtime for destination */
-    ret = get_obj_state(rctx.dpp, &obj_ctx, dest_bucket_info, stat_dest_obj, &dest_state, &manifest, stat_follow_olh, rctx.y);
+    ret = get_obj_state(rctx.dpp, &dest_obj_ctx, dest_bucket_info, stat_dest_obj, &dest_state, &manifest, stat_follow_olh, rctx.y);
     if (ret < 0)
       goto set_err_state;
 
@@ -4499,8 +4501,8 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
 
     if (copy_if_newer && canceled) {
       ldpp_dout(rctx.dpp, 20) << "raced with another write of obj: " << dest_obj << dendl;
-      obj_ctx.invalidate(dest_obj); /* object was overwritten */
-      ret = get_obj_state(rctx.dpp, &obj_ctx, dest_bucket_info, stat_dest_obj, &dest_state, &manifest, stat_follow_olh, rctx.y);
+      dest_obj_ctx.invalidate(dest_obj); /* object was overwritten */
+      ret = get_obj_state(rctx.dpp, &dest_obj_ctx, dest_bucket_info, stat_dest_obj, &dest_state, &manifest, stat_follow_olh, rctx.y);
       if (ret < 0) {
         ldpp_dout(rctx.dpp, 0) << "ERROR: " << __func__ << ": get_err_state() returned ret=" << ret << dendl;
         goto set_err_state;
@@ -4534,7 +4536,7 @@ set_err_state:
     // for OP_LINK_OLH to call set_olh() with a real olh_epoch
     if (olh_epoch && *olh_epoch > 0) {
       constexpr bool log_data_change = true;
-      ret = set_olh(rctx.dpp, obj_ctx, dest_bucket_info, dest_obj, false, nullptr,
+      ret = set_olh(rctx.dpp, dest_obj_ctx, dest_bucket_info, dest_obj, false, nullptr,
                     *olh_epoch, real_time(), false, rctx.y, zones_trace, log_data_change);
     } else {
       // we already have the latest copy
@@ -4609,7 +4611,8 @@ int RGWRados::copy_obj_to_remote_dest(const DoutPrefixProvider *dpp,
  * err: stores any errors resulting from the get of the original object
  * Returns: 0 on success, -ERR# otherwise.
  */
-int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
+int RGWRados::copy_obj(RGWObjectCtx& src_obj_ctx,
+	       RGWObjectCtx& dest_obj_ctx,
                const ACLOwner& owner,
                const rgw_user& remote_user,
                req_info *info,
@@ -4670,7 +4673,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   if (remote_src || !source_zone.empty()) {
     rgw_zone_set_entry source_trace_entry{source_zone.id, std::nullopt};
     const req_context rctx{dpp, y, nullptr};
-    return fetch_remote_obj(obj_ctx, remote_user, info, source_zone,
+    return fetch_remote_obj(dest_obj_ctx, remote_user, info, source_zone,
                dest_obj, src_obj, dest_bucket_info, &src_bucket_info,
                dest_placement, src_mtime, mtime, mod_ptr,
                unmod_ptr, high_precision_time,
@@ -4680,7 +4683,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   }
 
   map<string, bufferlist> src_attrs;
-  RGWRados::Object src_op_target(this, src_bucket_info, obj_ctx, src_obj);
+  RGWRados::Object src_op_target(this, src_bucket_info, src_obj_ctx, src_obj);
   RGWRados::Object::Read read_op(&src_op_target);
 
   read_op.conds.mod_ptr = mod_ptr;
@@ -4737,7 +4740,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   RGWObjManifest *amanifest = nullptr;
 
   constexpr bool follow_olh = true;
-  ret = get_obj_state(dpp, &obj_ctx, src_bucket_info, src_obj,
+  ret = get_obj_state(dpp, &src_obj_ctx, src_bucket_info, src_obj,
                       &astate, &amanifest, follow_olh, y);
   if (ret < 0) {
     return ret;
@@ -4814,7 +4817,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
 
   if (copy_data) { /* refcounting tail wouldn't work here, just copy the data */
     attrs.erase(RGW_ATTR_TAIL_TAG);
-    return copy_obj_data(obj_ctx, owner, dest_bucket_info, dest_placement, read_op, obj_size - 1, dest_obj,
+    return copy_obj_data(dest_obj_ctx, owner, dest_bucket_info, dest_placement, read_op, obj_size - 1, dest_obj,
                          mtime, real_time(), attrs, olh_epoch, delete_at, petag, dpp, y);
   }
 
@@ -4831,7 +4834,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   RGWObjManifest *pmanifest; 
   ldpp_dout(dpp, 20) << "dest_obj=" << dest_obj << " src_obj=" << src_obj << " copy_itself=" << (int)copy_itself << dendl;
 
-  RGWRados::Object dest_op_target(this, dest_bucket_info, obj_ctx, dest_obj);
+  RGWRados::Object dest_op_target(this, dest_bucket_info, dest_obj_ctx, dest_obj);
   RGWRados::Object::Write write_op(&dest_op_target);
 
   string tag;

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1133,7 +1133,7 @@ public:
                std::string *ptag,
                std::string *petag, optional_yield y);
 
-  int fetch_remote_obj(RGWObjectCtx& obj_ctx,
+  int fetch_remote_obj(RGWObjectCtx& dest_obj_ctx,
                        const rgw_user& user_id,
                        req_info *info,
                        const rgw_zone_id& source_zone,
@@ -1180,7 +1180,8 @@ public:
    *                             are overwritten by values contained in attrs parameter.
    * Returns: 0 on success, -ERR# otherwise.
    */
-  int copy_obj(RGWObjectCtx& obj_ctx,
+  int copy_obj(RGWObjectCtx& src_obj_ctx,
+               RGWObjectCtx& dest_obj_ctx,
                const ACLOwner& owner, // owner of destination object
                const rgw_user& remote_user, // uid for fetch_remote_obj() auth
                req_info *info,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -2903,6 +2903,7 @@ int RadosObject::copy_object(const ACLOwner& owner,
 				optional_yield y)
 {
   return store->getRados()->copy_obj(*rados_ctx,
+				     *static_cast<RadosObject*>(dest_object)->rados_ctx,
 				     owner,
 				     remote_user,
 				     info,

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -59,6 +59,8 @@
 #include "RadosImport.h"
 
 #include "osd/ECUtil.h"
+#include "objclass/objclass.h"
+#include "cls/refcount/cls_refcount_ops.h"
 
 using namespace std::chrono_literals;
 using namespace librados;
@@ -2750,8 +2752,30 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     }
     else
       ret = 0;
-    string s(bl.c_str(), bl.length());
-    cout << s;
+
+    if (attr_name == "refcount")  {
+      obj_refcount oref;
+      auto p = bl.cbegin();
+      decode(oref, p);
+      for (auto itr = oref.refs.begin(); itr != oref.refs.end(); itr++) {
+	if (!itr->first.empty()) {
+	  cout << itr->first << "::" << itr->second << std::endl;
+	}
+	else {
+	  cout << "wildcard reference::" << itr->second << std::endl;
+	}
+      }
+      if (!oref.retired_refs.empty()) {
+	cout << "--------------------------------------" << std::endl;
+	for (const auto & ref : oref.retired_refs) {
+	  cout << "retired_refs::" << ref << std::endl;
+	}
+      }
+    }
+    else {
+      string s(bl.c_str(), bl.length());
+      cout << s << std::endl;
+    }
   } else if (strcmp(nargs[0], "rmxattr") == 0) {
     if (!pool_name || nargs.size() < (obj_name ? 2 : 3)) {
       usage(cerr);


### PR DESCRIPTION
Server-side copy copies the manifest from SRC->DST after incrementing the ref_count on the SRC tail-objects. The problem was that it uses the task-id as ref_tag and it got lost after the ref increment.When deleting the tail-objects from the COPY it passed in the obj_tag as ref_tag and since it was different from the one used during ref_inc it was ignored and the tail objects were never removed. This PR changes the ref_tag used for ref increment passing an MD5 of the bucket-name and the oid which is recreated when the COPY object is deleted

Fixes: https://tracker.ceph.com/issues/66286





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
