### PR TITLE
qa/workunits/erasure-code: add a new bash script that can be used to

### DIFF
--- a/qa/workunits/erasure-code/plugin-comparison.sh
+++ b/qa/workunits/erasure-code/plugin-comparison.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# This script uses ceph_erasure_code_non_regression to encode
+# data with a specified set of plugins, techniques and stripe widths.
+# md5sums of each chunk are calculated and added to the output file
+# so that the output of each plugin can be inspected and compared.
+#
+# An example invocation:
+#
+#  PLUGIN_DIRECTORY=/ceph/build/lib \
+#  CEPH_ERASURE_CODE_NON_REGRESSION=/ceph/build/bin/ceph_erasure_code_non_regression \
+#  K=3 M=1 STRIPE_WIDTHS="128 256" /ceph/qa/workunits/erasure-code/plugin-comparison.sh
+#
+# This will create an output directory called plugin_comparison and
+# an output file called plugin_comparison/output
+#
+
+set -e
+
+export PATH=/sbin:$PATH
+
+: ${CEPH_ERASURE_CODE_NON_REGRESSION:=ceph_erasure_code_non_regression}
+: ${PLUGIN_DIRECTORY:=/ceph/build/lib}
+: ${OUTPUT_DIRECTORY:=plugin_comparison}
+: ${OUTPUT_FILE:=output}
+: ${PLUGINS:=isa jerasure}
+#: ${TECHNIQUES:=vandermonde cauchy liberation reed_sol_r6_op blaum_roth liber8tion}
+: ${TECHNIQUES:=vandermonde cauchy reed_sol_r6_op}
+: ${STRIPE_WIDTHS:=4096 10000}
+: ${K:=3}
+: ${M:=1 2}
+
+declare -rA isa_techniques=(
+    [vandermonde]="reed_sol_van"
+    [cauchy]="cauchy"
+)
+
+declare -rA jerasure_techniques=(
+    [vandermonde]="reed_sol_van"
+    [cauchy]="cauchy_good"
+    [reed_sol_r6_op]="reed_sol_r6_op"
+    [blaum_roth]="blaum_roth"
+    [liberation]="liberation"
+    [liber8tion]="liber8tion"
+)
+
+function get_technique_name()
+{
+    local plugin=$1
+    local technique=$2
+
+    declare -n techniques="${plugin}_techniques"
+    echo ${techniques["$technique"]}
+}
+
+function technique_is_raid6() {
+    local technique=$1
+    local r6_techniques="liberation reed_sol_r6_op blaum_roth liber8tion"
+
+    if [[ $r6_techniques =~ $technique ]]; then
+        return 0
+    fi
+    return 1
+}
+
+mkdir ${OUTPUT_DIRECTORY}
+
+for stripe_width in ${STRIPE_WIDTHS} ; do
+    for technique in ${TECHNIQUES} ; do
+        for plugin in ${PLUGINS} ; do  
+            technique_parameter=$(get_technique_name $plugin $technique)
+            if [[ -z $technique_parameter ]]; then continue; fi
+            for k in ${K} ; do
+                for m in ${M} ; do
+                    chunk_counter=$(($k+$m))
+                    if [ $m -ne 2 ] && technique_is_raid6 $technique; then continue; fi
+                    if [ $m -gt $k ]; then continue; fi
+                    ${CEPH_ERASURE_CODE_NON_REGRESSION} --plugin $plugin --stripe-width $stripe_width --parameter k=$k \
+                        --parameter m=$m --parameter technique=$technique_parameter --base ${OUTPUT_DIRECTORY} --create
+                    for ((chunk = 0; chunk < $chunk_counter; chunk++)) do
+                        md5sum ${OUTPUT_DIRECTORY}/plugin\=$plugin\ stripe-width\=$stripe_width\ k\=$k\ m\=$m\ technique\=$technique_parameter/$chunk >> ${OUTPUT_DIRECTORY}/${OUTPUT_FILE}
+                    done
+                    echo ' ' >> ${OUTPUT_DIRECTORY}/${OUTPUT_FILE}
+                done
+            done
+        done
+    done
+done


### PR DESCRIPTION
compare the output of selected ec plugins and techniques

This PR adds a new script that calls ceph_erasure_code_non_regression to generate encoded chunks for a specified list of plugins and techniques (and stripe widths, K and M values). 

A hash of each chunk is calculated and added to an output file, which can then be inspected to compare the output of the plugins. This is useful when trying to decide if it would be possible to switch from one plugin to another. 

In the following example it can be seen that the ISA reed_sol_van technique produces different parity chunks for M>1 than the Jerasure reed_sol_van technique, so it would not be straightforward to switch the plugin for an existing pool using the reed_sol_van technique.

An example run:

`CEPH_ERASURE_CODE_NON_REGRESSION=/ceph/build/bin/ceph_erasure_code_non_regression STRIPE_WIDTHS="256" K=3 M=3 /ceph/qa/workunits/erasure-code/plugin-comparison.sh`

```
[root@9d9c7969fd9a build]# cat plugin_comparison/output
489715dfc67930395b840e6f62f87310  plugin_comparison/plugin=isa stripe-width=256 k=3 m=3 technique=reed_sol_van/0
f2dfcedc0cbd3b8247267941e44ede2b  plugin_comparison/plugin=isa stripe-width=256 k=3 m=3 technique=reed_sol_van/1
3b86c3580ddae1fd8a2bf7b0d94ef931  plugin_comparison/plugin=isa stripe-width=256 k=3 m=3 technique=reed_sol_van/2
3041babbcf88ebd486a4e103e7cdc4ae  plugin_comparison/plugin=isa stripe-width=256 k=3 m=3 technique=reed_sol_van/3
72af377096a80419bc2d607031ad3404  plugin_comparison/plugin=isa stripe-width=256 k=3 m=3 technique=reed_sol_van/4
4d88897a89854d5732fd094b401d3107  plugin_comparison/plugin=isa stripe-width=256 k=3 m=3 technique=reed_sol_van/5

489715dfc67930395b840e6f62f87310  plugin_comparison/plugin=jerasure stripe-width=256 k=3 m=3 technique=reed_sol_van/0
f2dfcedc0cbd3b8247267941e44ede2b  plugin_comparison/plugin=jerasure stripe-width=256 k=3 m=3 technique=reed_sol_van/1
3b86c3580ddae1fd8a2bf7b0d94ef931  plugin_comparison/plugin=jerasure stripe-width=256 k=3 m=3 technique=reed_sol_van/2
3041babbcf88ebd486a4e103e7cdc4ae  plugin_comparison/plugin=jerasure stripe-width=256 k=3 m=3 technique=reed_sol_van/3
858b48eb0c113ee3f217e91a426fc4fd  plugin_comparison/plugin=jerasure stripe-width=256 k=3 m=3 technique=reed_sol_van/4
b50e4bdf05f80ba7cab1164505cd6e87  plugin_comparison/plugin=jerasure stripe-width=256 k=3 m=3 technique=reed_sol_van/5

...

```
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
