### PR TITLE
doc/cephadm/upgrade: ceph-ci containers are hosted at quay.ceph.io

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -193,7 +193,7 @@ you need. For example, the following command upgrades to a development build:
 
 .. prompt:: bash #
 
-  ceph orch upgrade start --image quay.io/ceph-ci/ceph:recent-git-branch-name
+  ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:recent-git-branch-name
 
 For more information about available container images, see :ref:`containers`.
 


### PR DESCRIPTION
relates to https://tracker.ceph.com/issues/66937#note-13 where:
> docker pull quay.io/ceph-ci/ceph:wip-66937-squid
Error response from daemon: unauthorized: access to the requested resource is not authorized

https://docs.ceph.com/en/latest/cephadm/upgrade/#using-customized-container-images recommended this url format for development builds

but that doc also links to https://docs.ceph.com/en/latest/install/containers/#development-builds which refers to `https://quay.ceph.io/organization/ceph-ci`

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
