### PR TITLE
reef: doc/cephfs: edit "is mount helper present"

### DIFF
--- a/doc/cephfs/mount-using-kernel-driver.rst
+++ b/doc/cephfs/mount-using-kernel-driver.rst
@@ -20,16 +20,18 @@ Complete General Prerequisites
 Go through the prerequisites required by both, kernel as well as FUSE mounts,
 in `Mount CephFS: Prerequisites`_ page.
 
-Is mount helper is present?
----------------------------
+Is mount helper present?
+------------------------
 ``mount.ceph`` helper is installed by Ceph packages. The helper passes the
-monitor address(es) and CephX user keyrings automatically saving the Ceph
-admin the effort to pass these details explicitly while mounting CephFS. In
-case the helper is not present on the client machine, CephFS can still be
-mounted using kernel but by passing these details explicitly to the ``mount``
-command. To check whether it is present on your system, do::
+monitor address(es) and CephX user keyrings, saving the Ceph admin the effort
+of passing these details explicitly while mounting CephFS. If the helper is not
+present on the client machine, CephFS can still be mounted using the kernel
+driver, but only by passing these details explicitly to the ``mount`` command.
+To check whether ``mount.ceph`` is present on your system, run the following command:
 
-    stat /sbin/mount.ceph
+.. prompt:: bash #
+
+   stat /sbin/mount.ceph
 
 Which Kernel Version?
 ---------------------


### PR DESCRIPTION
Edit the section called "Is mount helper present?", the title of which prior to this commit was "Is mount helper is present?". Other small disambiguating improvements have been made to the text in the section. An unselectable prompt has been added before a command.

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 0ebfb3eda8e2fc88662530bbddc84f2efcc4e13c)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
