### PR TITLE
squid: mds: QuiesceDbManager: mark next retry event during bootstrap

### DIFF
--- a/src/mds/QuiesceDbManager.h
+++ b/src/mds/QuiesceDbManager.h
@@ -281,7 +281,7 @@ class QuiesceDbManager {
     std::unordered_map<RequestContext*, int> done_requests;
 
     void* quiesce_db_thread_main();
-    bool db_thread_has_work() const;
+    virtual bool db_thread_has_work() const;
 
     using IsMemberBool = bool;
     using ShouldExitBool = bool;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66585

---

backport of https://github.com/ceph/ceph/pull/57946
parent tracker: https://tracker.ceph.com/issues/66406

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh