### PR TITLE
script/backport-create-issue: retry without if assignee is invalid

### DIFF
--- a/src/script/backport-create-issue
+++ b/src/script/backport-create-issue
@@ -34,7 +34,7 @@ import os
 import re
 import time
 from redminelib import Redmine  # https://pypi.org/project/python-redmine/
-from redminelib.exceptions import ResourceAttrError
+from redminelib.exceptions import ResourceAttrError, ValidationError
 
 redmine_endpoint = "https://tracker.ceph.com"
 project_name = "Ceph"
@@ -239,16 +239,26 @@ def update_relations(r, issue, dry_run):
         if dry_run:
             logging.info(url(issue) + " add backport to " + release)
             continue
-        other = r.issue.create(project_id=issue['project']['id'],
-                               tracker_id=backport_tracker_id,
-                               subject=subject,
-                               priority_id=issue['priority']['id'],
-                               assigned_to_id=assigned_to_id,
-                               target_version=None,
-                               custom_fields=[{
-                                   "id": release_id,
-                                   "value": release,
-                               }])
+        create_args = {
+            "project_id": issue['project']['id'],
+            "tracker_id": backport_tracker_id,
+            "subject": subject,
+            "priority_id": issue['priority']['id'],
+            "assigned_to_id": assigned_to_id,
+            "target_version": None,
+            "custom_fields": [
+                {
+                    "id": release_id,
+                    "value": release,
+                }
+            ]
+        }
+        try:
+            other = r.issue.create(**create_args)
+        except ValidationError as e:
+            # try without an assignee
+            del create_args['assigned_to_id']
+            other = r.issue.create(**create_args)
         logging.debug("Rate-limiting to avoid seeming like a spammer")
         time.sleep(delay_seconds)
         r.issue_relation.create(issue_id=issue['id'],


### PR DESCRIPTION
Resolves:

    WARNING:root:Missing issues will be created in Backport tracker of the relevant Redmine project
    INFO:root:Redmine key was read from '$REDMINE_API_KEY'; using it
    INFO:root:Processing 35 issues with status Pending Backport
    Traceback (most recent call last):
      File "/home/runner/work/ceph/ceph/src/script/backport-create-issue", line 411, in <module>
        iterate_over_backports(redmine, issues, dry_run=args.dry_run)
      File "/home/runner/work/ceph/ceph/src/script/backport-create-issue", line 354, in iterate_over_backports
        update_relations(r, issue, dry_run)
      File "/home/runner/work/ceph/ceph/src/script/backport-create-issue", line 242, in update_relations
        other = r.issue.create(project_id=issue['project']['id'],
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/redminelib/managers/base.py", line 187, in create
        response = self.redmine.engine.request(self.resource_class.http_method_create, url, data=request)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/redminelib/engines/base.py", line 83, in request
        return self.process_response(self.session.request(method, url, **kwargs))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/redminelib/engines/base.py", line 178, in process_response
        raise exceptions.ValidationError(', '.join(': '.join(e) if isinstance(e, list) else e for e in errors))
    redminelib.exceptions.ValidationError: Assignee is invalid
    Examining issue#66797 (1/35)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
