### PR TITLE
RGW|BN : fix for persistent topic changing endpoint\endpointargs

### DIFF
--- a/qa/suites/rgw/notifications/tasks/kafka/test_kafka.yaml
+++ b/qa/suites/rgw/notifications/tasks/kafka/test_kafka.yaml
@@ -4,5 +4,5 @@ tasks:
       kafka_version: 2.6.0
 - notification-tests:
     client.0:
-      extra_attr: ["kafka_test"]
+      extra_attr: ["kafka_test", "data_path_v2_kafka_test"]
       rgw_server: client.0

--- a/qa/tasks/notification_tests.py
+++ b/qa/tasks/notification_tests.py
@@ -220,7 +220,7 @@ def run_tests(ctx, config):
     for client, client_config in config.items():
         (remote,) = ctx.cluster.only(client).remotes.keys()
 
-        attr = ["!kafka_test", "!amqp_test", "!amqp_ssl_test", "!kafka_security_test", "!modification_required", "!manual_test", "!http_test"]
+        attr = ["!kafka_test", "!data_path_v2_kafka_test", "!amqp_test", "!amqp_ssl_test", "!kafka_security_test", "!modification_required", "!manual_test", "!http_test"]
 
         if 'extra_attr' in client_config:
             attr = client_config.get('extra_attr')

--- a/src/cls/2pc_queue/cls_2pc_queue_client.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_client.h
@@ -33,6 +33,13 @@ int cls_2pc_queue_list_entries(librados::IoCtx& io_ctx, const std::string& queue
 
 // list all pending reservations in the queue
 int cls_2pc_queue_list_reservations(librados::IoCtx& io_ctx, const std::string& queue_name, cls_2pc_reservations& reservations);
+
+// return push_endpoint, push_endpoint_args and arn_topic
+int cls_2pc_queue_get_topic_attrs(librados::IoCtx &io_ctx, const std::string &queue_name, std::string &push_endpoint,
+                                  std::string &push_endpoint_args, std::string &arn_topic, bool &topic_attrs_set);
+// return push_endpoint, push_endpoint_args and arn_topic
+int cls_2pc_queue_update_attrs(librados::IoCtx& io_ctx, const std::string& queue_name, const std::string& push_endpoint,
+                                   const std::string& push_endpoint_args, const std::string& arn_topic);
 #endif
 
 // optionally async method for getting capacity (bytes) 
@@ -91,4 +98,15 @@ void cls_2pc_queue_expire_reservations(librados::ObjectWriteOperation& op,
 // if there is no guarantee against two clienst deleting entries at the same time, you can leave the entries_to_remove unprovided or input zero entries_to_remove
 // the function will count how many entries it needs to removed
 void cls_2pc_queue_remove_entries(librados::ObjectWriteOperation& op, const std::string& end_marker, uint64_t entries_to_remove=0);
+
+// update the arn_topic, push_endpoint address and its arguments in the header of the queue
+void cls_2pc_queue_update_attrs(librados::ObjectWriteOperation& op, std::string& push_endpoint,
+                                std::string& push_endpoint_args, std::string& arn_topic);
+
+// optionally async method for getting arn_topic, push_endpoint address and its arguments in the header of the queue
+// after answer is received, call cls_2pc_queue_get_topic_attrs_result() to parse the results
+void cls_2pc_queue_get_topic_attrs(librados::ObjectReadOperation& op,  bufferlist* obl, int* prval);
+
+int cls_2pc_queue_get_topic_attrs_result(const bufferlist &bl, std::string &push_endpoint, std::string &push_endpoint_args,
+                                     std::string &arn_topic, bool &topic_attrs_set);
 

--- a/src/cls/2pc_queue/cls_2pc_queue_const.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_const.h
@@ -12,4 +12,6 @@
 #define TPC_QUEUE_LIST_ENTRIES "2pc_queue_list_entries"
 #define TPC_QUEUE_REMOVE_ENTRIES "2pc_queue_remove_entries"
 #define TPC_QUEUE_EXPIRE_RESERVATIONS "2pc_queue_expire_reservations"
+#define TPC_QUEUE_GET_TOPIC_ATTRS "2pc_queue_get_topic_attrs"
+#define TPC_QUEUE_UPDATE_ATTRS "2pc_queue_update_attrs"
 

--- a/src/cls/2pc_queue/cls_2pc_queue_ops.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_ops.h
@@ -207,3 +207,56 @@ struct cls_2pc_queue_remove_op {
   }
 };
 WRITE_CLASS_ENCODER(cls_2pc_queue_remove_op)
+
+struct cls_2pc_queue_update_attrs_op {
+  std::string push_endpoint;
+  std::string push_endpoint_args;
+  std::string arn_topic;
+
+  cls_2pc_queue_update_attrs_op() {}
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(push_endpoint, bl);
+    encode(push_endpoint_args, bl);
+    encode(arn_topic, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(push_endpoint, bl);
+    decode(push_endpoint_args, bl);
+    decode(arn_topic, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_2pc_queue_update_attrs_op)
+
+struct cls_queue_get_topic_attrs_ret {
+  std::string push_endpoint;
+  std::string push_endpoint_args;
+  std::string arn_topic;
+  bool topic_attrs_set;
+
+  cls_queue_get_topic_attrs_ret() {}
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(push_endpoint, bl);
+    encode(push_endpoint_args, bl);
+    encode(arn_topic, bl);
+    encode(topic_attrs_set, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(push_endpoint, bl);
+    decode(push_endpoint_args, bl);
+    decode(arn_topic, bl);
+    decode(topic_attrs_set, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_queue_get_topic_attrs_ret)

--- a/src/cls/2pc_queue/cls_2pc_queue_types.h
+++ b/src/cls/2pc_queue/cls_2pc_queue_types.h
@@ -59,14 +59,22 @@ struct cls_2pc_urgent_data
   cls_2pc_reservations reservations; // reservation list (keyed by id)
   bool has_xattrs{false};
   uint32_t committed_entries{0}; // how many entries have been committed so far
+  std::string push_endpoint;
+  std::string push_endpoint_args;
+  std::string arn_topic;
+  bool topic_attrs_set{false};
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(reserved_size, bl);
     encode(last_id, bl);
     encode(reservations, bl);
     encode(has_xattrs, bl);
     encode(committed_entries, bl);
+    encode(push_endpoint, bl);
+    encode(push_endpoint_args, bl);
+    encode(arn_topic, bl);
+    encode(topic_attrs_set, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -78,6 +86,12 @@ struct cls_2pc_urgent_data
     decode(has_xattrs, bl);
     if (struct_v >= 2) {
       decode(committed_entries, bl);
+    }
+    if (struct_v >= 3) {
+      decode(push_endpoint, bl);
+      decode(push_endpoint_args, bl);
+      decode(arn_topic, bl);
+      decode(topic_attrs_set, bl);
     }
     DECODE_FINISH(bl);
   }
@@ -94,6 +108,10 @@ struct cls_2pc_urgent_data
     }
     f->close_section();
     f->dump_bool("has_xattrs", has_xattrs);
+    f->dump_string("push_endpoint", push_endpoint);
+    f->dump_string("push_endpoint_args", push_endpoint_args);
+    f->dump_string("arn_topic", arn_topic);
+    f->dump_bool("topic_attrs_set", topic_attrs_set);
   }
 
   static void generate_test_instances(std::list<cls_2pc_urgent_data*>& ls) {

--- a/src/rgw/driver/rados/rgw_notify.h
+++ b/src/rgw/driver/rados/rgw_notify.h
@@ -34,7 +34,11 @@ void shutdown();
 
 // create persistent delivery queue for a topic (endpoint)
 // this operation also add a topic queue to the common (to all RGWs) list of all topics
-int add_persistent_topic(const DoutPrefixProvider* dpp, librados::IoCtx& rados_ioctx, const std::string& topic_queue, optional_yield y);
+int add_persistent_topic(const DoutPrefixProvider* dpp, librados::IoCtx& rados_ioctx, const rgw_pubsub_dest &dest, optional_yield y);
+
+// update persistent delivery queue attrs for a topic (endpoint)
+// this operation also updates a topic queue to the common (to all RGWs) list of all topics
+int update_persistent_topic_attrs(const DoutPrefixProvider* dpp, librados::IoCtx& rados_ioctx, const rgw_pubsub_dest &dest, optional_yield y);
 
 // remove persistent delivery queue for a topic (endpoint)
 // this operation also remove the topic queue from the common (to all RGWs) list of all topics

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -1728,10 +1728,18 @@ int RadosStore::list_account_topics(const DoutPrefixProvider* dpp,
 
 int RadosStore::add_persistent_topic(const DoutPrefixProvider* dpp,
                                      optional_yield y,
-                                     const std::string& topic_queue)
+                                     const rgw_pubsub_dest &dest)
 {
   return rgw::notify::add_persistent_topic(
-      dpp, getRados()->get_notif_pool_ctx(), topic_queue, y);
+      dpp, getRados()->get_notif_pool_ctx(), dest, y);
+}
+
+int RadosStore::update_persistent_topic_attrs(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     const rgw_pubsub_dest &dest)
+{
+  return rgw::notify::update_persistent_topic_attrs(
+      dpp, getRados()->get_notif_pool_ctx(), dest, y);
 }
 
 int RadosStore::remove_persistent_topic(const DoutPrefixProvider* dpp,

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -321,7 +321,10 @@ class RadosStore : public StoreDriver {
                             TopicList& listing) override;
     int add_persistent_topic(const DoutPrefixProvider* dpp,
                              optional_yield y,
-                             const std::string& topic_queue) override;
+                             const rgw_pubsub_dest &dest) override;
+    int update_persistent_topic_attrs(const DoutPrefixProvider* dpp,
+                             optional_yield y,
+                             const rgw_pubsub_dest &dest) override;
     int remove_persistent_topic(const DoutPrefixProvider* dpp,
                                 optional_yield y,
                                 const std::string& topic_queue) override;

--- a/src/rgw/driver/rados/topic.cc
+++ b/src/rgw/driver/rados/topic.cc
@@ -357,7 +357,7 @@ class MetadataHandler : public RGWMetadataHandler {
       librados::IoCtx ioctx;
       r = rgw_init_ioctx(dpp, &rados, zone.notif_pool, ioctx, true, false);
       if (r >= 0) {
-        r = rgw::notify::add_persistent_topic(dpp, ioctx, info.dest.persistent_queue, y);
+        r = rgw::notify::add_persistent_topic(dpp, ioctx, info.dest, y);
       }
       if (r < 0) {
         ldpp_dout(dpp, 1) << "ERROR: failed to create queue for persistent topic "

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -46,6 +46,7 @@ struct rgw_pubsub_bucket_topics;
 class RGWZonePlacementInfo;
 struct rgw_pubsub_topic;
 struct RGWOIDCProviderInfo;
+struct rgw_pubsub_dest;
 
 using RGWBucketListNameFilter = std::function<bool (const std::string&)>;
 
@@ -503,7 +504,10 @@ class Driver {
     // write_topic_v2()/remove_topic_v2()
     virtual int add_persistent_topic(const DoutPrefixProvider* dpp,
                                      optional_yield y,
-                                     const std::string& topic_queue) = 0;
+                                     const rgw_pubsub_dest& dest) = 0;
+    virtual int update_persistent_topic_attrs(const DoutPrefixProvider* dpp,
+                                     optional_yield y,
+                                     const rgw_pubsub_dest& dest) = 0;
     virtual int remove_persistent_topic(const DoutPrefixProvider* dpp,
                                         optional_yield y,
                                         const std::string& topic_queue) = 0;

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1913,7 +1913,14 @@ namespace rgw::sal {
 
   int DBStore::add_persistent_topic(const DoutPrefixProvider* dpp,
                                     optional_yield y,
-                                    const std::string& topic_queue)
+                                    const rgw_pubsub_dest &dest)
+  {
+    return -ENOTSUP;
+  }
+
+  int DBStore::update_persistent_topic_attrs(const DoutPrefixProvider* dpp,
+                                    optional_yield y,
+                                    const rgw_pubsub_dest &dest)
   {
     return -ENOTSUP;
   }

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -889,7 +889,10 @@ public:
 
       int add_persistent_topic(const DoutPrefixProvider* dpp,
                                optional_yield y,
-                               const std::string& topic_queue) override;
+                               const rgw_pubsub_dest &dest) override;
+      int update_persistent_topic_attrs(const DoutPrefixProvider* dpp,
+                               optional_yield y,
+                               const rgw_pubsub_dest &dest) override;
       int remove_persistent_topic(const DoutPrefixProvider* dpp,
                                   optional_yield y,
                                   const std::string& topic_queue) override;

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -465,9 +465,16 @@ std::unique_ptr<Notification> FilterDriver::get_notification(
 
 int FilterDriver::add_persistent_topic(const DoutPrefixProvider* dpp,
                                        optional_yield y,
-                                       const std::string& topic_queue)
+                                       const rgw_pubsub_dest &dest)
 {
-  return next->add_persistent_topic(dpp, y, topic_queue);
+  return next->add_persistent_topic(dpp, y, dest);
+}
+
+int FilterDriver::update_persistent_topic_attrs(const DoutPrefixProvider* dpp,
+                                       optional_yield y,
+                                       const rgw_pubsub_dest &dest)
+{
+  return next->update_persistent_topic_attrs(dpp, y, dest);
 }
 
 int FilterDriver::remove_persistent_topic(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -355,7 +355,10 @@ public:
   }
   int add_persistent_topic(const DoutPrefixProvider* dpp,
                            optional_yield y,
-                           const std::string& topic_queue) override;
+                           const rgw_pubsub_dest &dest) override;
+  int update_persistent_topic_attrs(const DoutPrefixProvider* dpp,
+                           optional_yield y,
+                           const rgw_pubsub_dest &dest) override;
   int remove_persistent_topic(const DoutPrefixProvider* dpp,
                               optional_yield y,
                               const std::string& topic_queue) override;

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -2957,25 +2957,26 @@ def wait_for_queue_to_drain(topic_name, tenant=None, account=None, http_port=Non
     log.info('waited for %ds for queue %s to drain', time_diff, topic_name)
 
 
-@attr('basic_test')
+@attr('kafka_test')
 def test_ps_s3_persistent_topic_stats():
     """ test persistent topic stats """
     conn = connection()
     zonegroup = get_config_zonegroup()
-
-    # create random port for the http server
-    host = get_ip()
-    port = random.randint(10000, 20000)
 
     # create bucket
     bucket_name = gen_bucket_name()
     bucket = conn.create_bucket(bucket_name)
     topic_name = bucket_name + TOPIC_SUFFIX
 
+    # start kafka receiver
+    host = get_ip()
+    task, receiver = create_kafka_receiver_thread(topic_name)
+    task.start()
+
     # create s3 topic
-    endpoint_address = 'http://'+host+':'+str(port)
-    endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'+ \
-            '&retry_sleep_duration=1'
+    endpoint_address = 'kafka://' + host + ':1234' # wrong port
+    endpoint_args = 'push-endpoint='+endpoint_address+'&kafka-ack-level=broker&persistent=true'+ \
+                    '&retry_sleep_duration=1'
     topic_conf = PSTopicS3(conn, topic_name, zonegroup, endpoint_args=endpoint_args)
     topic_arn = topic_conf.set_config()
     # create s3 notification
@@ -3022,37 +3023,43 @@ def test_ps_s3_persistent_topic_stats():
     # topic stats
     get_stats_persistent_topic(topic_name, 2 * number_of_objects)
 
-    # start an http server in a separate thread
-    http_server = HTTPServerWithEvents((host, port))
+    # change the endpoint port
+    endpoint_address = 'kafka://' + host
+    endpoint_args = 'push-endpoint='+endpoint_address+'&kafka-ack-level=broker&persistent=true'+ \
+                    '&retry_sleep_duration=1'
+    topic_conf = PSTopicS3(conn, topic_name, zonegroup, endpoint_args=endpoint_args)
+    topic_arn = topic_conf.set_config()
 
-    wait_for_queue_to_drain(topic_name, http_port=port)
+    wait_for_queue_to_drain(topic_name)
 
     # cleanup
     s3_notification_conf.del_config()
     topic_conf.del_config()
     # delete the bucket
     conn.delete_bucket(bucket_name)
-    http_server.close()
+    receiver.close(task)
 
-@attr('basic_test')
+@attr('kafka_test')
 def test_persistent_topic_dump():
     """ test persistent topic dump """
     conn = connection()
     zonegroup = get_config_zonegroup()
-
-    # create random port for the http server
-    host = get_ip()
-    port = random.randint(10000, 20000)
 
     # create bucket
     bucket_name = gen_bucket_name()
     bucket = conn.create_bucket(bucket_name)
     topic_name = bucket_name + TOPIC_SUFFIX
 
+    # start kafka receiver
+    host = get_ip()
+    task, receiver = create_kafka_receiver_thread(topic_name)
+    task.start()
+
+
     # create s3 topic
-    endpoint_address = 'http://'+host+':'+str(port)
-    endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'+ \
-            '&retry_sleep_duration=1'
+    endpoint_address = 'kafka://WrongHost' # wrong port
+    endpoint_args = 'push-endpoint='+endpoint_address+'&kafka-ack-level=broker&persistent=true'+ \
+                    '&retry_sleep_duration=1'
     topic_conf = PSTopicS3(conn, topic_name, zonegroup, endpoint_args=endpoint_args)
     topic_arn = topic_conf.set_config()
     # create s3 notification
@@ -3103,10 +3110,14 @@ def test_persistent_topic_dump():
     parsed_result = json.loads(result[0])
     assert_equal(len(parsed_result), 2*number_of_objects)
 
-    # start an http server in a separate thread
-    http_server = HTTPServerWithEvents((host, port))
+    # change the endpoint port
+    endpoint_address = 'kafka://' + host
+    endpoint_args = 'push-endpoint='+endpoint_address+'&kafka-ack-level=broker&persistent=true'+ \
+                    '&retry_sleep_duration=1'
+    topic_conf = PSTopicS3(conn, topic_name, zonegroup, endpoint_args=endpoint_args)
+    topic_arn = topic_conf.set_config()
 
-    wait_for_queue_to_drain(topic_name, http_port=port)
+    wait_for_queue_to_drain(topic_name,)
 
     result = admin(['topic', 'dump', '--topic', topic_name], get_config_cluster())
     assert_equal(result[1], 0)
@@ -3118,7 +3129,7 @@ def test_persistent_topic_dump():
     topic_conf.del_config()
     # delete the bucket
     conn.delete_bucket(bucket_name)
-    http_server.close()
+    receiver.close(task)
 
 
 def ps_s3_persistent_topic_configs(persistency_time, config_dict):
@@ -3653,33 +3664,50 @@ def test_ps_s3_persistent_multiple_gateways():
     http_server.close()
 
 
-@attr('http_test')
-def test_ps_s3_persistent_multiple_endpoints():
-    """ test pushing persistent notification when one of the endpoints has error """
-    conn = connection()
+def persistent_topic_multiple_endpoints(conn, endpoint_type):
     zonegroup = get_config_zonegroup()
-
-    # create random port for the http server
-    host = get_ip()
-    port = random.randint(10000, 20000)
-    # start an http server in a separate thread
-    number_of_objects = 10
-    http_server = HTTPServerWithEvents((host, port))
 
     # create bucket
     bucket_name = gen_bucket_name()
     bucket = conn.create_bucket(bucket_name)
     topic_name = bucket_name + TOPIC_SUFFIX
+    topic_name_1 = topic_name+'_1'
+
+    host = get_ip()
+    task = None
+    port = None
+    if endpoint_type == 'http':
+        # create random port for the http server
+        port = random.randint(10000, 20000)
+        # start an http server in a separate thread
+        receiver = HTTPServerWithEvents((host, port))
+        endpoint_address = 'http://'+host+':'+str(port)
+        endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'+ \
+                        '&retry_sleep_duration=1'
+    elif endpoint_type == 'amqp':
+        # start amqp receiver
+        exchange = 'ex1'
+        task, receiver = create_amqp_receiver_thread(exchange, topic_name_1)
+        task.start()
+        endpoint_address = 'amqp://' + host
+        endpoint_args = 'push-endpoint='+endpoint_address+'&amqp-exchange='+exchange+'&amqp-ack-level=broker&persistent=true'+ \
+                        '&retry_sleep_duration=1'
+    elif endpoint_type == 'kafka':
+        # start kafka receiver
+        task, receiver = create_kafka_receiver_thread(topic_name_1)
+        task.start()
+        endpoint_address = 'kafka://' + host
+        endpoint_args = 'push-endpoint='+endpoint_address+'&kafka-ack-level=broker&persistent=true'+ \
+                        '&retry_sleep_duration=1'
+    else:
+        return SkipTest('Unknown endpoint type: ' + endpoint_type)
 
     # create two s3 topics
-    endpoint_address = 'http://'+host+':'+str(port)
-    endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'+ \
-            '&retry_sleep_duration=1'
-    topic_conf1 = PSTopicS3(conn, topic_name+'_1', zonegroup, endpoint_args=endpoint_args)
+    topic_conf1 = PSTopicS3(conn, topic_name_1, zonegroup, endpoint_args=endpoint_args)
     topic_arn1 = topic_conf1.set_config()
     endpoint_address = 'http://kaboom:9999'
     endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'+ \
-            '&retry_sleep_duration=1'
+                    '&retry_sleep_duration=1'
     topic_conf2 = PSTopicS3(conn, topic_name+'_2', zonegroup, endpoint_args=endpoint_args)
     topic_arn2 = topic_conf2.set_config()
 
@@ -3701,6 +3729,7 @@ def test_ps_s3_persistent_multiple_endpoints():
 
     client_threads = []
     start_time = time.time()
+    number_of_objects = 10
     for i in range(number_of_objects):
         key = bucket.new_key(str(i))
         content = str(os.urandom(1024*1024))
@@ -3711,9 +3740,8 @@ def test_ps_s3_persistent_multiple_endpoints():
 
     keys = list(bucket.list())
 
-    wait_for_queue_to_drain(topic_name+'_1')
-
-    http_server.verify_s3_events(keys, exact_match=True, deletions=False)
+    wait_for_queue_to_drain(topic_name_1, http_port=port)
+    receiver.verify_s3_events(keys, exact_match=True, deletions=False)
 
     # delete objects from the bucket
     client_threads = []
@@ -3724,9 +3752,8 @@ def test_ps_s3_persistent_multiple_endpoints():
         client_threads.append(thr)
     [thr.join() for thr in client_threads]
 
-    wait_for_queue_to_drain(topic_name+'_1')
-
-    http_server.verify_s3_events(keys, exact_match=True, deletions=True)
+    wait_for_queue_to_drain(topic_name_1, http_port=port)
+    receiver.verify_s3_events(keys, exact_match=True, deletions=True)
 
     # cleanup
     s3_notification_conf1.del_config()
@@ -3734,7 +3761,22 @@ def test_ps_s3_persistent_multiple_endpoints():
     s3_notification_conf2.del_config()
     topic_conf2.del_config()
     conn.delete_bucket(bucket_name)
-    http_server.close()
+    receiver.close(task)
+
+
+@attr('http_test')
+def test_persistent_multiple_endpoints_http():
+    """ test pushing persistent notification when one of the endpoints has error, http endpoint """
+    conn = connection()
+    persistent_topic_multiple_endpoints(conn, 'http')
+
+
+@attr('kafka_test')
+def test_persistent_multiple_endpoints_kafka():
+    """ test pushing persistent notification when one of the endpoints has error, kafka endpoint """
+    conn = connection()
+    persistent_topic_multiple_endpoints(conn, 'kafka')
+
 
 def persistent_notification(endpoint_type, conn, account=None):
     """ test pushing persistent notification """
@@ -4668,17 +4710,13 @@ def test_persistent_ps_s3_reload():
     http_server.close()
 
 
-@attr('data_path_v2_test')
-def test_persistent_ps_s3_data_path_v2_migration():
+@attr('data_path_v2_kafka_test')
+def test_persistent_data_path_v2_migration():
     """ test data path v2 persistent migration """
     if get_config_cluster() == 'noname':
         return SkipTest('realm is needed for migration test')
     conn = connection()
     zonegroup = get_config_zonegroup()
-
-    # create random port for the http server
-    host = get_ip()
-    http_port = random.randint(10000, 20000)
 
     # disable v2 notification
     zonegroup_modify_feature(enable=False, feature_name=zonegroup_feature_notification_v2)
@@ -4688,10 +4726,13 @@ def test_persistent_ps_s3_data_path_v2_migration():
     bucket = conn.create_bucket(bucket_name)
     topic_name = bucket_name + TOPIC_SUFFIX
 
-    # create s3 topic
-    endpoint_address = 'http://'+host+':'+str(http_port)
-    endpoint_args = 'push-endpoint='+endpoint_address+'&persistent=true'+ \
-            '&retry_sleep_duration=1'
+    # start kafka receiver
+    host = get_ip()
+    task, receiver = create_kafka_receiver_thread(topic_name)
+    task.start()
+    endpoint_address = 'kafka://' + host
+    endpoint_args = 'push-endpoint='+endpoint_address+'&kafka-ack-level=broker&persistent=true'+ \
+                    '&retry_sleep_duration=1'
     topic_conf = PSTopicS3(conn, topic_name, zonegroup, endpoint_args=endpoint_args)
     topic_arn = topic_conf.set_config()
     # create s3 notification
@@ -4758,14 +4799,11 @@ def test_persistent_ps_s3_data_path_v2_migration():
         # topic stats
         get_stats_persistent_topic(topic_name, 2 * number_of_objects)
 
-        # start an http server in a separate thread
-        http_server = HTTPServerWithEvents((host, http_port))
-
-        wait_for_queue_to_drain(topic_name, http_port=http_port)
+        wait_for_queue_to_drain(topic_name)
         # verify events
         keys = list(bucket.list())
         # exact match is false because the notifications are persistent.
-        http_server.verify_s3_events(keys, exact_match=False)
+        receiver.verify_s3_events(keys, exact_match=False)
 
     except Exception as e:
         assert False, str(e)
@@ -4782,8 +4820,7 @@ def test_persistent_ps_s3_data_path_v2_migration():
         [thr.join() for thr in client_threads]
         # delete the bucket
         conn.delete_bucket(bucket_name)
-        if http_server:
-            http_server.close()
+        receiver.close(task)
 
 
 @attr('data_path_v2_test')


### PR DESCRIPTION
Previously endpoint and endpoint_args where held in the each entry of the persistent queue,
this meant that when the topic updates its endpoint/endpoint_args ,entries wouldn't got this update,
to fix this issue, we store the endpoint and the endpoint_args in the header of the queue (urgent_data)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
