### PR TITLE
reef: mgr/prometheus: s/pkg_resources.packaging/packaging/

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -659,6 +659,7 @@ BuildArch:      noarch
 Group:          System/Filesystems
 %endif
 Requires:       python%{python3_pkgversion}-bcrypt
+Requires:       python%{python3_pkgversion}-packaging
 Requires:       python%{python3_pkgversion}-pecan
 Requires:       python%{python3_pkgversion}-pyOpenSSL
 Requires:       python%{python3_pkgversion}-requests

--- a/debian/ceph-mgr-modules-core.requires
+++ b/debian/ceph-mgr-modules-core.requires
@@ -1,5 +1,6 @@
 natsort
 CherryPy
+packaging
 pecan
 werkzeug
 requests

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1,7 +1,6 @@
 import cherrypy
 import yaml
 from collections import defaultdict
-from pkg_resources import packaging  # type: ignore
 import json
 import math
 import os
@@ -9,6 +8,7 @@ import re
 import threading
 import time
 import enum
+from packaging import version  # type: ignore
 from collections import namedtuple
 
 from mgr_module import CLIReadCommand, MgrModule, MgrStandbyModule, PG_STATES, Option, ServiceInfoT, HandleCommandResult, CLIWriteCommand
@@ -34,7 +34,7 @@ DEFAULT_PORT = 9283
 # ipv6 isn't yet configured / supported and CherryPy throws an uncaught
 # exception.
 if cherrypy is not None:
-    Version = packaging.version.Version
+    Version = version.Version
     v = Version(cherrypy.__version__)
     # the issue was fixed in 3.2.3. it's present in 3.2.2 (current version on
     # centos:7) and back to at least 3.0.0.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66414

---

backport of https://github.com/ceph/ceph/pull/57700
parent tracker: https://tracker.ceph.com/issues/66201

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh