### PR TITLE
squid: mgr/dashboard: fix edit bucket failing in other selected gateways

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -292,8 +292,8 @@ class RgwBucket(RgwRESTController):
                                              retention_period_days,
                                              retention_period_years)
 
-    def _get_policy(self, bucket: str):
-        rgw_client = RgwClient.admin_instance()
+    def _get_policy(self, bucket: str, daemon_name, owner):
+        rgw_client = RgwClient.instance(owner, daemon_name)
         return rgw_client.get_bucket_policy(bucket)
 
     def _set_policy(self, bucket_name: str, policy: str, daemon_name, owner):
@@ -364,7 +364,7 @@ class RgwBucket(RgwRESTController):
         result['encryption'] = encryption['Status']
         result['versioning'] = versioning['Status']
         result['mfa_delete'] = versioning['MfaDelete']
-        result['bucket_policy'] = self._get_policy(bucket_name)
+        result['bucket_policy'] = self._get_policy(bucket_name, daemon_name, result['owner'])
         result['acl'] = self._get_acl(bucket_name, daemon_name, result['owner'])
 
         # Append the locking configuration.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66425

---

backport of https://github.com/ceph/ceph/pull/57931
parent tracker: https://tracker.ceph.com/issues/66395

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh