### PR TITLE
common/async: add primitives for structured concurrency with c++20 coroutines

### DIFF
--- a/src/common/async/co_spawn_group.h
+++ b/src/common/async/co_spawn_group.h
@@ -1,0 +1,101 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/execution/executor.hpp>
+#include "cancel_on_error.h"
+#include "detail/co_spawn_group.h"
+
+namespace ceph::async {
+
+/// \brief Tracks a group of coroutines to await all of their completions.
+///
+/// The wait() function can be used to await the completion of all children.
+/// If any child coroutines exit with an exception, the first such exception
+/// is rethrown by wait(). The cancel_on_error option controls whether these
+/// exceptions trigger the cancellation of other children.
+///
+/// All child coroutines are canceled by cancel() or co_spawn_group destruction.
+/// This allows the parent coroutine to share memory with its child coroutines
+/// without fear of dangling references.
+///
+/// This class is not thread-safe, so a strand executor should be used in
+/// multi-threaded contexts.
+///
+/// Example:
+/// \code
+/// awaitable<void> child(task& t);
+///
+/// awaitable<void> parent(std::span<task> tasks)
+/// {
+///   // process all tasks in parallel
+///   auto ex = co_await boost::asio::this_coro::executor;
+///   auto group = co_spawn_group{ex, tasks.size()};
+///
+///   for (auto& t : tasks) {
+///     group.spawn(child(t));
+///   }
+///   co_await group.wait();
+/// }
+/// \endcode
+template <boost::asio::execution::executor Executor>
+class co_spawn_group {
+  using impl_type = detail::co_spawn_group_impl<Executor>;
+  boost::intrusive_ptr<impl_type> impl;
+
+ public:
+  co_spawn_group(Executor ex, size_t limit,
+                 cancel_on_error on_error = cancel_on_error::none)
+    : impl(new impl_type(ex, limit, on_error))
+  {
+  }
+
+  ~co_spawn_group()
+  {
+    impl->cancel();
+  }
+
+  using executor_type = Executor;
+  executor_type get_executor() const
+  {
+    return impl->get_executor();
+  }
+
+  /// Spawn the given coroutine \ref cr on the group's executor. Throws a
+  /// std::length_error exception if the number of outstanding coroutines
+  /// would exceed the group's limit.
+  void spawn(boost::asio::awaitable<void, executor_type> cr)
+  {
+    impl->spawn(std::move(cr));
+  }
+
+  /// Wait for all outstanding coroutines before returning. If any of the
+  /// spawned coroutines exit with an exception, the first exception is
+  /// rethrown.
+  ///
+  /// After wait() completes, whether by exception or co_return, the spawn
+  /// group can be reused to spawn and await additional coroutines.
+  boost::asio::awaitable<void, executor_type> wait()
+  {
+    return impl->wait();
+  }
+
+  /// Cancel all outstanding coroutines.
+  void cancel()
+  {
+    impl->cancel();
+  }
+};
+
+} // namespace ceph::async

--- a/src/common/async/co_throttle.h
+++ b/src/common/async/co_throttle.h
@@ -1,0 +1,113 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 Red Hat <contact@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <boost/intrusive_ptr.hpp>
+#include "common/async/cancel_on_error.h"
+#include "common/async/detail/co_throttle_impl.h"
+
+namespace ceph::async {
+
+/// A coroutine throttle that allows a parent coroutine to spawn and manage
+/// multiple child coroutines, while enforcing an upper bound on concurrency.
+///
+/// Child coroutines must be of type awaitable<void>. Exceptions thrown by
+/// children are rethrown to the parent on its next call to spawn() or wait().
+/// The cancel_on_error option controls whether these exceptions errors trigger
+/// the cancellation of other children.
+///
+/// All child coroutines are canceled by cancel() or co_throttle destruction.
+/// This allows the parent coroutine to share memory with its child coroutines
+/// without fear of dangling references.
+///
+/// This class is not thread-safe, so a strand executor should be used in
+/// multi-threaded contexts.
+///
+/// Example:
+/// \code
+/// awaitable<void> child(task& t);
+///
+/// awaitable<void> parent(std::span<task> tasks)
+/// {
+///   // process all tasks, up to 10 at a time
+///   auto ex = co_await boost::asio::this_coro::executor;
+///   auto throttle = co_throttle{ex, 10};
+///
+///   for (auto& t : tasks) {
+///     co_await throttle.spawn(child(t));
+///   }
+///   co_await throttle.wait();
+/// }
+/// \endcode
+template <boost::asio::execution::executor Executor>
+class co_throttle {
+  using impl_type = detail::co_throttle_impl<Executor>;
+  boost::intrusive_ptr<impl_type> impl;
+
+ public:
+  using executor_type = Executor;
+  executor_type get_executor() const noexcept { return impl->get_executor(); }
+
+  static constexpr size_t max_limit = std::numeric_limits<size_t>::max();
+
+  co_throttle(const executor_type& ex, size_t limit,
+              cancel_on_error on_error = cancel_on_error::none)
+    : impl(new impl_type(ex, limit, on_error))
+  {
+  }
+
+  ~co_throttle()
+  {
+    cancel();
+  }
+
+  co_throttle(const co_throttle&) = delete;
+  co_throttle& operator=(const co_throttle&) = delete;
+
+  /// Try to spawn the given coroutine \ref cr. If this would exceed the
+  /// concurrency limit, wait for another coroutine to complete first. This
+  /// default limit can be overridden with the optional \ref smaller_limit
+  /// argument.
+  ///
+  /// If any spawned coroutines exit with an exception, the first exception is
+  /// rethrown by the next call to spawn() or wait(). If spawn() has an
+  /// exception to rethrow, it will spawn \cr first only in the case of
+  /// cancel_on_error::none. New coroutines can be spawned by later calls to
+  /// spawn() regardless of cancel_on_error.
+  auto spawn(boost::asio::awaitable<void, executor_type> cr,
+             size_t smaller_limit = max_limit)
+      -> boost::asio::awaitable<void, executor_type>
+  {
+    return impl->spawn(std::move(cr), smaller_limit);
+  }
+
+  /// Wait for all associated coroutines to complete. If any of these coroutines
+  /// exit with an exception, the first of those exceptions is rethrown.
+  auto wait()
+      -> boost::asio::awaitable<void, executor_type>
+  {
+    return impl->wait();
+  }
+
+  /// Cancel all associated coroutines.
+  void cancel()
+  {
+    impl->cancel();
+  }
+};
+
+} // namespace ceph::async

--- a/src/common/async/co_waiter.h
+++ b/src/common/async/co_waiter.h
@@ -1,0 +1,166 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <exception>
+#include <optional>
+#include <boost/asio/append.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/execution/executor.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include "include/ceph_assert.h"
+
+namespace ceph::async {
+
+/// Captures an awaitable handler for deferred completion or cancellation.
+template <typename Ret, boost::asio::execution::executor Executor>
+class co_waiter {
+  using signature = void(std::exception_ptr, Ret);
+  using token_type = boost::asio::use_awaitable_t<Executor>;
+  using handler_type = typename boost::asio::async_result<
+      token_type, signature>::handler_type;
+  std::optional<handler_type> handler;
+
+  struct op_cancellation {
+    co_waiter* self;
+    op_cancellation(co_waiter* self) : self(self) {}
+    void operator()(boost::asio::cancellation_type_t type) {
+      if (type != boost::asio::cancellation_type::none) {
+        self->cancel();
+      }
+    }
+  };
+ public:
+  co_waiter() = default;
+
+  // copy and move are disabled because the cancellation handler captures 'this'
+  co_waiter(const co_waiter&) = delete;
+  co_waiter& operator=(const co_waiter&) = delete;
+
+  /// Returns true if there's a handler awaiting completion.
+  bool waiting() const { return handler.has_value(); }
+
+  /// Returns an awaitable that blocks until complete() or cancel().
+  boost::asio::awaitable<Ret, Executor> get()
+  {
+    ceph_assert(!handler);
+    token_type token;
+    return boost::asio::async_initiate<token_type, signature>(
+        [this] (handler_type h) {
+          auto slot = boost::asio::get_associated_cancellation_slot(h);
+          if (slot.is_connected()) {
+            slot.template emplace<op_cancellation>(this);
+          }
+          handler.emplace(std::move(h));
+        }, token);
+  }
+
+  /// Schedule the completion handler with the given arguments.
+  void complete(std::exception_ptr eptr, Ret value)
+  {
+    ceph_assert(handler);
+    auto h = boost::asio::append(std::move(*handler), eptr, std::move(value));
+    handler.reset();
+    boost::asio::dispatch(std::move(h));
+  }
+
+  /// Cancel the coroutine with an operation_aborted exception.
+  void cancel()
+  {
+    if (handler) {
+      auto eptr = std::make_exception_ptr(
+          boost::system::system_error(
+              boost::asio::error::operation_aborted));
+      complete(eptr, Ret{});
+    }
+  }
+
+  /// Destroy the completion handler.
+  void shutdown()
+  {
+    handler.reset();
+  }
+};
+
+// specialization for Ret=void
+template <boost::asio::execution::executor Executor>
+class co_waiter<void, Executor> {
+  using signature = void(std::exception_ptr);
+  using token_type = boost::asio::use_awaitable_t<Executor>;
+  using handler_type = typename boost::asio::async_result<
+      token_type, signature>::handler_type;
+  std::optional<handler_type> handler;
+
+  struct op_cancellation {
+    co_waiter* self;
+    op_cancellation(co_waiter* self) : self(self) {}
+    void operator()(boost::asio::cancellation_type_t type) {
+      if (type != boost::asio::cancellation_type::none) {
+        self->cancel();
+      }
+    }
+  };
+ public:
+  co_waiter() = default;
+
+  // copy and move are disabled because the cancellation handler captures 'this'
+  co_waiter(const co_waiter&) = delete;
+  co_waiter& operator=(const co_waiter&) = delete;
+
+  /// Returns true if there's a handler awaiting completion.
+  bool waiting() const { return handler.has_value(); }
+
+  /// Returns an awaitable that blocks until complete() or cancel().
+  boost::asio::awaitable<void, Executor> get()
+  {
+    ceph_assert(!handler);
+    token_type token;
+    return boost::asio::async_initiate<token_type, signature>(
+        [this] (handler_type h) {
+          auto slot = boost::asio::get_associated_cancellation_slot(h);
+          if (slot.is_connected()) {
+            slot.template emplace<op_cancellation>(this);
+          }
+          handler.emplace(std::move(h));
+        }, token);
+  }
+
+  /// Schedule the completion handler with the given arguments.
+  void complete(std::exception_ptr eptr)
+  {
+    ceph_assert(handler);
+    auto h = boost::asio::append(std::move(*handler), eptr);
+    handler.reset();
+    boost::asio::dispatch(std::move(h));
+  }
+
+  /// Cancel the coroutine with an operation_aborted exception.
+  void cancel()
+  {
+    if (handler) {
+      auto eptr = std::make_exception_ptr(
+          boost::system::system_error(
+              boost::asio::error::operation_aborted));
+      complete(eptr);
+    }
+  }
+
+  /// Destroy the completion handler.
+  void shutdown()
+  {
+    handler.reset();
+  }
+};
+
+} // namespace ceph::async

--- a/src/common/async/detail/co_spawn_group.h
+++ b/src/common/async/detail/co_spawn_group.h
@@ -1,0 +1,182 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <exception>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/bind_cancellation_slot.hpp>
+#include <boost/asio/cancellation_signal.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/execution/executor.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+#include "common/async/cancel_on_error.h"
+#include "common/async/co_waiter.h"
+#include "common/async/service.h"
+#include "include/scope_guard.h"
+
+namespace ceph::async::detail {
+
+template <boost::asio::execution::executor Executor>
+class co_spawn_group_impl;
+
+// A cancellable co_spawn() completion handler that notifies the co_spawn_group
+// upon completion. This holds a reference to the implementation in order to
+// extend its lifetime. This is required for per-op cancellation because the
+// cancellation_signals must outlive these coroutine frames.
+template <typename Executor>
+class co_spawn_group_handler {
+  using impl_type = co_spawn_group_impl<Executor>;
+  using size_type = typename impl_type::size_type;
+  boost::intrusive_ptr<impl_type> impl;
+  boost::asio::cancellation_slot slot;
+  size_type index;
+ public:
+  co_spawn_group_handler(boost::intrusive_ptr<impl_type> impl,
+                         boost::asio::cancellation_slot slot, size_type index)
+      : impl(std::move(impl)), slot(std::move(slot)), index(index)
+  {}
+
+  using executor_type = typename impl_type::executor_type;
+  executor_type get_executor() const noexcept
+  {
+    return impl->get_executor();
+  }
+
+  using cancellation_slot_type = boost::asio::cancellation_slot;
+  cancellation_slot_type get_cancellation_slot() const noexcept
+  {
+    return slot;
+  }
+
+  void operator()(std::exception_ptr eptr)
+  {
+    impl->child_complete(index, eptr);
+  }
+};
+
+// Reference-counted spawn group implementation.
+template <boost::asio::execution::executor Executor>
+class co_spawn_group_impl :
+    public boost::intrusive_ref_counter<co_spawn_group_impl<Executor>,
+        boost::thread_unsafe_counter>,
+    public service_list_base_hook
+{
+ public:
+  using size_type = uint16_t;
+
+  co_spawn_group_impl(Executor ex, size_type limit,
+                      cancel_on_error on_error)
+    : svc(boost::asio::use_service<service<co_spawn_group_impl>>(
+            boost::asio::query(ex, boost::asio::execution::context))),
+      ex(ex),
+      signals(std::make_unique<boost::asio::cancellation_signal[]>(limit)),
+      limit(limit), on_error(on_error)
+  {
+    // register for service_shutdown() notifications
+    svc.add(*this);
+  }
+  ~co_spawn_group_impl()
+  {
+    svc.remove(*this);
+  }
+
+  using executor_type = Executor;
+  executor_type get_executor() const noexcept
+  {
+    return ex;
+  }
+
+  void child_complete(size_type index, std::exception_ptr e)
+  {
+    if (e) {
+      if (!eptr) {
+        eptr = e;
+      }
+      if (on_error == cancel_on_error::all) {
+        cancel_from(0);
+      } else if (on_error == cancel_on_error::after) {
+        cancel_from(index + 1);
+      }
+    }
+    if (++completed == spawned) {
+      complete();
+    }
+  }
+
+  void spawn(boost::asio::awaitable<void, executor_type> cr)
+  {
+    boost::asio::co_spawn(get_executor(), std::move(cr), completion());
+  }
+
+  boost::asio::awaitable<void, executor_type> wait()
+  {
+    if (completed < spawned) {
+      co_await waiter.get();
+    }
+
+    // clear for reuse
+    completed = 0;
+    spawned = 0;
+
+    if (eptr) {
+      std::rethrow_exception(std::exchange(eptr, nullptr));
+    }
+  }
+
+  void cancel()
+  {
+    cancel_from(0);
+  }
+
+  void service_shutdown()
+  {
+    waiter.shutdown();
+  }
+
+ private:
+  service<co_spawn_group_impl>& svc;
+  co_waiter<void, executor_type> waiter;
+  executor_type ex;
+  std::unique_ptr<boost::asio::cancellation_signal[]> signals;
+  std::exception_ptr eptr;
+  const size_type limit;
+  size_type spawned = 0;
+  size_type completed = 0;
+  const cancel_on_error on_error;
+
+  void cancel_from(size_type begin)
+  {
+    for (size_type i = begin; i < spawned; i++) {
+      signals[i].emit(boost::asio::cancellation_type::terminal);
+    }
+  }
+
+  void complete()
+  {
+    if (waiter.waiting()) {
+      waiter.complete(nullptr);
+    }
+  }
+
+  co_spawn_group_handler<executor_type> completion()
+  {
+    if (spawned >= limit) {
+      throw std::length_error("spawn group maximum size exceeded");
+    }
+    const size_type index = spawned++;
+    return {boost::intrusive_ptr{this}, signals[index].slot(), index};
+  }
+};
+
+} // namespace ceph::async::detail

--- a/src/common/async/detail/co_throttle_impl.h
+++ b/src/common/async/detail/co_throttle_impl.h
@@ -1,0 +1,222 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 Red Hat <contact@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <boost/asio/append.hpp>
+#include <boost/asio/bind_cancellation_slot.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/execution/executor.hpp>
+#include <boost/intrusive/list.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+#include "common/async/cancel_on_error.h"
+#include "common/async/co_waiter.h"
+#include "common/async/service.h"
+#include "include/ceph_assert.h"
+
+namespace ceph::async::detail {
+
+// Coroutine throttle implementation. This is reference-counted so the
+// co_spawn() completion handlers can extend the implementation's lifetime.
+// This is required for per-op cancellation because the cancellation_signals
+// must outlive their coroutine frames.
+template <boost::asio::execution::executor Executor>
+class co_throttle_impl :
+    public boost::intrusive_ref_counter<co_throttle_impl<Executor>,
+        boost::thread_unsafe_counter>,
+    public service_list_base_hook
+{
+ public:
+  using executor_type = Executor;
+  executor_type get_executor() const { return ex; }
+
+  co_throttle_impl(const executor_type& ex, size_t limit,
+                   cancel_on_error on_error)
+    : svc(boost::asio::use_service<service<co_throttle_impl>>(
+            boost::asio::query(ex, boost::asio::execution::context))),
+      ex(ex), limit(limit), on_error(on_error),
+      children(new child[limit])
+  {
+    // register for service_shutdown() notifications
+    svc.add(*this);
+
+    // initialize the free list
+    for (size_t i = 0; i < limit; i++) {
+      free.push_back(children[i]);
+    }
+  }
+  ~co_throttle_impl()
+  {
+    svc.remove(*this);
+  }
+
+  auto spawn(boost::asio::awaitable<void, executor_type> cr,
+             size_t smaller_limit)
+      -> boost::asio::awaitable<void, executor_type>
+  {
+    if (unreported_exception && on_error != cancel_on_error::none) {
+      std::rethrow_exception(std::exchange(unreported_exception, nullptr));
+    }
+
+    const size_t current_limit = std::min(smaller_limit, limit);
+    if (count >= current_limit) {
+      co_await wait_for(current_limit - 1);
+      if (unreported_exception && on_error != cancel_on_error::none) {
+        std::rethrow_exception(std::exchange(unreported_exception, nullptr));
+      }
+    }
+
+    ++count;
+
+    // move a free child to the outstanding list
+    ceph_assert(!free.empty());
+    child& c = free.front();
+    free.pop_front();
+    outstanding.push_back(c);
+
+    // spawn the coroutine with its associated cancellation signal
+    c.signal.emplace();
+    c.canceled = false;
+
+    boost::asio::co_spawn(get_executor(), std::move(cr),
+        boost::asio::bind_cancellation_slot(c.signal->slot(),
+            child_completion{this, c}));
+
+    if (unreported_exception) {
+      std::rethrow_exception(std::exchange(unreported_exception, nullptr));
+    }
+  }
+
+  auto wait()
+      -> boost::asio::awaitable<void, executor_type>
+  {
+    if (count > 0) {
+      co_await wait_for(0);
+    }
+    if (unreported_exception) {
+      std::rethrow_exception(std::exchange(unreported_exception, nullptr));
+    }
+  }
+
+  void cancel()
+  {
+    while (!outstanding.empty()) {
+      child& c = outstanding.front();
+      outstanding.pop_front();
+
+      c.canceled = true;
+      c.signal->emit(boost::asio::cancellation_type::terminal);
+    }
+  }
+
+  void service_shutdown()
+  {
+    waiter.shutdown();
+  }
+
+ private:
+  service<co_throttle_impl>& svc;
+  executor_type ex;
+  const size_t limit;
+  const cancel_on_error on_error;
+
+  size_t count = 0;
+  size_t wait_for_count = 0;
+
+  std::exception_ptr unreported_exception;
+
+  // track each spawned coroutine for cancellation. these are stored in an
+  // array, and recycled after each use via the free list
+  struct child : boost::intrusive::list_base_hook<> {
+    std::optional<boost::asio::cancellation_signal> signal;
+    bool canceled = false;
+  };
+  std::unique_ptr<child[]> children;
+
+  using child_list = boost::intrusive::list<child,
+        boost::intrusive::constant_time_size<false>>;
+  child_list outstanding;
+  child_list free;
+
+  co_waiter<void, executor_type> waiter;
+
+  // return an awaitable that completes once count <= target_count
+  auto wait_for(size_t target_count)
+      -> boost::asio::awaitable<void, executor_type>
+  {
+    wait_for_count = target_count;
+    return waiter.get();
+  }
+
+  void on_complete(child& c, std::exception_ptr eptr)
+  {
+    --count;
+
+    if (c.canceled) {
+      // if the child was canceled, it was already removed from outstanding
+      ceph_assert(!c.is_linked());
+      c.canceled = false;
+      c.signal.reset();
+      free.push_back(c);
+    } else {
+      // move back to the free list
+      ceph_assert(c.is_linked());
+      auto next = outstanding.erase(outstanding.iterator_to(c));
+      c.signal.reset();
+      free.push_back(c);
+
+      if (eptr) {
+        if (eptr && !unreported_exception) {
+          unreported_exception = eptr;
+        }
+
+        // handle cancel_on_error. cancellation signals may recurse into
+        // on_complete(), so move the entries into a separate list first
+        child_list to_cancel;
+        if (on_error == cancel_on_error::after) {
+          to_cancel.splice(to_cancel.end(), outstanding,
+                           next, outstanding.end());
+        } else if (on_error == cancel_on_error::all) {
+          to_cancel = std::move(outstanding);
+        }
+
+        for (auto i = to_cancel.begin(); i != to_cancel.end(); ++i) {
+          child& c = *i;
+          i = to_cancel.erase(i);
+
+          c.canceled = true;
+          c.signal->emit(boost::asio::cancellation_type::terminal);
+        }
+      }
+    }
+
+    // maybe wake the waiter
+    if (waiter.waiting() && count <= wait_for_count) {
+      waiter.complete(nullptr);
+    }
+  }
+
+  struct child_completion {
+    boost::intrusive_ptr<co_throttle_impl> impl;
+    child& c;
+
+    void operator()(std::exception_ptr eptr) {
+      impl->on_complete(c, eptr);
+    }
+  };
+};
+
+} // namespace ceph::async::detail

--- a/src/common/async/parallel_for_each.h
+++ b/src/common/async/parallel_for_each.h
@@ -1,0 +1,86 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <concepts>
+#include <iterator>
+#include <ranges>
+#include <type_traits>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/execution/executor.hpp>
+#include <boost/asio/this_coro.hpp>
+#include "co_spawn_group.h"
+
+namespace ceph::async {
+
+/// Call a coroutine with each element in the given range then wait for all
+/// of them to complete. The first exception is rethrown to the caller. The
+/// cancel_on_error option controls whether these exceptions trigger the
+/// cancellation of other children.
+///
+/// Example:
+/// \code
+/// awaitable<void> child(task& t);
+///
+/// awaitable<void> parent(std::span<task> tasks)
+/// {
+///   co_await parallel_for_each(tasks.begin(), tasks.end(), child);
+/// }
+/// \endcode
+template <typename Iterator, typename Sentinel, typename VoidAwaitableFactory,
+          typename Value = std::iter_reference_t<Iterator>,
+          typename VoidAwaitable = std::invoke_result_t<
+              VoidAwaitableFactory, Value>,
+          typename AwaitableT = typename VoidAwaitable::value_type,
+          typename AwaitableExecutor = typename VoidAwaitable::executor_type>
+    requires (std::input_iterator<Iterator> &&
+              std::sentinel_for<Sentinel, Iterator> &&
+              std::same_as<AwaitableT, void> &&
+              boost::asio::execution::executor<AwaitableExecutor>)
+auto parallel_for_each(Iterator begin, Sentinel end,
+                       VoidAwaitableFactory&& factory,
+                       cancel_on_error on_error = cancel_on_error::none)
+    -> boost::asio::awaitable<void, AwaitableExecutor>
+{
+  const size_t count = std::ranges::distance(begin, end);
+  if (!count) {
+    co_return;
+  }
+  auto ex = co_await boost::asio::this_coro::executor;
+  auto group = co_spawn_group{ex, count, on_error};
+  for (Iterator i = begin; i != end; ++i) {
+    group.spawn(factory(*i));
+  }
+  co_await group.wait();
+}
+
+/// \overload
+template <typename Range, typename VoidAwaitableFactory,
+          typename Value = std::ranges::range_reference_t<Range>,
+          typename VoidAwaitable = std::invoke_result_t<
+              VoidAwaitableFactory, Value>,
+          typename AwaitableT = typename VoidAwaitable::value_type,
+          typename AwaitableExecutor = typename VoidAwaitable::executor_type>
+    requires (std::ranges::range<Range> &&
+              std::same_as<AwaitableT, void> &&
+              boost::asio::execution::executor<AwaitableExecutor>)
+auto parallel_for_each(Range&& range, VoidAwaitableFactory&& factory,
+                       cancel_on_error on_error = cancel_on_error::none)
+    -> boost::asio::awaitable<void, AwaitableExecutor>
+{
+  return parallel_for_each(std::begin(range), std::end(range),
+                           std::move(factory), on_error);
+}
+
+} // namespace ceph::async

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -361,9 +361,16 @@ add_executable(unittest_async_completion test_async_completion.cc)
 add_ceph_unittest(unittest_async_completion)
 target_link_libraries(unittest_async_completion ceph-common Boost::system)
 
+
 add_executable(unittest_async_max_concurrent_for_each test_async_max_concurrent_for_each.cc)
 add_ceph_unittest(unittest_async_max_concurrent_for_each)
 target_link_libraries(unittest_async_max_concurrent_for_each ceph-common Boost::system Boost::context)
+
+if(NOT WIN32)
+add_executable(unittest_async_co_throttle test_async_co_throttle.cc)
+add_ceph_unittest(unittest_async_co_throttle)
+target_link_libraries(unittest_async_co_throttle ceph-common Boost::system)
+endif(NOT WIN32)
 
 add_executable(unittest_async_shared_mutex test_async_shared_mutex.cc)
 add_ceph_unittest(unittest_async_shared_mutex)

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -367,6 +367,10 @@ add_ceph_unittest(unittest_async_max_concurrent_for_each)
 target_link_libraries(unittest_async_max_concurrent_for_each ceph-common Boost::system Boost::context)
 
 if(NOT WIN32)
+add_executable(unittest_async_co_spawn_group test_async_co_spawn_group.cc)
+add_ceph_unittest(unittest_async_co_spawn_group)
+target_link_libraries(unittest_async_co_spawn_group ceph-common Boost::system)
+
 add_executable(unittest_async_co_throttle test_async_co_throttle.cc)
 add_ceph_unittest(unittest_async_co_throttle)
 target_link_libraries(unittest_async_co_throttle ceph-common Boost::system)

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -388,6 +388,10 @@ add_executable(unittest_async_yield_waiter test_async_yield_waiter.cc)
 add_ceph_unittest(unittest_async_yield_waiter)
 target_link_libraries(unittest_async_yield_waiter ceph-common Boost::system Boost::context)
 
+add_executable(unittest_async_parallel_for_each test_async_parallel_for_each.cc)
+add_ceph_unittest(unittest_async_parallel_for_each)
+target_link_libraries(unittest_async_parallel_for_each ceph-common Boost::system)
+
 add_executable(unittest_cdc test_cdc.cc
   $<TARGET_OBJECTS:unit-main>)
 target_link_libraries(unittest_cdc global ceph-common)

--- a/src/test/common/test_async_co_spawn_group.cc
+++ b/src/test/common/test_async_co_spawn_group.cc
@@ -1,0 +1,511 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "common/async/co_spawn_group.h"
+
+#include <latch>
+#include <optional>
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/bind_cancellation_slot.hpp>
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/defer.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/thread_pool.hpp>
+#include <gtest/gtest.h>
+#include "common/async/co_waiter.h"
+
+namespace ceph::async {
+
+namespace asio = boost::asio;
+namespace errc = boost::system::errc;
+using boost::system::error_code;
+
+using executor_type = asio::any_io_executor;
+
+template <typename T>
+auto capture(std::optional<T>& opt)
+{
+  return [&opt] (T value) { opt = std::move(value); };
+}
+
+template <typename T>
+auto capture(asio::cancellation_signal& signal, std::optional<T>& opt)
+{
+  return asio::bind_cancellation_slot(signal.slot(), capture(opt));
+}
+
+TEST(co_spawn_group, spawn_limit)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto group = co_spawn_group{ex, 1};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  group.spawn(cr());
+  EXPECT_THROW(group.spawn(cr()), std::length_error);
+}
+
+TEST(co_spawn_group, wait_empty)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto group = co_spawn_group{ex, 1};
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(co_spawn_group, spawn_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto group = co_spawn_group{ex, 10};
+
+  co_waiter<void, executor_type> waiter;
+  group.spawn(waiter.get());
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  // shut down before wait()
+}
+
+TEST(co_spawn_group, spawn_wait)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto group = co_spawn_group{ex, 10};
+
+  co_waiter<void, executor_type> waiter;
+  group.spawn(waiter.get());
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiter.complete(nullptr);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(co_spawn_group, spawn_wait_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+
+  co_waiter<void, executor_type> waiter;
+  auto cr = [ex, &waiter] () -> asio::awaitable<void> {
+    auto group = co_spawn_group{ex, 1};
+    group.spawn(waiter.get());
+    co_await group.wait();
+  };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, cr(), capture(result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  // shut down before wait() completes
+}
+
+TEST(co_spawn_group, spawn_wait_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+
+  co_waiter<void, executor_type> waiter;
+  auto cr = [ex, &waiter] () -> asio::awaitable<void> {
+    auto group = co_spawn_group{ex, 1};
+    group.spawn(waiter.get());
+    co_await group.wait();
+  };
+
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, cr(), capture(signal, result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before wait() completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_spawn_group, spawn_wait_exception_order)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto group = co_spawn_group{ex, 2};
+
+  co_waiter<void, executor_type> waiter1;
+  group.spawn(waiter1.get());
+
+  co_waiter<void, executor_type> waiter2;
+  group.spawn(waiter2.get());
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiter2.complete(std::make_exception_ptr(std::runtime_error{"oops"}));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiter1.complete(std::make_exception_ptr(std::logic_error{"oops"}));
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  EXPECT_THROW(std::rethrow_exception(*result), std::runtime_error);
+}
+
+TEST(co_spawn_group, spawn_complete_wait)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto group = co_spawn_group{ex, 2};
+
+  co_waiter<void, executor_type> waiter;
+  group.spawn(waiter.get());
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+
+  waiter.complete(std::make_exception_ptr(std::runtime_error{"oops"}));
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped()); // no waiter means ctx can stop
+  ctx.restart();
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  EXPECT_THROW(std::rethrow_exception(*result), std::runtime_error);
+}
+
+TEST(co_spawn_group, spawn_wait_wait)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto group = co_spawn_group{ex, 1};
+
+  co_waiter<void, executor_type> waiter;
+  group.spawn(waiter.get());
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+
+  waiter.complete(std::make_exception_ptr(std::runtime_error{"oops"}));
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  EXPECT_THROW(std::rethrow_exception(*result), std::runtime_error);
+
+  result.reset();
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.restart();
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(co_spawn_group, spawn_wait_spawn_wait)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto group = co_spawn_group{ex, 1};
+
+  co_waiter<void, executor_type> waiter;
+  group.spawn(waiter.get());
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiter.complete(nullptr);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_FALSE(*result);
+
+  group.spawn(waiter.get());
+
+  result.reset();
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.restart();
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiter.complete(nullptr);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(co_spawn_group, spawn_cancel_wait_spawn_wait)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto group = co_spawn_group{ex, 1};
+
+  co_waiter<void, executor_type> waiter;
+  group.spawn(waiter.get());
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+
+  group.cancel();
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped()); // no waiter means ctx can stop
+  ctx.restart();
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+
+  group.spawn(waiter.get());
+
+  result.reset();
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.restart();
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiter.complete(nullptr);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(co_spawn_group, spawn_wait_cancel_spawn_wait)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto group = co_spawn_group{ex, 1};
+
+  co_waiter<void, executor_type> waiter;
+  group.spawn(waiter.get());
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before waiter completes
+  group.cancel();
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+
+  group.spawn(waiter.get());
+
+  result.reset();
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.restart();
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiter.complete(nullptr);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(co_spawn_group, cancel_on_error_after)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto group = co_spawn_group{ex, 3, cancel_on_error::after};
+
+  co_waiter<void, executor_type> waiter1;
+  group.spawn(waiter1.get());
+
+  co_waiter<void, executor_type> waiter2;
+  group.spawn(waiter2.get());
+
+  co_waiter<void, executor_type> waiter3;
+  group.spawn(waiter3.get());
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiter2.complete(std::make_exception_ptr(std::runtime_error{"oops"}));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiter1.complete(nullptr);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  EXPECT_THROW(std::rethrow_exception(*result), std::runtime_error);
+}
+
+TEST(co_spawn_group, cancel_on_error_all)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto group = co_spawn_group{ex, 3, cancel_on_error::all};
+
+  co_waiter<void, executor_type> waiter1;
+  group.spawn(waiter1.get());
+
+  co_waiter<void, executor_type> waiter2;
+  group.spawn(waiter2.get());
+
+  co_waiter<void, executor_type> waiter3;
+  group.spawn(waiter3.get());
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, group.wait(), capture(result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiter2.complete(std::make_exception_ptr(std::runtime_error{"oops"}));
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  EXPECT_THROW(std::rethrow_exception(*result), std::runtime_error);
+}
+
+TEST(co_spawn_group, cross_thread_cancel)
+{
+  // run the coroutine in a background thread
+  asio::thread_pool ctx{1};
+  executor_type ex = ctx.get_executor();
+
+  std::latch waiting{1};
+
+  auto cr = [ex, &waiting] () -> asio::awaitable<void> {
+    auto group = co_spawn_group{ex, 1};
+    co_waiter<void, executor_type> waiter;
+    group.spawn(waiter.get());
+    // decrement the latch after group.wait() suspends
+    asio::defer(ex, [&waiting] { waiting.count_down(); });
+    co_await group.wait();
+  };
+
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> result;
+  // without bind_executor(), tsan identifies a data race on signal.emit()
+  asio::co_spawn(ex, cr(), bind_executor(ex, capture(signal, result)));
+
+  waiting.wait(); // wait until we've suspended in group.wait()
+
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.join();
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+} // namespace ceph::async

--- a/src/test/common/test_async_co_throttle.cc
+++ b/src/test/common/test_async_co_throttle.cc
@@ -1,0 +1,548 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2023 Red Hat <contact@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "common/async/co_throttle.h"
+
+#include <latch>
+#include <optional>
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/bind_cancellation_slot.hpp>
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/cancellation_signal.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/defer.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/thread_pool.hpp>
+#include <gtest/gtest.h>
+#include "common/async/co_waiter.h"
+
+namespace ceph::async {
+
+namespace asio = boost::asio;
+namespace errc = boost::system::errc;
+using boost::system::error_code;
+
+using executor_type = asio::any_io_executor;
+
+using void_waiter = co_waiter<void, executor_type>;
+
+auto capture(std::optional<std::exception_ptr>& eptr)
+{
+  return [&eptr] (std::exception_ptr e) { eptr = e; };
+}
+
+auto capture(asio::cancellation_signal& signal,
+             std::optional<std::exception_ptr>& eptr)
+{
+  return asio::bind_cancellation_slot(signal.slot(), capture(eptr));
+}
+
+asio::awaitable<void> wait(void_waiter& waiter, bool& completed)
+{
+  co_await waiter.get();
+  completed = true;
+}
+
+TEST(co_throttle, wait_empty)
+{
+  constexpr size_t limit = 1;
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+
+  auto cr = [&] () -> asio::awaitable<void> {
+    auto throttle = co_throttle{co_await asio::this_coro::executor, limit};
+    co_await throttle.wait();
+  };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, cr(), capture(result));
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(co_throttle, spawn_over_limit)
+{
+  constexpr size_t limit = 1;
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+
+  void_waiter waiter1;
+  void_waiter waiter2;
+  bool spawn1_completed = false;
+  bool spawn2_completed = false;
+
+  auto cr = [&] () -> asio::awaitable<void> {
+    auto throttle = co_throttle{co_await asio::this_coro::executor, limit};
+    co_await throttle.spawn(waiter1.get());
+    spawn1_completed = true;
+    co_await throttle.spawn(waiter2.get());
+    spawn2_completed = true;
+    co_await throttle.wait();
+  };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, cr(), capture(result));
+
+  ctx.poll(); // run until spawn2 blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_TRUE(spawn1_completed);
+  EXPECT_FALSE(spawn2_completed);
+
+  waiter1.complete(nullptr);
+
+  ctx.poll(); // run until wait blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  EXPECT_TRUE(spawn2_completed);
+
+  waiter2.complete(nullptr);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(co_throttle, spawn_over_smaller_limit)
+{
+  constexpr size_t limit = 2;
+  constexpr size_t smaller_limit = 1;
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+
+  void_waiter waiter1;
+  void_waiter waiter2;
+  bool spawn1_completed = false;
+  bool spawn2_completed = false;
+
+  auto cr = [&] () -> asio::awaitable<void> {
+    auto throttle = co_throttle{co_await asio::this_coro::executor, limit};
+    co_await throttle.spawn(waiter1.get());
+    spawn1_completed = true;
+    co_await throttle.spawn(waiter2.get(), smaller_limit);
+    spawn2_completed = true;
+    co_await throttle.wait();
+  };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, cr(), capture(result));
+
+  ctx.poll(); // run until spawn2 blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_TRUE(spawn1_completed);
+  EXPECT_FALSE(spawn2_completed);
+
+  waiter1.complete(nullptr);
+
+  ctx.poll(); // run until wait blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_TRUE(spawn2_completed);
+
+  waiter2.complete(nullptr);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(co_throttle, spawn_cancel)
+{
+  constexpr size_t limit = 1;
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+
+  void_waiter waiter1;
+  void_waiter waiter2;
+  bool spawn1_completed = false;
+  bool spawn2_completed = false;
+
+  auto cr = [&] () -> asio::awaitable<void> {
+    auto throttle = co_throttle{co_await asio::this_coro::executor, limit};
+    co_await throttle.spawn(waiter1.get());
+    spawn1_completed = true;
+    co_await throttle.spawn(waiter2.get());
+    spawn2_completed = true;
+    co_await throttle.wait();
+  };
+
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, cr(), capture(signal, result));
+
+  ctx.poll(); // run until spawn2 blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_TRUE(spawn1_completed);
+  EXPECT_FALSE(spawn2_completed);
+
+  // cancel before spawn2 completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped()); // poll runs to completion
+  EXPECT_FALSE(spawn2_completed);
+  ASSERT_TRUE(result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_throttle, wait_cancel)
+{
+  constexpr size_t limit = 1;
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+
+  void_waiter waiter;
+  bool spawn_completed = false;
+
+  auto cr = [&] () -> asio::awaitable<void> {
+    auto throttle = co_throttle{co_await asio::this_coro::executor, limit};
+    co_await throttle.spawn(waiter.get());
+    spawn_completed = true;
+    co_await throttle.wait();
+  };
+
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, cr(), capture(signal, result));
+
+  ctx.poll(); // run until wait blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_TRUE(spawn_completed);
+  EXPECT_FALSE(result);
+
+  // cancel before wait completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped()); // poll runs to completion
+  ASSERT_TRUE(result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_throttle, spawn_shutdown)
+{
+  constexpr size_t limit = 1;
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+
+  void_waiter waiter1;
+  void_waiter waiter2;
+  bool spawn1_completed = false;
+
+  auto cr = [&] () -> asio::awaitable<void> {
+    auto throttle = co_throttle{co_await asio::this_coro::executor, limit};
+    co_await throttle.spawn(waiter1.get());
+    spawn1_completed = true;
+    co_await throttle.spawn(waiter2.get());
+  };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, cr(), capture(result));
+
+  ctx.poll(); // run until spawn2 blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_TRUE(spawn1_completed);
+  EXPECT_FALSE(result);
+  // shut down before spawn2 completes
+}
+
+TEST(co_throttle, wait_shutdown)
+{
+  constexpr size_t limit = 1;
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+
+  void_waiter waiter;
+  bool spawn_completed = false;
+
+  auto cr = [&] () -> asio::awaitable<void> {
+    auto throttle = co_throttle{co_await asio::this_coro::executor, limit};
+    co_await throttle.spawn(waiter.get());
+    spawn_completed = true;
+    co_await throttle.wait();
+  };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, cr(), capture(result));
+
+  ctx.poll(); // run until wait blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_TRUE(spawn_completed);
+  EXPECT_FALSE(result);
+  // shut down before wait completes
+}
+
+TEST(co_throttle, spawn_error)
+{
+  constexpr size_t limit = 2;
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+
+  void_waiter waiter1;
+  void_waiter waiter2;
+  void_waiter waiter3;
+  bool cr1_completed = false;
+  bool cr2_completed = false;
+  bool cr3_completed = false;
+  std::exception_ptr spawn3_eptr;
+
+  auto cr = [&] () -> asio::awaitable<void> {
+    auto throttle = co_throttle{co_await asio::this_coro::executor, limit};
+    co_await throttle.spawn(wait(waiter1, cr1_completed));
+    co_await throttle.spawn(wait(waiter2, cr2_completed));
+    try {
+      co_await throttle.spawn(wait(waiter3, cr3_completed));
+    } catch (const std::exception&) {
+      spawn3_eptr = std::current_exception();
+    }
+    co_await throttle.wait();
+  };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, cr(), capture(result));
+
+  ctx.poll(); // run until spawn3 blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(cr1_completed);
+  EXPECT_FALSE(cr2_completed);
+  EXPECT_FALSE(cr3_completed);
+
+  waiter2.complete(std::make_exception_ptr(std::runtime_error{"oops"}));
+
+  ctx.poll(); // run until wait blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_TRUE(spawn3_eptr);
+  EXPECT_THROW(std::rethrow_exception(spawn3_eptr), std::runtime_error);
+  EXPECT_FALSE(result);
+
+  waiter1.complete(nullptr);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped()); // wait still blocked
+
+  waiter3.complete(nullptr);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+  EXPECT_TRUE(cr1_completed);
+  EXPECT_FALSE(cr2_completed);
+  EXPECT_TRUE(cr3_completed); // cr3 isn't canceled by cr2's error
+}
+
+TEST(co_throttle, wait_error)
+{
+  constexpr size_t limit = 1;
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+
+  void_waiter waiter;
+
+  auto cr = [&] () -> asio::awaitable<void> {
+    auto throttle = co_throttle{co_await asio::this_coro::executor, limit};
+    co_await throttle.spawn(waiter.get());
+    co_await throttle.wait();
+  };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, cr(), capture(result));
+
+  ctx.poll(); // run until wait blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiter.complete(std::make_exception_ptr(std::runtime_error{"oops"}));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  EXPECT_THROW(std::rethrow_exception(*result), std::runtime_error);
+}
+
+TEST(co_throttle, spawn_cancel_on_error_after)
+{
+  constexpr size_t limit = 2;
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+
+  void_waiter waiter1;
+  void_waiter waiter2;
+  void_waiter waiter3;
+  void_waiter waiter4;
+  bool cr1_completed = false;
+  bool cr2_completed = false;
+  bool cr3_completed = false;
+  bool cr4_completed = false;
+  std::exception_ptr spawn3_eptr;
+
+  auto cr = [&] () -> asio::awaitable<void> {
+    auto ex = co_await asio::this_coro::executor;
+    auto throttle = co_throttle{ex, limit, cancel_on_error::after};
+    co_await throttle.spawn(wait(waiter1, cr1_completed));
+    co_await throttle.spawn(wait(waiter2, cr2_completed));
+    try {
+      co_await throttle.spawn(wait(waiter3, cr3_completed));
+    } catch (const std::exception&) {
+      spawn3_eptr = std::current_exception();
+    }
+    co_await throttle.spawn(wait(waiter4, cr4_completed));
+    co_await throttle.wait();
+  };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, cr(), capture(result));
+
+  ctx.poll(); // run until spawn3 blocks
+  ASSERT_FALSE(ctx.stopped());
+
+  waiter2.complete(std::make_exception_ptr(std::runtime_error{"oops"}));
+
+  ctx.poll(); // run until wait blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(cr1_completed);
+  ASSERT_TRUE(spawn3_eptr);
+  EXPECT_THROW(std::rethrow_exception(spawn3_eptr), std::runtime_error);
+
+  waiter1.complete(nullptr);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped()); // wait still blocked
+  EXPECT_FALSE(result);
+  EXPECT_TRUE(cr1_completed);
+  EXPECT_FALSE(cr4_completed);
+
+  waiter4.complete(nullptr);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+  EXPECT_FALSE(cr2_completed); // exited by exception
+  EXPECT_FALSE(cr3_completed); // cr3 canceled
+  EXPECT_TRUE(cr4_completed); // cr4 not canceled
+}
+
+TEST(co_throttle, spawn_cancel_on_error_all)
+{
+  constexpr size_t limit = 2;
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+
+  void_waiter waiter1;
+  void_waiter waiter2;
+  void_waiter waiter3;
+  void_waiter waiter4;
+  bool cr1_completed = false;
+  bool cr2_completed = false;
+  bool cr3_completed = false;
+  bool cr4_completed = false;
+  std::exception_ptr spawn3_eptr;
+
+  auto cr = [&] () -> asio::awaitable<void> {
+    auto ex = co_await asio::this_coro::executor;
+    auto throttle = co_throttle{ex, limit, cancel_on_error::all};
+    co_await throttle.spawn(wait(waiter1, cr1_completed));
+    co_await throttle.spawn(wait(waiter2, cr2_completed));
+    try {
+      co_await throttle.spawn(wait(waiter3, cr3_completed));
+    } catch (const std::exception&) {
+      spawn3_eptr = std::current_exception();
+    }
+    co_await throttle.spawn(wait(waiter4, cr4_completed));
+    co_await throttle.wait();
+  };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ex, cr(), capture(result));
+
+  ctx.poll(); // run until spawn3 blocks
+  ASSERT_FALSE(ctx.stopped());
+
+  waiter2.complete(std::make_exception_ptr(std::runtime_error{"oops"}));
+
+  ctx.poll(); // run until wait blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_TRUE(spawn3_eptr);
+  EXPECT_THROW(std::rethrow_exception(spawn3_eptr), std::runtime_error);
+  EXPECT_FALSE(cr4_completed);
+
+  waiter4.complete(nullptr);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+  EXPECT_FALSE(cr1_completed); // cr1 canceled
+  EXPECT_FALSE(cr2_completed); // exited by exception
+  EXPECT_FALSE(cr3_completed); // cr3 canceled
+  EXPECT_TRUE(cr4_completed); // cr4 not canceled
+}
+
+TEST(co_throttle, cross_thread_cancel)
+{
+  constexpr size_t limit = 1;
+  // run the coroutine in a background thread
+  asio::thread_pool ctx{1};
+  executor_type ex = ctx.get_executor();
+
+  std::latch waiting{1};
+
+  auto cr = [ex, &waiting] () -> asio::awaitable<void> {
+    auto throttle = co_throttle{ex, limit};
+    co_waiter<void, executor_type> waiter;
+    co_await throttle.spawn(waiter.get());
+    // decrement the latch after throttle.wait() suspends
+    asio::defer(ex, [&waiting] { waiting.count_down(); });
+    co_await throttle.wait();
+  };
+
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> result;
+  // without bind_executor(), tsan identifies a data race on signal.emit()
+  asio::co_spawn(ex, cr(), bind_executor(ex, capture(signal, result)));
+
+  waiting.wait(); // wait until we've suspended in throttle.wait()
+
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.join();
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+} // namespace ceph::async

--- a/src/test/common/test_async_max_concurrent_for_each.cc
+++ b/src/test/common/test_async_max_concurrent_for_each.cc
@@ -39,6 +39,12 @@ void wait_for(std::chrono::milliseconds dur, asio::yield_context yield)
   timer.async_wait(yield);
 }
 
+asio::awaitable<void> wait_for(std::chrono::milliseconds dur)
+{
+  auto timer = asio::steady_timer{co_await asio::this_coro::executor, dur};
+  co_await timer.async_wait(asio::use_awaitable);
+}
+
 struct null_sentinel {};
 bool operator==(const char* c, null_sentinel) { return !*c; }
 static_assert(std::sentinel_for<null_sentinel, const char*>);
@@ -214,6 +220,110 @@ TEST(range_yield, over_limit)
   asio::spawn(ctx, [&] (asio::yield_context yield) {
         constexpr auto arr = std::array{1,2,3,4,5,6,7,8,9,10};
         max_concurrent_for_each(arr, 2, yield, cr);
+      }, rethrow);
+  ctx.run();
+
+  EXPECT_EQ(0, concurrent);
+  EXPECT_EQ(2, max_concurrent);
+  EXPECT_EQ(10, completed);
+}
+
+TEST(iterator_co, empty)
+{
+  int* end = nullptr;
+  auto cr = [] (int) -> asio::awaitable<void> { co_return; };
+
+  asio::io_context ctx;
+  asio::co_spawn(ctx, [&] () -> asio::awaitable<void> {
+        co_await max_concurrent_for_each(end, end, 10, cr);
+      }, rethrow);
+  ctx.run();
+}
+
+TEST(iterator_co, over_limit)
+{
+  int concurrent = 0;
+  int max_concurrent = 0;
+  int completed = 0;
+
+  auto cr = [&] (int) -> asio::awaitable<void> {
+    ++concurrent;
+    if (max_concurrent < concurrent) {
+      max_concurrent = concurrent;
+    }
+
+    co_await wait_for(1ms);
+
+    --concurrent;
+    ++completed;
+  };
+
+  asio::io_context ctx;
+  asio::co_spawn(ctx, [&] () -> asio::awaitable<void> {
+        constexpr auto arr = std::array{1,2,3,4,5,6,7,8,9,10};
+        co_await max_concurrent_for_each(begin(arr), end(arr), 2, cr);
+      }, rethrow);
+  ctx.run();
+
+  EXPECT_EQ(0, concurrent);
+  EXPECT_EQ(2, max_concurrent);
+  EXPECT_EQ(10, completed);
+}
+
+TEST(iterator_co, sentinel)
+{
+  const char* begin = "hello";
+  null_sentinel end;
+
+  size_t completed = 0;
+  auto cr = [&completed] (char c) -> asio::awaitable<void> {
+    ++completed;
+    co_return;
+  };
+
+  asio::io_context ctx;
+  asio::co_spawn(ctx, [&] () -> asio::awaitable<void> {
+        co_await max_concurrent_for_each(begin, end, 10, cr);
+      }, rethrow);
+  ctx.run();
+
+  EXPECT_EQ(completed, 5);
+}
+
+TEST(range_co, empty)
+{
+  constexpr std::array<int, 0> arr{};
+  auto cr = [] (int) -> asio::awaitable<void> { co_return; };
+
+  asio::io_context ctx;
+  asio::co_spawn(ctx, [&] () -> asio::awaitable<void> {
+        co_await max_concurrent_for_each(arr, 10, cr);
+      }, rethrow);
+  ctx.run();
+}
+
+TEST(range_co, over_limit)
+{
+  int concurrent = 0;
+  int max_concurrent = 0;
+  int completed = 0;
+
+  auto cr = [&] (int) -> asio::awaitable<void> {
+    ++concurrent;
+    if (max_concurrent < concurrent) {
+      max_concurrent = concurrent;
+    }
+
+    co_await wait_for(1ms);
+
+    --concurrent;
+    ++completed;
+  };
+
+  asio::io_context ctx;
+  asio::co_spawn(ctx, [&] () -> asio::awaitable<void> {
+        constexpr auto arr = std::array{1,2,3,4,5,6,7,8,9,10};
+        co_await max_concurrent_for_each(arr, 2, cr);
       }, rethrow);
   ctx.run();
 

--- a/src/test/common/test_async_parallel_for_each.cc
+++ b/src/test/common/test_async_parallel_for_each.cc
@@ -1,0 +1,258 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "common/async/parallel_for_each.h"
+
+#include <optional>
+#include <boost/asio/bind_cancellation_slot.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/io_context.hpp>
+#include <gtest/gtest.h>
+#include "common/async/co_waiter.h"
+
+namespace ceph::async {
+
+namespace asio = boost::asio;
+namespace errc = boost::system::errc;
+using boost::system::error_code;
+
+using executor_type = asio::io_context::executor_type;
+
+template <typename T>
+using awaitable = asio::awaitable<T, executor_type>;
+
+using void_waiter = co_waiter<void, executor_type>;
+
+template <typename T>
+auto capture(std::optional<T>& opt)
+{
+  return [&opt] (T value) { opt = std::move(value); };
+}
+
+template <typename T>
+auto capture(asio::cancellation_signal& signal, std::optional<T>& opt)
+{
+  return asio::bind_cancellation_slot(signal.slot(), capture(opt));
+}
+
+TEST(parallel_for_each, empty)
+{
+  asio::io_context ctx;
+
+  int* end = nullptr;
+  auto cr = [] (int i) -> awaitable<void> { co_return; };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ctx, parallel_for_each(end, end, cr), capture(result));
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(parallel_for_each, shutdown)
+{
+  asio::io_context ctx;
+
+  void_waiter waiters[2];
+  auto cr = [] (void_waiter& w) -> awaitable<void> { return w.get(); };
+
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ctx, parallel_for_each(waiters, cr), capture(signal, result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  // shut down before any waiters complete
+}
+
+TEST(parallel_for_each, cancel)
+{
+  asio::io_context ctx;
+
+  void_waiter waiters[2];
+  auto cr = [] (void_waiter& w) -> awaitable<void> { return w.get(); };
+
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ctx, parallel_for_each(waiters, cr), capture(signal, result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before any waiters complete
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(parallel_for_each, complete_shutdown)
+{
+  asio::io_context ctx;
+
+  void_waiter waiters[2];
+  auto cr = [] (void_waiter& w) -> awaitable<void> { return w.get(); };
+
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ctx, parallel_for_each(waiters, cr), capture(signal, result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiters[0].complete(nullptr);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  // shut down before final waiter completes
+}
+
+TEST(parallel_for_each, complete_cancel)
+{
+  asio::io_context ctx;
+
+  void_waiter waiters[2];
+  auto cr = [] (void_waiter& w) -> awaitable<void> { return w.get(); };
+
+  asio::cancellation_signal signal;
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ctx, parallel_for_each(waiters, cr), capture(signal, result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiters[0].complete(nullptr);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before final waiter completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(parallel_for_each, complete_complete)
+{
+  asio::io_context ctx;
+
+  void_waiter waiters[2];
+  auto cr = [] (void_waiter& w) -> awaitable<void> { return w.get(); };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ctx, parallel_for_each(waiters, cr), capture(result));
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiters[0].complete(nullptr);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  waiters[1].complete(nullptr);
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+struct null_sentinel {};
+bool operator==(const char* c, null_sentinel) { return !*c; }
+static_assert(std::sentinel_for<null_sentinel, const char*>);
+
+TEST(parallel_for_each, sentinel)
+{
+  asio::io_context ctx;
+
+  const char* begin = "hello";
+  null_sentinel end;
+
+  size_t count = 0;
+  auto cr = [&count] (char c) -> awaitable<void> {
+    ++count;
+    co_return;
+  };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ctx, parallel_for_each(begin, end, cr), capture(result));
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+  EXPECT_EQ(count, 5);
+}
+
+TEST(parallel_for_each, move_iterator)
+{
+  asio::io_context ctx;
+
+  using value_type = std::unique_ptr<int>;
+  value_type values[] = {
+    std::make_unique<int>(42),
+    std::make_unique<int>(43),
+  };
+
+  auto begin = std::make_move_iterator(std::begin(values));
+  auto end = std::make_move_iterator(std::end(values));
+
+  auto cr = [] (value_type v) -> awaitable<void> {
+    if (!v) {
+      throw std::invalid_argument("empty");
+    }
+    co_return;
+  };
+
+  std::optional<std::exception_ptr> result;
+  asio::co_spawn(ctx, parallel_for_each(begin, end, cr), capture(result));
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+
+  EXPECT_FALSE(values[0]);
+  EXPECT_FALSE(values[1]);
+}
+
+} // namespace ceph::async


### PR DESCRIPTION
squashed/cleaned up commits that were initially part of the wip-coro-after-reef feature branch

more recently, a similar set of primitives were merged for stackful coroutines in https://github.com/ceph/ceph/pull/57188

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
