### PR TITLE
rgw: PubObj uses RGWObjTags by value

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3921,11 +3921,8 @@ int RGWPutObj::verify_permission(optional_yield y)
 
   rgw_add_to_iam_environment(s->env, "s3:x-amz-acl", s->canned_acl);
 
-  if (obj_tags != nullptr && obj_tags->count() > 0){
-    auto tags = obj_tags->get_tags();
-    for (const auto& kv: tags){
-      rgw_add_to_iam_environment(s->env, "s3:RequestObjectTag/"+kv.first, kv.second);
-    }
+  for (const auto& kv: obj_tags.get_tags()) {
+    rgw_add_to_iam_environment(s->env, "s3:RequestObjectTag/"+kv.first, kv.second);
   }
 
   // add server-side encryption headers
@@ -4185,7 +4182,7 @@ void RGWPutObj::execute(optional_yield y)
 		       s->object.get(), s->src_object.get(), s,
 		       rgw::notify::ObjectCreatedPut, y);
   if(!multipart) {
-    op_ret = res->publish_reserve(this, obj_tags.get());
+    op_ret = res->publish_reserve(this, &obj_tags);
     if (op_ret < 0) {
       return;
     }
@@ -4470,7 +4467,7 @@ void RGWPutObj::execute(optional_yield y)
     return;
   }
   encode_delete_at_attr(delete_at, attrs);
-  encode_obj_tags_attr(obj_tags.get(), attrs);
+  encode_obj_tags_attr(obj_tags, attrs);
   rgw_cond_decode_objtags(s, attrs);
 
   /* Add a custom metadata to expose the information whether an object

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1227,7 +1227,7 @@ protected:
   std::string etag;
   bool chunked_upload;
   RGWAccessControlPolicy policy;
-  std::unique_ptr <RGWObjTags> obj_tags;
+  RGWObjTags obj_tags;
   const char *dlo_manifest;
   RGWSLOInfo *slo_info;
   rgw::sal::Attrs attrs;
@@ -2218,18 +2218,14 @@ inline void encode_delete_at_attr(boost::optional<ceph::real_time> delete_at,
   attrs[RGW_ATTR_DELETE_AT] = delatbl;
 } /* encode_delete_at_attr */
 
-inline void encode_obj_tags_attr(RGWObjTags* obj_tags, std::map<std::string, bufferlist>& attrs)
+inline void encode_obj_tags_attr(const RGWObjTags& obj_tags, std::map<std::string, bufferlist>& attrs)
 {
-  if (obj_tags == nullptr){
-    // we assume the user submitted a tag format which we couldn't parse since
-    // this wouldn't be parsed later by get/put obj tags, lets delete if the
-    // attr was populated
+  if (obj_tags.empty()) {
     return;
   }
-
   bufferlist tagsbl;
-  obj_tags->encode(tagsbl);
-  attrs[RGW_ATTR_TAGS] = tagsbl;
+  obj_tags.encode(tagsbl);
+  attrs[RGW_ATTR_TAGS] = std::move(tagsbl);
 }
 
 inline int encode_dlo_manifest_attr(const char * const dlo_manifest,

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2591,8 +2591,7 @@ int RGWPutObj_ObjStore_S3::get_params(optional_yield y)
   /* handle object tagging */
   auto tag_str = s->info.env->get("HTTP_X_AMZ_TAGGING");
   if (tag_str){
-    obj_tags = std::make_unique<RGWObjTags>();
-    ret = obj_tags->set_from_string(tag_str);
+    ret = obj_tags.set_from_string(tag_str);
     if (ret < 0){
       ldpp_dout(this,0) << "setting obj tags failed with " << ret << dendl;
       if (ret == -ERR_INVALID_TAG){


### PR DESCRIPTION
stop wrapping RGWObjTags in a unique_ptr, and just use empty() or count() to determine whether any tags are present

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
