### PR TITLE
squid: mgr: excute cmd 'ceph orch apply osd' returned without error info

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1220,11 +1220,11 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         """
 
         if inbuf and all_available_devices:
-            return HandleCommandResult(-errno.EINVAL, '-i infile and --all-available-devices are mutually exclusive')
+            return HandleCommandResult(-errno.EINVAL, stderr='-i infile and --all-available-devices are mutually exclusive')
 
         if not inbuf and not all_available_devices:
             # one parameter must be present
-            return HandleCommandResult(-errno.EINVAL, '--all-available-devices is required')
+            return HandleCommandResult(-errno.EINVAL, stderr='--all-available-devices is required')
 
         if inbuf:
             if unmanaged is not None:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66787

---

backport of https://github.com/ceph/ceph/pull/58154
parent tracker: https://tracker.ceph.com/issues/66574

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh