### PR TITLE
tests: make sure nvmetcli and nvme-cli are up to date

### DIFF
--- a/qa/distros/container-hosts/centos_9.stream.yaml
+++ b/qa/distros/container-hosts/centos_9.stream.yaml
@@ -5,3 +5,7 @@ overrides:
     allowlist:
       - scontext=system_u:system_r:logrotate_t:s0
 
+tasks:
+- pexec:
+    all:
+    - sudo dnf install nvmetcli nvme-cli -y

--- a/qa/distros/container-hosts/centos_9.stream_runc.yaml
+++ b/qa/distros/container-hosts/centos_9.stream_runc.yaml
@@ -8,6 +8,6 @@ overrides:
 tasks:
 - pexec:
     all:
-    - sudo dnf install runc -y
+    - sudo dnf install runc nvmetcli nvme-cli -y
     - sudo sed -i 's/^#runtime = "crun"/runtime = "runc"/g' /usr/share/containers/containers.conf
     - sudo sed -i 's/runtime = "crun"/#runtime = "crun"/g' /usr/share/containers/containers.conf

--- a/qa/tasks/nvme_loop.py
+++ b/qa/tasks/nvme_loop.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import json
 
 from io import StringIO
 from teuthology import misc as teuthology
@@ -66,10 +67,33 @@ def task(ctx, config):
 
         with contextutil.safe_while(sleep=1, tries=15) as proceed:
             while proceed():
-                p = remote.run(args=['sudo', 'nvme', 'list'], stdout=StringIO())
+                p = remote.run(args=['sudo', 'nvme', 'list', '-o', 'json'], stdout=StringIO())
                 new_devs = []
-                for line in p.stdout.getvalue().splitlines():
-                    dev, _, vendor = line.split()[0:3]
+                # `nvme list -o json` will return the following output:
+                '''{
+                     "Devices" : [
+                       {
+                         "DevicePath" : "/dev/nvme0n1",
+                         "Firmware" : "8DV101H0",
+                         "Index" : 0,
+                         "ModelNumber" : "INTEL SSDPEDMD400G4",
+                         "ProductName" : "Unknown Device",
+                         "SerialNumber" : "PHFT620400WB400BGN"
+                       },
+                       {
+                         "DevicePath" : "/dev/nvme1n1",
+                         "Firmware" : "5.15.0-1",
+                         "Index" : 1,
+                         "ModelNumber" : "Linux",
+                         "ProductName" : "Unknown Device",
+                         "SerialNumber" : "7672ce414766ba44a8e5"
+                       }
+                     ]
+                   }'''
+                nvme_list = json.loads(p.stdout.getvalue())
+                for device in nvme_list['Devices']:
+                    dev = device['DevicePath']
+                    vendor = device['ModelNumber']
                     if dev.startswith('/dev/') and vendor == 'Linux':
                         new_devs.append(dev)
                 log.info(f'new_devs {new_devs}')


### PR DESCRIPTION
Otherwise jobs end up with the following failure:

```
2024-06-25T14:22:18.659 INFO:teuthology.orchestra.run.smithi098.stderr:Failed to write to /dev/nvme-fabrics: Invalid argument
```

Also, the output of `nvme list` has changed so we have to update `qa/tasks/nvme_loop.py` accordingly.