### PR TITLE
quincy: tools/cephfs: recover alternate_name of dentries from journal

### DIFF
--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -554,6 +554,7 @@ void CDentry::encode_remote(inodeno_t& ino, unsigned char d_type,
 
   // marker, name, ino
   ENCODE_START(2, 1, bl);
+  // WARNING: always put new fields at the end of bl
   encode(ino, bl);
   encode(d_type, bl);
   encode(alternate_name, bl);

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -586,6 +586,15 @@ void CDentry::dump(Formatter *f) const
   make_path(path);
 
   f->dump_string("path", path.get_path());
+  if (auto s =  get_alternate_name(); !s.empty()) {
+    bufferlist bl, b64;
+    bl.append(s);
+    bl.encode_base64(b64);
+    auto encoded = std::string_view(b64.c_str(), b64.length());
+    f->dump_string("alternate_name", encoded);
+  } else {
+    f->dump_string("alternate_name", "");
+  }
   f->dump_unsigned("path_ino", path.get_ino().val);
   f->dump_unsigned("snap_first", first);
   f->dump_unsigned("snap_last", last);

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2364,6 +2364,7 @@ void CDir::_omap_commit_ops(int r, int op_prio, int64_t metapool, version_t vers
       bl.append('i');         // inode
 
       ENCODE_START(2, 1, bl);
+      // WARNING: always put new fields at the end of bl
       encode(item.alternate_name, bl);
       _encode_primary_inode_base(item, dfts, bl);
       ENCODE_FINISH(bl);

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -861,7 +861,7 @@ int JournalTool::recover_dentries(
       }
 
       if ((other_pool || write_dentry) && !dry_run) {
-        dout(4) << "writing I dentry " << key << " into frag "
+        dout(4) << "writing i dentry " << key << " into frag "
           << frag_oid.name << dendl;
         dout(20) << " dnfirst = " << fb.dnfirst << dendl;
         if (!fb.alternate_name.empty()) {
@@ -872,11 +872,14 @@ int JournalTool::recover_dentries(
           dout(20) << " alternate_name = b64:" << encoded << dendl;
         }
 
-        // Compose: Dentry format is dnfirst, [I|L], InodeStore(bare=true)
+        // Compose: Dentry format is dnfirst, [i|l], InodeStore
         bufferlist dentry_bl;
         encode(fb.dnfirst, dentry_bl);
-        encode('I', dentry_bl);
-        encode_fullbit_as_inode(fb, true, &dentry_bl);
+        encode('i', dentry_bl);
+        ENCODE_START(2, 1, dentry_bl);
+        encode(fb.alternate_name, dentry_bl);
+        encode_fullbit_as_inode(fb, &dentry_bl);
+        ENCODE_FINISH(dentry_bl);
 
         // Record for writing to RADOS
         write_vals[key] = dentry_bl;
@@ -931,12 +934,15 @@ int JournalTool::recover_dentries(
         dout(4) << "writing L dentry " << key << " into frag "
           << frag_oid.name << dendl;
 
-        // Compose: Dentry format is dnfirst, [I|L], InodeStore(bare=true)
+        // Compose: Dentry format is dnfirst, [I|L], ino, d_type, alternate_name
         bufferlist dentry_bl;
         encode(rb.dnfirst, dentry_bl);
-        encode('L', dentry_bl);
+        encode('l', dentry_bl);
+        ENCODE_START(2, 1, dentry_bl);
         encode(rb.ino, dentry_bl);
         encode(rb.d_type, dentry_bl);
+        encode(rb.alternate_name, dentry_bl);
+        ENCODE_FINISH(dentry_bl);
 
         // Record for writing to RADOS
         write_vals[key] = dentry_bl;
@@ -1055,10 +1061,10 @@ int JournalTool::recover_dentries(
       dout(4) << "writing root ino " << root_oid.name
                << " version " << fb.inode->version << dendl;
 
-      // Compose: root ino format is magic,InodeStore(bare=false)
+      // Compose: root ino format is magic,InodeStore
       bufferlist new_root_ino_bl;
       encode(std::string(CEPH_FS_ONDISK_MAGIC), new_root_ino_bl);
-      encode_fullbit_as_inode(fb, false, &new_root_ino_bl);
+      encode_fullbit_as_inode(fb, &new_root_ino_bl);
 
       // Write to RADOS
       r = output.write_full(root_oid.name, new_root_ino_bl);
@@ -1168,7 +1174,6 @@ int JournalTool::erase_region(JournalScanner const &js, uint64_t const pos, uint
  */
 void JournalTool::encode_fullbit_as_inode(
   const EMetaBlob::fullbit &fb,
-  const bool bare,
   bufferlist *out_bl)
 {
   ceph_assert(out_bl != NULL);
@@ -1183,11 +1188,7 @@ void JournalTool::encode_fullbit_as_inode(
   new_inode.old_inodes = fb.old_inodes;
 
   // Serialize InodeStore
-  if (bare) {
-    new_inode.encode_bare(*out_bl, CEPH_FEATURES_SUPPORTED_DEFAULT);
-  } else {
-    new_inode.encode(*out_bl, CEPH_FEATURES_SUPPORTED_DEFAULT);
-  }
+  new_inode.encode(*out_bl, CEPH_FEATURES_SUPPORTED_DEFAULT);
 }
 
 /**

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -863,6 +863,14 @@ int JournalTool::recover_dentries(
       if ((other_pool || write_dentry) && !dry_run) {
         dout(4) << "writing I dentry " << key << " into frag "
           << frag_oid.name << dendl;
+        dout(20) << " dnfirst = " << fb.dnfirst << dendl;
+        if (!fb.alternate_name.empty()) {
+          bufferlist bl, b64;
+          bl.append(fb.alternate_name);
+          bl.encode_base64(b64);
+          auto encoded = std::string_view(b64.c_str(), b64.length());
+          dout(20) << " alternate_name = b64:" << encoded << dendl;
+        }
 
         // Compose: Dentry format is dnfirst, [I|L], InodeStore(bare=true)
         bufferlist dentry_bl;

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -1007,7 +1007,7 @@ int JournalTool::recover_dentries(
    */
   for (const auto& fb : metablob.roots) {
     inodeno_t ino = fb.inode->ino;
-    dout(4) << "updating root 0x" << std::hex << ino << std::dec << dendl;
+    dout(4) << "updating root " << ino << dendl;
 
     object_t root_oid = InodeStore::get_object_name(ino, frag_t(), ".inode");
     dout(4) << "object id " << root_oid.name << dendl;
@@ -1238,7 +1238,7 @@ int JournalTool::consume_inos(const std::set<inodeno_t> &inos)
     {
       const inodeno_t ino = *i;
       if (ino_table.force_consume(ino)) {
-        dout(4) << "Used ino 0x" << std::hex << ino << std::dec
+        dout(4) << "Used ino " << ino
           << " requires inotable update" << dendl;
         inotable_modified = true;
       }

--- a/src/tools/cephfs/JournalTool.h
+++ b/src/tools/cephfs/JournalTool.h
@@ -78,7 +78,6 @@ class JournalTool : public MDSUtility
     // Backing store helpers
     void encode_fullbit_as_inode(
         const EMetaBlob::fullbit &fb,
-        const bool bare,
         bufferlist *out_bl);
     int consume_inos(const std::set<inodeno_t> &inos);
 


### PR DESCRIPTION
N.B. this drops the QA commit because fs:fscrypt does not exist in quincy.


backport tracker: https://tracker.ceph.com/issues/66594

---

backport of https://github.com/ceph/ceph/pull/55792
parent tracker: https://tracker.ceph.com/issues/64602

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh