### PR TITLE
rgw: add support sse-c to bucket policy conditions

### DIFF
--- a/src/rgw/rgw_iam_policy_keywords.gperf
+++ b/src/rgw/rgw_iam_policy_keywords.gperf
@@ -103,6 +103,7 @@ Null, TokenKind::cond_op, TokenID::Null, (uint64_t) Type::null, true, true
 #s3:x-amz-grant-full-control, TokenKind::cond_key, TokenID::s3x_amz_grant_permission, (uint64_t) Type::boolean, true, false
 #s3:x-amz-copy-source, TokenKind::cond_key, TokenID::s3x_amz_copy_source, (uint64_t) Type::string, true, false
 #s3:x-amz-server-side-encryption, TokenKind::cond_key, TokenID::s3x_amz_server_side_encryption, (uint64_t) Type::boolean, true, false
+#s3:x-amz-server-side-encryption-customer-algorithm, TokenKind::cond_key, TokenID::s3x_amz_server_side_encryption_customer_algorithm, (uint64_t) Type::boolean, true, false
 #s3:x-amz-server-side-encryption-aws-kms-key-id, TokenKind::cond_key, TokenID::s3x_amz_server_side_encryption_aws_kms_key_id, (uint64_t) Type::arn, true, false
 #s3:x-amz-metadata-directive, TokenKind::cond_key, TokenID::s3x_amz_metadata_directive, (uint64_t) Type::string, true, false
 #s3:x-amz-storage-class, TokenKind::cond_key, TokenID::s3x_amz_storage_class, (uint64_t) Type::string, true, false

--- a/src/rgw/rgw_iam_policy_keywords.h
+++ b/src/rgw/rgw_iam_policy_keywords.h
@@ -77,6 +77,7 @@ enum class TokenID {
   s3x_amz_grant_permission,
   s3x_amz_copy_source,
   s3x_amz_server_side_encryption,
+  s3x_amz_server_side_encryption_customer_algorithm,
   s3x_amz_server_side_encryption_aws_kms_key_id,
   s3x_amz_metadata_directive,
   s3x_amz_storage_class,

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -772,6 +772,12 @@ static void rgw_iam_add_crypt_attrs(rgw::IAM::Environment& e,
     rgw_add_to_iam_environment(e, s3_encrypt_attr, h->second);
   }
 
+  constexpr auto customer_algo_attr = "x-amz-server-side-encryption-customer-algorithm";
+  constexpr auto s3_customer_algo_attr = "s3:x-amz-server-side-encryption-customer-algorithm";
+  if (auto h = attrs.find(customer_algo_attr); h != attrs.end()) {
+    rgw_add_to_iam_environment(e, s3_customer_algo_attr, h->second);
+  }
+
   constexpr auto kms_attr = "x-amz-server-side-encryption-aws-kms-key-id";
   constexpr auto s3_kms_attr = "s3:x-amz-server-side-encryption-aws-kms-key-id";
   if (auto h = attrs.find(kms_attr); h != attrs.end()) {


### PR DESCRIPTION
Allow restricting requests regarding SSE-C encryption with bucket policy.
cf. https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html#ssec-require-condition-key

Fixes: https://tracker.ceph.com/issues/67053