### PR TITLE
qa/suites/upgrade/reef-p2p/reef-p2p-parallel: increment upgrade to 18.2.2

### DIFF
--- a/qa/suites/upgrade/reef-p2p/reef-p2p-parallel/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/reef-p2p/reef-p2p-parallel/point-to-point-upgrade.yaml
@@ -3,7 +3,7 @@ meta:
    Run ceph on two nodes, using one of them as a client,
    with a separate client-only node.
    Use xfs beneath the osds.
-   install ceph/reef v18.2.1 and the v18.2.x point versions
+   install ceph/reef v18.2.2 and the subsequent v18.2.x point versions
    run workload and upgrade-sequence in parallel
    (every point release should be tested)
    run workload and upgrade-sequence in parallel
@@ -70,32 +70,32 @@ openstack:
     count: 3
     size: 30 # GB
 tasks:
-- print: "****  done reef about to install v18.2.0 "
+- print: "****  done reef about to install v18.2.2 "
+  # See https://tracker.ceph.com/issues/66505. Versions < v18.2.2 contain the crc bug.
 - install:
-    tag: v18.2.0
+    tag: v18.2.2
     # line below can be removed its from jewel test
     #exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev', 'librgw2']
-- print: "**** done v18.2.0 install"
+- print: "**** done v18.2.2 install"
 - ceph:
    fs: xfs
    add_osds_to_crush: true
 - print: "**** done ceph xfs"
 - sequential:
    - workload
-- print: "**** done workload v18.2.0"
+- print: "**** done workload v18.2.2"
 
-
-#######  upgrade to v18.2.1
-- install.upgrade:
-    #exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev']
-    mon.a:
-      tag: v18.2.1
-    mon.b:
-      tag: v18.2.1
-- parallel:
-   - workload_reef
-   - upgrade-sequence_reef
-- print: "**** done parallel reef v18.2.1"
+# TODO: uncomment when v18.2.3 is available
+#######  upgrade to v18.2.3
+# - install.upgrade:
+#    mon.a:
+#      tag: v18.2.3
+#    mon.b:
+#      tag: v18.2.3
+#- parallel:
+#   - workload_reef
+#   - upgrade-sequence_reef
+#- print: "**** done parallel reef v18.2.3"
 
 ####  upgrade to latest reef
 - install.upgrade:
@@ -118,7 +118,7 @@ workload_reef:
    full_sequential:
    - workunit:
        branch: reef
-       # tag: v18.2.1
+       # tag: v18.2.2
        clients:
          client.1:
          - rados/test.sh


### PR DESCRIPTION
Instead of installing 18.2.0, which still contains the osdmap crc bug tracked in https://tracker.ceph.com/issues/63389, we should install v18.2.2 since this contains the fix. Then, we upgrade to reef_latest. In this scenario, we do not expect to see the crc bug. If we test any upgrade path before that, we will hit the warning and the test will fail.

Fixes: https://tracker.ceph.com/issues/66505





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
