### PR TITLE
mgr/dashboard: fix clone async validators with different groups

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/global.feature.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/global.feature.po.ts
@@ -38,3 +38,7 @@ And('I go to the {string} tab', (names: string) => {
     cy.contains('.nav.nav-tabs a', name).click();
   }
 });
+
+And('I wait for {string} seconds', (seconds: number) => {
+  cy.wait(seconds * 1000);
+});

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/snapshots.e2e-spec.feature
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/snapshots.e2e-spec.feature
@@ -1,6 +1,6 @@
 Feature: CephFS Snapshot Management
 
-    Goal: To test out the CephFS snapshot management features
+    Goal: To test out the CephFS snapshot and clone management features
 
     Background: Login
         Given I am logged in
@@ -32,6 +32,48 @@ Feature: CephFS Snapshot Management
         When I expand the row "test_cephfs"
         And I go to the "Snapshots" tab
         Then I should see a table in the expanded row
+
+    Scenario: Create a CephFS Subvolume Snapshot
+        Given I am on the "cephfs" page
+        When I expand the row "test_cephfs"
+        And I go to the "Snapshots" tab
+        And I click on "Create" button from the expanded row
+        And enter "snapshotName" "test_snapshot" in the modal
+        And I click on "Create Snapshot" button
+        Then I should see a row with "test_snapshot" in the expanded row
+
+    Scenario: Create a CephFS Subvolume Snapshot Clone
+        Given I am on the "cephfs" page
+        When I expand the row "test_cephfs"
+        And I go to the "Snapshots" tab
+        And I select a row "test_snapshot" in the expanded row
+        And I click on "Clone" button from the table actions in the expanded row
+        And enter "cloneName" "test_clone" in the modal
+        And I click on "Create Clone" button
+        Then I wait for "5" seconds
+        And I go to the "Subvolumes" tab
+        Then I should see a row with "test_clone" in the expanded row
+
+    Scenario: Remove a CephFS Subvolume Snapshot Clone
+        Given I am on the "cephfs" page
+        When I expand the row "test_cephfs"
+        And I go to the "Subvolumes" tab
+        And I select a row "test_clone" in the expanded row
+        And I click on "Remove" button from the table actions in the expanded row
+        And I check the tick box in modal
+        And I click on "Remove Subvolume" button
+        Then I wait for "5" seconds
+        And I should not see a row with "test_clone" in the expanded row
+
+    Scenario: Remove a CephFS Subvolume Snapshot
+        Given I am on the "cephfs" page
+        When I expand the row "test_cephfs"
+        And I go to the "Snapshots" tab
+        And I select a row "test_snapshot" in the expanded row
+        And I click on "Remove" button from the table actions in the expanded row
+        And I check the tick box in modal
+        And I click on "Remove Snapshot" button
+        Then I should not see a row with "test_snapshot" in the expanded row
 
     Scenario: Remove a CephFS Subvolume
         Given I am on the "cephfs" page

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.ts
@@ -113,7 +113,7 @@ export class CephfsSubvolumeSnapshotsListComponent implements OnInit, OnChanges 
         click: () => this.cloneModal()
       },
       {
-        name: this.actionLabels.DELETE,
+        name: this.actionLabels.REMOVE,
         permission: 'delete',
         icon: Icons.destroy,
         disable: () => !this.selection.hasSingleSelection,
@@ -224,7 +224,7 @@ export class CephfsSubvolumeSnapshotsListComponent implements OnInit, OnChanges 
     const subVolumeGroupName = this.activeGroupName;
     const fsName = this.fsName;
     this.modalRef = this.modalService.show(CriticalConfirmationModalComponent, {
-      actionDescription: 'Delete',
+      actionDescription: this.actionLabels.REMOVE,
       itemNames: [snapshotName],
       itemDescription: 'Snapshot',
       submitAction: () =>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.ts
@@ -270,7 +270,8 @@ export class CephfsSubvolumeSnapshotsListComponent implements OnInit, OnChanges 
               this.cephfsSubvolumeService,
               null,
               null,
-              this.fsName
+              this.fsName,
+              this.activeGroupName
             )
           ],
           required: true,
@@ -284,12 +285,23 @@ export class CephfsSubvolumeSnapshotsListComponent implements OnInit, OnChanges 
           name: 'groupName',
           value: this.activeGroupName,
           label: $localize`Group name`,
+          valueChangeListener: true,
+          dependsOn: 'cloneName',
           typeConfig: {
             options: allGroups
           }
         }
       ],
       submitButtonText: $localize`Create Clone`,
+      updateAsyncValidators: (value: any) =>
+        CdValidators.unique(
+          this.cephfsSubvolumeService.exists,
+          this.cephfsSubvolumeService,
+          null,
+          null,
+          this.fsName,
+          value
+        ),
       onSubmit: (value: any) => {
         this.cephfsSubvolumeService
           .createSnapshotClone(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-form-modal-field-config.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-form-modal-field-config.ts
@@ -13,6 +13,11 @@ export class CdFormModalFieldConfig {
   validators: ValidatorFn[];
   asyncValidators?: AsyncValidatorFn[];
 
+  // Used when you want to dynamically update the
+  // async validators based on the field value
+  valueChangeListener?: boolean;
+  dependsOn?: string;
+
   // --- Specific field properties ---
   typeConfig?: {
     [prop: string]: any;


### PR DESCRIPTION


https://github.com/ceph/ceph/assets/71764184/98373d6d-1583-4197-aafc-51ef9a3215c5



Providing a way to dynamically update the async validator based on the selector field so that when the selected value changes, the depended field like the clone name gets validated again against the new value

Fixes: https://tracker.ceph.com/issues/66703





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
