### PR TITLE
script/ceph-backport: robustness adjustments for local git repo quirks

### DIFF
--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -292,7 +292,7 @@ function cherry_pick_phase {
         git checkout -b "$local_branch" FETCH_HEAD
     fi
 
-    git fetch "$upstream_remote" "pull/$original_pr/head:pr-$original_pr"
+    git fetch "$upstream_remote" "$merge_commit_sha"
 
     set +x
     maybe_restore_set_x

--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -258,13 +258,13 @@ function cherry_pick_phase {
     fi
 
     set -x
-    git fetch "$upstream_remote"
+    git fetch "$upstream_remote" "refs/heads/${milestone}"
 
     if git show-ref --verify --quiet "refs/heads/$local_branch" ; then
         if [ "$FORCE" ] ; then
             if [ "$non_interactive" ] ; then
                 git checkout "$local_branch"
-                git reset --hard "${upstream_remote}/${milestone}"
+                git reset --hard FETCH_HEAD
             else
                 echo
                 echo "A local branch $local_branch already exists and the --force option was given."
@@ -276,7 +276,7 @@ function cherry_pick_phase {
                 [ "$yes_or_no_answer" ] && yes_or_no_answer="${yes_or_no_answer:0:1}"
                 if [ "$yes_or_no_answer" = "y" ] ; then
                     git checkout "$local_branch"
-                    git reset --hard "${upstream_remote}/${milestone}"
+                    git reset --hard FETCH_HEAD
                 else
                     info "OK, bailing out!"
                     false
@@ -289,7 +289,7 @@ function cherry_pick_phase {
             false
         fi
     else
-        git checkout "${upstream_remote}/${milestone}" -b "$local_branch"
+        git checkout -b "$local_branch" FETCH_HEAD
     fi
 
     git fetch "$upstream_remote" "pull/$original_pr/head:pr-$original_pr"


### PR DESCRIPTION



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
