### PR TITLE
crimson/os/seastore/btree: interrupt transactions immediately when getting children

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -1491,9 +1491,9 @@ private:
     // checking the lba child must be atomic with creating
     // and linking the absent child
     if (v.has_child()) {
-      return v.get_child_fut().safe_then(
-        [on_found=std::move(on_found), node_iter, c,
-        parent_entry](auto child) mutable {
+      return trans_intr::make_interruptible(std::move(v.get_child_fut())
+      ).si_then([on_found=std::move(on_found), node_iter, c,
+                parent_entry](auto child) {
         LOG_PREFIX(FixedKVBtree::lookup_internal_level);
         SUBTRACET(seastore_fixedkv_tree,
           "got child on {}, pos: {}, res: {}",
@@ -1561,9 +1561,9 @@ private:
     // checking the lba child must be atomic with creating
     // and linking the absent child
     if (v.has_child()) {
-      return v.get_child_fut().safe_then(
-        [on_found=std::move(on_found), node_iter, c,
-        parent_entry](auto child) mutable {
+      return trans_intr::make_interruptible(std::move(v.get_child_fut())
+      ).si_then([on_found=std::move(on_found), node_iter, c,
+                parent_entry](auto child) {
         LOG_PREFIX(FixedKVBtree::lookup_leaf);
         SUBTRACET(seastore_fixedkv_tree,
           "got child on {}, pos: {}, res: {}",
@@ -2116,9 +2116,9 @@ private:
     // checking the lba child must be atomic with creating
     // and linking the absent child
     if (v.has_child()) {
-      return v.get_child_fut().safe_then(
-        [do_merge=std::move(do_merge), &pos,
-        donor_iter, donor_is_left, c, parent_pos](auto child) mutable {
+      return trans_intr::make_interruptible(std::move(v.get_child_fut())
+      ).si_then([do_merge=std::move(do_merge), &pos,
+                donor_iter, donor_is_left, c, parent_pos](auto child) {
         LOG_PREFIX(FixedKVBtree::merge_level);
         SUBTRACET(seastore_fixedkv_tree,
           "got child on {}, pos: {}, res: {}",


### PR DESCRIPTION
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
