### PR TITLE
submodule: remove the boost_redis submodule again

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -75,9 +75,6 @@
 [submodule "src/qatzip"]
 	path = src/qatzip
 	url = https://github.com/intel/qatzip.git
-[submodule "src/boost_redis"]
-	path = src/boost_redis
-	url = https://github.com/boostorg/redis.git
 [submodule "src/BLAKE3"]
 	path = src/BLAKE3
 	url = https://github.com/BLAKE3-team/BLAKE3.git


### PR DESCRIPTION
b6d585645ca7d469fd9fe453ff37ca6bdb914d98 accidentally added back the boost_redis submodule that was removed in 862246cdefc12acfbd2711c7677a252c59634c9d

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
