### PR TITLE
quincy: mds: Implement remove for ceph vxattrs 

### DIFF
--- a/doc/cephfs/quota.rst
+++ b/doc/cephfs/quota.rst
@@ -37,15 +37,28 @@ To view quota limit::
    system call. Instead, a specific CephFS extended attribute can be viewed by
    running ``getfattr /some/dir -n ceph.<some-xattr>``.
 
-To remove a quota, set the value of extended attribute to ``0``::
+To remove or disable a quota, remove the respective extended attribute or set
+the value to ``0``.
+
+Utilizing remove::
+
+  $ setfattr -x ceph.quota.max_bytes /some/dir
+  $ getfattr /some/dir -n ceph.quota.max_bytes
+  /some/dir/: ceph.quota.max_bytes: No such attribute
+  $
+  $ setfattr -x ceph.quota.max_files /some/dir
+  $ getfattr /some/dir/ -n ceph.quota.max_files
+  /some/dir/: ceph.quota.max_files: No such attribute
+
+Remove by setting value to zero::
 
   $ setfattr -n ceph.quota.max_bytes -v 0 /some/dir
   $ getfattr /some/dir -n ceph.quota.max_bytes
-  dir1/: ceph.quota.max_bytes: No such attribute
+  /some/dir/: ceph.quota.max_bytes: No such attribute
   $
   $ setfattr -n ceph.quota.max_files -v 0 /some/dir
-  $ getfattr dir1/ -n ceph.quota.max_files
-  dir1/: ceph.quota.max_files: No such attribute
+  $ getfattr /some/dir/ -n ceph.quota.max_files
+  /some/dir/: ceph.quota.max_files: No such attribute
 
 Space Usage Reporting and CephFS Quotas
 ---------------------------------------

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -1382,6 +1382,20 @@ class CephFSMount(object):
             # gives you [''] instead of []
             return []
 
+    def removexattr(self, path, key, **kwargs):
+        """
+        Wrap setfattr removal.
+
+        :param path: relative to mount point
+        :param key: xattr name
+        :return: None
+        """
+        kwargs['args'] = ["setfattr", "-x", key, path]
+        if kwargs.pop('sudo', False):
+            kwargs['args'].insert(0, 'sudo')
+            kwargs['omit_sudo'] = False
+        self.run_shell(**kwargs)
+
     def setfattr(self, path, key, val, **kwargs):
         """
         Wrap setfattr.

--- a/qa/workunits/fs/misc/general_vxattrs.sh
+++ b/qa/workunits/fs/misc/general_vxattrs.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# test setfattr remove, and check values of vxattr
+# after remove for vxattr, where possible.
+
+set -ex
+
+mkdir -p dir
+
+#ceph.dir.pin test, def val -1, reset val -1
+getfattr -n ceph.dir.pin dir | grep 'ceph.dir.pin="-1"'
+setfattr -n ceph.dir.pin dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -n ceph.dir.pin -v 1 dir
+getfattr -n ceph.dir.pin dir | grep 'ceph.dir.pin="1"'
+setfattr -x ceph.dir.pin dir
+getfattr -n ceph.dir.pin dir | grep 'ceph.dir.pin="-1"'
+
+#TODO: Once test machines support getfattr for vxattr, uncomment getfattr below
+#see: https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/thread/EZL3POLMQLMMNBPAJ2QQ2BAKH44VUNJU/#JJNRRYLUKUAUN5HIL5A7Q4N63OCLWQXF
+#for further detail
+
+#ceph.dir.pin.distributed, def val 0, reset val 0
+#getfattr -n ceph.dir.pin.distributed dir | grep 'ceph.dir.pin.distributed="0"'
+setfattr -n ceph.dir.pin.distributed dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -n ceph.dir.pin.distributed -v 1 dir
+#getfattr -n ceph.dir.pin.distributed dir | grep 'ceph.dir.pin.distributed="1"'
+setfattr -x ceph.dir.pin.distributed dir
+#getfattr -n ceph.dir.pin.distributed dir | grep 'ceph.dir.pin.distributed="0"'
+
+#ceph.dir.pin.random def val 0, reset val 0
+#getfattr -n ceph.dir.pin.random dir | grep 'ceph.dir.pin.random="0"'
+setfattr -n ceph.dir.pin.random dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -n ceph.dir.pin.random -v 0.01 dir
+#getfattr -n ceph.dir.pin.random dir | grep 'ceph.dir.pin.random="0.01"'
+setfattr -x ceph.dir.pin.random dir
+#getfattr -n ceph.dir.pin.random dir | grep 'ceph.dir.pin.random="0"'
+
+#ceph.quota, def value 0, reset val 0
+setfattr -n ceph.quota.max_bytes dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -n ceph.quota.max_bytes -v 100000000 dir
+#getfattr -n ceph.quota.max_bytes dir | grep 'ceph.quota.max_bytes="100000000"'
+setfattr -x ceph.quota.max_bytes dir
+setfattr -n ceph.quota.max_files dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -n ceph.quota.max_files -v 10000 dir
+#getfattr -n ceph.quota.max_files dir | grep 'ceph.quota.max_files="10000"'
+setfattr -x ceph.quota.max_files dir
+
+rmdir dir
+
+echo OK
+

--- a/qa/workunits/fs/misc/layout_vxattrs.sh
+++ b/qa/workunits/fs/misc/layout_vxattrs.sh
@@ -105,6 +105,23 @@ getfattr -n ceph.file.layout.stripe_count dir/file | grep -q 8
 getfattr -n ceph.file.layout.object_size dir/file | grep -q 10485760
 getfattr -n ceph.file.layout.pool_namespace dir/file | grep -q dirns
 
+#Per https://docs.ceph.com/en/latest/cephfs/file-layouts/#clearing-layouts, pool_namespace
+#can be individually removed, while other layout xattrs must be cleared together.
+setfattr -x ceph.dir.layout.pool dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -x ceph.dir.layout.pool_id dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -x ceph.dir.layout.pool_name dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -x ceph.dir.layout.stripe_unit dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -x ceph.dir.layout.stripe_count dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -x ceph.dir.layout.object_size dir 2>&1 | grep "setfattr: dir: Invalid argument"
+
+setfattr -x ceph.file.layout.pool dir/file 2>&1 | grep "setfattr: dir/file: Invalid argument"
+setfattr -x ceph.file.layout.pool_id dir/file 2>&1 | grep "setfattr: dir/file: Invalid argument"
+setfattr -x ceph.file.layout.pool_name dir/file 2>&1 | grep "setfattr: dir/file: Invalid argument"
+setfattr -x ceph.file.layout.stripe_unit dir/file 2>&1 | grep "setfattr: dir/file: Invalid argument"
+setfattr -x ceph.file.layout.stripe_count dir/file 2>&1 | grep "setfattr: dir/file: Invalid argument"
+setfattr -x ceph.file.layout.object_size dir/file 2>&1 | grep "setfattr: dir/file: Invalid argument"
+setfattr -x ceph.file.layout.pool_namespace dir/file
+
 setfattr -x ceph.dir.layout.pool_namespace dir
 getfattr -n ceph.dir.layout dir | grep -q -v pool_namespace=dirns
 

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -228,8 +228,7 @@ public:
                           std::string name,
                           std::string value,
                           file_layout_t *layout);
-  void handle_set_vxattr(MDRequestRef& mdr, CInode *cur);
-  void handle_remove_vxattr(MDRequestRef& mdr, CInode *cur);
+  void handle_client_setvxattr(MDRequestRef& mdr, CInode *cur);
   void handle_client_getvxattr(MDRequestRef& mdr);
   void handle_client_setxattr(MDRequestRef& mdr);
   void handle_client_removexattr(MDRequestRef& mdr);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66733

---

backport of https://github.com/ceph/ceph/pull/53755
parent tracker: https://tracker.ceph.com/issues/62793

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh