### PR TITLE
quincy: qa/cephfs: fix test_single_path_authorize_on_nonalphanumeric_fsname

### DIFF
--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -975,6 +975,8 @@ class TestFsAuthorize(CapsHelper):
         That fs authorize command works on filesystems with names having [_.-] characters
         """
         self.mount_a.umount_wait(require_clean=True)
+        # let's unmount both client before deleting the FS
+        self.mount_b.umount_wait(require_clean=True)
         self.mds_cluster.delete_all_filesystems()
         fs_name = "cephfs-_."
         self.fs = self.mds_cluster.newfs(name=fs_name)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66930

---

backport of https://github.com/ceph/ceph/pull/58311
parent tracker: https://tracker.ceph.com/issues/66077

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh