### PR TITLE
os/bluestore: Fix BlueRocksEnv attempts to use POSIX

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.h
+++ b/src/os/bluestore/BlueRocksEnv.h
@@ -17,6 +17,14 @@ class BlueFS;
 
 class BlueRocksEnv : public rocksdb::EnvWrapper {
 public:
+  // See FileSystem::RegisterDbPaths.
+  rocksdb::Status RegisterDbPaths(const std::vector<std::string>& paths) override {
+    return rocksdb::Status::OK();
+  }
+  // See FileSystem::UnregisterDbPaths.
+  rocksdb::Status UnregisterDbPaths(const std::vector<std::string>& paths) override {
+    return rocksdb::Status::OK();
+  }
   // Create a brand new sequentially-readable file with the specified name.
   // On success, stores a pointer to the new file in *result and returns OK.
   // On failure, stores nullptr in *result and returns non-OK.  If the file does
@@ -52,12 +60,38 @@ public:
     std::unique_ptr<rocksdb::WritableFile>* result,
     const rocksdb::EnvOptions& options) override;
 
+  // Create an object that writes to a file with the specified name.
+  // `WritableFile::Append()`s will append after any existing content.  If the
+  // file does not already exist, creates it.
+  //
+  // On success, stores a pointer to the file in *result and returns OK.  On
+  // failure stores nullptr in *result and returns non-OK.
+  //
+  // The returned file will only be accessed by one thread at a time.
+  rocksdb::Status ReopenWritableFile(
+    const std::string& fname,
+    std::unique_ptr<rocksdb::WritableFile>* result,
+    const rocksdb::EnvOptions& options) override {
+      return rocksdb::Status::NotSupported("ReopenWritableFile() not supported.");
+    }
+
   // Reuse an existing file by renaming it and opening it as writable.
   rocksdb::Status ReuseWritableFile(
     const std::string& fname,
     const std::string& old_fname,
     std::unique_ptr<rocksdb::WritableFile>* result,
     const rocksdb::EnvOptions& options) override;
+
+  // Open `fname` for random read and write, if file doesn't exist the file
+  // will be created.  On success, stores a pointer to the new file in
+  // *result and returns OK.  On failure returns non-OK.
+  //
+  // The returned file will only be accessed by one thread at a time.
+  rocksdb::Status NewRandomRWFile(const std::string& fname,
+                                 std::unique_ptr<rocksdb::RandomRWFile>* result,
+                                 const rocksdb::EnvOptions& options)override {
+    return rocksdb::Status::NotSupported("RandomRWFile is not implemented in this Env");
+  }
 
   // Create an object that represents a directory. Will fail if directory
   // doesn't exist. If the directory exists, it will open the directory
@@ -85,6 +119,11 @@ public:
 
   // Delete the named file.
   rocksdb::Status DeleteFile(const std::string& fname) override;
+
+  // Truncate the named file to the specified size.
+  rocksdb::Status Truncate(const std::string& fname, size_t size) override {
+    return rocksdb::Status::NotSupported("Truncate is not supported for this Env");
+  }
 
   // Create the specified directory. Returns error if directory exists.
   rocksdb::Status CreateDir(const std::string& dirname) override;


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/66717.

How is it possible that we are mixing BlueFS and posix operations?

BlueRocksEnv implements rocksdb::Env interface.
To make things simpler it inherits from rocksdb::EnvWrapper. The rocksdb::EnvWrapper is initialized from DefaultEnv, which brings default implementation for threads and files.
We override file-related interface.

The problem is when we forget to implement something, or if rocksdb::Env interface gets expanded. The function returns ENOTSUPP, and rocksdb can handle it. But it does not matter, because it is implemented in DefaultEnv.

In future we should drop inheriting from EnvWrapper and call DefaultEnv directly wherever we need.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
