### PR TITLE
squid: mds: initialize epoch for quiescedb

### DIFF
--- a/src/mds/QuiesceDb.h
+++ b/src/mds/QuiesceDb.h
@@ -124,8 +124,8 @@ namespace QuiesceInterface {
 }
 
 struct QuiesceDbVersion {
-  epoch_t epoch;
-  QuiesceSetVersion set_version;
+  epoch_t epoch = 0;
+  QuiesceSetVersion set_version = 0;
   auto operator<=>(QuiesceDbVersion const& other) const = default;
   QuiesceDbVersion& operator+(unsigned int delta) {
     set_version += delta;

--- a/src/mds/QuiesceDbManager.h
+++ b/src/mds/QuiesceDbManager.h
@@ -227,7 +227,7 @@ class QuiesceDbManager {
     // the database.
     struct Db {
       QuiesceTimePoint time_zero;
-      epoch_t epoch;
+      epoch_t epoch = 0;
       QuiesceSetVersion set_version = 0;
       using Sets = std::unordered_map<QuiesceSetId, QuiesceSet>;
       Sets sets;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66619

---

backport of https://github.com/ceph/ceph/pull/57993
parent tracker: https://tracker.ceph.com/issues/66449

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh