### PR TITLE
common: reduce counter schema output

### DIFF
--- a/src/test/perf_counters.cc
+++ b/src/test/perf_counters.cc
@@ -334,80 +334,45 @@ TEST(PerfCounters, TestLabeledCountersOnly) {
   ASSERT_EQ(R"({
     "name1": [
         {
-            "labels": {
-                "label1": "val1"
+            "foo": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "foo": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "bar": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
-            }
-        },
-        {
-            "labels": {
-                "label1": "val3"
-            },
-            "counters": {
-                "foo": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "bar": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "bar": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ],
     "name2": [
         {
-            "labels": {
-                "label2": "val2"
+            "foo": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "foo": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "bar": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "bar": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ]
@@ -519,133 +484,111 @@ TEST(PerfCounters, TestLabelStrings) {
   ASSERT_EQ(R"({
     "bad_ctrs": [
         {
-            "labels": {
-                "label1": "val1"
+            "foo": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "foo": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "bar": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "bar": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ],
     "bad_ctrs2": [
         {
-            "labels": {},
-            "counters": {
-                "foo": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "bar": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "foo": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "bar": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ],
     "good_ctrs": [
         {
-            "labels": {
-                "label1": "",
-                "label3": "val4"
+            "foo": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "foo": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "bar": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "bar": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ],
     "only_key": [
         {
-            "labels": {},
-            "counters": {
-                "foo": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "bar": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "foo": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "bar": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ],
     "too_many_delimiters": [
         {
-            "labels": {
-                "label1": "val1"
+            "foo": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "foo": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "bar": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "bar": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ]

--- a/src/test/test_perf_counters_cache.cc
+++ b/src/test/test_perf_counters_cache.cc
@@ -166,145 +166,125 @@ TEST(PerfCountersCache, TestEviction) {
   ASSERT_EQ(R"({
     "key1": [
         {
-            "labels": {
-                "label1": "val1"
+            "test_counter": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "test_counter": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time_avg": {
-                    "type": 5,
-                    "metric_type": "gauge",
-                    "value_type": "real-integer-pair",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "test_time": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "test_time_avg": {
+                "type": 5,
+                "metric_type": "gauge",
+                "value_type": "real-integer-pair",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ],
     "key2": [
         {
-            "labels": {
-                "label2": "val2"
+            "test_counter": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "test_counter": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time_avg": {
-                    "type": 5,
-                    "metric_type": "gauge",
-                    "value_type": "real-integer-pair",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "test_time": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "test_time_avg": {
+                "type": 5,
+                "metric_type": "gauge",
+                "value_type": "real-integer-pair",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ],
     "key3": [
         {
-            "labels": {
-                "label3": "val3"
+            "test_counter": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "test_counter": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time_avg": {
-                    "type": 5,
-                    "metric_type": "gauge",
-                    "value_type": "real-integer-pair",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "test_time": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "test_time_avg": {
+                "type": 5,
+                "metric_type": "gauge",
+                "value_type": "real-integer-pair",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ],
     "key4": [
         {
-            "labels": {
-                "label4": "val4"
+            "test_counter": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "test_counter": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time_avg": {
-                    "type": 5,
-                    "metric_type": "gauge",
-                    "value_type": "real-integer-pair",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "test_time": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "test_time_avg": {
+                "type": 5,
+                "metric_type": "gauge",
+                "value_type": "real-integer-pair",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ]
@@ -387,145 +367,125 @@ TEST(PerfCountersCache, TestEviction) {
   ASSERT_EQ(R"({
     "key3": [
         {
-            "labels": {
-                "label3": "val3"
+            "test_counter": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "test_counter": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time_avg": {
-                    "type": 5,
-                    "metric_type": "gauge",
-                    "value_type": "real-integer-pair",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "test_time": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "test_time_avg": {
+                "type": 5,
+                "metric_type": "gauge",
+                "value_type": "real-integer-pair",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ],
     "key4": [
         {
-            "labels": {
-                "label4": "val4"
+            "test_counter": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "test_counter": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time_avg": {
-                    "type": 5,
-                    "metric_type": "gauge",
-                    "value_type": "real-integer-pair",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "test_time": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "test_time_avg": {
+                "type": 5,
+                "metric_type": "gauge",
+                "value_type": "real-integer-pair",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ],
     "key5": [
         {
-            "labels": {
-                "label5": "val5"
+            "test_counter": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "test_counter": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time_avg": {
-                    "type": 5,
-                    "metric_type": "gauge",
-                    "value_type": "real-integer-pair",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "test_time": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "test_time_avg": {
+                "type": 5,
+                "metric_type": "gauge",
+                "value_type": "real-integer-pair",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ],
     "key6": [
         {
-            "labels": {
-                "label6": "val6"
+            "test_counter": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "test_counter": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time_avg": {
-                    "type": 5,
-                    "metric_type": "gauge",
-                    "value_type": "real-integer-pair",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "test_time": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "test_time_avg": {
+                "type": 5,
+                "metric_type": "gauge",
+                "value_type": "real-integer-pair",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ]
@@ -588,73 +548,63 @@ TEST(PerfCountersCache, TestLabeledCounters) {
   ASSERT_EQ(R"({
     "key1": [
         {
-            "labels": {
-                "label1": "val1"
+            "test_counter": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "test_counter": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time_avg": {
-                    "type": 5,
-                    "metric_type": "gauge",
-                    "value_type": "real-integer-pair",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "test_time": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "test_time_avg": {
+                "type": 5,
+                "metric_type": "gauge",
+                "value_type": "real-integer-pair",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ],
     "key2": [
         {
-            "labels": {
-                "label2": "val2"
+            "test_counter": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "test_counter": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time_avg": {
-                    "type": 5,
-                    "metric_type": "gauge",
-                    "value_type": "real-integer-pair",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "test_time": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "test_time_avg": {
+                "type": 5,
+                "metric_type": "gauge",
+                "value_type": "real-integer-pair",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ]
@@ -830,73 +780,63 @@ TEST(PerfCountersCache, TestLabeledTimes) {
   ASSERT_EQ(R"({
     "key1": [
         {
-            "labels": {
-                "label1": "val1"
+            "test_counter": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "test_counter": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time_avg": {
-                    "type": 5,
-                    "metric_type": "gauge",
-                    "value_type": "real-integer-pair",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "test_time": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "test_time_avg": {
+                "type": 5,
+                "metric_type": "gauge",
+                "value_type": "real-integer-pair",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ],
     "key2": [
         {
-            "labels": {
-                "label2": "val2"
+            "test_counter": {
+                "type": 2,
+                "metric_type": "gauge",
+                "value_type": "integer",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             },
-            "counters": {
-                "test_counter": {
-                    "type": 2,
-                    "metric_type": "gauge",
-                    "value_type": "integer",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time": {
-                    "type": 1,
-                    "metric_type": "gauge",
-                    "value_type": "real",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                },
-                "test_time_avg": {
-                    "type": 5,
-                    "metric_type": "gauge",
-                    "value_type": "real-integer-pair",
-                    "description": "",
-                    "nick": "",
-                    "priority": 0,
-                    "units": "none"
-                }
+            "test_time": {
+                "type": 1,
+                "metric_type": "gauge",
+                "value_type": "real",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
+            },
+            "test_time_avg": {
+                "type": 5,
+                "metric_type": "gauge",
+                "value_type": "real-integer-pair",
+                "description": "",
+                "nick": "",
+                "priority": 0,
+                "units": "none"
             }
         }
     ]


### PR DESCRIPTION
Counter schema output is just one schema per
key instead of one schema for each set of labels
per key.

This commit also includes subsequent changes to
the exporter to process the new counter schema
format and create metrics for prometheus.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
