### PR TITLE
rgw/s3select: JSON output format 

### DIFF
--- a/qa/rgw/s3tests-branch.yaml
+++ b/qa/rgw/s3tests-branch.yaml
@@ -1,4 +1,4 @@
 overrides:
   s3tests:
      force-branch: ceph-master
-     git_remote: https://github.com/ceph/
+     # git_remote: https://github.com/ceph/

--- a/qa/rgw/s3tests-branch.yaml
+++ b/qa/rgw/s3tests-branch.yaml
@@ -1,4 +1,4 @@
 overrides:
   s3tests:
      force-branch: ceph-master
-     # git_remote: https://github.com/ceph/
+     git_remote: https://github.com/ceph/

--- a/src/rgw/rgw_s3select.cc
+++ b/src/rgw/rgw_s3select.cc
@@ -427,6 +427,9 @@ int RGWSelectObj_ObjStore_S3::run_s3select_on_csv(const char* query, const char*
     csv.use_header_info=true;
   }
 
+  if(m_outputFormat == OutputFormat::JSON) {
+    csv.output_json_format = true;
+  }
   m_s3_csv_object.set_csv_query(&s3select_syntax, csv);
 
   m_s3_csv_object.set_external_system_functions(fp_s3select_continue,
@@ -479,6 +482,9 @@ int RGWSelectObj_ObjStore_S3::run_s3select_on_parquet(const char* query)
     //parsing the SQL statement.
     s3select_syntax.parse_query(m_sql_query.c_str());
     parquet_object::csv_definitions parquet;
+    if(m_outputFormat == OutputFormat::JSON) {
+    parquet.output_json_format = true;
+    }
 
   m_s3_parquet_object.set_external_system_functions(fp_s3select_continue,
 						fp_s3select_result_format,
@@ -539,6 +545,10 @@ int RGWSelectObj_ObjStore_S3::run_s3select_on_json(const char* query, const char
     ldpp_dout(this, 10) << s3select_json_error_msg << dendl;
     return -EINVAL;
   } 
+
+  if(m_outputFormat == OutputFormat::JSON) {
+    json.output_json_format = true;
+  }
 
   //parsing the SQL statement
   s3select_syntax.parse_query(m_sql_query.c_str());
@@ -619,6 +629,10 @@ int RGWSelectObj_ObjStore_S3::handle_aws_cli_parameters(std::string& sql_query)
   } else if (m_s3select_query.find(input_tag+"><Parquet") != std::string::npos) {
     m_parquet_type=true;
     ldpp_dout(this, 10) << "s3select: engine is set to process Parquet objects" << dendl;
+  }
+
+  if (m_s3select_query.find(output_tag+"><JSON") != std::string::npos) {
+    m_outputFormat = OutputFormat::JSON;
   }
 
   extract_by_tag(m_s3select_query, "Expression", sql_query);

--- a/src/rgw/rgw_s3select.cc
+++ b/src/rgw/rgw_s3select.cc
@@ -821,6 +821,11 @@ int RGWSelectObj_ObjStore_S3::parquet_processing(bufferlist& bl, off_t ofs, off_
       }
       append_in_callback += it.length();
       ldout(s->cct, 10) << "S3select: part " << part_no++ << " it.length() = " << it.length() << dendl;
+      if ((ofs + len) > it.length()){
+	ldpp_dout(this, 10) << "s3select: offset and length may cause invalid read: ofs = " << ofs << " len = " << len << " it.length() = " << it.length() << dendl;
+	ofs = 0;
+	len = it.length();
+      }
       requested_buffer.append(&(it)[0]+ofs, len);
     }
     ldout(s->cct, 10) << "S3select:append_in_callback = " << append_in_callback << dendl;

--- a/src/rgw/rgw_s3select.cc
+++ b/src/rgw/rgw_s3select.cc
@@ -426,8 +426,7 @@ int RGWSelectObj_ObjStore_S3::run_s3select_on_csv(const char* query, const char*
   } else if (m_header_info.compare("USE")==0) {
     csv.use_header_info=true;
   }
