### PR TITLE
quincy: doc/cephadm/monitoring.rst: Bad command reference

### DIFF
--- a/doc/cephadm/services/monitoring.rst
+++ b/doc/cephadm/services/monitoring.rst
@@ -451,14 +451,16 @@ Configuring SSL/TLS for Grafana
 
 ``cephadm`` deploys Grafana using the certificate defined in the ceph
 key/value store. If no certificate is specified, ``cephadm`` generates a
-self-signed certificate during the deployment of the Grafana service.
+self-signed certificate during the deployment of the Grafana service. The previous 
+method was to reference the config-key path mgr/cephadm/grafana_<crt|key>, but has
+been replaced with direct key paths for each node that is running the service.
 
 A custom certificate can be configured using the following commands:
 
 .. prompt:: bash #
 
-  ceph config-key set mgr/cephadm/grafana_key -i $PWD/key.pem
-  ceph config-key set mgr/cephadm/grafana_crt -i $PWD/certificate.pem
+  ceph config-key set mgr/cephadm/<hostname>/grafana_key -i $PWD/key.pem
+  ceph config-key set mgr/cephadm/<hostname>/grafana_crt -i $PWD/certificate.pem
 
 If you have already deployed Grafana, run ``reconfig`` on the service to
 update its configuration:


### PR DESCRIPTION
I have not been able to make the Grafana containers pull the certificate from the config-key /mgr/cephadm/grafana_key or /mgr/cephadm/grafana_crt no matter what order I try. Removing them and adding them redeploying the containers nothing works except for using direct paths to the config-key with the hostnames. After trial and error I decided to try and find something that referenced this behavior and came across this. https://tracker.ceph.com/issues/56508
I changed the cephadm code by the following PR:

https://github.com/ceph/ceph/pull/47098

to store the grafana cert/key per node. Now instead of using the same path mgr/cephadm/grafana_crt for all the nodes we store a different cert/key per each node using the path: mgr/cephadm/<hostname>/grafana_crt

Since I can't reproduce the issue on my env it would be great if you can get the code of this PR and test it on your env. I'll follow up with you with any support you need to test/fix the issues.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
