### PR TITLE
mgr/cephadm: adding mTLS for ceph mgmt-gateway and backend services communication

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -2421,11 +2421,23 @@ def prepare_dashboard(
             pathify(ctx.dashboard_crt.name): '/tmp/dashboard.crt:z',
             pathify(ctx.dashboard_key.name): '/tmp/dashboard.key:z'
         }
-        cli(['dashboard', 'set-ssl-certificate', '-i', '/tmp/dashboard.crt'], extra_mounts=mounts)
-        cli(['dashboard', 'set-ssl-certificate-key', '-i', '/tmp/dashboard.key'], extra_mounts=mounts)
     else:
-        logger.info('Generating a dashboard self-signed certificate...')
-        cli(['dashboard', 'create-self-signed-cert'])
+        logger.info('Using certmgr to generate dashboard self-signed certificate...')
+        cert_key = json_loads_retry(lambda: cli(['orch', 'certmgr', 'generate-certificates', 'dashboard'],
+                                                verbosity=CallVerbosity.QUIET_UNLESS_ERROR))
+        mounts = {}
+        if cert_key:
+            cert_file = write_tmp(cert_key['cert'], uid, gid)
+            key_file = write_tmp(cert_key['key'], uid, gid)
+            mounts = {
+                cert_file.name: '/tmp/dashboard.crt:z',
+                key_file.name: '/tmp/dashboard.key:z'
+            }
+        else:
+            logger.error('Cannot generate certificates for Ceph dashboard.')
+
+    cli(['dashboard', 'set-ssl-certificate', '-i', '/tmp/dashboard.crt'], extra_mounts=mounts)
+    cli(['dashboard', 'set-ssl-certificate-key', '-i', '/tmp/dashboard.key'], extra_mounts=mounts)
 
     logger.info('Creating initial admin user...')
     password = ctx.initial_dashboard_password or generate_password()

--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -167,6 +167,7 @@ from cephadmlib import templating
 from cephadmlib.daemons.ceph import get_ceph_mounts_for_type, ceph_daemons
 from cephadmlib.daemons import (
     Ceph,
+    CephExporter,
     CephIscsi,
     CephNvmeof,
     CustomContainer,
@@ -866,6 +867,10 @@ def create_daemon_dirs(
     elif daemon_type == NodeProxy.daemon_type:
         node_proxy = NodeProxy.init(ctx, fsid, ident.daemon_id)
         node_proxy.create_daemon_dirs(data_dir, uid, gid)
+
+    elif daemon_type == CephExporter.daemon_type:
+        ceph_exporter = CephExporter.init(ctx, fsid, ident.daemon_id)
+        ceph_exporter.create_daemon_dirs(data_dir, uid, gid)
 
     else:
         daemon = daemon_form_create(ctx, ident)

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -282,7 +282,8 @@ class TestCephAdm(object):
     @mock.patch('cephadmlib.firewalld.Firewalld', mock_bad_firewalld)
     @mock.patch('cephadm.Firewalld', mock_bad_firewalld)
     @mock.patch('cephadm.logger')
-    def test_skip_firewalld(self, _logger, cephadm_fs):
+    @mock.patch('cephadm.json_loads_retry', return_value=None)
+    def test_skip_firewalld(self, _logger, _jlr, cephadm_fs):
         """
         test --skip-firewalld actually skips changing firewall
         """

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -10,7 +10,6 @@ import json
 import logging
 import socket
 import ssl
-import tempfile
 import threading
 import time
 
@@ -20,11 +19,12 @@ from ceph.utils import datetime_now, http_req
 from ceph.deployment.inventory import Devices
 from ceph.deployment.service_spec import ServiceSpec, PlacementSpec
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
-from cephadm.ssl_cert_utils import SSLCerts
 from mgr_util import test_port_allocation, PortAlreadyInUse
+from mgr_util import verify_tls_files
+import tempfile
 
 from urllib.error import HTTPError, URLError
-from typing import Any, Dict, List, Set, TYPE_CHECKING, Optional, MutableMapping
+from typing import Any, Dict, List, Set, TYPE_CHECKING, Optional, MutableMapping, IO
 
 if TYPE_CHECKING:
     from cephadm.module import CephadmOrchestrator
@@ -46,9 +46,10 @@ class AgentEndpoint:
 
     def __init__(self, mgr: "CephadmOrchestrator") -> None:
         self.mgr = mgr
-        self.ssl_certs = SSLCerts()
         self.server_port = 7150
         self.server_addr = self.mgr.get_mgr_ip()
+        self.key_file: IO[bytes]
+        self.cert_file: IO[bytes]
 
     def configure_routes(self) -> None:
         conf = {'/': {'tools.trailing_slash.on': False}}
@@ -57,19 +58,19 @@ class AgentEndpoint:
         cherrypy.tree.mount(self.node_proxy_endpoint, '/node-proxy', config=conf)
 
     def configure_tls(self, server: Server) -> None:
-        old_cert = self.mgr.cert_key_store.get_cert('agent_endpoint_root_cert')
-        old_key = self.mgr.cert_key_store.get_key('agent_endpoint_key')
-
-        if old_cert and old_key:
-            self.ssl_certs.load_root_credentials(old_cert, old_key)
-        else:
-            self.ssl_certs.generate_root_cert(self.mgr.get_mgr_ip())
-            self.mgr.cert_key_store.save_cert('agent_endpoint_root_cert', self.ssl_certs.get_root_cert())
-            self.mgr.cert_key_store.save_key('agent_endpoint_key', self.ssl_certs.get_root_key())
-
-        host = self.mgr.get_hostname()
         addr = self.mgr.get_mgr_ip()
-        server.ssl_certificate, server.ssl_private_key = self.ssl_certs.generate_cert_files(host, addr)
+        host = self.mgr.get_hostname()
+        cert, key = self.mgr.cert_mgr.generate_cert(host, addr)
+        self.cert_file = tempfile.NamedTemporaryFile()
+        self.cert_file.write(cert.encode('utf-8'))
+        self.cert_file.flush()  # cert_tmp must not be gc'ed
+
+        self.key_file = tempfile.NamedTemporaryFile()
+        self.key_file.write(key.encode('utf-8'))
+        self.key_file.flush()  # pkey_tmp must not be gc'ed
+
+        verify_tls_files(self.cert_file.name, self.key_file.name)
+        server.ssl_certificate, server.ssl_private_key = self.cert_file.name, self.key_file.name
 
     def find_free_port(self) -> None:
         max_port = self.server_port + 150
@@ -94,7 +95,7 @@ class AgentEndpoint:
 class NodeProxyEndpoint:
     def __init__(self, mgr: "CephadmOrchestrator"):
         self.mgr = mgr
-        self.ssl_root_crt = self.mgr.http_server.agent.ssl_certs.get_root_cert()
+        self.ssl_root_crt = self.mgr.cert_mgr.get_root_ca()
         self.ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         self.ssl_ctx.check_hostname = False
         self.ssl_ctx.verify_mode = ssl.CERT_NONE
@@ -301,7 +302,7 @@ class NodeProxyEndpoint:
         endpoint: List[Any] = ['led', led_type]
         device: str = id_drive if id_drive else ''
 
-        ssl_root_crt = self.mgr.http_server.agent.ssl_certs.get_root_cert()
+        ssl_root_crt = self.mgr.cert_mgr.get_root_ca()
         ssl_ctx = ssl.create_default_context()
         ssl_ctx.check_hostname = True
         ssl_ctx.verify_mode = ssl.CERT_REQUIRED
@@ -774,14 +775,13 @@ class AgentMessageThread(threading.Thread):
         self.mgr.agent_cache.sending_agent_message[self.host] = True
         try:
             assert self.agent
-            root_cert = self.agent.ssl_certs.get_root_cert()
+            root_cert = self.mgr.cert_mgr.get_root_ca()
             root_cert_tmp = tempfile.NamedTemporaryFile()
             root_cert_tmp.write(root_cert.encode('utf-8'))
             root_cert_tmp.flush()
             root_cert_fname = root_cert_tmp.name
 
-            cert, key = self.agent.ssl_certs.generate_cert(
-                self.mgr.get_hostname(), self.mgr.get_mgr_ip())
+            cert, key = self.mgr.cert_mgr.generate_cert(self.mgr.get_hostname(), self.mgr.get_mgr_ip())
 
             cert_tmp = tempfile.NamedTemporaryFile()
             cert_tmp.write(cert.encode('utf-8'))
@@ -950,7 +950,7 @@ class CephadmAgentHelpers:
         down = False
         try:
             assert self.agent
-            assert self.agent.ssl_certs.get_root_cert()
+            assert self.mgr.cert_mgr.get_root_ca()
         except Exception:
             self.mgr.log.debug(
                 f'Delaying checking agent on {host} until cephadm endpoint finished creating root cert')
@@ -974,7 +974,7 @@ class CephadmAgentHelpers:
                 # so it's necessary to check this one specifically
                 root_cert_match = False
                 try:
-                    root_cert = self.agent.ssl_certs.get_root_cert()
+                    root_cert = self.mgr.cert_mgr.get_root_ca()
                     if last_deps and root_cert in last_deps:
                         root_cert_match = True
                 except Exception:

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -1,6 +1,5 @@
 
-from cephadm.ssl_cert_utils import SSLCerts
-from threading import Lock
+from cephadm.ssl_cert_utils import SSLCerts, SSLConfigException
 from typing import TYPE_CHECKING, Tuple, Union, List
 
 if TYPE_CHECKING:
@@ -13,31 +12,21 @@ class CertMgr:
     CEPHADM_ROOT_CA_KEY = 'cephadm_root_ca_key'
 
     def __init__(self, mgr: "CephadmOrchestrator", ip: str) -> None:
-        self.lock = Lock()
-        self.initialized = False
-        with self.lock:
-            if self.initialized:
-                return
-            self.initialized = True
-            self.mgr = mgr
-            self.ssl_certs: SSLCerts = SSLCerts()
-            old_cert = self.mgr.cert_key_store.get_cert(self.CEPHADM_ROOT_CA_CERT)
-            old_key = self.mgr.cert_key_store.get_key(self.CEPHADM_ROOT_CA_KEY)
-            if old_key and old_cert:
+        self.ssl_certs: SSLCerts = SSLCerts()
+        old_cert = mgr.cert_key_store.get_cert(self.CEPHADM_ROOT_CA_CERT)
+        old_key = mgr.cert_key_store.get_key(self.CEPHADM_ROOT_CA_KEY)
+        if old_key and old_cert:
+            try:
                 self.ssl_certs.load_root_credentials(old_cert, old_key)
-            else:
-                self.ssl_certs.generate_root_cert(ip)
-                self.mgr.cert_key_store.save_cert(self.CEPHADM_ROOT_CA_CERT, self.ssl_certs.get_root_cert())
-                self.mgr.cert_key_store.save_key(self.CEPHADM_ROOT_CA_KEY, self.ssl_certs.get_root_key())
+            except SSLConfigException:
+                raise Exception("Cannot load cephadm root CA certificates.")
+        else:
+            self.ssl_certs.generate_root_cert(ip)
+            mgr.cert_key_store.save_cert(self.CEPHADM_ROOT_CA_CERT, self.ssl_certs.get_root_cert())
+            mgr.cert_key_store.save_key(self.CEPHADM_ROOT_CA_KEY, self.ssl_certs.get_root_key())
 
     def get_root_ca(self) -> str:
-        with self.lock:
-            if self.initialized:
-                return self.ssl_certs.get_root_cert()
-        raise Exception("Not initialized")
+        return self.ssl_certs.get_root_cert()
 
-    def generate_cert(self, host_fqdn: Union[str, List[str]], node_ip: str) -> Tuple[str, str]:
-        with self.lock:
-            if self.initialized:
-                return self.ssl_certs.generate_cert(host_fqdn, node_ip)
-        raise Exception("Not initialized")
+    def generate_cert(self, host_fqdn: Union[str, List[str]], node_ip: Union[str, List[str]]) -> Tuple[str, str]:
+        return self.ssl_certs.generate_cert(host_fqdn, node_ip)

--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -1,0 +1,43 @@
+
+from cephadm.ssl_cert_utils import SSLCerts
+from threading import Lock
+from typing import TYPE_CHECKING, Tuple, Union, List
+
+if TYPE_CHECKING:
+    from cephadm.module import CephadmOrchestrator
+
+
+class CertMgr:
+
+    CEPHADM_ROOT_CA_CERT = 'cephadm_root_ca_cert'
+    CEPHADM_ROOT_CA_KEY = 'cephadm_root_ca_key'
+
+    def __init__(self, mgr: "CephadmOrchestrator", ip: str) -> None:
+        self.lock = Lock()
+        self.initialized = False
+        with self.lock:
+            if self.initialized:
+                return
+            self.initialized = True
+            self.mgr = mgr
+            self.ssl_certs: SSLCerts = SSLCerts()
+            old_cert = self.mgr.cert_key_store.get_cert(self.CEPHADM_ROOT_CA_CERT)
+            old_key = self.mgr.cert_key_store.get_key(self.CEPHADM_ROOT_CA_KEY)
+            if old_key and old_cert:
+                self.ssl_certs.load_root_credentials(old_cert, old_key)
+            else:
+                self.ssl_certs.generate_root_cert(ip)
+                self.mgr.cert_key_store.save_cert(self.CEPHADM_ROOT_CA_CERT, self.ssl_certs.get_root_cert())
+                self.mgr.cert_key_store.save_key(self.CEPHADM_ROOT_CA_KEY, self.ssl_certs.get_root_key())
+
+    def get_root_ca(self) -> str:
+        with self.lock:
+            if self.initialized:
+                return self.ssl_certs.get_root_cert()
+        raise Exception("Not initialized")
+
+    def generate_cert(self, host_fqdn: Union[str, List[str]], node_ip: str) -> Tuple[str, str]:
+        with self.lock:
+            if self.initialized:
+                return self.ssl_certs.generate_cert(host_fqdn, node_ip)
+        raise Exception("Not initialized")

--- a/src/pybind/mgr/cephadm/http_server.py
+++ b/src/pybind/mgr/cephadm/http_server.py
@@ -31,7 +31,8 @@ class CephadmHttpServer(threading.Thread):
         self.service_discovery = ServiceDiscovery(mgr)
         self.cherrypy_shutdown_event = threading.Event()
         self._service_discovery_port = self.mgr.service_discovery_port
-        self.secure_monitoring_stack = self.mgr.secure_monitoring_stack
+        security_enabled, mgmt_gw_enabled = self.mgr._get_security_config()
+        self.security_enabled = security_enabled
         super().__init__(target=self.run)
 
     def configure_cherrypy(self) -> None:
@@ -45,12 +46,13 @@ class CephadmHttpServer(threading.Thread):
         self.agent.configure()
         self.service_discovery.configure(self.mgr.service_discovery_port,
                                          self.mgr.get_mgr_ip(),
-                                         self.secure_monitoring_stack)
+                                         self.security_enabled)
 
     def config_update(self) -> None:
         self.service_discovery_port = self.mgr.service_discovery_port
-        if self.secure_monitoring_stack != self.mgr.secure_monitoring_stack:
-            self.secure_monitoring_stack = self.mgr.secure_monitoring_stack
+        security_enabled, mgmt_gw_enabled = self.mgr._get_security_config()
+        if self.security_enabled != security_enabled:
+            self.security_enabled = security_enabled
             self.restart()
 
     @property

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1912,16 +1912,10 @@ class CertKeyStore():
 
     host_cert = [
         'grafana_cert',
-        'alertmanager_cert',
-        'prometheus_cert',
-        'node_exporter_cert',
     ]
 
     host_key = [
         'grafana_key',
-        'alertmanager_key',
-        'prometheus_key',
-        'node_exporter_key',
     ]
 
     service_name_key = [
@@ -1951,22 +1945,15 @@ class CertKeyStore():
             'agent_endpoint_root_cert': Cert(),  # cert
             'mgmt_gw_root_cert': Cert(),  # cert
             'service_discovery_root_cert': Cert(),  # cert
+            'cephadm_root_ca_cert': Cert(),  # cert
             'grafana_cert': {},  # host -> cert
-            'alertmanager_cert': {},  # host -> cert
-            'prometheus_cert': {},  # host -> cert
-            'node_exporter_cert': {},  # host -> cert
         }
         # Similar to certs but for priv keys. Entries in known_certs
         # that don't have a key here are probably certs in PEM format
         # so there is no need to store a separate key
         self.known_keys = {
-            'agent_endpoint_key': PrivKey(),  # key
-            'service_discovery_key': PrivKey(),  # key
-            'mgmt_gw_root_key': PrivKey(),  # cert
+            'cephadm_root_ca_key': PrivKey(),  # cert
             'grafana_key': {},  # host -> key
-            'alertmanager_key': {},  # host -> key
-            'prometheus_key': {},  # host -> key
-            'node_exporter_key': {},  # host -> key
             'iscsi_ssl_key': {},  # service-name -> key
             'ingress_ssl_key': {},  # service-name -> key
             'nvmeof_server_key': {},  # service-name -> key

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -1942,9 +1942,7 @@ class CertKeyStore():
             'nvmeof_server_cert': {},  # service-name -> cert
             'nvmeof_client_cert': {},  # service-name -> cert
             'nvmeof_root_ca_cert': {},  # service-name -> cert
-            'agent_endpoint_root_cert': Cert(),  # cert
-            'mgmt_gw_root_cert': Cert(),  # cert
-            'service_discovery_root_cert': Cert(),  # cert
+            'mgmt_gw_cert': Cert(),  # cert
             'cephadm_root_ca_cert': Cert(),  # cert
             'grafana_cert': {},  # host -> cert
         }
@@ -1952,6 +1950,7 @@ class CertKeyStore():
         # that don't have a key here are probably certs in PEM format
         # so there is no need to store a separate key
         self.known_keys = {
+            'mgmt_gw_key': PrivKey(),  # cert
             'cephadm_root_ca_key': PrivKey(),  # cert
             'grafana_key': {},  # host -> key
             'iscsi_ssl_key': {},  # service-name -> key

--- a/src/pybind/mgr/cephadm/migrations.py
+++ b/src/pybind/mgr/cephadm/migrations.py
@@ -421,32 +421,6 @@ class Migrations:
                 logger.info(f'Migrating certs/keys for {spec.service_name()} spec to cert store')
                 self.mgr.spec_store._save_certs_and_keys(spec)
 
-        # Migrate service discovery and agent endpoint certs
-        # These constants were taken from where these certs were
-        # originally generated and should be the location they
-        # were store at prior to the cert store
-        KV_STORE_AGENT_ROOT_CERT = 'cephadm_agent/root/cert'
-        KV_STORE_AGENT_ROOT_KEY = 'cephadm_agent/root/key'
-        KV_STORE_SD_ROOT_CERT = 'service_discovery/root/cert'
-        KV_STORE_SD_ROOT_KEY = 'service_discovery/root/key'
-
-        agent_endpoint_cert = self.mgr.get_store(KV_STORE_AGENT_ROOT_CERT)
-        if agent_endpoint_cert:
-            logger.info('Migrating agent root cert to cert store')
-            self.mgr.cert_key_store.save_cert('agent_endpoint_root_cert', agent_endpoint_cert)
-        agent_endpoint_key = self.mgr.get_store(KV_STORE_AGENT_ROOT_KEY)
-        if agent_endpoint_key:
-            logger.info('Migrating agent root key to cert store')
-            self.mgr.cert_key_store.save_key('agent_endpoint_key', agent_endpoint_key)
-        service_discovery_cert = self.mgr.get_store(KV_STORE_SD_ROOT_CERT)
-        if service_discovery_cert:
-            logger.info('Migrating service discovery cert to cert store')
-            self.mgr.cert_key_store.save_cert('service_discovery_root_cert', service_discovery_cert)
-        service_discovery_key = self.mgr.get_store(KV_STORE_SD_ROOT_KEY)
-        if service_discovery_key:
-            logger.info('Migrating service discovery key to cert store')
-            self.mgr.cert_key_store.save_key('service_discovery_key', service_discovery_key)
-
         # grafana certs are stored based on the host they are placed on
         for grafana_daemon in self.mgr.cache.get_daemons_by_type('grafana'):
             logger.info(f'Checking for cert/key for {grafana_daemon.name()}')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2992,7 +2992,8 @@ Then run the following:
             # this daemon type doesn't need deps mgmt
             pass
 
-        if daemon_type in ['prometheus', 'node-exporter', 'alertmanager', 'grafana']:
+        if daemon_type in ['prometheus', 'node-exporter', 'alertmanager', 'grafana',
+                           'ceph-exporter']:
             deps.append(f'secure_monitoring_stack:{self.secure_monitoring_stack}')
 
         return sorted(deps)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -15,6 +15,7 @@ from urllib.error import HTTPError
 from threading import Event
 
 from ceph.deployment.service_spec import PrometheusSpec
+from cephadm.cert_mgr import CertMgr
 
 import string
 from typing import List, Dict, Optional, Callable, Tuple, TypeVar, \
@@ -538,11 +539,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         super(CephadmOrchestrator, self).__init__(*args, **kwargs)
         self._cluster_fsid: str = self.get('mon_map')['fsid']
         self.last_monmap: Optional[datetime.datetime] = None
+        self.cert_mgr = CertMgr(self, self.get_mgr_ip())
 
         # for serve()
         self.run = True
         self.event = Event()
-
         self.ssh = ssh.SSHManager(self)
 
         if self.get_store('pause'):
@@ -2609,6 +2610,9 @@ Then run the following:
                 raise OrchestratorError(
                     f'If {service_name} is removed then the following OSDs will remain, --force to proceed anyway\n{msg}')
 
+        if service_name == 'mgmt-gateway':
+            self.set_module_option('secure_monitoring_stack', False)
+
         found = self.spec_store.rm(service_name)
         if found and service_name.startswith('osd.'):
             self.spec_store.finally_rm(service_name)
@@ -2899,7 +2903,7 @@ Then run the following:
             server_port = ''
             try:
                 server_port = str(self.http_server.agent.server_port)
-                root_cert = self.http_server.agent.ssl_certs.get_root_cert()
+                root_cert = self.cert_mgr.get_root_ca()
             except Exception:
                 pass
             deps = sorted([self.get_mgr_ip(), server_port, root_cert,
@@ -2909,7 +2913,7 @@ Then run the following:
             server_port = ''
             try:
                 server_port = str(self.http_server.agent.server_port)
-                root_cert = self.http_server.agent.ssl_certs.get_root_cert()
+                root_cert = self.cert_mgr.get_root_ca()
             except Exception:
                 pass
             deps = sorted([self.get_mgr_ip(), server_port, root_cert])
@@ -3138,14 +3142,14 @@ Then run the following:
         user, password = self._get_prometheus_credentials()
         return {'user': user,
                 'password': password,
-                'certificate': self.http_server.service_discovery.ssl_certs.get_root_cert()}
+                'certificate': self.cert_mgr.get_root_ca()}
 
     @handle_orch_error
     def get_alertmanager_access_info(self) -> Dict[str, str]:
         user, password = self._get_alertmanager_credentials()
         return {'user': user,
                 'password': password,
-                'certificate': self.http_server.service_discovery.ssl_certs.get_root_cert()}
+                'certificate': self.cert_mgr.get_root_ca()}
 
     @handle_orch_error
     def cert_store_cert_ls(self) -> Dict[str, Any]:
@@ -3396,6 +3400,9 @@ Then run the following:
 
         host_count = len(self.inventory.keys())
         max_count = self.max_count_per_host
+
+        if spec.service_type == 'mgmt-gateway':
+            self.set_module_option('secure_monitoring_stack', True)
 
         if spec.placement.count is not None:
             if spec.service_type in ['mon', 'mgr']:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -539,7 +539,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         super(CephadmOrchestrator, self).__init__(*args, **kwargs)
         self._cluster_fsid: str = self.get('mon_map')['fsid']
         self.last_monmap: Optional[datetime.datetime] = None
-        self.cert_mgr = CertMgr(self, self.get_mgr_ip())
 
         # for serve()
         self.run = True
@@ -674,6 +673,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         self.cert_key_store = CertKeyStore(self)
         self.cert_key_store.load()
+
+        self.cert_mgr = CertMgr(self, self.get_mgr_ip())
 
         # ensure the host lists are in sync
         for h in self.inventory.keys():
@@ -3086,6 +3087,14 @@ Then run the following:
         return (user, password)
 
     @handle_orch_error
+    def generate_certificates(self, module_name: str) -> Optional[Dict[str, str]]:
+        supported_moduels = ['dashboard', 'prometheus']
+        if module_name not in supported_moduels:
+            raise OrchestratorError(f'Unsupported modlue {module_name}. Supported moduels are: {supported_moduels}')
+        cert, key = self.cert_mgr.generate_cert(self.get_hostname(), self.get_mgr_ip())
+        return {'cert': cert, 'key': key}
+
+    @handle_orch_error
     def set_prometheus_access_info(self, user: str, password: str) -> str:
         self.set_store(PrometheusService.USER_CFG_KEY, user)
         self.set_store(PrometheusService.PASS_CFG_KEY, password)
@@ -3296,13 +3305,6 @@ Then run the following:
         self.tuned_profiles.rm_setting(profile_name, setting)
         self._kick_serve_loop()
         return f'Removed setting {setting} from tuned profile {profile_name}'
-
-    @handle_orch_error
-    def service_discovery_dump_cert(self) -> str:
-        root_cert = self.cert_key_store.get_cert('service_discovery_root_cert')
-        if not root_cert:
-            raise OrchestratorError('No certificate found for service discovery')
-        return root_cert
 
     def set_health_warning(self, name: str, summary: str, count: int, detail: List[str]) -> None:
         self.health_checks[name] = {

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -702,7 +702,7 @@ class CephadmServe:
         if service_type == 'agent':
             try:
                 assert self.mgr.http_server.agent
-                assert self.mgr.http_server.agent.ssl_certs.get_root_cert()
+                assert self.mgr.cert_mgr.get_root_ca()
             except Exception:
                 self.log.info(
                     'Delaying applying agent spec until cephadm endpoint root cert created')

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1095,7 +1095,7 @@ class CephadmServe:
                 action = 'reconfig'
                 # we need only redeploy if secure_monitoring_stack or mgmt-gateway value has changed:
                 # TODO(redo): check if we should just go always with redeploy (it's fast enough)
-                if dd.daemon_type in ['prometheus', 'node-exporter', 'alertmanager']:
+                if dd.daemon_type in ['prometheus', 'node-exporter', 'alertmanager', 'ceph-exporter']:
                     diff = list(set(last_deps).symmetric_difference(set(deps)))
                     REDEPLOY_TRIGGERS = ['secure_monitoring_stack', 'mgmt-gateway']
                     if any(svc in e for e in diff for svc in REDEPLOY_TRIGGERS):

--- a/src/pybind/mgr/cephadm/service_discovery.py
+++ b/src/pybind/mgr/cephadm/service_discovery.py
@@ -7,17 +7,17 @@ except ImportError:
         pass
 
 import logging
-import socket
 
 import orchestrator  # noqa
 from mgr_module import ServiceInfoT
 from mgr_util import build_url
-from typing import Dict, List, TYPE_CHECKING, cast, Collection, Callable, NamedTuple, Optional
+from typing import Dict, List, TYPE_CHECKING, cast, Collection, Callable, NamedTuple, Optional, IO
 from cephadm.services.monitoring import AlertmanagerService, NodeExporterService, PrometheusService
 import secrets
+from mgr_util import verify_tls_files
+import tempfile
 
 from cephadm.services.ingress import IngressSpec
-from cephadm.ssl_cert_utils import SSLCerts
 from cephadm.services.cephadmservice import CephExporterService
 from cephadm.services.nvmeof import NvmeofService
 
@@ -47,9 +47,10 @@ class ServiceDiscovery:
 
     def __init__(self, mgr: "CephadmOrchestrator") -> None:
         self.mgr = mgr
-        self.ssl_certs = SSLCerts()
         self.username: Optional[str] = None
         self.password: Optional[str] = None
+        self.key_file: IO[bytes]
+        self.cert_file: IO[bytes]
 
     def validate_password(self, realm: str, username: str, password: str) -> bool:
         return (password == self.password and username == self.username)
@@ -86,18 +87,20 @@ class ServiceDiscovery:
             self.mgr.set_store('service_discovery/root/username', self.username)
 
     def configure_tls(self, server: Server) -> None:
-        old_cert = self.mgr.cert_key_store.get_cert('service_discovery_root_cert')
-        old_key = self.mgr.cert_key_store.get_key('service_discovery_key')
-        if old_key and old_cert:
-            self.ssl_certs.load_root_credentials(old_cert, old_key)
-        else:
-            self.ssl_certs.generate_root_cert(self.mgr.get_mgr_ip())
-            self.mgr.cert_key_store.save_cert('service_discovery_root_cert', self.ssl_certs.get_root_cert())
-            self.mgr.cert_key_store.save_key('service_discovery_key', self.ssl_certs.get_root_key())
         addr = self.mgr.get_mgr_ip()
-        host_fqdn = socket.getfqdn(addr)
-        server.ssl_certificate, server.ssl_private_key = self.ssl_certs.generate_cert_files(
-            host_fqdn, addr)
+        host = self.mgr.get_hostname()
+        cert, key = self.mgr.cert_mgr.generate_cert(host, addr)
+        self.cert_file = tempfile.NamedTemporaryFile()
+        self.cert_file.write(cert.encode('utf-8'))
+        self.cert_file.flush()  # cert_tmp must not be gc'ed
+
+        self.key_file = tempfile.NamedTemporaryFile()
+        self.key_file.write(key.encode('utf-8'))
+        self.key_file.flush()  # pkey_tmp must not be gc'ed
+
+        verify_tls_files(self.cert_file.name, self.key_file.name)
+
+        server.ssl_certificate, server.ssl_private_key = self.cert_file.name, self.key_file.name
 
     def configure(self, port: int, addr: str, enable_security: bool) -> None:
         # we create a new server to enforce TLS/SSL config refresh

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1342,7 +1342,6 @@ class CephadmAgent(CephService):
         agent = self.mgr.http_server.agent
         try:
             assert agent
-            assert agent.ssl_certs.get_root_cert()
             assert agent.server_port
         except Exception:
             raise OrchestratorError(
@@ -1355,15 +1354,15 @@ class CephadmAgent(CephService):
                'host': daemon_spec.host,
                'device_enhanced_scan': str(self.mgr.device_enhanced_scan)}
 
-        listener_cert, listener_key = agent.ssl_certs.generate_cert(daemon_spec.host, self.mgr.inventory.get_addr(daemon_spec.host))
+        listener_cert, listener_key = self.mgr.cert_mgr.generate_cert(daemon_spec.host, self.mgr.inventory.get_addr(daemon_spec.host))
         config = {
             'agent.json': json.dumps(cfg),
             'keyring': daemon_spec.keyring,
-            'root_cert.pem': agent.ssl_certs.get_root_cert(),
+            'root_cert.pem': self.mgr.cert_mgr.get_root_ca(),
             'listener.crt': listener_cert,
             'listener.key': listener_key,
         }
 
         return config, sorted([str(self.mgr.get_mgr_ip()), str(agent.server_port),
-                               agent.ssl_certs.get_root_cert(),
+                               self.mgr.cert_mgr.get_root_ca(),
                                str(self.mgr.get_module_option('device_enhanced_scan'))])

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1263,7 +1263,7 @@ class CephExporterService(CephService):
                                               'mon', 'allow r',
                                               'mgr', 'allow r',
                                               'osd', 'allow r'])
-        exporter_config = {}
+        exporter_config: Dict[str, Any] = {}
         if spec.sock_dir:
             exporter_config.update({'sock-dir': spec.sock_dir})
         if spec.port:
@@ -1296,6 +1296,7 @@ class CephExporterService(CephService):
         node_ip = self.mgr.inventory.get_addr(daemon_spec.host)
         host_fqdn = self.mgr.get_fqdn(daemon_spec.host)
         return self.mgr.cert_mgr.generate_cert(host_fqdn, node_ip)
+
 
 class CephfsMirrorService(CephService):
     TYPE = 'cephfs-mirror'

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -97,7 +97,8 @@ class GrafanaService(CephadmService):
                 'http_port': grafana_port,
                 'protocol': spec.protocol,
                 'http_addr': grafana_ip,
-                'use_url_prefix': mgmt_gw_enabled
+                'use_url_prefix': mgmt_gw_enabled,
+                'domain': daemon_spec.host,
             })
 
         if 'dashboard' in self.mgr.get('mgr_map')['modules'] and spec.initial_admin_password:

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -8,10 +8,10 @@ from mgr_module import HandleCommandResult
 
 from orchestrator import DaemonDescription
 from ceph.deployment.service_spec import AlertManagerSpec, GrafanaSpec, ServiceSpec, \
