### PR TITLE
common/async: fix duplicate definition errors from SharedMutexImpl

### DIFF
--- a/src/common/async/detail/shared_mutex.h
+++ b/src/common/async/detail/shared_mutex.h
@@ -156,7 +156,7 @@ inline void SharedMutexImpl::lock()
   }
 }
 
-void SharedMutexImpl::lock(boost::system::error_code& ec)
+inline void SharedMutexImpl::lock(boost::system::error_code& ec)
 {
   std::unique_lock lock{mutex};
 
@@ -181,7 +181,7 @@ inline bool SharedMutexImpl::try_lock()
   return false;
 }
 
-void SharedMutexImpl::unlock()
+inline void SharedMutexImpl::unlock()
 {
   RequestList granted;
   {
@@ -245,7 +245,7 @@ inline void SharedMutexImpl::lock_shared()
   }
 }
 
-void SharedMutexImpl::lock_shared(boost::system::error_code& ec)
+inline void SharedMutexImpl::lock_shared(boost::system::error_code& ec)
 {
   std::unique_lock lock{mutex};
 
@@ -303,8 +303,8 @@ inline void SharedMutexImpl::cancel()
   complete(std::move(canceled), boost::asio::error::operation_aborted);
 }
 
-void SharedMutexImpl::complete(RequestList&& requests,
-                               boost::system::error_code ec)
+inline void SharedMutexImpl::complete(RequestList&& requests,
+                                      boost::system::error_code ec)
 {
   while (!requests.empty()) {
     auto& request = requests.front();


### PR DESCRIPTION
the linker complains that several SharedMutexImpl functions are duplicated, if "common/async/shared_mutex.h" is included by more than one translation unit

added 'inline' to the function definitions so they're shared instead of duplicated

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
