### PR TITLE
quincy: install-deps.sh, do_cmake.sh: almalinux is another el flavour

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -29,7 +29,7 @@ if [ -r /etc/os-release ]; then
             PYBUILD="3.7"
           fi
           ;;
-      rhel|centos)
+      almalinux|rocky|rhel|centos)
           MAJOR_VER=$(echo "$VERSION_ID" | sed -e 's/\..*$//')
           if [ "$MAJOR_VER" -ge "9" ] ; then
               PYBUILD="3.9"

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -403,14 +403,14 @@ else
 	$SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y remove ceph-build-deps
 	if [ "$control" != "debian/control" ] ; then rm $control; fi
         ;;
-    centos|fedora|rhel|ol|virtuozzo)
+    almalinux|rocky|centos|fedora|rhel|ol|virtuozzo)
         builddepcmd="dnf -y builddep --allowerasing"
         echo "Using dnf to install dependencies"
         case "$ID" in
             fedora)
                 $SUDO dnf install -y dnf-utils
                 ;;
-            centos|rhel|ol|virtuozzo)
+            almalinux|rocky|centos|rhel|ol|virtuozzo)
                 MAJOR_VERSION="$(echo $VERSION_ID | cut -d. -f1)"
                 $SUDO dnf install -y dnf-utils selinux-policy-targeted
                 rpm --quiet --query epel-release || \


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66898

---

backport of https://github.com/ceph/ceph/pull/53849
parent tracker: https://tracker.ceph.com/issues/66895

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh