### PR TITLE
mon: fix `fs set down` to adjust max_mds only when cluster is not down

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -976,6 +976,11 @@ function test_mon_mds()
   ceph fs set $FS_NAME cluster_down true
   ceph fs set $FS_NAME cluster_down false
 
+  ceph fs set $FS_NAME max_mds 2
+  ceph fs get $FS_NAME | expect_true grep -P -q 'max_mds\t2'
+  ceph fs set $FS_NAME down false
+  ceph fs get $FS_NAME | expect_true grep -P -q 'max_mds\t2'
+
   ceph mds compat rm_incompat 4
   ceph mds compat rm_incompat 4
 

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -598,6 +598,11 @@ int FileSystemCommandHandler::set_val(Monitor *mon, FSMap& fsmap, MonOpRequestRe
 
       ss << fsp->get_mds_map().get_fs_name();
 
+      if (!is_down && fsp->get_mds_map().get_max_mds() > 0) {
+        ss << " is already online";
+        return 0;
+      }
+
       modify_filesystem(fsmap, fsv,
           [is_down](auto&& fs)
       {


### PR DESCRIPTION
Applying `fs set down false` on an up cluster will set the cluster's max_mds to 1, regardless of the cluster's current max_mds.

`fs set down false` should only change max_mds when the cluster was set to down. Otherwise, the cluster should remain unchanged.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
