### PR TITLE
squid: librbd: make diff-iterate in fast-diff mode aware of encryption

### DIFF
--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -10,6 +10,7 @@
 #include "librbd/internal.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ImageDispatchSpec.h"
+#include "librbd/io/Utils.h"
 #include "librbd/object_map/DiffRequest.h"
 #include "include/rados/librados.hpp"
 #include "include/interval_set.h"
@@ -275,15 +276,15 @@ std::pair<uint64_t, uint64_t> DiffIterate<I>::calc_object_diff_range() {
   if (first_period_off != last_period_off) {
     // map only the tail of the first period and the front of the last
     // period instead of the entire range for efficiency
-    Striper::file_to_extents(m_image_ctx.cct, &m_image_ctx.layout,
-                             m_offset, first_period_off + period - m_offset,
-                             0, 0, &object_extents);
-    Striper::file_to_extents(m_image_ctx.cct, &m_image_ctx.layout,
-                        last_period_off, m_offset + m_length - last_period_off,
-                        0, 0, &object_extents);
+    io::util::area_to_object_extents(&m_image_ctx, m_offset,
+                                     first_period_off + period - m_offset,
+                                     io::ImageArea::DATA, 0, &object_extents);
+    io::util::area_to_object_extents(&m_image_ctx, last_period_off,
+                                     m_offset + m_length - last_period_off,
+                                     io::ImageArea::DATA, 0, &object_extents);
   } else {
-    Striper::file_to_extents(m_image_ctx.cct, &m_image_ctx.layout, m_offset,
-                             m_length, 0, 0, &object_extents);
+    io::util::area_to_object_extents(&m_image_ctx, m_offset, m_length,
+                                     io::ImageArea::DATA, 0, &object_extents);
   }
   return {object_extents.front().object_no, object_extents.back().object_no + 1};
 }
@@ -380,47 +381,43 @@ int DiffIterate<I>::execute() {
     uint64_t read_len = std::min(period_off + period - off, left);
 
     if (fast_diff_enabled) {
-      // map to extents
-      std::map<object_t,std::vector<ObjectExtent> > object_extents;
-      Striper::file_to_extents(cct, m_image_ctx.format_string,
-                               &m_image_ctx.layout, off, read_len, 0,
-                               object_extents, 0);
+      // map to objects (there would be one extent per object)
+      striper::LightweightObjectExtents object_extents;
+      io::util::area_to_object_extents(&m_image_ctx, off, read_len,
+                                       io::ImageArea::DATA, 0, &object_extents);
 
       // get diff info for each object and merge adjacent stripe units
       // into an aggregate (this also sorts them)
       io::SparseExtents aggregate_sparse_extents;
-      for (auto& [object, extents] : object_extents) {
-        const uint64_t object_no = extents.front().objectno;
-        ceph_assert(object_no >= start_object_no && object_no < end_object_no);
-        uint8_t diff_state = object_diff_state[object_no - start_object_no];
-        ldout(cct, 20) << "object " << object << ": diff_state="
-                       << (int)diff_state << dendl;
+      for (const auto& oe : object_extents) {
+        ceph_assert(oe.object_no >= start_object_no &&
+                    oe.object_no < end_object_no);
+        uint8_t diff_state = object_diff_state[oe.object_no - start_object_no];
+        ldout(cct, 20) << "object "
+                       << util::data_object_name(&m_image_ctx, oe.object_no)
+                       << ": diff_state=" << (int)diff_state << dendl;
 
         if (diff_state == object_map::DIFF_STATE_HOLE &&
             from_snap_id == 0 && !parent_diff.empty()) {
           // no data in child object -- report parent diff instead
-          for (auto& oe : extents) {
-            for (auto& be : oe.buffer_extents) {
-              interval_set<uint64_t> o;
-              o.insert(off + be.first, be.second);
-              o.intersection_of(parent_diff);
-              ldout(cct, 20) << " reporting parent overlap " << o << dendl;
-              for (auto e = o.begin(); e != o.end(); ++e) {
-                aggregate_sparse_extents.insert(e.get_start(), e.get_len(),
-                                                {io::SPARSE_EXTENT_STATE_DATA,
-                                                 e.get_len()});
-              }
+          for (const auto& be : oe.buffer_extents) {
+            interval_set<uint64_t> o;
+            o.insert(off + be.first, be.second);
+            o.intersection_of(parent_diff);
+            ldout(cct, 20) << " reporting parent overlap " << o << dendl;
+            for (auto e = o.begin(); e != o.end(); ++e) {
+              aggregate_sparse_extents.insert(e.get_start(), e.get_len(),
+                                              {io::SPARSE_EXTENT_STATE_DATA,
+                                               e.get_len()});
             }
           }
         } else if (diff_state == object_map::DIFF_STATE_HOLE_UPDATED ||
                    diff_state == object_map::DIFF_STATE_DATA_UPDATED) {
           auto state = (diff_state == object_map::DIFF_STATE_HOLE_UPDATED ?
               io::SPARSE_EXTENT_STATE_ZEROED : io::SPARSE_EXTENT_STATE_DATA);
-          for (auto& oe : extents) {
-            for (auto& be : oe.buffer_extents) {
-              aggregate_sparse_extents.insert(off + be.first, be.second,
-                                              {state, be.second});
-            }
+          for (const auto& be : oe.buffer_extents) {
+            aggregate_sparse_extents.insert(off + be.first, be.second,
+                                            {state, be.second});
           }
         }
       }

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -7346,12 +7346,41 @@ TEST_F(TestLibRBD, FlushAioPP)
   ioctx.close();
 }
 
+struct diff_extent {
+  diff_extent(uint64_t _offset, uint64_t _length, bool _exists,
+              uint64_t object_size) :
+    offset(_offset), length(_length), exists(_exists)
+  {
+    if (object_size != 0) {
+      offset -= offset % object_size;
+      length = object_size;
+    }
+  }
+  uint64_t offset;
+  uint64_t length;
+  bool exists;
+  bool operator==(const diff_extent& o) const {
+    return offset == o.offset && length == o.length && exists == o.exists;
+  }
+};
+
+ostream& operator<<(ostream & o, const diff_extent& e) {
+  return o << '(' << e.offset << '~' << e.length << ' '
+           << (e.exists ? "true" : "false") << ')';
+}
 
 int iterate_cb(uint64_t off, size_t len, int exists, void *arg)
 {
   //cout << "iterate_cb " << off << "~" << len << std::endl;
   interval_set<uint64_t> *diff = static_cast<interval_set<uint64_t> *>(arg);
   diff->insert(off, len);
+  return 0;
+}
+
+int vector_iterate_cb(uint64_t off, size_t len, int exists, void *arg)
+{
+  auto diff = static_cast<std::vector<diff_extent>*>(arg);
+  diff->push_back(diff_extent(off, len, exists, 0));
   return 0;
 }
 
@@ -7429,6 +7458,360 @@ template <typename T>
 class DiffIterateTest : public TestLibRBD {
 public:
   static const uint8_t whole_object = T::whole_object;
+
+  void test_deterministic(uint64_t object_off, uint64_t len) {
+    rados_ioctx_t ioctx;
+    ASSERT_EQ(0, rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx));
+
+    rbd_image_t image;
+    int order = 22;
+    std::string name = this->get_temp_image_name();
+    ASSERT_EQ(0, create_image(ioctx, name.c_str(), 20 << 20, &order));
+    ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
+    test_deterministic(image, object_off, len, 1);
+
+    ASSERT_EQ(0, rbd_close(image));
+    rados_ioctx_destroy(ioctx);
+  }
+
+  void test_deterministic_pp(uint64_t object_off, uint64_t len) {
+    librados::IoCtx ioctx;
+    ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+
+    librbd::RBD rbd;
+    librbd::Image image;
+    int order = 22;
+    std::string name = this->get_temp_image_name();
+    ASSERT_EQ(0, create_image_pp(rbd, ioctx, name.c_str(), 20 << 20, &order));
+    ASSERT_EQ(0, rbd.open(ioctx, image, name.c_str(), NULL));
+    test_deterministic_pp(image, object_off, len, 1);
+  }
+
+private:
+  void test_deterministic(rbd_image_t image, uint64_t object_off,
+                          uint64_t len, uint64_t block_size) {
+    uint64_t off1 = 0;
+    uint64_t off2 = 4 << 20;
+    uint64_t size = 20 << 20;
+    uint64_t extent_len = round_up_to(object_off + len, block_size);
+
+    rbd_image_info_t info;
+    ASSERT_EQ(0, rbd_stat(image, &info, sizeof(info)));
+    ASSERT_EQ(size, info.size);
+    ASSERT_EQ(5, info.num_objs);
+    ASSERT_EQ(4 << 20, info.obj_size);
+    ASSERT_EQ(22, info.order);
+
+    uint64_t object_size = 0;
+    if (whole_object) {
+      object_size = 1 << info.order;
+    }
+
+    std::vector<diff_extent> extents;
+    ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(0u, extents.size());
+
+    ASSERT_EQ(-ENOENT, rbd_diff_iterate2(image, "snap1", 0, size, true,
+                                         whole_object, vector_iterate_cb,
+                                         &extents));
+
+    ASSERT_EQ(0, rbd_snap_create(image, "snap1"));
+
+    std::string buf(len, '1');
+    ASSERT_EQ(len, rbd_write(image, off1 + object_off, len, buf.data()));
+    ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(1u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    extents.clear();
+
+    ASSERT_EQ(0, rbd_snap_create(image, "snap2"));
+
+    ASSERT_EQ(len, rbd_write(image, off2 + object_off, len, buf.data()));
+    ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(2u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    extents.clear();
+
+    ASSERT_EQ(0, rbd_snap_create(image, "snap3"));
+
+    // 1. beginning of time -> HEAD
+    ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(2u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    extents.clear();
+
+    // 2. snap1 -> HEAD
+    ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(2u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    extents.clear();
+
+    // 3. snap2 -> HEAD
+    ASSERT_EQ(0, rbd_diff_iterate2(image, "snap2", 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(1u, extents.size());
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[0]);
+    extents.clear();
+
+    // 4. snap3 -> HEAD
+    ASSERT_EQ(0, rbd_diff_iterate2(image, "snap3", 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(0u, extents.size());
+
+    ASSERT_PASSED(validate_object_map, image);
+    ASSERT_EQ(0, rbd_snap_set(image, "snap3"));
+
+    // 5. beginning of time -> snap3
+    ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(2u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    extents.clear();
+
+    // 6. snap1 -> snap3
+    ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(2u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    extents.clear();
+
+    // 7. snap2 -> snap3
+    ASSERT_EQ(0, rbd_diff_iterate2(image, "snap2", 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(1u, extents.size());
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[0]);
+    extents.clear();
+
+    // 8. snap3 -> snap3
+    ASSERT_EQ(0, rbd_diff_iterate2(image, "snap3", 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(0u, extents.size());
+
+    ASSERT_PASSED(validate_object_map, image);
+    ASSERT_EQ(0, rbd_snap_set(image, "snap2"));
+
+    // 9. beginning of time -> snap2
+    ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(1u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    extents.clear();
+
+    // 10. snap1 -> snap2
+    ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(1u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    extents.clear();
+
+    // 11. snap2 -> snap2
+    ASSERT_EQ(0, rbd_diff_iterate2(image, "snap2", 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(0u, extents.size());
+
+    // 12. snap3 -> snap2
+    ASSERT_EQ(-EINVAL, rbd_diff_iterate2(image, "snap3", 0, size, true,
+                                         whole_object, vector_iterate_cb,
+                                         &extents));
+
+    ASSERT_PASSED(validate_object_map, image);
+    ASSERT_EQ(0, rbd_snap_set(image, "snap1"));
+
+    // 13. beginning of time -> snap1
+    ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(0u, extents.size());
+
+    // 14. snap1 -> snap1
+    ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, whole_object,
+                                   vector_iterate_cb, &extents));
+    ASSERT_EQ(0u, extents.size());
+
+    // 15. snap2 -> snap1
+    ASSERT_EQ(-EINVAL, rbd_diff_iterate2(image, "snap2", 0, size, true,
+                                         whole_object, vector_iterate_cb,
+                                         &extents));
+
+    // 16. snap3 -> snap1
+    ASSERT_EQ(-EINVAL, rbd_diff_iterate2(image, "snap3", 0, size, true,
+                                         whole_object, vector_iterate_cb,
+                                         &extents));
+
+    ASSERT_PASSED(validate_object_map, image);
+  }
+
+  void test_deterministic_pp(librbd::Image& image, uint64_t object_off,
+                             uint64_t len, uint64_t block_size) {
+    uint64_t off1 = 0 << 20;
+    uint64_t off2 = 4 << 20;
+    uint64_t size = 20 << 20;
+    uint64_t extent_len = round_up_to(object_off + len, block_size);
+
+    librbd::image_info_t info;
+    ASSERT_EQ(0, image.stat(info, sizeof(info)));
+    ASSERT_EQ(size, info.size);
+    ASSERT_EQ(5, info.num_objs);
+    ASSERT_EQ(4 << 20, info.obj_size);
+    ASSERT_EQ(22, info.order);
+
+    uint64_t object_size = 0;
+    if (whole_object) {
+      object_size = 1 << info.order;
+    }
+
+    std::vector<diff_extent> extents;
+    ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(0u, extents.size());
+
+    ASSERT_EQ(-ENOENT, image.diff_iterate2("snap1", 0, size, true,
+                                           whole_object, vector_iterate_cb,
+                                           &extents));
+
+    ASSERT_EQ(0, image.snap_create("snap1"));
+
+    ceph::bufferlist bl;
+    bl.append(std::string(len, '1'));
+    ASSERT_EQ(len, image.write(off1 + object_off, len, bl));
+    ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(1u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    extents.clear();
+
+    ASSERT_EQ(0, image.snap_create("snap2"));
+
+    ASSERT_EQ(len, image.write(off2 + object_off, len, bl));
+    ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(2u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    extents.clear();
+
+    ASSERT_EQ(0, image.snap_create("snap3"));
+
+    // 1. beginning of time -> HEAD
+    ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(2u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    extents.clear();
+
+    // 2. snap1 -> HEAD
+    ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(2u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    extents.clear();
+
+    // 3. snap2 -> HEAD
+    ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(1u, extents.size());
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[0]);
+    extents.clear();
+
+    // 4. snap3 -> HEAD
+    ASSERT_EQ(0, image.diff_iterate2("snap3", 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(0u, extents.size());
+
+    ASSERT_PASSED(validate_object_map, image);
+    ASSERT_EQ(0, image.snap_set("snap3"));
+
+    // 5. beginning of time -> snap3
+    ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(2u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    extents.clear();
+
+    // 6. snap1 -> snap3
+    ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(2u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[1]);
+    extents.clear();
+
+    // 7. snap2 -> snap3
+    ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(1u, extents.size());
+    ASSERT_EQ(diff_extent(off2, extent_len, true, object_size), extents[0]);
+    extents.clear();
+
+    // 8. snap3 -> snap3
+    ASSERT_EQ(0, image.diff_iterate2("snap3", 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(0u, extents.size());
+
+    ASSERT_PASSED(validate_object_map, image);
+    ASSERT_EQ(0, image.snap_set("snap2"));
+
+    // 9. beginning of time -> snap2
+    ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(1u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    extents.clear();
+
+    // 10. snap1 -> snap2
+    ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(1u, extents.size());
+    ASSERT_EQ(diff_extent(off1, extent_len, true, object_size), extents[0]);
+    extents.clear();
+
+    // 11. snap2 -> snap2
+    ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(0u, extents.size());
+
+    // 12. snap3 -> snap2
+    ASSERT_EQ(-EINVAL, image.diff_iterate2("snap3", 0, size, true,
+                                           whole_object, vector_iterate_cb,
+                                           &extents));
+
+    ASSERT_PASSED(validate_object_map, image);
+    ASSERT_EQ(0, image.snap_set("snap1"));
+
+    // 13. beginning of time -> snap1
+    ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(0u, extents.size());
+
+    // 14. snap1 -> snap1
+    ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, whole_object,
+                                     vector_iterate_cb, &extents));
+    ASSERT_EQ(0u, extents.size());
+
+    // 15. snap2 -> snap1
+    ASSERT_EQ(-EINVAL, image.diff_iterate2("snap2", 0, size, true,
+                                           whole_object, vector_iterate_cb,
+                                           &extents));
+
+    // 16. snap3 -> snap1
+    ASSERT_EQ(-EINVAL, image.diff_iterate2("snap3", 0, size, true,
+                                           whole_object, vector_iterate_cb,
+                                           &extents));
+
+    ASSERT_PASSED(validate_object_map, image);
+  }
 };
 
 template <bool _whole_object>
@@ -7489,366 +7872,18 @@ TYPED_TEST(DiffIterateTest, DiffIterate)
   ioctx.close();
 }
 
-struct diff_extent {
-  diff_extent(uint64_t _offset, uint64_t _length, bool _exists,
-              uint64_t object_size) :
-    offset(_offset), length(_length), exists(_exists)
-  {
-    if (object_size != 0) {
-      offset -= offset % object_size;
-      length = object_size;
-    }
-  }
-  uint64_t offset;
-  uint64_t length;
-  bool exists;
-  bool operator==(const diff_extent& o) const {
-    return offset == o.offset && length == o.length && exists == o.exists;
-  }
-};
-
-ostream& operator<<(ostream & o, const diff_extent& e) {
-  return o << '(' << e.offset << '~' << e.length << ' ' << (e.exists ? "true" : "false") << ')';
-}
-
-int vector_iterate_cb(uint64_t off, size_t len, int exists, void *arg)
-{
-  //cout << "iterate_cb " << off << "~" << len << std::endl;
-  vector<diff_extent> *diff = static_cast<vector<diff_extent> *>(arg);
-  diff->push_back(diff_extent(off, len, exists, 0));
-  return 0;
-}
-
 TYPED_TEST(DiffIterateTest, DiffIterateDeterministic)
 {
   REQUIRE(!is_feature_enabled(RBD_FEATURE_STRIPINGV2));
 
-  rados_ioctx_t ioctx;
-  ASSERT_EQ(0, rados_ioctx_create(this->_cluster, this->m_pool_name.c_str(),
-                                  &ioctx));
-
-  rbd_image_t image;
-  int order = 22;
-  std::string name = this->get_temp_image_name();
-  uint64_t size = 20 << 20;
-
-  ASSERT_EQ(0, create_image(ioctx, name.c_str(), size, &order));
-  ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
-
-  uint64_t object_size = 0;
-  if (this->whole_object) {
-    object_size = 1 << order;
-  }
-
-  std::vector<diff_extent> extents;
-  ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(0u, extents.size());
-
-  ASSERT_EQ(-ENOENT, rbd_diff_iterate2(image, "snap1", 0, size, true,
-                                       this->whole_object, vector_iterate_cb,
-                                       &extents));
-
-  ASSERT_EQ(0, rbd_snap_create(image, "snap1"));
-
-  std::string buf(256, '1');
-  ASSERT_EQ(256, rbd_write(image, 0, 256, buf.data()));
-  ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(1u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  extents.clear();
-
-  ASSERT_EQ(0, rbd_snap_create(image, "snap2"));
-
-  ASSERT_EQ(256, rbd_write(image, 1 << order, 256, buf.data()));
-  ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(2u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
-  extents.clear();
-
-  ASSERT_EQ(0, rbd_snap_create(image, "snap3"));
-
-  // 1. beginning of time -> HEAD
-  ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(2u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
-  extents.clear();
-
-  // 2. snap1 -> HEAD
-  ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(2u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
-  extents.clear();
-
-  // 3. snap2 -> HEAD
-  ASSERT_EQ(0, rbd_diff_iterate2(image, "snap2", 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(1u, extents.size());
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[0]);
-  extents.clear();
-
-  // 4. snap3 -> HEAD
-  ASSERT_EQ(0, rbd_diff_iterate2(image, "snap3", 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(0u, extents.size());
-
-  ASSERT_PASSED(this->validate_object_map, image);
-  ASSERT_EQ(0, rbd_snap_set(image, "snap3"));
-
-  // 5. beginning of time -> snap3
-  ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(2u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
-  extents.clear();
-
-  // 6. snap1 -> snap3
-  ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(2u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
-  extents.clear();
-
-  // 7. snap2 -> snap3
-  ASSERT_EQ(0, rbd_diff_iterate2(image, "snap2", 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(1u, extents.size());
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[0]);
-  extents.clear();
-
-  // 8. snap3 -> snap3
-  ASSERT_EQ(0, rbd_diff_iterate2(image, "snap3", 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(0u, extents.size());
-
-  ASSERT_PASSED(this->validate_object_map, image);
-  ASSERT_EQ(0, rbd_snap_set(image, "snap2"));
-
-  // 9. beginning of time -> snap2
-  ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(1u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  extents.clear();
-
-  // 10. snap1 -> snap2
-  ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(1u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  extents.clear();
-
-  // 11. snap2 -> snap2
-  ASSERT_EQ(0, rbd_diff_iterate2(image, "snap2", 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(0u, extents.size());
-
-  // 12. snap3 -> snap2
-  ASSERT_EQ(-EINVAL, rbd_diff_iterate2(image, "snap3", 0, size, true,
-                                       this->whole_object, vector_iterate_cb,
-                                       &extents));
-
-  ASSERT_PASSED(this->validate_object_map, image);
-  ASSERT_EQ(0, rbd_snap_set(image, "snap1"));
-
-  // 13. beginning of time -> snap1
-  ASSERT_EQ(0, rbd_diff_iterate2(image, NULL, 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(0u, extents.size());
-
-  // 14. snap1 -> snap1
-  ASSERT_EQ(0, rbd_diff_iterate2(image, "snap1", 0, size, true, this->whole_object,
-                                 vector_iterate_cb, &extents));
-  ASSERT_EQ(0u, extents.size());
-
-  // 15. snap2 -> snap1
-  ASSERT_EQ(-EINVAL, rbd_diff_iterate2(image, "snap2", 0, size, true,
-                                       this->whole_object, vector_iterate_cb,
-                                       &extents));
-
-  // 16. snap3 -> snap1
-  ASSERT_EQ(-EINVAL, rbd_diff_iterate2(image, "snap3", 0, size, true,
-                                       this->whole_object, vector_iterate_cb,
-                                       &extents));
-
-  ASSERT_PASSED(this->validate_object_map, image);
-
-  ASSERT_EQ(0, rbd_close(image));
-  rados_ioctx_destroy(ioctx);
+  this->test_deterministic(0, 256);
 }
 
 TYPED_TEST(DiffIterateTest, DiffIterateDeterministicPP)
 {
   REQUIRE(!is_feature_enabled(RBD_FEATURE_STRIPINGV2));
 
-  librados::IoCtx ioctx;
-  ASSERT_EQ(0, this->_rados.ioctx_create(this->m_pool_name.c_str(), ioctx));
-
-  librbd::RBD rbd;
-  librbd::Image image;
-  int order = 22;
-  std::string name = this->get_temp_image_name();
-  uint64_t size = 20 << 20;
-
-  ASSERT_EQ(0, create_image_pp(rbd, ioctx, name.c_str(), size, &order));
-  ASSERT_EQ(0, rbd.open(ioctx, image, name.c_str(), NULL));
-
-  uint64_t object_size = 0;
-  if (this->whole_object) {
-    object_size = 1 << order;
-  }
-
-  std::vector<diff_extent> extents;
-  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(0u, extents.size());
-
-  ASSERT_EQ(-ENOENT, image.diff_iterate2("snap1", 0, size, true,
-                                         this->whole_object, vector_iterate_cb,
-                                         &extents));
-
-  ASSERT_EQ(0, image.snap_create("snap1"));
-
-  ceph::bufferlist bl;
-  bl.append(std::string(256, '1'));
-  ASSERT_EQ(256, image.write(0, 256, bl));
-  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(1u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  extents.clear();
-
-  ASSERT_EQ(0, image.snap_create("snap2"));
-
-  ASSERT_EQ(256, image.write(1 << order, 256, bl));
-  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(2u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
-  extents.clear();
-
-  ASSERT_EQ(0, image.snap_create("snap3"));
-
-  // 1. beginning of time -> HEAD
-  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(2u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
-  extents.clear();
-
-  // 2. snap1 -> HEAD
-  ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(2u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
-  extents.clear();
-
-  // 3. snap2 -> HEAD
-  ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(1u, extents.size());
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[0]);
-  extents.clear();
-
-  // 4. snap3 -> HEAD
-  ASSERT_EQ(0, image.diff_iterate2("snap3", 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(0u, extents.size());
-
-  ASSERT_PASSED(this->validate_object_map, image);
-  ASSERT_EQ(0, image.snap_set("snap3"));
-
-  // 5. beginning of time -> snap3
-  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(2u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
-  extents.clear();
-
-  // 6. snap1 -> snap3
-  ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(2u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[1]);
-  extents.clear();
-
-  // 7. snap2 -> snap3
-  ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(1u, extents.size());
-  ASSERT_EQ(diff_extent(1 << order, 256, true, object_size), extents[0]);
-  extents.clear();
-
-  // 8. snap3 -> snap3
-  ASSERT_EQ(0, image.diff_iterate2("snap3", 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(0u, extents.size());
-
-  ASSERT_PASSED(this->validate_object_map, image);
-  ASSERT_EQ(0, image.snap_set("snap2"));
-
-  // 9. beginning of time -> snap2
-  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(1u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  extents.clear();
-
-  // 10. snap1 -> snap2
-  ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(1u, extents.size());
-  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
-  extents.clear();
-
-  // 11. snap2 -> snap2
-  ASSERT_EQ(0, image.diff_iterate2("snap2", 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(0u, extents.size());
-
-  // 12. snap3 -> snap2
-  ASSERT_EQ(-EINVAL, image.diff_iterate2("snap3", 0, size, true,
-                                         this->whole_object, vector_iterate_cb,
-                                         &extents));
-
-  ASSERT_PASSED(this->validate_object_map, image);
-  ASSERT_EQ(0, image.snap_set("snap1"));
-
-  // 13. beginning of time -> snap1
-  ASSERT_EQ(0, image.diff_iterate2(NULL, 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(0u, extents.size());
-
-  // 14. snap1 -> snap1
-  ASSERT_EQ(0, image.diff_iterate2("snap1", 0, size, true, this->whole_object,
-                                   vector_iterate_cb, &extents));
-  ASSERT_EQ(0u, extents.size());
-
-  // 15. snap2 -> snap1
-  ASSERT_EQ(-EINVAL, image.diff_iterate2("snap2", 0, size, true,
-                                         this->whole_object, vector_iterate_cb,
-                                         &extents));
-
-  // 16. snap3 -> snap1
-  ASSERT_EQ(-EINVAL, image.diff_iterate2("snap3", 0, size, true,
-                                         this->whole_object, vector_iterate_cb,
-                                         &extents));
-
-  ASSERT_PASSED(this->validate_object_map, image);
+  this->test_deterministic_pp(0, 256);
 }
 
 TYPED_TEST(DiffIterateTest, DiffIterateDiscard)

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -7652,8 +7652,8 @@ private:
 
   void test_deterministic_pp(librbd::Image& image, uint64_t object_off,
                              uint64_t len, uint64_t block_size) {
-    uint64_t off1 = 0 << 20;
-    uint64_t off2 = 4 << 20;
+    uint64_t off1 = 8 << 20;
+    uint64_t off2 = 16 << 20;
     uint64_t size = 20 << 20;
     uint64_t extent_len = round_up_to(object_off + len, block_size);
 
@@ -7876,14 +7876,22 @@ TYPED_TEST(DiffIterateTest, DiffIterateDeterministic)
 {
   REQUIRE(!is_feature_enabled(RBD_FEATURE_STRIPINGV2));
 
-  this->test_deterministic(0, 256);
+  EXPECT_NO_FATAL_FAILURE(this->test_deterministic(0, 256));
+  EXPECT_NO_FATAL_FAILURE(this->test_deterministic((1 << 20) - 256, 256));
+  EXPECT_NO_FATAL_FAILURE(this->test_deterministic((1 << 20) - 128, 256));
+  EXPECT_NO_FATAL_FAILURE(this->test_deterministic(1 << 20, 256));
+  EXPECT_NO_FATAL_FAILURE(this->test_deterministic((4 << 20) - 256, 256));
 }
 
 TYPED_TEST(DiffIterateTest, DiffIterateDeterministicPP)
 {
   REQUIRE(!is_feature_enabled(RBD_FEATURE_STRIPINGV2));
 
-  this->test_deterministic_pp(0, 256);
+  EXPECT_NO_FATAL_FAILURE(this->test_deterministic_pp(0, 2));
+  EXPECT_NO_FATAL_FAILURE(this->test_deterministic_pp((3 << 20) - 2, 2));
+  EXPECT_NO_FATAL_FAILURE(this->test_deterministic_pp((3 << 20) - 1, 2));
+  EXPECT_NO_FATAL_FAILURE(this->test_deterministic_pp(3 << 20, 2));
+  EXPECT_NO_FATAL_FAILURE(this->test_deterministic_pp((4 << 20) - 2, 2));
 }
 
 TYPED_TEST(DiffIterateTest, DiffIterateDiscard)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66744

---

backport of https://github.com/ceph/ceph/pull/58201
parent tracker: https://tracker.ceph.com/issues/66570