### PR TITLE
squid: test/rgw/notifications: allow http server to buffer more requests

### DIFF
--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -201,6 +201,7 @@ class HTTPServerWithEvents(ThreadingHTTPServer):
         self.delay = delay
         self.cloudevents = cloudevents
         self.addr = addr
+        self.request_queue_size = 100
         self.lock = threading.Lock()
         ThreadingHTTPServer.__init__(self, addr, HTTPPostHandler)
         log.info('http server created on %s', self.addr)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66243

---

backport of https://github.com/ceph/ceph/pull/57638
parent tracker: https://tracker.ceph.com/issues/66033

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh