### PR TITLE
quincy: test/librbd: clean up unused TEST_COOKIE variable

### DIFF
--- a/src/test/librbd/exclusive_lock/test_mock_PostAcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PostAcquireRequest.cc
@@ -84,8 +84,6 @@ using ::testing::SetArgPointee;
 using ::testing::StrEq;
 using ::testing::WithArg;
 
-static const std::string TEST_COOKIE("auto 123");
-
 class TestMockExclusiveLockPostAcquireRequest : public TestMockFixture {
 public:
   typedef PostAcquireRequest<MockTestImageCtx> MockPostAcquireRequest;

--- a/src/test/librbd/exclusive_lock/test_mock_PreAcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PreAcquireRequest.cc
@@ -44,8 +44,6 @@ using ::testing::SetArgPointee;
 using ::testing::StrEq;
 using ::testing::WithArg;
 
-static const std::string TEST_COOKIE("auto 123");
-
 class TestMockExclusiveLockPreAcquireRequest : public TestMockFixture {
 public:
   typedef PreAcquireRequest<MockTestImageCtx> MockPreAcquireRequest;

--- a/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
@@ -70,8 +70,6 @@ using ::testing::Return;
 using ::testing::StrEq;
 using ::testing::WithArg;
 
-static const std::string TEST_COOKIE("auto 123");
-
 class TestMockExclusiveLockPreReleaseRequest : public TestMockFixture {
 public:
   typedef ImageDispatch<MockTestImageCtx> MockImageDispatch;


### PR DESCRIPTION
Backport https://github.com/ceph/ceph/pull/58466 to quincy as this popped up in regular (not arm64) `make check`.