### PR TITLE
reef: mon/MDSMonitor: set birth time on FSMap during encode

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -45,6 +45,13 @@
   a large buildup of session metadata resulting in the MDS going read-only due to
   the RADOS operation exceeding the size threshold. `mds_session_metadata_threshold`
   config controls the maximum size that a (encoded) session metadata can grow.
+* CephFS: A new "mds last-seen" command is available for querying the last time
+  an MDS was in the FSMap, subject to a pruning threshold.
+* CephFS: For clusters with multiple CephFS file systems, all the snap-schedule
+  commands now expect the '--fs' argument.
+* CephFS: The period specifier ``m`` now implies minutes and the period specifier
+  ``M`` now implies months. This has been made consistent with the rest
+  of the system.
 * RGW: New tools have been added to radosgw-admin for identifying and
   correcting issues with versioned bucket indexes. Historical bugs with the
   versioned bucket index transaction workflow made it possible for the index

--- a/doc/cephfs/administration.rst
+++ b/doc/cephfs/administration.rst
@@ -280,6 +280,17 @@ Mark the file system rank as repaired. Unlike the name suggests, this command
 does not change a MDS; it manipulates the file system rank which has been
 marked damaged.
 
+::
+
+    ceph mds last-seen <name>
+
+Learn the when the MDS named ``name`` was last in the FSMap. The JSON output
+includes the epoch the MDS was last seen. Historically information is limited by
+the following ``mon`` configuration:
+
+
+.. confval:: mon_fsmap_prune_threshold
+
 
 Required Client Features
 ------------------------

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -4,6 +4,7 @@ import logging
 import uuid
 from io import StringIO
 from os.path import join as os_path_join
+import re
 from time import sleep
 
 from teuthology.exceptions import CommandFailedError
@@ -185,6 +186,108 @@ class TestAdminCommands(CephFSTestCase):
 
         self.wait_for_health(health_warn, 30)
 
+
+class TestMdsLastSeen(CephFSTestCase):
+    """
+    Tests for `mds last-seen` command.
+    """
+
+    MDSS_REQUIRED = 2
+
+    def test_in_text(self):
+        """
+        That `mds last-seen` returns 0 for an MDS currently in the map.
+        """
+
+        status = self.fs.status()
+        r0 = self.fs.get_rank(0, status=status)
+        s = self.get_ceph_cmd_stdout("mds", "last-seen", r0['name'])
+        seconds = int(re.match(r"^(\d+)s$", s).group(1))
+        self.assertEqual(seconds, 0)
+
+    def test_in_json(self):
+        """
+        That `mds last-seen` returns 0 for an MDS currently in the map.
+        """
+
+        status = self.fs.status()
+        r0 = self.fs.get_rank(0, status=status)
+        s = self.get_ceph_cmd_stdout("--format=json", "mds", "last-seen", r0['name'])
+        J = json.loads(s)
+        seconds = int(re.match(r"^(\d+)s$", J['last-seen']).group(1))
+        self.assertEqual(seconds, 0)
+
+    def test_unknown(self):
+        """
+        That `mds last-seen` returns ENOENT for an mds not in recent maps.
+        """
+
+        try:
+            self.get_ceph_cmd_stdout("--format=json", "mds", "last-seen", 'foo')
+        except CommandFailedError as e:
+            self.assertEqual(e.exitstatus, errno.ENOENT)
+        else:
+            self.fail("non-existent mds should fail ENOENT")
+
+    def test_standby(self):
+        """
+        That `mds last-seen` returns 0 for a standby.
+        """
+
+        status = self.fs.status()
+        for info in status.get_standbys():
+            s = self.get_ceph_cmd_stdout("--format=json", "mds", "last-seen", info['name'])
+            J = json.loads(s)
+            seconds = int(re.match(r"^(\d+)s$", J['last-seen']).group(1))
+            self.assertEqual(seconds, 0)
+
+    def test_stopped(self):
+        """
+        That `mds last-seen` returns >0 for mds that is stopped.
+        """
+
+        status = self.fs.status()
+        r0 = self.fs.get_rank(0, status=status)
+        self.fs.mds_stop(mds_id=r0['name'])
+        self.fs.rank_fail()
+        sleep(2)
+        with safe_while(sleep=1, tries=self.fs.beacon_timeout, action='wait for last-seen >0') as proceed:
+            while proceed():
+                s = self.get_ceph_cmd_stdout("--format=json", "mds", "last-seen", r0['name'])
+                J = json.loads(s)
+                seconds = int(re.match(r"^(\d+)s$", J['last-seen']).group(1))
+                if seconds == 0:
+                    continue
+                self.assertGreater(seconds, 1)
+                break
+
+    def test_gc(self):
+        """
+        That historical mds information is eventually garbage collected.
+        """
+
+        prune_time = 20
+        sleep_time = 2
+        self.config_set('mon', 'mon_fsmap_prune_threshold', prune_time)
+        status = self.fs.status()
+        r0 = self.fs.get_rank(0, status=status)
+        self.fs.mds_stop(mds_id=r0['name'])
+        self.fs.rank_fail()
+        last = 0
+        for i in range(prune_time):
+            sleep(sleep_time) # we will sleep twice prune_time
+            try:
+                s = self.get_ceph_cmd_stdout("--format=json", "mds", "last-seen", r0['name'])
+                J = json.loads(s)
+                seconds = int(re.match(r"^(\d+)s$", J['last-seen']).group(1))
+                self.assertGreater(seconds, last)
+                log.debug("last_seen: %ds", seconds)
+                last = seconds
+            except CommandFailedError as e:
+                self.assertEqual(e.exitstatus, errno.ENOENT)
+                self.assertGreaterEqual(last + sleep_time + 1, prune_time) # rounding error add 1
+                return
+        self.fail("map was no garbage collected as expected")
 
 @classhook('_add_valid_tell')
 class TestValidTell(TestAdminCommands):

--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -184,6 +184,7 @@ class HealthTest(DashboardTestCase):
                 })
             }),
             'fs_map': JObj({
+                'btime': str,
                 'compat': JObj({
                     'compat': JObj({}, allow_unknown=True, unknown_schema=str),
                     'incompat': JObj(

--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -779,6 +779,18 @@ options:
   services:
   - mon
   with_legacy: true
+- name: mon_fsmap_prune_threshold
+  type: secs
+  level: advanced
+  desc: prune fsmap older than this threshold in seconds
+  fmt_desc: The monitors keep historical fsmaps in memory to optimize asking
+    when an MDS daemon was last seen in the FSMap. This option controls
+    how far back in time the monitors will look.
+  default: 300
+  flags:
+  - runtime
+  services:
+  - mon
 - name: mds_beacon_mon_down_grace
   type: secs
   level: advanced

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -133,6 +133,7 @@ void Filesystem::dump(Formatter *f) const
 void FSMap::dump(Formatter *f) const
 {
   f->dump_int("epoch", epoch);
+  f->dump_string("btime", fmt::format("{}", btime));
   // Use 'default' naming to match 'set-default' CLI
   f->dump_int("default_fscid", legacy_client_fscid);
 
@@ -166,6 +167,7 @@ void FSMap::dump(Formatter *f) const
 FSMap &FSMap::operator=(const FSMap &rhs)
 {
   epoch = rhs.epoch;
+  btime = rhs.btime;
   next_filesystem_id = rhs.next_filesystem_id;
   legacy_client_fscid = rhs.legacy_client_fscid;
   default_compat = rhs.default_compat;
@@ -206,6 +208,7 @@ void FSMap::generate_test_instances(std::list<FSMap*>& ls)
 void FSMap::print(ostream& out) const
 {
   out << "e" << epoch << std::endl;
+  out << "btime " << fmt::format("{}", btime) << std::endl;
   out << "enable_multiple, ever_enabled_multiple: " << enable_multiple << ","
       << ever_enabled_multiple << std::endl;
   out << "default compat: " << default_compat << std::endl;
@@ -296,6 +299,7 @@ void FSMap::print_summary(Formatter *f, ostream *out) const
 {
   if (f) {
     f->dump_unsigned("epoch", get_epoch());
+    f->dump_string("btime", fmt::format("{}", btime));
     for (const auto &p : filesystems) {
       auto& fs = p.second;
       f->dump_unsigned("id", fs->fscid);
@@ -651,6 +655,7 @@ void FSMap::encode(bufferlist& bl, uint64_t features) const
   encode(standby_daemons, bl, features);
   encode(standby_epochs, bl);
   encode(ever_enabled_multiple, bl);
+  encode(btime, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -679,6 +684,9 @@ void FSMap::decode(bufferlist::const_iterator& p)
   decode(standby_epochs, p);
   if (struct_v >= 7) {
     decode(ever_enabled_multiple, p);
+  }
+  if (struct_v >= 8) {
+    decode(btime, p);
   }
   DECODE_FINISH(p);
 }

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -25,6 +25,7 @@
 #include <errno.h>
 
 #include "include/types.h"
+#include "common/ceph_time.h"
 #include "common/Clock.h"
 #include "mds/MDSMap.h"
 
@@ -278,9 +279,10 @@ class FSMap {
 public:
   friend class MDSMonitor;
   friend class PaxosFSMap;
+  using real_clock = ceph::real_clock;
   using mds_info_t = MDSMap::mds_info_t;
 
-  static const version_t STRUCT_VERSION = 7;
+  static const version_t STRUCT_VERSION = 8;
   static const version_t STRUCT_VERSION_TRIM_TO = 7;
 
   FSMap() : default_compat(MDSMap::get_compat_set_default()) {}
@@ -288,6 +290,7 @@ public:
   FSMap(const FSMap &rhs)
     :
       epoch(rhs.epoch),
+      btime(rhs.btime),
       next_filesystem_id(rhs.next_filesystem_id),
       legacy_client_fscid(rhs.legacy_client_fscid),
       default_compat(rhs.default_compat),
@@ -570,6 +573,13 @@ public:
   epoch_t get_epoch() const { return epoch; }
   void inc_epoch() { epoch++; }
 
+  void set_btime() {
+    btime = real_clock::now();
+  }
+  auto get_btime() const {
+    return btime;
+  }
+
   version_t get_struct_version() const { return struct_version; }
   bool is_struct_old() const {
     return struct_version < STRUCT_VERSION_TRIM_TO;
@@ -644,6 +654,8 @@ public:
 
 protected:
   epoch_t epoch = 0;
+  ceph::real_time btime = real_clock::zero();
+
   uint64_t next_filesystem_id = FS_CLUSTER_ID_ANONYMOUS + 1;
   fs_cluster_id_t legacy_client_fscid = FS_CLUSTER_ID_NONE;
   CompatSet default_compat;

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -193,6 +193,7 @@ void MDSMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   if (!g_conf()->mon_mds_skip_sanity) {
     pending.sanity(true);
   }
+  pending.set_btime();
 
   // Set 'modified' on maps modified this epoch
   for (auto &p : pending.filesystems) {

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -980,6 +980,52 @@ bool MDSMonitor::preprocess_command(MonOpRequestRef op)
       ds << fsmap;
     }
     r = 0;
+  } else if (prefix == "mds last-seen") {
+    std::string id;
+    cmd_getval(cmdmap, "id", id);
+
+    dout(10) << "last seen check for " << id << dendl;
+
+    auto& history = get_fsmap_history();
+    auto now = real_clock::now();
+    bool found = false;
+    /* Special case:
+     * If the mons consider the MDS "in" the latest FSMap, then the mds
+     * is always "last seen" **now** (for the purposes of this API).  We
+     * don't look at past beacons because that is only managed by the
+     * leader and the logic is fudged in places in the event of suspected
+     * network partitions.
+     */
+    std::chrono::seconds since = std::chrono::seconds(0);
+
+    for (auto& [epoch, fsmaph] : boost::adaptors::reverse(history)) {
+      dout(25) << "looking at epoch " << epoch << dendl;
+      auto* info = fsmaph.find_by_name(id);
+      if (info) {
+        dout(10) << "found: " << *info << dendl;
+        found = true;
+        if (f) {
+          f->open_object_section("mds last-seen");
+          f->dump_object("info", *info);
+          f->dump_string("last-seen", fmt::format("{}", since));
+          f->dump_int("epoch", epoch);
+          f->close_section();
+          f->flush(ds);
+        } else {
+          ds << fmt::format("{}", since);
+        }
+        break;
+      }
+      /* If the MDS appears in the next epoch, then it went away as of this epoch's btime.
+       */
+      since = std::chrono::duration_cast<std::chrono::seconds>(now - fsmaph.get_btime());
+    }
+    if (found) {
+      r = 0;
+    } else {
+      ss << "mds " << id << " not found in recent FSMaps";
+      r = -ENOENT;
+    }
   } else if (prefix == "mds ok-to-stop") {
     vector<string> ids;
     if (!cmd_getval(cmdmap, "ids", ids)) {
@@ -2345,6 +2391,39 @@ bool MDSMonitor::maybe_promote_standby(FSMap &fsmap, Filesystem& fs)
 
 void MDSMonitor::tick()
 {
+  {
+    auto _history_prune_time = g_conf().get_val<std::chrono::seconds>("mon_fsmap_prune_threshold");
+    set_fsmap_history_threshold(_history_prune_time);
+    dout(20) << _history_prune_time << dendl;
+    prune_fsmap_history();
+    auto& history = get_fsmap_history();
+    auto now = real_clock::now();
+    if (auto it = history.begin(); it != history.end()) {
+      auto start = it->second.get_epoch();
+      dout(20) << "oldest epoch in history is " << start << dendl;
+      for (;;) {
+        --start;
+        bufferlist bl;
+        FSMap fsmaph;
+        int err = get_version(start, bl);
+        if (err == -ENOENT) {
+          break;
+        }
+	ceph_assert(err == 0);
+	ceph_assert(bl.length());
+	fsmaph.decode(bl);
+        auto btime = fsmaph.get_btime();
+        auto since = std::chrono::duration_cast<std::chrono::milliseconds>(now - btime);
+        dout(20) << "loaded epoch " << fsmaph.get_epoch() << " which is " << since << " old" << dendl;
+        if (since <= _history_prune_time) {
+          put_fsmap_history(fsmaph);
+        } else {
+          break;
+        }
+      }
+    }
+  }
+
   if (!is_active() || !is_leader()) return;
 
   auto &pending = get_pending_fsmap_writeable();

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -294,6 +294,9 @@ COMMAND("versions",
 
 #define FS_NAME_GOODCHARS "[A-Za-z0-9-_.]"
 COMMAND_WITH_FLAG("mds stat", "show MDS status", "mds", "r", FLAG(HIDDEN))
+COMMAND("mds last-seen name=id,type=CephString,req=true",
+	"fetch metadata for mds <id>",
+	"mds", "r")
 COMMAND("fs dump "
 	"name=epoch,type=CephInt,req=false,range=0",
 	"dump all CephFS status, optionally from epoch", "mds", "r")

--- a/src/mon/PaxosFSMap.h
+++ b/src/mon/PaxosFSMap.h
@@ -15,6 +15,8 @@
 #ifndef CEPH_PAXOS_FSMAP_H
 #define CEPH_PAXOS_FSMAP_H
 
+#include <chrono>
+
 #include "mds/FSMap.h"
 #include "mds/MDSMap.h"
 
@@ -39,13 +41,58 @@ protected:
     return pending_fsmap;
   }
 
+  void prune_fsmap_history() {
+    auto now = real_clock::now();
+    for (auto it = history.begin(); it != history.end(); ) {
+      auto since = now - it->second.get_btime();
+      /* Be sure to not make the map empty */
+      auto itnext = std::next(it);
+      if (itnext == history.end()) {
+        break;
+      }
+      /* Keep the map just before the prune time threshold:
+       * [ e-1             (lifetime > history_prune_time) | e (lifetime 1s) ]
+       * If an mds was removed in (e), then we want to be able to say it was
+       * last seen 1 second ago.
+       */
+      auto since2 = now - itnext->second.get_btime();
+      if (since > history_prune_time && since2 > history_prune_time) {
+        it = history.erase(it);
+      } else {
+        break;
+      }
+    }
+  }
+
+  void put_fsmap_history(const FSMap& _fsmap) {
+    auto now = real_clock::now();
+    auto since = now - _fsmap.get_btime();
+    if (since < history_prune_time) {
+      history.emplace(std::piecewise_construct, std::forward_as_tuple(_fsmap.get_epoch()), std::forward_as_tuple(_fsmap));
+    }
+  }
+
+  void set_fsmap_history_threshold(std::chrono::seconds t) {
+    history_prune_time = t;
+  }
+  std::chrono::seconds get_fsmap_history_threshold() const {
+    return history_prune_time;
+  }
+
+  const auto& get_fsmap_history() const {
+    return history;
+  }
+
   void decode(ceph::buffer::list &bl) {
     fsmap.decode(bl);
+    put_fsmap_history(fsmap);
     pending_fsmap = FSMap(); /* nuke it to catch invalid access */
   }
 
 private:
   /* Keep these PRIVATE to prevent unprotected manipulation. */
+  std::map<epoch_t, FSMap> history;
+  std::chrono::seconds history_prune_time = std::chrono::seconds(0);
   FSMap fsmap; /* the current epoch */
   FSMap pending_fsmap; /* the next epoch */
 };

--- a/src/pybind/mgr/dashboard/controllers/health.py
+++ b/src/pybind/mgr/dashboard/controllers/health.py
@@ -44,6 +44,7 @@ HEALTH_MINIMAL_SCHEMA = ({
                 'failed': ([int], ''),
                 'metadata_pool': (int, ''),
                 'epoch': (int, ''),
+                'btime': (str, ''),
                 'stopped': ([int], ''),
                 'max_mds': (int, ''),
                 'compat': ({

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -4907,6 +4907,9 @@ paths:
                                 balancer:
                                   description: ''
                                   type: string
+                                btime:
+                                  description: ''
+                                  type: string
                                 compat:
                                   description: ''
                                   properties:
@@ -5026,6 +5029,7 @@ paths:
                               - failed
                               - metadata_pool
                               - epoch
+                              - btime
                               - stopped
                               - max_mds
                               - compat

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -167,7 +167,7 @@ setenv =
     check: OPENAPI_FILE_TMP={envtmpdir}/{env:OPENAPI_FILE}
 commands =
      python3 -m dashboard.controllers.docs {env:OPENAPI_FILE_TMP:{env:OPENAPI_FILE}}
-     check: diff {env:OPENAPI_FILE} {env:OPENAPI_FILE_TMP}
+     check: diff -au {env:OPENAPI_FILE} {env:OPENAPI_FILE_TMP}
 
 [testenv:openapi-doc]
 description = Generate Sphinx documentation from OpenAPI specification


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66780

---

backport of https://github.com/ceph/ceph/pull/53503
parent tracker: https://tracker.ceph.com/issues/62849

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh