### PR TITLE
qa: failfast mount for better performance and unblock `fs volume ls`

### DIFF
--- a/qa/cephfs/conf/mgr.yaml
+++ b/qa/cephfs/conf/mgr.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     conf:
       mgr:
+        client mount timeout: 30
         debug client: 20
         debug mgr: 20
         debug ms: 1

--- a/qa/suites/fs/functional/tasks/snap-schedule.yaml
+++ b/qa/suites/fs/functional/tasks/snap-schedule.yaml
@@ -15,6 +15,7 @@ overrides:
       - is full \(reached quota
       - POOL_FULL
       - POOL_BACKFILLFULL
+      - cluster \[WRN\] evicting unresponsive client
 
 tasks:
   - cephfs_test_runner:


### PR DESCRIPTION
During teuthology tests, the tearing down of the cluster between two tests causes the config to be reset and a config_notify generated. This leads to a race to create a new mount using the old fscid. But by the time the mount is attempted the new fs gets created with a new fscid. This situation leads to the client mount waiting for a connection completion notification from the mds for 5 minutes (default timeout) and eventually giving up.
However, the default teuthology command timeout is 2 minutes. So, teuthology fails the command and declares the job as failed way before the mount can timeout.

The resolution to this case is to lower the client mount timeout to 30 seconds so that the config_notify fails fast paving the way for successive commands to get executed with the new fs.

An unhandled cluster warning about an unresponsive client also gets emitted later during qa job termination which leads to teuthology declaring the job as failed. As of now this warning seems harmless since it is emitted during cluster cleanup phase.
So, this warning is added to the log-ignorelist section in the snap-schedule YAML.

Fixes: https://tracker.ceph.com/issues/66009
Signed-off-by: Milind Changire <mchangir@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
