### PR TITLE
get-packages.rst: Remove deprecated apt-key

### DIFF
--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -84,9 +84,9 @@ major releases (e.g., ``luminous``, ``mimic``, ``nautilus``) and development rel
 APT
 ~~~
 
-To install the ``release.asc`` key, execute the following::
+To install the ``release.gpg`` key, execute the following::
 
-	wget -q -O- 'https://download.ceph.com/keys/release.asc' | sudo apt-key add -
+	wget -q -O /usr/share/keyring/ceph.gpg 'https://download.ceph.com/keys/release.gpg'
 
 
 RPM
@@ -135,7 +135,7 @@ get the short codename, and replace ``{codename}`` in the following command.
 .. prompt:: bash $
    :substitutions:
 
-   sudo apt-add-repository 'deb https://download.ceph.com/debian-|stable-release|/ {codename} main'
+   sudo apt-add-repository 'deb [arch=amd64 signed-by=/usr/share/keyrings/ceph.gpg] https://download.ceph.com/debian-|stable-release|/ {codename} main'
 
 For early Linux distributions, you may execute the following command
 


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests


`apt-key` is being [deprecated](https://askubuntu.com/questions/1286545/what-commands-exactly-should-replace-the-deprecated-apt-key) and the command should be replaced in this documentation.

Signed-off-by: Landon Lengyel <landon@almonde.org>