### PR TITLE
reef: qa/suites/rados/verify/validater: increase heartbeat grace timeout

### DIFF
--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -8,7 +8,8 @@ overrides:
   ceph:
     conf:
       global:
-        osd heartbeat grace: 80
+        # see https://tracker.ceph.com/issues/65768
+        osd heartbeat grace: 160
         # see https://tracker.ceph.com/issues/62992
         osd op thread timeout: 150
       mon:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67109

---

backport of https://github.com/ceph/ceph/pull/57485
parent tracker: https://tracker.ceph.com/issues/65768

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh