### PR TITLE
squid: client: check mds down status before getting mds_gid_t from mdsmap

### DIFF
--- a/qa/tasks/mgr/dashboard/test_cephfs.py
+++ b/qa/tasks/mgr/dashboard/test_cephfs.py
@@ -347,3 +347,17 @@ class CephfsTest(DashboardTestCase):
         self.assertEqual(stats['subdirs'], 1)
 
         self.rm_dir('/animal')
+
+    def test_cephfs_clients_get_after_mds_down(self):
+        fs_id = self.get_fs_id()
+        self._get(f"/api/cephfs/{fs_id}/clients")
+        self.assertStatus(200)
+
+        self.fs.fail()
+        params = {'suppress_client_ls_errors': 'False'}
+        self._get(f"/api/cephfs/{fs_id}/clients", params=params)
+        self.assertStatus(500)
+
+        self.fs.set_joinable()
+        self._get(f"/api/cephfs/{fs_id}/clients")
+        self.assertStatus(200)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6271,6 +6271,11 @@ int Client::resolve_mds(
   if (role_r == 0) {
     // We got a role, resolve it to a GID
     const auto& mdsmap = fsmap->get_filesystem(role.fscid).get_mds_map();
+    if (mdsmap.is_down(role.rank)) {
+      lderr(cct) << __func__ << ": targets rank: " << role.rank
+                 << " is down" << dendl;
+      return -CEPHFS_EAGAIN;
+    }
     auto& info = mdsmap.get_info(role.rank);
     ldout(cct, 10) << __func__ << ": resolved " << mds_spec << " to role '"
       << role << "' aka " << info.human_name() << dendl;

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -129,10 +129,17 @@ class CephFS(RESTController):
         return self.fs_status(fs_id)
 
     @RESTController.Resource('GET')
-    def clients(self, fs_id):
+    def clients(self, fs_id, **kwargs):
+        flag = kwargs.pop('suppress_client_ls_errors', 'True')
+        if flag not in ('True', 'False'):
+            raise DashboardException(msg='suppress_client_ls_errors value '
+                                         'needs to be either True or False '
+                                         f'but provided {flag}',
+                                     component='cephfs')
+
         fs_id = self.fs_id_to_int(fs_id)
 
-        return self._clients(fs_id)
+        return self._clients(fs_id, suppress_client_ls_errors=flag)
 
     @RESTController.Resource('DELETE', path='/client/{client_id}')
     def evict(self, fs_id, client_id):
@@ -375,17 +382,23 @@ class CephFS(RESTController):
             "versions": mds_versions
         }
 
-    def _clients(self, fs_id):
+    def _clients(self, fs_id, **kwargs):
+        suppress_get_errors = kwargs.pop('suppress_client_ls_errors', 'True')
         cephfs_clients = self.cephfs_clients.get(fs_id, None)
         if cephfs_clients is None:
             cephfs_clients = CephFSClients(mgr, fs_id)
             self.cephfs_clients[fs_id] = cephfs_clients
 
         try:
-            status, clients = cephfs_clients.get()
+            status, clients = cephfs_clients.get(suppress_get_errors)
         except AttributeError:
             raise cherrypy.HTTPError(404,
                                      "No cephfs with id {0}".format(fs_id))
+        except RuntimeError:
+            raise cherrypy.HTTPError(500,
+                                     f"Could not fetch client(s), maybe there "
+                                     f"is no active MDS on CephFS {fs_id} or "
+                                     "the FS is in failed state.")
 
         if clients is None:
             raise cherrypy.HTTPError(404,
@@ -633,11 +646,14 @@ class CephFSClients(object):
         self.fscid = fscid
 
     @ViewCache()
-    def get(self):
+    def get(self, suppress_errors='True'):
         try:
             ret = CephService.send_command('mds', 'session ls', srv_spec='{0}:0'.format(self.fscid))
         except RuntimeError:
-            ret = []
+            if suppress_errors == 'True':
+                ret = []
+            else:
+                raise
         return ret
 
 

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -134,7 +134,7 @@ class CephFS(RESTController):
         if flag not in ('True', 'False'):
             raise DashboardException(msg='suppress_client_ls_errors value '
                                          'needs to be either True or False '
-                                         f'but provided {flag}',
+                                         f'but provided "{flag}"',
                                      component='cephfs')
 
         fs_id = self.fs_id_to_int(fs_id)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64606

---

backport of https://github.com/ceph/ceph/pull/52258
parent tracker: https://tracker.ceph.com/issues/61844

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh