### PR TITLE
src/test/rgw/test_multlti.md:update documentation for multi tests run

### DIFF
--- a/src/test/rgw/test_multi.md
+++ b/src/test/rgw/test_multi.md
@@ -9,7 +9,15 @@ $ cd /path/to/ceph/src/test/rgw/
 $ nosetests test_multi.py
 ```
 This will assume a configuration file called `/path/to/ceph/src/test/rgw/test_multi.conf` exists.
-To use a different configuration file, set the `RGW_MULTI_TEST_CONF` environment variable to point to that file.
+To use a different configuration file, set the `RGW_MULTI_TEST_CONF` environment variable to point to that file. Here is an example of configuration file:
+```
+[DEFAULT]
+num_zonegroup=1
+num_zones=3
+gateway_per_zone=1
+no_bootstrap=false
+log_level=5
+```
 Since we use the same entry point file for all tests, running specific tests is possible using the following format:
 ```
 $ nosetests test_multi.py:<specific_test_name>
@@ -19,6 +27,10 @@ To run multiple tests based on wildcard string, use the following format:
 $ nosetests test_multi.py -m "<wildcard string>"
 ```
 Note that the test to run, does not have to be inside the `test_multi.py` file.
+Some tests have attributes set based on their current reliability. You can filter tests based on their attributes:
+```
+$ nosetests test_multi.py -a "!fails_with_rgw"
+```
 Note that different options for running specific and multiple tests exists in the [nose documentation](https://nose.readthedocs.io/en/latest/usage.html#options), as well as other options to control the execution of the tests.
 ## Configuration
 ### Environment Variables


### PR DESCRIPTION

Update test_multi.md documentation with configuration example file and example on how to filter tests based on attributes.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
