### PR TITLE
quincy: qa: account for rbd_trash object in krbd_data_pool.sh + related ceph{,adm} task fixes

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -414,12 +414,7 @@ def create_rbd_pool(ctx, config):
             args=['sudo', 'ceph', '--cluster', cluster_name,
                   'osd', 'pool', 'create', 'rbd', '8'])
         mon_remote.run(
-            args=[
-                'sudo', 'ceph', '--cluster', cluster_name,
-                'osd', 'pool', 'application', 'enable',
-                'rbd', 'rbd', '--yes-i-really-mean-it'
-            ],
-            check_status=False)
+            args=['rbd', '--cluster', cluster_name, 'pool', 'init', 'rbd'])
     yield
 
 @contextlib.contextmanager

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1441,13 +1441,6 @@ def crush_setup(ctx, config):
 def create_rbd_pool(ctx, config):
     if config.get('create_rbd_pool', False):
       cluster_name = config['cluster']
-      log.info('Waiting for OSDs to come up')
-      teuthology.wait_until_osds_up(
-          ctx,
-          cluster=ctx.cluster,
-          remote=ctx.ceph[cluster_name].bootstrap_remote,
-          ceph_cluster=cluster_name,
-      )
       log.info('Creating RBD pool')
       _shell(ctx, cluster_name, ctx.ceph[cluster_name].bootstrap_remote,
           args=['sudo', 'ceph', '--cluster', cluster_name,

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1443,8 +1443,7 @@ def create_rbd_pool(ctx, config):
       cluster_name = config['cluster']
       log.info('Creating RBD pool')
       _shell(ctx, cluster_name, ctx.ceph[cluster_name].bootstrap_remote,
-          args=['sudo', 'ceph', '--cluster', cluster_name,
-                'osd', 'pool', 'create', 'rbd', '8'])
+          args=['ceph', 'osd', 'pool', 'create', 'rbd', '8'])
       _shell(ctx, cluster_name, ctx.ceph[cluster_name].bootstrap_remote,
           args=['rbd', 'pool', 'init', 'rbd'])
     yield

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1453,10 +1453,7 @@ def create_rbd_pool(ctx, config):
           args=['sudo', 'ceph', '--cluster', cluster_name,
                 'osd', 'pool', 'create', 'rbd', '8'])
       _shell(ctx, cluster_name, ctx.ceph[cluster_name].bootstrap_remote,
-          args=['sudo', 'ceph', '--cluster', cluster_name,
-                'osd', 'pool', 'application', 'enable',
-                'rbd', 'rbd', '--yes-i-really-mean-it'
-          ])
+          args=['rbd', 'pool', 'init', 'rbd'])
     yield
 
 

--- a/qa/workunits/rbd/krbd_data_pool.sh
+++ b/qa/workunits/rbd/krbd_data_pool.sh
@@ -146,14 +146,14 @@ for pool in rbd rbdnonzero; do
     done
 done
 
-# rbd_directory, rbd_children, rbd_info + img0 header + ...
-NUM_META_RBDS=$((3 + 1 + 3 * (1*2 + 3*2)))
-# rbd_directory, rbd_children, rbd_info + ...
-NUM_META_CLONESONLY=$((3 + 2 * 3 * (3*2)))
+# rbd_directory, rbd_children, rbd_info + rbd_trash + img0 header + ...
+NUM_META_RBDS=$((4 + 1 + 3 * (1*2 + 3*2)))
+# rbd_directory, rbd_children, rbd_info + rbd_trash + ...
+NUM_META_CLONESONLY=$((4 + 2 * 3 * (3*2)))
 
 [[ $(rados -p rbd ls | wc -l) -eq $((NUM_META_RBDS + 5 * NUM_OBJECTS)) ]]
-[[ $(rados -p repdata ls | wc -l) -eq $((1 + 14 * NUM_OBJECTS)) ]]
-[[ $(rados -p ecdata ls | wc -l) -eq $((1 + 14 * NUM_OBJECTS)) ]]
+[[ $(rados -p repdata ls | wc -l) -eq $((2 + 14 * NUM_OBJECTS)) ]]
+[[ $(rados -p ecdata ls | wc -l) -eq $((2 + 14 * NUM_OBJECTS)) ]]
 [[ $(rados -p rbdnonzero ls | wc -l) -eq $((NUM_META_RBDS + 5 * NUM_OBJECTS)) ]]
 [[ $(rados -p clonesonly ls | wc -l) -eq $((NUM_META_CLONESONLY + 6 * NUM_OBJECTS)) ]]
 
@@ -192,8 +192,8 @@ done
 
 # mkfs_and_mount should discard some objects everywhere but in clonesonly
 [[ $(list_HEADs rbd | wc -l) -lt $((NUM_META_RBDS + 5 * NUM_OBJECTS)) ]]
-[[ $(list_HEADs repdata | wc -l) -lt $((1 + 14 * NUM_OBJECTS)) ]]
-[[ $(list_HEADs ecdata | wc -l) -lt $((1 + 14 * NUM_OBJECTS)) ]]
+[[ $(list_HEADs repdata | wc -l) -lt $((2 + 14 * NUM_OBJECTS)) ]]
+[[ $(list_HEADs ecdata | wc -l) -lt $((2 + 14 * NUM_OBJECTS)) ]]
 [[ $(list_HEADs rbdnonzero | wc -l) -lt $((NUM_META_RBDS + 5 * NUM_OBJECTS)) ]]
 [[ $(list_HEADs clonesonly | wc -l) -eq $((NUM_META_CLONESONLY + 6 * NUM_OBJECTS)) ]]
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66909

---

backport of https://github.com/ceph/ceph/pull/58507
parent tracker: https://tracker.ceph.com/issues/66886