### PR TITLE
reef: mon/AuthMonitor: provide command to rotate the key for a user credential

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -64,6 +64,18 @@
 
 >=19.0.0
 
+* cephx: key rotation is now possible using `ceph auth rotate`. Previously,
+  this was only possible by deleting and then recreating the key.
+* ceph: a new --daemon-output-file switch is available for `ceph tell` commands
+  to dump output to a file local to the daemon. For commands which produce
+  large amounts of output, this avoids a potential spike in memory usage on the
+  daemon, allows for faster streaming writes to a file local to the daemon, and
+  reduces time holding any locks required to execute the command. For analysis,
+  it is necessary to retrieve the file from the host running the daemon
+  manually. Currently, only --format=json|json-pretty are supported.
+* RGW: GetObject and HeadObject requests now return a x-rgw-replicated-at
+  header for replicated objects. This timestamp can be compared against the
+  Last-Modified header to determine how long the object took to replicate.
 * The cephfs-shell utility is now packaged for RHEL 9 / CentOS 9 as required
   python dependencies are now available in EPEL9.
 * RGW: S3 multipart uploads using Server-Side Encryption now replicate correctly in

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -748,6 +748,20 @@ You may also :ref:`Modify user capabilities<modify-user-capabilities>` directly 
 results to a keyring file, and then import the keyring into your main
 ``ceph.keyring`` file.
 
+
+Key rotation
+------------
+
+To rotate the secret for an entity, use:
+
+.. prompt:: bash #
+
+    ceph auth rotate <entity>
+
+This avoids the need to delete and recreate the entity when its key is
+compromised, lost, or scheduled for rotation.
+
+
 Command Line Usage
 ==================
 

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -869,6 +869,7 @@ bool AuthMonitor::preprocess_command(MonOpRequestRef op)
   string prefix;
   cmd_getval(cmdmap, "prefix", prefix);
   if (prefix == "auth add" ||
+      prefix == "auth rotate" ||
       prefix == "auth del" ||
       prefix == "auth rm" ||
       prefix == "auth get-or-create" ||
@@ -1915,6 +1916,40 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
 
     wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
 					      get_last_committed() + 1));
+    return true;
+  } else if (prefix == "auth rotate") {
+    if (entity_name.empty()) {
+      ss << "bad entity name";
+      err = -EINVAL;
+      goto done;
+    }
+
+    EntityAuth entity_auth;
+    if (!mon.key_server.get_auth(entity, entity_auth)) {
+      ss << "entity does not exist";
+      err = -ENOENT;
+      goto done;
+    }
+
+    entity_auth.key.create(g_ceph_context, CEPH_CRYPTO_AES);
+
+    KeyServerData::Incremental auth_inc;
+    auth_inc.op = KeyServerData::AUTH_INC_ADD;
+    auth_inc.name = entity;
+    auth_inc.auth = entity_auth;
+    push_cephx_inc(auth_inc);
+
+    {
+      KeyRing kr;
+      kr.add(entity, entity_auth);
+      if (f) {
+        kr.encode_formatted("auth", f.get(), rdata);
+      } else {
+        kr.encode_plaintext(rdata);
+      }
+    }
+    wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs, rdata,
+                                              get_last_committed() + 1));
     return true;
   }
 done:

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -163,6 +163,10 @@ COMMAND("auth add "
 	"add auth info for <entity> from input file, or random key if no "
         "input is given, and/or any caps specified in the command",
 	"auth", "rwx")
+COMMAND("auth rotate "
+	"name=entity,type=CephString",
+	"rotate entity key",
+	"auth", "rwx")
 COMMAND("auth get-or-create-key "
 	"name=entity,type=CephString "
 	"name=caps,type=CephString,n=N,req=false",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66618

---

backport of https://github.com/ceph/ceph/pull/58121
parent tracker: https://tracker.ceph.com/issues/66509

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh