### PR TITLE
squid: qa/tasks: Initialize 'monitoring_profiles' spec to an empty dict

### DIFF
--- a/qa/tasks/cbt.py
+++ b/qa/tasks/cbt.py
@@ -64,7 +64,7 @@ class CBT(Task):
                    (remote.ssh.get_transport().getpeername() for (remote, role_list) in remotes_and_roles)]
             benchmark_config['cosbench']['auth'] = "username=cosbench:operator;password=intel2012;url=http://%s:80/auth/v1.0;retry=9" %(ips[0])
         client_endpoints_config = self.config.get('client_endpoints', None)
-        monitoring_profiles = self.config.get('monitoring_profiles', None)
+        monitoring_profiles = self.config.get('monitoring_profiles', {})
 
         return dict(
             cluster=cluster_config,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66807

---

backport of https://github.com/ceph/ceph/pull/58388
parent tracker: https://tracker.ceph.com/issues/66799

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh