### PR TITLE
test/librbd: clean up unused TEST_COOKIE variable

### DIFF
--- a/src/test/librbd/exclusive_lock/test_mock_PostAcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PostAcquireRequest.cc
@@ -84,8 +84,6 @@ using ::testing::SetArgPointee;
 using ::testing::StrEq;
 using ::testing::WithArg;
 
-static const std::string TEST_COOKIE("auto 123");
-
 class TestMockExclusiveLockPostAcquireRequest : public TestMockFixture {
 public:
   typedef PostAcquireRequest<MockTestImageCtx> MockPostAcquireRequest;

--- a/src/test/librbd/exclusive_lock/test_mock_PreAcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PreAcquireRequest.cc
@@ -44,8 +44,6 @@ using ::testing::SetArgPointee;
 using ::testing::StrEq;
 using ::testing::WithArg;
 
-static const std::string TEST_COOKIE("auto 123");
-
 class TestMockExclusiveLockPreAcquireRequest : public TestMockFixture {
 public:
   typedef PreAcquireRequest<MockTestImageCtx> MockPreAcquireRequest;

--- a/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
@@ -70,8 +70,6 @@ using ::testing::Return;
 using ::testing::StrEq;
 using ::testing::WithArg;
 
-static const std::string TEST_COOKIE("auto 123");
-
 class TestMockExclusiveLockPreReleaseRequest : public TestMockFixture {
 public:
   typedef ImageDispatch<MockTestImageCtx> MockImageDispatch;


### PR DESCRIPTION
Clean it up because
```
/home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/test/librbd/exclusive_lock/test_mock_PreAcquireRequest.cc:47:26: error: unused variable 'TEST_COOKIE' [-Werror,-Wunused-const-variable]
static const std::string TEST_COOKIE("auto 123");
                         ^
1 error generated.
```

Ref: https://jenkins.ceph.com/job/ceph-pull-requests-arm64/59242/consoleFull#-5120798632a811ea2-3e7b-466b-84b4-d13df7e35809





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
