### PR TITLE
squid: tools/cephfs: recover alternate_name of dentries from journal

### DIFF
--- a/qa/suites/fs/fscrypt/tasks/1-tests/fscrypt-common.yaml
+++ b/qa/suites/fs/fscrypt/tasks/1-tests/fscrypt-common.yaml
@@ -1,3 +1,10 @@
+overrides:
+  install:
+    extra_system_packages:
+      rpm:
+        - fscrypt
+      deb:
+        - fscrypt
 tasks:
   - cephfs_test_runner:
       fail_on_skip: false

--- a/qa/tasks/cephfs/test_fscrypt.py
+++ b/qa/tasks/cephfs/test_fscrypt.py
@@ -1,13 +1,95 @@
+from io import StringIO
+from os.path import basename
+import random
+import string
+
 from logging import getLogger
 
-from io import StringIO
+from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from tasks.cephfs.xfstests_dev import XFSTestsDev
-
 
 log = getLogger(__name__)
 
+class FSCryptTestCase(CephFSTestCase):
+    CLIENTS_REQUIRED = 1
 
-class TestFscrypt(XFSTestsDev):
+    def setUp(self):
+        super().setUp()
+
+        self.protector = ''.join(random.choice(string.ascii_letters) for _ in range(8))
+        self.key_file = "/tmp/key"
+        self.path = "dir/"
+
+        self.mount_a.run_shell_payload("sudo fscrypt --help")
+        self.mount_a.run_shell_payload("sudo fscrypt setup --help")
+        self.mount_a.run_shell_payload("sudo fscrypt setup --force --quiet")
+        self.mount_a.run_shell_payload("sudo fscrypt status")
+        self.mount_a.run_shell_payload(f"sudo fscrypt setup --quiet {self.mount_a.hostfs_mntpt}")
+        self.mount_a.run_shell_payload("sudo fscrypt status")
+        self.mount_a.run_shell_payload(f"sudo dd if=/dev/urandom of={self.key_file} bs=32 count=1")
+        self.mount_a.run_shell_payload(f"mkdir -p {self.path}")
+        self.mount_a.run_shell_payload(f"sudo fscrypt encrypt --quiet --source=raw_key --name={self.protector} --no-recovery --skip-unlock --key={self.key_file} {self.path}")
+        self.mount_a.run_shell_payload(f"sudo fscrypt unlock --quiet --key=/tmp/key {self.path}")
+
+    def tearDown(self):
+        self.mount_a.run_shell_payload(f"sudo fscrypt purge --force --quiet {self.mount_a.hostfs_mntpt}")
+
+        super().tearDown()
+
+class TestFSCrypt(FSCryptTestCase):
+
+    def test_fscrypt_basic_mount(self):
+        """
+        That fscrypt can be setup and ingest files.
+        """
+
+        self.mount_a.run_shell_payload(f"cp -av /usr/include {self.path}/")
+
+class TestFSCryptRecovery(FSCryptTestCase):
+
+    def test_fscrypt_journal_recovery(self):
+        """
+        That alternate_name can be recovered from the journal.
+        """
+
+        file = ''.join(random.choice(string.ascii_letters) for _ in range(255))
+
+        self.mount_a.run_shell_payload(f"cd {self.path} && dd if=/dev/urandom of={file} bs=512 count=1 oflag=sync && sync . && stat {file}")
+
+        def verify_alternate_name():
+            J = self.fs.read_cache("/dir", depth=0)
+            self.assertEqual(len(J), 1)
+            inode = J[0]
+            dirfrags = inode['dirfrags']
+            self.assertEqual(len(dirfrags), 1)
+            dirfrag = dirfrags[0]
+            dentries = dirfrag['dentries']
+            self.assertEqual(len(dentries), 1)
+            # we don't know it's encrypted name, so we cannot verify that it's {file}
+            dentry = dentries[0]
+            name = basename(dentry['path'])
+            # https://github.com/ceph/ceph-client/blob/fec50db7033ea478773b159e0e2efb135270e3b7/fs/ceph/crypto.h#L65-L90
+            self.assertEqual(len(name), 240)
+            alternate_name = dentry['alternate_name']
+            self.assertGreater(len(alternate_name), 240)
+
+        verify_alternate_name()
+
+        self.fs.fail()
+
+        self.fs.journal_tool(['event', 'recover_dentries', 'list'], 0)
+        self.fs.journal_tool(['journal', 'reset', '--yes-i-really-really-mean-it'], 0)
+
+        self.fs.set_joinable()
+        self.fs.wait_for_daemons()
+
+        verify_alternate_name()
+
+        self.mount_a.run_shell_payload(f"cd {self.path} && find")
+        self.mount_a.run_shell_payload(f"cd {self.path} && stat {file}")
+
+
+class TestFSCryptXFS(XFSTestsDev):
 
     def setup_xfsprogs_devs(self):
         self.install_xfsprogs = True

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -600,6 +600,15 @@ void CDentry::dump(Formatter *f) const
   make_path(path);
 
   f->dump_string("path", path.get_path());
+  if (auto s =  get_alternate_name(); !s.empty()) {
+    bufferlist bl, b64;
+    bl.append(s);
+    bl.encode_base64(b64);
+    auto encoded = std::string_view(b64.c_str(), b64.length());
+    f->dump_string("alternate_name", encoded);
+  } else {
+    f->dump_string("alternate_name", "");
+  }
   f->dump_unsigned("path_ino", path.get_ino().val);
   f->dump_unsigned("snap_first", first);
   f->dump_unsigned("snap_last", last);

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -568,6 +568,7 @@ void CDentry::encode_remote(inodeno_t& ino, unsigned char d_type,
 
   // marker, name, ino
   ENCODE_START(2, 1, bl);
+  // WARNING: always put new fields at the end of bl
   encode(ino, bl);
   encode(d_type, bl);
   encode(alternate_name, bl);

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2500,6 +2500,7 @@ void CDir::_omap_commit_ops(int r, int op_prio, int64_t metapool, version_t vers
       bl.append('i');         // inode
 
       ENCODE_START(2, 1, bl);
+      // WARNING: always put new fields at the end of bl
       encode(item.alternate_name, bl);
       _encode_primary_inode_base(item, dfts, bl);
       ENCODE_FINISH(bl);

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -890,6 +890,14 @@ int JournalTool::recover_dentries(
       if ((other_pool || write_dentry) && !dry_run) {
         dout(4) << "writing I dentry " << key << " into frag "
           << frag_oid.name << dendl;
+        dout(20) << " dnfirst = " << fb.dnfirst << dendl;
+        if (!fb.alternate_name.empty()) {
+          bufferlist bl, b64;
+          bl.append(fb.alternate_name);
+          bl.encode_base64(b64);
+          auto encoded = std::string_view(b64.c_str(), b64.length());
+          dout(20) << " alternate_name = b64:" << encoded << dendl;
+        }
 
         // Compose: Dentry format is dnfirst, [I|L], InodeStore(bare=true)
         bufferlist dentry_bl;

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -1034,7 +1034,7 @@ int JournalTool::recover_dentries(
    */
   for (const auto& fb : metablob.roots) {
     inodeno_t ino = fb.inode->ino;
-    dout(4) << "updating root 0x" << std::hex << ino << std::dec << dendl;
+    dout(4) << "updating root " << ino << dendl;
 
     object_t root_oid = InodeStore::get_object_name(ino, frag_t(), ".inode");
     dout(4) << "object id " << root_oid.name << dendl;
@@ -1265,7 +1265,7 @@ int JournalTool::consume_inos(const std::set<inodeno_t> &inos)
     {
       const inodeno_t ino = *i;
       if (ino_table.force_consume(ino)) {
-        dout(4) << "Used ino 0x" << std::hex << ino << std::dec
+        dout(4) << "Used ino " << ino
           << " requires inotable update" << dendl;
         inotable_modified = true;
       }

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -888,7 +888,7 @@ int JournalTool::recover_dentries(
       }
 
       if ((other_pool || write_dentry) && !dry_run) {
-        dout(4) << "writing I dentry " << key << " into frag "
+        dout(4) << "writing i dentry " << key << " into frag "
           << frag_oid.name << dendl;
         dout(20) << " dnfirst = " << fb.dnfirst << dendl;
         if (!fb.alternate_name.empty()) {
@@ -899,11 +899,14 @@ int JournalTool::recover_dentries(
           dout(20) << " alternate_name = b64:" << encoded << dendl;
         }
 
-        // Compose: Dentry format is dnfirst, [I|L], InodeStore(bare=true)
+        // Compose: Dentry format is dnfirst, [i|l], InodeStore
         bufferlist dentry_bl;
         encode(fb.dnfirst, dentry_bl);
-        encode('I', dentry_bl);
-        encode_fullbit_as_inode(fb, true, &dentry_bl);
+        encode('i', dentry_bl);
+        ENCODE_START(2, 1, dentry_bl);
+        encode(fb.alternate_name, dentry_bl);
+        encode_fullbit_as_inode(fb, &dentry_bl);
+        ENCODE_FINISH(dentry_bl);
 
         // Record for writing to RADOS
         write_vals[key] = dentry_bl;
@@ -958,12 +961,15 @@ int JournalTool::recover_dentries(
         dout(4) << "writing L dentry " << key << " into frag "
           << frag_oid.name << dendl;
 
-        // Compose: Dentry format is dnfirst, [I|L], InodeStore(bare=true)
+        // Compose: Dentry format is dnfirst, [I|L], ino, d_type, alternate_name
         bufferlist dentry_bl;
         encode(rb.dnfirst, dentry_bl);
-        encode('L', dentry_bl);
+        encode('l', dentry_bl);
+        ENCODE_START(2, 1, dentry_bl);
         encode(rb.ino, dentry_bl);
         encode(rb.d_type, dentry_bl);
+        encode(rb.alternate_name, dentry_bl);
+        ENCODE_FINISH(dentry_bl);
 
         // Record for writing to RADOS
         write_vals[key] = dentry_bl;
@@ -1082,10 +1088,10 @@ int JournalTool::recover_dentries(
       dout(4) << "writing root ino " << root_oid.name
                << " version " << fb.inode->version << dendl;
 
-      // Compose: root ino format is magic,InodeStore(bare=false)
+      // Compose: root ino format is magic,InodeStore
       bufferlist new_root_ino_bl;
       encode(std::string(CEPH_FS_ONDISK_MAGIC), new_root_ino_bl);
-      encode_fullbit_as_inode(fb, false, &new_root_ino_bl);
+      encode_fullbit_as_inode(fb, &new_root_ino_bl);
 
       // Write to RADOS
       r = output.write_full(root_oid.name, new_root_ino_bl);
@@ -1195,7 +1201,6 @@ int JournalTool::erase_region(JournalScanner const &js, uint64_t const pos, uint
  */
 void JournalTool::encode_fullbit_as_inode(
   const EMetaBlob::fullbit &fb,
-  const bool bare,
   bufferlist *out_bl)
 {
   ceph_assert(out_bl != NULL);
@@ -1210,11 +1215,7 @@ void JournalTool::encode_fullbit_as_inode(
   new_inode.old_inodes = fb.old_inodes;
 
   // Serialize InodeStore
-  if (bare) {
-    new_inode.encode_bare(*out_bl, CEPH_FEATURES_SUPPORTED_DEFAULT);
-  } else {
-    new_inode.encode(*out_bl, CEPH_FEATURES_SUPPORTED_DEFAULT);
-  }
+  new_inode.encode(*out_bl, CEPH_FEATURES_SUPPORTED_DEFAULT);
 }
 
 /**

--- a/src/tools/cephfs/JournalTool.h
+++ b/src/tools/cephfs/JournalTool.h
@@ -78,7 +78,6 @@ class JournalTool : public MDSUtility
     // Backing store helpers
     void encode_fullbit_as_inode(
         const EMetaBlob::fullbit &fb,
-        const bool bare,
         bufferlist *out_bl);
     int consume_inos(const std::set<inodeno_t> &inos);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66593

---

backport of https://github.com/ceph/ceph/pull/55792
parent tracker: https://tracker.ceph.com/issues/64602

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh