### PR TITLE
reef: qa/cephfs: add MDS_CLIENTS_BROKEN_ROOTSQUASH to ignorelist

### DIFF
--- a/qa/suites/fs/functional/tasks/admin.yaml
+++ b/qa/suites/fs/functional/tasks/admin.yaml
@@ -7,6 +7,8 @@ overrides:
       - missing required features
       - \(MDS_CACHE_OVERSIZED\)
       - \(MDS_TRIM\)
+      - \(MDS_CLIENTS_BROKEN_ROOTSQUASH\)
+      - report clients with broken root_squash implementation
 tasks:
   - cephfs_test_runner:
       fail_on_skip: false


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66680

---

backport of https://github.com/ceph/ceph/pull/57528
parent tracker: https://tracker.ceph.com/issues/66075

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh