### PR TITLE
osd: Call release_reserved_pushes in PGRecovery destructor

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1031,9 +1031,7 @@ struct OSDShard {
   epoch_t get_max_waiting_epoch();
 
   /// push osdmap into shard
-  void consume_map(
-    const OSDMapRef& osdmap,
-    unsigned *pushes_to_free);
+  void consume_map(const OSDMapRef& osdmap);
 
   int _wake_pg_slot(spg_t pgid, OSDShardPGSlot *slot);
 

--- a/src/osd/scheduler/OpSchedulerItem.cc
+++ b/src/osd/scheduler/OpSchedulerItem.cc
@@ -195,6 +195,13 @@ void PGRecovery::run(
   pg->unlock();
 }
 
+PGRecovery::~PGRecovery()
+{
+  // Call release_reserved_pushes to release the recovery_ops_reserved resource
+  if (reserved_pushes > 0)
+    osd->release_reserved_pushes(reserved_pushes);
+}
+
 void PGRecoveryContext::run(
   OSD *osd,
   OSDShard *sdata,

--- a/src/osd/scheduler/OpSchedulerItem.h
+++ b/src/osd/scheduler/OpSchedulerItem.h
@@ -220,6 +220,11 @@ public:
   const spg_t& get_ordering_token() const final {
     return get_pgid();
   }
+
+  PGOpQueueable &operator=(const PGOpQueueable &) = delete;
+  PGOpQueueable &operator=(PGOpQueueable &&) = delete;
+  PGOpQueueable(const PGOpQueueable&)  = delete;
+  PGOpQueueable(PGOpQueueable&&) = delete;
 };
 
 class PGOpItem : public PGOpQueueable {
@@ -492,17 +497,18 @@ class PGRecovery : public PGOpQueueable {
   epoch_t epoch_queued;
   uint64_t reserved_pushes;
   int priority;
+  OSDService *osd;
 public:
   PGRecovery(
     spg_t pg,
     epoch_t epoch_queued,
     uint64_t reserved_pushes,
-    int priority)
+    int priority, OSDService *service)
     : PGOpQueueable(pg),
       time_queued(ceph_clock_now()),
       epoch_queued(epoch_queued),
       reserved_pushes(reserved_pushes),
-      priority(priority) {}
+      priority(priority), osd(service) {}
   std::ostream &print(std::ostream &rhs) const final {
     return rhs << "PGRecovery(pgid=" << get_pgid()
 	       << " epoch_queued=" << epoch_queued
@@ -522,6 +528,7 @@ public:
   op_scheduler_class get_scheduler_class() const final {
     return priority_to_scheduler_class(priority);
   }
+  ~PGRecovery();
 };
 
 class PGRecoveryContext : public PGOpQueueable {


### PR DESCRIPTION
The current way of release resource(release_reserved_pushes) is not simple and race prone. To make it simple call release_reserved_pushes from the PGRecovery destructor instead of calling at multiple places.

fixes: https://tracker.ceph.com/issues/66749





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
