### PR TITLE
squid: mgr/rgw: fix error handling in rgw zone create

### DIFF
--- a/src/python-common/ceph/rgw/rgwam_core.py
+++ b/src/python-common/ceph/rgw/rgwam_core.py
@@ -818,7 +818,7 @@ class RGWAM:
 
         zonegroup = period.get_master_zonegroup()
         if not zonegroup:
-            raise RGWAMException('Cannot find master zonegroup of realm {realm_name}')
+            raise RGWAMException(f'Cannot find master zonegroup of realm {realm_name}')
 
         zone = self.create_zone(realm, zonegroup, rgw_spec.rgw_zone,
                                 False,  # secondary zone


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66648

---

backport of https://github.com/ceph/ceph/pull/58142
parent tracker: https://tracker.ceph.com/issues/66568

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh