### PR TITLE
squid: mgr/dashboard: Add a new chart for replication delta per shard in rgw sync overview grafana dashboard

### DIFF
--- a/monitoring/ceph-mixin/dashboards/rgw.libsonnet
+++ b/monitoring/ceph-mixin/dashboards/rgw.libsonnet
@@ -112,6 +112,45 @@ local g = import 'grafonnet/grafana.libsonnet';
         8,
         7
       ),
+      $.timeSeriesPanel(
+        lineInterpolation='linear',
+        lineWidth=1,
+        drawStyle='line',
+        axisPlacement='auto',
+        title='Replication(Time) Delta per shard',
+        datasource='$datasource',
+        gridPosition={ h: 7, w: 16, x: 8, y: 7 },
+        fillOpacity=0,
+        pointSize=5,
+        showPoints='auto',
+        unit='s',
+        displayMode='table',
+        showLegend=true,
+        placement='right',
+        tooltip={ mode: 'multi', sort: 'desc' },
+        stackingMode='none',
+        spanNulls=false,
+        decimals=2,
+        thresholdsMode='absolute',
+        sortBy='Last *',
+        sortDesc=true
+      )
+      .addCalcs(['lastNotNull'])
+      .addThresholds([
+        { color: 'green', value: null },
+        { color: 'red', value: 80 },
+      ])
+      .addTargets(
+        [
+          $.addTargetSchema(
+            expr='rate(ceph_rgw_sync_delta_sync_delta[$__rate_interval])',
+            datasource='$datasource',
+            instant=false,
+            legendFormat='{{instance_id}} - {{shard_id}}',
+            range=true,
+          ),
+        ]
+      ),
     ]),
   'radosgw-overview.json':
     local RgwOverviewPanel(

--- a/monitoring/ceph-mixin/dashboards_out/radosgw-sync-overview.json
+++ b/monitoring/ceph-mixin/dashboards_out/radosgw-sync-overview.json
@@ -416,6 +416,100 @@
                "show": true
             }
          ]
+      },
+      {
+         "datasource": "$datasource",
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "palette-classic"
+               },
+               "custom": {
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                     "legend": false,
+                     "tooltip": false,
+                     "viz": false
+                  },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                     "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                     "group": "A",
+                     "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                     "mode": "off"
+                  }
+               },
+               "decimals": 2,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "unit": "s"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 16,
+            "x": 8,
+            "y": 7
+         },
+         "id": 6,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Last *",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "9.1.3",
+         "targets": [
+            {
+               "datasource": "$datasource",
+               "expr": "rate(ceph_rgw_sync_delta_sync_delta[$__rate_interval])",
+               "format": "time_series",
+               "instant": false,
+               "intervalFactor": 1,
+               "legendFormat": "{{instance_id}} - {{shard_id}}",
+               "range": true,
+               "refId": "A"
+            }
+         ],
+         "title": "Replication(Time) Delta per shard",
+         "type": "timeseries"
       }
    ],
    "refresh": "30s",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67101

---

backport of https://github.com/ceph/ceph/pull/58644
parent tracker: https://tracker.ceph.com/issues/66994

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh