### PR TITLE
crimson/os/seastore: consider segment_header_t::modify_time as the segments' modify_time for no-tail OOL segments

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -43,6 +43,7 @@ struct segment_info_t {
 
   sea_time_point modify_time = NULL_TIME;
 
+  // Might be unavailable(0), see mount() -> init_modify_time()
   std::size_t num_extents = 0;
 
   segment_off_t written_to = 0;
@@ -74,6 +75,13 @@ struct segment_info_t {
   void set_empty();
 
   void set_closed();
+
+  void init_modify_time(sea_time_point _modify_time) {
+    ceph_assert(modify_time == NULL_TIME);
+    ceph_assert(num_extents == 0);
+    ceph_assert(_modify_time != NULL_TIME);
+    modify_time = _modify_time;
+  }
 
   void update_modify_time(sea_time_point _modify_time, std::size_t _num_extents) {
     ceph_assert(!is_closed());
@@ -225,6 +233,15 @@ public:
   void mark_closed(segment_id_t);
 
   void update_written_to(segment_type_t, paddr_t);
+
+  void init_modify_time(
+      segment_id_t id, sea_time_point tp) {
+    if (tp == NULL_TIME) {
+      return;
+    }
+
+    segments[id].init_modify_time(tp);
+  }
 
   void update_modify_time(
       segment_id_t id, sea_time_point tp, std::size_t num) {

--- a/src/crimson/os/seastore/journal/segment_allocator.cc
+++ b/src/crimson/os/seastore/journal/segment_allocator.cc
@@ -93,6 +93,7 @@ SegmentAllocator::do_open(bool is_mkfs)
       alloc_tail = JOURNAL_SEQ_NULL;
     }
     auto header = segment_header_t{
+      timepoint_to_mod(seastar::lowres_system_clock::now()),
       new_segment_seq,
       segment_id,
       dirty_tail,

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -371,6 +371,7 @@ std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
              << ", dirty_tail=" << header.dirty_tail
              << ", alloc_tail=" << header.alloc_tail
              << ", segment_nonce=" << header.segment_nonce
+	     << ", modify_time=" << mod_time_point_printer_t{header.modify_time}
              << ")";
 }
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1799,6 +1799,8 @@ using segment_nonce_t = uint32_t;
  * 4) Replay from the latest tails
  */
 struct segment_header_t {
+  mod_time_point_t modify_time;
+
   segment_seq_t segment_seq;
   segment_id_t physical_segment_id; // debugging
 
@@ -1817,6 +1819,7 @@ struct segment_header_t {
 
   DENC(segment_header_t, v, p) {
     DENC_START(1, 1, p);
+    denc(v.modify_time, p);
     denc(v.segment_seq, p);
     denc(v.physical_segment_id, p);
     denc(v.dirty_tail, p);


### PR DESCRIPTION
OOL segments don't contain record headers anymore, we use segment_header_t::modify_time as the approximation of segment modify_time

Fixes: https://tracker.ceph.com/issues/67106
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
