### PR TITLE
squid: mgr/dashboard: bump cheroot to > 10.0

### DIFF
--- a/src/pybind/mgr/dashboard/constraints.txt
+++ b/src/pybind/mgr/dashboard/constraints.txt
@@ -4,3 +4,4 @@ bcrypt~=3.1
 python3-saml~=1.4
 requests~=2.26
 Routes~=2.4
+cheroot~=10.0


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66664

---

backport of https://github.com/ceph/ceph/pull/57001
parent tracker: https://tracker.ceph.com/issues/55837

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh