### PR TITLE
squid: qa/tasks/mgr/test_progress.py: deal with pre-exisiting pool

### DIFF
--- a/qa/tasks/mgr/test_progress.py
+++ b/qa/tasks/mgr/test_progress.py
@@ -174,7 +174,15 @@ class TestProgress(MgrTestCase):
 
         # Remove all other pools
         for pool in self.mgr_cluster.mon_manager.get_osd_dump_json()['pools']:
-            self.mgr_cluster.mon_manager.remove_pool(pool['pool_name'])
+            # There might be some pools that wasn't created with this test.
+            # So we would use a raw cluster command to remove them.
+            pool_name = pool['pool_name']
+            if pool_name in self.mgr_cluster.mon_manager.pools:
+                self.mgr_cluster.mon_manager.remove_pool(pool_name)
+            else:
+                self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                    'osd', 'pool', 'rm', pool_name, pool_name,
+                    "--yes-i-really-really-mean-it")
 
         self._load_module("progress")
         self.mgr_cluster.mon_manager.raw_cluster_cmd('progress', 'clear')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66689

---

backport of https://github.com/ceph/ceph/pull/57401
parent tracker: https://tracker.ceph.com/issues/65826

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh