### PR TITLE
crimson: access coll_map under alien tp with a lock

### DIFF
--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -233,12 +233,9 @@ seastar::future<CollectionRef> AlienStore::create_new_collection(const coll_t& c
   logger().debug("{}", __func__);
   assert(tp);
   return tp->submit([this, cid] {
-    return store->create_new_collection(cid);
-  }).then([this, cid] (ObjectStore::CollectionHandle c) {
-    return seastar::make_ready_future<CollectionRef>(
-      get_alien_coll_ref(std::move(c)));
+    ObjectStore::CollectionHandle c = store->create_new_collection(cid);
+    return get_alien_coll_ref(std::move(c));
   });
-
 }
 
 seastar::future<CollectionRef> AlienStore::open_collection(const coll_t& cid)
@@ -246,13 +243,12 @@ seastar::future<CollectionRef> AlienStore::open_collection(const coll_t& cid)
   logger().debug("{}", __func__);
   assert(tp);
   return tp->submit([this, cid] {
-    return store->open_collection(cid);
-  }).then([this] (ObjectStore::CollectionHandle c) {
+    ObjectStore::CollectionHandle c = store->open_collection(cid);
     if (!c) {
-      return seastar::make_ready_future<CollectionRef>();
+      return CollectionRef{};
+    } else {
+      return get_alien_coll_ref(std::move(c));
     }
-    return seastar::make_ready_future<CollectionRef>(
-      get_alien_coll_ref(std::move(c)));
   });
 }
 

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -131,6 +131,7 @@ seastar::future<> AlienStore::stop()
     for (auto [cid, ch]: coll_map) {
       static_cast<AlienCollection*>(ch.get())->collection.reset();
     }
+    coll_map.clear();
     store.reset();
     cct.reset();
     g_ceph_context = nullptr;

--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -150,5 +150,6 @@ private:
    *    are released before unmounting and stopping the store.
    */
   std::unordered_map<coll_t, CollectionRef> coll_map;
+  CollectionRef get_alien_coll_ref(ObjectStore::CollectionHandle c);
 };
 }

--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -148,6 +148,8 @@ private:
    *    instance to the alien thread pool to be released.
    * 2. OSD shutdown needs to *guarantee* that all outstanding CollectionRefs
    *    are released before unmounting and stopping the store.
+   *
+   * coll_map is accessed exclusively from alien threadpool threads.
    */
   std::unordered_map<coll_t, CollectionRef> coll_map;
   CollectionRef get_alien_coll_ref(ObjectStore::CollectionHandle c);

--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -149,8 +149,10 @@ private:
    * 2. OSD shutdown needs to *guarantee* that all outstanding CollectionRefs
    *    are released before unmounting and stopping the store.
    *
-   * coll_map is accessed exclusively from alien threadpool threads.
+   * coll_map is accessed exclusively from alien threadpool threads under the
+   * coll_map_lock.
    */
+  std::mutex coll_map_lock;
   std::unordered_map<coll_t, CollectionRef> coll_map;
   CollectionRef get_alien_coll_ref(ObjectStore::CollectionHandle c);
 };


### PR DESCRIPTION


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
