### PR TITLE
squid: mgr/nfs: Don't crash ceph-mgr if NFS clusters are unavailable.

### DIFF
--- a/src/pybind/mgr/nfs/export.py
+++ b/src/pybind/mgr/nfs/export.py
@@ -15,10 +15,9 @@ from typing import (
 from os.path import normpath
 import cephfs
 
-from rados import TimedOut, ObjectNotFound, Rados, LIBRADOS_ALL_NSPACES
+from rados import TimedOut, ObjectNotFound, Rados
 
 from object_format import ErrorResponse
-from orchestrator import NoOrchestrator
 from mgr_module import NFS_POOL_NAME as POOL_NAME, NFS_GANESHA_SUPPORTED_FSALS
 
 from .ganesha_conf import (
@@ -30,7 +29,6 @@ from .ganesha_conf import (
     format_block)
 from .exception import NFSException, NFSInvalidOperation, FSNotFound, NFSObjectNotFound
 from .utils import (
-    CONF_PREFIX,
     EXPORT_PREFIX,
     NonFatalError,
     USER_CONF_PREFIX,
@@ -50,11 +48,7 @@ log = logging.getLogger(__name__)
 
 def known_cluster_ids(mgr: 'Module') -> Set[str]:
     """Return the set of known cluster IDs."""
-    try:
-        clusters = set(available_clusters(mgr))
-    except NoOrchestrator:
-        clusters = nfs_rados_configs(mgr.rados)
-    return clusters
+    return set(available_clusters(mgr))
 
 
 def _check_rados_notify(ioctx: Any, obj: str) -> None:
@@ -163,21 +157,6 @@ class NFSRados:
                 if obj.key.startswith(USER_CONF_PREFIX):
                     return True
         return False
-
-
-def nfs_rados_configs(rados: 'Rados', nfs_pool: str = POOL_NAME) -> Set[str]:
-    """Return a set of all the namespaces in the nfs_pool where nfs
-    configuration objects are found. The namespaces also correspond
-    to the cluster ids.
-    """
-    ns: Set[str] = set()
-    prefixes = (EXPORT_PREFIX, CONF_PREFIX, USER_CONF_PREFIX)
-    with rados.open_ioctx(nfs_pool) as ioctx:
-        ioctx.set_namespace(LIBRADOS_ALL_NSPACES)
-        for obj in ioctx.list_objects():
-            if obj.key.startswith(prefixes):
-                ns.add(obj.nspace)
-    return ns
 
 
 class AppliedExportResults:

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -5,6 +5,7 @@ from typing import List, Tuple, TYPE_CHECKING
 
 from object_format import ErrorResponseBase
 import orchestrator
+from orchestrator import NoOrchestrator
 import cephfs
 from mgr_util import CephfsClient, open_filesystem
 
@@ -67,7 +68,11 @@ def available_clusters(mgr: 'Module') -> List[str]:
     return value: ['vstart']
     '''
     # TODO check cephadm cluster list with rados pool conf objects
-    completion = mgr.describe_service(service_type='nfs')
+    try:
+        completion = mgr.describe_service(service_type='nfs')
+    except NoOrchestrator:
+        log.exception("No orchestrator configured")
+        return []
     orchestrator.raise_if_exception(completion)
     assert completion.result is not None
     return [cluster.spec.service_id for cluster in completion.result

--- a/src/pybind/mgr/nfs/utils.py
+++ b/src/pybind/mgr/nfs/utils.py
@@ -8,6 +8,9 @@ import orchestrator
 from orchestrator import NoOrchestrator
 import cephfs
 from mgr_util import CephfsClient, open_filesystem
+from mgr_module import NFS_POOL_NAME as POOL_NAME
+
+from rados import Rados, LIBRADOS_ALL_NSPACES, ObjectNotFound
 
 if TYPE_CHECKING:
     from nfs.module import Module
@@ -67,16 +70,34 @@ def available_clusters(mgr: 'Module') -> List[str]:
     <ServiceDescription of <NFSServiceSpec for service_name=nfs.vstart>>
     return value: ['vstart']
     '''
-    # TODO check cephadm cluster list with rados pool conf objects
     try:
         completion = mgr.describe_service(service_type='nfs')
     except NoOrchestrator:
-        log.exception("No orchestrator configured")
-        return []
+        log.debug("No orchestrator configured")
+        return nfs_rados_configs(mgr.rados)
     orchestrator.raise_if_exception(completion)
     assert completion.result is not None
     return [cluster.spec.service_id for cluster in completion.result
             if cluster.spec.service_id]
+
+
+def nfs_rados_configs(rados: 'Rados', nfs_pool: str = POOL_NAME) -> List[str]:
+    """Return a list of all the namespaces in the nfs_pool where nfs
+    configuration objects are found. The namespaces also correspond
+    to the cluster ids.
+    """
+    ns: List[str] = []
+    prefixes = (EXPORT_PREFIX, CONF_PREFIX, USER_CONF_PREFIX)
+    try:
+        with rados.open_ioctx(nfs_pool) as ioctx:
+            ioctx.set_namespace(LIBRADOS_ALL_NSPACES)
+            for obj in ioctx.list_objects():
+                if obj.key.startswith(prefixes):
+                    ns.append(obj.nspace)
+    except ObjectNotFound:
+        log.debug("Failed to open pool %s", nfs_pool)
+    finally:
+        return ns
 
 
 def restart_nfs_service(mgr: 'Module', cluster_id: str) -> None:


### PR DESCRIPTION
backport trackers: 

https://tracker.ceph.com/issues/66701
https://tracker.ceph.com/issues/67197

---

backport of https://github.com/ceph/ceph/pull/56876 and https://github.com/ceph/ceph/pull/58535

parent trackers: 
https://tracker.ceph.com/issues/56246
https://tracker.ceph.com/issues/66800

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh