### PR TITLE
crimson/os/seastore: track transactions/conflicts/outstanding periodically

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -277,6 +277,8 @@ public:
 
   virtual ~ExtentCallbackInterface() = default;
 
+  virtual shard_stats_t& get_shard_stats() = 0;
+
   /// Creates empty transaction
   /// weak transaction should be type READ
   virtual TransactionRef create_transaction(

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -2469,7 +2469,7 @@ void SeaStore::Shard::init_managers()
   shard_stats = {};
 
   transaction_manager = make_transaction_manager(
-      device, secondaries, is_test);
+      device, secondaries, shard_stats, is_test);
   collection_manager = std::make_unique<collection_manager::FlatCollectionManager>(
       *transaction_manager);
   onode_manager = std::make_unique<crimson::os::seastore::onode::FLTreeOnodeManager>(

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -677,6 +677,18 @@ seastar::future<> SeaStore::report_stats()
          (double)io_total.pending_read_num/seastar::smp::count,
          (double)io_total.pending_bg_num/seastar::smp::count,
          (double)io_total.pending_flush_num/seastar::smp::count);
+
+    std::ostringstream oss_pending;
+    for (const auto &s : shard_io_stats) {
+      oss_pending << s.pending_io_num
+                 << "(" << s.starting_io_num
+                 << "," << s.waiting_collock_io_num
+                 << "," << s.waiting_throttler_io_num
+                 << "," << s.processing_inlock_io_num
+                 << "," << s.processing_postlock_io_num
+                 << ") ";
+    }
+    INFO("details: {}", oss_pending.str());
     return seastar::now();
   });
 }

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -206,6 +206,8 @@ public:
 
     device_stats_t get_device_stats(bool report_detail) const;
 
+    shard_stats_t get_io_stats(bool report_detail) const;
+
   private:
     struct internal_context_t {
       CollectionRef ch;
@@ -501,6 +503,9 @@ public:
     void register_metrics();
 
     mutable shard_stats_t shard_stats;
+    mutable seastar::lowres_clock::time_point last_tp =
+      seastar::lowres_clock::time_point::min();
+    mutable shard_stats_t last_shard_stats;
   };
 
 public:
@@ -577,6 +582,7 @@ private:
   mutable seastar::lowres_clock::time_point last_tp =
     seastar::lowres_clock::time_point::min();
   mutable std::vector<device_stats_t> shard_device_stats;
+  mutable std::vector<shard_stats_t> shard_io_stats;
 };
 
 std::unique_ptr<SeaStore> make_seastore(

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2367,6 +2367,26 @@ struct writer_stats_printer_t {
 };
 std::ostream& operator<<(std::ostream&, const writer_stats_printer_t&);
 
+struct shard_stats_t {
+  // transaction_type_t::MUTATE
+  uint64_t io_num = 0;
+  uint64_t repeat_io_num = 0;
+  uint64_t pending_io_num = 0;
+  uint64_t starting_io_num = 0;
+  uint64_t waiting_collock_io_num = 0;
+  uint64_t waiting_throttler_io_num = 0;
+  uint64_t processing_inlock_io_num = 0;
+  uint64_t processing_postlock_io_num = 0;
+
+  // transaction_type_t::READ
+  uint64_t read_num = 0;
+  uint64_t repeat_read_num = 0;
+  uint64_t pending_read_num = 0;
+
+  uint64_t flush_num = 0;
+  uint64_t pending_flush_num = 0;
+};
+
 }
 
 WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::seastore_meta_t)

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2396,6 +2396,65 @@ struct shard_stats_t {
 
   uint64_t flush_num = 0;
   uint64_t pending_flush_num = 0;
+
+  uint64_t get_bg_num() const {
+    return trim_alloc_num +
+           trim_dirty_num +
+           cleaner_main_num +
+           cleaner_cold_num;
+  }
+
+  uint64_t get_repeat_bg_num() const {
+    return repeat_trim_alloc_num +
+           repeat_trim_dirty_num +
+           repeat_cleaner_main_num +
+           repeat_cleaner_cold_num;
+  }
+
+  void add(const shard_stats_t &o) {
+    io_num += o.io_num;
+    repeat_io_num += o.repeat_io_num;
+    pending_io_num += o.pending_io_num;
+    starting_io_num += o.starting_io_num;
+    waiting_collock_io_num += o.waiting_collock_io_num;
+    waiting_throttler_io_num += o.waiting_throttler_io_num;
+    processing_inlock_io_num += o.processing_inlock_io_num;
+    processing_postlock_io_num += o.processing_postlock_io_num;
+
+    read_num += o.read_num;
+    repeat_read_num += o.repeat_read_num;
+    pending_read_num += o.pending_read_num;
+
+    pending_bg_num += o.pending_bg_num;
+    trim_alloc_num += o.trim_alloc_num;
+    repeat_trim_alloc_num += o.repeat_trim_alloc_num;
+    trim_dirty_num += o.trim_dirty_num;
+    repeat_trim_dirty_num += o.repeat_trim_dirty_num;
+    cleaner_main_num += o.cleaner_main_num;
+    repeat_cleaner_main_num += o.repeat_cleaner_main_num;
+    cleaner_cold_num += o.cleaner_cold_num;
+    repeat_cleaner_cold_num += o.repeat_cleaner_cold_num;
+
+    flush_num += o.flush_num;
+    pending_flush_num += o.pending_flush_num;
+  }
+
+  void minus(const shard_stats_t &o) {
+    // realtime(e.g. pending) stats are not related
+    io_num -= o.io_num;
+    repeat_io_num -= o.repeat_io_num;
+    read_num -= o.read_num;
+    repeat_read_num -= o.repeat_read_num;
+    trim_alloc_num -= o.trim_alloc_num;
+    repeat_trim_alloc_num -= o.repeat_trim_alloc_num;
+    trim_dirty_num -= o.trim_dirty_num;
+    repeat_trim_dirty_num -= o.repeat_trim_dirty_num;
+    cleaner_main_num -= o.cleaner_main_num;
+    repeat_cleaner_main_num -= o.repeat_cleaner_main_num;
+    cleaner_cold_num -= o.cleaner_cold_num;
+    repeat_cleaner_cold_num -= o.repeat_cleaner_cold_num;
+    flush_num -= o.flush_num;
+  }
 };
 
 }

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2383,6 +2383,17 @@ struct shard_stats_t {
   uint64_t repeat_read_num = 0;
   uint64_t pending_read_num = 0;
 
+  // transaction_type_t::TRIM_DIRTY~CLEANER_COLD
+  uint64_t pending_bg_num = 0;
+  uint64_t trim_alloc_num = 0;
+  uint64_t repeat_trim_alloc_num = 0;
+  uint64_t trim_dirty_num = 0;
+  uint64_t repeat_trim_dirty_num = 0;
+  uint64_t cleaner_main_num = 0;
+  uint64_t repeat_cleaner_main_num = 0;
+  uint64_t cleaner_cold_num = 0;
+  uint64_t repeat_cleaner_cold_num = 0;
+
   uint64_t flush_num = 0;
   uint64_t pending_flush_num = 0;
 };

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -65,7 +65,8 @@ public:
     CacheRef cache,
     LBAManagerRef lba_manager,
     ExtentPlacementManagerRef &&epm,
-    BackrefManagerRef&& backref_manager);
+    BackrefManagerRef&& backref_manager,
+    shard_stats_t& shard_stats);
 
   /// Writes initial metadata to disk
   using mkfs_ertr = base_ertr;
@@ -662,6 +663,10 @@ public:
    * ExtentCallbackInterface
    */
 
+  shard_stats_t& get_shard_stats() {
+    return shard_stats;
+  }
+
   /// weak transaction should be type READ
   TransactionRef create_transaction(
       Transaction::src_t src,
@@ -833,6 +838,8 @@ private:
   WritePipeline write_pipeline;
 
   bool full_extent_integrity_check = true;
+
+  shard_stats_t& shard_stats;
 
   rewrite_extent_ret rewrite_logical_extent(
     Transaction& t,
@@ -1010,5 +1017,6 @@ using TransactionManagerRef = std::unique_ptr<TransactionManager>;
 TransactionManagerRef make_transaction_manager(
     Device *primary_device,
     const std::vector<Device*> &secondary_devices,
+    shard_stats_t& shard_stats,
     bool is_test);
 }

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -411,11 +411,16 @@ seastar::future<> OSD::start()
             shard_stats[seastar::this_shard_id()] = stats;
           }).then([this, FNAME] {
             std::ostringstream oss;
+            double agg_ru = 0;
+            int cnt = 0;
             for (const auto &stats : shard_stats) {
+              agg_ru += stats.reactor_utilization;
+              ++cnt;
               oss << int(stats.reactor_utilization);
               oss << ",";
             }
-            INFO("reactor_utilizations: {}", oss.str());
+            INFO("reactor_utilizations: {}({})",
+                 int(agg_ru/cnt), oss.str());
           });
         });
         gate.dispatch_in_background("stats_store", *this, [this] {

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -139,11 +139,13 @@ seastar::future<bufferlist> TMDriver::read(
 
 void TMDriver::init()
 {
+  shard_stats = {};
+
   std::vector<Device*> sec_devices;
 #ifndef NDEBUG
-  tm = make_transaction_manager(device.get(), sec_devices, true);
+  tm = make_transaction_manager(device.get(), sec_devices, shard_stats, true);
 #else
-  tm = make_transaction_manager(device.get(), sec_devices, false);
+  tm = make_transaction_manager(device.get(), sec_devices, shard_stats, false);
 #endif
 }
 

--- a/src/crimson/tools/store_nbd/tm_driver.h
+++ b/src/crimson/tools/store_nbd/tm_driver.h
@@ -41,6 +41,9 @@ private:
   using TransactionManagerRef = crimson::os::seastore::TransactionManagerRef;
   TransactionManagerRef tm;
 
+  using shard_stats_t = crimson::os::seastore::shard_stats_t;
+  shard_stats_t shard_stats;
+
   seastar::future<> mkfs();
   void init();
   void clear();

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -273,6 +273,7 @@ protected:
   Cache* cache;
   ExtentPlacementManager *epm;
   uint64_t seq = 0;
+  shard_stats_t shard_stats;
 
   TMTestState() : EphemeralTestState(1, 0) {}
 
@@ -292,7 +293,8 @@ protected:
 	"seastore_full_integrity_check", "false");
     }
 #endif
-    tm = make_transaction_manager(p_dev, sec_devices, true);
+    shard_stats = {};
+    tm = make_transaction_manager(p_dev, sec_devices, shard_stats, true);
     epm = tm->get_epm();
     lba_manager = tm->get_lba_manager();
     cache = tm->get_cache();


### PR DESCRIPTION
Also minor improvements to the original stats to make them clear.

Now the report looks like (included https://github.com/ceph/ceph/pull/58250, fio random writes):
```
INFO  2024-07-09 10:40:21,725 [shard  0:main] seastore_epm - ExtentPlacementManager::get_device_stats:
tier-main: iops=5734.93,depth=1.25,batch=1.11,bwMiB=29.04,sizeB=5309.09(3009.69,828.42,1470.98)
  inline: iops=3097.46,depth=1.01,batch=1.21,bwMiB=18.73,sizeB=6342.02(2084.70,1533.81,2723.52)
  oolmdat: iops=0.00,depth=-nan,batch=-nan,bwMiB=0.00,sizeB=-nan(-nan,-nan,-nan)
  ooldata: iops=2637.47,depth=1.54,batch=1.00,bwMiB=10.30,sizeB=4096.00(4096.00,0.00,0.00)
  mainmdat: iops=0.00,depth=-nan,batch=-nan,bwMiB=0.00,sizeB=-nan(-nan,-nan,-nan)
  maindata: iops=0.00,depth=-nan,batch=-nan,bwMiB=0.00,sizeB=-nan(-nan,-nan,-nan)
MUTATE: rps=5226.44,bwMiB=19.87,sizeB=3987.40(3210.42,776.98)
  inline: rps=2588.97,bwMiB=9.57,sizeB=3876.76(2308.25,1568.51)
  ooldata: rps=2637.47,bwMiB=10.30,sizeB=4096.00(4096.00,0.00)
TRIM_DIRTY: rps=0.00,bwMiB=0.00,sizeB=-nan(-nan,-nan)
TRIM_ALLOC: rps=1149.49,bwMiB=0.95,sizeB=862.76(418.69,444.07)
  inline: rps=1149.49,bwMiB=0.95,sizeB=862.76(418.69,444.07)
CLEANER_MAIN: rps=0.00,bwMiB=0.00,sizeB=-nan(-nan,-nan)
CLEANER_COLD: rps=0.00,bwMiB=0.00,sizeB=-nan(-nan,-nan)
INFO  2024-07-09 10:40:21,725 [shard  0:main] seastore - SeaStore::get_io_stats: iops=2579.97,0.00,1149.49(1149.49,0.00,0.00,0.00),0.00 conflicts=0.03,-nan,0.00(0.00,-nan,-nan,-nan) outstanding=11(0,5,0,3,3),0,0,0
INFO  2024-07-09 10:40:21,727 [shard  0:main] osd - OSD::start: reactor_utilizations: 89(88,88,94,91,99,95,89,84,89,93,83,92,88,88,91,83,89,85,84,84,89,93,90,91,82,96,87,88,90,89,85,99,)
INFO  2024-07-09 10:40:21,727 [shard  0:main] seastore - SeaStore: device IOPS: 180000.34 5625.01(5734.85,5639.85,5282.86,5533.36,5268.36,5515.86,5432.86,5629.85,5842.35,5746.35,5667.35,5623.35,5603.35,5782.85,5698.85,5777.85,5780.35,5677.35,5504.86,5534.86,5660.35,5859.35,5920.35,5849.85,5637.85,5123.37,5769.35,5828.35,5741.85,5659.85,5726.85,4945.37,)
INFO  2024-07-09 10:40:21,727 [shard  0:main] seastore - SeaStore: device bandwidth(MiB): 928.13 29.00(29.04,28.75,27.59,28.69,28.47,28.76,27.82,28.60,30.33,29.81,28.80,29.49,28.86,29.75,29.50,29.37,29.63,29.11,27.91,27.91,29.15,30.07,30.27,30.37,28.53,27.39,29.74,29.70,29.52,29.34,29.33,26.53,)
INFO  2024-07-09 10:40:21,727 [shard  0:main] seastore - SeaStore: device per-writer depth: 1.31
INFO  2024-07-09 10:40:21,727 [shard  0:main] seastore - SeaStore: device IO size(B): 5406.73
INFO  2024-07-09 10:40:21,727 [shard  0:main] seastore - SeaStore: trans IOPS: 84300.82,0.00,33984.62,0.00 per-shard: 2634.40,0.00,1062.02,0.00
INFO  2024-07-09 10:40:21,727 [shard  0:main] seastore - SeaStore: trans conflicts: 0.07,-nan,0.00
INFO  2024-07-09 10:40:21,727 [shard  0:main] seastore - SeaStore: trans outstanding: 3263,0,15,0 per-shard: 101.97,0.00,0.47,0.00
INFO  2024-07-09 10:40:21,727 [shard  0:main] seastore - SeaStore: details: 11(0,5,0,3,3) 8(0,4,0,3,1) 15(0,9,0,4,2) 49(0,41,0,4,4) 272(0,265,0,4,3) 26(0,22,0,3,1) 18(0,11,0,4,3) 0(0,0,0,0,0) 10(0,5,0,4,1) 64(0,57,0,4,3) 12(0,7,0,3,2) 3(0,0,0,2,1) 13(0,7,0,3,3) 1(0,0,0,1,0) 9(0,4,0,4,1) 32(0,26,0,4,2) 0(0,0,0,0,0) 1(0,0,0,1,0) 1(0,0,0,1,0) 19(0,14,0,4,1) 9(0,4,0,4,1) 21(0,15,0,4,2) 0(0,0,0,0,0) 0(0,0,0,0,0) 13(0,7,0,3,3) 21(0,14,0,4,3) 7(0,3,0,3,1) 7(0,2,0,3,2) 0(0,0,0,0,0) 3(0,0,0,2,1) 18(0,11,0,4,3) 2600(0,2595,0,4,1)
```

I think it reveals an opportunity to optimize the collection lock, because there are quite a lot of waiters. I'm working on a solution.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
