### PR TITLE
build: Fixes build failure on IBM Power

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -225,6 +225,7 @@ elseif(HAVE_POWER8)
     list(APPEND crc32_srcs
       crc32c_ppc_asm.S
       crc32c_ppc_fast_zero_asm.S)
+    set_source_files_properties(crc32c_ppc_asm.S PROPERTIES COMPILE_FLAGS -D__ASSEMBLY__)
   endif(HAVE_PPC64LE)
 elseif(HAVE_ARMV8_CRC)
   list(APPEND crc32_srcs


### PR DESCRIPTION
Building Ceph on IBM Power is failing with error

```
[ 46%] Linking CXX executable ../../bin/ceph-authtool
cd /builddir/build/BUILD/ceph-19.0.0-2896-g6f942bab/redhat-linux-build/src/tools && /usr/bin/cmake -E cmake_link_script CMakeFiles/ceph-authtool.dir/link.txt --verbose=1
/usr/bin/c++ -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong   -m64 -mcpu=power9 -mtune=power9 -fasynchronous-unwind-tables -fstack-clash-protection -Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -rdynamic -pie "CMakeFiles/ceph-authtool.dir/ceph_authtool.cc.o" -o ../../bin/ceph-authtool  -Wl,-rpath,/builddir/build/BUILD/ceph-19.0.0-2896-g6f942bab/redhat-linux-build/lib: ../../lib/libglobal.a -ldl /usr/lib64/librt.a -lresolv /usr/lib64/libcrypto.so ../../lib/libceph-common.so.2 -lresolv /usr/lib64/libcrypto.so ../../lib/libjson_spirit.a ../../lib/libcommon_utf8.a ../../lib/liberasure_code.a ../../lib/libextblkdev.a -lcap ../../boost/lib/libboost_thread.a ../../boost/lib/libboost_chrono.a ../../boost/lib/libboost_atomic.a ../../boost/lib/libboost_system.a ../../boost/lib/libboost_random.a ../../boost/lib/libboost_program_options.a ../../boost/lib/libboost_date_time.a ../../boost/lib/libboost_iostreams.a ../../boost/lib/libboost_regex.a /usr/lib64/libblkid.so -ldl /usr/lib64/libudev.so /usr/lib64/libibverbs.so /usr/lib64/librdmacm.so /usr/lib64/libz.so ../opentelemetry-cpp/sdk/src/trace/libopentelemetry_trace.a ../opentelemetry-cpp/sdk/src/resource/libopentelemetry_resources.a ../opentelemetry-cpp/sdk/src/common/libopentelemetry_common.a ../opentelemetry-cpp/exporters/jaeger/libopentelemetry_exporter_jaeger_trace.a ../opentelemetry-cpp/ext/src/http/client/curl/libopentelemetry_http_client_curl.a /usr/lib64/libcurl.so /usr/lib64/libthrift.so 
make[2]: Leaving directory '/builddir/build/BUILD/ceph-19.0.0-2896-g6f942bab/redhat-linux-build'
/usr/bin/ld: ../../lib/libceph-common.so.2: undefined reference to `MAX_SIZE'
/usr/bin/ld: ../../lib/libceph-common.so.2: undefined reference to `.barrett_constants'
/usr/bin/ld: ../../lib/libceph-common.so.2: undefined reference to `.short_constants'
/usr/bin/ld: ../../lib/libceph-common.so.2: undefined reference to `.constants'
collect2: error: ld returned 1 exit status
make[2]: *** [src/tools/CMakeFiles/ceph-authtool.dir/build.make:127: bin/ceph-authtool] Error 1
make[1]: *** [CMakeFiles/Makefile2:8962: src/tools/CMakeFiles/ceph-authtool.dir/all] Error 2
```

Fixes: https://tracker.ceph.com/issues/66306

Signed-off-by: Sudeesh John sudeeshjohn@in.ibm.com