### PR TITLE
Few improvements to smb mgr module and docs

### DIFF
--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -55,7 +55,7 @@ Create Cluster
 
 .. code:: bash
 
-    $ ceph smb cluster create <cluster_id> {user|active-directory} [--domain-realm=<domain_realm>] [--domain-join-user-pass=<domain_join_user_pass>] [--custom-dns=<custom_dns>] [--placement=<placement>]
+    $ ceph smb cluster create <cluster_id> {user|active-directory} [--domain-realm=<domain_realm>] [--domain-join-user-pass=<domain_join_user_pass>] [--define-user-pass=<define_user_pass>] [--custom-dns=<custom_dns>] [--placement=<placement>]
 
 Create a new logical cluster, identified by the cluster id value. The cluster
 create command must specify the authentication mode the cluster will use. This
@@ -78,6 +78,9 @@ domain_realm
 domain_join_user_pass
     A string in the form ``<username>%<password>`` that will be used to join
     Samba servers to the AD domain.
+define_user_pass
+    A string in the form ``<username>%<password>`` that will be used for
+    authentication in ``user`` auth_mode.
 custom_dns
     Optional. Can be specified multiple times. One or more IP Addresses that
     will be applied to the Samba containers to override the default DNS

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -758,7 +758,7 @@ def _check_cluster(cluster: ClusterRef, staging: _Staging) -> None:
                 cluster,
                 msg="cluster in use by shares",
                 status={
-                    'clusters': [
+                    'shares': [
                         shid
                         for cid, shid in share_ids
                         if cid == cluster.cluster_id


### PR DESCRIPTION
- Fix a wrong field name in error response while trying to remove a cluster with active shares.
- Add a missing option to `ceph smb cluster create` in docs.
