### PR TITLE
feat add client_sub_type for test mclock qos by rados bench

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5484,6 +5484,16 @@ options:
   level: dev
   desc: Maximum RAM hybrid allocator should use before enabling bitmap supplement
   default: 64_M
+- name: client_sub_type
+  type: str
+  level: dev
+  desc: client sub type for osd mclock
+  default: client
+  enum_values:
+  - client
+  - background_recovery
+  - background_best_effort
+  with_legacy: true
 - name: bluestore_volume_selection_policy
   type: str
   level: dev

--- a/src/include/msgr.h
+++ b/src/include/msgr.h
@@ -95,6 +95,16 @@ struct ceph_entity_name {
 
 #define CEPH_ENTITY_TYPE_ANY    0xFF
 
+/*
+ * TYPE_CLIENT <==> TYPE_SUB_CLIENT
+ * CEPH_ENTITY_TYPE_* is a variable of type __u8, with a maximum of no more than 255 (0xFF),
+ * CEPH_ENTITY_SUB_TYPE_* is a variable of type int, NOT shift bit,
+ * in order not to conflict with CEPH_ENTITY_TYPE_*, CEPH_ENTITY_SUB_TYPE_* starts with 256
+ */
+#define CEPH_ENTITY_SUB_TYPE_CLIENT                    CEPH_ENTITY_TYPE_CLIENT
+#define CEPH_ENTITY_SUB_TYPE_BACKGROUND_RECOVERY       258
+#define CEPH_ENTITY_SUB_TYPE_BACKGROUND_BEST_EFFORT    259
+
 extern const char *ceph_entity_type_name(int type);
 
 /*

--- a/src/include/msgr.h
+++ b/src/include/msgr.h
@@ -157,8 +157,15 @@ struct ceph_msg_connect_reply {
 	__u8 flags;
 } __attribute__ ((packed));
 
-#define CEPH_MSG_CONNECT_LOSSY  1  /* messages i send may be safely dropped */
-
+#define CEPH_MSG_CONNECT_LOSSY                            (1ULL) /* messages i send may be safely dropped */
+/*
+ * the parameter ClientIdentFrame.flags is uint64_t.
+ * in order to facilitate backport new features from community in the future.
+ * we used the high 4 bits (57-60)
+ */
+#define CEPH_MSG_CONNECT_SUB_TYPE_CLIENT                  (1ULL << 57) /* mclock client */
+#define CEPH_MSG_CONNECT_SUB_TYPE_BACKGROUND_RECOVERY     (1ULL << 58) /* mclock background recovery */
+#define CEPH_MSG_CONNECT_SUB_TYPE_BACKGROUND_BEST_EFFORT  (1ULL << 59) /* mclock background best effort */
 
 /*
  * message header

--- a/src/msg/Connection.h
+++ b/src/msg/Connection.h
@@ -46,6 +46,7 @@ struct Connection : public RefCountedObjectSafe {
   RefCountedPtr priv;
   int peer_type = -1;
   int64_t peer_id = -1;  // [msgr2 only] the 0 of osd.0, 4567 or client.4567
+  int peer_client_sub_type = -1; // client/background_recovery/best_effort
   safe_item_history<entity_addrvec_t> peer_addrs;
   utime_t last_keepalive, last_keepalive_ack;
   bool anon = false;  ///< anonymous outgoing connection
@@ -180,6 +181,18 @@ public:
   bool peer_is_mds() const { return peer_type == CEPH_ENTITY_TYPE_MDS; }
   bool peer_is_osd() const { return peer_type == CEPH_ENTITY_TYPE_OSD; }
   bool peer_is_client() const { return peer_type == CEPH_ENTITY_TYPE_CLIENT; }
+
+  int get_peer_client_sub_type() const { return peer_client_sub_type; }
+  void set_peer_client_sub_type(int t) { peer_client_sub_type = t; }
+  bool peer_sub_type_is_client() const {
+    return peer_client_sub_type == CEPH_ENTITY_SUB_TYPE_CLIENT;
+  }
+  bool peer_sub_type_is_background_recovery() const {
+    return peer_client_sub_type == CEPH_ENTITY_SUB_TYPE_BACKGROUND_RECOVERY;
+  }
+  bool peer_sub_type_is_background_best_effort() const {
+    return peer_client_sub_type == CEPH_ENTITY_SUB_TYPE_BACKGROUND_BEST_EFFORT;
+  }
 
   /// which of the peer's addrs is actually in use for this connection
   virtual entity_addr_t get_peer_socket_addr() const = 0;

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -2413,7 +2413,7 @@ CtPtr ProtocolV2::handle_client_ident(ceph::bufferlist &payload)
       client_sub_type = CEPH_ENTITY_SUB_TYPE_BACKGROUND_BEST_EFFORT;
     }
 
-    connection->policy = messenger->get_policy(client_sub_type);
+    connection->set_peer_client_sub_type(client_sub_type);
 
     ldout(cct, 5) << __func__ << " my_identity()=" <<  messenger->get_mytype()
                   << ", peer_identity=" << connection->get_peer_type()

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1906,6 +1906,22 @@ CtPtr ProtocolV2::send_client_ident() {
     flags |= CEPH_MSG_CONNECT_LOSSY;
   }
 
+  if (messenger->get_mytype() == CEPH_ENTITY_TYPE_CLIENT &&
+      connection->get_peer_type() == CEPH_ENTITY_TYPE_OSD) {
+    auto client_sub_type = cct->_conf->client_sub_type;
+    if (client_sub_type == "client") {
+      flags |= CEPH_MSG_CONNECT_SUB_TYPE_CLIENT;
+    } else if (client_sub_type == "background_recovery") {
+      flags |= CEPH_MSG_CONNECT_SUB_TYPE_BACKGROUND_RECOVERY;
+    } else if (client_sub_type == "background_best_effort") {
+      flags |= CEPH_MSG_CONNECT_SUB_TYPE_BACKGROUND_BEST_EFFORT;
+    }
+    ldout(cct, 5) << __func__ << " my_identity()=" <<  messenger->get_mytype()
+                  << ", peer_identity=" << connection->get_peer_type()
+                  << ", client_sub_type=" << client_sub_type
+                  << std::hex << ", flags=" << flags << std::dec << dendl;
+  }
+
   auto client_ident = ClientIdentFrame::Encode(
       messenger->get_myaddrs(),
       connection->target_addr,

--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -244,7 +244,19 @@ public:
     auto type = op->get_req()->get_type();
     if (type == CEPH_MSG_OSD_OP ||
 	type == CEPH_MSG_OSD_BACKOFF) {
-      return op_scheduler_class::client;
+      /*
+       * use connection client_sub_type to distinguish opclass types
+       */
+      switch (op->get_req()->get_connection()->get_peer_client_sub_type()) {
+      case CEPH_ENTITY_SUB_TYPE_CLIENT:
+        return op_scheduler_class::client;
+      case CEPH_ENTITY_SUB_TYPE_BACKGROUND_RECOVERY:
+        return op_scheduler_class::background_recovery;
+      case CEPH_ENTITY_SUB_TYPE_BACKGROUND_BEST_EFFORT:
+        return op_scheduler_class::background_best_effort;
+      default: // other default fast client
+        return op_scheduler_class::client;
+      }
     } else {
       return op_scheduler_class::immediate;
     }


### PR DESCRIPTION
**osd mclock did not satisfy reservations** : https://tracker.ceph.com/issues/66682

```
commit dcf4d8308c1f2cadc7e4b30a677988dc2d2be0a2
Author: zhangjianwei2 <zhangjianwei2_yewu@cmss.chinamobile.com>
Date:   Wed Jun 26 10:11:45 2024 +0800

    osd/scheduler: use client_sub_type mark opclass

    - rados bench --client_sub_type=client/background_recovery/background_best_effort

commit 6bce0be480a2d2651467041b86bb06e8c7b00129
Author: zhangjianwei2 <zhangjianwei2_yewu@cmss.chinamobile.com>
Date:   Wed Jun 26 10:06:20 2024 +0800

    src/msg: mark client_sub_type for connection


commit 736905595427da8a2e427058a83502daae7a956f
Author: zhangjianwei2 <zhangjianwei2_yewu@cmss.chinamobile.com>
Date:   Wed Jun 26 09:58:07 2024 +0800

    src/msg: add client_sub_type entity for osd

    - only msgr V2 supported
    - add SUB_TYPE client type
      - CEPH_ENTITY_SUB_TYPE_CLIENT
      - CEPH_ENTITY_SUB_TYPE_BACKGROUND_RECOVERY
      - CEPH_ENTITY_SUB_TYPE_BACKGROUND_BEST_EFFORT


commit 10b8195fd5723fdec0cfb8441deec6c8d06411f9
Author: zhangjianwei2 <zhangjianwei2_yewu@cmss.chinamobile.com>
Date:   Wed Jun 26 10:21:29 2024 +0800

    src/msg: add client_sub_type for connection

    - only msgr V2 supported
    - Using ClientIdentFrame.flags mark client_sub_type when creating connection
      - CEPH_MSG_CONNECT_SUB_TYPE_CLIENT
      - CEPH_MSG_CONNECT_SUB_TYPE_BACKGROUND_RECOVERY
      - CEPH_MSG_CONNECT_SUB_TYPE_BACKGROUND_BEST_EFFORT
    - client_sub_type
      - client
      - background_recovery
      - background_best_effort
    - issue
      - https://tracker.ceph.com/issues/66682
```


```
# cat shell/test_512KB_bench.sh
#!/bin/sh

name1=$(echo $RANDOM)
name2=$(echo $RANDOM)

rados --client_sub_type=client  bench 180 write --no-cleanup -p test-pool-0 -t 40 -b 512KB --show-time --no-verify --run-name bw_based_qos_test_$name1_$name2 > 512KB_client 2>&1 &
rados --client_sub_type=background_recovery bench 180 write --no-cleanup -p test-pool-0 -t 40 -b 512KB --show-time --no-verify --run-name bw_based_qos_test_$name1_$name2 > 512KB_recovery 2>&1 &
rados --client_sub_type=background_best_effort bench 180 write --no-cleanup -p test-pool-0 -t 40 -b 512KB --show-time --no-verify --run-name bw_based_qos_test_$name1_$name2 > 512KB_best_effort 2>&1 &

wait

```

