### PR TITLE
squid: qa/cephfs: improvements for "mds fail" and "fs fail"

### DIFF
--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -2134,7 +2134,7 @@ class TestFSFail(TestAdminCommands):
     MDSS_REQUIRED = 2
     CLIENTS_REQUIRED = 1
 
-    def test_with_health_warn_oversize_cache(self):
+    def test_with_health_warn_cache_oversized(self):
         '''
         Test that, when health warning MDS_CACHE_OVERSIZE is present for an
         MDS, command "ceph fs fail" fails without confirmation flag and passes
@@ -2199,7 +2199,7 @@ class TestMDSFail(TestAdminCommands):
     MDSS_REQUIRED = 2
     CLIENTS_REQUIRED = 1
 
-    def test_with_health_warn_oversize_cache(self):
+    def test_with_health_warn_cache_oversized(self):
         '''
         Test that, when health warning MDS_CACHE_OVERSIZE is present for an
         MDS, command "ceph mds fail" fails without confirmation flag and

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -104,24 +104,6 @@ class TestAdminCommands(CephFSTestCase):
         mds_id = mds_id.replace('mds.', '')
         return mds_id
 
-    def wait_till_health_warn(self, health_warn, active_mds_id, sleep=3,
-                              tries=10):
-        errmsg = (f'Expected health warning "{health_warn}" to eventually '
-                  'show up in output of command "ceph health detail". Tried '
-                  f'{tries} times with interval of {sleep} seconds but the '
-                  'health warning didn\'t turn up.')
-
-        with safe_while(sleep=sleep, tries=tries, action=errmsg) as proceed:
-            while proceed():
-                self.get_ceph_cmd_stdout(
-                    f'tell mds.{active_mds_id} cache status')
-
-                health_report = json.loads(self.get_ceph_cmd_stdout(
-                    'health detail --format json'))
-
-                if health_warn in health_report['checks']:
-                    return
-
     def gen_health_warn_mds_cache_oversized(self):
         health_warn = 'MDS_CACHE_OVERSIZED'
 
@@ -129,7 +111,7 @@ class TestAdminCommands(CephFSTestCase):
         self.config_set('mds', 'mds_health_cache_threshold', '1.00000')
         self.mount_a.open_n_background('.', 400)
 
-        self.wait_till_health_warn(health_warn, active_mds_id)
+        self.wait_for_health(health_warn, 30)
 
     def gen_health_warn_mds_trim(self):
         health_warn = 'MDS_TRIM'
@@ -142,7 +124,7 @@ class TestAdminCommands(CephFSTestCase):
         self.config_set('mds', 'mds_log_trim_threshold', '1')
         self.mount_a.open_n_background('.', 400)
 
-        self.wait_till_health_warn(health_warn, active_mds_id)
+        self.wait_for_health(health_warn, 30)
 
 
 @classhook('_add_valid_tell')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66935

---

backport of https://github.com/ceph/ceph/pull/57492
parent tracker: https://tracker.ceph.com/issues/66933

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh