### PR TITLE
squid: rgw/datalog: fix LazyFIFO race fix

### DIFF
--- a/src/rgw/driver/rados/rgw_log_backing.h
+++ b/src/rgw/driver/rados/rgw_log_backing.h
@@ -269,7 +269,7 @@ class LazyFIFO {
       // FIFO supports multiple clients by design, so it's safe to
       // race to create them.
       std::unique_ptr<rgw::cls::fifo::FIFO> fifo_tmp;
-      auto r = rgw::cls::fifo::FIFO::create(dpp, ioctx, oid, &fifo, y);
+      auto r = rgw::cls::fifo::FIFO::create(dpp, ioctx, oid, &fifo_tmp, y);
       if (r) {
 	return r;
       }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66913

---

backport of https://github.com/ceph/ceph/pull/58491
parent tracker: https://tracker.ceph.com/issues/66880

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh