### PR TITLE
doc/dev/crimson: making it more user-friendly, re-arranging chapters and fixing typos

### DIFF
--- a/doc/dev/crimson/crimson.rst
+++ b/doc/dev/crimson/crimson.rst
@@ -16,8 +16,7 @@ Building Crimson
 Crimson is not enabled by default. Enable it at build time by running::
 
   $ WITH_SEASTAR=true ./install-deps.sh
-  $ mkdir build && cd build
-  $ cmake -DWITH_SEASTAR=ON ..
+  $ ./do_cmake.sh -DWITH_SEASTAR=ON
 
 Please note, `ASan`_ is enabled by default if Crimson is built from a source
 cloned using ``git``.
@@ -28,7 +27,7 @@ Testing crimson with cephadm
 ===============================
 
 The Ceph CI/CD pipeline builds containers with
-``crimson-osd`` subsitituted for ``ceph-osd``.
+``crimson-osd`` substituted for ``ceph-osd``.
 
 Once a branch at commit <sha1> has been built and is available in
 ``shaman``, you can deploy it using the cephadm instructions outlined
@@ -44,27 +43,6 @@ use a Crimson build:
 You'll likely need to supply the ``--allow-mismatched-release`` flag to
 use a non-release branch.
 
-Additionally, prior to deploying OSDs, you'll need to
-`Configure Crimson with Bluestore`_ and enable Crimson to
-direct the default pools to be created as Crimson pools.  From the cephadm shell run:
-
-.. prompt:: bash #
-
-   ceph config set global 'enable_experimental_unrecoverable_data_corrupting_features' crimson
-   ceph osd set-allow-crimson --yes-i-really-mean-it
-   ceph config set mon osd_pool_default_crimson true
-
-The first command enables the ``crimson`` experimental feature.  Crimson
-is highly experimental, and malfunctions including crashes
-and data loss are to be expected.
-
-The second enables the ``allow_crimson`` OSDMap flag.  The monitor will
-not allow ``crimson-osd`` to boot without that flag.
-
-The last causes pools to be created by default with the ``crimson`` flag.
-Crimson pools are restricted to operations supported by Crimson.
-``Crimson-osd`` won't instantiate PGs from non-Crimson pools.
-
 Configure Crimson with Bluestore
 ================================
 
@@ -76,7 +54,7 @@ one of the two following configuration options:
 
    #. These two options, along with ``crimson_alien_op_num_threads``,
       can't be changed after deployment.
-   #. `vstart.sh`_ sets this options using the ``--crimson-smp`` flag.
+   #. `vstart.sh`_ sets these options using the ``--crimson-smp`` flag.
 
 
 1) ``crimson_seastar_num_threads``
@@ -103,7 +81,7 @@ one of the two following configuration options:
 
 2) ``crimson_seastar_cpu_cores`` and ``crimson_alien_thread_cpu_cores``.
 
-   Explictily set the CPU core allocation for each ``crimson-osd``
+   Explicitly set the CPU core allocation for each ``crimson-osd``
    and for the BlueStore back end. It's recommended for each set to be mutually exclusive.
 
    For example, for deploying two nodes with eight CPU cores and two OSDs each:
@@ -144,10 +122,112 @@ one of the two following configuration options:
 Running Crimson
 ===============
 
-As you might expect, Crimson does not yet have as extensive a feature set as does ``ceph-osd``.
+.. note::
+   Crimson is in a tech preview stage. 
+   As you might expect, Crimson does not yet have as extensive a feature set as does ceph-osd. 
+   Malfunctions including crashes and data loss are to be expected. 
 
