### PR TITLE
squid: mon/AuthMonitor: provide command to rotate the key for a user credential

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,5 +1,14 @@
 >=19.0.0
 
+* cephx: key rotation is now possible using `ceph auth rotate`. Previously,
+  this was only possible by deleting and then recreating the key.
+* ceph: a new --daemon-output-file switch is available for `ceph tell` commands
+  to dump output to a file local to the daemon. For commands which produce
+  large amounts of output, this avoids a potential spike in memory usage on the
+  daemon, allows for faster streaming writes to a file local to the daemon, and
+  reduces time holding any locks required to execute the command. For analysis,
+  it is necessary to retrieve the file from the host running the daemon
+  manually. Currently, only --format=json|json-pretty are supported.
 * RGW: GetObject and HeadObject requests now return a x-rgw-replicated-at
   header for replicated objects. This timestamp can be compared against the
   Last-Modified header to determine how long the object took to replicate.

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -744,6 +744,20 @@ You may also :ref:`Modify user capabilities<modify-user-capabilities>` directly 
 results to a keyring file, and then import the keyring into your main
 ``ceph.keyring`` file.
 
+
+Key rotation
+------------
+
+To rotate the secret for an entity, use:
+
+.. prompt:: bash #
+
+    ceph auth rotate <entity>
+
+This avoids the need to delete and recreate the entity when its key is
+compromised, lost, or scheduled for rotation.
+
+
 Command Line Usage
 ==================
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -163,6 +163,10 @@ COMMAND("auth add "
 	"add auth info for <entity> from input file, or random key if no "
         "input is given, and/or any caps specified in the command",
 	"auth", "rwx")
+COMMAND("auth rotate "
+	"name=entity,type=CephString",
+	"rotate entity key",
+	"auth", "rwx")
 COMMAND("auth get-or-create-key "
 	"name=entity,type=CephString "
 	"name=caps,type=CephString,n=N,req=false",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66617

---

backport of https://github.com/ceph/ceph/pull/58121
parent tracker: https://tracker.ceph.com/issues/66509

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh