### PR TITLE
client: retry readdir if dir is invalidated

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9405,6 +9405,12 @@ int Client::_readdir_cache_cb(dir_result_t *dirp, add_dirent_cb_t cb, void *p,
     int r = _getattr(dn->inode, mask, dirp->perms);
     if (r < 0)
       return r;
+
+    /* fix https://tracker.ceph.com/issues/56288 */
+    if (dirp->inode->dir == NULL) {
+      ldout(cct, 0) << " dir is closed, so we should return" << dendl;
+      return -CEPHFS_EAGAIN;
+    }
     
     // the content of readdir_cache may change after _getattr(), so pd may be invalid iterator    
     pd = dir->readdir_cache.begin() + idx;


### PR DESCRIPTION
cephfs: fix issues/56288

fix a crash in cephfs client：when doing a readdir operation in _readdir_cache_cb, the memory that dir pointed maybe already  freeed
      
Fixes: https://tracker.ceph.com/issues/56288
Signed-off-by: Tod Chen <chentao.2022@bytedance.com>

@vshankar 
