### PR TITLE
squid: mgr/cephadm: Cert Store + use secure_channel for grpc requests

### DIFF
--- a/src/cephadm/cephadmlib/daemons/nvmeof.py
+++ b/src/cephadm/cephadmlib/daemons/nvmeof.py
@@ -80,7 +80,13 @@ class CephNvmeof(ContainerDaemonForm):
         self, data_dir: str, files: Dict[str, str]
     ) -> Dict[str, str]:
         mounts = dict()
-        for fn in ['server_cert', 'server_key', 'client_cert', 'client_key']:
+        for fn in [
+            'server_cert',
+            'server_key',
+            'client_cert',
+            'client_key',
+            'root_ca_cert',
+        ]:
             if fn in files:
                 mounts[
                     os.path.join(data_dir, fn)

--- a/src/cephadm/cephadmlib/daemons/nvmeof.py
+++ b/src/cephadm/cephadmlib/daemons/nvmeof.py
@@ -76,12 +76,24 @@ class CephNvmeof(ContainerDaemonForm):
         mounts[log_dir] = '/var/log/ceph:z'
         return mounts
 
+    def _get_tls_cert_key_mounts(
+        self, data_dir: str, files: Dict[str, str]
+    ) -> Dict[str, str]:
+        mounts = dict()
+        for fn in ['server_cert', 'server_key', 'client_cert', 'client_key']:
+            if fn in files:
+                mounts[
+                    os.path.join(data_dir, fn)
+                ] = f'/{fn.replace("_", ".")}'
+        return mounts
+
     def customize_container_mounts(
         self, ctx: CephadmContext, mounts: Dict[str, str]
     ) -> None:
         data_dir = self.identity.data_dir(ctx.data_dir)
         log_dir = os.path.join(ctx.log_dir, self.identity.fsid)
         mounts.update(self._get_container_mounts(data_dir, log_dir))
+        mounts.update(self._get_tls_cert_key_mounts(data_dir, self.files))
 
     def customize_container_binds(
         self, ctx: CephadmContext, binds: List[List[str]]

--- a/src/pybind/mgr/cephadm/agent.py
+++ b/src/pybind/mgr/cephadm/agent.py
@@ -44,10 +44,6 @@ cherrypy.log.access_log.propagate = False
 
 class AgentEndpoint:
 
-    # TODO: move these constants to migrations
-    KV_STORE_AGENT_ROOT_CERT = 'cephadm_agent/root/cert'
-    KV_STORE_AGENT_ROOT_KEY = 'cephadm_agent/root/key'
-
     def __init__(self, mgr: "CephadmOrchestrator") -> None:
         self.mgr = mgr
         self.ssl_certs = SSLCerts()

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -19,6 +19,7 @@ from ceph.deployment.service_spec import (
     IngressSpec,
     RGWSpec,
     IscsiServiceSpec,
+    NvmeofServiceSpec,
 )
 from ceph.utils import str_to_datetime, datetime_to_str, datetime_now
 from orchestrator import OrchestratorError, HostSpec, OrchestratorEvent, service_to_daemon_types
@@ -390,6 +391,31 @@ class SpecStore():
                     ingress_spec.ssl_key,
                     service_name=ingress_spec.service_name(),
                     user_made=True)
+        elif spec.service_type == 'nvmeof':
+            nvmeof_spec = cast(NvmeofServiceSpec, spec)
+            for cert_attr in [
+                'server_cert',
+                'client_cert',
+                'root_ca_cert'
+            ]:
+                cert = getattr(nvmeof_spec, cert_attr, None)
+                if cert:
+                    self.mgr.cert_key_store.save_cert(
+                        f'nvmeof_{cert_attr}',
+                        cert,
+                        service_name=nvmeof_spec.service_name(),
+                        user_made=True)
+            for key_attr in [
+                'server_key',
+                'client_key',
+            ]:
+                key = getattr(nvmeof_spec, key_attr, None)
+                if key:
+                    self.mgr.cert_key_store.save_key(
+                        f'nvmeof_{key_attr}',
+                        key,
+                        service_name=nvmeof_spec.service_name(),
+                        user_made=True)
 
     def rm(self, service_name: str) -> bool:
         if service_name not in self._specs:
@@ -428,6 +454,12 @@ class SpecStore():
         if spec.service_type == 'ingress':
             self.mgr.cert_key_store.rm_cert('ingress_ssl_cert', service_name=spec.service_name())
             self.mgr.cert_key_store.rm_key('ingress_ssl_key', service_name=spec.service_name())
+        if spec.service_type == 'nvmeof':
+            self.mgr.cert_key_store.rm_cert('nvmeof_server_cert', service_name=spec.service_name())
+            self.mgr.cert_key_store.rm_cert('nvmeof_client_cert', service_name=spec.service_name())
+            self.mgr.cert_key_store.rm_cert('nvmeof_root_ca_cert', service_name=spec.service_name())
+            self.mgr.cert_key_store.rm_key('nvmeof_server_key', service_name=spec.service_name())
+            self.mgr.cert_key_store.rm_key('nvmeof_client_key', service_name=spec.service_name())
 
     def get_created(self, spec: ServiceSpec) -> Optional[datetime.datetime]:
         return self.spec_created.get(spec.service_name())
@@ -1842,6 +1874,9 @@ class CertKeyStore():
         'rgw_frontend_ssl_cert',
         'iscsi_ssl_cert',
         'ingress_ssl_cert',
+        'nvmeof_server_cert',
+        'nvmeof_client_cert',
+        'nvmeof_root_ca_cert',
     ]
 
     host_cert = [
@@ -1861,6 +1896,8 @@ class CertKeyStore():
     service_name_key = [
         'iscsi_ssl_key',
         'ingress_ssl_key',
+        'nvmeof_server_key',
+        'nvmeof_client_key',
     ]
 
     known_certs: Dict[str, Any] = {}
@@ -1877,6 +1914,9 @@ class CertKeyStore():
             'rgw_frontend_ssl_cert': {},  # service-name -> cert
             'iscsi_ssl_cert': {},  # service-name -> cert
             'ingress_ssl_cert': {},  # service-name -> cert
+            'nvmeof_server_cert': {},  # service-name -> cert
+            'nvmeof_client_cert': {},  # service-name -> cert
+            'nvmeof_root_ca_cert': {},  # service-name -> cert
             'agent_endpoint_root_cert': Cert(),  # cert
             'service_discovery_root_cert': Cert(),  # cert
             'grafana_cert': {},  # host -> cert
@@ -1896,6 +1936,8 @@ class CertKeyStore():
             'node_exporter_key': {},  # host -> key
             'iscsi_ssl_key': {},  # service-name -> key
             'ingress_ssl_key': {},  # service-name -> key
+            'nvmeof_server_key': {},  # service-name -> key
+            'nvmeof_client_key': {},  # service-name -> key
         }
 
     def get_cert(self, entity: str, service_name: str = '', host: str = '') -> str:

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -376,6 +376,20 @@ class SpecStore():
                     iscsi_spec.ssl_key,
                     service_name=iscsi_spec.service_name(),
                     user_made=True)
+        elif spec.service_type == 'ingress':
+            ingress_spec = cast(IngressSpec, spec)
+            if ingress_spec.ssl_cert:
+                self.mgr.cert_key_store.save_cert(
+                    'ingress_ssl_cert',
+                    ingress_spec.ssl_cert,
+                    service_name=ingress_spec.service_name(),
+                    user_made=True)
+            if ingress_spec.ssl_key:
+                self.mgr.cert_key_store.save_key(
+                    'ingress_ssl_key',
+                    ingress_spec.ssl_key,
+                    service_name=ingress_spec.service_name(),
+                    user_made=True)
 
     def rm(self, service_name: str) -> bool:
         if service_name not in self._specs:
@@ -411,6 +425,9 @@ class SpecStore():
         if spec.service_type == 'iscsi':
             self.mgr.cert_key_store.rm_cert('iscsi_ssl_cert', service_name=spec.service_name())
             self.mgr.cert_key_store.rm_key('iscsi_ssl_key', service_name=spec.service_name())
+        if spec.service_type == 'ingress':
+            self.mgr.cert_key_store.rm_cert('ingress_ssl_cert', service_name=spec.service_name())
+            self.mgr.cert_key_store.rm_key('ingress_ssl_key', service_name=spec.service_name())
 
     def get_created(self, spec: ServiceSpec) -> Optional[datetime.datetime]:
         return self.spec_created.get(spec.service_name())

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -48,6 +48,26 @@ class HostCacheStatus(enum.Enum):
     devices = 'devices'
 
 
+class OrchSecretNotFound(OrchestratorError):
+    def __init__(
+        self,
+        message: Optional[str] = '',
+        entity: Optional[str] = '',
+        service_name: Optional[str] = '',
+        hostname: Optional[str] = ''
+    ):
+        if not message:
+            message = f'No secret found for entity {entity}'
+            if service_name:
+                message += f' with service name {service_name}'
+            if hostname:
+                message += f' with hostname {hostname}'
+        super().__init__(message)
+        self.entity = entity
+        self.service_name = service_name
+        self.hostname = hostname
+
+
 class Inventory:
     """
     The inventory stores a HostSpec for all hosts persistently.

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -8,7 +8,7 @@ import logging
 import math
 import socket
 from typing import TYPE_CHECKING, Dict, List, Iterator, Optional, Any, Tuple, Set, Mapping, cast, \
-    NamedTuple, Type, ValuesView
+    NamedTuple, Type, ValuesView, Union
 
 import orchestrator
 from ceph.deployment import inventory
@@ -30,6 +30,8 @@ HOST_CACHE_PREFIX = "host."
 SPEC_STORE_PREFIX = "spec."
 AGENT_CACHE_PREFIX = 'agent.'
 NODE_PROXY_CACHE_PREFIX = 'node_proxy'
+CERT_STORE_CERT_PREFIX = 'cert_store.cert.'
+CERT_STORE_KEY_PREFIX = 'cert_store.key.'
 
 
 class HostCacheStatus(enum.Enum):
@@ -1686,6 +1688,282 @@ class AgentCache():
         self.agent_timestamp[daemon_spec.host] = datetime_now()
         self.agent_counter[daemon_spec.host] = 1
         self.save_agent(daemon_spec.host)
+
+
+class Cert():
+    def __init__(self, cert: str = '', user_made: bool = False) -> None:
+        self.cert = cert
+        self.user_made = user_made
+
+    def __bool__(self) -> bool:
+        return bool(self.cert)
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, Cert):
+            return self.cert == other.cert and self.user_made == other.user_made
+        return NotImplemented
+
+    def to_json(self) -> Dict[str, Union[str, bool]]:
+        return {
+            'cert': self.cert,
+            'user_made': self.user_made
+        }
+
+    @classmethod
+    def from_json(cls, data: Dict[str, Union[str, bool]]) -> 'Cert':
+        if 'cert' not in data:
+            return cls()
+        cert = data['cert']
+        if not isinstance(cert, str):
+            raise OrchestratorError('Tried to make Cert object with non-string cert')
+        if any(k not in ['cert', 'user_made'] for k in data.keys()):
+            raise OrchestratorError(f'Got unknown field for Cert object. Fields: {data.keys()}')
+        user_made: Union[str, bool] = data.get('user_made', False)
+        if not isinstance(user_made, bool):
+            if isinstance(user_made, str):
+                if user_made.lower() == 'true':
+                    user_made = True
+                elif user_made.lower() == 'false':
+                    user_made = False
+            try:
+                user_made = bool(user_made)
+            except Exception:
+                raise OrchestratorError(f'Expected user_made field in Cert object to be bool but got {type(user_made)}')
+        return cls(cert=cert, user_made=user_made)
+
+
+class PrivKey():
+    def __init__(self, key: str = '', user_made: bool = False) -> None:
+        self.key = key
+        self.user_made = user_made
+
+    def __bool__(self) -> bool:
+        return bool(self.key)
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, PrivKey):
+            return self.key == other.key and self.user_made == other.user_made
+        return NotImplemented
+
+    def to_json(self) -> Dict[str, Union[str, bool]]:
+        return {
+            'key': self.key,
+            'user_made': self.user_made
+        }
+
+    @classmethod
+    def from_json(cls, data: Dict[str, str]) -> 'PrivKey':
+        if 'key' not in data:
+            return cls()
+        key = data['key']
+        if not isinstance(key, str):
+            raise OrchestratorError('Tried to make PrivKey object with non-string key')
+        if any(k not in ['key', 'user_made'] for k in data.keys()):
+            raise OrchestratorError(f'Got unknown field for PrivKey object. Fields: {data.keys()}')
+        user_made: Union[str, bool] = data.get('user_made', False)
+        if not isinstance(user_made, bool):
+            if isinstance(user_made, str):
+                if user_made.lower() == 'true':
+                    user_made = True
+                elif user_made.lower() == 'false':
+                    user_made = False
+            try:
+                user_made = bool(user_made)
+            except Exception:
+                raise OrchestratorError(f'Expected user_made field in PrivKey object to be bool but got {type(user_made)}')
+        return cls(key=key, user_made=user_made)
+
+
+class CertKeyStore():
+    service_name_cert = [
+        'rgw_frontend_ssl_cert',
+        'iscsi_ssl_cert',
+        'ingress_ssl_cert',
+    ]
+
+    host_cert = [
+        'grafana_cert',
+        'alertmanager_cert',
+        'prometheus_cert',
+        'node_exporter_cert',
+    ]
+
+    host_key = [
+        'grafana_key',
+        'alertmanager_key',
+        'prometheus_key',
+        'node_exporter_key',
+    ]
+
+    service_name_key = [
+        'iscsi_ssl_key',
+        'ingress_ssl_key',
+    ]
+
+    known_certs: Dict[str, Any] = {}
+    known_keys: Dict[str, Any] = {}
+
+    def __init__(self, mgr: 'CephadmOrchestrator') -> None:
+        self.mgr: CephadmOrchestrator = mgr
+        self._init_known_cert_key_dicts()
+
+    def _init_known_cert_key_dicts(self) -> None:
+        # In an effort to try and track all the certs we manage in cephadm
+        # we're being explicit here and listing them out.
+        self.known_certs = {
+            'rgw_frontend_ssl_cert': {},  # service-name -> cert
+            'iscsi_ssl_cert': {},  # service-name -> cert
+            'ingress_ssl_cert': {},  # service-name -> cert
+            'agent_endpoint_root_cert': Cert(),  # cert
+            'service_discovery_root_cert': Cert(),  # cert
+            'grafana_cert': {},  # host -> cert
+            'alertmanager_cert': {},  # host -> cert
+            'prometheus_cert': {},  # host -> cert
+            'node_exporter_cert': {},  # host -> cert
+        }
+        # Similar to certs but for priv keys. Entries in known_certs
+        # that don't have a key here are probably certs in PEM format
+        # so there is no need to store a separate key
+        self.known_keys = {
+            'agent_endpoint_key': PrivKey(),  # key
+            'service_discovery_key': PrivKey(),  # key
+            'grafana_key': {},  # host -> key
+            'alertmanager_key': {},  # host -> key
+            'prometheus_key': {},  # host -> key
+            'node_exporter_key': {},  # host -> key
+            'iscsi_ssl_key': {},  # service-name -> key
+            'ingress_ssl_key': {},  # service-name -> key
+        }
+
+    def get_cert(self, entity: str, service_name: str = '', host: str = '') -> str:
+        self._validate_cert_entity(entity, service_name, host)
+
+        cert = Cert()
+        if entity in self.service_name_cert or entity in self.host_cert:
+            var = service_name if entity in self.service_name_cert else host
+            if var not in self.known_certs[entity]:
+                return ''
+            cert = self.known_certs[entity][var]
+        else:
+            cert = self.known_certs[entity]
+        if not cert or not isinstance(cert, Cert):
+            return ''
+        return cert.cert
+
+    def save_cert(self, entity: str, cert: str, service_name: str = '', host: str = '', user_made: bool = False) -> None:
+        self._validate_cert_entity(entity, service_name, host)
+
+        cert_obj = Cert(cert, user_made)
+
+        j: Union[str, Dict[Any, Any], None] = None
+        if entity in self.service_name_cert or entity in self.host_cert:
+            var = service_name if entity in self.service_name_cert else host
+            j = {}
+            self.known_certs[entity][var] = cert_obj
+            for service_name in self.known_certs[entity].keys():
+                j[var] = Cert.to_json(self.known_certs[entity][var])
+        else:
+            self.known_certs[entity] = cert_obj
+            j = Cert.to_json(cert_obj)
+        self.mgr.set_store(CERT_STORE_CERT_PREFIX + entity, json.dumps(j))
+
+    def rm_cert(self, entity: str, service_name: str = '', host: str = '') -> None:
+        self.save_cert(entity, cert='', service_name=service_name, host=host)
+
+    def _validate_cert_entity(self, entity: str, service_name: str = '', host: str = '') -> None:
+        if entity not in self.known_certs.keys():
+            raise OrchestratorError(f'Attempted to access cert for unknown entity {entity}')
+
+        if entity in self.host_cert and not host:
+            raise OrchestratorError(f'Need host to access cert for entity {entity}')
+
+        if entity in self.service_name_cert and not service_name:
+            raise OrchestratorError(f'Need service name to access cert for entity {entity}')
+
+    def cert_ls(self) -> Dict[str, Union[bool, Dict[str, bool]]]:
+        ls: Dict[str, Any] = {}
+        for k, v in self.known_certs.items():
+            if k in self.service_name_cert or k in self.host_cert:
+                tmp: Dict[str, Any] = {key: True for key in v if v[key]}
+                ls[k] = tmp if tmp else False
+            else:
+                ls[k] = bool(v)
+        return ls
+
+    def get_key(self, entity: str, service_name: str = '', host: str = '') -> str:
+        self._validate_key_entity(entity, host)
+
+        key = PrivKey()
+        if entity in self.host_key or entity in self.service_name_key:
+            var = service_name if entity in self.service_name_key else host
+            if var not in self.known_keys[entity]:
+                return ''
+            key = self.known_keys[entity][var]
+        else:
+            key = self.known_keys[entity]
+        if not key or not isinstance(key, PrivKey):
+            return ''
+        return key.key
+
+    def save_key(self, entity: str, key: str, service_name: str = '', host: str = '', user_made: bool = False) -> None:
+        self._validate_key_entity(entity, host)
+
+        pkey = PrivKey(key, user_made)
+
+        j: Union[str, Dict[Any, Any], None] = None
+        if entity in self.host_key or entity in self.service_name_key:
+            var = service_name if entity in self.service_name_key else host
+            j = {}
+            self.known_keys[entity][var] = pkey
+            for k in self.known_keys[entity]:
+                j[k] = PrivKey.to_json(self.known_keys[entity][k])
+        else:
+            self.known_keys[entity] = pkey
+            j = PrivKey.to_json(pkey)
+        self.mgr.set_store(CERT_STORE_KEY_PREFIX + entity, json.dumps(j))
+
+    def rm_key(self, entity: str, service_name: str = '', host: str = '') -> None:
+        self.save_key(entity, key='', service_name=service_name, host=host)
+
+    def _validate_key_entity(self, entity: str, host: str = '') -> None:
+        if entity not in self.known_keys.keys():
+            raise OrchestratorError(f'Attempted to access priv key for unknown entity {entity}')
+
+        if entity in self.host_key and not host:
+            raise OrchestratorError(f'Need host to access priv key for entity {entity}')
+
+    def key_ls(self) -> Dict[str, Union[bool, Dict[str, bool]]]:
+        ls: Dict[str, Any] = {}
+        for k, v in self.known_keys.items():
+            if k in self.host_key or k in self.service_name_key:
+                tmp: Dict[str, Any] = {key: True for key in v if v[key]}
+                ls[k] = tmp if tmp else False
+            else:
+                ls[k] = bool(v)
+        return ls
+
+    def load(self) -> None:
+        for k, v in self.mgr.get_store_prefix(CERT_STORE_CERT_PREFIX).items():
+            entity = k[len(CERT_STORE_CERT_PREFIX):]
+            self.known_certs[entity] = json.loads(v)
+            if entity in self.service_name_cert or entity in self.host_cert:
+                for k in self.known_certs[entity]:
+                    cert_obj = Cert.from_json(self.known_certs[entity][k])
+                    self.known_certs[entity][k] = cert_obj
+            else:
+                cert_obj = Cert.from_json(self.known_certs[entity])
+                self.known_certs[entity] = cert_obj
+
+        for k, v in self.mgr.get_store_prefix(CERT_STORE_KEY_PREFIX).items():
+            entity = k[len(CERT_STORE_KEY_PREFIX):]
+            self.known_keys[entity] = json.loads(v)
+            if entity in self.host_key or entity in self.service_name_key:
+                for k in self.known_keys[entity]:
+                    priv_key_obj = PrivKey.from_json(self.known_keys[entity][k])
+                    self.known_keys[entity][k] = priv_key_obj
+            else:
+                priv_key_obj = PrivKey.from_json(self.known_keys[entity])
+                self.known_keys[entity] = priv_key_obj
 
 
 class EventStore():

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -78,8 +78,18 @@ from .services.jaeger import ElasticSearchService, JaegerAgentService, JaegerCol
 from .services.node_proxy import NodeProxy
 from .services.smb import SMBService
 from .schedule import HostAssignment
-from .inventory import Inventory, SpecStore, HostCache, AgentCache, EventStore, \
-    ClientKeyringStore, ClientKeyringSpec, TunedProfileStore, NodeProxyCache
+from .inventory import (
+    Inventory,
+    SpecStore,
+    HostCache,
+    AgentCache,
+    EventStore,
+    ClientKeyringStore,
+    ClientKeyringSpec,
+    TunedProfileStore,
+    NodeProxyCache,
+    CertKeyStore,
+)
 from .upgrade import CephadmUpgrade
 from .template import TemplateMgr
 from .utils import CEPH_IMAGE_TYPES, RESCHEDULE_FROM_OFFLINE_HOSTS_TYPES, forall_hosts, \
@@ -653,6 +663,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self.tuned_profiles.load()
 
         self.tuned_profile_utils = TunedProfileUtils(self)
+
+        self.cert_key_store = CertKeyStore(self)
+        self.cert_key_store.load()
 
         # ensure the host lists are in sync
         for h in self.inventory.keys():

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -87,6 +87,7 @@ from .inventory import (
     TunedProfileStore,
     NodeProxyCache,
     CertKeyStore,
+    OrchSecretNotFound,
 )
 from .upgrade import CephadmUpgrade
 from .template import TemplateMgr
@@ -3148,12 +3149,7 @@ Then run the following:
     ) -> str:
         cert = self.cert_key_store.get_cert(entity, service_name or '', hostname or '')
         if not cert:
-            err_msg = f'No cert found for entity {entity}'
-            if service_name:
-                err_msg += f' with service name {service_name}'
-            if hostname:
-                err_msg += f' with hostname {hostname}'
-            raise OrchestratorError(err_msg)
+            raise OrchSecretNotFound(entity=entity, service_name=service_name, hostname=hostname)
         return cert
 
     @handle_orch_error
@@ -3165,12 +3161,7 @@ Then run the following:
     ) -> str:
         key = self.cert_key_store.get_key(entity, service_name or '', hostname or '')
         if not key:
-            err_msg = f'No key found for entity {entity}'
-            if service_name:
-                err_msg += f' with service name {service_name}'
-            if hostname:
-                err_msg += f' with hostname {hostname}'
-            raise OrchestratorError(err_msg)
+            raise OrchSecretNotFound(entity=entity, service_name=service_name, hostname=hostname)
         return key
 
     @handle_orch_error

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3132,6 +3132,14 @@ Then run the following:
                 'certificate': self.http_server.service_discovery.ssl_certs.get_root_cert()}
 
     @handle_orch_error
+    def cert_store_cert_ls(self) -> Dict[str, Any]:
+        return self.cert_key_store.cert_ls()
+
+    @handle_orch_error
+    def cert_store_key_ls(self) -> Dict[str, Any]:
+        return self.cert_key_store.key_ls()
+
+    @handle_orch_error
     def apply_mon(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -14,8 +14,6 @@ from tempfile import TemporaryDirectory, NamedTemporaryFile
 from urllib.error import HTTPError
 from threading import Event
 
-from cephadm.service_discovery import ServiceDiscovery
-
 from ceph.deployment.service_spec import PrometheusSpec
 
 import string
@@ -3249,7 +3247,7 @@ Then run the following:
 
     @handle_orch_error
     def service_discovery_dump_cert(self) -> str:
-        root_cert = self.get_store(ServiceDiscovery.KV_STORE_SD_ROOT_CERT)
+        root_cert = self.cert_key_store.get_cert('service_discovery_root_cert')
         if not root_cert:
             raise OrchestratorError('No certificate found for service discovery')
         return root_cert

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3140,6 +3140,40 @@ Then run the following:
         return self.cert_key_store.key_ls()
 
     @handle_orch_error
+    def cert_store_get_cert(
+        self,
+        entity: str,
+        service_name: Optional[str] = None,
+        hostname: Optional[str] = None
+    ) -> str:
+        cert = self.cert_key_store.get_cert(entity, service_name or '', hostname or '')
+        if not cert:
+            err_msg = f'No cert found for entity {entity}'
+            if service_name:
+                err_msg += f' with service name {service_name}'
+            if hostname:
+                err_msg += f' with hostname {hostname}'
+            raise OrchestratorError(err_msg)
+        return cert
+
+    @handle_orch_error
+    def cert_store_get_key(
+        self,
+        entity: str,
+        service_name: Optional[str] = None,
+        hostname: Optional[str] = None
+    ) -> str:
+        key = self.cert_key_store.get_key(entity, service_name or '', hostname or '')
+        if not key:
+            err_msg = f'No key found for entity {entity}'
+            if service_name:
+                err_msg += f' with service name {service_name}'
+            if hostname:
+                err_msg += f' with hostname {hostname}'
+            raise OrchestratorError(err_msg)
+        return key
+
+    @handle_orch_error
     def apply_mon(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -136,8 +136,10 @@ class CephadmServe:
 
     def _check_certificates(self) -> None:
         for d in self.mgr.cache.get_daemons_by_type('grafana'):
-            cert = self.mgr.get_store(f'{d.hostname}/grafana_crt')
-            key = self.mgr.get_store(f'{d.hostname}/grafana_key')
+            host = d.hostname
+            assert host is not None
+            cert = self.mgr.cert_key_store.get_cert('grafana_cert', host=host)
+            key = self.mgr.cert_key_store.get_key('grafana_key', host=host)
             if (not cert or not cert.strip()) and (not key or not key.strip()):
                 # certificate/key are empty... nothing to check
                 return

--- a/src/pybind/mgr/cephadm/service_discovery.py
+++ b/src/pybind/mgr/cephadm/service_discovery.py
@@ -45,11 +45,6 @@ class Route(NamedTuple):
 
 class ServiceDiscovery:
 
-    # TODO: these constants should only be needed for migration purposes
-    # after completion of the cert store. Make sure to move them.
-    KV_STORE_SD_ROOT_CERT = 'service_discovery/root/cert'
-    KV_STORE_SD_ROOT_KEY = 'service_discovery/root/key'
-
     def __init__(self, mgr: "CephadmOrchestrator") -> None:
         self.mgr = mgr
         self.ssl_certs = SSLCerts()

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -485,6 +485,8 @@ class PrometheusService(CephadmService):
         }
 
         if self.mgr.secure_monitoring_stack:
+            # NOTE: this prometheus root cert is managed by the prometheus module
+            # we are using it in a read only fashion in the cephadm module
             cfg_key = 'mgr/prometheus/root/cert'
             cmd = {'prefix': 'config-key get', 'key': cfg_key}
             ret, mgr_prometheus_rootca, err = self.mgr.mon_command(cmd)
@@ -493,7 +495,12 @@ class PrometheusService(CephadmService):
             else:
                 node_ip = self.mgr.inventory.get_addr(daemon_spec.host)
                 host_fqdn = self._inventory_get_fqdn(daemon_spec.host)
-                cert, key = self.mgr.http_server.service_discovery.ssl_certs.generate_cert(host_fqdn, node_ip)
+                cert = self.mgr.cert_key_store.get_cert('prometheus_cert', host=daemon_spec.host)
+                key = self.mgr.cert_key_store.get_key('prometheus_key', host=daemon_spec.host)
+                if not (cert and key):
+                    cert, key = self.mgr.http_server.service_discovery.ssl_certs.generate_cert(host_fqdn, node_ip)
+                    self.mgr.cert_key_store.save_cert('prometheus_cert', cert, host=daemon_spec.host)
+                    self.mgr.cert_key_store.save_key('prometheus_key', key, host=daemon_spec.host)
                 r: Dict[str, Any] = {
                     'files': {
                         'prometheus.yml': self.mgr.template.render('services/prometheus/prometheus.yml.j2', context),
@@ -586,6 +593,15 @@ class PrometheusService(CephadmService):
             'dashboard set-prometheus-api-host',
             service_url
         )
+
+    def pre_remove(self, daemon: DaemonDescription) -> None:
+        """
+        Called before prometheus daemon is removed.
+        """
+        if daemon.hostname is not None:
+            # delete cert/key entires for this prometheus daemon
+            self.mgr.cert_key_store.rm_cert('prometheus_cert', host=daemon.hostname)
+            self.mgr.cert_key_store.rm_key('prometheus_key', host=daemon.hostname)
 
     def ok_to_stop(self,
                    daemon_ids: List[str],

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -121,9 +121,6 @@ class GrafanaService(CephadmService):
         return config_file, sorted(deps)
 
     def prepare_certificates(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[str, str]:
-        # TODO: move these variables to migrations
-        # cert_path = f'{daemon_spec.host}/grafana_crt'
-        # key_path = f'{daemon_spec.host}/grafana_key'
         cert = self.mgr.cert_key_store.get_cert('grafana_cert', host=daemon_spec.host)
         pkey = self.mgr.cert_key_store.get_key('grafana_key', host=daemon_spec.host)
         certs_present = (cert and pkey)

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -60,15 +60,20 @@ class NvmeofService(CephService):
                 or not spec.client_key
                 or not spec.server_cert
                 or not spec.server_key
+                or not spec.root_ca_cert
             ):
-                self.mgr.log.error(f'enable_auth set for {spec.service_name()} spec, but at '
-                                   'least one of server/client cert/key fields missing. TLS '
-                                   f'not being set up for {daemon_spec.name()}')
+                err_msg = 'enable_auth is true but '
+                for cert_key_attr in ['server_key', 'server_cert', 'client_key', 'client_cert', 'root_ca_cert']:
+                    if not hasattr(spec, cert_key_attr):
+                        err_msg += f'{cert_key_attr}, '
+                err_msg += 'attribute(s) missing from nvmeof spec'
+                self.mgr.log.error(err_msg)
             else:
                 daemon_spec.extra_files['server_cert'] = spec.server_cert
                 daemon_spec.extra_files['client_cert'] = spec.client_cert
                 daemon_spec.extra_files['server_key'] = spec.server_key
                 daemon_spec.extra_files['client_key'] = spec.client_key
+                daemon_spec.extra_files['root_ca_cert'] = spec.root_ca_cert
 
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
         daemon_spec.deps = []

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -53,6 +53,23 @@ class NvmeofService(CephService):
 
         daemon_spec.keyring = keyring
         daemon_spec.extra_files = {'ceph-nvmeof.conf': gw_conf}
+
+        if spec.enable_auth:
+            if (
+                not spec.client_cert
+                or not spec.client_key
+                or not spec.server_cert
+                or not spec.server_key
+            ):
+                self.mgr.log.error(f'enable_auth set for {spec.service_name()} spec, but at '
+                                   'least one of server/client cert/key fields missing. TLS '
+                                   f'not being set up for {daemon_spec.name()}')
+            else:
+                daemon_spec.extra_files['server_cert'] = spec.server_cert
+                daemon_spec.extra_files['client_cert'] = spec.client_cert
+                daemon_spec.extra_files['server_key'] = spec.server_key
+                daemon_spec.extra_files['client_key'] = spec.client_key
+
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
         daemon_spec.deps = []
         return daemon_spec

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -89,9 +89,10 @@ class NvmeofService(CephService):
 
             for dd in daemon_descrs:
                 assert dd.hostname is not None
+                service_name = dd.service_name()
 
                 if not spec:
-                    logger.warning(f'No ServiceSpec found for {dd.service_name()}')
+                    logger.warning(f'No ServiceSpec found for {service_name}')
                     continue
 
                 ip = utils.resolve_ip(self.mgr.inventory.get_addr(dd.hostname))
@@ -104,7 +105,7 @@ class NvmeofService(CephService):
                     cmd_dicts.append({
                         'prefix': 'dashboard nvmeof-gateway-add',
                         'inbuf': service_url,
-                        'name': dd.hostname
+                        'name': service_name
                     })
             return cmd_dicts
 
@@ -140,11 +141,12 @@ class NvmeofService(CephService):
         """
         # to clean the keyring up
         super().post_remove(daemon, is_failed_deploy=is_failed_deploy)
+        service_name = daemon.service_name()
 
         # remove config for dashboard nvmeof gateways if any
         ret, out, err = self.mgr.mon_command({
             'prefix': 'dashboard nvmeof-gateway-rm',
-            'name': daemon.hostname,
+            'name': service_name,
         })
         if not ret:
             logger.info(f'{daemon.hostname} removed from nvmeof gateways dashboard config')

--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -41,10 +41,10 @@ config_file = /etc/ceph/ceph.conf
 id = {{ rados_id }}
 
 [mtls]
-server_key = {{ spec.server_key }}
-client_key = {{ spec.client_key }}
-server_cert = {{ spec.server_cert }}
-client_cert = {{ spec.client_cert }}
+server_key = /server.key
+client_key = /client.key
+server_cert = /server.cert
+client_cert = /client.cert
 
 [spdk]
 tgt_path = {{ spec.tgt_path }}

--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -45,6 +45,7 @@ server_key = /server.key
 client_key = /client.key
 server_cert = /server.cert
 client_cert = /client.cert
+root_ca_cert = /root.ca.cert
 
 [spdk]
 tgt_path = {{ spec.tgt_path }}

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -8,7 +8,14 @@ import pytest
 
 from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection
 from cephadm.serve import CephadmServe
-from cephadm.inventory import HostCacheStatus, ClientKeyringSpec
+from cephadm.inventory import (
+    HostCacheStatus,
+    ClientKeyringSpec,
+    Cert,
+    PrivKey,
+    CERT_STORE_CERT_PREFIX,
+    CERT_STORE_KEY_PREFIX,
+)
 from cephadm.services.osd import OSD, OSDRemovalQueue, OsdIdClaims
 from cephadm.utils import SpecialHostLabels
 
@@ -1689,6 +1696,173 @@ class TestCephadm(object):
         assert cephadm_module.cache._get_host_cache_entry_status('hostXXX') == HostCacheStatus.stray
         assert cephadm_module.cache._get_host_cache_entry_status(
             'host.nothing.com') == HostCacheStatus.stray
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    def test_cert_store_save_cert(self, _set_store, cephadm_module: CephadmOrchestrator):
+        cephadm_module.cert_key_store._init_known_cert_key_dicts()
+
+        agent_endpoint_root_cert = 'fake-agent-cert'
+        alertmanager_host1_cert = 'fake-alertm-host1-cert'
+        rgw_frontend_rgw_foo_host2_cert = 'fake-rgw-cert'
+        cephadm_module.cert_key_store.save_cert('agent_endpoint_root_cert', agent_endpoint_root_cert)
+        cephadm_module.cert_key_store.save_cert('alertmanager_cert', alertmanager_host1_cert, host='host1')
+        cephadm_module.cert_key_store.save_cert('rgw_frontend_ssl_cert', rgw_frontend_rgw_foo_host2_cert, service_name='rgw.foo', user_made=True)
+
+        expected_calls = [
+            mock.call(f'{CERT_STORE_CERT_PREFIX}agent_endpoint_root_cert', json.dumps(Cert(agent_endpoint_root_cert).to_json())),
+            mock.call(f'{CERT_STORE_CERT_PREFIX}alertmanager_cert', json.dumps({'host1': Cert(alertmanager_host1_cert).to_json()})),
+            mock.call(f'{CERT_STORE_CERT_PREFIX}rgw_frontend_ssl_cert', json.dumps({'rgw.foo': Cert(rgw_frontend_rgw_foo_host2_cert, True).to_json()})),
+        ]
+        _set_store.assert_has_calls(expected_calls)
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    def test_cert_store_cert_ls(self, _set_store, cephadm_module: CephadmOrchestrator):
+        cephadm_module.cert_key_store._init_known_cert_key_dicts()
+
+        expected_ls = {
+            'rgw_frontend_ssl_cert': False,
+            'iscsi_ssl_cert': False,
+            'ingress_ssl_cert': False,
+            'agent_endpoint_root_cert': False,
+            'service_discovery_root_cert': False,
+            'grafana_cert': False,
+            'alertmanager_cert': False,
+            'prometheus_cert': False,
+            'node_exporter_cert': False,
+        }
+        assert cephadm_module.cert_key_store.cert_ls() == expected_ls
+
+        cephadm_module.cert_key_store.save_cert('agent_endpoint_root_cert', 'xxx')
+        expected_ls['agent_endpoint_root_cert'] = True
+        assert cephadm_module.cert_key_store.cert_ls() == expected_ls
+
+        cephadm_module.cert_key_store.save_cert('alertmanager_cert', 'xxx', host='host1')
+        cephadm_module.cert_key_store.save_cert('alertmanager_cert', 'xxx', host='host2')
+        expected_ls['alertmanager_cert'] = {}
+        expected_ls['alertmanager_cert']['host1'] = True
+        expected_ls['alertmanager_cert']['host2'] = True
+        assert cephadm_module.cert_key_store.cert_ls() == expected_ls
+
+        cephadm_module.cert_key_store.save_cert('rgw_frontend_ssl_cert', 'xxx', service_name='rgw.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('rgw_frontend_ssl_cert', 'xxx', service_name='rgw.bar', user_made=True)
+        expected_ls['rgw_frontend_ssl_cert'] = {}
+        expected_ls['rgw_frontend_ssl_cert']['rgw.foo'] = True
+        expected_ls['rgw_frontend_ssl_cert']['rgw.bar'] = True
+        assert cephadm_module.cert_key_store.cert_ls() == expected_ls
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    def test_cert_store_save_key(self, _set_store, cephadm_module: CephadmOrchestrator):
+        cephadm_module.cert_key_store._init_known_cert_key_dicts()
+
+        agent_endpoint_key = 'fake-agent-key'
+        grafana_host1_key = 'fake-grafana-host1-cert'
+        cephadm_module.cert_key_store.save_key('agent_endpoint_key', agent_endpoint_key)
+        cephadm_module.cert_key_store.save_key('grafana_key', grafana_host1_key, host='host1')
+
+        expected_calls = [
+            mock.call(f'{CERT_STORE_KEY_PREFIX}agent_endpoint_key', json.dumps(PrivKey(agent_endpoint_key).to_json())),
+            mock.call(f'{CERT_STORE_KEY_PREFIX}grafana_key', json.dumps({'host1': PrivKey(grafana_host1_key).to_json()})),
+        ]
+        _set_store.assert_has_calls(expected_calls)
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
+    def test_cert_store_key_ls(self, _set_store, cephadm_module: CephadmOrchestrator):
+        cephadm_module.cert_key_store._init_known_cert_key_dicts()
+
+        expected_ls = {
+            'agent_endpoint_key': False,
+            'service_discovery_key': False,
+            'grafana_key': False,
+            'alertmanager_key': False,
+            'prometheus_key': False,
+            'node_exporter_key': False,
+            'iscsi_ssl_key': False,
+            'ingress_ssl_key': False,
+        }
+        assert cephadm_module.cert_key_store.key_ls() == expected_ls
+
+        cephadm_module.cert_key_store.save_key('agent_endpoint_key', 'xxx')
+        expected_ls['agent_endpoint_key'] = True
+        assert cephadm_module.cert_key_store.key_ls() == expected_ls
+
+        cephadm_module.cert_key_store.save_key('alertmanager_key', 'xxx', host='host1')
+        cephadm_module.cert_key_store.save_key('alertmanager_key', 'xxx', host='host2')
+        expected_ls['alertmanager_key'] = {}
+        expected_ls['alertmanager_key']['host1'] = True
+        expected_ls['alertmanager_key']['host2'] = True
+        assert cephadm_module.cert_key_store.key_ls() == expected_ls
+
+    @mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix")
+    def test_cert_store_load(self, _get_store_prefix, cephadm_module: CephadmOrchestrator):
+        cephadm_module.cert_key_store._init_known_cert_key_dicts()
+
+        agent_endpoint_root_cert = 'fake-agent-cert'
+        alertmanager_host1_cert = 'fake-alertm-host1-cert'
+        rgw_frontend_rgw_foo_host2_cert = 'fake-rgw-cert'
+        agent_endpoint_key = 'fake-agent-key'
+        grafana_host1_key = 'fake-grafana-host1-cert'
+
+        def _fake_prefix_store(key):
+            if key == 'cert_store.cert.':
+                return {
+                    f'{CERT_STORE_CERT_PREFIX}agent_endpoint_root_cert': json.dumps(Cert(agent_endpoint_root_cert).to_json()),
+                    f'{CERT_STORE_CERT_PREFIX}alertmanager_cert': json.dumps({'host1': Cert(alertmanager_host1_cert).to_json()}),
+                    f'{CERT_STORE_CERT_PREFIX}rgw_frontend_ssl_cert': json.dumps({'rgw.foo': Cert(rgw_frontend_rgw_foo_host2_cert, True).to_json()})
+                }
+            elif key == 'cert_store.key.':
+                return {
+                    f'{CERT_STORE_KEY_PREFIX}agent_endpoint_key': json.dumps(PrivKey(agent_endpoint_key).to_json()),
+                    f'{CERT_STORE_KEY_PREFIX}grafana_key': json.dumps({'host1': PrivKey(grafana_host1_key).to_json()}),
+                }
+            else:
+                raise Exception(f'Get store with unexpected value {key}')
+
+        _get_store_prefix.side_effect = _fake_prefix_store
+        cephadm_module.cert_key_store.load()
+        assert cephadm_module.cert_key_store.known_certs['agent_endpoint_root_cert'] == Cert(agent_endpoint_root_cert)
+        assert cephadm_module.cert_key_store.known_certs['alertmanager_cert']['host1'] == Cert(alertmanager_host1_cert)
+        assert cephadm_module.cert_key_store.known_certs['rgw_frontend_ssl_cert']['rgw.foo'] == Cert(rgw_frontend_rgw_foo_host2_cert, True)
+        assert cephadm_module.cert_key_store.known_keys['agent_endpoint_key'] == PrivKey(agent_endpoint_key)
+        assert cephadm_module.cert_key_store.known_keys['grafana_key']['host1'] == PrivKey(grafana_host1_key)
+
+    def test_cert_store_get_cert_key(self, cephadm_module: CephadmOrchestrator):
+        cephadm_module.cert_key_store._init_known_cert_key_dicts()
+
+        agent_endpoint_root_cert = 'fake-agent-cert'
+        alertmanager_host1_cert = 'fake-alertm-host1-cert'
+        rgw_frontend_rgw_foo_host2_cert = 'fake-rgw-cert'
+        cephadm_module.cert_key_store.save_cert('agent_endpoint_root_cert', agent_endpoint_root_cert)
+        cephadm_module.cert_key_store.save_cert('alertmanager_cert', alertmanager_host1_cert, host='host1')
+        cephadm_module.cert_key_store.save_cert('rgw_frontend_ssl_cert', rgw_frontend_rgw_foo_host2_cert, service_name='rgw.foo', user_made=True)
+
+        assert cephadm_module.cert_key_store.get_cert('agent_endpoint_root_cert') == agent_endpoint_root_cert
+        assert cephadm_module.cert_key_store.get_cert('alertmanager_cert', host='host1') == alertmanager_host1_cert
+        assert cephadm_module.cert_key_store.get_cert('rgw_frontend_ssl_cert', service_name='rgw.foo') == rgw_frontend_rgw_foo_host2_cert
+        assert cephadm_module.cert_key_store.get_cert('service_discovery_root_cert') == ''
+        assert cephadm_module.cert_key_store.get_cert('grafana_cert', host='host1') == ''
+        assert cephadm_module.cert_key_store.get_cert('iscsi_ssl_cert', service_name='iscsi.foo') == ''
+
+        with pytest.raises(OrchestratorError, match='Attempted to access cert for unknown entity'):
+            cephadm_module.cert_key_store.get_cert('unknown_entity')
+        with pytest.raises(OrchestratorError, match='Need host to access cert for entity'):
+            cephadm_module.cert_key_store.get_cert('grafana_cert')
+        with pytest.raises(OrchestratorError, match='Need service name to access cert for entity'):
+            cephadm_module.cert_key_store.get_cert('rgw_frontend_ssl_cert', host='foo')
+
+        agent_endpoint_key = 'fake-agent-key'
+        grafana_host1_key = 'fake-grafana-host1-cert'
+        cephadm_module.cert_key_store.save_key('agent_endpoint_key', agent_endpoint_key)
+        cephadm_module.cert_key_store.save_key('grafana_key', grafana_host1_key, host='host1')
+
+        assert cephadm_module.cert_key_store.get_key('agent_endpoint_key') == agent_endpoint_key
+        assert cephadm_module.cert_key_store.get_key('grafana_key', host='host1') == grafana_host1_key
+        assert cephadm_module.cert_key_store.get_key('service_discovery_key') == ''
+        assert cephadm_module.cert_key_store.get_key('alertmanager_key', host='host1') == ''
+
+        with pytest.raises(OrchestratorError, match='Attempted to access priv key for unknown entity'):
+            cephadm_module.cert_key_store.get_key('unknown_entity')
+        with pytest.raises(OrchestratorError, match='Need host to access priv key for entity'):
+            cephadm_module.cert_key_store.get_key('grafana_key')
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.services.nfs.NFSService.run_grace_tool", mock.MagicMock())

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1704,14 +1704,23 @@ class TestCephadm(object):
         agent_endpoint_root_cert = 'fake-agent-cert'
         alertmanager_host1_cert = 'fake-alertm-host1-cert'
         rgw_frontend_rgw_foo_host2_cert = 'fake-rgw-cert'
+        nvmeof_client_cert = 'fake-nvmeof-client-cert'
+        nvmeof_server_cert = 'fake-nvmeof-server-cert'
+        nvmeof_root_ca_cert = 'fake-nvmeof-root-ca-cert'
         cephadm_module.cert_key_store.save_cert('agent_endpoint_root_cert', agent_endpoint_root_cert)
         cephadm_module.cert_key_store.save_cert('alertmanager_cert', alertmanager_host1_cert, host='host1')
         cephadm_module.cert_key_store.save_cert('rgw_frontend_ssl_cert', rgw_frontend_rgw_foo_host2_cert, service_name='rgw.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_server_cert', nvmeof_server_cert, service_name='nvmeof.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_client_cert', nvmeof_client_cert, service_name='nvmeof.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_root_ca_cert', nvmeof_root_ca_cert, service_name='nvmeof.foo', user_made=True)
 
         expected_calls = [
             mock.call(f'{CERT_STORE_CERT_PREFIX}agent_endpoint_root_cert', json.dumps(Cert(agent_endpoint_root_cert).to_json())),
             mock.call(f'{CERT_STORE_CERT_PREFIX}alertmanager_cert', json.dumps({'host1': Cert(alertmanager_host1_cert).to_json()})),
             mock.call(f'{CERT_STORE_CERT_PREFIX}rgw_frontend_ssl_cert', json.dumps({'rgw.foo': Cert(rgw_frontend_rgw_foo_host2_cert, True).to_json()})),
+            mock.call(f'{CERT_STORE_CERT_PREFIX}nvmeof_server_cert', json.dumps({'nvmeof.foo': Cert(nvmeof_server_cert, True).to_json()})),
+            mock.call(f'{CERT_STORE_CERT_PREFIX}nvmeof_client_cert', json.dumps({'nvmeof.foo': Cert(nvmeof_client_cert, True).to_json()})),
+            mock.call(f'{CERT_STORE_CERT_PREFIX}nvmeof_root_ca_cert', json.dumps({'nvmeof.foo': Cert(nvmeof_root_ca_cert, True).to_json()})),
         ]
         _set_store.assert_has_calls(expected_calls)
 
@@ -1729,6 +1738,9 @@ class TestCephadm(object):
             'alertmanager_cert': False,
             'prometheus_cert': False,
             'node_exporter_cert': False,
+            'nvmeof_client_cert': False,
+            'nvmeof_server_cert': False,
+            'nvmeof_root_ca_cert': False,
         }
         assert cephadm_module.cert_key_store.cert_ls() == expected_ls
 
@@ -1750,18 +1762,35 @@ class TestCephadm(object):
         expected_ls['rgw_frontend_ssl_cert']['rgw.bar'] = True
         assert cephadm_module.cert_key_store.cert_ls() == expected_ls
 
+        cephadm_module.cert_key_store.save_cert('nvmeof_client_cert', 'xxx', service_name='nvmeof.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_server_cert', 'xxx', service_name='nvmeof.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_root_ca_cert', 'xxx', service_name='nvmeof.foo', user_made=True)
+        expected_ls['nvmeof_client_cert'] = {}
+        expected_ls['nvmeof_client_cert']['nvmeof.foo'] = True
+        expected_ls['nvmeof_server_cert'] = {}
+        expected_ls['nvmeof_server_cert']['nvmeof.foo'] = True
+        expected_ls['nvmeof_root_ca_cert'] = {}
+        expected_ls['nvmeof_root_ca_cert']['nvmeof.foo'] = True
+        assert cephadm_module.cert_key_store.cert_ls() == expected_ls
+
     @mock.patch("cephadm.module.CephadmOrchestrator.set_store")
     def test_cert_store_save_key(self, _set_store, cephadm_module: CephadmOrchestrator):
         cephadm_module.cert_key_store._init_known_cert_key_dicts()
 
         agent_endpoint_key = 'fake-agent-key'
-        grafana_host1_key = 'fake-grafana-host1-cert'
+        grafana_host1_key = 'fake-grafana-host1-key'
+        nvmeof_client_key = 'nvmeof-client-key'
+        nvmeof_server_key = 'nvmeof-server-key'
         cephadm_module.cert_key_store.save_key('agent_endpoint_key', agent_endpoint_key)
         cephadm_module.cert_key_store.save_key('grafana_key', grafana_host1_key, host='host1')
+        cephadm_module.cert_key_store.save_key('nvmeof_client_key', nvmeof_client_key, service_name='nvmeof.foo')
+        cephadm_module.cert_key_store.save_key('nvmeof_server_key', nvmeof_server_key, service_name='nvmeof.foo')
 
         expected_calls = [
             mock.call(f'{CERT_STORE_KEY_PREFIX}agent_endpoint_key', json.dumps(PrivKey(agent_endpoint_key).to_json())),
             mock.call(f'{CERT_STORE_KEY_PREFIX}grafana_key', json.dumps({'host1': PrivKey(grafana_host1_key).to_json()})),
+            mock.call(f'{CERT_STORE_KEY_PREFIX}nvmeof_client_key', json.dumps({'nvmeof.foo': PrivKey(nvmeof_client_key).to_json()})),
+            mock.call(f'{CERT_STORE_KEY_PREFIX}nvmeof_server_key', json.dumps({'nvmeof.foo': PrivKey(nvmeof_server_key).to_json()})),
         ]
         _set_store.assert_has_calls(expected_calls)
 
@@ -1778,6 +1807,8 @@ class TestCephadm(object):
             'node_exporter_key': False,
             'iscsi_ssl_key': False,
             'ingress_ssl_key': False,
+            'nvmeof_client_key': False,
+            'nvmeof_server_key': False,
         }
         assert cephadm_module.cert_key_store.key_ls() == expected_ls
 
@@ -1792,6 +1823,14 @@ class TestCephadm(object):
         expected_ls['alertmanager_key']['host2'] = True
         assert cephadm_module.cert_key_store.key_ls() == expected_ls
 
+        cephadm_module.cert_key_store.save_key('nvmeof_client_key', 'xxx', service_name='nvmeof.foo')
+        cephadm_module.cert_key_store.save_key('nvmeof_server_key', 'xxx', service_name='nvmeof.foo')
+        expected_ls['nvmeof_server_key'] = {}
+        expected_ls['nvmeof_server_key']['nvmeof.foo'] = True
+        expected_ls['nvmeof_client_key'] = {}
+        expected_ls['nvmeof_client_key']['nvmeof.foo'] = True
+        assert cephadm_module.cert_key_store.key_ls() == expected_ls
+
     @mock.patch("cephadm.module.CephadmOrchestrator.get_store_prefix")
     def test_cert_store_load(self, _get_store_prefix, cephadm_module: CephadmOrchestrator):
         cephadm_module.cert_key_store._init_known_cert_key_dicts()
@@ -1801,18 +1840,28 @@ class TestCephadm(object):
         rgw_frontend_rgw_foo_host2_cert = 'fake-rgw-cert'
         agent_endpoint_key = 'fake-agent-key'
         grafana_host1_key = 'fake-grafana-host1-cert'
+        nvmeof_server_cert = 'nvmeof-server-cert'
+        nvmeof_client_cert = 'nvmeof-client-cert'
+        nvmeof_root_ca_cert = 'nvmeof-root-ca-cert'
+        nvmeof_server_key = 'nvmeof-server-key'
+        nvmeof_client_key = 'nvmeof-client-key'
 
         def _fake_prefix_store(key):
             if key == 'cert_store.cert.':
                 return {
                     f'{CERT_STORE_CERT_PREFIX}agent_endpoint_root_cert': json.dumps(Cert(agent_endpoint_root_cert).to_json()),
                     f'{CERT_STORE_CERT_PREFIX}alertmanager_cert': json.dumps({'host1': Cert(alertmanager_host1_cert).to_json()}),
-                    f'{CERT_STORE_CERT_PREFIX}rgw_frontend_ssl_cert': json.dumps({'rgw.foo': Cert(rgw_frontend_rgw_foo_host2_cert, True).to_json()})
+                    f'{CERT_STORE_CERT_PREFIX}rgw_frontend_ssl_cert': json.dumps({'rgw.foo': Cert(rgw_frontend_rgw_foo_host2_cert, True).to_json()}),
+                    f'{CERT_STORE_CERT_PREFIX}nvmeof_server_cert': json.dumps({'nvmeof.foo': Cert(nvmeof_server_cert, True).to_json()}),
+                    f'{CERT_STORE_CERT_PREFIX}nvmeof_client_cert': json.dumps({'nvmeof.foo': Cert(nvmeof_client_cert, True).to_json()}),
+                    f'{CERT_STORE_CERT_PREFIX}nvmeof_root_ca_cert': json.dumps({'nvmeof.foo': Cert(nvmeof_root_ca_cert, True).to_json()}),
                 }
             elif key == 'cert_store.key.':
                 return {
                     f'{CERT_STORE_KEY_PREFIX}agent_endpoint_key': json.dumps(PrivKey(agent_endpoint_key).to_json()),
                     f'{CERT_STORE_KEY_PREFIX}grafana_key': json.dumps({'host1': PrivKey(grafana_host1_key).to_json()}),
+                    f'{CERT_STORE_KEY_PREFIX}nvmeof_server_key': json.dumps({'nvmeof.foo': PrivKey(nvmeof_server_key).to_json()}),
+                    f'{CERT_STORE_KEY_PREFIX}nvmeof_client_key': json.dumps({'nvmeof.foo': PrivKey(nvmeof_client_key).to_json()}),
                 }
             else:
                 raise Exception(f'Get store with unexpected value {key}')
@@ -1822,8 +1871,13 @@ class TestCephadm(object):
         assert cephadm_module.cert_key_store.known_certs['agent_endpoint_root_cert'] == Cert(agent_endpoint_root_cert)
         assert cephadm_module.cert_key_store.known_certs['alertmanager_cert']['host1'] == Cert(alertmanager_host1_cert)
         assert cephadm_module.cert_key_store.known_certs['rgw_frontend_ssl_cert']['rgw.foo'] == Cert(rgw_frontend_rgw_foo_host2_cert, True)
+        assert cephadm_module.cert_key_store.known_certs['nvmeof_server_cert']['nvmeof.foo'] == Cert(nvmeof_server_cert, True)
+        assert cephadm_module.cert_key_store.known_certs['nvmeof_client_cert']['nvmeof.foo'] == Cert(nvmeof_client_cert, True)
+        assert cephadm_module.cert_key_store.known_certs['nvmeof_root_ca_cert']['nvmeof.foo'] == Cert(nvmeof_root_ca_cert, True)
         assert cephadm_module.cert_key_store.known_keys['agent_endpoint_key'] == PrivKey(agent_endpoint_key)
         assert cephadm_module.cert_key_store.known_keys['grafana_key']['host1'] == PrivKey(grafana_host1_key)
+        assert cephadm_module.cert_key_store.known_keys['nvmeof_server_key']['nvmeof.foo'] == PrivKey(nvmeof_server_key)
+        assert cephadm_module.cert_key_store.known_keys['nvmeof_client_key']['nvmeof.foo'] == PrivKey(nvmeof_client_key)
 
     def test_cert_store_get_cert_key(self, cephadm_module: CephadmOrchestrator):
         cephadm_module.cert_key_store._init_known_cert_key_dicts()
@@ -1831,16 +1885,23 @@ class TestCephadm(object):
         agent_endpoint_root_cert = 'fake-agent-cert'
         alertmanager_host1_cert = 'fake-alertm-host1-cert'
         rgw_frontend_rgw_foo_host2_cert = 'fake-rgw-cert'
+        nvmeof_client_cert = 'fake-nvmeof-client-cert'
+        nvmeof_server_cert = 'fake-nvmeof-server-cert'
         cephadm_module.cert_key_store.save_cert('agent_endpoint_root_cert', agent_endpoint_root_cert)
         cephadm_module.cert_key_store.save_cert('alertmanager_cert', alertmanager_host1_cert, host='host1')
         cephadm_module.cert_key_store.save_cert('rgw_frontend_ssl_cert', rgw_frontend_rgw_foo_host2_cert, service_name='rgw.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_server_cert', nvmeof_server_cert, service_name='nvmeof.foo', user_made=True)
+        cephadm_module.cert_key_store.save_cert('nvmeof_client_cert', nvmeof_client_cert, service_name='nvmeof.foo', user_made=True)
 
         assert cephadm_module.cert_key_store.get_cert('agent_endpoint_root_cert') == agent_endpoint_root_cert
         assert cephadm_module.cert_key_store.get_cert('alertmanager_cert', host='host1') == alertmanager_host1_cert
         assert cephadm_module.cert_key_store.get_cert('rgw_frontend_ssl_cert', service_name='rgw.foo') == rgw_frontend_rgw_foo_host2_cert
+        assert cephadm_module.cert_key_store.get_cert('nvmeof_server_cert', service_name='nvmeof.foo') == nvmeof_server_cert
+        assert cephadm_module.cert_key_store.get_cert('nvmeof_client_cert', service_name='nvmeof.foo') == nvmeof_client_cert
         assert cephadm_module.cert_key_store.get_cert('service_discovery_root_cert') == ''
         assert cephadm_module.cert_key_store.get_cert('grafana_cert', host='host1') == ''
         assert cephadm_module.cert_key_store.get_cert('iscsi_ssl_cert', service_name='iscsi.foo') == ''
+        assert cephadm_module.cert_key_store.get_cert('nvmeof_root_ca_cert', service_name='nvmeof.foo') == ''
 
         with pytest.raises(OrchestratorError, match='Attempted to access cert for unknown entity'):
             cephadm_module.cert_key_store.get_cert('unknown_entity')
@@ -1851,11 +1912,17 @@ class TestCephadm(object):
 
         agent_endpoint_key = 'fake-agent-key'
         grafana_host1_key = 'fake-grafana-host1-cert'
+        nvmeof_server_key = 'nvmeof-server-key'
         cephadm_module.cert_key_store.save_key('agent_endpoint_key', agent_endpoint_key)
         cephadm_module.cert_key_store.save_key('grafana_key', grafana_host1_key, host='host1')
+        cephadm_module.cert_key_store.save_key('agent_endpoint_key', agent_endpoint_key)
+        cephadm_module.cert_key_store.save_key('grafana_key', grafana_host1_key, host='host1')
+        cephadm_module.cert_key_store.save_key('nvmeof_server_key', nvmeof_server_key, service_name='nvmeof.foo')
 
         assert cephadm_module.cert_key_store.get_key('agent_endpoint_key') == agent_endpoint_key
         assert cephadm_module.cert_key_store.get_key('grafana_key', host='host1') == grafana_host1_key
+        assert cephadm_module.cert_key_store.get_key('nvmeof_server_key', service_name='nvmeof.foo') == nvmeof_server_key
+        assert cephadm_module.cert_key_store.get_key('nvmeof_client_key', service_name='nvmeof.foo') == ''
         assert cephadm_module.cert_key_store.get_key('service_discovery_key') == ''
         assert cephadm_module.cert_key_store.get_key('alertmanager_key', host='host1') == ''
 

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -426,10 +426,11 @@ config_file = /etc/ceph/ceph.conf
 id = nvmeof.{nvmeof_daemon_id}
 
 [mtls]
-server_key = ./server.key
-client_key = ./client.key
-server_cert = ./server.crt
-client_cert = ./client.crt
+server_key = /server.key
+client_key = /client.key
+server_cert = /server.cert
+client_cert = /client.cert
+root_ca_cert = /root.ca.cert
 
 [spdk]
 tgt_path = /usr/local/bin/nvmf_tgt

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -1155,8 +1155,8 @@ class TestMonitoring:
         _run_cephadm.side_effect = async_side_effect(("{}", "", 0))
 
         with with_host(cephadm_module, "test"):
-            cephadm_module.set_store("test/grafana_crt", grafana_cert)
-            cephadm_module.set_store("test/grafana_key", grafana_key)
+            cephadm_module.cert_key_store.save_cert('grafana_cert', grafana_cert, host='test')
+            cephadm_module.cert_key_store.save_key('grafana_key', grafana_key, host='test')
             with with_service(
                 cephadm_module, PrometheusSpec("prometheus")
             ) as _, with_service(cephadm_module, ServiceSpec("mgr")) as _, with_service(

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -692,6 +692,9 @@ class TestMonitoring:
                     use_current_daemon_image=False,
                 )
 
+                assert cephadm_module.cert_key_store.get_cert('alertmanager_cert', host='test') == 'mycert'
+                assert cephadm_module.cert_key_store.get_key('alertmanager_key', host='test') == 'mykey'
+
     @patch("cephadm.serve.CephadmServe._run_cephadm")
     @patch("cephadm.module.CephadmOrchestrator.get_mgr_ip", lambda _: '::1')
     def test_prometheus_config_security_disabled(self, _run_cephadm, cephadm_module: CephadmOrchestrator):

--- a/src/pybind/mgr/dashboard/services/nvmeof_conf.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_conf.py
@@ -2,7 +2,11 @@
 
 import json
 
+from orchestrator import OrchestratorError
+
 from .. import mgr
+from ..exceptions import DashboardException
+from ..services.orchestrator import OrchClient
 
 
 class NvmeofGatewayAlreadyExists(Exception):
@@ -58,3 +62,44 @@ class NvmeofGatewaysConfig(object):
             raise NvmeofGatewayDoesNotExist(name)
         del config['gateways'][name]
         cls._save_config(config)
+
+    @classmethod
+    def get_service_info(cls):
+        try:
+            config = cls.get_gateways_config()
+            service_name = list(config['gateways'].keys())[0]
+            addr = config['gateways'][service_name]['service_url']
+            return service_name, addr
+        except (KeyError, IndexError) as e:
+            raise DashboardException(
+                msg=f'NVMe-oF configuration is not set: {e}',
+            )
+
+    @classmethod
+    def get_client_cert(cls, service_name: str):
+        client_cert = cls.from_cert_store('nvmeof_client_cert', service_name)
+        return client_cert.encode() if client_cert else None
+
+    @classmethod
+    def get_client_key(cls, service_name: str):
+        client_key = cls.from_cert_store('nvmeof_client_key', service_name, key=True)
+        return client_key.encode() if client_key else None
+
+    @classmethod
+    def get_root_ca_cert(cls, service_name: str):
+        root_ca_cert = cls.from_cert_store('nvmeof_root_ca_cert', service_name)
+        return root_ca_cert.encode() if root_ca_cert else None
+
+    @classmethod
+    def from_cert_store(cls, entity: str, service_name: str, key=False):
+        try:
+            orch = OrchClient.instance()
+            if orch.available():
+                if key:
+                    return orch.cert_store.get_key(entity, service_name)
+                return orch.cert_store.get_cert(entity, service_name)
+            return None
+        except OrchestratorError as e:
+            raise DashboardException(
+                msg=f'Failed to get {entity} for {service_name}: {e}',
+            )

--- a/src/pybind/mgr/dashboard/services/nvmeof_conf.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_conf.py
@@ -87,8 +87,17 @@ class NvmeofGatewaysConfig(object):
 
     @classmethod
     def get_root_ca_cert(cls, service_name: str):
-        root_ca_cert = cls.from_cert_store('nvmeof_root_ca_cert', service_name)
-        return root_ca_cert.encode() if root_ca_cert else None
+        try:
+            root_ca_cert = cls.from_cert_store('nvmeof_root_ca_cert', service_name)
+            return root_ca_cert.encode()
+        except DashboardException:
+            # If root_ca_cert is not set, use server_cert as root_ca_cert
+            return cls.get_server_cert(service_name)
+
+    @classmethod
+    def get_server_cert(cls, service_name: str):
+        server_cert = cls.from_cert_store('nvmeof_server_cert', service_name)
+        return server_cert.encode() if server_cert else None
 
     @classmethod
     def from_cert_store(cls, entity: str, service_name: str, key=False):

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -200,6 +200,19 @@ class UpgradeManager(ResourceManager):
         return self.api.upgrade_stop()
 
 
+class CertStoreManager(ResourceManager):
+
+    @wait_api_result
+    def get_cert(self, entity: str, service_name: Optional[str] = None,
+                 hostname: Optional[str] = None) -> str:
+        return self.api.cert_store_get_cert(entity, service_name, hostname)
+
+    @wait_api_result
+    def get_key(self, entity: str, service_name: Optional[str] = None,
+                hostname: Optional[str] = None) -> str:
+        return self.api.cert_store_get_key(entity, service_name, hostname)
+
+
 class OrchClient(object):
 
     _instance = None
@@ -220,6 +233,7 @@ class OrchClient(object):
         self.osds = OsdManager(self.api)
         self.daemons = DaemonManager(self.api)
         self.upgrades = UpgradeManager(self.api)
+        self.cert_store = CertStoreManager(self.api)
 
     def available(self, features: Optional[List[str]] = None) -> bool:
         available = self.status()['available']

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -557,6 +557,12 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def cert_store_cert_ls(self) -> OrchResult[Dict[str, Any]]:
+        raise NotImplementedError()
+
+    def cert_store_key_ls(self) -> OrchResult[Dict[str, Any]]:
+        raise NotImplementedError()
+
     @handle_orch_error
     def apply(self, specs: Sequence["GenericSpec"], no_overwrite: bool = False) -> List[str]:
         """

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -563,6 +563,22 @@ class Orchestrator(object):
     def cert_store_key_ls(self) -> OrchResult[Dict[str, Any]]:
         raise NotImplementedError()
 
+    def cert_store_get_cert(
+        self,
+        entity: str,
+        service_name: Optional[str] = None,
+        hostname: Optional[str] = None
+    ) -> OrchResult[str]:
+        raise NotImplementedError()
+
+    def cert_store_get_key(
+        self,
+        entity: str,
+        service_name: Optional[str] = None,
+        hostname: Optional[str] = None
+    ) -> OrchResult[str]:
+        raise NotImplementedError()
+
     @handle_orch_error
     def apply(self, specs: Sequence["GenericSpec"], no_overwrite: bool = False) -> List[str]:
         """

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1160,6 +1160,30 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
             result_str = self._process_cert_store_json(key_ls, 0)
             return HandleCommandResult(stdout=result_str)
 
+    @_cli_read_command('orch cert-store get cert')
+    def _cert_store_get_cert(
+        self,
+        entity: str,
+        _end_positional_: int = 0,
+        service_name: Optional[str] = None,
+        hostname: Optional[str] = None
+    ) -> HandleCommandResult:
+        completion = self.cert_store_get_cert(entity, service_name, hostname)
+        cert = raise_if_exception(completion)
+        return HandleCommandResult(stdout=cert)
+
+    @_cli_read_command('orch cert-store get key')
+    def _cert_store_get_key(
+        self,
+        entity: str,
+        _end_positional_: int = 0,
+        service_name: Optional[str] = None,
+        hostname: Optional[str] = None
+    ) -> HandleCommandResult:
+        completion = self.cert_store_get_key(entity, service_name, hostname)
+        key = raise_if_exception(completion)
+        return HandleCommandResult(stdout=key)
+
     def _get_credentials(self, username: Optional[str] = None, password: Optional[str] = None, inbuf: Optional[str] = None) -> Tuple[str, str]:
 
         _username = username

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1129,6 +1129,37 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
 
             return HandleCommandResult(stdout=table.get_string())
 
+    def _process_cert_store_json(self, d: Dict[str, Any], level: int = 0) -> str:
+        result_str = ''
+        indent = '  ' * level
+        for k, v in d.items():
+            if isinstance(v, dict):
+                result_str += f'{indent}{k}\n'
+                result_str += self._process_cert_store_json(v, level + 1)
+            else:
+                result_str += f'{indent}{k} - {v}\n'
+        return result_str
+
+    @_cli_read_command('orch cert-store cert ls')
+    def _cert_store_cert_ls(self, format: Format = Format.plain) -> HandleCommandResult:
+        completion = self.cert_store_cert_ls()
+        cert_ls = raise_if_exception(completion)
+        if format != Format.plain:
+            return HandleCommandResult(stdout=to_format(cert_ls, format, many=False, cls=None))
+        else:
+            result_str = self._process_cert_store_json(cert_ls, 0)
+            return HandleCommandResult(stdout=result_str)
+
+    @_cli_read_command('orch cert-store key ls')
+    def _cert_store_key_ls(self, format: Format = Format.plain) -> HandleCommandResult:
+        completion = self.cert_store_key_ls()
+        key_ls = raise_if_exception(completion)
+        if format != Format.plain:
+            return HandleCommandResult(stdout=to_format(key_ls, format, many=False, cls=None))
+        else:
+            result_str = self._process_cert_store_json(key_ls, 0)
+            return HandleCommandResult(stdout=result_str)
+
     def _get_credentials(self, username: Optional[str] = None, password: Optional[str] = None, inbuf: Optional[str] = None) -> Tuple[str, str]:
 
         _username = username

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1331,6 +1331,7 @@ class NvmeofServiceSpec(ServiceSpec):
                  server_cert: Optional[str] = None,
                  client_key: Optional[str] = None,
                  client_cert: Optional[str] = None,
+                 root_ca_cert: Optional[str] = None,
                  spdk_path: Optional[str] = None,
                  tgt_path: Optional[str] = None,
                  spdk_timeout: Optional[float] = 60.0,
@@ -1415,6 +1416,8 @@ class NvmeofServiceSpec(ServiceSpec):
         self.client_key = client_key
         #: ``client_cert`` client certificate
         self.client_cert = client_cert
+        #: ``root_ca_cert`` CA cert for server/client certs
+        self.root_ca_cert = root_ca_cert
         #: ``spdk_path`` path to SPDK
         self.spdk_path = spdk_path or '/usr/local/bin/nvmf_tgt'
         #: ``tgt_path`` nvmeof target path
@@ -1469,9 +1472,13 @@ class NvmeofServiceSpec(ServiceSpec):
             raise SpecValidationError('Cannot add NVMEOF: No Pool specified')
 
         if self.enable_auth:
-            if not all([self.server_key, self.server_cert, self.client_key, self.client_cert]):
-                raise SpecValidationError(
-                    'enable_auth is true but client/server certificates are missing')
+            if not all([self.server_key, self.server_cert, self.client_key, self.client_cert, self.root_ca_cert]):
+                err_msg = 'enable_auth is true but '
+                for cert_key_attr in ['server_key', 'server_cert', 'client_key', 'client_cert', 'root_ca_cert']:
+                    if not hasattr(self, cert_key_attr):
+                        err_msg += f'{cert_key_attr}, '
+                err_msg += 'attribute(s) not set in the spec'
+                raise SpecValidationError(err_msg)
 
         if self.transports not in ['tcp']:
             raise SpecValidationError('Invalid transport. Valid values are tcp')

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1408,13 +1408,13 @@ class NvmeofServiceSpec(ServiceSpec):
         #: ``bdevs_per_cluster`` number of bdevs per cluster
         self.bdevs_per_cluster = bdevs_per_cluster
         #: ``server_key`` gateway server key
-        self.server_key = server_key or './server.key'
+        self.server_key = server_key
         #: ``server_cert`` gateway server certificate
-        self.server_cert = server_cert or './server.crt'
+        self.server_cert = server_cert
         #: ``client_key`` client key
-        self.client_key = client_key or './client.key'
+        self.client_key = client_key
         #: ``client_cert`` client certificate
-        self.client_cert = client_cert or './client.crt'
+        self.client_cert = client_cert
         #: ``spdk_path`` path to SPDK
         self.spdk_path = spdk_path or '/usr/local/bin/nvmf_tgt'
         #: ``tgt_path`` nvmeof target path
@@ -1469,7 +1469,7 @@ class NvmeofServiceSpec(ServiceSpec):
             raise SpecValidationError('Cannot add NVMEOF: No Pool specified')
 
         if self.enable_auth:
-            if not any([self.server_key, self.server_cert, self.client_key, self.client_cert]):
+            if not all([self.server_key, self.server_cert, self.client_key, self.client_cert]):
                 raise SpecValidationError(
                     'enable_auth is true but client/server certificates are missing')
 

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1472,9 +1472,11 @@ class NvmeofServiceSpec(ServiceSpec):
             raise SpecValidationError('Cannot add NVMEOF: No Pool specified')
 
         if self.enable_auth:
-            if not all([self.server_key, self.server_cert, self.client_key, self.client_cert, self.root_ca_cert]):
+            if not all([self.server_key, self.server_cert, self.client_key,
+                        self.client_cert, self.root_ca_cert]):
                 err_msg = 'enable_auth is true but '
-                for cert_key_attr in ['server_key', 'server_cert', 'client_key', 'client_cert', 'root_ca_cert']:
+                for cert_key_attr in ['server_key', 'server_cert', 'client_key',
+                                      'client_cert', 'root_ca_cert']:
                     if not hasattr(self, cert_key_attr):
                         err_msg += f'{cert_key_attr}, '
                 err_msg += 'attribute(s) not set in the spec'


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/55564 and https://github.com/ceph/ceph/pull/57712

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
