### PR TITLE
quincy: cephadm: turn off cgroups_split setting  when bootstrapping with --no-cgroups-split

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -5919,6 +5919,10 @@ def command_bootstrap(ctx):
 
     cli(['config', 'set', 'mgr', 'mgr/cephadm/container_init', str(ctx.container_init), '--force'])
 
+    if ctx.no_cgroups_split:
+        logger.info('Setting mgr/cephadm/cgroups_split to false')
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/cgroups_split', 'false', '--force'])
+
     if not ctx.skip_dashboard:
         prepare_dashboard(ctx, uid, gid, cli, wait_for_mgr_restart)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66957

---

backport of https://github.com/ceph/ceph/pull/58379
parent tracker: https://tracker.ceph.com/issues/66848

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh