### PR TITLE
squid: mgr/dashboard: Expand Cluster improvements   

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/create-cluster.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/create-cluster.po.ts
@@ -4,7 +4,7 @@ import { HostsPageHelper } from './hosts.po';
 import { ServicesPageHelper } from './services.po';
 
 const pages = {
-  index: { url: '#/expand-cluster', id: 'cd-create-cluster' }
+  index: { url: '#/expand-cluster?welcome=true', id: 'cd-create-cluster' }
 };
 export class CreateClusterWizardHelper extends PageHelper {
   pages = pages;
@@ -28,7 +28,7 @@ export class CreateClusterWizardHelper extends PageHelper {
 
 export class CreateClusterHostPageHelper extends HostsPageHelper {
   pages = {
-    index: { url: '#/expand-cluster', id: 'cd-wizard' },
+    index: { url: '#/expand-cluster?welcome=true', id: 'cd-wizard' },
     add: { url: '', id: 'cd-host-form' }
   };
 
@@ -42,7 +42,7 @@ export class CreateClusterHostPageHelper extends HostsPageHelper {
 
 export class CreateClusterServicePageHelper extends ServicesPageHelper {
   pages = {
-    index: { url: '#/expand-cluster', id: 'cd-wizard' },
+    index: { url: '#/expand-cluster?welcome=true', id: 'cd-wizard' },
     create: { url: '', id: 'cd-service-form' }
   };
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/osds.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/osds.po.ts
@@ -15,6 +15,11 @@ export class OSDsPageHelper extends PageHelper {
 
   create(deviceType: 'hdd' | 'ssd', hostname?: string, expandCluster = false) {
     cy.get('[aria-label="toggle advanced mode"]').click();
+    cy.get('[aria-label="toggle advanced mode"]').then(($button) => {
+      if ($button.hasClass('collapsed')) {
+        cy.wrap($button).click();
+      }
+    });
     // Click Primary devices Add button
     cy.get('cd-osd-devices-selection-groups[name="Primary"]').as('primaryGroups');
     cy.get('@primaryGroups').find('button').click();

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/urls.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/urls.po.ts
@@ -3,7 +3,7 @@ import { PageHelper } from '../page-helper.po';
 export class UrlsCollection extends PageHelper {
   pages = {
     // Cluster expansion
-    welcome: { url: '#/expand-cluster', id: 'cd-create-cluster' },
+    welcome: { url: '#/expand-cluster?welcome=true', id: 'cd-create-cluster' },
 
     // Landing page
     dashboard: { url: '#/dashboard', id: 'cd-dashboard' },

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.html
@@ -9,20 +9,20 @@
               class="bold">Hosts</td>
           <td>{{ hostsCount }}</td>
         </tr>
-        <tr>
+        <tr *ngIf="!isSimpleDeployment; else simpleDeploymentTextTpl">
           <td>
-          <dl>
-            <dt>
-              <p i18n>Storage Capacity</p>
-            </dt>
-            <dd>
-              <p i18n>Number of devices</p>
-            </dd>
-            <dd>
-              <p i18n>Raw capacity</p>
-            </dd>
-          </dl>
-        </td>
+            <dl>
+              <dt>
+                <p i18n>Storage Capacity</p>
+              </dt>
+              <dd>
+                <p i18n>Number of devices</p>
+              </dd>
+              <dd>
+                <p i18n>Raw capacity</p>
+              </dd>
+            </dl>
+          </td>
           <td class="pt-5"><p>{{ totalDevices }}</p><p>
             {{ totalCapacity | dimlessBinary }}</p></td>
         </tr>
@@ -40,13 +40,28 @@
     </fieldset>
   </div>
 
-<div class="col-lg-9">
+  <div class="col-lg-9">
   <legend i18n
           class="cd-header">Host Details</legend>
   <cd-hosts [hiddenColumns]="['services', 'status']"
             [hideToolHeader]="true"
             [hasTableDetails]="false"
-            [showGeneralActionsOnly]="true">
-  </cd-hosts>
+            [showGeneralActionsOnly]="true"
+            [showExpandClusterBtn]="false">
+    </cd-hosts>
+  </div>
 </div>
-</div>
+<ng-template #simpleDeploymentTextTpl>
+  <tr>
+    <td>
+      <dl>
+        <dt>
+          <p i18n>Storage Capacity</p>
+        </dt>
+        <dd>
+          <p i18n>{{deploymentDescText}}</p>
+        </dd>
+      </dl>
+    </td>
+  </tr>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster-review.component.ts
@@ -23,6 +23,8 @@ export class CreateClusterReviewComponent implements OnInit {
   services: Array<CephServiceSpec> = [];
   totalCPUs = 0;
   totalMemory = 0;
+  deploymentDescText: string;
+  isSimpleDeployment = true;
 
   constructor(
     public wizardStepsService: WizardStepsService,
@@ -40,6 +42,7 @@ export class CreateClusterReviewComponent implements OnInit {
     let dbDevices = 0;
     let dbDeviceCapacity = 0;
 
+    this.isSimpleDeployment = this.osdService.isDeployementModeSimple;
     const hostContext = new CdTableFetchDataContext(() => undefined);
     this.hostService.list(hostContext.toParams(), 'true').subscribe((resp: object[]) => {
       this.hosts = resp;
@@ -65,6 +68,21 @@ export class CreateClusterReviewComponent implements OnInit {
     if (this.osdService.osdDevices['db']) {
       dbDevices = this.osdService.osdDevices['db']?.length;
       dbDeviceCapacity = this.osdService.osdDevices['db']['capacity'];
+    }
+
+    if (this.isSimpleDeployment) {
+      this.osdService.getDeploymentOptions().subscribe((optionsObj) => {
+        if (!_.isEmpty(optionsObj)) {
+          Object.keys(optionsObj.options).forEach((option) => {
+            if (
+              this.osdService.selectedFormValues &&
+              this.osdService.selectedFormValues.get('deploymentOption').value === option
+            ) {
+              this.deploymentDescText = optionsObj.options[option].desc;
+            }
+          });
+        }
+      });
     }
 
     this.totalDevices = dataDevices + walDevices + dbDevices;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.html
@@ -1,5 +1,5 @@
 <div class="container h-75"
-     *ngIf="!startClusterCreation">
+     *ngIf="startClusterCreation">
   <div class="row h-100 justify-content-center align-items-center">
     <div class="blank-page">
       <!-- htmllint img-req-src="false" -->
@@ -30,7 +30,7 @@
 </div>
 
 <div class="card"
-     *ngIf="startClusterCreation">
+     *ngIf="!startClusterCreation">
   <div class="card-header"
        i18n>Expand Cluster</div>
   <div class="container-fluid">
@@ -45,7 +45,8 @@
           <cd-hosts [hiddenColumns]="['services']"
                     [hideMaintenance]="true"
                     [hasTableDetails]="false"
-                    [showGeneralActionsOnly]="true"></cd-hosts>
+                    [showGeneralActionsOnly]="true"
+                    [showExpandClusterBtn]="false"></cd-hosts>
         </div>
         <div *ngSwitchCase="'2'"
              class="ms-5">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.spec.ts
@@ -59,6 +59,8 @@ describe('CreateClusterComponent', () => {
   });
 
   it('should have project name as heading in welcome screen', () => {
+    component.startClusterCreation = true;
+    fixture.detectChanges();
     const heading = fixture.debugElement.query(By.css('h3')).nativeElement;
     expect(heading.innerHTML).toBe(`Welcome to ${projectConstants.projectName}`);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/create-cluster/create-cluster.component.ts
@@ -7,7 +7,7 @@ import {
   TemplateRef,
   ViewChild
 } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import _ from 'lodash';
@@ -68,7 +68,8 @@ export class CreateClusterComponent implements OnInit, OnDestroy {
     private clusterService: ClusterService,
     private modalService: ModalService,
     private taskWrapper: TaskWrapperService,
-    private osdService: OsdService
+    private osdService: OsdService,
+    private route: ActivatedRoute
   ) {
     this.permissions = this.authStorageService.getPermissions();
     this.currentStepSub = this.wizardStepsService
@@ -80,6 +81,14 @@ export class CreateClusterComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    this.route.queryParams.subscribe((params) => {
+      // reading 'welcome' value true/false to toggle expand-cluster wizand view and welcome view
+      const showWelcomeScreen = params['welcome'];
+      if (showWelcomeScreen) {
+        this.startClusterCreation = showWelcomeScreen;
+      }
+    });
+
     this.osdService.getDeploymentOptions().subscribe((options) => {
       this.deploymentOption = options;
       this.selectedOption = { option: options.recommended_option, encrypted: false };
@@ -91,7 +100,7 @@ export class CreateClusterComponent implements OnInit, OnDestroy {
   }
 
   createCluster() {
-    this.startClusterCreation = true;
+    this.startClusterCreation = false;
   }
 
   skipClusterCreation() {
@@ -244,5 +253,6 @@ export class CreateClusterComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.currentStepSub.unsubscribe();
+    this.osdService.selectedFormValues = null;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
@@ -26,6 +26,12 @@
                             id="host-actions"
                             [tableActions]="tableActions">
           </cd-table-actions>
+          <cd-table-actions [permission]="permissions.hosts"
+                            [selection]="selection"
+                            btnColor="light"
+                            class="btn-group"
+                            [tableActions]="expandClusterActions">
+          </cd-table-actions>
         </div>
         <cd-host-details cdTableDetail
                          [permissions]="permissions"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -78,12 +78,16 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
   @Input()
   showGeneralActionsOnly = false;
 
+  @Input()
+  showExpandClusterBtn = true;
+
   permissions: Permissions;
   columns: Array<CdTableColumn> = [];
   hosts: Array<object> = [];
   isLoadingHosts = false;
   cdParams = { fromLink: '/hosts' };
   tableActions: CdTableAction[];
+  expandClusterActions: CdTableAction[];
   selection = new CdTableSelection();
   modalRef: NgbModalRef;
   isExecuting = false;
@@ -125,6 +129,16 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
   ) {
     super();
     this.permissions = this.authStorageService.getPermissions();
+    this.expandClusterActions = [
+      {
+        name: this.actionLabels.EXPAND_CLUSTER,
+        permission: 'create',
+        icon: Icons.expand,
+        routerLink: '/expand-cluster',
+        disable: (selection: CdTableSelection) => this.getDisable('add', selection),
+        visible: () => this.showExpandClusterBtn
+      }
+    ];
     this.tableActions = [
       {
         name: this.actionLabels.ADD,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
@@ -237,6 +237,7 @@ describe('OsdFormComponent', () => {
 
     describe('without data devices selected', () => {
       it('should disable preview button', () => {
+        component.simpleDeployment = false;
         expectPreviewButton(false);
       });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.ts
@@ -1,4 +1,12 @@
-import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewChild
+} from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 import { Router } from '@angular/router';
 
@@ -34,7 +42,7 @@ import { OsdFeature } from './osd-feature.interface';
   templateUrl: './osd-form.component.html',
   styleUrls: ['./osd-form.component.scss']
 })
-export class OsdFormComponent extends CdForm implements OnInit {
+export class OsdFormComponent extends CdForm implements OnInit, OnDestroy {
   @ViewChild('dataDeviceSelectionGroups')
   dataDeviceSelectionGroups: OsdDevicesSelectionGroupsComponent;
 
@@ -121,12 +129,23 @@ export class OsdFormComponent extends CdForm implements OnInit {
 
     this.osdService.getDeploymentOptions().subscribe((options) => {
       this.deploymentOptions = options;
-      this.form.get('deploymentOption').setValue(this.deploymentOptions?.recommended_option);
+      if (!this.osdService.selectedFormValues) {
+        this.form.get('deploymentOption').setValue(this.deploymentOptions?.recommended_option);
+      }
 
       if (this.deploymentOptions?.recommended_option) {
         this.enableFeatures();
       }
     });
+
+    // restoring form value on back/next
+    if (this.osdService.selectedFormValues) {
+      this.form = _.cloneDeep(this.osdService.selectedFormValues);
+      this.form
+        .get('deploymentOption')
+        .setValue(this.osdService.selectedFormValues.value?.deploymentOption);
+    }
+    this.simpleDeployment = this.osdService.isDeployementModeSimple;
     this.form.get('walSlots').valueChanges.subscribe((value) => this.setSlots('wal', value));
     this.form.get('dbSlots').valueChanges.subscribe((value) => this.setSlots('db', value));
     _.each(this.features, (feature) => {
@@ -282,5 +301,10 @@ export class OsdFormComponent extends CdForm implements OnInit {
       });
       this.previewButtonPanel.submitButton.loading = false;
     }
+  }
+
+  ngOnDestroy() {
+    this.osdService.selectedFormValues = _.cloneDeep(this.form);
+    this.osdService.isDeployementModeSimple = this.dataDeviceSelectionGroups?.devices?.length === 0;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
@@ -53,6 +53,8 @@ describe('LoginComponent', () => {
     component.login();
 
     expect(routerNavigateSpy).toHaveBeenCalledTimes(1);
-    expect(routerNavigateSpy).toHaveBeenCalledWith(['/expand-cluster']);
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['/expand-cluster'], {
+      queryParams: { welcome: true }
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
@@ -70,7 +70,11 @@ export class LoginComponent implements OnInit {
       if (!this.postInstalled && this.route.snapshot.queryParams['returnUrl'] === '/dashboard') {
         url = '/expand-cluster';
       }
-      this.router.navigate([url]);
+      if (url == '/expand-cluster') {
+        this.router.navigate([url], { queryParams: { welcome: true } });
+      } else {
+        this.router.navigate([url]);
+      }
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
@@ -11,6 +11,7 @@ import { DeploymentOptions } from '../models/osd-deployment-options';
 import { OsdSettings } from '../models/osd-settings';
 import { SmartDataResponseV1 } from '../models/smart';
 import { DeviceService } from '../services/device.service';
+import { CdFormGroup } from '../forms/cd-form-group';
 
 @Injectable({
   providedIn: 'root'
@@ -20,6 +21,8 @@ export class OsdService {
   private uiPath = 'ui-api/osd';
 
   osdDevices: InventoryDeviceType[] = [];
+  selectedFormValues: CdFormGroup;
+  isDeployementModeSimple: boolean = true;
 
   osdRecvSpeedModalPriorities = {
     KNOWN_PRIORITIES: [

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
@@ -145,6 +145,7 @@ export class ActionLabelsI18n {
   DEACTIVATE: string;
   ATTACH: string;
   AUTHORIZE: string;
+  EXPAND_CLUSTER: string;
 
   constructor() {
     /* Create a new item */
@@ -228,6 +229,7 @@ export class ActionLabelsI18n {
     this.DEACTIVATE = $localize`Deactivate`;
 
     this.ATTACH = $localize`Attach`;
+    this.EXPAND_CLUSTER = $localize`Expand Cluster`;
   }
 }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
@@ -27,7 +27,7 @@ export enum Icons {
   right = 'fa fa-arrow-right', // Mark in
   down = 'fa fa-arrow-down', // Mark Down
   erase = 'fa fa-eraser', // Purge  color: bd.$white;
-
+  expand = 'fa fa-expand', // Expand cluster
   user = 'fa fa-user', // User, Initiators
   users = 'fa fa-users', // Users, Groups
   share = 'fa fa-share-alt', // share


### PR DESCRIPTION
backport tracker:
https://tracker.ceph.com/issues/66645

<hr style="borser:2px solid grey"/>
backport of #57927
parent tracker: https://tracker.ceph.com/issues/66344
<hr style="borser:2px solid grey"/>

**Conflicts**

File - `app.constants.ts`
removed below code - 
`this.CONNECT = $localize`Connect`;
    this.DISCONNECT = $localize`Disconnect`;
    this.RECONNECT = $localize`Reconnect`;`
<hr style="borser:2px solid grey"/>
worked on expand cluster screen hide/show and persisting osd form values

Fixes: https://tracker.ceph.com/issues/66344

Signed-off-by: Naman Munet <nmunet@redhat.com>
(cherry picked from commit aa4d6b58459079a3b59ffdd1c9913c0a07a1549a)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
