### PR TITLE
doc/cephfs: improve mount-using-fuse

### DIFF
--- a/doc/cephfs/mount-using-fuse.rst
+++ b/doc/cephfs/mount-using-fuse.rst
@@ -2,27 +2,32 @@
  Mount CephFS using FUSE
 ========================
 
-`ceph-fuse`_ is an alternate way of mounting CephFS, although it mounts it
-in userspace. Therefore, performance of FUSE can be relatively lower but FUSE
-clients can be more manageable, especially while upgrading CephFS.
+`ceph-fuse`_ can be used as an alternative to the :ref:`CephFS kernel
+driver<cephfs-mount-using-kernel-driver>` to mount CephFS file systems.
+`ceph-fuse`_ mounts are made in userspace. This means that `ceph-fuse`_ mounts
+are less performant than kernel driver mounts, but they are easier to manage
+and easier to upgrade.
 
 Prerequisites
 =============
 
-Go through the prerequisites required by both, kernel as well as FUSE mounts,
-in `Mount CephFS: Prerequisites`_ page.
+Ensure that you have all the prerequisites required by both kernel and FUSE
+mounts, as listed on the `Mount CephFS: Prerequisites`_ page.
 
 .. note:: Mounting CephFS using FUSE requires superuser privileges (sudo/root).
-          The libfuse interface does not provide a mechanism to trim cache entries in the
-          kernel so a remount (``mount(2)``) system call is required to force the kernel
-          to drop the cached metadata. ``ceph-fuse`` issues these remount system calls
-          periodically in response to cache pressure in the MDS or due to metadata cache revocations.
+   The libfuse interface does not provide a mechanism to trim cache entries in
+   the kernel so a remount (``mount(2)``) system call is required to force the
+   kernel to drop the cached metadata. ``ceph-fuse`` issues these remount
+   system calls periodically in response to cache pressure in the MDS or due to
+   metadata cache revocations.
 
 Synopsis
 ========
-In general, the command to mount CephFS via FUSE looks like this::
+This is the general form of the command for mounting CephFS via FUSE: 
 
-    ceph-fuse {mountpoint} {options}
+.. prompt:: bash #
+
+   ceph-fuse {mountpoint} {options}
 
 Mounting CephFS
 ===============

--- a/doc/cephfs/mount-using-kernel-driver.rst
+++ b/doc/cephfs/mount-using-kernel-driver.rst
@@ -1,3 +1,5 @@
+.. _cephfs-mount-using-kernel-driver:
+
 =================================
  Mount CephFS using Kernel Driver
 =================================


### PR DESCRIPTION
Improve the first twenty percent of doc/cephfs/mount-using-fuse.rst. This commit changes the text so that it is clearer that FUSE is an alternative to mounting CephFS with the kernel driver. This commit also links to the kernel driver page from the "FUSE-mount" page.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
