### PR TITLE
cmake: add WITH_SYSTEM_BLAKE3 and WITH_SYSTEM_XXHASH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,11 @@ else()
   set(HAVE_BLKID OFF)
 endif(LINUX)
 
+option(WITH_SYSTEM_BLAKE3 "Use system packages for BLAKE3" OFF)
+if(WITH_SYSTEM_BLAKE3)
+  find_package(blake3 REQUIRED)
+endif()
+
 option(WITH_OPENLDAP "OPENLDAP is here" ON)
 if(WITH_OPENLDAP)
   find_package(OpenLDAP REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,11 @@ if(WITH_SYSTEM_BLAKE3)
   find_package(blake3 REQUIRED)
 endif()
 
+option(WITH_SYSTEM_XXHASH "Use system packages for xxHash" OFF)
+if(WITH_SYSTEM_XXHASH)
+  find_package(xxHash 0.8.2 REQUIRED)
+endif()
+
 option(WITH_OPENLDAP "OPENLDAP is here" ON)
 if(WITH_OPENLDAP)
   find_package(OpenLDAP REQUIRED)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -121,6 +121,7 @@
 %else # not x86_64
 %bcond_with system_qat
 %endif
+%bcond_without system_blake3
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel} >= 8 || 0%{?openEuler}
 %global weak_deps 1
 %endif
@@ -376,6 +377,9 @@ BuildRequires:  utf8proc-devel
 %if 0%{with system_qat}
 BuildRequires:  qatlib-devel
 BuildRequires:  qatzip-devel
+%endif
+%if 0%{with system_blake3}
+BuildRequires:  blake3-devel
 %endif
 %if 0%{with seastar}
 BuildRequires:  c-ares-devel
@@ -1504,6 +1508,9 @@ cmake .. \
 %if 0%{with system_qat}
     -DWITH_SYSTEM_QATLIB:BOOL=ON \
     -DWITH_SYSTEM_QATZIP:BOOL=ON \
+%endif
+%if 0%{with system_blake3}
+    -DWITH_SYSTEM_BLAKER3:BOOL=ON \
 %endif
 %if 0%{with seastar}
     -DWITH_SEASTAR:BOOL=ON \

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -122,6 +122,7 @@
 %bcond_with system_qat
 %endif
 %bcond_without system_blake3
+%bcond_without system_xxhash
 %if 0%{?fedora} || 0%{?suse_version} || 0%{?rhel} >= 8 || 0%{?openEuler}
 %global weak_deps 1
 %endif
@@ -380,6 +381,9 @@ BuildRequires:  qatzip-devel
 %endif
 %if 0%{with system_blake3}
 BuildRequires:  blake3-devel
+%endif
+%if 0%{with system_xxhash}
+BuildRequires:  xxhash-devel >= 0.8.2
 %endif
 %if 0%{with seastar}
 BuildRequires:  c-ares-devel
@@ -1511,6 +1515,9 @@ cmake .. \
 %endif
 %if 0%{with system_blake3}
     -DWITH_SYSTEM_BLAKER3:BOOL=ON \
+%endif
+%if 0%{with system_xxhash}
+    -DWITH_SYSTEM_XXHASH:BOOL=ON \
 %endif
 %if 0%{with seastar}
     -DWITH_SEASTAR:BOOL=ON \

--- a/cmake/modules/FindxxHash.cmake
+++ b/cmake/modules/FindxxHash.cmake
@@ -1,0 +1,52 @@
+# - Find xxHash
+#
+# XXHASH_INCLUDE_DIR - Where to find libxxHash.h
+# XXHASH_LIBRARIES - List of libraries when using xxHash.
+# xxHash_FOUND - True if xxHash found.
+# XXHASH_VERSION_STRING
+# XXHASH_VERSION_MAJOR
+# XXHASH_VERSION_MINOR
+# XXHASH_VERSION_RELEASE
+
+find_package(PkgConfig QUIET)
+pkg_search_module(PC_xxhash xxhash QUIET)
+
+find_path(XXHASH_INCLUDE_DIR
+  NAMES xxhash.h
+  HINTS ${PC_xxhash_INCLUDE_DIRS})
+
+find_library(XXHASH_LIBRARIES
+  NAMES xxhash
+  HINTS ${PC_xxhash_LIBRARY_DIRS})
+
+# parse version defines from header:
+#define XXH_VERSION_MAJOR    0
+#define XXH_VERSION_MINOR    8
+#define XXH_VERSION_RELEASE  2
+if(XXHASH_INCLUDE_DIR)
+  foreach(ver "MAJOR" "MINOR" "RELEASE")
+    file(STRINGS "${XXHASH_INCLUDE_DIR}/xxhash.h" XX_VER_LINE
+      REGEX "^#define[ \t]+XXH_VERSION_${ver}[ \t]+[^ \t]+$")
+    string(REGEX REPLACE "^#define[ \t]+XXH_VERSION_${ver}[ \t]+([0-9]*)$"
+      "\\1" XXHASH_VERSION_${ver} "${XX_VER_LINE}")
+    unset(XX_VER_LINE)
+  endforeach()
+  set(XXHASH_VERSION_STRING "${XXHASH_VERSION_MAJOR}.${XXHASH_VERSION_MINOR}.${XXHASH_VERSION_RELEASE}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(xxHash
+  FOUND_VAR xxHash_FOUND
+  REQUIRED_VARS XXHASH_LIBRARIES XXHASH_INCLUDE_DIR
+  VERSION_VAR XXHASH_VERSION_STRING)
+
+if(xxHash_FOUND AND NOT TARGET xxHash::xxhash)
+  add_library(xxHash::xxhash UNKNOWN IMPORTED)
+  set_target_properties(xxHash::xxhash PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${XXHASH_INCLUDE_DIR}"
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+    IMPORTED_LOCATION "${XXHASH_LIBRARIES}")
+endif()
+
+mark_as_advanced(XXHASH_INCLUDE_DIR XXHASH_LIBRARIES XXHASH_VERSION_STRING
+  XXHASH_VERSION_MAJOR XXHASH_VERSION_MINOR XXHASH_VERSION_RELEASE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -331,7 +331,7 @@ list(APPEND mds_files
 
 add_subdirectory(json_spirit)
 
-include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/xxHash")
+add_subdirectory(xxHash/cmake_unofficial)
 
 # use the rapidjson headers from s3select's submodule
 if(NOT TARGET RapidJSON::RapidJSON)
@@ -423,7 +423,6 @@ set(libcommon_files
   ${CMAKE_BINARY_DIR}/src/include/ceph_ver.h
   ceph_ver.c
   global/global_context.cc
-  xxHash/xxhash.c
   common/error_code.cc
   common/tracer.cc
   log/Log.cc
@@ -493,6 +492,7 @@ set(ceph_common_deps
   Boost::date_time
   Boost::iostreams
   StdFilesystem::filesystem
+  xxHash::xxhash
   ${FMT_LIB}
   ${BLKID_LIBRARIES}
   ${Backtrace_LIBRARIES}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,8 +200,10 @@ if(HAS_GLIBCXX_ASSERTIONS AND CMAKE_BUILD_TYPE STREQUAL Debug)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-D_GLIBCXX_ASSERTIONS>)
 endif()
 
-# add BLAKE3 before we clobber CMAKE_ASM_COMPILER
-add_subdirectory(BLAKE3/c EXCLUDE_FROM_ALL)
+if(NOT WITH_SYSTEM_BLAKE3)
+  # add BLAKE3 before we clobber CMAKE_ASM_COMPILER
+  add_subdirectory(BLAKE3/c EXCLUDE_FROM_ALL)
+endif()
 
 include(SIMDExt)
 if(HAVE_INTEL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -331,7 +331,9 @@ list(APPEND mds_files
 
 add_subdirectory(json_spirit)
 
-add_subdirectory(xxHash/cmake_unofficial)
+if(NOT WITH_SYSTEM_XXHASH)
+  add_subdirectory(xxHash/cmake_unofficial)
+endif()
 
 # use the rapidjson headers from s3select's submodule
 if(NOT TARGET RapidJSON::RapidJSON)

--- a/src/common/Checksummer.h
+++ b/src/common/Checksummer.h
@@ -8,7 +8,7 @@
 #include "include/byteorder.h"
 #include "include/ceph_assert.h"
 
-#include "xxHash/xxhash.h"
+#include <xxhash.h>
 
 class Checksummer {
 public:

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -122,7 +122,6 @@ add_library(crimson-common STATIC
   ${PROJECT_SOURCE_DIR}/src/osd/OSDMap.cc
   ${PROJECT_SOURCE_DIR}/src/osd/PGPeeringEvent.cc
   ${PROJECT_SOURCE_DIR}/src/common/scrub_types.cc
-  ${PROJECT_SOURCE_DIR}/src/xxHash/xxhash.c
   ${crimson_common_srcs}
   $<TARGET_OBJECTS:common_mountcephfs_objs>
   $<TARGET_OBJECTS:common-options-objs>)
@@ -137,7 +136,9 @@ set(crimson_common_deps
   Boost::random
   json_spirit)
 
-set(crimson_common_public_deps crimson::cflags)
+set(crimson_common_public_deps
+  crimson::cflags
+  xxHash::xxhash)
 if(WITH_JAEGER)
   list(APPEND crimson_common_public_deps jaeger_base)
 endif()

--- a/src/global/CMakeLists.txt
+++ b/src/global/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 endif()
 
 add_library(libglobal_objs OBJECT ${libglobal_srcs})
-target_link_libraries(libglobal_objs legacy-option-headers)
+target_link_libraries(libglobal_objs legacy-option-headers xxHash::xxhash)
 
 add_library(global-static STATIC
   $<TARGET_OBJECTS:libglobal_objs>)

--- a/src/mon/CMakeLists.txt
+++ b/src/mon/CMakeLists.txt
@@ -41,7 +41,8 @@ target_link_libraries(mon
   legacy-option-headers
   kv
   heap_profiler
-  ${FMT_LIB})
+  ${FMT_LIB}
+  xxHash::xxhash)
 if(WITH_JAEGER)
   target_link_libraries(mon jaeger_base)
 endif()

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -40,7 +40,8 @@ endif()
 add_library(os STATIC ${libos_srcs})
 target_link_libraries(os
   legacy-option-headers
-  blk)
+  blk
+  xxHash::xxhash)
 
 target_link_libraries(os heap_profiler kv)
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -278,7 +278,6 @@ endif()
 target_link_libraries(rgw_common
   PRIVATE
     legacy-option-headers
-    global
     cls_2pc_queue_client
     cls_cmpomap_client
     cls_lock_client
@@ -302,6 +301,7 @@ target_link_libraries(rgw_common
     ${ARROW_FLIGHT_LIBRARIES}
     ${LMDB_LIBRARIES}
   PUBLIC
+    global
     ${LUA_LIBRARIES}
     RapidJSON::RapidJSON
     Boost::context
@@ -352,7 +352,7 @@ if(WITH_JAEGER)
 endif()
 
 if(WITH_RADOSGW_DBSTORE)
-  target_link_libraries(rgw_common PRIVATE global dbstore)
+  target_link_libraries(rgw_common PRIVATE dbstore)
 endif()
 
 if(WITH_RADOSGW_MOTR)
@@ -432,7 +432,7 @@ endif()
 target_link_libraries(rgw_a
   PRIVATE
     legacy-option-headers
-    common_utf8 global
+    common_utf8
     ${CRYPTO_LIBS}
     ${ARROW_LIBRARIES}
     ${ARROW_FLIGHT_LIBRARIES}
@@ -506,7 +506,7 @@ target_link_libraries(radosgw-admin
   cls_rgw_client cls_otp_client cls_lock_client cls_refcount_client
   cls_log_client cls_timeindex_client
   cls_version_client cls_user_client
-  global ${LIB_RESOLV}
+  ${LIB_RESOLV}
   OATH::OATH
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES})
 
@@ -525,7 +525,7 @@ target_link_libraries(radosgw-es ${rgw_libs} librados
   cls_rgw_client cls_otp_client cls_lock_client cls_refcount_client
   cls_log_client cls_timeindex_client
   cls_version_client cls_user_client
-  global ${LIB_RESOLV}
+  ${LIB_RESOLV}
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES})
 install(TARGETS radosgw-es DESTINATION bin)
 
@@ -545,7 +545,7 @@ target_link_libraries(radosgw-object-expirer ${rgw_libs} librados
   cls_rgw_client cls_otp_client cls_lock_client cls_refcount_client
   cls_log_client cls_timeindex_client
   cls_version_client cls_user_client
-  global ${LIB_RESOLV}
+  ${LIB_RESOLV}
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES})
 install(TARGETS radosgw-object-expirer DESTINATION bin)
 
@@ -605,15 +605,11 @@ install(TARGETS rgw DESTINATION ${CMAKE_INSTALL_LIBDIR})
 if(WITH_TESTS)
   add_executable(ceph_rgw_jsonparser
     rgw_jsonparser.cc)
-  target_link_libraries(ceph_rgw_jsonparser
-    ${rgw_libs}
-    global)
+  target_link_libraries(ceph_rgw_jsonparser ${rgw_libs})
 
   add_executable(ceph_rgw_multiparser
     rgw_multiparser.cc)
-  target_link_libraries(ceph_rgw_multiparser
-    ${rgw_libs}
-    global)
+  target_link_libraries(ceph_rgw_multiparser ${rgw_libs})
 
   install(TARGETS
     ceph_rgw_jsonparser

--- a/src/rgw/driver/dbstore/CMakeLists.txt
+++ b/src/rgw/driver/dbstore/CMakeLists.txt
@@ -24,7 +24,7 @@ set(dbstore_mgr_srcs
     dbstore_mgr.cc
     )
 
-add_library(dbstore_lib ${dbstore_srcs})
+add_library(dbstore_lib STATIC ${dbstore_srcs})
 target_include_directories(dbstore_lib
     PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
     PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw/store/rados"

--- a/src/rgw/rgw_blake3_digest.h
+++ b/src/rgw/rgw_blake3_digest.h
@@ -17,7 +17,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include "BLAKE3/c/blake3.h"
+#include <blake3.h>
 
 namespace rgw { namespace digest {
 

--- a/src/rgw/rgw_file_int.h
+++ b/src/rgw/rgw_file_int.h
@@ -24,7 +24,7 @@
 #include <boost/container/flat_map.hpp>
 #include <boost/variant.hpp>
 #include <boost/optional.hpp>
-#include "xxhash.h"
+#include <xxhash.h>
 #include "include/buffer.h"
 #include "common/cohort_lru.h"
 #include "common/ceph_timer.h"

--- a/src/rgw/rgw_xxh_digest.h
+++ b/src/rgw/rgw_xxh_digest.h
@@ -17,10 +17,9 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include "rgw_crc_digest.h"
 
 #define XXH_INLINE_ALL 1 /* required for streaming variants */
-#include "xxhash.h"
+#include <xxhash.h>
 
 namespace rgw { namespace digest {
 

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -6,14 +6,14 @@ install(TARGETS ceph_perf_objectstore
 
 add_library(store_test_fixture OBJECT store_test_fixture.cc)
 target_include_directories(store_test_fixture PRIVATE
-  $<TARGET_PROPERTY:GTest::GTest,INTERFACE_INCLUDE_DIRECTORIES>
+  $<TARGET_PROPERTY:GTest::GTest,INTERFACE_INCLUDE_DIRECTORIES>)
+target_link_libraries(store_test_fixture PUBLIC
+  os
   legacy-option-headers)
 
-add_executable(ceph_test_objectstore
-  store_test.cc
-  $<TARGET_OBJECTS:store_test_fixture>)
+add_executable(ceph_test_objectstore store_test.cc)
 target_link_libraries(ceph_test_objectstore
-  os
+  store_test_fixture
   ceph-common
   ${UNITTEST_LIBS}
   global

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -143,7 +143,6 @@ target_link_libraries(ceph_test_rgw_manifest
   cls_version_client
   cls_user_client
   librados
-  global
   ${BLKID_LIBRARIES}
   ${CURL_LIBRARIES}
   ${EXPAT_LIBRARIES}
@@ -164,7 +163,6 @@ target_link_libraries(ceph_test_rgw_obj
   cls_version_client
   cls_user_client
   librados
-  global
   ceph-common
   ${CURL_LIBRARIES}
   ${EXPAT_LIBRARIES}
@@ -188,7 +186,6 @@ target_link_libraries(unittest_rgw_crypto
   cls_version_client
   cls_user_client
   librados
-  global
   ${CURL_LIBRARIES}
   ${EXPAT_LIBRARIES}
   ${CMAKE_DL_LIBS}
@@ -224,7 +221,6 @@ target_link_libraries(unittest_rgw_iam_policy
   cls_version_client
   cls_user_client
   librados
-  global
   ${CURL_LIBRARIES}
   ${EXPAT_LIBRARIES}
   ${CMAKE_DL_LIBS}
@@ -332,7 +328,7 @@ target_link_libraries(radosgw-cr-test ${rgw_libs} librados
   cls_rgw_client cls_otp_client cls_lock_client cls_refcount_client
   cls_log_client cls_timeindex_client
   cls_version_client cls_user_client
-  global ${LIB_RESOLV}
+  ${LIB_RESOLV}
   OATH::OATH
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES}
   GTest::GTest)


### PR DESCRIPTION
~~based on ~~https://github.com/ceph/ceph/pull/55076~~ https://github.com/ceph/ceph/pull/58429 for now~~

centos 9 and fedora have up-to-date blake3-devel and xxhash-devel packages. adds cmake options WITH_SYSTEM_BLAKE3/XXHASH (off by default) to build against those packages instead of their submodules. ceph.spec.in adds those rpm dependencies and tells cmake to use them

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
