### PR TITLE
cls/rgw: define lc ops in terms of ObjectOperation instead of IoCtx

### DIFF
--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -940,13 +940,14 @@ void cls_rgw_gc_remove(librados::ObjectWriteOperation& op, const vector<string>&
   op.exec(RGW_CLASS, RGW_GC_REMOVE, in);
 }
 
-int cls_rgw_lc_get_head(IoCtx& io_ctx, const string& oid, cls_rgw_lc_obj_head& head)
+void cls_rgw_lc_get_head(ObjectReadOperation& op, bufferlist& out)
 {
-  bufferlist in, out;
-  int r = io_ctx.exec(oid, RGW_CLASS, RGW_LC_GET_HEAD, in, out);
-  if (r < 0)
-    return r;
+  bufferlist in;
+  op.exec(RGW_CLASS, RGW_LC_GET_HEAD, in, &out, nullptr);
+}
 
+int cls_rgw_lc_get_head_decode(const bufferlist& out, cls_rgw_lc_obj_head& head)
+{
   cls_rgw_lc_get_head_ret ret;
   try {
     auto iter = out.cbegin();
@@ -954,32 +955,32 @@ int cls_rgw_lc_get_head(IoCtx& io_ctx, const string& oid, cls_rgw_lc_obj_head& h
   } catch (ceph::buffer::error& err) {
     return -EIO;
   }
-  head = ret.head;
+  head = std::move(ret.head);
 
- return r;
+  return 0;
 }
 
-int cls_rgw_lc_put_head(IoCtx& io_ctx, const string& oid, cls_rgw_lc_obj_head& head)
+void cls_rgw_lc_put_head(ObjectWriteOperation& op, const cls_rgw_lc_obj_head& head)
 {
-  bufferlist in, out;
+  bufferlist in;
   cls_rgw_lc_put_head_op call;
   call.head = head;
   encode(call, in);
-  int r = io_ctx.exec(oid, RGW_CLASS, RGW_LC_PUT_HEAD, in, out);
-  return r;
+  op.exec(RGW_CLASS, RGW_LC_PUT_HEAD, in);
 }
 
-int cls_rgw_lc_get_next_entry(IoCtx& io_ctx, const string& oid, const string& marker,
-			      cls_rgw_lc_entry& entry)
+void cls_rgw_lc_get_next_entry(ObjectReadOperation& op, const string& marker,
+                               bufferlist& out)
 {
-  bufferlist in, out;
+  bufferlist in;
   cls_rgw_lc_get_next_entry_op call;
   call.marker = marker;
   encode(call, in);
-  int r = io_ctx.exec(oid, RGW_CLASS, RGW_LC_GET_NEXT_ENTRY, in, out);
-  if (r < 0)
-    return r;
+  op.exec(RGW_CLASS, RGW_LC_GET_NEXT_ENTRY, in, &out, nullptr);
+}
 
+int cls_rgw_lc_get_next_entry_decode(const bufferlist& out, cls_rgw_lc_entry& entry)
+{
   cls_rgw_lc_get_next_entry_ret ret;
   try {
     auto iter = out.cbegin();
@@ -987,45 +988,42 @@ int cls_rgw_lc_get_next_entry(IoCtx& io_ctx, const string& oid, const string& ma
   } catch (ceph::buffer::error& err) {
     return -EIO;
   }
-  entry = ret.entry;
+  entry = std::move(ret.entry);
 
- return r;
+  return 0;
 }
 
-int cls_rgw_lc_rm_entry(IoCtx& io_ctx, const string& oid,
-			const cls_rgw_lc_entry& entry)
+void cls_rgw_lc_rm_entry(ObjectWriteOperation& op,
+                         const cls_rgw_lc_entry& entry)
 {
-  bufferlist in, out;
+  bufferlist in;
   cls_rgw_lc_rm_entry_op call;
   call.entry = entry;
   encode(call, in);
-  int r = io_ctx.exec(oid, RGW_CLASS, RGW_LC_RM_ENTRY, in, out);
- return r;
+  op.exec(RGW_CLASS, RGW_LC_RM_ENTRY, in);
 }
 
-int cls_rgw_lc_set_entry(IoCtx& io_ctx, const string& oid,
-			 const cls_rgw_lc_entry& entry)
+void cls_rgw_lc_set_entry(ObjectWriteOperation& op,
+                          const cls_rgw_lc_entry& entry)
 {
   bufferlist in, out;
   cls_rgw_lc_set_entry_op call;
   call.entry = entry;
   encode(call, in);
-  int r = io_ctx.exec(oid, RGW_CLASS, RGW_LC_SET_ENTRY, in, out);
-  return r;
+  op.exec(RGW_CLASS, RGW_LC_SET_ENTRY, in);
 }
 
-int cls_rgw_lc_get_entry(IoCtx& io_ctx, const string& oid,
-			 const std::string& marker, cls_rgw_lc_entry& entry)
+void cls_rgw_lc_get_entry(ObjectReadOperation& op, const std::string& marker,
+                          bufferlist& out)
 {
-  bufferlist in, out;
-  cls_rgw_lc_get_entry_op call{marker};;
+  bufferlist in;
+  cls_rgw_lc_get_entry_op call{marker};
   encode(call, in);
-  int r = io_ctx.exec(oid, RGW_CLASS, RGW_LC_GET_ENTRY, in, out);
+  op.exec(RGW_CLASS, RGW_LC_GET_ENTRY, in, &out, nullptr);
+}
 
-  if (r < 0) {
-    return r;
-  }
-
+int cls_rgw_lc_get_entry_decode(const bufferlist& out, cls_rgw_lc_entry& entry)
+{
   cls_rgw_lc_get_entry_ret ret;
   try {
     auto iter = out.cbegin();
@@ -1035,28 +1033,24 @@ int cls_rgw_lc_get_entry(IoCtx& io_ctx, const string& oid,
   }
 
   entry = std::move(ret.entry);
-  return r;
+  return 0;
 }
 
-int cls_rgw_lc_list(IoCtx& io_ctx, const string& oid,
-                    const string& marker,
-                    uint32_t max_entries,
-                    vector<cls_rgw_lc_entry>& entries)
+void cls_rgw_lc_list(ObjectReadOperation& op, const string& marker,
+                     uint32_t max_entries, bufferlist& out)
 {
-  bufferlist in, out;
-  cls_rgw_lc_list_entries_op op;
+  bufferlist in;
+  cls_rgw_lc_list_entries_op call;
+  call.marker = marker;
+  call.max_entries = max_entries;
 
-  entries.clear();
+  encode(call, in);
 
-  op.marker = marker;
-  op.max_entries = max_entries;
+  op.exec(RGW_CLASS, RGW_LC_LIST_ENTRIES, in, &out, nullptr);
+}
 
-  encode(op, in);
-
-  int r = io_ctx.exec(oid, RGW_CLASS, RGW_LC_LIST_ENTRIES, in, out);
-  if (r < 0)
-    return r;
-
+int cls_rgw_lc_list_decode(const bufferlist& out, std::vector<cls_rgw_lc_entry>& entries)
+{
   cls_rgw_lc_list_entries_ret ret;
   try {
     auto iter = out.cbegin();
@@ -1069,7 +1063,7 @@ int cls_rgw_lc_list(IoCtx& io_ctx, const string& oid,
 	    [](const cls_rgw_lc_entry& a, const cls_rgw_lc_entry& b)
 	      { return a.bucket < b.bucket; });
   entries = std::move(ret.entries);
-  return r;
+  return 0;
 }
 
 void cls_rgw_mp_upload_part_info_update(librados::ObjectWriteOperation& op,

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -609,19 +609,19 @@ int cls_rgw_gc_list(librados::IoCtx& io_ctx, std::string& oid, std::string& mark
 #endif
 
 /* lifecycle */
-// these overloads which call io_ctx.operate() should not be called in the rgw.
-// rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
-#ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_rgw_lc_get_head(librados::IoCtx& io_ctx, const std::string& oid, cls_rgw_lc_obj_head& head);
-int cls_rgw_lc_put_head(librados::IoCtx& io_ctx, const std::string& oid, cls_rgw_lc_obj_head& head);
-int cls_rgw_lc_get_next_entry(librados::IoCtx& io_ctx, const std::string& oid, const std::string& marker, cls_rgw_lc_entry& entry);
-int cls_rgw_lc_rm_entry(librados::IoCtx& io_ctx, const std::string& oid, const cls_rgw_lc_entry& entry);
-int cls_rgw_lc_set_entry(librados::IoCtx& io_ctx, const std::string& oid, const cls_rgw_lc_entry& entry);
-int cls_rgw_lc_get_entry(librados::IoCtx& io_ctx, const std::string& oid, const std::string& marker, cls_rgw_lc_entry& entry);
-int cls_rgw_lc_list(librados::IoCtx& io_ctx, const std::string& oid,
-		    const std::string& marker, uint32_t max_entries,
-                    std::vector<cls_rgw_lc_entry>& entries);
-#endif
+void cls_rgw_lc_get_head(librados::ObjectReadOperation& op, bufferlist& bl);
+int cls_rgw_lc_get_head_decode(const bufferlist& bl, cls_rgw_lc_obj_head& head);
+void cls_rgw_lc_put_head(librados::ObjectWriteOperation& op, const cls_rgw_lc_obj_head& head);
+void cls_rgw_lc_get_next_entry(librados::ObjectReadOperation& op, const std::string& marker, bufferlist& bl);
+int cls_rgw_lc_get_next_entry_decode(const bufferlist& bl, cls_rgw_lc_entry& entry);
+void cls_rgw_lc_rm_entry(librados::ObjectWriteOperation& op, const cls_rgw_lc_entry& entry);
+void cls_rgw_lc_set_entry(librados::ObjectWriteOperation& op, const cls_rgw_lc_entry& entry);
+void cls_rgw_lc_get_entry(librados::ObjectReadOperation& op, const std::string& marker, bufferlist& bl);
+int cls_rgw_lc_get_entry_decode(const bufferlist& bl, cls_rgw_lc_entry& entry);
+void cls_rgw_lc_list(librados::ObjectReadOperation& op,
+                     const std::string& marker, uint32_t max_entries,
+                     bufferlist& bl);
+int cls_rgw_lc_list_decode(const bufferlist& bl, std::vector<cls_rgw_lc_entry>& entries);
 
 /* multipart */
 void cls_rgw_mp_upload_part_info_update(librados::ObjectWriteOperation& op, const std::string& part_key, const RGWUploadPartInfo& info);

--- a/src/rgw/driver/rados/rgw_cr_tools.cc
+++ b/src/rgw/driver/rados/rgw_cr_tools.cc
@@ -115,7 +115,7 @@ int RGWBucketLifecycleConfigCR::Request::_send_request(const DoutPrefixProvider 
     return -EIO;
   }
 
-  int ret = lc->set_bucket_config(params.bucket,
+  int ret = lc->set_bucket_config(dpp, null_yield, params.bucket,
                                   params.bucket_attrs,
                                   &params.config);
   if (ret < 0) {

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -370,7 +370,7 @@ int RadosBucket::remove(const DoutPrefixProvider* dpp,
   if (get_attrs().count(RGW_ATTR_LC)) {
     constexpr bool merge_attrs = false; // don't update xattrs, we're deleting
     (void) store->getRados()->get_lc()->remove_bucket_config(
-      this, get_attrs(), merge_attrs);
+      dpp, y, this, get_attrs(), merge_attrs);
   }
 
   // remove bucket-topic mapping
@@ -3604,7 +3604,8 @@ int LCRadosSerializer::try_lock(const DoutPrefixProvider *dpp, utime_t dur, opti
   return lock.lock_exclusive(ioctx, oid);
 }
 
-int RadosLifecycle::get_entry(const std::string& oid, const std::string& marker,
+int RadosLifecycle::get_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                              const std::string& oid, const std::string& marker,
 			      std::unique_ptr<LCEntry>* entry)
 {
   cls_rgw_lc_entry cls_entry;
@@ -3612,16 +3613,12 @@ int RadosLifecycle::get_entry(const std::string& oid, const std::string& marker,
   if (ret)
     return ret;
 
-  LCEntry* e;
-  e = new StoreLCEntry(cls_entry.bucket, cls_entry.start_time, cls_entry.status);
-  if (!e)
-    return -ENOMEM;
-
-  entry->reset(e);
+  *entry = std::make_unique<StoreLCEntry>(cls_entry.bucket, cls_entry.start_time, cls_entry.status);
   return 0;
 }
 
-int RadosLifecycle::get_next_entry(const std::string& oid, const std::string& marker,
+int RadosLifecycle::get_next_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                                   const std::string& oid, const std::string& marker,
 				   std::unique_ptr<LCEntry>* entry)
 {
   cls_rgw_lc_entry cls_entry;
@@ -3631,16 +3628,12 @@ int RadosLifecycle::get_next_entry(const std::string& oid, const std::string& ma
   if (ret)
     return ret;
 
-  LCEntry* e;
-  e = new StoreLCEntry(cls_entry.bucket, cls_entry.start_time, cls_entry.status);
-  if (!e)
-    return -ENOMEM;
-
-  entry->reset(e);
+  *entry = std::make_unique<StoreLCEntry>(cls_entry.bucket, cls_entry.start_time, cls_entry.status);
   return 0;
 }
 
-int RadosLifecycle::set_entry(const std::string& oid, LCEntry& entry)
+int RadosLifecycle::set_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                              const std::string& oid, LCEntry& entry)
 {
   cls_rgw_lc_entry cls_entry;
 
@@ -3651,8 +3644,9 @@ int RadosLifecycle::set_entry(const std::string& oid, LCEntry& entry)
   return cls_rgw_lc_set_entry(*store->getRados()->get_lc_pool_ctx(), oid, cls_entry);
 }
 
-int RadosLifecycle::list_entries(const std::string& oid, const std::string& marker,
-				 uint32_t max_entries, std::vector<std::unique_ptr<LCEntry>>& entries)
+int RadosLifecycle::list_entries(const DoutPrefixProvider* dpp, optional_yield y,
+                                 const std::string& oid, const std::string& marker,
+                                 uint32_t max_entries, std::vector<std::unique_ptr<LCEntry>>& entries)
 {
   entries.clear();
 
@@ -3670,7 +3664,8 @@ int RadosLifecycle::list_entries(const std::string& oid, const std::string& mark
   return ret;
 }
 
-int RadosLifecycle::rm_entry(const std::string& oid, LCEntry& entry)
+int RadosLifecycle::rm_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                             const std::string& oid, LCEntry& entry)
 {
   cls_rgw_lc_entry cls_entry;
 
@@ -3681,23 +3676,20 @@ int RadosLifecycle::rm_entry(const std::string& oid, LCEntry& entry)
   return cls_rgw_lc_rm_entry(*store->getRados()->get_lc_pool_ctx(), oid, cls_entry);
 }
 
-int RadosLifecycle::get_head(const std::string& oid, std::unique_ptr<LCHead>* head)
+int RadosLifecycle::get_head(const DoutPrefixProvider* dpp, optional_yield y,
+                             const std::string& oid, std::unique_ptr<LCHead>* head)
 {
   cls_rgw_lc_obj_head cls_head;
   int ret = cls_rgw_lc_get_head(*store->getRados()->get_lc_pool_ctx(), oid, cls_head);
   if (ret)
     return ret;
 
-  LCHead* h;
-  h = new StoreLCHead(cls_head.start_date, cls_head.shard_rollover_date, cls_head.marker);
-  if (!h)
-    return -ENOMEM;
-
-  head->reset(h);
+  *head = std::make_unique<StoreLCHead>(cls_head.start_date, cls_head.shard_rollover_date, cls_head.marker);
   return 0;
 }
 
-int RadosLifecycle::put_head(const std::string& oid, LCHead& head)
+int RadosLifecycle::put_head(const DoutPrefixProvider* dpp, optional_yield y,
+                             const std::string& oid, LCHead& head)
 {
   cls_rgw_lc_obj_head cls_head;
 

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -875,15 +875,24 @@ public:
   RadosLifecycle(RadosStore* _st) : store(_st) {}
 
   using StoreLifecycle::get_entry;
-  virtual int get_entry(const std::string& oid, const std::string& marker, std::unique_ptr<LCEntry>* entry) override;
-  virtual int get_next_entry(const std::string& oid, const std::string& marker, std::unique_ptr<LCEntry>* entry) override;
-  virtual int set_entry(const std::string& oid, LCEntry& entry) override;
-  virtual int list_entries(const std::string& oid, const std::string& marker,
+  virtual int get_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                        const std::string& oid, const std::string& marker,
+                        std::unique_ptr<LCEntry>* entry) override;
+  virtual int get_next_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                             const std::string& oid, const std::string& marker,
+                             std::unique_ptr<LCEntry>* entry) override;
+  virtual int set_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                        const std::string& oid, LCEntry& entry) override;
+  virtual int list_entries(const DoutPrefixProvider* dpp, optional_yield y,
+                           const std::string& oid, const std::string& marker,
 			   uint32_t max_entries,
 			   std::vector<std::unique_ptr<LCEntry>>& entries) override;
-  virtual int rm_entry(const std::string& oid, LCEntry& entry) override;
-  virtual int get_head(const std::string& oid, std::unique_ptr<LCHead>* head) override;
-  virtual int put_head(const std::string& oid, LCHead& head) override;
+  virtual int rm_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, LCEntry& entry) override;
+  virtual int get_head(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, std::unique_ptr<LCHead>* head) override;
+  virtual int put_head(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, LCHead& head) override;
   virtual std::unique_ptr<LCSerializer> get_serializer(const std::string& lock_name,
 						       const std::string& oid,
 						       const std::string& cookie) override;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -653,10 +653,12 @@ public:
   bool going_down();
   void start_processor();
   void stop_processor();
-  int set_bucket_config(rgw::sal::Bucket* bucket,
+  int set_bucket_config(const DoutPrefixProvider* dpp, optional_yield y,
+                        rgw::sal::Bucket* bucket,
                         const rgw::sal::Attrs& bucket_attrs,
                         RGWLifecycleConfiguration *config);
-  int remove_bucket_config(rgw::sal::Bucket* bucket,
+  int remove_bucket_config(const DoutPrefixProvider* dpp, optional_yield y,
+                           rgw::sal::Bucket* bucket,
                            const rgw::sal::Attrs& bucket_attrs,
 			   bool merge_attrs = true);
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6090,7 +6090,8 @@ void RGWPutLC::execute(optional_yield y)
     return;
   }
 
-  op_ret = driver->get_rgwlc()->set_bucket_config(s->bucket.get(), s->bucket_attrs, &new_config);
+  op_ret = driver->get_rgwlc()->set_bucket_config(this, y, s->bucket.get(),
+                                                  s->bucket_attrs, &new_config);
   if (op_ret < 0) {
     return;
   }
@@ -6106,7 +6107,8 @@ void RGWDeleteLC::execute(optional_yield y)
     return;
   }
 
-  op_ret = driver->get_rgwlc()->remove_bucket_config(s->bucket.get(), s->bucket_attrs);
+  op_ret = driver->get_rgwlc()->remove_bucket_config(this, y, s->bucket.get(),
+                                                     s->bucket_attrs);
   if (op_ret < 0) {
     return;
   }

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1554,21 +1554,30 @@ public:
   /** Get an empty entry */
   virtual std::unique_ptr<LCEntry> get_entry() = 0;
   /** Get an entry matching the given marker */
-  virtual int get_entry(const std::string& oid, const std::string& marker, std::unique_ptr<LCEntry>* entry) = 0;
+  virtual int get_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                        const std::string& oid, const std::string& marker,
+                        std::unique_ptr<LCEntry>* entry) = 0;
   /** Get the entry following the given marker */
-  virtual int get_next_entry(const std::string& oid, const std::string& marker, std::unique_ptr<LCEntry>* entry) = 0;
+  virtual int get_next_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                             const std::string& oid, const std::string& marker,
+                             std::unique_ptr<LCEntry>* entry) = 0;
   /** Store a modified entry in then backing store */
-  virtual int set_entry(const std::string& oid, LCEntry& entry) = 0;
+  virtual int set_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                        const std::string& oid, LCEntry& entry) = 0;
   /** List all known entries */
-  virtual int list_entries(const std::string& oid, const std::string& marker,
+  virtual int list_entries(const DoutPrefixProvider* dpp, optional_yield y,
+                           const std::string& oid, const std::string& marker,
 			   uint32_t max_entries,
 			   std::vector<std::unique_ptr<LCEntry>>& entries) = 0;
   /** Remove an entry from the backing store */
-  virtual int rm_entry(const std::string& oid, LCEntry& entry) = 0;
+  virtual int rm_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, LCEntry& entry) = 0;
   /** Get a head */
-  virtual int get_head(const std::string& oid, std::unique_ptr<LCHead>* head) = 0;
+  virtual int get_head(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, std::unique_ptr<LCHead>* head) = 0;
   /** Store a modified head to the backing store */
-  virtual int put_head(const std::string& oid, LCHead& head) = 0;
+  virtual int put_head(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, LCHead& head) = 0;
 
   /** Get a serializer for lifecycle */
   virtual std::unique_ptr<LCSerializer> get_serializer(const std::string& lock_name,

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -1838,40 +1838,47 @@ namespace rgw::sal {
     return std::make_unique<DBLifecycle>(this);
   }
 
-  int DBLifecycle::get_entry(const std::string& oid, const std::string& marker,
-			      std::unique_ptr<LCEntry>* entry)
+  int DBLifecycle::get_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                             const std::string& oid, const std::string& marker,
+                             std::unique_ptr<LCEntry>* entry)
   {
     return store->getDB()->get_entry(oid, marker, entry);
   }
 
-  int DBLifecycle::get_next_entry(const std::string& oid, const std::string& marker,
+  int DBLifecycle::get_next_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                                  const std::string& oid, const std::string& marker,
 				  std::unique_ptr<LCEntry>* entry)
   {
     return store->getDB()->get_next_entry(oid, marker, entry);
   }
 
-  int DBLifecycle::set_entry(const std::string& oid, LCEntry& entry)
+  int DBLifecycle::set_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                             const std::string& oid, LCEntry& entry)
   {
     return store->getDB()->set_entry(oid, entry);
   }
 
-  int DBLifecycle::list_entries(const std::string& oid, const std::string& marker,
+  int DBLifecycle::list_entries(const DoutPrefixProvider* dpp, optional_yield y,
+                                const std::string& oid, const std::string& marker,
   				 uint32_t max_entries, vector<std::unique_ptr<LCEntry>>& entries)
   {
     return store->getDB()->list_entries(oid, marker, max_entries, entries);
   }
 
-  int DBLifecycle::rm_entry(const std::string& oid, LCEntry& entry)
+  int DBLifecycle::rm_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                            const std::string& oid, LCEntry& entry)
   {
     return store->getDB()->rm_entry(oid, entry);
   }
 
-  int DBLifecycle::get_head(const std::string& oid, std::unique_ptr<LCHead>* head)
+  int DBLifecycle::get_head(const DoutPrefixProvider* dpp, optional_yield y,
+                            const std::string& oid, std::unique_ptr<LCHead>* head)
   {
     return store->getDB()->get_head(oid, head);
   }
 
-  int DBLifecycle::put_head(const std::string& oid, LCHead& head)
+  int DBLifecycle::put_head(const DoutPrefixProvider* dpp, optional_yield y,
+                            const std::string& oid, LCHead& head)
   {
     return store->getDB()->put_head(oid, head);
   }

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -45,15 +45,24 @@ public:
   DBLifecycle(DBStore* _st) : store(_st) {}
 
   using StoreLifecycle::get_entry;
-  virtual int get_entry(const std::string& oid, const std::string& marker, std::unique_ptr<LCEntry>* entry) override;
-  virtual int get_next_entry(const std::string& oid, const std::string& marker, std::unique_ptr<LCEntry>* entry) override;
-  virtual int set_entry(const std::string& oid, LCEntry& entry) override;
-  virtual int list_entries(const std::string& oid, const std::string& marker,
+  virtual int get_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                        const std::string& oid, const std::string& marker,
+                        std::unique_ptr<LCEntry>* entry) override;
+  virtual int get_next_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                             const std::string& oid, const std::string& marker,
+                             std::unique_ptr<LCEntry>* entry) override;
+  virtual int set_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                        const std::string& oid, LCEntry& entry) override;
+  virtual int list_entries(const DoutPrefixProvider* dpp, optional_yield y,
+                           const std::string& oid, const std::string& marker,
 			   uint32_t max_entries,
 			   std::vector<std::unique_ptr<LCEntry>>& entries) override;
-  virtual int rm_entry(const std::string& oid, LCEntry& entry) override;
-  virtual int get_head(const std::string& oid, std::unique_ptr<LCHead>* head) override;
-  virtual int put_head(const std::string& oid, LCHead& head) override;
+  virtual int rm_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, LCEntry& entry) override;
+  virtual int get_head(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, std::unique_ptr<LCHead>* head) override;
+  virtual int put_head(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, LCHead& head) override;
   virtual std::unique_ptr<LCSerializer> get_serializer(const std::string& lock_name,
 						       const std::string& oid,
 						       const std::string& cookie) override;

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -1330,51 +1330,45 @@ std::unique_ptr<Lifecycle::LCEntry> FilterLifecycle::get_entry()
   return std::make_unique<FilterLCEntry>(std::move(e));
 }
 
-int FilterLifecycle::get_entry(const std::string& oid, const std::string& marker,
+int FilterLifecycle::get_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                               const std::string& oid, const std::string& marker,
 			       std::unique_ptr<LCEntry>* entry)
 {
   std::unique_ptr<LCEntry> ne;
-  int ret;
-
-  ret = next->get_entry(oid, marker, &ne);
+  int ret = next->get_entry(dpp, y, oid, marker, &ne);
   if (ret < 0)
     return ret;
 
-  LCEntry* e = new FilterLCEntry(std::move(ne));
-  entry->reset(e);
-
+  *entry = std::make_unique<FilterLCEntry>(std::move(ne));
   return 0;
 }
 
-int FilterLifecycle::get_next_entry(const std::string& oid, const std::string& marker,
+int FilterLifecycle::get_next_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                                    const std::string& oid, const std::string& marker,
 				    std::unique_ptr<LCEntry>* entry)
 {
   std::unique_ptr<LCEntry> ne;
-  int ret;
-
-  ret = next->get_next_entry(oid, marker, &ne);
+  int ret = next->get_next_entry(dpp, y, oid, marker, &ne);
   if (ret < 0)
     return ret;
 
-  LCEntry* e = new FilterLCEntry(std::move(ne));
-  entry->reset(e);
-
+  *entry = std::make_unique<FilterLCEntry>(std::move(ne));
   return 0;
 }
 
-int FilterLifecycle::set_entry(const std::string& oid, LCEntry& entry)
+int FilterLifecycle::set_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                               const std::string& oid, LCEntry& entry)
 {
-  return next->set_entry(oid, entry);
+  return next->set_entry(dpp, y, oid, entry);
 }
 
-int FilterLifecycle::list_entries(const std::string& oid, const std::string& marker,
+int FilterLifecycle::list_entries(const DoutPrefixProvider* dpp, optional_yield y,
+                                  const std::string& oid, const std::string& marker,
 				  uint32_t max_entries,
 				  std::vector<std::unique_ptr<LCEntry>>& entries)
 {
   std::vector<std::unique_ptr<LCEntry>> ne;
-  int ret;
-
-  ret = next->list_entries(oid, marker, max_entries, ne);
+  int ret = next->list_entries(dpp, y, oid, marker, max_entries, ne);
   if (ret < 0)
     return ret;
 
@@ -1385,29 +1379,28 @@ int FilterLifecycle::list_entries(const std::string& oid, const std::string& mar
   return 0;
 }
 
-int FilterLifecycle::rm_entry(const std::string& oid, LCEntry& entry)
+int FilterLifecycle::rm_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                              const std::string& oid, LCEntry& entry)
 {
-  return next->rm_entry(oid, entry);
+  return next->rm_entry(dpp, y, oid, entry);
 }
 
-int FilterLifecycle::get_head(const std::string& oid, std::unique_ptr<LCHead>* head)
+int FilterLifecycle::get_head(const DoutPrefixProvider* dpp, optional_yield y,
+                              const std::string& oid, std::unique_ptr<LCHead>* head)
 {
   std::unique_ptr<LCHead> nh;
-  int ret;
-
-  ret = next->get_head(oid, &nh);
+  int ret = next->get_head(dpp, y, oid, &nh);
   if (ret < 0)
     return ret;
 
-  LCHead* h = new FilterLCHead(std::move(nh));
-  head->reset(h);
-
+  *head = std::make_unique<FilterLCHead>(std::move(nh));
   return 0;
 }
 
-int FilterLifecycle::put_head(const std::string& oid, LCHead& head)
+int FilterLifecycle::put_head(const DoutPrefixProvider* dpp, optional_yield y,
+                              const std::string& oid, LCHead& head)
 {
-  return next->put_head(oid, *(dynamic_cast<FilterLCHead&>(head).next.get()));
+  return next->put_head(dpp, y, oid, *(dynamic_cast<FilterLCHead&>(head).next.get()));
 }
 
 std::unique_ptr<LCSerializer> FilterLifecycle::get_serializer(

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -1004,17 +1004,24 @@ public:
   virtual ~FilterLifecycle() = default;
 
   virtual std::unique_ptr<LCEntry> get_entry() override;
-  virtual int get_entry(const std::string& oid, const std::string& marker,
+  virtual int get_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                        const std::string& oid, const std::string& marker,
 			std::unique_ptr<LCEntry>* entry) override;
-  virtual int get_next_entry(const std::string& oid, const std::string& marker,
+  virtual int get_next_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                             const std::string& oid, const std::string& marker,
 			     std::unique_ptr<LCEntry>* entry) override;
-  virtual int set_entry(const std::string& oid, LCEntry& entry) override;
-  virtual int list_entries(const std::string& oid, const std::string& marker,
+  virtual int set_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                        const std::string& oid, LCEntry& entry) override;
+  virtual int list_entries(const DoutPrefixProvider* dpp, optional_yield y,
+                           const std::string& oid, const std::string& marker,
 			   uint32_t max_entries,
 			   std::vector<std::unique_ptr<LCEntry>>& entries) override;
-  virtual int rm_entry(const std::string& oid, LCEntry& entry) override;
-  virtual int get_head(const std::string& oid, std::unique_ptr<LCHead>* head) override;
-  virtual int put_head(const std::string& oid, LCHead& head) override;
+  virtual int rm_entry(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, LCEntry& entry) override;
+  virtual int get_head(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, std::unique_ptr<LCHead>* head) override;
+  virtual int put_head(const DoutPrefixProvider* dpp, optional_yield y,
+                       const std::string& oid, LCHead& head) override;
   virtual std::unique_ptr<LCSerializer> get_serializer(const std::string& lock_name,
 						       const std::string& oid,
 						       const std::string& cookie) override;


### PR DESCRIPTION
the IoCtx functions are synchronous and not meant to be used in rgw. replace them with ObjectOperation arguments for use with rgw_rados_operate() and optional_yield

these IoCtx functions _should_ have been hidden by the `CLS_CLIENT_HIDE_IOCTX` define, but that was never added to the `rgw_common` target which uses them

when enabling `rgw_asio_assert_yielding` from https://github.com/ceph/ceph/pull/58179 and running s3-tests, `test_lifecycle_set` triggers an assertion because `RGWLC::set_bucket_config()` didn't support `optional_yield`

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
