### PR TITLE
Revert "qa/tasks/cephfs: don't create a new CephManager if there is o…

### DIFF
--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -233,15 +233,10 @@ class CephClusterBase(RunCephCmd):
         (result,) = self._ctx.cluster.only(first_mon).remotes.keys()
         return result
 
-    def __init__(self, ctx, cluster_name='ceph') -> None:
+    def __init__(self, ctx) -> None:
         self._ctx = ctx
-        try:
-            manager = ctx.managers[cluster_name]
-        except Exception as e:
-            log.warn(f"Couldn't get a manager for cluster {cluster_name} from the context; exception: {e}")
-            manager = CephManager(self.admin_remote, ctx=ctx,
-                                  logger=log.getChild('ceph_manager'))
-        self.mon_manager = manager
+        self.mon_manager = CephManager(self.admin_remote, ctx=ctx,
+                                       logger=log.getChild('ceph_manager'))
 
     def get_config(self, key, service_type=None):
         """
@@ -313,8 +308,8 @@ class MDSClusterBase(CephClusterBase):
     as a separate instance outside of your (multiple) Filesystem instances.
     """
 
-    def __init__(self, ctx, cluster_name='ceph'):
-        super(MDSClusterBase, self).__init__(ctx, cluster_name=cluster_name)
+    def __init__(self, ctx):
+        super(MDSClusterBase, self).__init__(ctx)
 
     @property
     def mds_ids(self):
@@ -539,13 +534,13 @@ class FilesystemBase(MDSClusterBase):
     This object is for driving a CephFS filesystem.  The MDS daemons driven by
     MDSCluster may be shared with other Filesystems.
     """
-    def __init__(self, ctx, fs_config={}, fscid=None, name=None, create=False, cluster_name='ceph',
+    def __init__(self, ctx, fs_config={}, fscid=None, name=None, create=False,
                  **kwargs):
         """
         kwargs accepts recover: bool, allow_dangerous_metadata_overlay: bool,
         yes_i_really_really_mean_it: bool and fs_ops: list[str]
         """
-        super(FilesystemBase, self).__init__(ctx, cluster_name=cluster_name)
+        super(FilesystemBase, self).__init__(ctx)
 
         self.name = name
         self.id = None


### PR DESCRIPTION
…ne in the context"

This reverts commit 329edd3c56baff81cb76c5008ac2eaf7c110f9e1. This is temporary revert to unblock snap-scheule testing in teuthology.

See also: https://tracker.ceph.com/issues/66009

Fixes: https://tracker.ceph.com/issues/66763
Signedo-off-by: Milind Changire <mchangir@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
