### PR TITLE
cmake: more object libraries depend on legacy-option-headers

### DIFF
--- a/src/compressor/CMakeLists.txt
+++ b/src/compressor/CMakeLists.txt
@@ -8,6 +8,7 @@ if(HAVE_QATZIP AND HAVE_QAT)
                         QAT::qat
                         QAT::usdm
                         QAT::zip
+                        legacy-option-headers
                        )
 endif()
 

--- a/src/crush/CMakeLists.txt
+++ b/src/crush/CMakeLists.txt
@@ -9,3 +9,4 @@ set(crush_srcs
   CrushLocation.cc)
 
 add_library(crush_objs OBJECT ${crush_srcs})
+target_link_libraries(crush_objs PUBLIC legacy-option-headers)

--- a/src/erasure-code/jerasure/CMakeLists.txt
+++ b/src/erasure-code/jerasure/CMakeLists.txt
@@ -5,6 +5,7 @@ set(jerasure_utils_src
   ErasureCodeJerasure.cc)
 
 add_library(jerasure_utils OBJECT ${jerasure_utils_src})
+target_link_libraries(jerasure_utils legacy-option-headers)
 
 # Set the CFLAGS correctly for gf-complete based on SIMD compiler support
 set(GF_COMPILE_FLAGS)

--- a/src/mgr/CMakeLists.txt
+++ b/src/mgr/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(mgr_cap_obj OBJECT
   MgrCap.cc)
+target_link_libraries(mgr_cap_obj legacy-option-headers)
 
 if(WITH_MGR)
   set(mgr_srcs

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -141,11 +141,9 @@ if(WITH_BLUESTORE)
 endif()
 
 # fragmentation simulator
-add_library(ObjectStoreImitator OBJECT ObjectStoreImitator.cc)
-
 add_executable(ceph_test_fragmentation_sim
   Fragmentation_simulator.cc
-  $<TARGET_OBJECTS:ObjectStoreImitator>)
+  ObjectStoreImitator.cc)
 add_ceph_unittest(ceph_test_fragmentation_sim)
 target_link_libraries(ceph_test_fragmentation_sim os global)
 

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -6,7 +6,8 @@ install(TARGETS ceph_perf_objectstore
 
 add_library(store_test_fixture OBJECT store_test_fixture.cc)
 target_include_directories(store_test_fixture PRIVATE
-  $<TARGET_PROPERTY:GTest::GTest,INTERFACE_INCLUDE_DIRECTORIES>)
+  $<TARGET_PROPERTY:GTest::GTest,INTERFACE_INCLUDE_DIRECTORIES>
+  legacy-option-headers)
 
 add_executable(ceph_test_objectstore
   store_test.cc


### PR DESCRIPTION
tracking down missing cmake dependencies that lead to compilation failures like:
```
src/common/options/legacy_config_opts.h:10:10: fatal error: 'immutable-object-cache_legacy_options.h' file not found
#include "immutable-object-cache_legacy_options.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
followup to https://github.com/ceph/ceph/pull/57011, https://github.com/ceph/ceph/pull/57693, https://github.com/ceph/ceph/pull/57583, etc

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
