### PR TITLE
🧹 cephadmlib/daemons/nvmeof.py: black reformat

### DIFF
--- a/src/cephadm/cephadmlib/daemons/nvmeof.py
+++ b/src/cephadm/cephadmlib/daemons/nvmeof.py
@@ -63,7 +63,9 @@ class CephNvmeof(ContainerDaemonForm):
         return DaemonIdentity(self.fsid, self.daemon_type, self.daemon_id)
 
     @staticmethod
-    def _get_container_mounts(data_dir: str, log_dir: str) -> Dict[str, str]:
+    def _get_container_mounts(
+        data_dir: str, log_dir: str, mtls_dir: Optional[str] = None
+    ) -> Dict[str, str]:
         mounts = dict()
         mounts[os.path.join(data_dir, 'config')] = '/etc/ceph/ceph.conf:z'
         mounts[os.path.join(data_dir, 'keyring')] = '/etc/ceph/keyring:z'


### PR DESCRIPTION
# fix jenkins "make check" CI error

black ci error: https://jenkins.ceph.com/job/ceph-pull-requests/137944/consoleFull#-1762044592e2f9bd1b-f570-4eac-a6c0-0080730e3135

```log
check-black: commands[0] /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm> black --check -l78 -t py36 --skip-string-normalization -v cephadmlib/ Identified `/home/jenkins-build/build/workspace/ceph-pull-requests` as project root containing a .git directory. Found input source directory: "/home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib" /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/__init__.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/agent.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/call_wrappers.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/constants.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/container_daemon_form.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/container_engine_base.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/container_engines.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/container_types.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/context.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/context_getters.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemon_form.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemon_identity.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemons/__init__.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemons/ceph.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemons/custom.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemons/ingress.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemons/iscsi.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemons/monitoring.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemons/nfs.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemons/node_proxy.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemons/smb.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemons/snmp.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemons/tracing.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/data_utils.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/decorators.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/deploy.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/deployment_utils.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/exceptions.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/exe_utils.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/file_utils.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/firewalld.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/host_facts.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/locking.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/logging.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/net_utils.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/packagers.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/runscripts.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/ssh.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/sysctl.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/systemd.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/systemd_unit.py wasn't modified on disk since last run. /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/templating.py wasn't modified on disk since last run. would reformat /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm/cephadmlib/daemons/nvmeof.py

Oh no! 💥 💔 💥
1 file would be reformatted, 42 files would be left unchanged. check-black: exit 1 (0.66 seconds) /home/jenkins-build/build/workspace/ceph-pull-requests/src/cephadm> black --check -l78 -t py36 --skip-string-normalization -v cephadmlib/ pid=1799926 check-black: FAIL ✖ in 8.14 seconds
```
