### PR TITLE
make-dist: replace all '-' for '.' for rpm release

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -23,7 +23,7 @@ version=$1
 [ -z "$version" ] && version=$(git describe --long --match 'v*' | sed 's/^v//')
 if expr index $version '-' > /dev/null; then
     rpm_version=$(echo $version | cut -d - -f 1-1)
-    rpm_release=$(echo $version | cut -d - -f 2- | sed 's/-/./')
+    rpm_release=$(echo $version | cut -d - -f 2- | sed 's/-/./g')
 else
     rpm_version=$version
     rpm_release=0


### PR DESCRIPTION
Otherwise, a version like 'vX.Y.Z-foo-bar-baz' would end up as an rpm release of 'foo.bar-baz' in the spec file, and rpm will not like that very much because of that extra '-'.

Signed-off-by: Joao Eduardo Luis \<joao@clyso.com>
