### PR TITLE
quincy: doc/rados: edit troubleshooting-osd.rst

### DIFF
--- a/doc/rados/troubleshooting/troubleshooting-osd.rst
+++ b/doc/rados/troubleshooting/troubleshooting-osd.rst
@@ -655,7 +655,7 @@ Events from the OSD as it processes ops:
   is now being performed.
 - ``waiting for subops from``: The op has been sent to replica OSDs.
 
-Events from ```Filestore```:
+Events from ``Filestore``:
 
 - ``commit_queued_for_journal_write``: The op has been given to the FileStore.
 - ``write_thread_in_journal_buffer``: The op is in the journal's buffer and is waiting
@@ -667,7 +667,7 @@ Events from the OSD after data has been given to underlying storage:
 
 - ``op_commit``: The op has been committed (that is, written to journal) by the
   primary OSD.
-- ``op_applied``: The op has been `write()'en
+- ``op_applied``: The op has been `written with write()
   <https://www.freebsd.org/cgi/man.cgi?write(2)>`_ to the backing FS (that is,
   applied in memory but not flushed out to disk) on the primary.
 - ``sub_op_applied``: ``op_applied``, but for a replica's "subop".
@@ -676,8 +676,9 @@ Events from the OSD after data has been given to underlying storage:
   hears about the above, but for a particular replica (i.e. ``<X>``).
 - ``commit_sent``: We sent a reply back to the client (or primary OSD, for sub ops).
 
-Some of these events may appear redundant, but they cross important boundaries
-in the internal code (such as passing data across locks into new threads).
+Although some of these events may appear redundant, they cross important
+boundaries in the internal code (such as passing data across locks into new
+threads).
 
 
 Flapping OSDs


### PR DESCRIPTION
Make minor changes to the "Debugging Slow Requests" section of doc/rados/troubleshooting/troubleshooting-osd.rst in preparation for an expansion of this section in response to a reqeust from Joel Davidow.

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 8b211b9c7f9b173bb12028eb7108d13867883d6e)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