-    SNMPGatewaySpec, PrometheusSpec, MgmtGatewaySpec
+    SNMPGatewaySpec, PrometheusSpec
 from cephadm.services.cephadmservice import CephadmService, CephadmDaemonDeploySpec, get_dashboard_urls
-from cephadm.services.mgmt_gateway import MgmtGatewayService
-from mgr_util import verify_tls, ServerConfigException, create_self_signed_cert, build_url, get_cert_issuer_info, password_hash
+from cephadm.services.mgmt_gateway import get_mgmt_gw_internal_endpoint, get_mgmt_gw_external_endpoint
+from mgr_util import verify_tls, ServerConfigException, build_url, get_cert_issuer_info, password_hash
 from ceph.deployment.utils import wrap_ipv6
 
 logger = logging.getLogger(__name__)
@@ -28,11 +28,12 @@ class GrafanaService(CephadmService):
 
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
-        prometheus_user, prometheus_password = self.mgr._get_prometheus_credentials()
         deps = []  # type: List[str]
-        if self.mgr.secure_monitoring_stack and prometheus_user and prometheus_password:
-            deps.append(f'{hash(prometheus_user + prometheus_password)}')
+        security_enabled, mgmt_gw_enabled = self.mgr._get_security_config()
         deps.append(f'secure_monitoring_stack:{self.mgr.secure_monitoring_stack}')
+        prometheus_user, prometheus_password = self.mgr._get_prometheus_credentials()
+        if security_enabled and prometheus_user and prometheus_password:
+            deps.append(f'{hash(prometheus_user + prometheus_password)}')
 
         # add a dependency since url_prefix depends on the existence of mgmt-gateway
         deps += [d.name() for d in self.mgr.cache.get_daemons_by_service('mgmt-gateway')]
@@ -40,31 +41,40 @@ class GrafanaService(CephadmService):
         prom_services = []  # type: List[str]
         for dd in self.mgr.cache.get_daemons_by_service('prometheus'):
             assert dd.hostname is not None
-            addr = dd.ip if dd.ip else self._inventory_get_fqdn(dd.hostname)
+            addr = dd.ip if dd.ip else self.mgr.get_fqdn(dd.hostname)
             port = dd.ports[0] if dd.ports else 9095
-            protocol = 'https' if self.mgr.secure_monitoring_stack else 'http'
+            protocol = 'https' if security_enabled else 'http'
             prom_services.append(build_url(scheme=protocol, host=addr, port=port))
-
             deps.append(dd.name())
+
+        # in case mgmt-gw is enabeld we only use one url pointing to the internal
+        # mgmt gw for dashboard which will take care of HA in this case
+        if mgmt_gw_enabled:
+            prom_services = [f'{get_mgmt_gw_internal_endpoint(self.mgr)}/prometheus']
 
         daemons = self.mgr.cache.get_daemons_by_service('loki')
         loki_host = ''
         for i, dd in enumerate(daemons):
             assert dd.hostname is not None
             if i == 0:
-                addr = dd.ip if dd.ip else self._inventory_get_fqdn(dd.hostname)
+                addr = dd.ip if dd.ip else self.mgr.get_fqdn(dd.hostname)
                 loki_host = build_url(scheme='http', host=addr, port=3100)
 
             deps.append(dd.name())
 
-        root_cert = self.mgr.http_server.service_discovery.ssl_certs.get_root_cert()
+        root_cert = self.mgr.cert_mgr.get_root_ca()
+        cert, pkey = self.prepare_certificates(daemon_spec)
         oneline_root_cert = '\\n'.join([line.strip() for line in root_cert.splitlines()])
+        oneline_cert = '\\n'.join([line.strip() for line in cert.splitlines()])
+        oneline_key = '\\n'.join([line.strip() for line in pkey.splitlines()])
         grafana_data_sources = self.mgr.template.render('services/grafana/ceph-dashboard.yml.j2',
                                                         {'hosts': prom_services,
                                                          'prometheus_user': prometheus_user,
                                                          'prometheus_password': prometheus_password,
                                                          'cephadm_root_ca': oneline_root_cert,
-                                                         'security_enabled': self.mgr.secure_monitoring_stack,
+                                                         'cert': oneline_cert,
+                                                         'key': oneline_key,
+                                                         'security_enabled': security_enabled,
                                                          'loki_host': loki_host})
 
         spec: GrafanaSpec = cast(
@@ -80,7 +90,6 @@ class GrafanaService(CephadmService):
                 daemon_spec.port_ips = {str(grafana_port): ip_to_bind_to}
                 grafana_ip = ip_to_bind_to
 
-        mgmt_gw_enabled = len(self.mgr.cache.get_daemons_by_service('mgmt-gateway')) > 0
         grafana_ini = self.mgr.template.render(
             'services/grafana/grafana.ini.j2', {
                 'anonymous_access': spec.anonymous_access,
@@ -103,7 +112,6 @@ class GrafanaService(CephadmService):
             }
         )
 
-        cert, pkey = self.prepare_certificates(daemon_spec)
         config_file = {
             'files': {
                 "grafana.ini": grafana_ini,
@@ -190,19 +198,12 @@ class GrafanaService(CephadmService):
         # TODO: signed cert
         dd = self.get_active_daemon(daemon_descrs)
         assert dd.hostname is not None
-        addr = dd.ip if dd.ip else self._inventory_get_fqdn(dd.hostname)
+        addr = dd.ip if dd.ip else self.mgr.get_fqdn(dd.hostname)
         port = dd.ports[0] if dd.ports else self.DEFAULT_SERVICE_PORT
         spec = cast(GrafanaSpec, self.mgr.spec_store[dd.service_name()].spec)
 
-        mgmt_gw_daemons = self.mgr.cache.get_daemons_by_service('mgmt-gateway')
-        if mgmt_gw_daemons:
-            dd = mgmt_gw_daemons[0]
-            assert dd.hostname is not None
-            mgmt_gw_spec = cast(MgmtGatewaySpec, self.mgr.spec_store['mgmt-gateway'].spec)
-            mgmt_gw_port = dd.ports[0] if dd.ports else None
-            mgmt_gw_addr = self._inventory_get_fqdn(dd.hostname)
-            protocol = 'http' if mgmt_gw_spec.disable_https else 'https'
-            mgmt_gw_external_endpoint = build_url(scheme=protocol, host=mgmt_gw_addr, port=mgmt_gw_port)
+        mgmt_gw_external_endpoint = get_mgmt_gw_external_endpoint(self.mgr)
+        if mgmt_gw_external_endpoint is not None:
             self._set_value_on_dashboard(
                 'Grafana',
                 'dashboard get-grafana-api-url',
@@ -256,7 +257,7 @@ class AlertmanagerService(CephadmService):
 
     def get_alertmanager_certificates(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[str, str]:
         node_ip = self.mgr.inventory.get_addr(daemon_spec.host)
-        host_fqdn = self._inventory_get_fqdn(daemon_spec.host)
+        host_fqdn = self.mgr.get_fqdn(daemon_spec.host)
         cert, key = self.mgr.cert_mgr.generate_cert([host_fqdn, "alertmanager_servers"], node_ip)
         return cert, key
 
@@ -283,19 +284,25 @@ class AlertmanagerService(CephadmService):
             # in order to be consistent with _calc_daemon_deps().
             deps.append(dd.name())
 
+        security_enabled, mgmt_gw_enabled = self.mgr._get_security_config()
+        if mgmt_gw_enabled:
+            dashboard_urls = [f'{get_mgmt_gw_internal_endpoint(self.mgr)}/dashboard']
+        else:
+            dashboard_urls = get_dashboard_urls(self)
+
         snmp_gateway_urls: List[str] = []
         for dd in self.mgr.cache.get_daemons_by_service('snmp-gateway'):
             assert dd.hostname is not None
             assert dd.ports
-            addr = dd.ip if dd.ip else self._inventory_get_fqdn(dd.hostname)
+            addr = dd.ip if dd.ip else self.mgr.get_fqdn(dd.hostname)
             deps.append(dd.name())
 
             snmp_gateway_urls.append(build_url(scheme='http', host=addr,
                                      port=dd.ports[0], path='/alerts'))
 
         context = {
-            'secure_monitoring_stack': self.mgr.secure_monitoring_stack,
-            'dashboard_urls': get_dashboard_urls(self),
+            'security_enabled': security_enabled,
+            'dashboard_urls': dashboard_urls,
             'default_webhook_urls': default_webhook_urls,
             'snmp_gateway_urls': snmp_gateway_urls,
             'secure': secure,
@@ -307,17 +314,18 @@ class AlertmanagerService(CephadmService):
         for dd in self.mgr.cache.get_daemons_by_service('alertmanager'):
             assert dd.hostname is not None
             deps.append(dd.name())
-            addr = self._inventory_get_fqdn(dd.hostname)
+            addr = self.mgr.get_fqdn(dd.hostname)
             peers.append(build_url(host=addr, port=port).lstrip('/'))
 
-        mgmt_gw_enabled = len(self.mgr.cache.get_daemons_by_service('mgmt-gateway')) > 0
         deps.append(f'secure_monitoring_stack:{self.mgr.secure_monitoring_stack}')
-        if self.mgr.secure_monitoring_stack:
+        if security_enabled:
             alertmanager_user, alertmanager_password = self.mgr._get_alertmanager_credentials()
             if alertmanager_user and alertmanager_password:
                 deps.append(f'{hash(alertmanager_user + alertmanager_password)}')
             cert, key = self.get_alertmanager_certificates(daemon_spec)
             context = {
+                'enable_mtls': mgmt_gw_enabled,
+                'enable_basic_auth': True,  # TODO(redo): disable when ouath2-proxy is enabled
                 'alertmanager_web_user': alertmanager_user,
                 'alertmanager_web_password': password_hash(alertmanager_password),
             }
@@ -327,7 +335,7 @@ class AlertmanagerService(CephadmService):
                     'alertmanager.crt': cert,
                     'alertmanager.key': key,
                     'web.yml': self.mgr.template.render('services/alertmanager/web.yml.j2', context),
-                    'root_cert.pem': self.mgr.http_server.service_discovery.ssl_certs.get_root_cert()
+                    'root_cert.pem': self.mgr.cert_mgr.get_root_ca()
                 },
                 'peers': peers,
                 'web_config': '/etc/alertmanager/web.yml',
@@ -352,21 +360,16 @@ class AlertmanagerService(CephadmService):
     def config_dashboard(self, daemon_descrs: List[DaemonDescription]) -> None:
         dd = self.get_active_daemon(daemon_descrs)
         assert dd.hostname is not None
-        addr = dd.ip if dd.ip else self._inventory_get_fqdn(dd.hostname)
+        addr = dd.ip if dd.ip else self.mgr.get_fqdn(dd.hostname)
         port = dd.ports[0] if dd.ports else self.DEFAULT_SERVICE_PORT
-        protocol = 'https' if self.mgr.secure_monitoring_stack else 'http'
-
-        mgmt_gw_daemons = self.mgr.cache.get_daemons_by_service('mgmt-gateway')
-        if mgmt_gw_daemons:
-            dd = mgmt_gw_daemons[0]
-            assert dd.hostname is not None
-            mgmt_gw_addr = self._inventory_get_fqdn(dd.hostname)
-            mgmt_gw_internal_endpoint = build_url(scheme='https', host=mgmt_gw_addr, port=MgmtGatewayService.INTERNAL_SERVICE_PORT)
+        security_enabled, mgmt_gw_enabled = self.mgr._get_security_config()
+        protocol = 'https' if security_enabled else 'http'
+        if mgmt_gw_enabled:
             self._set_value_on_dashboard(
                 'AlertManager',
                 'dashboard get-alertmanager-api-host',
                 'dashboard set-alertmanager-api-host',
-                f'{mgmt_gw_internal_endpoint}/internal/alertmanager'
+                f'{get_mgmt_gw_internal_endpoint(self.mgr)}/alertmanager'
             )
             self._set_value_on_dashboard(
                 'Alertmanager',
@@ -413,8 +416,8 @@ class PrometheusService(CephadmService):
 
     def get_mgr_prometheus_certificates(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[str, str]:
         node_ip = self.mgr.inventory.get_addr(daemon_spec.host)
-        host_fqdn = self._inventory_get_fqdn(daemon_spec.host)
-        cert, key = self.mgr.cert_mgr.generate_cert([host_fqdn, "prometheus_servers"], node_ip)
+        host_fqdn = self.mgr.get_fqdn(daemon_spec.host)
+        cert, key = self.mgr.cert_mgr.generate_cert([host_fqdn, 'prometheus_servers'], node_ip)
         return cert, key
 
     def prepare_create(
@@ -450,9 +453,10 @@ class PrometheusService(CephadmService):
             retention_size = '0'
 
         # build service discovery end-point
+        security_enabled, mgmt_gw_enabled = self.mgr._get_security_config()
         port = self.mgr.service_discovery_port
         mgr_addr = wrap_ipv6(self.mgr.get_mgr_ip())
-        protocol = 'https' if self.mgr.secure_monitoring_stack else 'http'
+        protocol = 'https' if security_enabled else 'http'
         srv_end_point = f'{protocol}://{mgr_addr}:{port}/sd/prometheus/sd-config?'
 
         node_exporter_cnt = len(self.mgr.cache.get_daemons_by_service('node-exporter'))
@@ -464,6 +468,7 @@ class PrometheusService(CephadmService):
         mgr_prometheus_sd_url = f'{srv_end_point}service=mgr-prometheus'  # always included
         ceph_exporter_sd_url = f'{srv_end_point}service=ceph-exporter'  # always included
         nvmeof_sd_url = f'{srv_end_point}service=nvmeof'  # always included
+        mgmt_gw_enabled = len(self.mgr.cache.get_daemons_by_service('mgmt-gateway')) > 0
 
         alertmanager_user, alertmanager_password = self.mgr._get_alertmanager_credentials()
         prometheus_user, prometheus_password = self.mgr._get_prometheus_credentials()
@@ -471,9 +476,10 @@ class PrometheusService(CephadmService):
 
         # generate the prometheus configuration
         context = {
+            'alertmanager_url_prefix': '/alertmanager' if mgmt_gw_enabled else '/',
             'alertmanager_web_user': alertmanager_user,
             'alertmanager_web_password': alertmanager_password,
-            'secure_monitoring_stack': self.mgr.secure_monitoring_stack,
+            'security_enabled': security_enabled,
             'service_discovery_username': self.mgr.http_server.service_discovery.username,
             'service_discovery_password': self.mgr.http_server.service_discovery.password,
             'mgr_prometheus_sd_url': mgr_prometheus_sd_url,
@@ -494,12 +500,13 @@ class PrometheusService(CephadmService):
                 daemon_spec.port_ips = {str(port): ip_to_bind_to}
 
         web_context = {
+            'enable_mtls': mgmt_gw_enabled,
+            'enable_basic_auth': True,  # TODO(redo): disable when ouath2-proxy is enabled
             'prometheus_web_user': prometheus_user,
             'prometheus_web_password': password_hash(prometheus_password),
         }
 
-        mgmt_gw_enabled = len(self.mgr.cache.get_daemons_by_service('mgmt-gateway')) > 0
-        if self.mgr.secure_monitoring_stack:
+        if security_enabled:
             cert, key = self.get_mgr_prometheus_certificates(daemon_spec)
             r: Dict[str, Any] = {
                 'files': {
@@ -559,14 +566,15 @@ class PrometheusService(CephadmService):
         # add an explicit dependency on the active manager. This will force to
         # re-deploy prometheus if the mgr has changed (due to a fail-over i.e).
         deps.append(self.mgr.get_active_mgr().name())
-        if self.mgr.secure_monitoring_stack:
+        deps.append(f'secure_monitoring_stack:{self.mgr.secure_monitoring_stack}')
+        security_enabled, mgmt_gw_enabled = self.mgr._get_security_config()
+        if security_enabled:
             alertmanager_user, alertmanager_password = self.mgr._get_alertmanager_credentials()
             prometheus_user, prometheus_password = self.mgr._get_prometheus_credentials()
             if prometheus_user and prometheus_password:
                 deps.append(f'{hash(prometheus_user + prometheus_password)}')
             if alertmanager_user and alertmanager_password:
                 deps.append(f'{hash(alertmanager_user + alertmanager_password)}')
-        deps.append(f'secure_monitoring_stack:{self.mgr.secure_monitoring_stack}')
 
         # add a dependency since url_prefix depends on the existence of mgmt-gateway
         deps += [d.name() for d in self.mgr.cache.get_daemons_by_service('mgmt-gateway')]
@@ -588,21 +596,16 @@ class PrometheusService(CephadmService):
     def config_dashboard(self, daemon_descrs: List[DaemonDescription]) -> None:
         dd = self.get_active_daemon(daemon_descrs)
         assert dd.hostname is not None
-        addr = dd.ip if dd.ip else self._inventory_get_fqdn(dd.hostname)
+        addr = dd.ip if dd.ip else self.mgr.get_fqdn(dd.hostname)
         port = dd.ports[0] if dd.ports else self.DEFAULT_SERVICE_PORT
-        protocol = 'https' if self.mgr.secure_monitoring_stack else 'http'
-
-        mgmt_gw_daemons = self.mgr.cache.get_daemons_by_service('mgmt-gateway')
-        if mgmt_gw_daemons:
-            dd = mgmt_gw_daemons[0]
-            assert dd.hostname is not None
-            mgmt_gw_addr = self._inventory_get_fqdn(dd.hostname)
-            mgmt_gw_internal_endpoint = build_url(scheme='https', host=mgmt_gw_addr, port=MgmtGatewayService.INTERNAL_SERVICE_PORT)
+        security_enabled, mgmt_gw_enabled = self.mgr._get_security_config()
+        protocol = 'https' if security_enabled else 'http'
+        if mgmt_gw_enabled:
             self._set_value_on_dashboard(
                 'Prometheus',
                 'dashboard get-prometheus-api-host',
                 'dashboard set-prometheus-api-host',
-                f'{mgmt_gw_internal_endpoint}/internal/prometheus'
+                f'{get_mgmt_gw_internal_endpoint(self.mgr)}/prometheus'
             )
             self._set_value_on_dashboard(
                 'Prometheus',
@@ -640,20 +643,23 @@ class NodeExporterService(CephadmService):
 
     def get_node_exporter_certificates(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[str, str]:
         node_ip = self.mgr.inventory.get_addr(daemon_spec.host)
-        host_fqdn = self._inventory_get_fqdn(daemon_spec.host)
+        host_fqdn = self.mgr.get_fqdn(daemon_spec.host)
         cert, key = self.mgr.cert_mgr.generate_cert(host_fqdn, node_ip)
         return cert, key
 
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
-        deps = [f'secure_monitoring_stack:{self.mgr.secure_monitoring_stack}']
-        if self.mgr.secure_monitoring_stack:
+        deps = []
+        deps += [d.name() for d in self.mgr.cache.get_daemons_by_service('mgmt-gateway')]
+        deps += [f'secure_monitoring_stack:{self.mgr.secure_monitoring_stack}']
+        security_enabled, mgmt_gw_enabled = self.mgr._get_security_config()
+        if security_enabled:
             cert, key = self.get_node_exporter_certificates(daemon_spec)
-            mgmt_gw_enabled = len(self.mgr.cache.get_daemons_by_service('mgmt-gateway')) > 0
             r = {
                 'files': {
-                    'web.yml': self.mgr.template.render('services/node-exporter/web.yml.j2', {}),
-                    'root_cert.pem': self.mgr.http_server.service_discovery.ssl_certs.get_root_cert(),
+                    'web.yml': self.mgr.template.render('services/node-exporter/web.yml.j2',
+                                                        {'enable_mtls': mgmt_gw_enabled}),
+                    'root_cert.pem': self.mgr.cert_mgr.get_root_ca(),
                     'node_exporter.crt': cert,
                     'node_exporter.key': key,
                 },
@@ -713,7 +719,7 @@ class PromtailService(CephadmService):
         for i, dd in enumerate(daemons):
             assert dd.hostname is not None
             if i == 0:
-                loki_host = dd.ip if dd.ip else self._inventory_get_fqdn(dd.hostname)
+                loki_host = dd.ip if dd.ip else self.mgr.get_fqdn(dd.hostname)
 
             deps.append(dd.name())
 

--- a/src/pybind/mgr/cephadm/ssl_cert_utils.py
+++ b/src/pybind/mgr/cephadm/ssl_cert_utils.py
@@ -1,5 +1,5 @@
 
-from typing import Any, Tuple, IO, List
+from typing import Any, Tuple, IO, List, Union
 import ipaddress
 
 from datetime import datetime, timedelta
@@ -8,11 +8,6 @@ from cryptography.x509.oid import NameOID
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.backends import default_backend
-
-from orchestrator import OrchestratorError
-
-
-logger = logging.getLogger(__name__)
 
 
 class SSLConfigException(Exception):
@@ -64,19 +59,23 @@ class SSLCerts:
 
         return (cert_str, key_str)
 
-    def generate_cert(self, hosts: Any, addr: str) -> Tuple[str, str]:
-        have_ip = True
+    def generate_cert(self, _hosts: Union[str, List[str]], _addrs: Union[str, List[str]]) -> Tuple[str, str]:
+
+        addrs = [_addrs] if isinstance(_addrs, str) else _addrs
+        hosts = [_hosts] if isinstance(_hosts, str) else _hosts
+
+        valid_ips = True
         try:
-            ip = x509.IPAddress(ipaddress.ip_address(addr))
+            ips = [x509.IPAddress(ipaddress.ip_address(addr)) for addr in addrs]
         except Exception:
-            have_ip = False
+            valid_ips = False
 
         private_key = rsa.generate_private_key(
             public_exponent=65537, key_size=4096, backend=default_backend())
         public_key = private_key.public_key()
 
         builder = x509.CertificateBuilder()
-        builder = builder.subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, addr), ]))
+        builder = builder.subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, addrs[0]), ]))
         builder = builder.issuer_name(
             x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, u'cephadm-root'), ]))
         builder = builder.not_valid_before(datetime.now())
@@ -84,11 +83,9 @@ class SSLCerts:
         builder = builder.serial_number(x509.random_serial_number())
         builder = builder.public_key(public_key)
 
-        if isinstance(hosts, str):
-            hosts = [hosts]
         san_list: List[x509.GeneralName] = [x509.DNSName(host) for host in hosts]
-        if have_ip:
-            san_list.append(ip)
+        if valid_ips:
+            san_list.extend(ips)
 
         builder = builder.add_extension(
             x509.SubjectAlternativeName(
@@ -129,7 +126,7 @@ class SSLCerts:
         given_cert = x509.load_pem_x509_certificate(cert.encode('utf-8'), backend=default_backend())
         tz = given_cert.not_valid_after.tzinfo
         if datetime.now(tz) >= given_cert.not_valid_after:
-            raise OrchestratorError('Given cert is expired')
+            raise SSLConfigException('Given cert is expired')
         self.root_cert = given_cert
         self.root_key = serialization.load_pem_private_key(
             data=priv_key.encode('utf-8'), backend=default_backend(), password=None)

--- a/src/pybind/mgr/cephadm/templates/services/alertmanager/alertmanager.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/alertmanager/alertmanager.yml.j2
@@ -6,7 +6,7 @@ global:
 {% if not secure %}
   http_config:
     tls_config:
-{% if secure_monitoring_stack %}
+{% if security_enabled %}
       ca_file: root_cert.pem
 {% else %}
       insecure_skip_verify: true

--- a/src/pybind/mgr/cephadm/templates/services/alertmanager/web.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/alertmanager/web.yml.j2
@@ -1,5 +1,11 @@
 tls_server_config:
   cert_file: alertmanager.crt
   key_file: alertmanager.key
+{% if enable_mtls %}
+  client_auth_type: RequireAndVerifyClientCert
+  client_ca_file: root_cert.pem
+{% endif %}
+{% if enable_basic_auth %}
 basic_auth_users:
     {{ alertmanager_web_user }}: {{ alertmanager_web_password }}
+{% endif %}

--- a/src/pybind/mgr/cephadm/templates/services/grafana/ceph-dashboard.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/grafana/ceph-dashboard.yml.j2
@@ -27,6 +27,8 @@ datasources:
     secureJsonData:
       basicAuthPassword: {{ prometheus_password }}
       tlsCACert: "{{ cephadm_root_ca }}"
+      tlsClientCert: "{{ cert }}"
+      tlsClientKey: "{{ key }}"
 {% endif %}
 {% endfor %}
 

--- a/src/pybind/mgr/cephadm/templates/services/grafana/grafana.ini.j2
+++ b/src/pybind/mgr/cephadm/templates/services/grafana/grafana.ini.j2
@@ -8,15 +8,14 @@
   org_role = 'Viewer'
 {% endif %}
 [server]
-  domain = 'bootstrap.storage.lab'
+  domain = '{{ domain }}'
   protocol = {{ protocol }}
   cert_file = /etc/grafana/certs/cert_file
   cert_key = /etc/grafana/certs/cert_key
   http_port = {{ http_port }}
   http_addr = {{ http_addr }}
 {% if use_url_prefix %}
-  root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
-  serve_from_sub_path = true
+  root_url = %(protocol)s://%(domain)s/grafana/
 {% endif %}
 [snapshots]
   external_enabled = false

--- a/src/pybind/mgr/cephadm/templates/services/mgmt-gateway/external_server.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/mgmt-gateway/external_server.conf.j2
@@ -58,18 +58,33 @@ server {
     location /grafana {
         rewrite ^/grafana/(.*) /$1 break;
         proxy_pass {{ grafana_scheme }}://grafana_servers;
+        # clear any Authorization header as Prometheus and Alertmanager are using basic-auth browser
+        # will send this header if Grafana is running on the same node as one of those services
+        proxy_set_header Authorization "";
     }
 {% endif %}
 
 {% if prometheus_endpoints %}
     location /prometheus {
         proxy_pass {{ prometheus_scheme }}://prometheus_servers;
+
+        proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+        proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+        proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+        proxy_ssl_verify on;
+        proxy_ssl_verify_depth 2;
     }
 {% endif %}
 
 {% if alertmanager_endpoints %}
     location /alertmanager {
         proxy_pass {{ alertmanager_scheme }}://alertmanager_servers;
+
+        proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+        proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+        proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+        proxy_ssl_verify on;
+        proxy_ssl_verify_depth 2;
     }
 {% endif %}
 }

--- a/src/pybind/mgr/cephadm/templates/services/mgmt-gateway/internal_server.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/mgmt-gateway/internal_server.conf.j2
@@ -8,6 +8,14 @@ server {
     ssl_ciphers         AES128-SHA:AES256-SHA:RC4-SHA:DES-CBC3-SHA:RC4-MD5;
     ssl_prefer_server_ciphers on;
 
+{% if dashboard_endpoints %}
+    location /internal/dashboard {
+        rewrite ^/internal/dashboard/(.*) /$1 break;
+        proxy_pass {{ dashboard_scheme }}://dashboard_servers;
+        proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+    }
+{% endif %}
+
 {% if grafana_endpoints %}
     location /internal/grafana {
         rewrite ^/internal/grafana/(.*) /$1 break;
@@ -19,6 +27,12 @@ server {
     location /internal/prometheus {
         rewrite ^/internal/prometheus/(.*) /prometheus/$1 break;
         proxy_pass {{ prometheus_scheme }}://prometheus_servers;
+
+        proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+        proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+        proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+        proxy_ssl_verify on;
+        proxy_ssl_verify_depth 2;
     }
 {% endif %}
 
@@ -26,6 +40,12 @@ server {
     location /internal/alertmanager {
         rewrite ^/internal/alertmanager/(.*) /alertmanager/$1 break;
         proxy_pass {{ alertmanager_scheme }}://alertmanager_servers;
+
+        proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+        proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+        proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+        proxy_ssl_verify on;
+        proxy_ssl_verify_depth 2;
     }
 {% endif %}
 }

--- a/src/pybind/mgr/cephadm/templates/services/node-exporter/web.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/node-exporter/web.yml.j2
@@ -1,3 +1,7 @@
 tls_server_config:
   cert_file: node_exporter.crt
   key_file: node_exporter.key
+{% if enable_mtls %}
+  client_auth_type: RequireAndVerifyClientCert
+  client_ca_file: root_cert.pem
+{% endif %}

--- a/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
@@ -2,7 +2,7 @@
 global:
   scrape_interval: 10s
   evaluation_interval: 10s
-{% if not secure_monitoring_stack %}
+{% if not security_enabled %}
   external_labels:
     cluster: {{ cluster_fsid }}
 {% endif %}
@@ -13,13 +13,16 @@ rule_files:
 {% if alertmanager_sd_url %}
 alerting:
   alertmanagers:
-{% if secure_monitoring_stack %}
+{% if security_enabled %}
     - scheme: https
       basic_auth:
         username: {{ alertmanager_web_user }}
         password: {{ alertmanager_web_password }}
       tls_config:
         ca_file: root_cert.pem
+        cert_file: prometheus.crt
+        key_file:  prometheus.key
+      path_prefix: '{{ alertmanager_url_prefix }}'
       http_sd_configs:
         - url: {{ alertmanager_sd_url }}
           basic_auth:
@@ -36,10 +39,10 @@ alerting:
 
 scrape_configs:
   - job_name: 'ceph'
-{% if secure_monitoring_stack %}
+{% if security_enabled %}
     scheme: https
     tls_config:
-      ca_file: mgr_prometheus_cert.pem
+      ca_file: root_cert.pem
     honor_labels: true
     relabel_configs:
     - source_labels: [instance]
@@ -67,10 +70,12 @@ scrape_configs:
 
 {% if node_exporter_sd_url %}
   - job_name: 'node'
-{% if secure_monitoring_stack %}
+{% if security_enabled %}
     scheme: https
     tls_config:
       ca_file: root_cert.pem
+      cert_file: prometheus.crt
+      key_file:  prometheus.key
     http_sd_configs:
     - url: {{ node_exporter_sd_url }}
       basic_auth:
@@ -90,7 +95,7 @@ scrape_configs:
 
 {% if haproxy_sd_url %}
   - job_name: 'haproxy'
-{% if secure_monitoring_stack %}
+{% if security_enabled %}
     scheme: https
     tls_config:
       ca_file: root_cert.pem
@@ -113,7 +118,7 @@ scrape_configs:
 
 {% if ceph_exporter_sd_url %}
   - job_name: 'ceph-exporter'
-{% if secure_monitoring_stack %}
+{% if security_enabled %}
     honor_labels: true
     scheme: https
     tls_config:
@@ -138,7 +143,7 @@ scrape_configs:
 
 {% if nvmeof_sd_url %}
   - job_name: 'nvmeof'
-{% if secure_monitoring_stack %}
+{% if security_enabled %}
     honor_labels: true
     scheme: https
     tls_config:
@@ -156,7 +161,7 @@ scrape_configs:
 {% endif %}
 {% endif %}
 
-{% if not secure_monitoring_stack %}
+{% if not security_enabled %}
   - job_name: 'federate'
     scrape_interval: 15s
     honor_labels: true

--- a/src/pybind/mgr/cephadm/templates/services/prometheus/web.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/prometheus/web.yml.j2
@@ -1,5 +1,11 @@
 tls_server_config:
   cert_file: prometheus.crt
   key_file: prometheus.key
+{% if enable_mtls %}
+  client_auth_type: RequireAndVerifyClientCert
+  client_ca_file: root_cert.pem
+{% endif %}
+{% if enable_basic_auth %}
 basic_auth_users:
     {{ prometheus_web_user }}: {{ prometheus_web_password }}
+{% endif %}

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -95,7 +95,7 @@ def with_cephadm_module(module_options=None, store=None):
             mock.patch('cephadm.module.CephadmOrchestrator.get_module_option_ex', get_module_option_ex), \
             mock.patch("cephadm.module.CephadmOrchestrator.get_osdmap"), \
             mock.patch("cephadm.module.CephadmOrchestrator.remote"), \
-            mock.patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1'),\
+            mock.patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1'), \
             mock.patch("cephadm.agent.CephadmAgentHelpers._request_agent_acks"), \
             mock.patch("cephadm.agent.CephadmAgentHelpers._apply_agent", return_value=False), \
             mock.patch("cephadm.agent.CephadmAgentHelpers._agent_down", return_value=False), \

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -95,6 +95,7 @@ def with_cephadm_module(module_options=None, store=None):
             mock.patch('cephadm.module.CephadmOrchestrator.get_module_option_ex', get_module_option_ex), \
             mock.patch("cephadm.module.CephadmOrchestrator.get_osdmap"), \
             mock.patch("cephadm.module.CephadmOrchestrator.remote"), \
+            mock.patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1'),\
             mock.patch("cephadm.agent.CephadmAgentHelpers._request_agent_acks"), \
             mock.patch("cephadm.agent.CephadmAgentHelpers._apply_agent", return_value=False), \
             mock.patch("cephadm.agent.CephadmAgentHelpers._agent_down", return_value=False), \

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1701,8 +1701,6 @@ class TestCephadm(object):
     def test_cert_store_save_cert(self, _set_store, cephadm_module: CephadmOrchestrator):
         cephadm_module.cert_key_store._init_known_cert_key_dicts()
 
-        agent_endpoint_root_cert = 'fake-agent-cert'
-        alertmanager_host1_cert = 'fake-alertm-host1-cert'
         rgw_frontend_rgw_foo_host2_cert = 'fake-rgw-cert'
         nvmeof_client_cert = 'fake-nvmeof-client-cert'
         nvmeof_server_cert = 'fake-nvmeof-server-cert'
@@ -1715,8 +1713,6 @@ class TestCephadm(object):
         cephadm_module.cert_key_store.save_cert('nvmeof_root_ca_cert', nvmeof_root_ca_cert, service_name='nvmeof.foo', user_made=True)
 
         expected_calls = [
-            mock.call(f'{CERT_STORE_CERT_PREFIX}agent_endpoint_root_cert', json.dumps(Cert(agent_endpoint_root_cert).to_json())),
-            mock.call(f'{CERT_STORE_CERT_PREFIX}alertmanager_cert', json.dumps({'host1': Cert(alertmanager_host1_cert).to_json()})),
             mock.call(f'{CERT_STORE_CERT_PREFIX}rgw_frontend_ssl_cert', json.dumps({'rgw.foo': Cert(rgw_frontend_rgw_foo_host2_cert, True).to_json()})),
             mock.call(f'{CERT_STORE_CERT_PREFIX}nvmeof_server_cert', json.dumps({'nvmeof.foo': Cert(nvmeof_server_cert, True).to_json()})),
             mock.call(f'{CERT_STORE_CERT_PREFIX}nvmeof_client_cert', json.dumps({'nvmeof.foo': Cert(nvmeof_client_cert, True).to_json()})),
@@ -1732,9 +1728,8 @@ class TestCephadm(object):
             'rgw_frontend_ssl_cert': False,
             'iscsi_ssl_cert': False,
             'ingress_ssl_cert': False,
-            'agent_endpoint_root_cert': False,
-            'service_discovery_root_cert': False,
             'mgmt_gw_root_cert': False,
+            'cephadm_root_ca_cert': False,
             'grafana_cert': False,
             'alertmanager_cert': False,
             'prometheus_cert': False,
@@ -1743,17 +1738,6 @@ class TestCephadm(object):
             'nvmeof_server_cert': False,
             'nvmeof_root_ca_cert': False,
         }
-        assert cephadm_module.cert_key_store.cert_ls() == expected_ls
-
-        cephadm_module.cert_key_store.save_cert('agent_endpoint_root_cert', 'xxx')
-        expected_ls['agent_endpoint_root_cert'] = True
-        assert cephadm_module.cert_key_store.cert_ls() == expected_ls
-
-        cephadm_module.cert_key_store.save_cert('alertmanager_cert', 'xxx', host='host1')
-        cephadm_module.cert_key_store.save_cert('alertmanager_cert', 'xxx', host='host2')
-        expected_ls['alertmanager_cert'] = {}
-        expected_ls['alertmanager_cert']['host1'] = True
-        expected_ls['alertmanager_cert']['host2'] = True
         assert cephadm_module.cert_key_store.cert_ls() == expected_ls
 
         cephadm_module.cert_key_store.save_cert('rgw_frontend_ssl_cert', 'xxx', service_name='rgw.foo', user_made=True)
@@ -1778,17 +1762,15 @@ class TestCephadm(object):
     def test_cert_store_save_key(self, _set_store, cephadm_module: CephadmOrchestrator):
         cephadm_module.cert_key_store._init_known_cert_key_dicts()
 
-        agent_endpoint_key = 'fake-agent-key'
         grafana_host1_key = 'fake-grafana-host1-key'
         nvmeof_client_key = 'nvmeof-client-key'
         nvmeof_server_key = 'nvmeof-server-key'
-        cephadm_module.cert_key_store.save_key('agent_endpoint_key', agent_endpoint_key)
+        grafana_host1_key = 'fake-grafana-host1-cert'
         cephadm_module.cert_key_store.save_key('grafana_key', grafana_host1_key, host='host1')
         cephadm_module.cert_key_store.save_key('nvmeof_client_key', nvmeof_client_key, service_name='nvmeof.foo')
         cephadm_module.cert_key_store.save_key('nvmeof_server_key', nvmeof_server_key, service_name='nvmeof.foo')
 
         expected_calls = [
-            mock.call(f'{CERT_STORE_KEY_PREFIX}agent_endpoint_key', json.dumps(PrivKey(agent_endpoint_key).to_json())),
             mock.call(f'{CERT_STORE_KEY_PREFIX}grafana_key', json.dumps({'host1': PrivKey(grafana_host1_key).to_json()})),
             mock.call(f'{CERT_STORE_KEY_PREFIX}nvmeof_client_key', json.dumps({'nvmeof.foo': PrivKey(nvmeof_client_key).to_json()})),
             mock.call(f'{CERT_STORE_KEY_PREFIX}nvmeof_server_key', json.dumps({'nvmeof.foo': PrivKey(nvmeof_server_key).to_json()})),
@@ -1800,29 +1782,14 @@ class TestCephadm(object):
         cephadm_module.cert_key_store._init_known_cert_key_dicts()
 
         expected_ls = {
-            'agent_endpoint_key': False,
-            'service_discovery_key': False,
             'grafana_key': False,
-            'alertmanager_key': False,
             'mgmt_gw_root_key': False,
-            'prometheus_key': False,
-            'node_exporter_key': False,
+            'cephadm_root_ca_key': False,
             'iscsi_ssl_key': False,
             'ingress_ssl_key': False,
             'nvmeof_client_key': False,
             'nvmeof_server_key': False,
         }
-        assert cephadm_module.cert_key_store.key_ls() == expected_ls
-
-        cephadm_module.cert_key_store.save_key('agent_endpoint_key', 'xxx')
-        expected_ls['agent_endpoint_key'] = True
-        assert cephadm_module.cert_key_store.key_ls() == expected_ls
-
-        cephadm_module.cert_key_store.save_key('alertmanager_key', 'xxx', host='host1')
-        cephadm_module.cert_key_store.save_key('alertmanager_key', 'xxx', host='host2')
-        expected_ls['alertmanager_key'] = {}
-        expected_ls['alertmanager_key']['host1'] = True
-        expected_ls['alertmanager_key']['host2'] = True
         assert cephadm_module.cert_key_store.key_ls() == expected_ls
 
         cephadm_module.cert_key_store.save_key('nvmeof_client_key', 'xxx', service_name='nvmeof.foo')
@@ -1837,10 +1804,7 @@ class TestCephadm(object):
     def test_cert_store_load(self, _get_store_prefix, cephadm_module: CephadmOrchestrator):
         cephadm_module.cert_key_store._init_known_cert_key_dicts()
 
-        agent_endpoint_root_cert = 'fake-agent-cert'
-        alertmanager_host1_cert = 'fake-alertm-host1-cert'
         rgw_frontend_rgw_foo_host2_cert = 'fake-rgw-cert'
-        agent_endpoint_key = 'fake-agent-key'
         grafana_host1_key = 'fake-grafana-host1-cert'
         nvmeof_server_cert = 'nvmeof-server-cert'
         nvmeof_client_cert = 'nvmeof-client-cert'
@@ -1851,8 +1815,6 @@ class TestCephadm(object):
         def _fake_prefix_store(key):
             if key == 'cert_store.cert.':
                 return {
-                    f'{CERT_STORE_CERT_PREFIX}agent_endpoint_root_cert': json.dumps(Cert(agent_endpoint_root_cert).to_json()),
-                    f'{CERT_STORE_CERT_PREFIX}alertmanager_cert': json.dumps({'host1': Cert(alertmanager_host1_cert).to_json()}),
                     f'{CERT_STORE_CERT_PREFIX}rgw_frontend_ssl_cert': json.dumps({'rgw.foo': Cert(rgw_frontend_rgw_foo_host2_cert, True).to_json()}),
                     f'{CERT_STORE_CERT_PREFIX}nvmeof_server_cert': json.dumps({'nvmeof.foo': Cert(nvmeof_server_cert, True).to_json()}),
                     f'{CERT_STORE_CERT_PREFIX}nvmeof_client_cert': json.dumps({'nvmeof.foo': Cert(nvmeof_client_cert, True).to_json()}),
@@ -1860,7 +1822,6 @@ class TestCephadm(object):
                 }
             elif key == 'cert_store.key.':
                 return {
-                    f'{CERT_STORE_KEY_PREFIX}agent_endpoint_key': json.dumps(PrivKey(agent_endpoint_key).to_json()),
                     f'{CERT_STORE_KEY_PREFIX}grafana_key': json.dumps({'host1': PrivKey(grafana_host1_key).to_json()}),
                     f'{CERT_STORE_KEY_PREFIX}nvmeof_server_key': json.dumps({'nvmeof.foo': PrivKey(nvmeof_server_key).to_json()}),
                     f'{CERT_STORE_KEY_PREFIX}nvmeof_client_key': json.dumps({'nvmeof.foo': PrivKey(nvmeof_client_key).to_json()}),
@@ -1870,13 +1831,10 @@ class TestCephadm(object):
 
         _get_store_prefix.side_effect = _fake_prefix_store
         cephadm_module.cert_key_store.load()
-        assert cephadm_module.cert_key_store.known_certs['agent_endpoint_root_cert'] == Cert(agent_endpoint_root_cert)
-        assert cephadm_module.cert_key_store.known_certs['alertmanager_cert']['host1'] == Cert(alertmanager_host1_cert)
         assert cephadm_module.cert_key_store.known_certs['rgw_frontend_ssl_cert']['rgw.foo'] == Cert(rgw_frontend_rgw_foo_host2_cert, True)
         assert cephadm_module.cert_key_store.known_certs['nvmeof_server_cert']['nvmeof.foo'] == Cert(nvmeof_server_cert, True)
         assert cephadm_module.cert_key_store.known_certs['nvmeof_client_cert']['nvmeof.foo'] == Cert(nvmeof_client_cert, True)
         assert cephadm_module.cert_key_store.known_certs['nvmeof_root_ca_cert']['nvmeof.foo'] == Cert(nvmeof_root_ca_cert, True)
-        assert cephadm_module.cert_key_store.known_keys['agent_endpoint_key'] == PrivKey(agent_endpoint_key)
         assert cephadm_module.cert_key_store.known_keys['grafana_key']['host1'] == PrivKey(grafana_host1_key)
         assert cephadm_module.cert_key_store.known_keys['nvmeof_server_key']['nvmeof.foo'] == PrivKey(nvmeof_server_key)
         assert cephadm_module.cert_key_store.known_keys['nvmeof_client_key']['nvmeof.foo'] == PrivKey(nvmeof_client_key)
@@ -1884,23 +1842,16 @@ class TestCephadm(object):
     def test_cert_store_get_cert_key(self, cephadm_module: CephadmOrchestrator):
         cephadm_module.cert_key_store._init_known_cert_key_dicts()
 
-        agent_endpoint_root_cert = 'fake-agent-cert'
-        alertmanager_host1_cert = 'fake-alertm-host1-cert'
         rgw_frontend_rgw_foo_host2_cert = 'fake-rgw-cert'
         nvmeof_client_cert = 'fake-nvmeof-client-cert'
         nvmeof_server_cert = 'fake-nvmeof-server-cert'
-        cephadm_module.cert_key_store.save_cert('agent_endpoint_root_cert', agent_endpoint_root_cert)
-        cephadm_module.cert_key_store.save_cert('alertmanager_cert', alertmanager_host1_cert, host='host1')
         cephadm_module.cert_key_store.save_cert('rgw_frontend_ssl_cert', rgw_frontend_rgw_foo_host2_cert, service_name='rgw.foo', user_made=True)
         cephadm_module.cert_key_store.save_cert('nvmeof_server_cert', nvmeof_server_cert, service_name='nvmeof.foo', user_made=True)
         cephadm_module.cert_key_store.save_cert('nvmeof_client_cert', nvmeof_client_cert, service_name='nvmeof.foo', user_made=True)
 
-        assert cephadm_module.cert_key_store.get_cert('agent_endpoint_root_cert') == agent_endpoint_root_cert
-        assert cephadm_module.cert_key_store.get_cert('alertmanager_cert', host='host1') == alertmanager_host1_cert
         assert cephadm_module.cert_key_store.get_cert('rgw_frontend_ssl_cert', service_name='rgw.foo') == rgw_frontend_rgw_foo_host2_cert
         assert cephadm_module.cert_key_store.get_cert('nvmeof_server_cert', service_name='nvmeof.foo') == nvmeof_server_cert
         assert cephadm_module.cert_key_store.get_cert('nvmeof_client_cert', service_name='nvmeof.foo') == nvmeof_client_cert
-        assert cephadm_module.cert_key_store.get_cert('service_discovery_root_cert') == ''
         assert cephadm_module.cert_key_store.get_cert('grafana_cert', host='host1') == ''
         assert cephadm_module.cert_key_store.get_cert('iscsi_ssl_cert', service_name='iscsi.foo') == ''
         assert cephadm_module.cert_key_store.get_cert('nvmeof_root_ca_cert', service_name='nvmeof.foo') == ''
@@ -1912,21 +1863,15 @@ class TestCephadm(object):
         with pytest.raises(OrchestratorError, match='Need service name to access cert for entity'):
             cephadm_module.cert_key_store.get_cert('rgw_frontend_ssl_cert', host='foo')
 
-        agent_endpoint_key = 'fake-agent-key'
         grafana_host1_key = 'fake-grafana-host1-cert'
         nvmeof_server_key = 'nvmeof-server-key'
-        cephadm_module.cert_key_store.save_key('agent_endpoint_key', agent_endpoint_key)
         cephadm_module.cert_key_store.save_key('grafana_key', grafana_host1_key, host='host1')
-        cephadm_module.cert_key_store.save_key('agent_endpoint_key', agent_endpoint_key)
         cephadm_module.cert_key_store.save_key('grafana_key', grafana_host1_key, host='host1')
         cephadm_module.cert_key_store.save_key('nvmeof_server_key', nvmeof_server_key, service_name='nvmeof.foo')
 
-        assert cephadm_module.cert_key_store.get_key('agent_endpoint_key') == agent_endpoint_key
         assert cephadm_module.cert_key_store.get_key('grafana_key', host='host1') == grafana_host1_key
         assert cephadm_module.cert_key_store.get_key('nvmeof_server_key', service_name='nvmeof.foo') == nvmeof_server_key
         assert cephadm_module.cert_key_store.get_key('nvmeof_client_key', service_name='nvmeof.foo') == ''
-        assert cephadm_module.cert_key_store.get_key('service_discovery_key') == ''
-        assert cephadm_module.cert_key_store.get_key('alertmanager_key', host='host1') == ''
 
         with pytest.raises(OrchestratorError, match='Attempted to access priv key for unknown entity'):
             cephadm_module.cert_key_store.get_key('unknown_entity')

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -346,8 +346,8 @@ class TestCephadm(object):
     ))
     def test_list_daemons(self, cephadm_module: CephadmOrchestrator):
         cephadm_module.service_cache_timeout = 10
-        with with_host(cephadm_module, 'test'):
-            CephadmServe(cephadm_module)._refresh_host_daemons('test')
+        with with_host(cephadm_module, 'myhost'):
+            CephadmServe(cephadm_module)._refresh_host_daemons('myhost')
             dds = wait(cephadm_module, cephadm_module.list_daemons())
             assert {d.name() for d in dds} == {'rgw.myrgw.foobar', 'haproxy.test.bar'}
 
@@ -1705,8 +1705,6 @@ class TestCephadm(object):
         nvmeof_client_cert = 'fake-nvmeof-client-cert'
         nvmeof_server_cert = 'fake-nvmeof-server-cert'
         nvmeof_root_ca_cert = 'fake-nvmeof-root-ca-cert'
-        cephadm_module.cert_key_store.save_cert('agent_endpoint_root_cert', agent_endpoint_root_cert)
-        cephadm_module.cert_key_store.save_cert('alertmanager_cert', alertmanager_host1_cert, host='host1')
         cephadm_module.cert_key_store.save_cert('rgw_frontend_ssl_cert', rgw_frontend_rgw_foo_host2_cert, service_name='rgw.foo', user_made=True)
         cephadm_module.cert_key_store.save_cert('nvmeof_server_cert', nvmeof_server_cert, service_name='nvmeof.foo', user_made=True)
         cephadm_module.cert_key_store.save_cert('nvmeof_client_cert', nvmeof_client_cert, service_name='nvmeof.foo', user_made=True)
@@ -1728,12 +1726,9 @@ class TestCephadm(object):
             'rgw_frontend_ssl_cert': False,
             'iscsi_ssl_cert': False,
             'ingress_ssl_cert': False,
-            'mgmt_gw_root_cert': False,
+            'mgmt_gw_cert': False,
             'cephadm_root_ca_cert': False,
             'grafana_cert': False,
-            'alertmanager_cert': False,
-            'prometheus_cert': False,
-            'node_exporter_cert': False,
             'nvmeof_client_cert': False,
             'nvmeof_server_cert': False,
             'nvmeof_root_ca_cert': False,
@@ -1783,7 +1778,7 @@ class TestCephadm(object):
 
         expected_ls = {
             'grafana_key': False,
-            'mgmt_gw_root_key': False,
+            'mgmt_gw_key': False,
             'cephadm_root_ca_key': False,
             'iscsi_ssl_key': False,
             'ingress_ssl_key': False,

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -378,11 +378,6 @@ def test_migrate_cert_store(cephadm_module: CephadmOrchestrator):
     assert cephadm_module.cert_key_store.get_cert('ingress_ssl_cert', service_name='ingress.rgw.foo')
     assert cephadm_module.cert_key_store.get_key('ingress_ssl_key', service_name='ingress.rgw.foo')
 
-    assert cephadm_module.cert_key_store.get_cert('agent_endpoint_root_cert')
-    assert cephadm_module.cert_key_store.get_key('agent_endpoint_key')
-    assert cephadm_module.cert_key_store.get_cert('service_discovery_root_cert')
-    assert cephadm_module.cert_key_store.get_key('service_discovery_key')
-
     assert cephadm_module.cert_key_store.get_cert('grafana_cert', host='host1')
     assert cephadm_module.cert_key_store.get_cert('grafana_cert', host='host2')
     assert cephadm_module.cert_key_store.get_key('grafana_key', host='host1')

--- a/src/pybind/mgr/cephadm/tests/test_node_proxy.py
+++ b/src/pybind/mgr/cephadm/tests/test_node_proxy.py
@@ -10,6 +10,15 @@ from cephadm.ssl_cert_utils import SSLCerts
 from . import node_proxy_data
 
 PORT = 58585
+fake_cert = """-----BEGIN CERTIFICATE-----\nMIICxjCCAa4CEQDIZSujNBlKaLJzmvntjukjMA0GCSqGSIb3DQEBDQUAMCExDTAL\nBgNVBAoMBENlcGgxEDAOBgNVBAMMB2NlcGhhZG0wHhcNMjIwNzEzMTE0NzA3WhcN\nMzIwNzEwMTE0NzA3WjAhMQ0wCwYDVQQKDARDZXBoMRAwDgYDVQQDDAdjZXBoYWRt\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyyMe4DMA+MeYK7BHZMHB\nq7zjliEOcNgxomjU8qbf5USF7Mqrf6+/87XWqj4pCyAW8x0WXEr6A56a+cmBVmt+\nqtWDzl020aoId6lL5EgLLn6/kMDCCJLq++Lg9cEofMSvcZh+lY2f+1p+C+00xent\nrLXvXGOilAZWaQfojT2BpRnNWWIFbpFwlcKrlg2G0cFjV5c1m6a0wpsQ9JHOieq0\nSvwCixajwq3CwAYuuiU1wjI4oJO4Io1+g8yB3nH2Mo/25SApCxMXuXh4kHLQr/T4\n4hqisvG4uJYgKMcSIrWj5o25mclByGi1UI/kZkCUES94i7Z/3ihx4Bad0AMs/9tw\nFwIDAQABMA0GCSqGSIb3DQEBDQUAA4IBAQAf+pwz7Gd7mDwU2LY0TQXsK6/8KGzh\nHuX+ErOb8h5cOAbvCnHjyJFWf6gCITG98k9nxU9NToG0WYuNm/max1y/54f0dtxZ\npUo6KSNl3w6iYCfGOeUIj8isi06xMmeTgMNzv8DYhDt+P2igN6LenqWTVztogkiV\nxQ5ZJFFLEw4sN0CXnrZX3t5ruakxLXLTLKeE0I91YJvjClSBGkVJq26wOKQNHMhx\npWxeydQ5EgPZY+Aviz5Dnxe8aB7oSSovpXByzxURSabOuCK21awW5WJCGNpmqhWK\nZzACBDEstccj57c4OGV0eayHJRsluVr2e9NHRINZA3qdB37e6gsI1xHo\n-----END CERTIFICATE-----\n"""
+
+
+class FakeCertMgr:
+    def get_root_ca(self):
+        return fake_cert
+
+    def generate_cert(self, host_fqdn, node_ip):
+        return fake_cert
 
 
 class FakeMgr:
@@ -29,6 +38,7 @@ class FakeMgr:
         self.http_server.agent = MagicMock()
         self.http_server.agent.ssl_certs = SSLCerts()
         self.http_server.agent.ssl_certs.generate_root_cert(self.get_mgr_ip())
+        self.cert_mgr = FakeCertMgr()
 
     def get_mgr_ip(self) -> str:
         return '0.0.0.0'

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -46,6 +46,8 @@ from orchestrator._interface import DaemonDescription
 
 from typing import Dict, List
 
+cephadm_root_ca = """-----BEGIN CERTIFICATE-----\\nMIIE7DCCAtSgAwIBAgIUE8b2zZ64geu2ns3Zfn3/4L+Cf6MwDQYJKoZIhvcNAQEL\\nBQAwFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MB4XDTI0MDYyNjE0NDA1M1oXDTM0\\nMDYyNzE0NDA1M1owFzEVMBMGA1UEAwwMY2VwaGFkbS1yb290MIICIjANBgkqhkiG\\n9w0BAQEFAAOCAg8AMIICCgKCAgEAsZRJsdtTr9GLG1lWFql5SGc46ldFanNJd1Gl\\nqXq5vgZVKRDTmNgAb/XFuNEEmbDAXYIRZolZeYKMHfn0pouPRSel0OsC6/02ZUOW\\nIuN89Wgo3IYleCFpkVIumD8URP3hwdu85plRxYZTtlruBaTRH38lssyCqxaOdEt7\\nAUhvYhcMPJThB17eOSQ73mb8JEC83vB47fosI7IhZuvXvRSuZwUW30rJanWNhyZq\\neS2B8qw2RSO0+77H6gA4ftBnitfsE1Y8/F9Z/f92JOZuSMQXUB07msznPbRJia3f\\nueO8gOc32vxd1A1/Qzp14uX34yEGY9ko2lW226cZO29IVUtXOX+LueQttwtdlpz8\\ne6Npm09pXhXAHxV/OW3M28MdXmobIqT/m9MfkeAErt5guUeC5y8doz6/3VQRjFEn\\nRpN0WkblgnNAQ3DONPc+Qd9Fi/wZV2X7bXoYpNdoWDsEOiE/eLmhG1A2GqU/mneP\\nzQ6u79nbdwTYpwqHpa+PvusXeLfKauzI8lLUJotdXy9EK8iHUofibB61OljYye6B\\nG3b8C4QfGsw8cDb4APZd/6AZYyMx/V3cGZ+GcOV7WvsC8k7yx5Uqasm/kiGQ3EZo\\nuNenNEYoGYrjb8D/8QzqNUTwlEh27/ps80tO7l2GGTvWVZL0PRZbmLDvO77amtOf\\nOiRXMoUCAwEAAaMwMC4wGwYDVR0RBBQwEocQAAAAAAAAAAAAAAAAAAAAATAPBgNV\\nHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQAxwzX5AhYEWhTV4VUwUj5+\\nqPdl4Q2tIxRokqyE+cDxoSd+6JfGUefUbNyBxDt0HaBq8obDqqrbcytxnn7mpnDu\\nhtiauY+I4Amt7hqFOiFA4cCLi2mfok6g2vL53tvhd9IrsfflAU2wy7hL76Ejm5El\\nA+nXlkJwps01Whl9pBkUvIbOn3pXX50LT4hb5zN0PSu957rjd2xb4HdfuySm6nW4\\n4GxtVWfmGA6zbC4XMEwvkuhZ7kD2qjkAguGDF01uMglkrkCJT3OROlNBuSTSBGqt\\ntntp5VytHvb7KTF7GttM3ha8/EU2KYaHM6WImQQTrOfiImAktOk4B3lzUZX3HYIx\\n+sByO4P4dCvAoGz1nlWYB2AvCOGbKf0Tgrh4t4jkiF8FHTXGdfvWmjgi1pddCNAy\\nn65WOCmVmLZPERAHOk1oBwqyReSvgoCFo8FxbZcNxJdlhM0Z6hzKggm3O3Dl88Xl\\n5euqJjh2STkBW8Xuowkg1TOs5XyWvKoDFAUzyzeLOL8YSG+gXV22gPTUaPSVAqdb\\nwd0Fx2kjConuC5bgTzQHs8XWA930U3XWZraj21Vaa8UxlBLH4fUro8H5lMSYlZNE\\nJHRNW8BkznAClaFSDG3dybLsrzrBFAu/Qb5zVkT1xyq0YkepGB7leXwq6vjWA5Pw\\nmZbKSphWfh0qipoqxqhfkw==\\n-----END CERTIFICATE-----\\n"""
+
 ceph_generated_cert = """-----BEGIN CERTIFICATE-----\nMIICxjCCAa4CEQDIZSujNBlKaLJzmvntjukjMA0GCSqGSIb3DQEBDQUAMCExDTAL\nBgNVBAoMBENlcGgxEDAOBgNVBAMMB2NlcGhhZG0wHhcNMjIwNzEzMTE0NzA3WhcN\nMzIwNzEwMTE0NzA3WjAhMQ0wCwYDVQQKDARDZXBoMRAwDgYDVQQDDAdjZXBoYWRt\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyyMe4DMA+MeYK7BHZMHB\nq7zjliEOcNgxomjU8qbf5USF7Mqrf6+/87XWqj4pCyAW8x0WXEr6A56a+cmBVmt+\nqtWDzl020aoId6lL5EgLLn6/kMDCCJLq++Lg9cEofMSvcZh+lY2f+1p+C+00xent\nrLXvXGOilAZWaQfojT2BpRnNWWIFbpFwlcKrlg2G0cFjV5c1m6a0wpsQ9JHOieq0\nSvwCixajwq3CwAYuuiU1wjI4oJO4Io1+g8yB3nH2Mo/25SApCxMXuXh4kHLQr/T4\n4hqisvG4uJYgKMcSIrWj5o25mclByGi1UI/kZkCUES94i7Z/3ihx4Bad0AMs/9tw\nFwIDAQABMA0GCSqGSIb3DQEBDQUAA4IBAQAf+pwz7Gd7mDwU2LY0TQXsK6/8KGzh\nHuX+ErOb8h5cOAbvCnHjyJFWf6gCITG98k9nxU9NToG0WYuNm/max1y/54f0dtxZ\npUo6KSNl3w6iYCfGOeUIj8isi06xMmeTgMNzv8DYhDt+P2igN6LenqWTVztogkiV\nxQ5ZJFFLEw4sN0CXnrZX3t5ruakxLXLTLKeE0I91YJvjClSBGkVJq26wOKQNHMhx\npWxeydQ5EgPZY+Aviz5Dnxe8aB7oSSovpXByzxURSabOuCK21awW5WJCGNpmqhWK\nZzACBDEstccj57c4OGV0eayHJRsluVr2e9NHRINZA3qdB37e6gsI1xHo\n-----END CERTIFICATE-----\n"""
 
 ceph_generated_key = """-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDLIx7gMwD4x5gr\nsEdkwcGrvOOWIQ5w2DGiaNTypt/lRIXsyqt/r7/ztdaqPikLIBbzHRZcSvoDnpr5\nyYFWa36q1YPOXTbRqgh3qUvkSAsufr+QwMIIkur74uD1wSh8xK9xmH6VjZ/7Wn4L\n7TTF6e2ste9cY6KUBlZpB+iNPYGlGc1ZYgVukXCVwquWDYbRwWNXlzWbprTCmxD0\nkc6J6rRK/AKLFqPCrcLABi66JTXCMjigk7gijX6DzIHecfYyj/blICkLExe5eHiQ\nctCv9PjiGqKy8bi4liAoxxIitaPmjbmZyUHIaLVQj+RmQJQRL3iLtn/eKHHgFp3Q\nAyz/23AXAgMBAAECggEAVoTB3Mm8azlPlaQB9GcV3tiXslSn+uYJ1duCf0sV52dV\nBzKW8s5fGiTjpiTNhGCJhchowqxoaew+o47wmGc2TvqbpeRLuecKrjScD0GkCYyQ\neM2wlshEbz4FhIZdgS6gbuh9WaM1dW/oaZoBNR5aTYo7xYTmNNeyLA/jO2zr7+4W\n5yES1lMSBXpKk7bDGKYY4bsX2b5RLr2Grh2u2bp7hoLABCEvuu8tSQdWXLEXWpXo\njwmV3hc6tabypIa0mj2Dmn2Dmt1ppSO0AZWG/WAizN3f4Z0r/u9HnbVrVmh0IEDw\n3uf2LP5o3msG9qKCbzv3lMgt9mMr70HOKnJ8ohMSKQKBgQDLkNb+0nr152HU9AeJ\nvdz8BeMxcwxCG77iwZphZ1HprmYKvvXgedqWtS6FRU+nV6UuQoPUbQxJBQzrN1Qv\nwKSlOAPCrTJgNgF/RbfxZTrIgCPuK2KM8I89VZv92TSGi362oQA4MazXC8RAWjoJ\nSu1/PHzK3aXOfVNSLrOWvIYeZQKBgQD/dgT6RUXKg0UhmXj7ExevV+c7oOJTDlMl\nvLngrmbjRgPO9VxLnZQGdyaBJeRngU/UXfNgajT/MU8B5fSKInnTMawv/tW7634B\nw3v6n5kNIMIjJmENRsXBVMllDTkT9S7ApV+VoGnXRccbTiDapBThSGd0wri/CuwK\nNWK1YFOeywKBgEDyI/XG114PBUJ43NLQVWm+wx5qszWAPqV/2S5MVXD1qC6zgCSv\nG9NLWN1CIMimCNg6dm7Wn73IM7fzvhNCJgVkWqbItTLG6DFf3/DPODLx1wTMqLOI\nqFqMLqmNm9l1Nec0dKp5BsjRQzq4zp1aX21hsfrTPmwjxeqJZdioqy2VAoGAXR5X\nCCdSHlSlUW8RE2xNOOQw7KJjfWT+WAYoN0c7R+MQplL31rRU7dpm1bLLRBN11vJ8\nMYvlT5RYuVdqQSP6BkrX+hLJNBvOLbRlL+EXOBrVyVxHCkDe+u7+DnC4epbn+N8P\nLYpwqkDMKB7diPVAizIKTBxinXjMu5fkKDs5n+sCgYBbZheYKk5M0sIxiDfZuXGB\nkf4mJdEkTI1KUGRdCwO/O7hXbroGoUVJTwqBLi1tKqLLarwCITje2T200BYOzj82\nqwRkCXGtXPKnxYEEUOiFx9OeDrzsZV00cxsEnX0Zdj+PucQ/J3Cvd0dWUspJfLHJ\n39gnaegswnz9KMQAvzKFdg==\n-----END PRIVATE KEY-----\n"""
@@ -603,17 +605,13 @@ class TestMonitoring:
     @patch("socket.getfqdn")
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
     @patch("cephadm.services.monitoring.password_hash", lambda password: 'alertmanager_password_hash')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: 'cephadm_root_cert')
+    @patch('cephadm.cert_mgr.CertMgr.generate_cert', lambda instance, fqdn, ip: ('mycert', 'mykey'))
     def test_alertmanager_config_security_enabled(self, _get_fqdn, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
 
         fqdn = 'host1.test'
         _get_fqdn.return_value = fqdn
-
-        def gen_cert(host, addr):
-            return ('mycert', 'mykey')
-
-        def get_root_cert():
-            return 'my_root_cert'
 
         with with_host(cephadm_module, 'test'):
             cephadm_module.secure_monitoring_stack = True
@@ -653,7 +651,8 @@ class TestMonitoring:
                   cert_file: alertmanager.crt
                   key_file: alertmanager.key
                 basic_auth_users:
-                    alertmanager_user: alertmanager_password_hash""").lstrip()
+                    alertmanager_user: alertmanager_password_hash
+                """).lstrip()
 
                 _run_cephadm.assert_called_with(
                     'test',
@@ -684,7 +683,7 @@ class TestMonitoring:
                                 'alertmanager.crt': 'mycert',
                                 'alertmanager.key': 'mykey',
                                 'web.yml': web_config,
-                                'root_cert.pem': 'my_root_cert'
+                                'root_cert.pem': 'cephadm_root_cert'
                             },
                             'peers': [],
                             'web_config': '/etc/alertmanager/web.yml',
@@ -836,6 +835,8 @@ class TestMonitoring:
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
     @patch("cephadm.services.monitoring.password_hash", lambda password: 'prometheus_password_hash')
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: 'cephadm_root_cert')
+    @patch('cephadm.cert_mgr.CertMgr.generate_cert', lambda instance, fqdn, ip: ('mycert', 'mykey'))
     def test_prometheus_config_security_enabled(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
         _run_cephadm.side_effect = async_side_effect(('{}', '', 0))
         s = RGWSpec(service_id="foo", placement=PlacementSpec(count=1), rgw_frontend_type='beast')
@@ -875,7 +876,8 @@ class TestMonitoring:
                   cert_file: prometheus.crt
                   key_file: prometheus.key
                 basic_auth_users:
-                    prometheus_user: prometheus_password_hash""").lstrip()
+                    prometheus_user: prometheus_password_hash
+                """).lstrip()
 
                 y = dedent("""
                 # This file is generated by cephadm.
@@ -894,6 +896,9 @@ class TestMonitoring:
                         password: alertmanager_plain_password
                       tls_config:
                         ca_file: root_cert.pem
+                        cert_file: prometheus.crt
+                        key_file:  prometheus.key
+                      path_prefix: '/'
                       http_sd_configs:
                         - url: https://[::1]:8765/sd/prometheus/sd-config?service=alertmanager
                           basic_auth:
@@ -906,7 +911,7 @@ class TestMonitoring:
                   - job_name: 'ceph'
                     scheme: https
                     tls_config:
-                      ca_file: mgr_prometheus_cert.pem
+                      ca_file: root_cert.pem
                     honor_labels: true
                     relabel_configs:
                     - source_labels: [instance]
@@ -924,6 +929,8 @@ class TestMonitoring:
                     scheme: https
                     tls_config:
                       ca_file: root_cert.pem
+                      cert_file: prometheus.crt
+                      key_file:  prometheus.key
                     http_sd_configs:
                     - url: https://[::1]:8765/sd/prometheus/sd-config?service=node-exporter
                       basic_auth:
@@ -998,8 +1005,7 @@ class TestMonitoring:
                         "config_blobs": {
                             'files': {
                                 'prometheus.yml': y,
-                                'root_cert.pem': '',
-                                'mgr_prometheus_cert.pem': '',
+                                'root_cert.pem': 'cephadm_root_cert',
                                 'web.yml': web_config,
                                 'prometheus.crt': 'mycert',
                                 'prometheus.key': 'mykey',
@@ -3194,8 +3200,12 @@ class TestSMB:
 class TestMgmtGateway:
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_service_endpoints")
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_external_certificates",
+           lambda instance, svc_spec, dspec: (ceph_generated_cert, ceph_generated_key))
+    @patch("cephadm.services.mgmt_gateway.MgmtGatewayService.get_internal_certificates",
+           lambda instance, dspec: (ceph_generated_cert, ceph_generated_key))
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
-    @patch('cephadm.ssl_cert_utils.SSLCerts.generate_cert', lambda instance, fqdn, ip: (ceph_generated_cert, ceph_generated_key))
+    @patch('cephadm.cert_mgr.CertMgr.get_root_ca', lambda instance: cephadm_root_ca)
     @patch("cephadm.services.mgmt_gateway.get_dashboard_endpoints", lambda _: (["ceph-node-2:8443", "ceph-node-2:8443"], "https"))
     def test_mgmt_gateway_config(self, get_service_endpoints_mock: List[str], _run_cephadm, cephadm_module: CephadmOrchestrator):
 
@@ -3311,14 +3321,29 @@ class TestMgmtGateway:
                                                  location /grafana {
                                                      rewrite ^/grafana/(.*) /$1 break;
                                                      proxy_pass https://grafana_servers;
+                                                     # clear any Authorization header as Prometheus and Alertmanager are using basic-auth browser
+                                                     # will send this header if Grafana is running on the same node as one of those services
+                                                     proxy_set_header Authorization "";
                                                  }
 
                                                  location /prometheus {
-                                                     proxy_pass http://prometheus_servers;
+                                                     proxy_pass https://prometheus_servers;
+
+                                                     proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+                                                     proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                     proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+                                                     proxy_ssl_verify on;
+                                                     proxy_ssl_verify_depth 2;
                                                  }
 
                                                  location /alertmanager {
-                                                     proxy_pass http://alertmanager_servers;
+                                                     proxy_pass https://alertmanager_servers;
+
+                                                     proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+                                                     proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                     proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+                                                     proxy_ssl_verify on;
+                                                     proxy_ssl_verify_depth 2;
                                                  }
                                              }"""),
                     "nginx_internal_server.conf": dedent("""
@@ -3331,6 +3356,12 @@ class TestMgmtGateway:
                                                  ssl_ciphers         AES128-SHA:AES256-SHA:RC4-SHA:DES-CBC3-SHA:RC4-MD5;
                                                  ssl_prefer_server_ciphers on;
 
+                                                 location /internal/dashboard {
+                                                     rewrite ^/internal/dashboard/(.*) /$1 break;
+                                                     proxy_pass https://dashboard_servers;
+                                                     proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+                                                 }
+
                                                  location /internal/grafana {
                                                      rewrite ^/internal/grafana/(.*) /$1 break;
                                                      proxy_pass https://grafana_servers;
@@ -3338,16 +3369,29 @@ class TestMgmtGateway:
 
                                                  location /internal/prometheus {
                                                      rewrite ^/internal/prometheus/(.*) /prometheus/$1 break;
-                                                     proxy_pass http://prometheus_servers;
+                                                     proxy_pass https://prometheus_servers;
+
+                                                     proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+                                                     proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                     proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+                                                     proxy_ssl_verify on;
+                                                     proxy_ssl_verify_depth 2;
                                                  }
 
                                                  location /internal/alertmanager {
                                                      rewrite ^/internal/alertmanager/(.*) /alertmanager/$1 break;
-                                                     proxy_pass http://alertmanager_servers;
+                                                     proxy_pass https://alertmanager_servers;
+
+                                                     proxy_ssl_certificate /etc/nginx/ssl/nginx_internal.crt;
+                                                     proxy_ssl_certificate_key /etc/nginx/ssl/nginx_internal.key;
+                                                     proxy_ssl_trusted_certificate /etc/nginx/ssl/ca.crt;
+                                                     proxy_ssl_verify on;
+                                                     proxy_ssl_verify_depth 2;
                                                  }
                                              }"""),
                     "nginx_internal.crt": f"{ceph_generated_cert}",
                     "nginx_internal.key": f"{ceph_generated_key}",
+                    "ca.crt": f"{cephadm_root_ca}",
                     "nginx.crt": f"{ceph_generated_cert}",
                     "nginx.key": f"{ceph_generated_key}",
                 }

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -619,8 +619,6 @@ class TestMonitoring:
             cephadm_module.secure_monitoring_stack = True
             cephadm_module.set_store(AlertmanagerService.USER_CFG_KEY, 'alertmanager_user')
             cephadm_module.set_store(AlertmanagerService.PASS_CFG_KEY, 'alertmanager_plain_password')
-            cephadm_module.http_server.service_discovery.ssl_certs.generate_cert = MagicMock(side_effect=gen_cert)
-            cephadm_module.http_server.service_discovery.ssl_certs.get_root_cert = MagicMock(side_effect=get_root_cert)
             with with_service(cephadm_module, AlertManagerSpec()):
 
                 y = dedent(f"""
@@ -695,9 +693,6 @@ class TestMonitoring:
                     }),
                     use_current_daemon_image=False,
                 )
-
-                assert cephadm_module.cert_key_store.get_cert('alertmanager_cert', host='test') == 'mycert'
-                assert cephadm_module.cert_key_store.get_key('alertmanager_key', host='test') == 'mykey'
 
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
@@ -856,8 +851,6 @@ class TestMonitoring:
             cephadm_module.set_store(AlertmanagerService.PASS_CFG_KEY, 'alertmanager_plain_password')
             cephadm_module.http_server.service_discovery.username = 'sd_user'
             cephadm_module.http_server.service_discovery.password = 'sd_password'
-            cephadm_module.http_server.service_discovery.ssl_certs.generate_cert = MagicMock(
-                side_effect=gen_cert)
             # host "test" needs to have networks for keepalive to be placed
             cephadm_module.cache.update_host_networks('test', {
                 '1.2.3.0/24': {

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -1224,7 +1224,7 @@ class TestMonitoring:
                           org_name = 'Main Org.'
                           org_role = 'Viewer'
                         [server]
-                          domain = 'bootstrap.storage.lab'
+                          domain = 'test'
                           protocol = https
                           cert_file = /etc/grafana/certs/cert_file
                           cert_key = /etc/grafana/certs/cert_key
@@ -1332,7 +1332,7 @@ class TestMonitoring:
                                     "  org_name = 'Main Org.'\n"
                                     "  org_role = 'Viewer'\n"
                                     '[server]\n'
-                                    "  domain = 'bootstrap.storage.lab'\n"
+                                    "  domain = 'test'\n"
                                     '  protocol = https\n'
                                     '  cert_file = /etc/grafana/certs/cert_file\n'
                                     '  cert_key = /etc/grafana/certs/cert_key\n'
@@ -1394,7 +1394,7 @@ class TestMonitoring:
                                     '[users]\n'
                                     '  default_theme = light\n'
                                     '[server]\n'
-                                    "  domain = 'bootstrap.storage.lab'\n"
+                                    "  domain = 'test'\n"
                                     '  protocol = https\n'
                                     '  cert_file = /etc/grafana/certs/cert_file\n'
                                     '  cert_key = /etc/grafana/certs/cert_key\n'

--- a/src/pybind/mgr/dashboard/tests/test_prometheus.py
+++ b/src/pybind/mgr/dashboard/tests/test_prometheus.py
@@ -39,7 +39,7 @@ class PrometheusControllerTest(ControllerTestCase):
         mock_request.assert_called_with('GET',
                                         self.prometheus_host_api + '/rules',
                                         json=None, params={},
-                                        verify=True, auth=None)
+                                        verify=True, cert=None, auth=None)
         assert mock_mon_command.called
 
     @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", return_value='cephadm')
@@ -55,7 +55,7 @@ class PrometheusControllerTest(ControllerTestCase):
                                         self.prometheus_host_api + '/rules',
                                         json=None,
                                         params={},
-                                        verify=True, auth=None)
+                                        verify=True, cert=None, auth=None)
         assert not mock_mon_command.called
 
     @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
@@ -63,14 +63,14 @@ class PrometheusControllerTest(ControllerTestCase):
         with patch('requests.request') as mock_request:
             self._get('/api/prometheus')
             mock_request.assert_called_with('GET', self.alert_host_api + '/alerts',
-                                            json=None, params={}, verify=True, auth=None)
+                                            json=None, params={}, verify=True, cert=None, auth=None)
 
     @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_get_silences(self):
         with patch('requests.request') as mock_request:
             self._get('/api/prometheus/silences')
             mock_request.assert_called_with('GET', self.alert_host_api + '/silences',
-                                            json=None, params={}, verify=True, auth=None)
+                                            json=None, params={}, verify=True, cert=None, auth=None)
 
     @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_add_silence(self):
@@ -78,7 +78,7 @@ class PrometheusControllerTest(ControllerTestCase):
             self._post('/api/prometheus/silence', {'id': 'new-silence'})
             mock_request.assert_called_with('POST', self.alert_host_api + '/silences',
                                             params=None, json={'id': 'new-silence'},
-                                            verify=True, auth=None)
+                                            verify=True, cert=None, auth=None)
 
     @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_update_silence(self):
@@ -86,14 +86,15 @@ class PrometheusControllerTest(ControllerTestCase):
             self._post('/api/prometheus/silence', {'id': 'update-silence'})
             mock_request.assert_called_with('POST', self.alert_host_api + '/silences',
                                             params=None, json={'id': 'update-silence'},
-                                            verify=True, auth=None)
+                                            verify=True, cert=None, auth=None)
 
     @patch("dashboard.controllers.prometheus.mgr.get_module_option_ex", lambda a, b, c=None: None)
     def test_expire_silence(self):
         with patch('requests.request') as mock_request:
             self._delete('/api/prometheus/silence/0')
             mock_request.assert_called_with('DELETE', self.alert_host_api + '/silence/0',
-                                            json=None, params=None, verify=True, auth=None)
+                                            json=None, params=None, verify=True, cert=None,
+                                            auth=None)
 
     def test_silences_empty_delete(self):
         with patch('requests.request') as mock_request:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -527,14 +527,6 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def service_discovery_dump_cert(self) -> OrchResult:
-        """
-        Returns service discovery server root certificate
-
-        :return: service discovery root certificate
-        """
-        raise NotImplementedError()
-
     def describe_service(self, service_type: Optional[str] = None, service_name: Optional[str] = None, refresh: bool = False) -> OrchResult[List['ServiceDescription']]:
         """
         Describe a service (of any kind) that is already configured in

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -794,7 +794,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def generate_certificates(self, module_name: str) -> OrchResult[Optional[Dict[str, str]]]:
-        """set prometheus access information"""
+        """generate cert/key for the module with the name module_name"""
         raise NotImplementedError()
 
     def set_custom_prometheus_alerts(self, alerts_file: str) -> OrchResult[str]:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -793,6 +793,10 @@ class Orchestrator(object):
         """set prometheus access information"""
         raise NotImplementedError()
 
+    def generate_certificates(self, module_name: str) -> OrchResult[Optional[Dict[str, str]]]:
+        """set prometheus access information"""
+        raise NotImplementedError()
+
     def set_custom_prometheus_alerts(self, alerts_file: str) -> OrchResult[str]:
         """set prometheus custom alerts files and schedule reconfig of prometheus"""
         raise NotImplementedError()

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1207,6 +1207,15 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
 
         return _username, _password
 
+    @_cli_write_command('orch certmgr generate-certificates')
+    def _cert_mgr_generate_certificates(self, module_name: str) -> HandleCommandResult:
+        try:
+            completion = self.generate_certificates(module_name)
+            result = raise_if_exception(completion)
+            return HandleCommandResult(stdout=json.dumps(result))
+        except ArgumentError as e:
+            return HandleCommandResult(-errno.EINVAL, "", (str(e)))
+
     @_cli_write_command('orch prometheus set-credentials')
     def _set_prometheus_access_info(self, username: Optional[str] = None, password: Optional[str] = None, inbuf: Optional[str] = None) -> HandleCommandResult:
         try:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -943,15 +943,6 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command('orch sd dump cert')
-    def _service_discovery_dump_cert(self) -> HandleCommandResult:
-        """
-        Returns service discovery server root certificate
-        """
-        completion = self.service_discovery_dump_cert()
-        raise_if_exception(completion)
-        return HandleCommandResult(stdout=completion.result_str())
-
     @_cli_read_command('orch ls')
     def _list_services(self,
                        service_type: Optional[str] = None,

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -10,13 +10,14 @@ import time
 import enum
 from packaging import version  # type: ignore
 from collections import namedtuple
+import tempfile
 
 from mgr_module import CLIReadCommand, MgrModule, MgrStandbyModule, PG_STATES, Option, ServiceInfoT, HandleCommandResult, CLIWriteCommand
 from mgr_util import get_default_addr, profile_method, build_url
 from orchestrator import OrchestratorClientMixin, raise_if_exception, OrchestratorError
 from rbd import RBD
 
-from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List, Callable
+from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List, Callable, IO
 
 LabelValues = Tuple[str, ...]
 Number = Union[int, float]
@@ -616,6 +617,8 @@ class Module(MgrModule, OrchestratorClientMixin):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(Module, self).__init__(*args, **kwargs)
+        self.key_file: IO[bytes]
+        self.cert_file: IO[bytes]
         self.metrics = self._setup_static_metrics()
         self.shutdown_event = threading.Event()
         self.collect_lock = threading.Lock()
@@ -1769,7 +1772,7 @@ class Module(MgrModule, OrchestratorClientMixin):
             'cephadm', 'secure_monitoring_stack', False)
         if cephadm_secure_monitoring_stack:
             try:
-                self.setup_cephadm_tls_config(server_addr, server_port)
+                self.setup_tls_config(server_addr, server_port)
                 return
             except Exception as e:
                 self.log.exception(f'Failed to setup cephadm based secure monitoring stack: {e}\n',
@@ -1789,28 +1792,29 @@ class Module(MgrModule, OrchestratorClientMixin):
         self.set_uri(build_url(scheme='http', host=self.get_server_addr(),
                      port=server_port, path='/'))
 
-    def setup_cephadm_tls_config(self, server_addr: str, server_port: int) -> None:
-        from cephadm.ssl_cert_utils import SSLCerts
-        # the ssl certs utils uses a NamedTemporaryFile for the cert files
-        # generated with generate_cert_files function. We need the SSLCerts
-        # object to not be cleaned up in order to have those temp files not
-        # be cleaned up, so making it an attribute of the module instead
-        # of just a standalone object
-        self.cephadm_monitoring_tls_ssl_certs = SSLCerts()
-        host = self.get_mgr_ip()
-        try:
-            old_cert = self.get_store('root/cert')
-            old_key = self.get_store('root/key')
-            if not old_cert or not old_key:
-                raise Exception('No old credentials for mgr-prometheus endpoint')
-            self.cephadm_monitoring_tls_ssl_certs.load_root_credentials(old_cert, old_key)
-        except Exception:
-            self.cephadm_monitoring_tls_ssl_certs.generate_root_cert(host)
-            self.set_store('root/cert', self.cephadm_monitoring_tls_ssl_certs.get_root_cert())
-            self.set_store('root/key', self.cephadm_monitoring_tls_ssl_certs.get_root_key())
+    def setup_tls_config(self, server_addr: str, server_port: int) -> None:
+        from mgr_util import verify_tls_files
+        cmd = {'prefix': 'orch certmgr generate-certificates',
+               'module_name': 'prometheus',
+               'format': 'json'}
+        ret, out, err = self.mon_command(cmd)
+        if ret != 0:
+            self.log.error(f'mon command to generate-certificates failed: {err}')
+            return
+        elif out is None:
+            self.log.error('mon command to generate-certificates failed to generate certificates')
+            return
 
-        cert_file_path, key_file_path = self.cephadm_monitoring_tls_ssl_certs.generate_cert_files(
-            self.get_hostname(), host)
+        cert_key = json.loads(out)
+        self.cert_file = tempfile.NamedTemporaryFile()
+        self.cert_file.write(cert_key['cert'].encode('utf-8'))
+        self.cert_file.flush()  # cert_tmp must not be gc'ed
+        self.key_file = tempfile.NamedTemporaryFile()
+        self.key_file.write(cert_key['key'].encode('utf-8'))
+        self.key_file.flush()  # pkey_tmp must not be gc'ed
+
+        verify_tls_files(self.cert_file.name, self.key_file.name)
+        cert_file_path, key_file_path = self.cert_file.name, self.key_file.name
 
         cherrypy.config.update({
             'server.socket_host': server_addr,


### PR DESCRIPTION
This PR builds on top of the PR https://github.com/ceph/ceph/pull/57535 which introduced the mgmt-gateway. In this PR mTLS support is introduced. Cephadm is acting as the root CA that generates and signs all the certificates to be used by all the backend applications (dashboard, monitoring, etc).

**Changes included in this PR**:
- [x]  Introducing `cert_mgr` new class to centralize certificates management in cephadm
- [x]  Introducing new cephadm command to generate self-signed certs (`ceph orch certmgr generate-certificates`)
- [x]  Add support for multiple ips/fqdns certificates generation
- [x] Adding mTLS support for `mgmt-gateway` and backend applications internal communication
- [x] Introducing monitoring high availability based on `mgmt-gateway` service
- [x] Adding TLS/SSL support for ceph-exporter
 
**Known issues:**
- Grafana doesn't support mTLS (but end-point is protected by basic-auth)

The following diagram represents the legacy Ceph mgmt backend architecture:

<img src="https://github.com/ceph/ceph/assets/15921511/8948a566-5ba3-4682-8cb5-afab8980291b" width="750">



The new architecture takes benefit of the `mgmt-gateway`  (introduced by https://github.com/ceph/ceph/pull/57535) and adds `mTLS` to improve the security for internal communications between the nginx reverse proxy and the backend applications (Ceph dashboard, Prometheus, Alertmanager, etc..). Direct connections between most of the applications are replaced by requests that are routed through the nginx reverse proxy to an upstream that represents the new end-point of the corresponding service. This way all the routing goes through the internal server of the nginx and we can benefit from its high availability support. 

**Note:**
Please notice that there're still direct connections between Prometheus and mgr-prometheus module and with alertmanager as well. This is because in this case we are using the service-discovery feature and we rely on Prometheus support to handle multiple targets. Following diagram depicts a simplified view of the new architecture:

<img src="https://github.com/ceph/ceph/assets/15921511/07279504-0eb0-4fa4-b255-1a7a768c6739" width="750">

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
