### PR TITLE
msg: insert PriorityDispatchers in sorted position

### DIFF
--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -106,6 +106,17 @@ private:
 
   ZTracer::Endpoint trace_endpoint;
 
+  static void insert_head(std::vector<PriorityDispatcher>& v,
+                          PriorityDispatcher d)
+  {
+    v.insert(std::lower_bound(v.begin(), v.end(), d), d);
+  }
+  static void insert_tail(std::vector<PriorityDispatcher>& v,
+                          PriorityDispatcher d)
+  {
+    v.insert(std::upper_bound(v.begin(), v.end(), d), d);
+  }
+
 protected:
   void set_endpoint_addr(const entity_addr_t& a,
                          const entity_name_t &name);
@@ -401,11 +412,10 @@ public:
    */
   void add_dispatcher_head(Dispatcher *d, PriorityDispatcher::priority_t priority=Dispatcher::PRIORITY_DEFAULT) {
     bool first = dispatchers.empty();
-    dispatchers.insert(dispatchers.begin(), PriorityDispatcher{priority, d});
-    std::stable_sort(dispatchers.begin(), dispatchers.end());
+    const PriorityDispatcher entry{priority, d};
+    insert_head(dispatchers, entry);
     if (d->ms_can_fast_dispatch_any()) {
-      fast_dispatchers.insert(fast_dispatchers.begin(), PriorityDispatcher{priority, d});
-      std::stable_sort(fast_dispatchers.begin(), fast_dispatchers.end());
+      insert_head(fast_dispatchers, entry);
     }
     if (first)
       ready();
@@ -419,11 +429,10 @@ public:
    */
   void add_dispatcher_tail(Dispatcher *d, PriorityDispatcher::priority_t priority=Dispatcher::PRIORITY_DEFAULT) {
     bool first = dispatchers.empty();
-    dispatchers.push_back(PriorityDispatcher{priority, d});
-    std::stable_sort(dispatchers.begin(), dispatchers.end());
+    const PriorityDispatcher entry{priority, d};
+    insert_tail(dispatchers, entry);
     if (d->ms_can_fast_dispatch_any()) {
-      fast_dispatchers.push_back(PriorityDispatcher{priority, d});
-      std::stable_sort(fast_dispatchers.begin(), fast_dispatchers.end());
+      insert_tail(fast_dispatchers, entry);
     }
     if (first)
       ready();


### PR DESCRIPTION
avoid calling stable_sort() after every insertion by inserting directly into the sorted position. use lower_bound() to insert at the head and upper_bound() to insert at the tail

this generally only happens during startup so isn't a performance problem, but std::stable_sort() was triggering strange valgrind warnings for "Mismatched free() / delete / delete []" when it allocates a temporary buffer

Fixes: https://tracker.ceph.com/issues/66336

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
