### PR TITLE
rgw/auth: RemoteApplier respects implicit tenants

### DIFF
--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -621,6 +621,9 @@ protected:
   const rgw::auth::ImplicitTenants& implicit_tenant_context;
   const rgw::auth::ImplicitTenants::implicit_tenant_flag_bits implicit_tenant_bit;
 
+  // AuthInfo::acct_user updated with implicit tenant if necessary
+  mutable rgw_user owner_acct_user;
+
   // account and policies are loaded by load_acct_info()
   mutable std::optional<RGWAccountInfo> account;
   mutable std::vector<IAM::Policy> policies;
@@ -660,7 +663,7 @@ public:
   std::string get_acct_name() const override { return info.acct_name; }
   std::string get_subuser() const override { return {}; }
   const std::string& get_tenant() const override {
-    return info.acct_user.tenant;
+    return owner_acct_user.tenant;
   }
   const std::optional<RGWAccountInfo>& get_account() const override {
     return account;


### PR DESCRIPTION
RemoteApplier::load_acct_info() and create_account() decide whether to add the implicit tenant. store the resulting rgw_user for use in get_aclowner(), is_owner_of(), and get_tenant()

potential fix for https://tracker.ceph.com/issues/66937? i don't know how to test this

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
