### PR TITLE
quincy: doc/dev: edit "Principles for format change"

### DIFF
--- a/doc/dev/encoding.rst
+++ b/doc/dev/encoding.rst
@@ -30,36 +30,35 @@ by a programmer by implementing the ``encode`` and ``decode`` methods.
 
 Principles for format change
 ----------------------------
-It is not unusual that the format of serialization changes. This
-process requires careful attention during both development
+It is not unusual for the format of serialization to change. This
+process requires careful attention both during development
 and review.
 
-The general rule is that a decoder must understand what had been
-encoded by an encoder. Most of the problems come from ensuring
-that compatibility continues between old decoders and new encoders
-as well as new decoders and old decoders. One should assume
-that -- if not otherwise derogated -- any mix (old/new) is
-possible in a cluster. There are 2 main reasons for that:
+The general rule is that a decoder must understand what has been encoded by an
+encoder. Most difficulties arise during the process of ensuring the continuity
+of compatibility of old decoders with new encoders, and ensuring the continuity
+of compatibility of new decoders with old decoders. One should assume -- if not
+otherwise specified -- that any mix of old and new is possible in a cluster.
+There are two primary concerns:
 
-1. Upgrades. Although there are recommendations related to the order
-   of entity types (mons/osds/clients), it is not mandatory and
-   no assumption should be made about it.
-2. Huge variability of client versions. It was always the case
-   that kernel (and thus kernel clients) upgrades are decoupled
-   from Ceph upgrades. Moreover, proliferation of containerization
-   bring the variability even to e.g. ``librbd`` -- now user space
-   libraries live on the container own.
+1. **Upgrades.** Although there are recommendations related to the order of
+   entity types (mons/OSDs/clients), it is not mandatory and no assumption
+   should be made.
+2. **Huge variability of client versions.** It has always been the case that
+   kernel upgrades (and thus kernel clients) are decoupled from Ceph upgrades.
+   Containerization brings variability even to ``librbd`` -- now user space
+   libraries live in the container itself:
 
-With this being said, there are few rules limiting the degree
-of interoperability between dencoders:
+There are a few rules limiting the degree of interoperability between
+dencoders:
 
 * ``n-2`` for dencoding between daemons,
-* ``n-3`` hard requirement for client-involved scenarios,
-* ``n-3..``  soft requirements for client-involved scenarios. Ideally
-  every client should be able to talk any version of daemons.
+* ``n-3`` hard requirement for client scenarios,
+* ``n-3..`` soft requirement for client scenarios. Ideally every client should
+  be able to talk to any version of daemons.
 
-As the underlying reasons are the same, the rules dencoders
-follow are virtually the same as for deprecations of our features
+As the underlying reasons are the same, the rules that dencoders
+follow are nearly the same as the rules for deprecations of our features
 bits. See the ``Notes on deprecation`` in ``src/include/ceph_features.h``.
 
 Frameworks


### PR DESCRIPTION
Improve "Principles for format change" in doc/dev/encoding.rst. This commit started as a response to Anthony D'Atri's suggestion here: https://github.com/ceph/ceph/pull/58299/files#r1656985564

Review of this section suggested to me that certain minor English usage improvements would be of benefit. The numbered lists in this section could still be made a bit clearer.

Co-authored-by: Anthony D'Atri <anthony.datri@gmail.com>
Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 570797e5588b67b8c72e5297b61f84d9aa48dc45)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
