### PR TITLE
mgr/dashboard: add better modal confirmations for critical actions

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html
@@ -5,10 +5,7 @@
   </ng-container>
 
   <ng-container class="modal-content">
-    <form name="deletionForm"
-          #formDir="ngForm"
-          [formGroup]="deletionForm"
-          novalidate>
+    <form [formGroup]="deletionForm" novalidate>
       <div class="modal-body">
         <cd-alert-panel *ngIf="infoMessage"
                         type="info"
@@ -19,30 +16,34 @@
         <ng-container *ngTemplateOutlet="bodyTemplate; context: bodyContext"></ng-container>
         <div class="question">
           <span *ngIf="itemNames; else noNames">
-            <p *ngIf="itemNames.length === 1; else manyNames"
-               i18n>Are you sure that you want to {{ actionDescription | lowercase }} <strong>{{ itemNames[0] }}</strong>?</p>
+            <p *ngIf="itemNames.length === 1; else manyNames" i18n>
+              Are you sure that you want to {{ actionDescription | lowercase }} <strong>{{ itemNames[0] }}</strong>?
+            </p>
             <ng-template #manyNames>
               <p i18n>Are you sure that you want to {{ actionDescription | lowercase }} the selected items?</p>
               <ul>
-                <li *ngFor="let itemName of itemNames"><strong>{{ itemName }}</strong></li>
+                <li *ngFor="let itemName of itemNames">
+                  <strong>{{ itemName }}</strong>
+                </li>
               </ul>
-            </ng-template >
+            </ng-template>
           </span>
           <ng-template #noNames>
             <p i18n>Are you sure that you want to {{ actionDescription | lowercase }} the selected {{ itemDescription }}?</p>
           </ng-template>
           <ng-container *ngTemplateOutlet="childFormGroupTemplate; context:{form:deletionForm}"></ng-container>
           <div class="form-group">
-            <div class="custom-control custom-checkbox">
-              <input type="checkbox"
-                     class="custom-control-input"
-                     name="confirmation"
-                     id="confirmation"
-                     formControlName="confirmation"
-                     autofocus>
-              <label class="custom-control-label"
-                     for="confirmation"
-                     i18n>Yes, I am sure.</label>
+            <label for="confirmationInput" i18n>Please type the resource name(s) to confirm deletion:</label>
+            <input type="text"
+                   class="form-control"
+                   id="confirmationInput"
+                   formControlName="confirmationInput"
+                   [ngClass]="{'is-invalid': deletionForm.controls.confirmationInput.invalid && (deletionForm.controls.confirmationInput.dirty || deletionForm.controls.confirmationInput.touched)}"
+                   (input)="onInputChange()"
+                   autofocus>
+            <div *ngIf="deletionForm.controls.confirmationInput.invalid && (deletionForm.controls.confirmationInput.dirty || deletionForm.controls.confirmationInput.touched)"
+                 class="invalid-feedback" i18n>
+              Resource name(s) should exactly match to confirm deletion.
             </div>
           </div>
         </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.ts
@@ -23,18 +23,25 @@ export class CriticalConfirmationModalComponent implements OnInit {
   backAction: Function;
   deletionForm: CdFormGroup;
   itemDescription: 'entry';
-  itemNames: string[];
+  itemNames: { poolName: string, namespace: string, imageName: string }[] = [];
   actionDescription = 'delete';
   infoMessage: string;
 
   childFormGroup: CdFormGroup;
   childFormGroupTemplate: TemplateRef<any>;
 
+  providedName: string;
+
   constructor(public activeModal: NgbActiveModal) {}
 
   ngOnInit() {
+    this.providedName = '';
+
     const controls = {
-      confirmation: new UntypedFormControl(false, [Validators.requiredTrue])
+      confirmationInput: new UntypedFormControl('', [
+        Validators.required,
+        this.confirmationValidator.bind(this)
+      ])
     };
     if (this.childFormGroup) {
       controls['child'] = this.childFormGroup;
@@ -43,6 +50,36 @@ export class CriticalConfirmationModalComponent implements OnInit {
     if (!(this.submitAction || this.submitActionObservable)) {
       throw new Error('No submit action defined');
     }
+  }
+
+  git clone --depth 1 --single-branch git@github.com:ceph/ceph.git
+  git clone --depth 1 --single-branch https://github.com/himanshu-0611/ceph-dev.git
+  
+  confirmationValidator(control: UntypedFormControl) {
+    const input = control.value;
+    this.providedName = input;
+  
+    let resourceName = 'default';
+  
+    if (this.itemNames.length > 0) {
+      const item = this.itemNames[0];
+  
+      if (typeof item === 'string') {
+        resourceName = item;
+      } else if (item.poolName && item.imageName) {
+        resourceName = `${item.poolName}/${item.imageName}`;
+      } else if (item.poolName) {
+        resourceName = item.poolName;
+      } else if (item.imageName) {
+        resourceName = item.imageName;
+      }
+    }
+  
+    return input === resourceName ? null : { mismatch: true };
+  }
+
+  onInputChange() {
+    this.deletionForm.controls.confirmationInput.updateValueAndValidity();
   }
 
   callSubmitAction() {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/66057
Signed-off-by: Himanshu Agarkar <agarkarhimanshu456@gmail.com>

https://github.com/ceph/ceph/assets/87313450/b4c561e5-5980-4689-9411-68229f8b1192

Currently if single resource has to be deleted, its working, but if multiple resources have to be deleted at once (users goes for multiselect deletion), the user will have to input name of the first resource to delete all of them.

Suggest if any further updates are required in the UI/backend.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