-object store backend
---------------------
+Enabling Crimson
+================
+
+After building Crimson and starting your cluster, but prior to deploying OSDs, you'll need to
+`Configure Crimson with Bluestore`_ and enable Crimson to
+direct the default pools to be created as Crimson pools.  You can proceed by running the following after you have a running cluster:
+
+.. note::
+   `vstart.sh`_ enables crimson automatically when `--crimson` is used.
+
+.. prompt:: bash #
+
+   ceph config set global 'enable_experimental_unrecoverable_data_corrupting_features' crimson
+   ceph osd set-allow-crimson --yes-i-really-mean-it
+   ceph config set mon osd_pool_default_crimson true
+
+The first command enables the ``crimson`` experimental feature.  
+
+The second enables the ``allow_crimson`` OSDMap flag.  The monitor will
+not allow ``crimson-osd`` to boot without that flag.
+
+The last causes pools to be created by default with the ``crimson`` flag.
+Crimson pools are restricted to operations supported by Crimson.
+``Crimson-osd`` won't instantiate PGs from non-Crimson pools.
+
+vstart.sh
+=========
+
+The following options can be used with ``vstart.sh``.
+
+``--crimson``
+    Start ``crimson-osd`` instead of ``ceph-osd``.
+
+``--nodaemon``
+    Do not daemonize the service.
+
+``--redirect-output``
+    Redirect the ``stdout`` and ``stderr`` to ``out/$type.$num.stdout``.
+
+``--osd-args``
+    Pass extra command line options to ``crimson-osd`` or ``ceph-osd``.
+    This is useful for passing Seastar options to ``crimson-osd``. For
+    example, one can supply ``--osd-args "--memory 2G"`` to set the amount of
+    memory to use. Please refer to the output of::
+
+      crimson-osd --help-seastar
+
+    for additional Seastar-specific command line options.
+
+``--crimson-smp``
+    The number of cores to use for each OSD.
+    If BlueStore is used, the balance of available cores
+    (as determined by `nproc`) will be assigned to the object store.
+
+``--bluestore``
+    Use the alienized BlueStore as the object store backend. This is the default (see below section on the `object store backend`_ for more details)
+
+``--cyanstore``
+    Use CyanStore as the object store backend.
+
+``--memstore``
+    Use the alienized MemStore as the object store backend.
+
+``--seastore``
+    Use SeaStore as the back end object store.
+
+``--seastore-devs``
+    Specify the block device used by SeaStore.
+
+``--seastore-secondary-devs``
+    Optional.  SeaStore supports multiple devices.  Enable this feature by
+    passing the block device to this option.
+
+``--seastore-secondary-devs-type``
+    Optional.  Specify the type of secondary devices.  When the secondary
+    device is slower than main device passed to ``--seastore-devs``, the cold
+    data in faster device will be evicted to the slower devices over time.
+    Valid types include ``HDD``, ``SSD``(default), ``ZNS``, and ``RANDOM_BLOCK_SSD``
+    Note secondary devices should not be faster than the main device.
+
+To start a cluster with a single Crimson node, run::
+
+  $  MGR=1 MON=1 OSD=1 MDS=0 RGW=0 ../src/vstart.sh \
+    --without-dashboard --bluestore --crimson \
+    --redirect-output
+
+Another SeaStore example::
+
+  $  MGR=1 MON=1 OSD=1 MDS=0 RGW=0 ../src/vstart.sh -n -x \
+    --without-dashboard --seastore \
+    --crimson --redirect-output \
+    --seastore-devs /dev/sda \
+    --seastore-secondary-devs /dev/sdb \
+    --seastore-secondary-devs-type HDD
+
+Stop this ``vstart`` cluster by running::
+
+  $ ../src/stop.sh --crimson
+
+Object Store Backend
+====================
 
 At the moment, ``crimson-osd`` offers both native and alienized object store
 backends. The native object store backends perform IO using the SeaStar reactor.
@@ -168,7 +248,7 @@ managed by the Seastar framework. They are:
 
 .. describe:: memstore
 
-   The memory backed object store
+   The memory backend object store
 
 .. describe:: bluestore
 
@@ -186,7 +266,7 @@ a replica of the thread that called `fork()`_. Tackling this problem in Crimson
 would unnecessarily complicate the code.
 
 Since supported GNU/Linux distributions use ``systemd``, which is able to
-daemonize the application, there is no need to daemonize ourselves. 
+daemonize processes, there is no need to daemonize ourselves. 
 Those using sysvinit can use ``start-stop-daemon`` to daemonize ``crimson-osd``.
 If this is does not work out, a helper utility may be devised.
 
@@ -220,98 +300,19 @@ does not send log messages directly to a specified ``log_file``. It writes
 the logging messages to stdout and/or syslog. This behavior can be
 changed using ``--log-to-stdout`` and ``--log-to-syslog`` command line
 options. By default, ``log-to-stdout`` is enabled, and ``--log-to-syslog`` is disabled.
