### PR TITLE
squid: cephadm/services/ingress: fixed keepalived config bug

### DIFF
--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -260,7 +260,10 @@ class IngressService(CephService):
             for subnet, ifaces in self.mgr.cache.networks.get(host, {}).items():
                 if ifaces and ipaddress.ip_address(bare_ip) in ipaddress.ip_network(subnet):
                     interface = list(ifaces.keys())[0]
-                    host_ip = ifaces[interface][0]
+                    for ip_addr in ifaces[interface]:
+                        if ip_addr != str(bare_ip):
+                            host_ip = ip_addr
+                            break
                     logger.info(
                         f'{bare_ip} is in {subnet} on {host} interface {interface}'
                     )
@@ -270,7 +273,10 @@ class IngressService(CephService):
                 for subnet, ifaces in self.mgr.cache.networks.get(host, {}).items():
                     if subnet in spec.virtual_interface_networks:
                         interface = list(ifaces.keys())[0]
-                        host_ip = ifaces[interface][0]
+                        for ip_addr in ifaces[interface]:
+                            if ip_addr != str(bare_ip):
+                                host_ip = ip_addr
+                                break
                         logger.info(
                             f'{spec.virtual_ip} will be configured on {host} interface '
                             f'{interface} (which is in subnet {subnet})'

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -1846,7 +1846,10 @@ class TestIngressService:
         with with_host(cephadm_module, 'test', addr='1.2.3.7'):
             cephadm_module.cache.update_host_networks('test', {
                 '1.2.3.0/24': {
-                    'if0': ['1.2.3.4']
+                    'if0': [
+                        '1.2.3.4',  # simulate already assigned VIP
+                        '1.2.3.1',  # simulate interface IP
+                    ]
                 }
             })
 
@@ -1894,7 +1897,7 @@ class TestIngressService:
                                 'auth_type PASS\n      '
                                 'auth_pass 12345\n  '
                                 '}\n  '
-                                'unicast_src_ip 1.2.3.4\n  '
+                                'unicast_src_ip 1.2.3.1\n  '
                                 'unicast_peer {\n  '
                                 '}\n  '
                                 'virtual_ipaddress {\n    '


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/57848


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
