### PR TITLE
quincy: override client features

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -391,6 +391,12 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
   if (cct->_conf->client_acl_type == "posix_acl")
     acl_type = POSIX_ACL;
 
+  if (auto str = cct->_conf->client_debug_inject_features; !str.empty()) {
+    myfeatures = feature_bitset_t(str);
+  } else {
+    myfeatures = feature_bitset_t(CEPHFS_FEATURES_CLIENT_SUPPORTED);
+  }
+
   lru.lru_set_midpoint(cct->_conf->client_cache_mid);
 
   // file handles
@@ -2301,7 +2307,7 @@ MetaSessionRef Client::_open_mds_session(mds_rank_t mds)
 
   auto m = make_message<MClientSession>(CEPH_SESSION_REQUEST_OPEN);
   m->metadata = metadata;
-  m->supported_features = feature_bitset_t(CEPHFS_FEATURES_CLIENT_SUPPORTED);
+  m->supported_features = myfeatures;
   m->metric_spec = feature_bitset_t(CEPHFS_METRIC_FEATURES_ALL);
   session->con->send_message2(std::move(m));
   return session;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1600,6 +1600,8 @@ private:
   uint64_t nr_metadata_request = 0;
   uint64_t nr_read_request = 0;
   uint64_t nr_write_request = 0;
+
+  feature_bitset_t myfeatures;
 };
 
 /**

--- a/src/common/options/mds-client.yaml.in
+++ b/src/common/options/mds-client.yaml.in
@@ -251,6 +251,14 @@ options:
   default: 0
   services:
   - mds_client
+- name: client_debug_inject_features
+  type: str
+  level: dev
+  services:
+  - mds_client
+  flags:
+  - startup
+  with_legacy: true
 - name: client_max_inline_size
   type: size
   level: dev

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -6,6 +6,10 @@
 #include "common/Formatter.h"
 #include "common/StackStringStream.h"
 
+#include <iostream>
+#include <sstream>
+#include <string>
+
 const mds_gid_t MDS_GID_NONE = mds_gid_t(0);
 
 using std::list;
@@ -428,7 +432,7 @@ feature_bitset_t::feature_bitset_t(unsigned long value)
   }
 }
 
-feature_bitset_t::feature_bitset_t(const vector<size_t>& array)
+void feature_bitset_t::init_array(const vector<size_t>& array)
 {
   if (!array.empty()) {
     size_t n = array.back();
@@ -445,6 +449,26 @@ feature_bitset_t::feature_bitset_t(const vector<size_t>& array)
       _vec[bit / bits_per_block] |= (block_type)1 << (bit % bits_per_block);
     }
   }
+}
+
+feature_bitset_t::feature_bitset_t(std::string_view str)
+{
+  std::stringstream ss;
+  std::vector<size_t> v;
+  std::string atom;
+
+  ss << str;
+  while (std::getline(ss, atom, ',')) {
+    v.push_back(std::stoul(atom));
+  }
+  std::sort(v.begin(), v.end());
+
+  init_array(v);
+}
+
+feature_bitset_t::feature_bitset_t(const vector<size_t>& array)
+{
+  init_array(array);
 }
 
 feature_bitset_t& feature_bitset_t::operator-=(const feature_bitset_t& other)

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -1169,6 +1169,7 @@ public:
   feature_bitset_t(const feature_bitset_t& other) : _vec(other._vec) {}
   feature_bitset_t(feature_bitset_t&& other) : _vec(std::move(other._vec)) {}
   feature_bitset_t(unsigned long value = 0);
+  feature_bitset_t(std::string_view);
   feature_bitset_t(const std::vector<size_t>& array);
   feature_bitset_t& operator=(const feature_bitset_t& other) {
     _vec = other._vec;
@@ -1222,6 +1223,8 @@ public:
   void dump(ceph::Formatter *f) const;
   void print(std::ostream& out) const;
 private:
+  void init_array(const std::vector<size_t>& v);
+
   std::vector<block_type> _vec;
 };
 WRITE_CLASS_ENCODER(feature_bitset_t)


### PR DESCRIPTION
This functionality needs to be in quincy to test upgrades from quincy -> reef/squid.

https://github.com/ceph/ceph/pull/58113
https://github.com/ceph/ceph/pull/58090


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
