### PR TITLE
mgr/test_orchestrator: add apply_mds command in the test_orch

### DIFF
--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -304,3 +304,11 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         assert all([isinstance(h[0], str) for h in spec.placement.hosts])
         assert all([isinstance(h[1], str) or h[1] is None for h in spec.placement.hosts])
         return spec.one_line_str()
+
+    @handle_orch_error
+    def apply_mds(self, spec):
+        #type: (ServiceSpec) -> str
+
+        assert not spec.placement.hosts or len(spec.placement.hosts) == spec.placement.count
+        assert all([isinstance(h, str) for h in spec.placement.hosts])
+        return spec.one_line_str()


### PR DESCRIPTION
so that when we are testing things with test_orchestrator as the orch back-end and do volume creation, it won't raise the below error
```
2024-07-19T13:40:46.349+0000 7f2d11a00640  0 [test_orchestrator ERROR orchestrator._interface]
Traceback (most recent call last):
  File "/ceph/src/pybind/mgr/orchestrator/_interface.py", line 139, in wrapper
    return OrchResult(f(*args, **kwargs))
  File "/ceph/src/pybind/mgr/orchestrator/_interface.py", line 618, in apply
    return raise_if_exception(reduce(merge, [fns[spec.service_type](spec) for spec in specs], OrchResult([])))
  File "/ceph/src/pybind/mgr/orchestrator/_interface.py", line 618, in <listcomp>
    return raise_if_exception(reduce(merge, [fns[spec.service_type](spec) for spec in specs], OrchResult([])))
  File "/ceph/src/pybind/mgr/orchestrator/_interface.py", line 762, in apply_mds
    raise NotImplementedError()
NotImplementedError
2024-07-19T13:40:46.349+0000 7f2d11a00640  0 [volumes ERROR volumes.fs.fs_util] Failed to create MDS daemons
Traceback (most recent call last):
  File "/ceph/src/pybind/mgr/volumes/fs/fs_util.py", line 55, in create_mds
    orchestrator.raise_if_exception(completion)
  File "/ceph/src/pybind/mgr/orchestrator/_interface.py", line 242, in raise_if_exception
    raise e
NotImplementedError
2024-07-19T13:40:46.350+0000 7f2d11a00640  0 [volumes INFO volumes.module] Finishing _cmd_fs_volume_create(name:foo, placement:1 ) < "None"
2024-07-19T13:40:46.350+0000 7f2d11a00640  0 [dashboard ERROR exception] Internal Server Error
Traceback (most recent call last):
  File "/ceph/src/pybind/mgr/dashboard/services/exception.py", line 47, in dashboard_exception_handler
    return handler(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/cherrypy/_cpdispatch.py", line 54, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/ceph/src/pybind/mgr/dashboard/controllers/_base_controller.py", line 263, in inner
    ret = func(*args, **kwargs)
  File "/ceph/src/pybind/mgr/dashboard/controllers/_rest_controller.py", line 193, in wrapper
    return func(*vpath, **params)
  File "/ceph/src/pybind/mgr/dashboard/controllers/cephfs.py", line 65, in create
    raise RuntimeError(
RuntimeError: Error creating volume foo with placement {'placement': {}, 'unmanaged': False}:
```

Fixes: https://tracker.ceph.com/issues/67044





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
