### PR TITLE
reef: qa: ignore variation of PG_DEGRADED health warning

### DIFF
--- a/qa/cephfs/overrides/pg_health.yaml
+++ b/qa/cephfs/overrides/pg_health.yaml
@@ -12,3 +12,4 @@ overrides:
       - PG_AVAILABILITY
       - PG_DEGRADED
       - Reduced data availability
+      - Degraded data redundancy


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65845

---

backport of https://github.com/ceph/ceph/pull/57165
parent tracker: https://tracker.ceph.com/issues/65700

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh