### PR TITLE
suites: host thrasher should check min_in before thrashing host

### DIFF
--- a/qa/suites/rados/thrash/thrashers/careful_host.yaml
+++ b/qa/suites/rados/thrash/thrashers/careful_host.yaml
@@ -21,6 +21,7 @@ tasks:
 - thrashosds:
     timeout: 1200
     min_in: 2
+    thrash_hosts: true
     chance_pgnum_grow: 1
     chance_pgnum_shrink: 1
     chance_pgpnum_fix: 1

--- a/qa/suites/rados/thrash/thrashers/default.yaml
+++ b/qa/suites/rados/thrash/thrashers/default.yaml
@@ -22,7 +22,6 @@ tasks:
 - thrashosds:
     timeout: 1200
     min_in: 2
-    thrash_hosts: true
     chance_pgnum_grow: 1
     chance_pgnum_shrink: 1
     chance_pgpnum_fix: 1

--- a/qa/suites/rados/thrash/thrashers/default_host.yaml
+++ b/qa/suites/rados/thrash/thrashers/default_host.yaml
@@ -10,6 +10,7 @@ overrides:
         osd scrub max interval: 120
         osd max backfills: 3
         osd snap trim sleep: 2
+        osd delete sleep: 1
       mon:
         mon min osdmap epochs: 50
         paxos service trim min: 10
@@ -21,7 +22,9 @@ tasks:
 - thrashosds:
     timeout: 1200
     min_in: 2
+    thrash_hosts: true
     chance_pgnum_grow: 1
     chance_pgnum_shrink: 1
     chance_pgpnum_fix: 1
-    aggressive_pg_num_changes: false
+    chance_bluestore_reshard: 1
+    bluestore_new_sharding: random

--- a/qa/suites/rados/thrash/thrashers/mapgap_host.yaml
+++ b/qa/suites/rados/thrash/thrashers/mapgap_host.yaml
@@ -1,0 +1,31 @@
+overrides:
+  ceph:
+    log-ignorelist:
+    - but it is still running
+    - objects unfound and apparently lost
+    - osd_map_cache_size
+    conf:
+      mon:
+        mon min osdmap epochs: 50
+        paxos service trim min: 10
+        # prune full osdmaps regularly
+        mon osdmap full prune min: 15
+        mon osdmap full prune interval: 2
+        mon osdmap full prune txsize: 2
+      osd:
+        osd map cache size: 1
+        osd scrub min interval: 60
+        osd scrub max interval: 120
+        osd scrub during recovery: false
+        osd max backfills: 6
+        osd beacon report interval: 30
+tasks:
+- thrashosds:
+    timeout: 1800
+    min_in: 2
+    thrash_hosts: true
+    chance_pgnum_grow: 0.25
+    chance_pgnum_shrink: 0.25
+    chance_pgpnum_fix: 0.25
+    chance_test_map_discontinuity: 2
+    map_discontinuity_sleep_time: 200

--- a/qa/suites/rados/thrash/thrashers/pggrow.yaml
+++ b/qa/suites/rados/thrash/thrashers/pggrow.yaml
@@ -21,6 +21,5 @@ tasks:
 - thrashosds:
     timeout: 1200
     min_in: 2
-    thrash_hosts: true
     chance_pgnum_grow: 2
     chance_pgpnum_fix: 1

--- a/qa/suites/rados/thrash/thrashers/pggrow_host.yaml
+++ b/qa/suites/rados/thrash/thrashers/pggrow_host.yaml
@@ -5,11 +5,11 @@ overrides:
     - objects unfound and apparently lost
     conf:
       osd:
-        osd debug reject backfill probability: .3
         osd scrub min interval: 60
         osd scrub max interval: 120
-        osd max backfills: 3
-        osd snap trim sleep: 2
+        filestore odsync write: true
+        osd max backfills: 2
+        osd snap trim sleep: .5
       mon:
         mon min osdmap epochs: 50
         paxos service trim min: 10
@@ -21,7 +21,6 @@ tasks:
 - thrashosds:
     timeout: 1200
     min_in: 2
-    chance_pgnum_grow: 1
-    chance_pgnum_shrink: 1
+    thrash_hosts: true
+    chance_pgnum_grow: 2
     chance_pgpnum_fix: 1
-    aggressive_pg_num_changes: false


### PR DESCRIPTION
We need to check if taking host out will cause the total in osds to be less then min_in

Fixes: https://tracker.ceph.com/issues/66657





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
