### PR TITLE
cephadm/smb: Determine samba version within container

### DIFF
--- a/src/cephadm/cephadm.py
+++ b/src/cephadm/cephadm.py
@@ -3528,6 +3528,8 @@ def list_daemons(
                                 version = CephIscsi.get_version(ctx, container_id)
                             if daemon_type == CephNvmeof.daemon_type:
                                 version = CephNvmeof.get_version(ctx, container_id)
+                            if daemon_type == SMB.daemon_type:
+                                version = SMB.get_version(ctx, container_id)
                             elif not version:
                                 if daemon_type in ceph_daemons():
                                     out, err, code = call(ctx,


### PR DESCRIPTION
Implement a `get_version()` method to figure out the version of samba running inside the container using _smbd_. This will help us to avoid reporting version as **_\<unknown\>_** while listing the daemons via `ceph orch ps`.

```
# ceph orch ps --daemon_type smb
NAME                            HOST      PORTS  STATUS        REFRESHED  AGE  MEM USE  MEM LIM  VERSION    IMAGE ID      CONTAINER ID  
smb.smbcluster.storage2.zxdpon  storage2  *:445  running (4d)     8m ago   4d        -        -  <unknown>  45fed2ab2897  a495f053efe8  
```