### PR TITLE
build: fix linking problem around the replayer tool

### DIFF
--- a/src/test/objectstore/allocsim/CMakeLists.txt
+++ b/src/test/objectstore/allocsim/CMakeLists.txt
@@ -6,5 +6,6 @@ target_link_libraries(replayer
     PRIVATE
     fmt
     librados
+    pthread
     Boost::program_options
 )


### PR DESCRIPTION
```
[2/634] Linking CXX executable bin/replayer
FAILED: bin/replayer
: && /opt/rh/gcc-toolset-11/root/usr/bin/g++ -O2 -g -DNDEBUG -rdynamic -pie src/test/objectstore/allocsim/CMakeFiles/replayer.dir/ops_replayer.cc.o -o bin/replayer  -Wl,-rpath,/home/rzarzynski/ceph1/build/lib  l
ib/libfmt.a  lib/librados.so.2.0.0  boost/lib/libboost_program_options.a  lib/libfmt.a  boost/lib/libboost_program_options.a  -Wl,-rpath-link,/home/rzarzynski/ceph1/build/lib  -Wl,--as-needed -latomic && :
/opt/rh/gcc-toolset-11/root/usr/bin/ld: src/test/objectstore/allocsim/CMakeFiles/replayer.dir/ops_replayer.cc.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/opt/rh/gcc-toolset-11/root/usr/bin/ld: /lib64/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
