### PR TITLE
Client: Fix async/sync I/O stalling due to buffer list exceeding INT_MAX

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11556,13 +11556,20 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
 
   // copy into fresh buffer (since our write may be resub, async)
   bufferlist bl;
+  size_t total_appended = 0;
   if (buf) {
     if (size > 0)
       bl.append(buf, size);
   } else if (iov){
     for (int i = 0; i < iovcnt; i++) {
       if (iov[i].iov_len > 0) {
-        bl.append((const char *)iov[i].iov_base, iov[i].iov_len);
+        if (total_appended + iov[i].iov_len >= static_cast<size_t>(size)) {
+          bl.append((const char *)iov[i].iov_base, size - total_appended);
+          break;
+        } else {
+          bl.append((const char *)iov[i].iov_base, iov[i].iov_len);
+          total_appended += iov[i].iov_len;
+        }
       }
     }
   }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -16022,7 +16022,7 @@ int64_t Client::ll_writev(struct Fh *fh, const struct iovec *iov, int iovcnt, in
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
     return -CEPHFS_EBADF;
   }
-  return _preadv_pwritev_locked(fh, iov, iovcnt, off, true, false);
+  return _preadv_pwritev_locked(fh, iov, iovcnt, off, true, true);
 }
 
 int64_t Client::ll_readv(struct Fh *fh, const struct iovec *iov, int iovcnt, int64_t off)
@@ -16037,7 +16037,7 @@ int64_t Client::ll_readv(struct Fh *fh, const struct iovec *iov, int iovcnt, int
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
     return -CEPHFS_EBADF;
   }
-  return _preadv_pwritev_locked(fh, iov, iovcnt, off, false, false);
+  return _preadv_pwritev_locked(fh, iov, iovcnt, off, false, true);
 }
 
 int64_t Client::ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov,

--- a/src/test/client/nonblocking.cc
+++ b/src/test/client/nonblocking.cc
@@ -18,6 +18,7 @@
 #include <string>
 
 #include <fmt/format.h>
+#include <sys/statvfs.h>
 
 #include "test/client/TestClient.h"
 

--- a/src/test/client/nonblocking.cc
+++ b/src/test/client/nonblocking.cc
@@ -621,6 +621,7 @@ TEST_F(TestClient, LlreadvContiguousLlwritevNonContiguous) {
   char filename[256];
 
   client->unmount();
+  
   TearDown();
   SetUp();
 
@@ -712,4 +713,77 @@ TEST_F(TestClient, LlreadvContiguousLlwritevNonContiguous) {
 
   client->ll_release(fh);
   ASSERT_EQ(0, client->ll_unlink(root, filename, myperm));        
+}
+
+TEST_F(TestClient, LlreadvLlwritevLargeBuffers) {
+  /* Test that async I/O code paths handle large buffers (total len >= 4GiB)*/
+  int mypid = getpid();
+  char filename[256];
+
+  client->unmount();
+  TearDown();
+  SetUp();
+
+  sprintf(filename, "test_llreadvllwritevlargebuffers%u", mypid);
+
+  Inode *root, *file;
+  root = client->get_root();
+  ASSERT_NE(root, (Inode *)NULL);
+
+  Fh *fh;
+  struct ceph_statx stx;
+
+  ASSERT_EQ(0, client->ll_createx(root, filename, 0666,
+                                  O_RDWR | O_CREAT | O_TRUNC,
+                                          &file, &fh, &stx, 0, 0, myperm));
+
+  struct statvfs stbuf;
+  int64_t rc;
+  rc = client->ll_statfs(root, &stbuf, myperm);
+  ASSERT_EQ(rc, 0);
+  int64_t fs_available_space = stbuf.f_bfree * stbuf.f_bsize;
+  ASSERT_GT(fs_available_space, 0);
+
+  const int64_t BUFSIZE = 1024 * 1024 * 1024;
+  int64_t bytes_written = 0, bytes_read = 0;
+
+  std::unique_ptr<C_SaferCond> writefinish = nullptr;
+  std::unique_ptr<C_SaferCond> readfinish = nullptr;
+  writefinish.reset(new C_SaferCond("test-nonblocking-writefinish-large-buffers"));
+  readfinish.reset(new C_SaferCond("test-nonblocking-readfinish-large-buffers"));
+
+  auto out_buf_0 = std::make_unique<char[]>(BUFSIZE * 3);
+  memset(out_buf_0.get(), 0xDD, BUFSIZE * 3);
+  auto out_buf_1 = std::make_unique<char[]>(BUFSIZE * 3);
+  memset(out_buf_1.get(), 0xFF, BUFSIZE * 3);
+
+  struct iovec iov_out[2] = {
+    {out_buf_0.get(), BUFSIZE * 3},
+    {out_buf_1.get(), BUFSIZE * 3}
+  };
+
+  bufferlist bl;
+  auto in_buf_0 = std::make_unique<char[]>(BUFSIZE * 3);
+  auto in_buf_1 = std::make_unique<char[]>(BUFSIZE * 3);
+
+  struct iovec iov_in[2] = {
+    {in_buf_0.get(), BUFSIZE * 3},
+    {in_buf_1.get(), BUFSIZE * 3}
+  };
+
+  rc = client->ll_preadv_pwritev(fh, iov_out, 2, 0, true, writefinish.get(),
+                                 nullptr);
+  ASSERT_EQ(rc, 0);
+  bytes_written = writefinish->wait();
+  // total write length is clamped to INT_MAX in write paths
+  ASSERT_EQ(bytes_written, INT_MAX);
+
+  rc = client->ll_preadv_pwritev(fh, iov_in, 2, 0, false, readfinish.get(), &bl);
+  ASSERT_EQ(rc, 0);
+  bytes_read = readfinish->wait();
+  // total read length is clamped to INT_MAX in read paths
+  ASSERT_EQ(bytes_read, INT_MAX);
+
+  client->ll_release(fh);
+  ASSERT_EQ(0, client->ll_unlink(root, filename, myperm));
 }

--- a/src/test/client/syncio.cc
+++ b/src/test/client/syncio.cc
@@ -18,6 +18,7 @@
 #include <string>
 
 #include <fmt/format.h>
+#include <sys/statvfs.h>
 
 #include "test/client/TestClient.h"
 
@@ -76,4 +77,65 @@ TEST_F(TestClient, LlreadvLlwritevInvalidFileHandleSync) {
 
     rc = client->ll_readv(fh, iov_in, 2, 0);
     ASSERT_EQ(rc, -CEPHFS_EBADF);
+}
+
+TEST_F(TestClient, LlreadvLlwritevLargeBuffersSync) {
+  /* Test that sync I/O code paths handle large buffers (total len >= 4GiB)*/
+  int mypid = getpid();
+  char filename[256];
+
+  client->unmount();
+  TearDown();
+  SetUp();
+
+  sprintf(filename, "test_llreadvllwritevlargebufferssync%u", mypid);
+
+  Inode *root, *file;
+  root = client->get_root();
+  ASSERT_NE(root, (Inode *)NULL);
+
+  Fh *fh;
+  struct ceph_statx stx;
+
+  ASSERT_EQ(0, client->ll_createx(root, filename, 0666,
+                                  O_RDWR | O_CREAT | O_TRUNC,
+                                          &file, &fh, &stx, 0, 0, myperm));
+
+  struct statvfs stbuf;
+  int64_t rc;
+  const int64_t BUFSIZE = 1024 * 1024 * 1024;
+  rc = client->ll_statfs(root, &stbuf, myperm);
+  ASSERT_EQ(rc, 0);
+  int64_t fs_available_space = stbuf.f_bfree * stbuf.f_bsize;
+  ASSERT_GT(fs_available_space, BUFSIZE * 6);
+
+  auto out_buf_0 = std::make_unique<char[]>(BUFSIZE * 3);
+  memset(out_buf_0.get(), 0xDD, BUFSIZE * 3);
+  auto out_buf_1 = std::make_unique<char[]>(BUFSIZE * 3);
+  memset(out_buf_1.get(), 0xFF, BUFSIZE * 3);
+
+  struct iovec iov_out[2] = {
+    {out_buf_0.get(), BUFSIZE * 3},
+    {out_buf_1.get(), BUFSIZE * 3}
+  };
+
+  bufferlist bl;
+  auto in_buf_0 = std::make_unique<char[]>(BUFSIZE * 3);
+  auto in_buf_1 = std::make_unique<char[]>(BUFSIZE * 3);
+
+  struct iovec iov_in[2] = {
+    {in_buf_0.get(), BUFSIZE * 3},
+    {in_buf_1.get(), BUFSIZE * 3}
+  };
+
+  rc = client->ll_writev(fh, iov_out, 2, 0);
+  // total write length is clamped to INT_MAX in write paths
+  ASSERT_EQ(rc, INT_MAX);
+
+  rc = client->ll_readv(fh, iov_in, 2, 0);
+  // total write length is clamped to INT_MAX in write paths
+  ASSERT_EQ(rc, INT_MAX);
+
+  client->ll_release(fh);
+  ASSERT_EQ(0, client->ll_unlink(root, filename, myperm));
 }


### PR DESCRIPTION
In linux, systems calls like `write()` anyways don't allow writes > 2GiB, the total write size passed to the `Client::_write` is clamped to `INT_MAX` but bufferlist is not handled. This PR addresses this issue which stalls async i/o due to:

```
unknown file: Failure
C++ exception with description "End of buffer [buffer:2]" thrown in the test body.
2024-05-28T16:17:06.854+0530 7f9a5d24c9c0  2 client.4311 unmount
2024-05-28T16:17:06.854+0530 7f9a5d24c9c0  2 client.4311 unmounting
```

which results in disconnected inode and cap leaks:

```
2024-05-28T16:17:11.855+0530 7f9a5d24c9c0  1 client.4311 dump_inode: DISCONNECTED inode 0x10000000001 #0x10000000001 ref 3 0x10000000001.head(faked_ino=0 nref=3 ll_ref=0 cap_refs={4=0,1024=1,4096=1,8192=2} open={3=0} mode=100666 size=0/4294967296 nlink=1 btime=2024-05-28T16:17:03.387546+0530 mtime=2024-05-28T16:17:03.387546+0530 ctime=2024-05-28T16:17:03.387546+0530 change_attr=0 caps=pAsxLsXsxFsxcrwb(0=pAsxLsXsxFsxcrwb) objectset[0x10000000001 ts 0/0 objects 1 dirty_or_tx 0] 0x7f9a2c009530)
2024-05-28T16:17:11.855+0530 7f9a5d24c9c0  2 client.4311 cache still has 0+1 items, waiting (for caps to release?)
```
Fixes: https://tracker.ceph.com/issues/66245
Signed-off-by: Dhairya Parmar <dparmar@redhat.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
