### PR TITLE
reef: debian: recursively adjust permissions of /var/lib/ceph/crash

### DIFF
--- a/debian/ceph-base.postinst
+++ b/debian/ceph-base.postinst
@@ -35,11 +35,13 @@ case "$1" in
 
         # adjust file and directory permissions
 	for DIR in /var/lib/ceph/* ; do
-	    if ! dpkg-statoverride --list $DIR >/dev/null
+	    if ! dpkg-statoverride --list "${DIR}" >/dev/null
 	    then
-		chown $SERVER_USER:$SERVER_GROUP $DIR
+		chown "${SERVER_USER}:${SERVER_GROUP}" "${DIR}"
 	    fi
 	done
+
+	chown "${SERVER_USER}:${SERVER_GROUP}" -R /var/lib/ceph/crash/*;
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
 	:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66860

---

backport of https://github.com/ceph/ceph/pull/55917
parent tracker: https://tracker.ceph.com/issues/64548

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh