### PR TITLE
reef: qa/cephfs: improvements for "mds fail" and "fs fail"

### DIFF
--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -121,6 +121,28 @@ class TestAdminCommands(CephFSTestCase):
                 if health_warn in health_report['checks']:
                     return
 
+    def gen_health_warn_mds_cache_oversized(self):
+        health_warn = 'MDS_CACHE_OVERSIZED'
+
+        self.config_set('mds', 'mds_cache_memory_limit', '1K')
+        self.config_set('mds', 'mds_health_cache_threshold', '1.00000')
+        self.mount_a.open_n_background('.', 400)
+
+        self.wait_till_health_warn(health_warn, active_mds_id)
+
+    def gen_health_warn_mds_trim(self):
+        health_warn = 'MDS_TRIM'
+
+        # for generating health warning MDS_TRIM
+        self.config_set('mds', 'mds_debug_subtrees', 'true')
+        # this will really really slow the trimming, so that MDS_TRIM stays
+        # for longer.
+        self.config_set('mds', 'mds_log_trim_decay_rate', '60')
+        self.config_set('mds', 'mds_log_trim_threshold', '1')
+        self.mount_a.open_n_background('.', 400)
+
+        self.wait_till_health_warn(health_warn, active_mds_id)
+
 
 @classhook('_add_valid_tell')
 class TestValidTell(TestAdminCommands):
@@ -1759,17 +1781,11 @@ class TestFSFail(TestAdminCommands):
         when confirmation flag is passed.
         '''
         health_warn = 'MDS_CACHE_OVERSIZED'
-        self.config_set('mds', 'mds_cache_memory_limit', '1K')
-        self.config_set('mds', 'mds_health_cache_threshold', '1.00000')
-        active_mds_id = self.fs.get_active_names()[0]
-
-        self.mount_a.open_n_background('.', 400)
-        self.wait_till_health_warn(health_warn, active_mds_id)
+        self.gen_health_warn_mds_cache_oversized()
 
         # actual testing begins now.
-        errmsg = 'mds_cache_oversized'
         self.negtest_ceph_cmd(args=f'fs fail {self.fs.name}',
-                              retval=1, errmsgs=errmsg)
+                              retval=1, errmsgs=health_warn)
         self.run_ceph_cmd(f'fs fail {self.fs.name} --yes-i-really-mean-it')
 
         # Bring and wait for MDS to be up since it is needed for unmounting
@@ -1784,21 +1800,11 @@ class TestFSFail(TestAdminCommands):
         confirmation flag is passed.
         '''
         health_warn = 'MDS_TRIM'
-        # for generating health warning MDS_TRIM
-        self.config_set('mds', 'mds_debug_subtrees', 'true')
-        # this will really really slow the trimming, so that MDS_TRIM stays
-        # for longer.
-        self.config_set('mds', 'mds_log_trim_decay_rate', '60')
-        self.config_set('mds', 'mds_log_trim_threshold', '1')
-        active_mds_id = self.fs.get_active_names()[0]
-
-        self.mount_a.open_n_background('.', 400)
-        self.wait_till_health_warn(health_warn, active_mds_id)
+        self.gen_health_warn_mds_trim()
 
         # actual testing begins now.
-        errmsg = 'mds_trim'
         self.negtest_ceph_cmd(args=f'fs fail {self.fs.name}',
-                              retval=1, errmsgs=errmsg)
+                              retval=1, errmsgs=health_warn)
         self.run_ceph_cmd(f'fs fail {self.fs.name} --yes-i-really-mean-it')
 
         # Bring and wait for MDS to be up since it is needed for unmounting
@@ -1815,19 +1821,11 @@ class TestFSFail(TestAdminCommands):
         '''
         health_warn = 'MDS_CACHE_OVERSIZED'
         self.fs.set_max_mds(2)
-        self.config_set('mds', 'mds_cache_memory_limit', '1K')
-        self.config_set('mds', 'mds_health_cache_threshold', '1.00000')
-        self.fs.wait_for_daemons()
-        mds1_id, mds2_id = self.fs.get_active_names()
-
-        self.mount_a.open_n_background('.', 400)
-        # MDS ID for which health warning has been generated.
-        self.wait_till_health_warn(health_warn, mds1_id)
+        self.gen_health_warn_mds_cache_oversized()
 
         # actual testing begins now.
-        errmsg = 'mds_cache_oversized'
         self.negtest_ceph_cmd(args=f'fs fail {self.fs.name}',
-                              retval=1, errmsgs=errmsg)
+                              retval=1, errmsgs=health_warn)
         self.run_ceph_cmd(f'fs fail {self.fs.name} --yes-i-really-mean-it')
 
         # Bring and wait for MDS to be up since it is needed for unmounting
@@ -1848,17 +1846,12 @@ class TestMDSFail(TestAdminCommands):
         passes when confirmation flag is passed.
         '''
         health_warn = 'MDS_CACHE_OVERSIZED'
-        self.config_set('mds', 'mds_cache_memory_limit', '1K')
-        self.config_set('mds', 'mds_health_cache_threshold', '1.00000')
-        active_mds_id = self.fs.get_active_names()[0]
-
-        self.mount_a.open_n_background('.', 400)
-        self.wait_till_health_warn(health_warn, active_mds_id)
+        self.gen_health_warn_mds_cache_oversized()
 
         # actual testing begins now.
-        errmsg = 'mds_cache_oversized'
+        active_mds_id = self.fs.get_active_names()[0]
         self.negtest_ceph_cmd(args=f'mds fail {active_mds_id}',
-                              retval=1, errmsgs=errmsg)
+                              retval=1, errmsgs=health_warn)
         self.run_ceph_cmd(f'mds fail {active_mds_id} --yes-i-really-mean-it')
 
     def test_with_health_warn_trim(self):
@@ -1868,21 +1861,12 @@ class TestMDSFail(TestAdminCommands):
         confirmation is passed.
         '''
         health_warn = 'MDS_TRIM'
-        # for generating health warning MDS_TRIM
-        self.config_set('mds', 'mds_debug_subtrees', 'true')
-        # this will really really slow the trimming, so that MDS_TRIM stays
-        # for longer.
-        self.config_set('mds', 'mds_log_trim_decay_rate', '60')
-        self.config_set('mds', 'mds_log_trim_threshold', '1')
-        active_mds_id = self.fs.get_active_names()[0]
-
-        self.mount_a.open_n_background('.', 400)
-        self.wait_till_health_warn(health_warn, active_mds_id)
+        self.gen_health_warn_mds_trim()
 
         # actual testing begins now...
-        errmsg = 'mds_trim'
+        active_mds_id = self.fs.get_active_names()[0]
         self.negtest_ceph_cmd(args=f'mds fail {active_mds_id}',
-                              retval=1, errmsgs=errmsg)
+                              retval=1, errmsgs=health_warn)
         self.run_ceph_cmd(f'mds fail {active_mds_id} --yes-i-really-mean-it')
 
     def test_with_health_warn_with_2_active_MDSs(self):
@@ -1894,13 +1878,8 @@ class TestMDSFail(TestAdminCommands):
         '''
         health_warn = 'MDS_CACHE_OVERSIZED'
         self.fs.set_max_mds(2)
-        self.config_set('mds', 'mds_cache_memory_limit', '1K')
-        self.config_set('mds', 'mds_health_cache_threshold', '1.00000')
-        self.fs.wait_for_daemons()
+        self.gen_health_warn_mds_cache_oversized()
         mds1_id, mds2_id = self.fs.get_active_names()
-
-        self.mount_a.open_n_background('.', 400)
-        self.wait_till_health_warn(health_warn, mds1_id)
 
         health_report = json.loads(self.get_ceph_cmd_stdout('health detail '
                                                             '--format json'))
@@ -1916,10 +1895,9 @@ class TestMDSFail(TestAdminCommands):
                                'than these two. This is definitely an error.')
 
         # actual testing begins now...
