### PR TITLE
quincy: common: fix compilation warnings in numa.cc

### DIFF
--- a/src/common/numa.cc
+++ b/src/common/numa.cc
@@ -156,6 +156,7 @@ static int easy_readdir(const std::string& dir, std::set<std::string> *out)
   return 0;
 }
 
+#ifdef HAVE_DPDK
 static std::string get_task_comm(pid_t tid)
 {
   static const char* comm_fmt = "/proc/self/task/%d/comm";
@@ -173,7 +174,7 @@ static std::string get_task_comm(pid_t tid)
   if (n < 0) {
     return "";
   }
-  assert(n <= sizeof(name));
+  assert(static_cast<size_t>(n) <= sizeof(name));
   if (name[n - 1] == '\n') {
     name[n - 1] = '\0';
   } else {
@@ -181,6 +182,7 @@ static std::string get_task_comm(pid_t tid)
   }
   return name;
 }
+#endif
 
 int set_cpu_affinity_all_threads(size_t cpu_set_size, cpu_set_t *cpu_set)
 {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67064

---

backport of https://github.com/ceph/ceph/pull/44794
parent tracker: https://tracker.ceph.com/issues/67063

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh