### PR TITLE
mgr/rgw: add ability for rgw realm bootstrap to create pools

### DIFF
--- a/src/pybind/mgr/rgw/module.py
+++ b/src/pybind/mgr/rgw/module.py
@@ -6,7 +6,13 @@ import base64
 import functools
 import sys
 
-from mgr_module import MgrModule, CLICommand, HandleCommandResult, Option
+from mgr_module import (
+    MgrModule,
+    CLICommand,
+    HandleCommandResult,
+    Option,
+    MonCommandFailed,
+)
 import orchestrator
 
 from ceph.deployment.service_spec import RGWSpec, PlacementSpec, SpecValidationError
@@ -46,6 +52,10 @@ else:
 
 
 class RGWSpecParsingError(Exception):
+    pass
+
+
+class PoolCreationError(Exception):
     pass
 
 
@@ -196,10 +206,14 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
         try:
             for spec in rgw_specs:
+                self.create_pools(spec)
                 RGWAM(self.env).realm_bootstrap(spec, start_radosgw)
         except RGWAMException as e:
             self.log.error('cmd run exception: (%d) %s' % (e.retcode, e.message))
             return HandleCommandResult(retval=e.retcode, stdout=e.stdout, stderr=e.stderr)
+        except PoolCreationError as e:
+            self.log.error(f'Pool creation failure: {str(e)}')
+            return HandleCommandResult(retval=-errno.EINVAL, stderr=str(e))
 
         return HandleCommandResult(retval=0, stdout="Realm(s) created correctly. Please, use 'ceph rgw realm tokens' to get the token.", stderr='')
 
@@ -228,6 +242,85 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                 rgw_specs.append(rgw_spec)
 
         return rgw_specs
+
+    def create_pools(self, spec: RGWSpec) -> None:
+        def _pool_create_command(
+            pool_name: str,
+            pool_type: str,
+            pool_attrs: Optional[Dict[str, Union[str, List[str]]]] = None
+        ) -> None:
+            try:
+                cmd_dict: Dict[str, Union[str, List[str]]] = {
+                    'prefix': 'osd pool create',
+                    'pool': pool_name,
+                    'pool_type': pool_type,
+                }
+                if pool_attrs:
+                    for k, v in pool_attrs.items():
+                        cmd_dict[k] = v
+                self.check_mon_command(cmd_dict)
+            except MonCommandFailed as e:
+                raise PoolCreationError(f'RGW module failed to create pool {pool_name} '
+                                        f'of type {pool_type} with attrs [{pool_attrs}]: {str(e)}')
+            # enable the rgw application on the pool
+            try:
+                self.check_mon_command({
+                    'prefix': 'osd pool application enable',
+                    'pool': pool_name,
+                    'app': 'rgw',
+                })
+            except MonCommandFailed as e:
+                raise PoolCreationError(f'Failed enabling application "rgw" on pool {pool_name}: {str(e)}')
+
+        zone_name = spec.rgw_zone
+        for pool_suffix in [
+            'buckets.index',
+            'meta',
+            'log',
+            'control'
+        ]:
+            # TODO: add size?
+            non_data_pool_attrs: Dict[str, Union[str, List[str]]] = {
+                'pg-num': '16' if 'index' in pool_suffix else '8',
+            }
+            _pool_create_command(f'{zone_name}.rgw.{pool_suffix}', 'replicated', non_data_pool_attrs)
+
+        if spec.data_pool_attributes:
+            if spec.data_pool_attributes.get('type', 'ec') == 'ec':
+                # we need to create ec profile
+                assert zone_name is not None
+                profile_name = self.create_zone_ec_profile(zone_name, spec.data_pool_attributes)
+                # now we can pass the ec profile into the pool create command
+                data_pool_attrs: Dict[str, Union[str, List[str]]] = {
+                    'erasure_code_profile': profile_name
+                }
+                if 'pg_num' in spec.data_pool_attributes:
+                    data_pool_attrs['pg_num'] = spec.data_pool_attributes['pg_num']
+                _pool_create_command(f'{zone_name}.rgw.buckets.data', 'erasure', data_pool_attrs)
+            else:
+                # replicated pool
+                data_pool_attrs = {k: v for k, v in spec.data_pool_attributes.items() if k != 'type'}
+                _pool_create_command(f'{zone_name}.rgw.buckets.data', 'replicated', data_pool_attrs)
+
+    def create_zone_ec_profile(self, zone_name: str, pool_attributes: Optional[Dict[str, str]]) -> str:
+        # creates ec profile and returns profile name
+        ec_pool_kv_pairs = {}
+        if pool_attributes is not None:
+            ec_pool_kv_pairs = {k: v for k, v in pool_attributes.items() if k not in ['type', 'pg_num']}
+        profile_name = f'{zone_name}_zone_data_pool_ec_profile'
+        profile_attrs = [f'{k}={v}' for k, v in ec_pool_kv_pairs.items()]
+        cmd_dict: Dict[str, Union[str, List[str]]] = {
+            'prefix': 'osd erasure-code-profile set',
+            'name': profile_name,
+        }
+        if profile_attrs:
+            cmd_dict['profile'] = profile_attrs
+        try:
+            self.check_mon_command(cmd_dict)
+        except MonCommandFailed as e:
+            raise PoolCreationError(f'RGW module failed to create ec profile {profile_name} '
+                                    f'with attrs {profile_attrs}: {str(e)}')
+        return profile_name
 
     @CLICommand('rgw realm zone-creds create', perm='rw')
     def _cmd_rgw_realm_new_zone_creds(self,


### PR DESCRIPTION
Specifically by setting the data_pool_attributes field in the RGW spec. For example
```
service_type: rgw
service_id: my_realm.my_zone
placement:
  count: 2
spec:
  data_pool_attributes:
    type: ec
    k: 6
    m: 2
  rgw_realm: my_realm
  rgw_zone: my_zone
  rgw_zonegroup: my_zonegroup
```
would create the my_zone.rgw.buckets.data pool as an ec pool with a new ec porfile with k=8 and m=2. Currently the ec profile fields this spec will make use of
are only "k", "m", "pg_num" and "crush-device-class". If other attributes are set, or if the pool type is "replicated" the key value pairs are assumed to
be ones that can be passed to the "ceph osd pool create" command. The other pools for the rgw zone (e.g. buckets index pool) are all made as replicated pool with
defaults settings





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
