### PR TITLE
quincy: mgr/cephadm: cleanup iscsi keyring upon daemon removal

### DIFF
--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -160,7 +160,8 @@ class IscsiService(CephService):
         """
         Called after the daemon is removed.
         """
-        logger.debug(f'Post remove daemon {self.TYPE}.{daemon.daemon_id}')
+        # to clean the keyring up
+        super().post_remove(daemon, is_failed_deploy=is_failed_deploy)
 
         # remove config for dashboard iscsi gateways
         ret, out, err = self.mgr.mon_command({


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65950

---

backport of https://github.com/ceph/ceph/pull/57181
parent tracker: https://tracker.ceph.com/issues/65717

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh