### PR TITLE
crush: fix the unreasonable weight_set poniter handling

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1538,10 +1538,9 @@ int CrushWrapper::adjust_item_weight_in_bucket(
       continue;
     }
     crush_choose_arg *arg = &cmap.args[-1 - bucket_id];
-    if (!arg->weight_set) {
+    if (!arg->weight_set || !arg->weight_set_positions) {
       continue;
     }
-    ceph_assert(arg->weight_set_positions > 0);
     vector<int> w(arg->weight_set_positions);
     for (unsigned i = 0; i < b->size; ++i) {
       for (unsigned j = 0; j < arg->weight_set_positions; ++j) {
@@ -2895,6 +2894,8 @@ int CrushWrapper::device_class_clone(
     auto& n = cmap.args[-1-bno];
     n.ids_size = 0; // FIXME: implement me someday
     n.weight_set_positions = o.weight_set_positions;
+    if (n.weight_set_positions == 0)
+      continue;
     n.weight_set = static_cast<crush_weight_set*>(calloc(
       n.weight_set_positions, sizeof(crush_weight_set)));
     for (size_t s = 0; s < n.weight_set_positions; ++s) {


### PR DESCRIPTION
Fixs: https://tracker.ceph.com/issues/66662

The related code: check weight_set pointer is not nullptr then assert weight_set_positions > 0 is unreasonable.
https://github.com/ceph/ceph/blob/ca74598065096e6fcbd8433c8779a2be0c889351/src/crush/CrushWrapper.cc#L1495
![image](https://github.com/ceph/ceph/assets/13496900/117d52bd-1f4f-4406-85ed-a22f2d1e1b7e)

The bucket related crush_choose_arg has set to 0 when add bucket. The class bucket will be cloned when set osd class, the crush_choose_arg is empty when add first osd to host bucket, the class bucket related crush_choose_arg copied from an empty one here. The weight_set_positions is 0 and weight_set is assigned a not-null pointer by calloc which is inconsistent with the above.
https://github.com/ceph/ceph/blob/ca74598065096e6fcbd8433c8779a2be0c889351/src/crush/CrushWrapper.cc#L2448
![image](https://github.com/ceph/ceph/assets/13496900/ea101509-65c1-4cbb-9dd0-b3ea157651ed)
https://github.com/ceph/ceph/blob/ca74598065096e6fcbd8433c8779a2be0c889351/src/crush/CrushWrapper.cc#L2730
![image](https://github.com/ceph/ceph/assets/13496900/09de89d3-d624-4c55-803d-988544f2589c)

We can easily reproduce this problem in our environment:
The gdb info show the data caused assert fail:
![image](https://github.com/ceph/ceph/assets/13496900/5ef79ac5-fb55-40b5-bb94-172d43b54dea)
![image](https://github.com/ceph/ceph/assets/13496900/343fe2c9-e448-4b5d-b85f-b23a2d694063)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
