### PR TITLE
crimson/os/seastore: write ool extents without padding

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1136,7 +1136,7 @@ record_t Cache::prepare_record(
   t.read_set.clear();
   t.write_set.clear();
 
-  record_t record(trans_src);
+  record_t record(record_type_t::JOURNAL, trans_src);
   auto commit_time = seastar::lowres_system_clock::now();
 
   // Add new copy of mutated blocks, set_io_wait to block until written

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -84,7 +84,7 @@ SegmentedOolWriter::do_write(
       return do_write(t, extents);
     });
   }
-  record_t record(record_type_t::JOURNAL, t.get_src());
+  record_t record(record_type_t::OOL, t.get_src());
   std::list<LogicalCachedExtentRef> pending_extents;
   auto commit_time = seastar::lowres_system_clock::now();
 

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -84,7 +84,7 @@ SegmentedOolWriter::do_write(
       return do_write(t, extents);
     });
   }
-  record_t record(t.get_src());
+  record_t record(record_type_t::JOURNAL, t.get_src());
   std::list<LogicalCachedExtentRef> pending_extents;
   auto commit_time = seastar::lowres_system_clock::now();
 

--- a/src/crimson/os/seastore/journal/record_submitter.cc
+++ b/src/crimson/os/seastore/journal/record_submitter.cc
@@ -493,7 +493,7 @@ void RecordSubmitter::account_submission(
   stats.record_batch_stats.increment(rg.get_size());
 
   for (const record_t& r : rg.records) {
-    auto src = r.type;
+    auto src = r.trans_type;
     assert(is_modify_transaction(src));
     auto& trans_stats = get_by_src(stats.stats_by_src, src);
     ++(trans_stats.num_records);

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -441,7 +441,7 @@ std::ostream &operator<<(std::ostream& out, const record_size_t& rsize)
 std::ostream &operator<<(std::ostream& out, const record_t& r)
 {
   return out << "record_t("
-             << "type=" << r.type
+             << "trans_type=" << r.trans_type
              << ", num_extents=" << r.extents.size()
              << ", num_deltas=" << r.deltas.size()
              << ", modify_time=" << sea_time_point_printer_t{r.modify_time}
@@ -552,7 +552,7 @@ ceph::bufferlist encode_records(
 
   for (auto& r: record_group.records) {
     record_header_t rheader{
-      r.type,
+      r.trans_type,
       (extent_len_t)r.deltas.size(),
       (extent_len_t)r.extents.size(),
       timepoint_to_mod(r.modify_time)

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -388,20 +388,32 @@ std::ostream &operator<<(std::ostream &out, const segment_tail_t &tail)
 
 extent_len_t record_size_t::get_raw_mdlength() const
 {
+  assert(record_type < record_type_t::MAX);
   // empty record is allowed to submit
-  return plain_mdlength +
-         ceph::encoded_sizeof_bounded<record_header_t>();
+  extent_len_t ret = plain_mdlength;
+  if (record_type == record_type_t::JOURNAL) {
+    ret += ceph::encoded_sizeof_bounded<record_header_t>();
+  } else {
+    // OOL won't contain metadata
+    assert(ret == 0);
+  }
+  return ret;
 }
 
 void record_size_t::account_extent(extent_len_t extent_len)
 {
   assert(extent_len);
-  plain_mdlength += ceph::encoded_sizeof_bounded<extent_info_t>();
+  if (record_type == record_type_t::JOURNAL) {
+    plain_mdlength += ceph::encoded_sizeof_bounded<extent_info_t>();
+  } else {
+    // OOL won't contain metadata
+  }
   dlength += extent_len;
 }
 
 void record_size_t::account(const delta_info_t& delta)
 {
+  assert(record_type == record_type_t::JOURNAL);
   assert(delta.bl.length());
   plain_mdlength += ceph::encoded_sizeof(delta);
 }
@@ -433,9 +445,26 @@ std::ostream &operator<<(std::ostream &os, transaction_type_t type)
 std::ostream &operator<<(std::ostream& out, const record_size_t& rsize)
 {
   return out << "record_size_t("
+             << "record_type=" << rsize.record_type
              << "raw_md=" << rsize.get_raw_mdlength()
              << ", data=" << rsize.dlength
              << ")";
+}
+
+std::ostream &operator<<(std::ostream& out, const record_type_t& type)
+{
+  switch (type) {
+  case record_type_t::JOURNAL:
+    return out << "JOURNAL";
+  case record_type_t::OOL:
+    return out << "OOL";
+  case record_type_t::MAX:
+    return out << "NULL";
+  default:
+    return out << "INVALID_RECORD_TYPE("
+               << static_cast<std::size_t>(type)
+               << ")";
+  }
 }
 
 std::ostream &operator<<(std::ostream& out, const record_t& r)
@@ -472,9 +501,16 @@ std::ostream& operator<<(std::ostream& out, const record_group_header_t& h)
 
 extent_len_t record_group_size_t::get_raw_mdlength() const
 {
-  return plain_mdlength +
-         sizeof(checksum_t) +
-         ceph::encoded_sizeof_bounded<record_group_header_t>();
+  assert(record_type < record_type_t::MAX);
+  extent_len_t ret = plain_mdlength;
+  if (record_type == record_type_t::JOURNAL) {
+    ret += sizeof(checksum_t);
+    ret += ceph::encoded_sizeof_bounded<record_group_header_t>();
+  } else {
+    // OOL won't contain metadata
+    assert(ret == 0);
+  }
+  return ret;
 }
 
 void record_group_size_t::account(
@@ -485,14 +521,23 @@ void record_group_size_t::account(
   assert(_block_size > 0);
   assert(rsize.dlength % _block_size == 0);
   assert(block_size == 0 || block_size == _block_size);
-  plain_mdlength += rsize.get_raw_mdlength();
-  dlength += rsize.dlength;
+  assert(record_type == RECORD_TYPE_NULL ||
+         record_type == rsize.record_type);
   block_size = _block_size;
+  record_type = rsize.record_type;
+  if (record_type == record_type_t::JOURNAL) {
+    plain_mdlength += rsize.get_raw_mdlength();
+  } else {
+    // OOL won't contain metadata
+    assert(rsize.get_raw_mdlength() == 0);
+  }
+  dlength += rsize.dlength;
 }
 
 std::ostream& operator<<(std::ostream& out, const record_group_size_t& size)
 {
   return out << "record_group_size_t("
+             << "record_type=" << size.record_type
              << "raw_md=" << size.get_raw_mdlength()
              << ", data=" << size.dlength
              << ", block_size=" << size.block_size

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1917,17 +1917,17 @@ struct record_size_t {
 std::ostream &operator<<(std::ostream&, const record_size_t&);
 
 struct record_t {
-  transaction_type_t type = TRANSACTION_TYPE_NULL;
+  transaction_type_t trans_type = TRANSACTION_TYPE_NULL;
   std::vector<extent_t> extents;
   std::vector<delta_info_t> deltas;
   record_size_t size;
   sea_time_point modify_time = NULL_TIME;
 
-  record_t(transaction_type_t type) : type{type} { }
+  record_t(transaction_type_t t_type) : trans_type{t_type} { }
 
   // unit test only
   record_t() {
-    type = transaction_type_t::MUTATE;
+    trans_type = transaction_type_t::MUTATE;
   }
 
   // unit test only
@@ -1940,7 +1940,7 @@ struct record_t {
     for (auto& d: _deltas) {
       push_back(std::move(d));
     }
-    type = transaction_type_t::MUTATE;
+    trans_type = transaction_type_t::MUTATE;
   }
 
   bool is_empty() const {


### PR DESCRIPTION
Follow up https://github.com/ceph/ceph/pull/57788, quote:

```
tier-main: iops=3969.97,depth=1.01,batch=1.32,bwMiB=29.62,sizeB=7824.19(3460.97,1448.24,2914.98)
  inline: iops=2077.98,depth=1.02,batch=1.42,bwMiB=13.24,sizeB=6682.12(2075.60,2667.54,1938.98)
  ...
  ooldata: iops=1891.98,depth=1.00,batch=1.22,bwMiB=16.38,sizeB=9078.53(4982.53,*109.08,3986.92*)
...
```

Under a short-time fio-rbd random write workload, the OSD log (SeaStore) roughly shows ~55% of the bandwidth comes from "ooldata", and ~45% of which comes from the unnecessary metadata+padding. This means ~25% of the bandwidth in this workload is unnecessary.

----

This PR tries to remove the unnecessary padding,
before this PR (the same random-write workload), e.g.:
```
tier-main: iops=5874.45,depth=1.01,batch=1.15,bwMiB=41.25,sizeB=7362.97(3192.01,902.86,3268.09)
  inline: iops=3281.47,depth=1.01,batch=1.16,bwMiB=19.68,sizeB=6288.48(2058.30,1532.98,2697.20)
  ...
  ooldata: iops=2592.98,depth=1.00,batch=1.13,bwMiB=21.57,sizeB=8722.76(4626.76,105.43,3990.57)
...
```
after this PR, e.g.:
```
tier-main: iops=5763.43,depth=1.28,batch=1.12,bwMiB=29.33,sizeB=5335.78(3061.96,827.21,1446.61)
  inline: iops=3065.46,depth=1.01,batch=1.23,bwMiB=18.79,sizeB=6426.93(2151.89,1555.24,2719.80)
  ...
  ooldata: iops=2697.97,depth=1.59,batch=1.00,bwMiB=10.54,sizeB=4096.00(4096.00,*0.00,0.00*)
...
```
The unnecessary ool paddings are proved to be removed.

Under my local test workload, although it looks to be CPU-bounded (not disk-bound), the overall performance (from fio client) increases ~5% with the disk bandwidth (from iostat) reduced by ~26%. The benefit might be better with a less performant disk or with more seastar shards.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