-
-
-vstart.sh
----------
-
-The following options can be used with ``vstart.sh``.
-
-``--crimson``
-    Start ``crimson-osd`` instead of ``ceph-osd``.
-
-``--nodaemon``
-    Do not daemonize the service.
-
-``--redirect-output``
-    Redirect the ``stdout`` and ``stderr`` to ``out/$type.$num.stdout``.
-
-``--osd-args``
-    Pass extra command line options to ``crimson-osd`` or ``ceph-osd``.
-    This is useful for passing Seastar options to ``crimson-osd``. For
-    example, one can supply ``--osd-args "--memory 2G"`` to set the amount of
-    memory to use. Please refer to the output of::
-
-      crimson-osd --help-seastar
-
-    for additional Seastar-specific command line options.
-
-``--cyanstore``
-    Use CyanStore as the object store backend.
-
-``--bluestore``
-    Use the alienized BlueStore as the object store backend. This is the default.
-
-``--crimson-smp``
-    The number of cores to use for each OSD.
-    If BlueStore is used, the balance of available cores
-    (as determined by `nproc`) will be assigned to the object store.
-
-``--memstore``
-    Use the alienized MemStore as the object store backend.
-
-``--seastore``
-    Use SeaStore as the back end object store.
-
-``--seastore-devs``
-    Specify the block device used by SeaStore.
-
-``--seastore-secondary-devs``
-    Optional.  SeaStore supports multiple devices.  Enable this feature by
-    passing the block device to this option.
-
-``--seastore-secondary-devs-type``
-    Optional.  Specify the type of secondary devices.  When the secondary
-    device is slower than main device passed to ``--seastore-devs``, the cold
-    data in faster device will be evicted to the slower devices over time.
-    Valid types include ``HDD``, ``SSD``(default), ``ZNS``, and ``RANDOM_BLOCK_SSD``
-    Note secondary devices should not be faster than the main device.
-
-To start a cluster with a single Crimson node, run::
-
-  $  MGR=1 MON=1 OSD=1 MDS=0 RGW=0 ../src/vstart.sh -n -x \
-    --without-dashboard --cyanstore \
-    --crimson --redirect-output \
-    --osd-args "--memory 4G"
-
-Here we assign 4 GiB memory and a single thread running on core-0 to ``crimson-osd``.
-
-Another SeaStore example::
-
-  $  MGR=1 MON=1 OSD=1 MDS=0 RGW=0 ../src/vstart.sh -n -x \
-    --without-dashboard --seastore \
-    --crimson --redirect-output \
-    --seastore-devs /dev/sda \
-    --seastore-secondary-devs /dev/sdb \
-    --seastore-secondary-devs-type HDD
-
-Stop this ``vstart`` cluster by running::
-
-  $ ../src/stop.sh --crimson
-
 Metrics and Tracing
 ===================
 
 Crimson offers three ways to report stats and metrics.
 
-pg stats reported to mgr
+PG stats reported to mgr
 ------------------------
 
 Crimson collects the per-pg, per-pool, and per-osd stats in a `MPGStats`
 message which is sent to the Ceph Managers. Manager modules can query
 them using the `MgrModule.get()` method.
 
-asock command
+Asock command
 -------------
 
 An admin socket command is offered for dumping metrics::
@@ -334,7 +335,7 @@ see `Prometheus`_ for more details.
 Profiling Crimson
 =================
 
-fio
+Fio
 ---
 
 ``crimson-store-nbd`` exposes configurable ``FuturizedStore`` internals as an
@@ -506,7 +507,7 @@ When a Seastar application crashes, it leaves us with a backtrace of addresses, 
 The ``seastar-addr2line`` utility provided by Seastar can be used to map these
 addresses to functions. The script expects input on ``stdin``,
 so we need to copy and paste the above addresses, then send EOF by inputting
-``control-D`` in the terminal.  One might  use ``echo`` or ``cat`` instead`::
+``control-D`` in the terminal.  One might  use ``echo`` or ``cat`` instead::
 
   $ ../src/seastar/scripts/seastar-addr2line -e bin/crimson-osd
 


### PR DESCRIPTION
This began as just fixing a few small things, however it was then recommended to me that I make any other changes I felt could be appropriate, since I am probably the target audience for this kind of document - a new user/developer of Crimson. A summary of the changes are as follows:

- Moving the section about setting essential flags which activate Crimson to its own place
- Making the commands safer and more appropriate; in particular the cmake and vstart commands
- Re-arranging the chapters to flow in order of the user's actions in setting up; that is, building Ceph for Crimson, starting the cluster, then setting the flags, then learning about extras and Crimson in general
- Fixing some typos   
- Emphasising the danger of activating Crimson in its own 'note' box for extra highlighting

I've added some comments to the 'files changed' section in an attempt to speed up the process of review. Blocks of text that have been rearranged _and_ edited can be very messy to review, so hopefully the in-line comments will help with that. 

Thanks!
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
