### PR TITLE
qa/standalone/mon: Fix mkfs  test & TEST_LOG failures

### DIFF
--- a/qa/standalone/mon/mkfs.sh
+++ b/qa/standalone/mon/mkfs.sh
@@ -129,8 +129,7 @@ function auth_cephx_key() {
     if mon_mkfs --key='corrupted key' ; then
         return 1
     else
-        rm -fr $MON_DIR/store.db
-        rm -fr $MON_DIR/kv_backend
+        rm -fr $MON_DIR
     fi
 
     mon_mkfs --key=$key

--- a/qa/standalone/mon/mon-cluster-log.sh
+++ b/qa/standalone/mon/mon-cluster-log.sh
@@ -134,7 +134,7 @@ function TEST_journald_cluster_log_level() {
     search_str="1.0 deep-scrub"
     TIMEOUT=60
     sleep $TIMEOUT
-    journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=7 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
+    sudo journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=7 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
     grep -q "$search_str" $dir/journal.log
     return_code=$?
     if [ $return_code -ne 0 ]; then
@@ -145,7 +145,7 @@ function TEST_journald_cluster_log_level() {
     ceph osd down 0
     TIMEOUT=20 wait_for_osd up 0 || return 1
     search_str="osd.0.*boot"
-    journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=6 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
+    sudo journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=6 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
     grep -q "$search_str" $dir/journal.log
     return_code=$?
     if [ $return_code -ne 0 ]; then
@@ -158,7 +158,7 @@ function TEST_journald_cluster_log_level() {
     TIMEOUT=60
     sleep $TIMEOUT
     search_str="1.1 deep-scrub"
-    journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=7 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
+    sudo journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=7 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
     grep -q "$search_str" $dir/journal.log
     return_code=$?
     if [ $return_code -eq 0 ]; then
@@ -172,7 +172,7 @@ function TEST_journald_cluster_log_level() {
     ceph osd unset noup
     TIMEOUT=60 wait_for_osd up 0 || return 1
     search_str="Health check failed: noup flag(s) set (OSDMAP_FLAGS)"
-    journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=4 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
+    sudo journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=4 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
     grep -q "$search_str" $dir/journal.log
     return_code=$?
     if [ $return_code -ne 0 ]; then
@@ -185,7 +185,7 @@ function TEST_journald_cluster_log_level() {
     WAIT_FOR_CLEAN_TIMEOUT=60 wait_for_clean
     search_str="Client client.admin marked osd.0 out, while it was still marked up"
     ceph log last | grep -q "$search_str" || return 1
-    journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=6 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
+    sudo journalctl _COMM=ceph-mon CEPH_CHANNEL=cluster PRIORITY=6 --output=json-pretty --since "60 seconds ago" |jq '.MESSAGE' > $dir/journal.log
     grep -q "$search_str" $dir/journal.log
     return_code=$?
     if [ $return_code -eq 0 ]; then

--- a/qa/standalone/mon/mon-cluster-log.sh
+++ b/qa/standalone/mon/mon-cluster-log.sh
@@ -59,6 +59,7 @@ function TEST_cluster_log_level() {
       ERRORS=$(($ERRORS + 1))
     fi
 
+    ceph config set mon.a mon_cluster_log_level info
     ceph osd down 0
     TIMEOUT=20 wait_for_osd up 0 || return 1
     grep -q "cluster [[]INF[]] osd.0.*boot" $dir/log
@@ -68,7 +69,6 @@ function TEST_cluster_log_level() {
       ERRORS=$(($ERRORS + 1))
     fi
 
-    ceph config set mon.a mon_cluster_log_level info
     ceph pg deep-scrub 1.1
     search_str="cluster [[]DBG[]] 1.1 deep-scrub"
     TIMEOUT=60 wait_for_string $dir/log "$search_str"


### PR DESCRIPTION
Fixing various failures in MON standalone test, e.g.,

test case involving mkfs command
and monitor + journal logs.

Fixes: https://tracker.ceph.com/issues/63784

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
