### PR TITLE
reef: qa/cephfs: a bug fix and few missing backport for caps_helper.py

### DIFF
--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -248,7 +248,7 @@ class MdsCapTester:
         Run test for read perm and, for write perm, run positive test if it
         is present and run negative test if not.
         """
-        if mntpt:
+        if mntpt and mntpt != '/':
             # beacaue we want to value of mntpt from test_set.path along with
             # slash that precedes it.
             mntpt = '/' + mntpt if mntpt[0] != '/' else mntpt

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -23,8 +23,10 @@ def gen_mon_cap_str(caps):
             perm, fsname = c[0], None
         elif len(c) == 2:
             perm, fsname = c
-        else:
-            raise RuntimeError('caps tuple received isn\'t right')
+        elif len(c) < 1:
+            raise RuntimeError('received no items caps tuple')
+        else: # len(c) > 2
+            raise RuntimeError('received too many items in caps tuple')
         return perm, fsname
 
     def _gen_mon_cap_str(c):
@@ -78,14 +80,16 @@ def gen_mds_cap_str(caps):
     caps = ((perm1, fsname1, cephfs_mntpt1), (perm2, fsname2, cephfs_mntpt2))
     """
     def _unpack_tuple(c):
-        if len(c) == 2:
+        if len(c) == 1:
+            perm, fsname, cephfs_mntpt = c[0], None, '/'
+        elif len(c) == 2:
             perm, fsname, cephfs_mntpt = c[0], c[1], '/'
         elif len(c) == 3:
             perm, fsname, cephfs_mntpt = c
-        elif len(c) < 2:
-            raise RuntimeError('received items are too less in caps')
+        elif len(c) < 1:
+            raise RuntimeError('received no items caps tuple')
         else: # len(c) > 3
-            raise RuntimeError('received items are too many in caps')
+            raise RuntimeError('received too many items in caps tuple')
 
         return perm, fsname, cephfs_mntpt
 

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -168,10 +168,10 @@ class MonCapTester:
         fsnames = get_fsnames_from_moncap(moncap)
         if fsnames == []:
             log.info('no FS name is mentioned in moncap, client has '
-                     'permission to list all files. moncap -\n{moncap}')
+                     f'permission to list all files. moncap -\n{moncap}')
             return
 
-        log.info('FS names are mentioned in moncap. moncap -\n{moncap}')
+        log.info(f'FS names are mentioned in moncap. moncap -\n{moncap}')
         log.info('testing for presence of these FS names in output of '
                  '"fs ls" command run by client.')
         for fsname in fsnames:

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -35,7 +35,7 @@ def gen_mon_cap_str(caps):
         return mon_cap
 
     if len(caps) == 1:
-        return _gen_mon_cap_str(caps[0])
+        return _gen_mon_cap_str(*caps[0])
 
     mon_cap = ''
     for i, c in enumerate(caps):
@@ -60,7 +60,7 @@ def gen_osd_cap_str(caps):
         return osd_cap
 
     if len(caps) == 1:
-        return _gen_osd_cap_str(caps[0])
+        return _gen_osd_cap_str(*caps[0])
 
     osd_cap = ''
     for i, c in enumerate(caps):
@@ -101,7 +101,7 @@ def gen_mds_cap_str(caps):
         return mds_cap
 
     if len(caps) == 1:
-        return _gen_mds_cap_str(caps[0])
+        return _gen_mds_cap_str(*caps[0])
 
     mds_cap = ''
     for i, c in enumerate(caps):

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -18,19 +18,7 @@ def gen_mon_cap_str(caps):
 
     caps = ((perm1, fsname1), (perm2, fsname2))
     """
-    def _unpack_tuple(c):
-        if len(c) == 1:
-            perm, fsname = c[0], None
-        elif len(c) == 2:
-            perm, fsname = c
-        elif len(c) < 1:
-            raise RuntimeError('received no items caps tuple')
-        else: # len(c) > 2
-            raise RuntimeError('received too many items in caps tuple')
-        return perm, fsname
-
-    def _gen_mon_cap_str(c):
-        perm, fsname = _unpack_tuple(c)
+    def _gen_mon_cap_str(perm, fsname=None):
         mon_cap = f'allow {perm}'
         if fsname:
             mon_cap += f' fsname={fsname}'
@@ -41,7 +29,7 @@ def gen_mon_cap_str(caps):
 
     mon_cap = ''
     for i, c in enumerate(caps):
-        mon_cap += _gen_mon_cap_str(c)
+        mon_cap += _gen_mon_cap_str(*c)
         if i != len(caps) - 1:
             mon_cap += ', '
 
@@ -54,8 +42,7 @@ def gen_osd_cap_str(caps):
 
     caps = ((perm1, fsname1), (perm2, fsname2))
     """
-    def _gen_osd_cap_str(c):
-        perm, fsname = c
+    def _gen_osd_cap_str(perm, fsname):
         osd_cap = f'allow {perm} tag cephfs'
         if fsname:
             osd_cap += f' data={fsname}'
@@ -66,7 +53,7 @@ def gen_osd_cap_str(caps):
 
     osd_cap = ''
     for i, c in enumerate(caps):
-        osd_cap += _gen_osd_cap_str(c)
+        osd_cap += _gen_osd_cap_str(*c)
         if i != len(caps) - 1:
             osd_cap += ', '
 
@@ -79,22 +66,7 @@ def gen_mds_cap_str(caps):
 
     caps = ((perm1, fsname1, cephfs_mntpt1), (perm2, fsname2, cephfs_mntpt2))
     """
-    def _unpack_tuple(c):
-        if len(c) == 1:
-            perm, fsname, cephfs_mntpt = c[0], None, '/'
-        elif len(c) == 2:
-            perm, fsname, cephfs_mntpt = c[0], c[1], '/'
-        elif len(c) == 3:
-            perm, fsname, cephfs_mntpt = c
-        elif len(c) < 1:
-            raise RuntimeError('received no items caps tuple')
-        else: # len(c) > 3
-            raise RuntimeError('received too many items in caps tuple')
-
-        return perm, fsname, cephfs_mntpt
-
-    def _gen_mds_cap_str(c):
-        perm, fsname, cephfs_mntpt = _unpack_tuple(c)
+    def _gen_mds_cap_str(perm, fsname=None, cephfs_mntpt='/'):
         mds_cap = f'allow {perm}'
         if fsname:
             mds_cap += f' fsname={fsname}'
@@ -109,7 +81,7 @@ def gen_mds_cap_str(caps):
 
     mds_cap = ''
     for i, c in enumerate(caps):
-        mds_cap +=  _gen_mds_cap_str(c)
+        mds_cap +=  _gen_mds_cap_str(*c)
         if i != len(caps) - 1:
             mds_cap += ', '
 


### PR DESCRIPTION
The first commit on this backport PR fixes https://tracker.ceph.com/issues/65970.

And rest of the commits bring caps_helper.py in reef branch as close as
possbile to caps_helper.py in main branch, so that such bugs can be avoided
in future.

These latter backports also ensure future backports since these commits will
already be present on reef branch hereonwards.

First commit is somewhat related to #54468.






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>