### PR TITLE
reef: mds: set the proper extra bl for the create request

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -2780,10 +2780,18 @@ void Server::dispatch_client_request(MDRequestRef& mdr)
 
     // funky.
   case CEPH_MDS_OP_CREATE:
-    if (mdr->has_completed)
+    if (mdr->has_completed) {
+      inodeno_t created;
+
+      ceph_assert(mdr->session);
+      mdr->session->have_completed_request(req->get_reqid().tid, &created);
+      ceph_assert(created != inodeno_t());
+
+      set_reply_extra_bl(req, created, mdr->reply_extra_bl);
       handle_client_open(mdr);  // already created.. just open
-    else
+    } else {
       handle_client_openc(mdr);
+    }
     break;
 
   case CEPH_MDS_OP_OPEN:

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4793,7 +4793,7 @@ void Server::handle_client_openc(MDRequestRef& mdr)
   } else if (mdr->client_request->get_connection()->has_feature(CEPH_FEATURE_REPLY_CREATE_INODE)) {
     dout(10) << "adding ino to reply to indicate inode was created" << dendl;
     // add the file created flag onto the reply if create_flags features is supported
-    encode(newi->ino(), mdr->reply_extra_bl);
+    encode(_inode->ino, mdr->reply_extra_bl);
   }
 
   journal_and_reply(mdr, newi, dn, le, fin);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -2560,7 +2560,7 @@ void Server::handle_client_request(const cref_t<MClientRequest> &req)
         auto reply = make_message<MClientReply>(*req, 0);
 	if (created != inodeno_t()) {
 	  bufferlist extra;
-	  encode(created, extra);
+	  set_reply_extra_bl(req, created, extra);
 	  reply->set_extra_bl(extra);
 	}
         mds->send_message_client(reply, session);

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -158,6 +158,7 @@ public:
   void force_clients_readonly();
 
   // -- requests --
+  void set_reply_extra_bl(const cref_t<MClientRequest> &req, inodeno_t ino, bufferlist& extra_bl);
   void trim_completed_request_list(ceph_tid_t tid, Session *session);
   void handle_client_request(const cref_t<MClientRequest> &m);
   void handle_client_reply(const cref_t<MClientReply> &m);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66614

---

backport of https://github.com/ceph/ceph/pull/57754
parent tracker: https://tracker.ceph.com/issues/63265

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh