### PR TITLE
cmake: work around xxhash 'inlining failed' errors in debug builds

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -312,6 +312,11 @@ target_include_directories(rgw_common
   PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw"
   PUBLIC "${LUA_INCLUDE_DIR}")
 
+# work around https://github.com/Cyan4973/xxHash/issues/943 for debug builds
+target_compile_definitions(rgw_common PUBLIC
+  $<$<CONFIG:Debug>:XXH_NO_INLINE_HINTS=1>
+  $<$<CONFIG:RelWithDebInfo>:XXH_NO_INLINE_HINTS=1>)
+
 if(WITH_RADOSGW_KAFKA_ENDPOINT)
   # used by rgw_kafka.cc
   target_link_libraries(rgw_common


### PR DESCRIPTION
rgw enables the XXH_INLINE_ALL define, but this causes debug builds to fail with errors like:
```
In file included from /home/cbodley/ceph/src/rgw/rgw_blake3_digest.h:23,
                 from /home/cbodley/ceph/src/rgw/rgw_cksum_digest.h:19:
In function ‘void XXH3_hashLong_internal_loop(xxh_u64*, const xxh_u8*, size_t, const xxh_u8*, size_t, XXH3_f_accumulate, XXH3_f_scrambleAcc)’,
    inlined from ‘XXH64_hash_t XXH3_hashLong_64b_internal(const void*, size_t, const void*, size_t, XXH3_f_accumulate, XXH3_f_scrambleAcc)’ at /home/cbodley/ceph/src/xxHash/xxhash.h:5607:32,
    inlined from ‘XXH64_hash_t XXH3_hashLong_64b_withSeed_internal(const void*, size_t, XXH64_hash_t, XXH3_f_accumulate, XXH3_f_scrambleAcc, XXH3_f_initCustomSecret)’ at /home/cbodley/ceph/src/xxHash/xxhash.h:5666:42,
    inlined from ‘XXH64_hash_t XXH3_hashLong_64b_withSeed(const void*, size_t, XXH64_hash_t, const xxh_u8*, size_t)’ at /home/cbodley/ceph/src/xxHash/xxhash.h:5685:47:
/home/cbodley/ceph/src/xxHash/xxhash.h:4822:1: error: inlining failed in call to ‘always_inline’ ‘void XXH3_scrambleAcc_sse2(void*, const void*)’: function not considered for inlining
 4822 | XXH3_scrambleAcc_sse2(void* XXH_RESTRICT acc, const void* XXH_RESTRICT secret)
      | ^~~~~~~~~~~~~~~~~~~~~
/home/cbodley/ceph/src/xxHash/xxhash.h:5545:19: note: called from here
 5545 |         f_scramble(acc, secret + secretSize - XXH_STRIPE_LEN);
      |         ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
for build types Debug and RelWithDebInfo, add extra define XXH_NO_INLINE_HINTS to remove the always_inline hints causing this error

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
