### PR TITLE
quincy: mgr/nfs: Don't crash ceph-mgr if NFS clusters are unavailable.

### DIFF
--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -15,9 +15,8 @@ from typing import (
 from os.path import normpath
 import cephfs
 
-from rados import TimedOut, ObjectNotFound, Rados, LIBRADOS_ALL_NSPACES
+from rados import TimedOut, ObjectNotFound, Rados
 
-from orchestrator import NoOrchestrator
 from mgr_module import NFS_POOL_NAME as POOL_NAME, NFS_GANESHA_SUPPORTED_FSALS
 
 from .ganesha_conf import (
@@ -29,7 +28,6 @@ from .ganesha_conf import (
     format_block)
 from .exception import NFSException, NFSInvalidOperation, FSNotFound, NFSObjectNotFound
 from .utils import (
-    CONF_PREFIX,
     EXPORT_PREFIX,
     USER_CONF_PREFIX,
     export_obj_name,
@@ -48,11 +46,7 @@ log = logging.getLogger(__name__)
 
 def known_cluster_ids(mgr: 'Module') -> Set[str]:
     """Return the set of known cluster IDs."""
-    try:
-        clusters = set(available_clusters(mgr))
-    except NoOrchestrator:
-        clusters = nfs_rados_configs(mgr.rados)
-    return clusters
+    return set(available_clusters(mgr))
 
 
 def export_cluster_checker(func: FuncT) -> FuncT:
@@ -169,21 +163,6 @@ class NFSRados:
                 if obj.key.startswith(USER_CONF_PREFIX):
                     return True
         return False
-
-
-def nfs_rados_configs(rados: 'Rados', nfs_pool: str = POOL_NAME) -> Set[str]:
-    """Return a set of all the namespaces in the nfs_pool where nfs
-    configuration objects are found. The namespaces also correspond
-    to the cluster ids.
-    """
-    ns: Set[str] = set()
-    prefixes = (EXPORT_PREFIX, CONF_PREFIX, USER_CONF_PREFIX)
-    with rados.open_ioctx(nfs_pool) as ioctx:
-        ioctx.set_namespace(LIBRADOS_ALL_NSPACES)
-        for obj in ioctx.list_objects():
-            if obj.key.startswith(prefixes):
-                ns.add(obj.nspace)
-    return ns
 
 
 class ExportMgr:

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -7,6 +7,9 @@ import orchestrator
 from orchestrator import NoOrchestrator
 import cephfs
 from mgr_util import CephfsClient, open_filesystem
+from mgr_module import NFS_POOL_NAME as POOL_NAME
+
+from rados import Rados, LIBRADOS_ALL_NSPACES, ObjectNotFound
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -42,16 +45,34 @@ def available_clusters(mgr: 'Module') -> List[str]:
     <ServiceDescription of <NFSServiceSpec for service_name=nfs.vstart>>
     return value: ['vstart']
     '''
-    # TODO check cephadm cluster list with rados pool conf objects
     try:
         completion = mgr.describe_service(service_type='nfs')
     except NoOrchestrator:
-        log.exception("No orchestrator configured")
-        return []
+        log.debug("No orchestrator configured")
+        return nfs_rados_configs(mgr.rados)
     orchestrator.raise_if_exception(completion)
     assert completion.result is not None
     return [cluster.spec.service_id for cluster in completion.result
             if cluster.spec.service_id]
+
+
+def nfs_rados_configs(rados: 'Rados', nfs_pool: str = POOL_NAME) -> List[str]:
+    """Return a list of all the namespaces in the nfs_pool where nfs
+    configuration objects are found. The namespaces also correspond
+    to the cluster ids.
+    """
+    ns: List[str] = []
+    prefixes = (EXPORT_PREFIX, CONF_PREFIX, USER_CONF_PREFIX)
+    try:
+        with rados.open_ioctx(nfs_pool) as ioctx:
+            ioctx.set_namespace(LIBRADOS_ALL_NSPACES)
+            for obj in ioctx.list_objects():
+                if obj.key.startswith(prefixes):
+                    ns.append(obj.nspace)
+    except ObjectNotFound:
+        log.debug("Failed to open pool %s", nfs_pool)
+    finally:
+        return ns
 
 
 def restart_nfs_service(mgr: 'Module', cluster_id: str) -> None:

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -4,6 +4,7 @@ import stat
 from typing import List, TYPE_CHECKING
 
 import orchestrator
+from orchestrator import NoOrchestrator
 import cephfs
 from mgr_util import CephfsClient, open_filesystem
 
@@ -42,7 +43,11 @@ def available_clusters(mgr: 'Module') -> List[str]:
     return value: ['vstart']
     '''
     # TODO check cephadm cluster list with rados pool conf objects
-    completion = mgr.describe_service(service_type='nfs')
+    try:
+        completion = mgr.describe_service(service_type='nfs')
+    except NoOrchestrator:
+        log.exception("No orchestrator configured")
+        return []
     orchestrator.raise_if_exception(completion)
     assert completion.result is not None
     return [cluster.spec.service_id for cluster in completion.result


### PR DESCRIPTION
backport trackers: 
https://tracker.ceph.com/issues/66700
https://tracker.ceph.com/issues/67195

---

backport of https://github.com/ceph/ceph/pull/56876 and https://github.com/ceph/ceph/pull/58535

parent trackers: 
https://tracker.ceph.com/issues/56246
https://tracker.ceph.com/issues/66800

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh