### PR TITLE
quincy: python-common: handle "anonymous_access: false" in to_json of Grafana spec

### DIFF
--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -383,6 +383,14 @@ spec:
   privacy_protocol: AES
   snmp_destination: 192.168.1.42:162
   snmp_version: V3
+---
+service_type: grafana
+service_name: grafana
+placement:
+  count: 1
+spec:
+  anonymous_access: false
+  initial_admin_password: password
 """.split('---\n'))
 def test_yaml(y):
     data = yaml.safe_load(y)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65726

---

backport of https://github.com/ceph/ceph/pull/56928
parent tracker: https://tracker.ceph.com/issues/65511

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh