### PR TITLE
squid: qa: fix log errors for cephadm tests

### DIFF
--- a/qa/suites/fs/nfs/overrides/ignore_mgr_down.yaml
+++ b/qa/suites/fs/nfs/overrides/ignore_mgr_down.yaml
@@ -7,3 +7,4 @@ overrides:
   ceph:
     log-ignorelist:
       - MGR_DOWN
+      - CEPHADM_FAILED_DAEMON

--- a/qa/suites/orch/cephadm/mgr-nfs-upgrade/4-final.yaml
+++ b/qa/suites/orch/cephadm/mgr-nfs-upgrade/4-final.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - CEPHADM_REFRESH_FAILED
 tasks:
 - vip.exec:
     host.a:

--- a/qa/suites/orch/cephadm/osds/1-start.yaml
+++ b/qa/suites/orch/cephadm/osds/1-start.yaml
@@ -22,6 +22,7 @@ overrides:
   ceph:
     log-ignorelist:
       - OSD_DOWN
+      - CEPHADM_FAILED_DAEMON
     conf:
       osd:
         osd shutdown pgref assert: true

--- a/qa/suites/orch/cephadm/smoke-roleless/1-start.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/1-start.yaml
@@ -24,3 +24,6 @@ overrides:
         osd shutdown pgref assert: true
     log-only-match:
       - CEPHADM_
+    log-ignorelist:
+      - CEPHADM_DAEMON_PLACE_FAIL
+      - CEPHADM_FAILED_DAEMON

--- a/qa/suites/orch/cephadm/smoke-small/start.yaml
+++ b/qa/suites/orch/cephadm/smoke-small/start.yaml
@@ -2,6 +2,9 @@ overrides:
   ceph:
     log-only-match:
       - CEPHADM_
+    log-ignorelist:
+      - CEPHADM_AGENT_DOWN
+      - CEPHADM_FAILED_DAEMON
 tasks:
 - cephadm:
     conf:

--- a/qa/suites/orch/cephadm/smoke/start.yaml
+++ b/qa/suites/orch/cephadm/smoke/start.yaml
@@ -5,6 +5,9 @@ overrides:
       - mons down
       - mon down
       - out of quorum
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_FAILED_DAEMON
+      - CEPHADM_AGENT_DOWN
     log-only-match:
       - CEPHADM_
 tasks:

--- a/qa/suites/orch/cephadm/thrash/1-start.yaml
+++ b/qa/suites/orch/cephadm/thrash/1-start.yaml
@@ -1,7 +1,7 @@
 overrides:
   ceph:
     log-ignorelist:
-    - \(CEPHADM_STRAY_DAEMON\)
+    - CEPHADM_STRAY_DAEMON
     log-only-match:
       - CEPHADM_
 tasks:

--- a/qa/suites/orch/cephadm/thrash/1-start.yaml
+++ b/qa/suites/orch/cephadm/thrash/1-start.yaml
@@ -1,7 +1,8 @@
 overrides:
   ceph:
     log-ignorelist:
-    - CEPHADM_STRAY_DAEMON
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_FAILED_DAEMON
     log-only-match:
       - CEPHADM_
 tasks:

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/simple.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/simple.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     log-ignorelist:
       - CEPHADM_STRAY_DAEMON
+      - CEPHADM_FAILED_DAEMON
+      - CEPHADM_AGENT_DOWN
     log-only-match:
       - CEPHADM_
 tasks:

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     log-ignorelist:
       - CEPHADM_STRAY_DAEMON
+      - CEPHADM_FAILED_DAEMON
+      - CEPHADM_AGENT_DOWN
     log-only-match:
       - CEPHADM_
 tasks:

--- a/qa/suites/orch/cephadm/workunits/task/test_extra_daemon_features.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_extra_daemon_features.yaml
@@ -11,6 +11,8 @@ overrides:
   ceph:
     log-only-match:
       - CEPHADM_
+    log-ignorelist:
+      - CEPHADM_FAILED_DAEMON
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/workunits/task/test_host_drain.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_host_drain.yaml
@@ -5,6 +5,9 @@ overrides:
       - mons down
       - mon down
       - out of quorum
+      - CEPHADM_STRAY_HOST
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_FAILED_DAEMON
     log-only-match:
       - CEPHADM_
 roles:

--- a/qa/suites/orch/cephadm/workunits/task/test_iscsi_container/test_iscsi_container.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_iscsi_container/test_iscsi_container.yaml
@@ -10,6 +10,8 @@ overrides:
   ceph:
     log-only-match:
       - CEPHADM_
+    log-ignorelist:
+      - CEPHADM_FAILED_DAEMON
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/workunits/task/test_monitoring_stack_basic.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_monitoring_stack_basic.yaml
@@ -5,6 +5,8 @@ overrides:
       - mons down
       - mon down
       - out of quorum
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_FAILED_DAEMON
     log-only-match:
       - CEPHADM_
 roles:

--- a/qa/suites/orch/cephadm/workunits/task/test_set_mon_crush_locations.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_set_mon_crush_locations.yaml
@@ -6,6 +6,7 @@ overrides:
       - mon down
       - mons down
       - out of quorum
+      - CEPHADM_FAILED_DAEMON
     log-only-match:
       - CEPHADM_
 roles:

--- a/qa/suites/rados/basic/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/basic/tasks/rados_api_tests.yaml
@@ -11,7 +11,7 @@ overrides:
     - \(POOL_APP_NOT_ENABLED\)
     - \(PG_AVAILABILITY\)
     - \(PG_DEGRADED\)
-    - \(CEPHADM_STRAY_DAEMON\)
+    - CEPHADM_STRAY_DAEMON
     conf:
       client:
         debug ms: 1


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66830

---

backport of https://github.com/ceph/ceph/pull/58344
parent tracker: https://tracker.ceph.com/issues/66751

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh