### PR TITLE
quincy: mds: do remove the cap when seqs equal or larger than last issue

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -4035,8 +4035,8 @@ void Locker::_do_cap_release(client_t client, inodeno_t ino, uint64_t cap_id,
                   new C_Locker_RetryCapRelease(this, client, ino, cap_id, mseq, seq));
     return;
   }
-  if (seq != cap->get_last_issue()) {
-    dout(7) << " issue_seq " << seq << " != " << cap->get_last_issue() << dendl;
+  if (seq < cap->get_last_issue()) {
+    dout(7) << " issue_seq " << seq << " < " << cap->get_last_issue() << dendl;
     // clean out any old revoke history
     cap->clean_revoke_from(seq);
     eval_cap_gather(in);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66624

---

backport of https://github.com/ceph/ceph/pull/56828
parent tracker: https://tracker.ceph.com/issues/64977

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh