### PR TITLE
squid: mgr/cephadm: redeploy when some dependency daemon is add/removed

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1093,7 +1093,7 @@ class CephadmServe:
                 action = 'reconfig'
                 # we need only redeploy if secure_monitoring_stack value has changed:
                 if dd.daemon_type in ['prometheus', 'node-exporter', 'alertmanager']:
-                    diff = list(set(last_deps) - set(deps))
+                    diff = list(set(last_deps).symmetric_difference(set(deps)))
                     if any('secure_monitoring_stack' in e for e in diff):
                         action = 'redeploy'
                 elif dd.daemon_type == 'jaeger-agent':

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -1418,7 +1418,6 @@ spec:
                             "deploy_arguments": [],
                             "params": {
                                 'tcp_ports': [4200, 9094],
-                                'reconfig': True,
                             },
                             "meta": {
                                 'service_name': 'alertmanager',
@@ -1432,7 +1431,7 @@ spec:
                             },
                             "config_blobs": {},
                         }),
-                        use_current_daemon_image=True,
+                        use_current_daemon_image=False,
                     )
 
 


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/58230


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
