### PR TITLE
squid: doc/cephfs: update cephfs-shell link

### DIFF
--- a/doc/cephfs/mount-prerequisites.rst
+++ b/doc/cephfs/mount-prerequisites.rst
@@ -2,11 +2,11 @@ Mount CephFS: Prerequisites
 ===========================
 
 You can use CephFS by mounting it to your local filesystem or by using
-`cephfs-shell`_. Mounting CephFS requires superuser privileges to trim
-dentries by issuing a remount of itself. CephFS can be mounted
-`using kernel`_ as well as `using FUSE`_. Both have their own
-advantages. Read the following section to understand more about both of
-these ways to mount CephFS.
+:ref:`cephfs-shell <cephfs-shell>`. Mounting CephFS requires superuser
+privileges to trim dentries by issuing a remount of itself. CephFS can be
+mounted `using kernel`_ as well as `using FUSE`_. Both have their own
+advantages. Read the following section to understand more about both of these
+ways to mount CephFS.
 
 For Windows CephFS mounts, please check the `ceph-dokan`_ page.
 
@@ -69,7 +69,7 @@ Ceph MON resides.
    individually, please check respective mount documents.
 
 .. _Client Authentication: ../client-auth
-.. _cephfs-shell: ../cephfs-shell
+.. _cephfs-shell: ..cephfs-shell
 .. _using kernel: ../mount-using-kernel-driver
 .. _using FUSE: ../mount-using-fuse
 .. _ceph-dokan: ../ceph-dokan

--- a/doc/man/8/cephfs-shell.rst
+++ b/doc/man/8/cephfs-shell.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _cephfs-shell:
+
 ===================================================
 cephfs-shell -- Shell-like tool talking with CephFS
 ===================================================


### PR DESCRIPTION
Repair the link to cephfs-shell.rst in doc/cephfs/cephfs-shell.rst that was broken in https://github.com/ceph/ceph/pull/41165/ when doc/cephfs/cephfs-shell.rst was moved to doc/man/8/cephfs-shell.rst.

This commit is made in response to a request by Lander Duncan that was made on the [ceph-users] mailing list, and can be seen here: https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/thread/F7V4CWLIYCAJ4JXI2JLNY6QPCFPR4SLA/

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 4f8903cf80a94596a1b17b4a07affb874f21ae76)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