-
-  if(m_outputFormat == OutputFormat::JSON) {
+  if (m_outputFormat == OutputFormat::JSON) {
     csv.output_json_format = true;
   }
   m_s3_csv_object.set_csv_query(&s3select_syntax, csv);
@@ -482,7 +481,7 @@ int RGWSelectObj_ObjStore_S3::run_s3select_on_parquet(const char* query)
     //parsing the SQL statement.
     s3select_syntax.parse_query(m_sql_query.c_str());
     parquet_object::csv_definitions parquet;
-    if(m_outputFormat == OutputFormat::JSON) {
+    if (m_outputFormat == OutputFormat::JSON) {
     parquet.output_json_format = true;
     }
 
@@ -546,7 +545,7 @@ int RGWSelectObj_ObjStore_S3::run_s3select_on_json(const char* query, const char
     return -EINVAL;
   } 
 
-  if(m_outputFormat == OutputFormat::JSON) {
+  if (m_outputFormat == OutputFormat::JSON) {
     json.output_json_format = true;
   }
 

--- a/src/rgw/rgw_s3select.cc
+++ b/src/rgw/rgw_s3select.cc
@@ -287,6 +287,7 @@ RGWSelectObj_ObjStore_S3::RGWSelectObj_ObjStore_S3():
   m_object_size_for_processing(0),
   m_parquet_type(false),
   m_json_type(false),
+  m_outputFormat(OutputFormat::CSV),
   chunk_number(0),
   m_requested_range(0),
   m_scan_offset(1024),

--- a/src/rgw/rgw_s3select_private.h
+++ b/src/rgw/rgw_s3select_private.h
@@ -241,6 +241,11 @@ private:
   const char* s3select_json_error = "InvalidJsonType";
 
 public:
+  enum class OutputFormat {
+            CSV,
+            JSON
+        };
+  OutputFormat m_outputFormat = OutputFormat::CSV;
   unsigned int chunk_number;
   size_t m_requested_range;
   size_t m_scan_offset;


### PR DESCRIPTION
-- comparing AWS vs CEPH

JSON input: (it is based on the structure of https://www.kaggle.com/datasets/mathurinache/citation-network-dataset )

**[ { "o": { "o_id": 1, "o2": { "o2_inner": 123, "o3": { "o3_inner": 456 } } } }, { "o": { "o_id": 2 } }, { "o": { "o_id": 3 } }, { "o": { "o_id": 4 } }]**

the above JSON is an input for queries  { `cat  $JSON | jq .`  provides a pretty view }

Query : 
`aws s3api select-object-content --bucket galsalomon-bucket  --expression-type 'SQL' --input-serialization '{"JSON": {"Type": "DOCUMENT"}, "CompressionType": "NONE"}' --output-serialization '{"JSON": {"RecordDelimiter" : "\n"}}' --profile openshift-dev --key $(basename ${AWS_INPUT_OBJECT}) --expression 'select * from s3object[*];' /dev/stdout  | jq .`

AWS : provide the correct outout JSON structure.
CEPH: provides wrong output JSON structure, the inner parts show as a "flat key" (e.g. o.o2.o3.o3_inner. : 456)

Query:
`expression 'select _1.o.o_id+1 from s3object[*][*];' `

AWS and CEPH provide the same results but with a difference in query.
in the case of AWS, it uses the construct `s3object[*][*]` which is not accepted by CEPH (i did not find  s3object[\*][\*] in the documentation)


this construct (s3object[\*][\*]) enable to process non-named JSON array/object. 
(CEPH is skipping non-named JSON structure)

Query : 'select count(0) from s3object[*];' 
AWS : return 1 (for s3object[\*][\*] it returns 4)
CEPH : return 4

Query :  'select _1 from s3object[*];' 
AWS : returns the object as a single row (upon [\*][\*] it returns as 4 rows)
CEPH : return 4 rows , not JSON structure but NULL, (for about the same reason above, the engine provides "flat key", _1 is not handled as star-operation)
  

-- running teuthology 

on Albin PR https://github.com/ceph/ceph/pull/55492
with https://github.com/ceph/s3-tests/pull/575

TODO: 
update s3select(master), teuthology.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