-        errmsg = 'mds_cache_oversized'
         self.negtest_ceph_cmd(args=f'mds fail {non_hw_mds_id}', retval=1,
-                              errmsgs=errmsg)
+                              errmsgs=health_warn)
         self.negtest_ceph_cmd(args=f'mds fail {hw_mds_id}', retval=1,
-                              errmsgs=errmsg)
+                              errmsgs=health_warn)
         self.run_ceph_cmd(f'mds fail {mds1_id} --yes-i-really-mean-it')
         self.run_ceph_cmd(f'mds fail {mds2_id} --yes-i-really-mean-it')

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -90,19 +90,6 @@ class TestAdminCommands(CephFSTestCase):
         if overwrites:
             self.run_ceph_cmd('osd', 'pool', 'set', n+"-data", 'allow_ec_overwrites', 'true')
 
-    def _get_unhealthy_mds_id(self, health_report, health_warn):
-        '''
-        Return MDS ID for which health warning in "health_warn" has been
-        generated.
-        '''
-        # variable "msg" should hold string something like this -
-        # 'mds.b(mds.0): Behind on trimming (865/10) max_segments: 10,
-        # num_segments: 86
-        msg = health_report['checks'][health_warn]['detail'][0]['message']
-        mds_id = msg.split('(')[0]
-        mds_id = mds_id.replace('mds.', '')
-        return mds_id
-
     def gen_health_warn_mds_cache_oversized(self):
         health_warn = 'MDS_CACHE_OVERSIZED'
 
@@ -1851,6 +1838,21 @@ class TestMDSFail(TestAdminCommands):
                               retval=1, errmsgs=health_warn)
         self.run_ceph_cmd(f'mds fail {active_mds_id} --yes-i-really-mean-it')
 
+    def _get_unhealthy_mds_id(self, health_warn):
+        '''
+        Return MDS ID for which health warning in "health_warn" has been
+        generated.
+        '''
+        health_report = json.loads(self.get_ceph_cmd_stdout('health detail '
+                                                            '--format json'))
+        # variable "msg" should hold string something like this -
+        # 'mds.b(mds.0): Behind on trimming (865/10) max_segments: 10,
+        # num_segments: 86
+        msg = health_report['checks'][health_warn]['detail'][0]['message']
+        mds_id = msg.split('(')[0]
+        mds_id = mds_id.replace('mds.', '')
+        return mds_id
+
     def test_with_health_warn_with_2_active_MDSs(self):
         '''
         Test when a CephFS has 2 active MDSs and one of them have either
@@ -1863,10 +1865,8 @@ class TestMDSFail(TestAdminCommands):
         self.gen_health_warn_mds_cache_oversized()
         mds1_id, mds2_id = self.fs.get_active_names()
 
-        health_report = json.loads(self.get_ceph_cmd_stdout('health detail '
-                                                            '--format json'))
         # MDS ID for which health warning has been generated.
-        hw_mds_id = self._get_unhealthy_mds_id(health_report, health_warn)
+        hw_mds_id = self._get_unhealthy_mds_id(health_warn)
         if mds1_id == hw_mds_id:
             non_hw_mds_id = mds2_id
         elif mds2_id == hw_mds_id:

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1743,7 +1743,7 @@ class TestFSFail(TestAdminCommands):
     MDSS_REQUIRED = 2
     CLIENTS_REQUIRED = 1
 
-    def test_with_health_warn_oversize_cache(self):
+    def test_with_health_warn_cache_oversized(self):
         '''
         Test that, when health warning MDS_CACHE_OVERSIZE is present for an
         MDS, command "ceph fs fail" fails without confirmation flag and passes
@@ -1808,7 +1808,7 @@ class TestMDSFail(TestAdminCommands):
     MDSS_REQUIRED = 2
     CLIENTS_REQUIRED = 1
 
-    def test_with_health_warn_oversize_cache(self):
+    def test_with_health_warn_cache_oversized(self):
         '''
         Test that, when health warning MDS_CACHE_OVERSIZE is present for an
         MDS, command "ceph mds fail" fails without confirmation flag and


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66936

---

backport of https://github.com/ceph/ceph/pull/57492
parent tracker: https://tracker.ceph.com/issues/66933

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh