### PR TITLE
mgr/dashboard: use assertEqual in test_iscsi

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -225,8 +225,8 @@ class IscsiTestController(ControllerTestCase, KVStoreMockMixin):
         # pylint: disable=protected-access
         with self.assertRaises(DashboardException) as ctx:
             IscsiTarget._validate(None, None, None, None, None, None)
-        self.assertEquals(ctx.exception.__str__(),
-                          "Target IQN is required")
+        self.assertEqual(ctx.exception.__str__(),
+                         "Target IQN is required")
 
     def test_validate_error_portals(self):
         # pylint: disable=protected-access
@@ -238,13 +238,13 @@ class IscsiTestController(ControllerTestCase, KVStoreMockMixin):
         settings = {'config': {'minimum_gateways': 1}}
         with self.assertRaises(DashboardException) as ctx:
             IscsiTarget._validate(target_iqn, target_controls, portals, disks, groups, settings)
-        self.assertEquals(ctx.exception.__str__(),
-                          "At least one portal is required")
+        self.assertEqual(ctx.exception.__str__(),
+                         "At least one portal is required")
         settings = {'config': {'minimum_gateways': 2}}
         with self.assertRaises(DashboardException) as ctx:
             IscsiTarget._validate(target_iqn, target_controls, portals, disks, groups, settings)
-        self.assertEquals(ctx.exception.__str__(),
-                          "At least 2 portals are required")
+        self.assertEqual(ctx.exception.__str__(),
+                         "At least 2 portals are required")
 
     def test_validate_error_target_control(self):
         # pylint: disable=protected-access
@@ -266,15 +266,15 @@ class IscsiTestController(ControllerTestCase, KVStoreMockMixin):
         }
         with self.assertRaises(DashboardException) as ctx:
             IscsiTarget._validate(target_iqn, target_controls, portals, disks, groups, settings)
-        self.assertEquals(ctx.exception.__str__(),
-                          "Target control target_name must be >= 1")
+        self.assertEqual(ctx.exception.__str__(),
+                         "Target control target_name must be >= 1")
         target_controls = {
             'target_name': 3
         }
         with self.assertRaises(DashboardException) as ctx:
             IscsiTarget._validate(target_iqn, target_controls, portals, disks, groups, settings)
-        self.assertEquals(ctx.exception.__str__(),
-                          "Target control target_name must be <= 2")
+        self.assertEqual(ctx.exception.__str__(),
+                         "Target control target_name must be <= 2")
 
     @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
     def test_validate_error_disk_control(self, _validate_image_mock):
@@ -301,13 +301,13 @@ class IscsiTestController(ControllerTestCase, KVStoreMockMixin):
         }
         with self.assertRaises(DashboardException) as ctx:
             IscsiTarget._validate(target_iqn, target_controls, portals, disks, groups, settings)
-        self.assertEquals(ctx.exception.__str__(),
-                          "Disk control max_data_area_mb must be >= 129")
+        self.assertEqual(ctx.exception.__str__(),
+                         "Disk control max_data_area_mb must be >= 129")
         settings['disk_controls_limits']['user:rbd']['max_data_area_mb']['min'] = 1
         with self.assertRaises(DashboardException) as ctx:
             IscsiTarget._validate(target_iqn, target_controls, portals, disks, groups, settings)
-        self.assertEquals(ctx.exception.__str__(),
-                          "Disk control max_data_area_mb must be <= 127")
+        self.assertEqual(ctx.exception.__str__(),
+                         "Disk control max_data_area_mb must be <= 127")
 
     @mock.patch('dashboard.controllers.iscsi.IscsiTarget._validate_image')
     def test_delete(self, _validate_image_mock):


### PR DESCRIPTION
Python asks in multiple places to use assertEqual instead of assertEquals:

  DeprecationWarning: Please use assertEqual instead.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
