### PR TITLE
squid: build: Make boost_url a list

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -162,7 +162,7 @@ function(do_build_boost root_dir version)
     set(boost_version 1.82.0)
     set(boost_sha256 a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6)
     string(REPLACE "." "_" boost_version_underscore ${boost_version} )
-    string(JOIN " " boost_url
+    list(APPEND boost_url
       https://boostorg.jfrog.io/artifactory/main/release/${boost_version}/source/boost_${boost_version_underscore}.tar.bz2
       https://download.ceph.com/qa/boost_${boost_version_underscore}.tar.bz2)
     set(source_dir


### PR DESCRIPTION
partial backport of https://github.com/ceph/ceph/pull/57581

backport tracker: https://tracker.ceph.com/issues/66724
original tracker: https://tracker.ceph.com/issues/66598

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
