### PR TITLE
ptl-tool: Fix token file name and variable names

### DIFF
--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -23,14 +23,14 @@
 #
 # Important files in your $HOME:
 #
-#  ~/.redmine_key -- Your redmine API key from right side of: https://tracker.ceph.com/my/account
+#  ~/.redmine_key -- Your redmine API access key from right side of: https://tracker.ceph.com/my/account
 #
-#  ~/.github.key -- Your github API key: https://github.com/settings/tokens
+#  ~/.github_token -- Your github Personal access token: https://github.com/settings/tokens
 #
 # Some important environment variables:
 #
 #  - PTL_TOOL_GITHUB_USER (your github username)
-#  - PTL_TOOL_GITHUB_API_KEY (your github api key, or what is stored in ~/.github.key)
+#  - PTL_TOOL_GITHUB_TOKEN (your github Personal access token, or what is stored in ~/.github_token)
 #  - PTL_TOOL_REDMINE_USER (your redmine username)
 #  - PTL_TOOL_REDMINE_API_KEY (your redmine api key, or what is stored in ~/redmine_key)
 #  - PTL_TOOL_USER (your desired username embedded in test branch names)
@@ -170,13 +170,13 @@ CI_REPO = os.getenv("PTL_TOOL_CI_REPO", "ceph-ci")
 CI_REMOTE_URL = os.getenv("PTL_TOOL_CI_REMOTE_URL", f"git@github.com:{BASE_PROJECT}/{CI_REPO}.git")
 GITDIR = os.getenv("PTL_TOOL_GITDIR", ".")
 GITHUB_USER = os.getenv("PTL_TOOL_GITHUB_USER", os.getenv("PTL_TOOL_USER", getuser()))
-GITHUB_API_KEY = None
+GITHUB_TOKEN = None
 try:
-    with open(expanduser("~/.github.key")) as f:
-        GITHUB_API_KEY = f.read().strip()
+    with open(expanduser("~/.github_token")) as f:
+        GITHUB_TOKEN = f.read().strip()
 except FileNotFoundError:
     pass
-GITHUB_API_KEY = os.getenv("PTL_TOOL_GITHUB_API_KEY", GITHUB_API_KEY)
+GITHUB_TOKEN = os.getenv("PTL_TOOL_GITHUB_TOKEN", GITHUB_TOKEN)
 INDICATIONS = [
     re.compile("(Reviewed-by: .+ <[\w@.-]+>)", re.IGNORECASE),
     re.compile("(Acked-by: .+ <[\w@.-]+>)", re.IGNORECASE),
@@ -230,7 +230,7 @@ BZ_MATCH = re.compile("(.*https?://bugzilla.redhat.com/.*)")
 TRACKER_MATCH = re.compile("(.*https?://tracker.ceph.com/.*)")
 
 def gitauth():
-    return (GITHUB_USER, GITHUB_API_KEY)
+    return (GITHUB_USER, GITHUB_TOKEN)
 
 def get(session, url, params=None, paging=True):
     if params is None:


### PR DESCRIPTION
* Renames .github.key to .github_token to make it identical to ceph-backport.sh script.
  This fix eliminates creating 2 files that stores the same thing.

* Rename the variables with the github/redmine conventions.







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>