### PR TITLE
squid: mds: relax divergent backtrace scrub failures for replicated ancestor inodes

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1004,6 +1004,19 @@ bool CInode::is_ancestor_of(const CInode *other, std::unordered_map<CInode const
   return false;
 }
 
+bool CInode::is_any_ancestor_inode_a_replica() {
+  CDentry *pdn = get_parent_dn();
+  while (pdn) {
+    CInode *diri = pdn->get_dir()->get_inode();
+    if (!diri->is_auth()) {
+      return true;
+    }
+    pdn = diri->get_parent_dn();
+  }
+
+  return false;
+}
+
 bool CInode::is_projected_ancestor_of(const CInode *other) const
 {
   while (other) {
@@ -4834,7 +4847,11 @@ void CInode::validate_disk_state(CInode::validated_data *results,
           dout(20) << "divergent backtraces are acceptable when dn "
                       "is being purged or has been renamed or moved to a "
                       "different directory " << *in << dendl;
-        }
+        } else if (in->is_any_ancestor_inode_a_replica()) {
+          results->backtrace.passed = true;
+          dout(20) << "divergent backtraces are acceptable when some "
+	              "ancestor inodes are replicas " << *in << dendl;
+	}
       } else {
         results->backtrace.passed = true;
       }

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -707,6 +707,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   const CDir *get_projected_parent_dir() const;
   CDir *get_projected_parent_dir();
   CInode *get_parent_inode();
+
+  bool is_any_ancestor_inode_a_replica();
   
   bool is_lt(const MDSCacheObject *r) const override {
     const CInode *o = static_cast<const CInode*>(r);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66272

---

backport of https://github.com/ceph/ceph/pull/57354
parent tracker: https://tracker.ceph.com/issues/64730

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh