### PR TITLE
mgr/dashboard: Add SSO through oauth2 protocol

### DIFF
--- a/qa/tasks/mgr/dashboard/test_auth.py
+++ b/qa/tasks/mgr/dashboard/test_auth.py
@@ -152,7 +152,8 @@ class AuthTest(DashboardTestCase):
         self._post("/api/auth/logout")
         self.assertStatus(200)
         self.assertJsonBody({
-            "redirect_url": "#/login"
+            "redirect_url": "#/login",
+            "protocol": 'local'
         })
         self._get("/api/host", version='1.1')
         self.assertStatus(401)
@@ -167,7 +168,8 @@ class AuthTest(DashboardTestCase):
         self._post("/api/auth/logout", set_cookies=True)
         self.assertStatus(200)
         self.assertJsonBody({
-            "redirect_url": "#/login"
+            "redirect_url": "#/login",
+            "protocol": 'local'
         })
         self._get("/api/host", set_cookies=True, version='1.1')
         self.assertStatus(401)

--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -10,7 +10,7 @@ import cherrypy
 
 from .. import mgr
 from ..exceptions import InvalidCredentialsError, UserDoesNotExist
-from ..services.auth import AuthManager, JwtManager
+from ..services.auth import AuthManager, AuthType, BaseAuth, JwtManager, OAuth2
 from ..services.cluster import ClusterModel
 from ..settings import Settings
 from . import APIDoc, APIRouter, ControllerAuthMixin, EndpointDoc, RESTController, allow_empty_body
@@ -132,7 +132,7 @@ class Auth(RESTController, ControllerAuthMixin):
                     'username': username,
                     'permissions': user_perms,
                     'pwdExpirationDate': pwd_expiration_date,
-                    'sso': mgr.SSO_DB.protocol == 'saml2',
+                    'sso': BaseAuth.from_protocol(mgr.SSO_DB.protocol).sso,
                     'pwdUpdateRequired': pwd_update_required
                 }
             mgr.ACCESS_CTRL_DB.increment_attempt(username)
@@ -156,21 +156,14 @@ class Auth(RESTController, ControllerAuthMixin):
     @RESTController.Collection('POST')
     @allow_empty_body
     def logout(self):
-        logger.debug('Logout successful')
-        token = JwtManager.get_token_from_header()
+        logger.debug('Logout started')
+        token = JwtManager.get_token(cherrypy.request)
         JwtManager.blocklist_token(token)
         self._delete_token_cookie(token)
-        redirect_url = '#/login'
-        if mgr.SSO_DB.protocol == 'saml2':
-            redirect_url = 'auth/saml2/slo'
         return {
-            'redirect_url': redirect_url
+            'redirect_url': BaseAuth.from_db(mgr.SSO_DB).LOGOUT_URL,
+            'protocol': BaseAuth.from_db(mgr.SSO_DB).get_auth_name()
         }
-
-    def _get_login_url(self):
-        if mgr.SSO_DB.protocol == 'saml2':
-            return 'auth/saml2/login'
-        return '#/login'
 
     @RESTController.Collection('POST', query_params=['token'])
     @EndpointDoc("Check token Authentication",
@@ -178,15 +171,18 @@ class Auth(RESTController, ControllerAuthMixin):
                  responses={201: AUTH_CHECK_SCHEMA})
     def check(self, token):
         if token:
-            user = JwtManager.get_user(token)
+            if mgr.SSO_DB.protocol == AuthType.OAUTH2:
+                user = OAuth2.get_user(token)
+            else:
+                user = JwtManager.get_user(token)
             if user:
                 return {
                     'username': user.username,
                     'permissions': user.permissions_dict(),
-                    'sso': mgr.SSO_DB.protocol == 'saml2',
+                    'sso': BaseAuth.from_db(mgr.SSO_DB).sso,
                     'pwdUpdateRequired': user.pwd_update_required
                 }
         return {
-            'login_url': self._get_login_url(),
+            'login_url': BaseAuth.from_db(mgr.SSO_DB).LOGIN_URL,
             'cluster_status': ClusterModel.from_db().dict()['status']
         }

--- a/src/pybind/mgr/dashboard/controllers/oauth2.py
+++ b/src/pybind/mgr/dashboard/controllers/oauth2.py
@@ -1,0 +1,32 @@
+import cherrypy
+
+from dashboard.exceptions import DashboardException
+from dashboard.services.auth.oauth2 import OAuth2
+
+from . import Endpoint, RESTController, Router
+
+
+@Router('/auth/oauth2', secure=False)
+class Oauth2(RESTController):
+
+    @Endpoint(json_response=False, version=None)
+    def login(self):
+        if not OAuth2.enabled():
+            raise DashboardException(500, msg='Failed to login: SSO OAuth2 is not enabled')
+
+        token = OAuth2.get_token(cherrypy.request)
+        if not token:
+            raise cherrypy.HTTPError()
+
+        raise cherrypy.HTTPRedirect(OAuth2.get_login_redirect_url(token))
+
+    @Endpoint(json_response=False, version=None)
+    def logout(self):
+        if not OAuth2.enabled():
+            raise DashboardException(500, msg='Failed to logout: SSO OAuth2 is not enabled')
+
+        token = OAuth2.get_token(cherrypy.request)
+        if not token:
+            raise cherrypy.HTTPError()
+
+        raise cherrypy.HTTPRedirect(OAuth2.get_logout_redirect_url(token))

--- a/src/pybind/mgr/dashboard/controllers/saml2.py
+++ b/src/pybind/mgr/dashboard/controllers/saml2.py
@@ -37,7 +37,7 @@ class Saml2(BaseController, ControllerAuthMixin):
         if not python_saml_imported:
             raise cherrypy.HTTPError(400, 'Required library not found: `python3-saml`')
         try:
-            OneLogin_Saml2_Settings(mgr.SSO_DB.saml2.onelogin_settings)
+            OneLogin_Saml2_Settings(mgr.SSO_DB.config.onelogin_settings)
         except OneLogin_Saml2_Error:
             raise cherrypy.HTTPError(400, 'Single Sign-On is not configured.')
 
@@ -46,19 +46,19 @@ class Saml2(BaseController, ControllerAuthMixin):
     def auth_response(self, **kwargs):
         Saml2._check_python_saml()
         req = Saml2._build_req(self._request, kwargs)
-        auth = OneLogin_Saml2_Auth(req, mgr.SSO_DB.saml2.onelogin_settings)
+        auth = OneLogin_Saml2_Auth(req, mgr.SSO_DB.config.onelogin_settings)
         auth.process_response()
         errors = auth.get_errors()
 
         if auth.is_authenticated():
             JwtManager.reset_user()
-            username_attribute = auth.get_attribute(mgr.SSO_DB.saml2.get_username_attribute())
+            username_attribute = auth.get_attribute(mgr.SSO_DB.config.get_username_attribute())
             if username_attribute is None:
                 raise cherrypy.HTTPError(400,
                                          'SSO error - `{}` not found in auth attributes. '
                                          'Received attributes: {}'
                                          .format(
-                                             mgr.SSO_DB.saml2.get_username_attribute(),
+                                             mgr.SSO_DB.config.get_username_attribute(),
                                              auth.get_attributes()))
             username = username_attribute[0]
             url_prefix = prepare_url_prefix(mgr.get_module_option('url_prefix', default=''))
@@ -85,21 +85,21 @@ class Saml2(BaseController, ControllerAuthMixin):
     @Endpoint(xml=True, version=None)
     def metadata(self):
         Saml2._check_python_saml()
-        saml_settings = OneLogin_Saml2_Settings(mgr.SSO_DB.saml2.onelogin_settings)
+        saml_settings = OneLogin_Saml2_Settings(mgr.SSO_DB.config.onelogin_settings)
         return saml_settings.get_sp_metadata()
 
     @Endpoint(json_response=False, version=None)
     def login(self):
         Saml2._check_python_saml()
         req = Saml2._build_req(self._request, {})
-        auth = OneLogin_Saml2_Auth(req, mgr.SSO_DB.saml2.onelogin_settings)
+        auth = OneLogin_Saml2_Auth(req, mgr.SSO_DB.config.onelogin_settings)
         raise cherrypy.HTTPRedirect(auth.login())
 
     @Endpoint(json_response=False, version=None)
     def slo(self):
         Saml2._check_python_saml()
         req = Saml2._build_req(self._request, {})
-        auth = OneLogin_Saml2_Auth(req, mgr.SSO_DB.saml2.onelogin_settings)
+        auth = OneLogin_Saml2_Auth(req, mgr.SSO_DB.config.onelogin_settings)
         raise cherrypy.HTTPRedirect(auth.logout())
 
     @Endpoint(json_response=False, version=None)
@@ -107,7 +107,7 @@ class Saml2(BaseController, ControllerAuthMixin):
         # pylint: disable=unused-argument
         Saml2._check_python_saml()
         JwtManager.reset_user()
-        token = JwtManager.get_token_from_header()
+        token = JwtManager.get_token(cherrypy.request)
         self._delete_token_cookie(token)
         url_prefix = prepare_url_prefix(mgr.get_module_option('url_prefix', default=''))
         raise cherrypy.HTTPRedirect("{}/#/login".format(url_prefix))

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.ts
@@ -42,6 +42,9 @@ export class AuthService {
   logout(callback: Function = null) {
     return this.http.post('api/auth/logout', null).subscribe((resp: any) => {
       this.authStorageService.remove();
+      if (resp.protocol == 'oauth2') {
+        return window.location.replace(resp.redirect_url);
+      }
       const url = _.get(this.route.snapshot.queryParams, 'returnUrl', '/login');
       this.router.navigate([url], { skipLocationChange: true });
       if (callback) {

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -275,6 +275,7 @@ class Module(MgrModule, CherryPyConfig):
                min=400, max=599),
         Option(name='redirect_resolve_ip_addr', type='bool', default=False),
         Option(name='cross_origin_url', type='str', default=''),
+        Option(name='sso_oauth2', type='bool', default=False),
     ]
     MODULE_OPTIONS.extend(options_schema_list())
     for options in PLUGIN_MANAGER.hook.get_options() or []:

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -193,6 +193,15 @@ class Role(object):
         return Role(r_dict['name'], r_dict['description'],
                     r_dict['scopes_permissions'])
 
+    @classmethod
+    def map_to_system_roles(cls, roles) -> List['Role']:
+        matches = []
+        for rn in SYSTEM_ROLES_NAMES:
+            for role in roles:
+                if role in SYSTEM_ROLES_NAMES[rn]:
+                    matches.append(rn)
+        return matches
+
 
 # static pre-defined system roles
 # this roles cannot be deleted nor updated
@@ -281,6 +290,12 @@ SYSTEM_ROLES = {
     POOL_MGR_ROLE.name: POOL_MGR_ROLE,
     CEPHFS_MGR_ROLE.name: CEPHFS_MGR_ROLE,
     GANESHA_MGR_ROLE.name: GANESHA_MGR_ROLE,
+}
+
+# static name-like roles list for role mapping
+SYSTEM_ROLES_NAMES = {
+    ADMIN_ROLE: [ADMIN_ROLE.name, 'admin'],
+    READ_ONLY_ROLE: [READ_ONLY_ROLE.name, 'read', 'guest', 'monitor']
 }
 
 

--- a/src/pybind/mgr/dashboard/services/auth/__init__.py
+++ b/src/pybind/mgr/dashboard/services/auth/__init__.py
@@ -1,0 +1,16 @@
+from .auth import AuthManager, AuthManagerTool, AuthType, BaseAuth, \
+    JwtManager, SSOAuth, decode_jwt_segment
+from .oauth2 import OAuth2
+from .saml2 import Saml2
+
+__all__ = [
+    'AuthManager',
+    'AuthManagerTool',
+    'AuthType',
+    'BaseAuth',
+    'SSOAuth',
+    'JwtManager',
+    'decode_jwt_segment',
+    'Saml2',
+    'OAuth2'
+]

--- a/src/pybind/mgr/dashboard/services/auth/oauth2.py
+++ b/src/pybind/mgr/dashboard/services/auth/oauth2.py
@@ -1,0 +1,151 @@
+import json
+from typing import Dict, List
+from urllib.parse import quote
+
+import cherrypy
+import requests
+
+from ... import mgr
+from ...services.auth import BaseAuth, SSOAuth, decode_jwt_segment
+from ...tools import prepare_url_prefix
+from ..access_control import Role, User, UserAlreadyExists
+
+
+class OAuth2(SSOAuth):
+    LOGIN_URL = 'auth/oauth2/login'
+    LOGOUT_URL = 'auth/oauth2/logout'
+    sso = True
+
+    class OAuth2Config(BaseAuth.Config):
+        pass
+
+    @staticmethod
+    def enabled():
+        return mgr.get_module_option('sso_oauth2')
+
+    def to_dict(self) -> 'BaseAuth.Config':
+        return self.OAuth2Config()
+
+    @classmethod
+    def from_dict(cls, s_dict: OAuth2Config) -> 'OAuth2':
+        # pylint: disable=unused-argument
+        return OAuth2()
+
+    @classmethod
+    def get_auth_name(cls):
+        return cls.__name__.lower()
+
+    @classmethod
+    # pylint: disable=protected-access
+    def get_token(cls, request: cherrypy._ThreadLocalProxy) -> str:
+        try:
+            return request.cookie['token'].value
+        except KeyError:
+            return request.headers.get('X-Access-Token')
+
+    @classmethod
+    def set_token(cls, token: str):
+        cherrypy.request.jwt = token
+        cherrypy.request.jwt_payload = cls.get_token_payload()
+        cherrypy.request.user = cls.get_user(token)
+
+    @classmethod
+    def get_token_payload(cls) -> Dict:
+        try:
+            return cherrypy.request.jwt_payload
+        except AttributeError:
+            pass
+        try:
+            return decode_jwt_segment(cherrypy.request.jwt.split(".")[1])
+        except AttributeError:
+            return {}
+
+    @classmethod
+    def set_token_payload(cls, token):
+        cherrypy.request.jwt_payload = decode_jwt_segment(token.split(".")[1])
+
+    @classmethod
+    def get_user_roles(cls):
+        roles: List[Role] = []
+        user_roles: List[Role] = []
+        try:
+            jwt_payload = cherrypy.request.jwt_payload
+        except AttributeError:
+            raise cherrypy.HTTPError()
+
+        # check for client roes
+        if 'resource_access' in jwt_payload:
+            # Find the first value where the key is not 'account'
+            roles = next((value['roles'] for key, value in jwt_payload['resource_access'].items()
+                          if key != "account"), user_roles)
+        # check for global roles
+        elif 'realm_access' in jwt_payload:
+            roles = next((value['roles'] for _, value in jwt_payload['realm_access'].items()),
+                         user_roles)
+        else:
+            raise cherrypy.HTTPError()
+        user_roles = Role.map_to_system_roles(roles)
+        return user_roles
+
+    @classmethod
+    def get_user(cls, token: str) -> User:
+        try:
+            return cherrypy.request.user
+        except AttributeError:
+            cls.set_token_payload(token)
+            cls._create_user()
+        return cherrypy.request.user
+
+    @classmethod
+    def _create_user(cls):
+        try:
+            jwt_payload = cherrypy.request.jwt_payload
+        except AttributeError:
+            raise cherrypy.HTTPError()
+        try:
+            user = mgr.ACCESS_CTRL_DB.create_user(
+                jwt_payload['sub'], None, jwt_payload['name'], jwt_payload['email'])
+        except UserAlreadyExists:
+            user = mgr.ACCESS_CTRL_DB.get_user(jwt_payload['sub'])
+        user.set_roles(cls.get_user_roles())
+        # set user last update to token time issued
+        user.last_update = jwt_payload['iat']
+        cherrypy.request.user = user
+
+    @classmethod
+    def reset_user(cls):
+        try:
+            mgr.ACCESS_CTRL_DB.delete_user(cherrypy.request.user.username)
+            cherrypy.request.user = None
+        except AttributeError:
+            raise cherrypy.HTTPError()
+
+    @classmethod
+    def get_token_iss(cls, token=''):
+        if token:
+            cls.set_token_payload(token)
+        return cls.get_token_payload()['iss']
+
+    @classmethod
+    def get_openid_config(cls, iss):
+        msg = 'Failed to logout: could not contact IDP'
+        try:
+            response = requests.get(f'{iss}/.well-known/openid-configuration')
+        except requests.exceptions.RequestException:
+            raise cherrypy.HTTPError(500, message=msg)
+        if response.status_code != 200:
+            raise cherrypy.HTTPError(500, message=msg)
+        return json.loads(response.text)
+
+    @classmethod
+    def get_login_redirect_url(cls, token) -> str:
+        url_prefix = prepare_url_prefix(mgr.get_module_option('url_prefix', default=''))
+        return f"{url_prefix}/#/login?access_token={token}"
+
+    @classmethod
+    def get_logout_redirect_url(cls, token) -> str:
+        openid_config = OAuth2.get_openid_config(OAuth2.get_token_iss(token))
+        end_session_url = openid_config.get('end_session_endpoint')
+        encoded_end_session_url = quote(end_session_url, safe="")
+        url_prefix = prepare_url_prefix(mgr.get_module_option('url_prefix', default=''))
+        return f'{url_prefix}/oauth2/sign_out?rd={encoded_end_session_url}'

--- a/src/pybind/mgr/dashboard/services/auth/saml2.py
+++ b/src/pybind/mgr/dashboard/services/auth/saml2.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from .auth import BaseAuth, SSOAuth
+
+
+class Saml2(SSOAuth):
+    LOGIN_URL = 'auth/saml2/login'
+    LOGOUT_URL = 'auth/saml2/slo'
+    sso = True
+
+    class Saml2Config(BaseAuth.Config):
+        onelogin_settings: Any
+
+    def __init__(self, onelogin_settings):
+        self.onelogin_settings = onelogin_settings
+
+    def get_username_attribute(self):
+        return self.onelogin_settings['sp']['attributeConsumingService']['requestedAttributes'][0][
+            'name']
+
+    def to_dict(self) -> 'Saml2Config':
+        return {
+            'onelogin_settings': self.onelogin_settings
+        }
+
+    @classmethod
+    def from_dict(cls, s_dict: Saml2Config) -> 'Saml2':
+        try:
+            return Saml2(s_dict['onelogin_settings'])
+        except KeyError:
+            return Saml2({})
+
+    @classmethod
+    def get_auth_name(cls):
+        return cls.__name__.lower()

--- a/src/pybind/mgr/dashboard/tests/test_auth.py
+++ b/src/pybind/mgr/dashboard/tests/test_auth.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
+from dashboard.services.auth import AuthType
+
 from .. import mgr
 from ..controllers.auth import Auth
 from ..services.auth import JwtManager
@@ -10,6 +12,7 @@ mgr.get_module_option.return_value = JwtManager.JWT_TOKEN_TTL
 mgr.get_store.return_value = 'jwt_secret'
 mgr.ACCESS_CTRL_DB = Mock()
 mgr.ACCESS_CTRL_DB.get_attempt.return_value = 1
+mgr.SSO_DB.protocol = AuthType.LOCAL
 
 
 class JwtManagerTest(unittest.TestCase):
@@ -67,5 +70,6 @@ class AuthTest(ControllerTestCase):
         self._post('/api/auth/logout')
         self.assertStatus(200)
         self.assertJsonBody({
-            'redirect_url': '#/login'
+            'redirect_url': '#/login',
+            'protocol': 'local'
         })

--- a/src/pybind/mgr/dashboard/tests/test_sso.py
+++ b/src/pybind/mgr/dashboard/tests/test_sso.py
@@ -166,7 +166,7 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
                       idp_metadata=self.IDP_METADATA)
 
         result = self.exec_cmd('sso enable saml2')
-        self.assertEqual(result, 'SSO is "enabled" with "SAML2" protocol.')
+        self.assertEqual(result, 'SSO is "enabled" with "saml2" protocol.')
 
     def test_sso_disable(self):
         result = self.exec_cmd('sso disable')
@@ -181,7 +181,7 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
                       idp_metadata=self.IDP_METADATA)
 
         result = self.exec_cmd('sso status')
-        self.assertEqual(result, 'SSO is "enabled" with "SAML2" protocol.')
+        self.assertEqual(result, 'SSO is "enabled" with "saml2" protocol.')
 
     def test_sso_show_saml2(self):
         result = self.exec_cmd('sso show saml2')


### PR DESCRIPTION
This PR intends to enable SSO in the dashboard through oauth2 protocol thanks to the `mgmt-gateway` and `oauth2-proxy` service. You can configure them following the documented steps in #58460

To access the dashboard with oauth2 SSO, you'll have to enable it:
 `ceph dashboard sso enable oauth2`

From the IDP configured of your choice:

- You'll need to set the Valid reditrect URI: `https://<host_name>|<IP_address>/oauth2/callback` wich has to be the same configured on the `oauth2-proxy` service, for the `redirec urls` field

- To login you need a valid user role, for administrator role you will have to configure the IDP's user with an 'administrator' role or 'read-only' for a read-only access

Possible improvements **TODO**: 

- [ ] Pluggable backend: [proposal](https://github.com/ceph/ceph/pull/58456#pullrequestreview-2230565811)
- [ ] Refactor auth + authen to [remove oauth2 user create/delete pattern](https://github.com/ceph/ceph/pull/58456#discussion_r1732583607)
- [ ] Mantain standalond backend: [Remove frontend redirect](https://github.com/ceph/ceph/pull/58456#discussion_r1732609434)
- [ ] Base auth router: [propsal](https://github.com/ceph/ceph/pull/58456#discussion_r1742005499)
- [ ] Refactor the JwtManager and OAuth2: [base class](https://github.com/ceph/ceph/pull/58456#discussion_r1750729272) and [factory pattern](https://github.com/ceph/ceph/pull/58456#discussion_r1750646987)
- [ ] Decorator for loggin on function start and stop: [proposal](https://github.com/ceph/ceph/pull/58456#discussion_r1751530433)
- [ ] Improve Idp's user roles mappging to Dashboard's user roles
- [ ] Redirect to Idp's login on token expiration


-------------

 
[screen-capture (20).webm](https://github.com/user-attachments/assets/431a1a44-f4c6-49ac-bf60-b755d1dfd331)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
