### PR TITLE
qa/workunits/cephtool: add extra privileges to cephtool script

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -888,7 +888,7 @@ function test_tell_output_file()
   # only one line of json
   expect_true sed '2q1' < /tmp/foo > /dev/null
   expect_true jq -e '.version | length > 0' < /tmp/foo
-  rm -f /tmp/foo
+  sudo rm -f /tmp/foo
 
   J=$(ceph tell --format=json-pretty --daemon-output-file=/tmp/foo "$name" version)
   expect_true jq -e '.path == "/tmp/foo"' <<<"$J"
@@ -896,24 +896,24 @@ function test_tell_output_file()
   # more than one line of json
   expect_false sed '2q1' < /tmp/foo > /dev/null
   expect_true jq -e '.version | length > 0' < /tmp/foo
-  rm -f /tmp/foo
+  sudo rm -f /tmp/foo
 
   # Test --daemon-output-file=:tmp:
   J=$(ceph tell --format=json --daemon-output-file=":tmp:" "$name" version)
   path=$(jq -r .path <<<"$J")
   expect_true test -e "$path"
   # only one line of json
-  expect_true sed '2q1' < "$path" > /dev/null
-  expect_true jq -e '.version | length > 0' < "$path"
-  rm -f "$path"
+  expect_true sudo sh -c "sed '2q1' < \"$path\" > /dev/null"
+  expect_true sudo sudo sh -c "jq -e '.version | length > 0' < \"$path\""
+  sudo rm -f "$path"
 
   J=$(ceph tell --format=json-pretty --daemon-output-file=":tmp:" "$name" version)
   path=$(jq -r .path <<<"$J")
   expect_true test -e "$path"
   # only one line of json
-  expect_false sed '2q1' < "$path" > /dev/null
-  expect_true jq -e '.version | length > 0' < "$path"
-  rm -f "$path"
+  expect_false sudo sh -c "sed '2q1' < \"$path\" > /dev/null"
+  expect_true sudo sh -c "jq -e '.version | length > 0' < \"$path\""
+  sudo rm -f "$path"
 }
 
 function test_mds_tell()


### PR DESCRIPTION
This is more of a workaround to an issue in the infrastructure
where files are made with root privileges, causing permission
issues when operations are used on them without sudo.

Fixes: https://tracker.ceph.com/issues/66881





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
