### PR TITLE
reef: qa: fix log errors for cephadm tests

### DIFF
--- a/qa/suites/orch/cephadm/mgr-nfs-upgrade/4-final.yaml
+++ b/qa/suites/orch/cephadm/mgr-nfs-upgrade/4-final.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - CEPHADM_REFRESH_FAILED
 tasks:
 - vip.exec:
     host.a:

--- a/qa/suites/orch/cephadm/osds/1-start.yaml
+++ b/qa/suites/orch/cephadm/osds/1-start.yaml
@@ -20,6 +20,9 @@ openstack:
     size: 10 # GB
 overrides:
   ceph:
+    log-ignorelist:
+      - OSD_DOWN
+      - CEPHADM_FAILED_DAEMON
     conf:
       osd:
         osd shutdown pgref assert: true

--- a/qa/suites/orch/cephadm/smoke-roleless/1-start.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/1-start.yaml
@@ -22,3 +22,8 @@ overrides:
     conf:
       osd:
         osd shutdown pgref assert: true
+    log-only-match:
+      - CEPHADM_
+    log-ignorelist:
+      - CEPHADM_DAEMON_PLACE_FAIL
+      - CEPHADM_FAILED_DAEMON

--- a/qa/suites/orch/cephadm/smoke-small/start.yaml
+++ b/qa/suites/orch/cephadm/smoke-small/start.yaml
@@ -1,3 +1,10 @@
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
+    log-ignorelist:
+      - CEPHADM_AGENT_DOWN
+      - CEPHADM_FAILED_DAEMON
 tasks:
 - cephadm:
     conf:

--- a/qa/suites/orch/cephadm/smoke/start.yaml
+++ b/qa/suites/orch/cephadm/smoke/start.yaml
@@ -1,3 +1,15 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - MON_DOWN
+      - mons down
+      - mon down
+      - out of quorum
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_FAILED_DAEMON
+      - CEPHADM_AGENT_DOWN
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm:
     conf:

--- a/qa/suites/orch/cephadm/thrash/1-start.yaml
+++ b/qa/suites/orch/cephadm/thrash/1-start.yaml
@@ -1,3 +1,10 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_FAILED_DAEMON
+    log-only-match:
+      - CEPHADM_
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/simple.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/simple.yaml
@@ -1,3 +1,11 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_FAILED_DAEMON
+      - CEPHADM_AGENT_DOWN
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm.shell:
     env: [sha1]

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
@@ -1,3 +1,11 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_FAILED_DAEMON
+      - CEPHADM_AGENT_DOWN
+    log-only-match:
+      - CEPHADM_
 tasks:
 - cephadm.shell:
     env: [sha1]

--- a/qa/suites/orch/cephadm/workunits/task/test_extra_daemon_features.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_extra_daemon_features.yaml
@@ -7,6 +7,12 @@ roles:
   - mon.b
   - mgr.b
   - osd.1
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
+    log-ignorelist:
+      - CEPHADM_FAILED_DAEMON
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/workunits/task/test_host_drain.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_host_drain.yaml
@@ -1,3 +1,15 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - MON_DOWN
+      - mons down
+      - mon down
+      - out of quorum
+      - CEPHADM_STRAY_HOST
+      - CEPHADM_STRAY_DAEMON
+      - CEPHADM_FAILED_DAEMON
+    log-only-match:
+      - CEPHADM_
 roles:
 - - host.a
   - mon.a

--- a/qa/suites/orch/cephadm/workunits/task/test_iscsi_container/test_iscsi_container.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_iscsi_container/test_iscsi_container.yaml
@@ -6,6 +6,12 @@ roles:
   - mon.a
   - mgr.a
   - client.0
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
+    log-ignorelist:
+      - CEPHADM_FAILED_DAEMON
 tasks:
 - install:
 - cephadm:

--- a/qa/suites/orch/cephadm/workunits/task/test_set_mon_crush_locations.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_set_mon_crush_locations.yaml
@@ -1,3 +1,14 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - MON_DOWN
+      - POOL_APP_NOT_ENABLED
+      - mon down
+      - mons down
+      - out of quorum
+      - CEPHADM_FAILED_DAEMON
+    log-only-match:
+      - CEPHADM_
 roles:
 - - host.a
   - osd.0


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66831

---

backport of https://github.com/ceph/ceph/pull/58344
parent tracker: https://tracker.ceph.com/issues/66751

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh