### PR TITLE
mgr/balancer: balance even if PGs are degraded

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -1015,18 +1015,13 @@ class Module(MgrModule):
 
         info = self.get('pg_status')
         unknown = info.get('unknown_pgs_ratio', 0.0)
-        degraded = info.get('degraded_ratio', 0.0)
         inactive = info.get('inactive_pgs_ratio', 0.0)
         misplaced = info.get('misplaced_ratio', 0.0)
         plan.pg_status = info
-        self.log.debug('unknown %f degraded %f inactive %f misplaced %g',
-                       unknown, degraded, inactive, misplaced)
+        self.log.debug('unknown %f inactive %f misplaced %g',
+                       unknown, inactive, misplaced)
         if unknown > 0.0:
             detail = 'Some PGs (%f) are unknown; try again later' % unknown
-            self.log.info(detail)
-            return -errno.EAGAIN, detail
-        elif degraded > 0.0:
-            detail = 'Some objects (%f) are degraded; try again later' % degraded
             self.log.info(detail)
             return -errno.EAGAIN, detail
         elif inactive > 0.0:


### PR DESCRIPTION
If a large number of OSDs fail (e.g. because a shared block.db failed), it can happen that OSDs in the same crush bucket get an over subscription of PGs (due to https://tracker.ceph.com/issues/15653). So we can then have PGs stuck backfill_toofull and degraded.

Ceph currently can't get itself out of this situation.

The MGR upmap balancer could easily resolve this (because the balancer balances UP, not ACTING). However currently the balancer doesn't operate at all if any PGs are degraded.

Fix by improving the balancer to operate even when PGs are degraded, perhaps only if there are any backfill_toofull PGs.

Fixes: https://tracker.ceph.com/issues/66755
