### PR TITLE
squid: RGW|Bucket notification: reload realm correctly

### DIFF
--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -4671,6 +4671,14 @@ def test_persistent_ps_s3_reload():
     print('delete all topics')
     delete_all_topics(conn, '', get_config_cluster())
 
+    # disable v2 notification
+    result = admin(['zonegroup', 'modify', '--disable-feature=notification_v2'], get_config_cluster())
+    assert_equal(result[1], 0)
+    result = admin(['period', 'update'], get_config_cluster())
+    assert_equal(result[1], 0)
+    result = admin(['period', 'commit'], get_config_cluster())
+    assert_equal(result[1], 0)
+
     # create random port for the http server
     host = get_ip()
     http_port = random.randint(10000, 20000)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66772

---

backport of https://github.com/ceph/ceph/pull/57655
parent tracker: https://tracker.ceph.com/issues/66206

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh