### PR TITLE
quincy: mgr/prometheus: s/pkg_resources.packaging/packaging/

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -654,6 +654,7 @@ BuildArch:      noarch
 Group:          System/Filesystems
 %endif
 Requires:       python%{python3_pkgversion}-bcrypt
+Requires:       python%{python3_pkgversion}-packaging
 Requires:       python%{python3_pkgversion}-pecan
 Requires:       python%{python3_pkgversion}-pyOpenSSL
 Requires:       python%{python3_pkgversion}-requests

--- a/debian/control
+++ b/debian/control
@@ -305,6 +305,7 @@ Depends: ${misc:Depends},
          ${shlibs:Depends},
          python3-dateutil,
          python3-openssl,
+         python3-packaging,
 Replaces: ceph-mgr (<< 15.1.0)
 Breaks: ceph-mgr (<< 15.1.0)
 Description: ceph manager modules which are always enabled

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -544,7 +544,7 @@ def verify_cacrt_content(crt):
     # type: (str) -> None
     from OpenSSL import crypto
     try:
-        x509 = crypto.load_certificate(crypto.FILETYPE_PEM, crt)
+        x509 = crypto.load_certificate(crypto.FILETYPE_PEM, crt.encode('utf-8'))
         if x509.has_expired():
             logger.warning('Certificate has expired: {}'.format(crt))
     except (ValueError, crypto.Error) as e:
@@ -581,7 +581,7 @@ def verify_tls(crt, key):
         raise ServerConfigException(
             'Invalid private key: {}'.format(str(e)))
     try:
-        _crt = crypto.load_certificate(crypto.FILETYPE_PEM, crt)
+        _crt = crypto.load_certificate(crypto.FILETYPE_PEM, crt.encode('utf-8'))
     except ValueError as e:
         raise ServerConfigException(
             'Invalid certificate key: {}'.format(str(e))

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1,6 +1,5 @@
 import cherrypy
 from collections import defaultdict
-from pkg_resources import packaging  # type: ignore
 import json
 import math
 import os
@@ -8,6 +7,8 @@ import re
 import threading
 import time
 import enum
+from packaging import version  # type: ignore
+
 from mgr_module import CLIReadCommand, MgrModule, MgrStandbyModule, PG_STATES, Option, ServiceInfoT, HandleCommandResult, CLIWriteCommand
 from mgr_util import get_default_addr, profile_method, build_url
 from rbd import RBD
@@ -32,7 +33,7 @@ DEFAULT_PORT = 9283
 # ipv6 isn't yet configured / supported and CherryPy throws an uncaught
 # exception.
 if cherrypy is not None:
-    Version = packaging.version.Version
+    Version = version.Version
     v = Version(cherrypy.__version__)
     # the issue was fixed in 3.2.3. it's present in 3.2.2 (current version on
     # centos:7) and back to at least 3.0.0.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66412

---

backport of https://github.com/ceph/ceph/pull/57700
parent tracker: https://tracker.ceph.com/issues/66201

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh