### PR TITLE
mgr/dashboard: add cephfs rename REST API

### DIFF
--- a/qa/tasks/mgr/dashboard/test_cephfs.py
+++ b/qa/tasks/mgr/dashboard/test_cephfs.py
@@ -94,6 +94,12 @@ class CephfsTest(DashboardTestCase):
         self.assertIsInstance(data, dict)
         return data
 
+    def rename_path(self, src_path, dst_path):
+        params = {'src_path': src_path, 'dst_path': dst_path}
+        self._put(f"/api/cephfs/{self.get_fs_id()}/rename-path",
+                  data=params)
+        self.assertStatus(200)
+
     @DashboardTestCase.RunAs('test', 'test', ['block-manager'])
     def test_access_permissions(self):
         fs_id = self.get_fs_id()
@@ -361,3 +367,9 @@ class CephfsTest(DashboardTestCase):
         self.fs.set_joinable()
         self._get(f"/api/cephfs/{fs_id}/clients")
         self.assertStatus(200)
+
+    def test_rename_path(self):
+        self.mk_dirs('/apple')
+        self.rename_path('/apple', '/orange')
+        self.ls_dir('/orange', 0)
+        self.rm_dir('/orange')

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -639,6 +639,17 @@ class CephFS(RESTController):
         cfs = self._cephfs_instance(fs_id)
         cfs.rm_snapshot(path, name)
 
+    @RESTController.Resource('PUT', path='/rename-path')
+    def rename_path(self, fs_id, src_path, dst_path) -> None:
+        """
+        Rename a file or directory.
+        :param fs_id: The filesystem identifier.
+        :param src_path: The path to the existing file or directory.
+        :param dst_path: The new name of the file or directory.
+        """
+        cfs = self._cephfs_instance(fs_id)
+        cfs.rename_path(src_path, dst_path)
+
 
 class CephFSClients(object):
     def __init__(self, module_inst, fscid):

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -3116,6 +3116,55 @@ paths:
       - jwt: []
       tags:
       - Cephfs
+  /api/cephfs/{fs_id}/rename-path:
+    put:
+      description: "\n        Rename a file or directory.\n        :param fs_id: The\
+        \ filesystem identifier.\n        :param src_path: The path to the existing\
+        \ file or directory.\n        :param dst_path: The new name of the file or\
+        \ directory.\n        "
+      parameters:
+      - in: path
+        name: fs_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                dst_path:
+                  type: string
+                src_path:
+                  type: string
+              required:
+              - src_path
+              - dst_path
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '202':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Operation is still executing. Please check the task queue.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - Cephfs
   /api/cephfs/{fs_id}/snapshot:
     delete:
       description: "\n        Remove a snapshot.\n        :param fs_id: The filesystem\

--- a/src/pybind/mgr/dashboard/services/cephfs.py
+++ b/src/pybind/mgr/dashboard/services/cephfs.py
@@ -298,3 +298,12 @@ class CephFS(object):
             rfiles = int(self.cfs.getxattr(path, 'ceph.dir.rfiles'))
             rsubdirs = int(self.cfs.getxattr(path, 'ceph.dir.rsubdirs'))
         return {'bytes': rbytes, 'files': rfiles, 'subdirs': rsubdirs}
+
+    def rename_path(self, src_path, dst_path) -> None:
+        """
+        Rename a file or directory.
+        :param src: the path to the existing file or directory.
+        :param dst: the new name of the file or directory.
+        """
+        logger.info("Renaming: from %s to %s", src_path, dst_path)
+        self.cfs.rename(src_path, dst_path)


### PR DESCRIPTION
Introduce rename for the cephfs REST API controller, we can rename the existing file or directory by it.

Fixes: https://tracker.ceph.com/issues/66797



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
