### PR TITLE
osd/OSD: add new asok_command to force trim osdmaps when necessary

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3174,7 +3174,7 @@ will start to track new ops received afterwards.";
     // the superblock's oldest_map. The superblock won't
     // be updated. Only the stored stale (no longer referenced)
     // osdmaps are removed.
-    int ret = trim_stale_maps();
+    ret = trim_stale_maps();
     if (ret < 0) {
      ss << " Error trimming stale osdmaps: " << cpp_strerror(ret);
      goto out;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7962,13 +7962,13 @@ void OSD::osdmap_subscribe(version_t epoch, bool force_request)
   }
 }
 
-void OSD::trim_maps(epoch_t oldest)
+bool OSD::trim_maps(epoch_t oldest)
 {
   epoch_t min = std::min(oldest, service.map_cache.cached_key_lower_bound());
   dout(20) <<  __func__ << ": min=" << min << " oldest_map="
            << superblock.get_oldest_map() << dendl;
   if (min <= superblock.get_oldest_map())
-    return;
+    return false;
 
   // Trim from the superblock's oldest_map up to `min`.
   // Break if we have exceeded the txn target size.
@@ -7989,6 +7989,7 @@ void OSD::trim_maps(epoch_t oldest)
   // we should not trim past service.map_cache.cached_key_lower_bound() 
   // as there may still be PGs with those map epochs recorded.
   ceph_assert(min <= service.map_cache.cached_key_lower_bound());
+  return true;
 }
 
 std::optional<epoch_t> OSD::get_epoch_from_osdmap_object(const ghobject_t& osdmap) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7784,7 +7784,7 @@ MPGStats* OSD::collect_pg_stats()
     }
     pg->with_pg_stats(now_is, [&](const pg_stat_t& s, epoch_t lec) {
 	m->pg_stat[pg->pg_id.pgid] = s;
-	min_last_epoch_clean = std::min(min_last_epoch_clean, lec);
+	min_last_epoch_clean = std::min(min_last_epoch_clean.load(), lec);
 	min_last_epoch_clean_pgs.push_back(pg->pg_id.pgid);
       });
   }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1843,7 +1843,7 @@ protected:
 
   ceph::coarse_mono_clock::time_point last_sent_beacon;
   ceph::mutex min_last_epoch_clean_lock = ceph::make_mutex("OSD::min_last_epoch_clean_lock");
-  epoch_t min_last_epoch_clean = 0;
+  std::atomic<epoch_t> min_last_epoch_clean = 0;
   // which pgs were scanned for min_lec
   std::vector<pg_t> min_last_epoch_clean_pgs;
   void send_beacon(const ceph::coarse_mono_clock::time_point& now);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1691,7 +1691,8 @@ protected:
 
   void handle_osd_map(class MOSDMap *m);
   void _committed_osd_maps(epoch_t first, epoch_t last, class MOSDMap *m);
-  void trim_maps(epoch_t oldest);
+  // return true if trimming actually happend, false otherwise
+  bool trim_maps(epoch_t oldest);
   void note_down_osd(int osd);
   void note_up_osd(int osd);
   friend struct C_OnMapCommit;


### PR DESCRIPTION
OSDs' osdmap trimming is based on the cluster_osdmap_trim_lower_bound sent out by monitors, which is only increased when all PGs within the cluster are clean

Consider the following scenario:
1. The cluster contains two pool `pool_a` and `pool_b`;
2. `pool_a` contains several thousand OSDs, which makes the osdmap very large (maybe several megabytes) and has a large scale PGs, say 65536; each OSD has a HD with about 10+TB space;
3. `pool_b` is a FULL-SSD pool, the OSDs of which have relatively small storage space, say about 1TB;
4. `pool_a` is under an expansion which involves backfilling over half of its PGs and takes weeks to finish;
5. Since the cluster_osdmap_trim_lower_bound won't be liftted until all PGs are clean, new OSDMaps will be accumulated in all OSDs, which will fill a large part of the storage spaces of `pool_b` OSDs.

This is actually happening in one of our largest RGW clusters, this PR provides a method to force trimming those small OSDs' osdmaps when it is safe.

Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
