### PR TITLE
rgw/datalog: fix LazyFIFO race fix

### DIFF
--- a/src/rgw/driver/rados/rgw_log_backing.h
+++ b/src/rgw/driver/rados/rgw_log_backing.h
@@ -269,7 +269,7 @@ class LazyFIFO {
       // FIFO supports multiple clients by design, so it's safe to
       // race to create them.
       std::unique_ptr<rgw::cls::fifo::FIFO> fifo_tmp;
-      auto r = rgw::cls::fifo::FIFO::create(dpp, ioctx, oid, &fifo, y);
+      auto r = rgw::cls::fifo::FIFO::create(dpp, ioctx, oid, &fifo_tmp, y);
       if (r) {
 	return r;
       }


### PR DESCRIPTION
initialize `fifo_tmp` to prevent the race on member variable `fifo` that was identified in 8fa844383f9c22e758f39ecdda74f70de054ad68

Fixes: https://tracker.ceph.com/issues/66880

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
