### PR TITLE
reef: qa/cephfs: fix test_single_path_authorize_on_nonalphanumeric_fsname

### DIFF
--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1470,6 +1470,8 @@ class TestFsAuthorize(CephFSTestCase):
         characters
         """
         self.mount_a.umount_wait(require_clean=True)
+        # let's unmount both client before deleting the FS
+        self.mount_b.umount_wait(require_clean=True)
         self.mds_cluster.delete_all_filesystems()
         fs_name = "cephfs-_."
         self.fs = self.mds_cluster.newfs(name=fs_name)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66931

---

backport of https://github.com/ceph/ceph/pull/58311
parent tracker: https://tracker.ceph.com/issues/66077

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh