### PR TITLE
cls/rgw: start replacing CLSRGWConcurrentIO

### DIFF
--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -192,32 +192,10 @@ void cls_rgw_bucket_init_index(ObjectWriteOperation& o)
   o.exec(RGW_CLASS, RGW_BUCKET_INIT_INDEX, in);
 }
 
-static bool issue_bucket_index_init_op(librados::IoCtx& io_ctx,
-				       const int shard_id,
-				       const string& oid,
-				       BucketIndexAioManager *manager) {
-  bufferlist in;
-  librados::ObjectWriteOperation op;
-  op.create(true);
-  cls_rgw_bucket_init_index(op);
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
 void cls_rgw_bucket_init_index2(ObjectWriteOperation& o)
 {
   bufferlist in;
   o.exec(RGW_CLASS, RGW_BUCKET_INIT_INDEX2, in);
-}
-
-static bool issue_bucket_index_init_op2(librados::IoCtx& io_ctx,
-				       const int shard_id,
-				       const string& oid,
-				       BucketIndexAioManager *manager) {
-  bufferlist in;
-  librados::ObjectWriteOperation op;
-  op.create(true);
-  cls_rgw_bucket_init_index2(op);
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
 }
 
 static bool issue_bucket_index_clean_op(librados::IoCtx& io_ctx,
@@ -242,32 +220,6 @@ static bool issue_bucket_set_tag_timeout_op(librados::IoCtx& io_ctx,
   ObjectWriteOperation op;
   op.exec(RGW_CLASS, RGW_BUCKET_SET_TAG_TIMEOUT, in);
   return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
-int CLSRGWIssueBucketIndexInit::issue_op(const int shard_id, const string& oid)
-{
-  return issue_bucket_index_init_op(io_ctx, shard_id, oid, &manager);
-}
-
-int CLSRGWIssueBucketIndexInit2::issue_op(const int shard_id, const string& oid)
-{
-  return issue_bucket_index_init_op2(io_ctx, shard_id, oid, &manager);
-}
-
-void CLSRGWIssueBucketIndexInit::cleanup()
-{
-  // Do best effort removal
-  for (auto citer = objs_container.begin(); citer != iter; ++citer) {
-    io_ctx.remove(citer->second);
-  }
-}
-
-void CLSRGWIssueBucketIndexInit2::cleanup()
-{
-  // Do best effort removal
-  for (auto citer = objs_container.begin(); citer != iter; ++citer) {
-    io_ctx.remove(citer->second);
-  }
 }
 
 int CLSRGWIssueBucketIndexClean::issue_op(const int shard_id, const string& oid)

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -198,23 +198,14 @@ void cls_rgw_bucket_init_index2(ObjectWriteOperation& o)
   o.exec(RGW_CLASS, RGW_BUCKET_INIT_INDEX2, in);
 }
 
-static bool issue_bucket_set_tag_timeout_op(librados::IoCtx& io_ctx,
-					    const int shard_id,
-					    const string& oid,
-					    uint64_t timeout,
-					    BucketIndexAioManager *manager) {
-  bufferlist in;
+void cls_rgw_bucket_set_tag_timeout(ObjectWriteOperation& op, uint64_t timeout)
+{
   rgw_cls_tag_timeout_op call;
   call.tag_timeout = timeout;
-  encode(call, in);
-  ObjectWriteOperation op;
-  op.exec(RGW_CLASS, RGW_BUCKET_SET_TAG_TIMEOUT, in);
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
 
-int CLSRGWIssueSetTagTimeout::issue_op(const int shard_id, const string& oid)
-{
-  return issue_bucket_set_tag_timeout_op(io_ctx, shard_id, oid, tag_timeout, &manager);
+  bufferlist in;
+  encode(call, in);
+  op.exec(RGW_CLASS, RGW_BUCKET_SET_TAG_TIMEOUT, in);
 }
 
 void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -186,7 +186,6 @@ bool BucketIndexAioManager::wait_for_completions(int valid_ret_code,
   return true;
 }
 
-// note: currently only called by testing code
 void cls_rgw_bucket_init_index(ObjectWriteOperation& o)
 {
   bufferlist in;
@@ -200,8 +199,14 @@ static bool issue_bucket_index_init_op(librados::IoCtx& io_ctx,
   bufferlist in;
   librados::ObjectWriteOperation op;
   op.create(true);
-  op.exec(RGW_CLASS, RGW_BUCKET_INIT_INDEX, in);
+  cls_rgw_bucket_init_index(op);
   return manager->aio_operate(io_ctx, shard_id, oid, &op);
+}
+
+void cls_rgw_bucket_init_index2(ObjectWriteOperation& o)
+{
+  bufferlist in;
+  o.exec(RGW_CLASS, RGW_BUCKET_INIT_INDEX2, in);
 }
 
 static bool issue_bucket_index_init_op2(librados::IoCtx& io_ctx,
@@ -211,7 +216,7 @@ static bool issue_bucket_index_init_op2(librados::IoCtx& io_ctx,
   bufferlist in;
   librados::ObjectWriteOperation op;
   op.create(true);
-  op.exec(RGW_CLASS, RGW_BUCKET_INIT_INDEX2, in);
+  cls_rgw_bucket_init_index2(op);
   return manager->aio_operate(io_ctx, shard_id, oid, &op);
 }
 

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -198,16 +198,6 @@ void cls_rgw_bucket_init_index2(ObjectWriteOperation& o)
   o.exec(RGW_CLASS, RGW_BUCKET_INIT_INDEX2, in);
 }
 
-static bool issue_bucket_index_clean_op(librados::IoCtx& io_ctx,
-					const int shard_id,
-					const string& oid,
-					BucketIndexAioManager *manager) {
-  bufferlist in;
-  librados::ObjectWriteOperation op;
-  op.remove();
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
 static bool issue_bucket_set_tag_timeout_op(librados::IoCtx& io_ctx,
 					    const int shard_id,
 					    const string& oid,
@@ -220,11 +210,6 @@ static bool issue_bucket_set_tag_timeout_op(librados::IoCtx& io_ctx,
   ObjectWriteOperation op;
   op.exec(RGW_CLASS, RGW_BUCKET_SET_TAG_TIMEOUT, in);
   return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
-int CLSRGWIssueBucketIndexClean::issue_op(const int shard_id, const string& oid)
-{
-  return issue_bucket_index_clean_op(io_ctx, shard_id, oid, &manager);
 }
 
 int CLSRGWIssueSetTagTimeout::issue_op(const int shard_id, const string& oid)

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -303,16 +303,8 @@ public:
 }; // class CLSRGWConcurrentIO
 
 
-class CLSRGWIssueSetTagTimeout : public CLSRGWConcurrentIO {
-  uint64_t tag_timeout;
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-public:
-  CLSRGWIssueSetTagTimeout(librados::IoCtx& ioc, std::map<int, std::string>& _bucket_objs,
-                     uint32_t _max_aio, uint64_t _tag_timeout) :
-    CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio), tag_timeout(_tag_timeout) {}
-  virtual ~CLSRGWIssueSetTagTimeout() override {}
-};
+void cls_rgw_bucket_set_tag_timeout(librados::ObjectWriteOperation& op,
+                                    uint64_t timeout);
 
 void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
                                  bool absolute,

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -303,34 +303,6 @@ public:
 }; // class CLSRGWConcurrentIO
 
 
-class CLSRGWIssueBucketIndexInit : public CLSRGWConcurrentIO {
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-  int valid_ret_code() override { return -EEXIST; }
-  void cleanup() override;
-public:
-  CLSRGWIssueBucketIndexInit(librados::IoCtx& ioc,
-			     std::map<int, std::string>& _bucket_objs,
-			     uint32_t _max_aio) :
-    CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio) {}
-  virtual ~CLSRGWIssueBucketIndexInit() override {}
-};
-
-
-class CLSRGWIssueBucketIndexInit2 : public CLSRGWConcurrentIO {
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-  int valid_ret_code() override { return -EEXIST; }
-  void cleanup() override;
-public:
-  CLSRGWIssueBucketIndexInit2(librados::IoCtx& ioc,
-			     std::map<int, std::string>& _bucket_objs,
-			     uint32_t _max_aio) :
-    CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio) {}
-  virtual ~CLSRGWIssueBucketIndexInit2() override {}
-};
-
-
 class CLSRGWIssueBucketIndexClean : public CLSRGWConcurrentIO {
 protected:
   int issue_op(int shard_id, const std::string& oid) override;

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -517,17 +517,6 @@ public:
   virtual ~CLSRGWIssueBucketRebuild() override {}
 };
 
-class CLSRGWIssueGetDirHeader : public CLSRGWConcurrentIO {
-  std::map<int, rgw_cls_list_ret>& result;
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-public:
-  CLSRGWIssueGetDirHeader(librados::IoCtx& io_ctx, std::map<int, std::string>& oids, std::map<int, rgw_cls_list_ret>& dir_headers,
-                          uint32_t max_aio) :
-    CLSRGWConcurrentIO(io_ctx, oids, max_aio), result(dir_headers) {}
-  virtual ~CLSRGWIssueGetDirHeader() override {}
-};
-
 class CLSRGWIssueSetBucketResharding : public CLSRGWConcurrentIO {
   cls_rgw_bucket_instance_entry entry;
 protected:
@@ -556,6 +545,11 @@ public:
     CLSRGWConcurrentIO(io_ctx, _bucket_objs, max_aio) {}
   virtual ~CLSRGWIssueBucketBILogStop() override {}
 };
+
+void cls_rgw_get_dir_header(librados::ObjectReadOperation& op,
+                            bufferlist& bl);
+int cls_rgw_get_dir_header_decode(const bufferlist& bl,
+                                  rgw_bucket_dir_header& header);
 
 int cls_rgw_get_dir_header_async(librados::IoCtx& io_ctx, const std::string& oid,
                                  boost::intrusive_ptr<RGWGetDirHeader_CB> cb);

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -369,54 +369,6 @@ int cls_rgw_usage_log_trim(librados::IoCtx& io_ctx, const std::string& oid, cons
                            uint64_t start_epoch, uint64_t end_epoch);
 #endif
 
-
-/**
- * Std::list the bucket with the starting object and filter prefix.
- * NOTE: this method do listing requests for each bucket index shards identified by
- *       the keys of the *list_results* std::map, which means the std::map should be populated
- *       by the caller to fill with each bucket index object id.
- *
- * io_ctx        - IO context for rados.
- * start_obj     - marker for the listing.
- * filter_prefix - filter prefix.
- * num_entries   - number of entries to request for each object (note the total
- *                 amount of entries returned depends on the number of shardings).
- * list_results  - the std::list results keyed by bucket index object id.
- * max_aio       - the maximum number of AIO (for throttling).
- *
- * Return 0 on success, a failure code otherwise.
-*/
-
-class CLSRGWIssueBucketList : public CLSRGWConcurrentIO {
-  cls_rgw_obj_key start_obj;
-  std::string filter_prefix;
-  std::string delimiter;
-  uint32_t num_entries;
-  bool list_versions;
-  std::map<int, rgw_cls_list_ret>& result; // request_id -> return value
-
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-  void reset_container(std::map<int, std::string>& objs) override;
-
-public:
-  CLSRGWIssueBucketList(librados::IoCtx& io_ctx,
-			const cls_rgw_obj_key& _start_obj,
-                        const std::string& _filter_prefix,
-			const std::string& _delimiter,
-			uint32_t _num_entries,
-                        bool _list_versions,
-                        std::map<int, std::string>& oids, // shard_id -> shard_oid
-			// shard_id -> return value
-                        std::map<int, rgw_cls_list_ret>& list_results,
-                        uint32_t max_aio) :
-  CLSRGWConcurrentIO(io_ctx, oids, max_aio),
-    start_obj(_start_obj), filter_prefix(_filter_prefix), delimiter(_delimiter),
-    num_entries(_num_entries), list_versions(_list_versions),
-    result(list_results)
-  {}
-};
-
 void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
                             const cls_rgw_obj_key& start_obj,
                             const std::string& filter_prefix,

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -303,23 +303,6 @@ public:
 }; // class CLSRGWConcurrentIO
 
 
-class CLSRGWIssueBucketIndexClean : public CLSRGWConcurrentIO {
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-  int valid_ret_code() override {
-    return -ENOENT;
-  }
-
-public:
-  CLSRGWIssueBucketIndexClean(librados::IoCtx& ioc,
-			      std::map<int, std::string>& _bucket_objs,
-			      uint32_t _max_aio) :
-  CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio)
-  {}
-  virtual ~CLSRGWIssueBucketIndexClean() override {}
-};
-
-
 class CLSRGWIssueSetTagTimeout : public CLSRGWConcurrentIO {
   uint64_t tag_timeout;
 protected:

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -264,6 +264,7 @@ public:
 
 /* bucket index */
 void cls_rgw_bucket_init_index(librados::ObjectWriteOperation& o);
+void cls_rgw_bucket_init_index2(librados::ObjectWriteOperation& o);
 
 class CLSRGWConcurrentIO {
 protected:

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -156,6 +156,7 @@ set(librgw_common_srcs
   rgw_lua_background.cc
   rgw_data_access.cc
   driver/rados/account.cc
+  driver/rados/bucket_index.cc
   driver/rados/buckets.cc
   driver/rados/cls_fifo_legacy.cc
   driver/rados/group.cc

--- a/src/rgw/driver/d4n/rgw_sal_d4n.cc
+++ b/src/rgw/driver/d4n/rgw_sal_d4n.cc
@@ -367,7 +367,9 @@ int D4NFilterObject::D4NFilterReadOp::drain(const DoutPrefixProvider* dpp, optio
 }
 
 int D4NFilterObject::D4NFilterReadOp::flush(const DoutPrefixProvider* dpp, rgw::AioResultList&& results, optional_yield y) {
-  int r = rgw::check_for_errors(results);
+  constexpr auto is_error = [] (int r) { return r < 0; };
+  int r = rgw::check_for_errors(results, is_error, dpp,
+                                "failed to read cache object");
 
   if (r < 0) {
     return r;

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2620,7 +2620,8 @@ int POSIXBucket::rebuild_index(const DoutPrefixProvider *dpp)
   return 0;
 }
 
-int POSIXBucket::set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout)
+int POSIXBucket::set_tag_timeout(const DoutPrefixProvider *dpp,
+                                 optional_yield y, uint64_t timeout)
 {
   return 0;
 }

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -538,7 +538,8 @@ public:
   virtual int remove_objs_from_index(const DoutPrefixProvider *dpp, std::list<rgw_obj_index_key>& objs_to_unlink) override;
   virtual int check_index(const DoutPrefixProvider *dpp, std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) override;
   virtual int rebuild_index(const DoutPrefixProvider *dpp) override;
-  virtual int set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout) override;
+  virtual int set_tag_timeout(const DoutPrefixProvider *dpp,
+                              optional_yield y, uint64_t timeout) override;
   virtual int purge_instance(const DoutPrefixProvider* dpp, optional_yield y) override;
 
   virtual std::unique_ptr<Bucket> clone() override {

--- a/src/rgw/driver/rados/bucket_index.cc
+++ b/src/rgw/driver/rados/bucket_index.cc
@@ -1,0 +1,194 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "bucket_index.h"
+
+#include <algorithm>
+#include <concepts>
+
+#include <fmt/format.h>
+
+#include "include/rados/librados.hpp"
+#include "common/async/yield_context.h"
+#include "common/dout.h"
+
+#include "cls/rgw/cls_rgw_client.h"
+
+#include "rgw_aio_throttle.h"
+#include "rgw_bucket_layout.h"
+#include "rgw_common.h"
+
+#include "rgw_tools.h"
+#include "rgw_zone.h"
+
+namespace rgwrados::bucket_index {
+
+auto shard_oid(std::string_view prefix, uint64_t gen,
+               const rgw::bucket_index_normal_layout& index, uint32_t shard)
+    -> std::string
+{
+  if (index.num_shards == 0) {
+    return std::string{prefix}; // legacy buckets have no gen or shard id
+  } else if (gen > 0) {
+    return fmt::format("{}.{}.{}", prefix, gen, shard);
+  } else {
+    // for backward compatibility, gen==0 is not added in the object name
+    return fmt::format("{}.{}", prefix, shard);
+  }
+}
+
+namespace {
+
+constexpr std::string_view dir_oid_prefix = ".dir.";
+
+std::string make_oid_prefix(std::string_view bucket_id)
+{
+  return fmt::format("{}{}", dir_oid_prefix, bucket_id);
+}
+
+int open_index_pool(const DoutPrefixProvider* dpp,
+                    librados::Rados& rados,
+                    const rgw::SiteConfig& site,
+                    const RGWBucketInfo& info,
+                    librados::IoCtx& ioctx)
+{
+  constexpr bool create = true;
+  constexpr bool mostly_omap = true;
+
+  const rgw_pool& explicit_pool = info.bucket.explicit_placement.index_pool;
+  if (!explicit_pool.empty()) {
+    return rgw_init_ioctx(dpp, &rados, explicit_pool,
+                          ioctx, create, mostly_omap);
+  }
+
+  const rgw_placement_rule* rule = &info.placement_rule;
+  if (rule->empty()) {
+    const auto& zonegroup = site.get_zonegroup();
+    rule = &zonegroup.default_placement;
+  }
+
+  const auto& zone = site.get_zone_params();
+  auto i = zone.placement_pools.find(rule->name);
+  if (i == zone.placement_pools.end()) {
+    ldpp_dout(dpp, 0) << "could not find placement rule " << *rule
+        << " within zonegroup" << dendl;
+    return -EINVAL;
+  }
+
+  return rgw_init_ioctx(dpp, &rados, i->second.index_pool,
+                        ioctx, create, mostly_omap);
+}
+
+// transfer matching entries from one list to another
+void transfer_if(rgw::AioResultList& from,
+                 rgw::AioResultList& to,
+                 std::invocable<int> auto pred)
+{
+  auto is_error = [&pred] (const rgw::AioResult& e) { return pred(e.result); };
+  auto i = std::find_if(from.begin(), from.end(), is_error);
+  while (i != from.end()) {
+    auto& entry = *i;
+    auto next = from.erase(i);
+    to.push_back(entry);
+    i = std::find_if(next, from.end(), is_error);
+  }
+}
+
+} // anonymous namespace
+
+int init(const DoutPrefixProvider* dpp,
+         optional_yield y,
+         librados::Rados& rados,
+         const rgw::SiteConfig& site,
+         const RGWBucketInfo& info,
+         const rgw::bucket_index_layout_generation& index,
+         bool judge_support_logrecord)
+{
+  if (index.layout.type != rgw::BucketIndexType::Normal) {
+    return 0;
+  }
+
+  librados::IoCtx ioctx;
+  int ret = open_index_pool(dpp, rados, site, info, ioctx);
+  if (ret < 0) {
+    return ret;
+  }
+  const std::string oid_prefix = make_oid_prefix(info.bucket.bucket_id);
+
+  // issue up to max_aio requests in parallel
+  const auto max_aio = dpp->get_cct()->_conf->rgw_bucket_index_max_aio;
+  auto aio = rgw::make_throttle(max_aio, y);
+  constexpr uint64_t cost = 1; // 1 throttle unit per request
+  constexpr uint64_t id = 0; // ids unused
+
+  // ignore EEXIST errors from exclusive create
+  constexpr auto is_error = [] (int r) { return r < 0 && r != -EEXIST; };
+  constexpr auto is_ok = [] (int r) { return r == 0; };
+
+  // track successful completions so we can roll back on error
+  rgw::AioResultList created;
+
+  for (uint32_t shard = 0; shard < num_shards(index.layout.normal); shard++) {
+    librados::ObjectWriteOperation op;
+    op.create(true);
+    if (judge_support_logrecord) {
+      cls_rgw_bucket_init_index2(op);
+    } else {
+      cls_rgw_bucket_init_index(op);
+    }
+
+    rgw_raw_obj obj; // obj.pool is empty and unused
+    obj.oid = shard_oid(oid_prefix, index.gen, index.layout.normal, shard);
+
+    auto completed = aio->get(obj, rgw::Aio::librados_op(
+            ioctx, std::move(op), y), cost, id);
+    ret = rgw::check_for_errors(completed, is_error, dpp,
+                                "failed to init index object");
+    transfer_if(completed, created, is_ok);
+
+    if (ret < 0) {
+      break;
+    }
+  }
+
+  {
+    auto completed = aio->drain();
+    int r = rgw::check_for_errors(completed, is_error, dpp,
+                                  "failed to init index object");
+    if (ret == 0 && r == 0) {
+      return 0;
+    }
+    transfer_if(completed, created, is_ok);
+  }
+
+  // on error, try to delete any objects that were successfully created
+  for (const rgw::AioResult& e : created) {
+    librados::ObjectWriteOperation op;
+    op.remove();
+
+    auto completed = aio->get(e.obj, rgw::Aio::librados_op(
+            ioctx, std::move(op), y), cost, id);
+    std::ignore = rgw::check_for_errors(completed, is_error, dpp,
+                                        "failed to remove index object");
+  }
+
+  auto completed = aio->drain();
+  std::ignore = rgw::check_for_errors(completed, is_error, dpp,
+                                      "failed to remove index object");
+
+  return ret;
+}
+
+} // namespace rgwrados::bucket_index

--- a/src/rgw/driver/rados/bucket_index.h
+++ b/src/rgw/driver/rados/bucket_index.h
@@ -1,0 +1,52 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "include/rados/librados_fwd.hpp"
+
+class DoutPrefixProvider;
+class optional_yield;
+class RGWBucketInfo;
+
+namespace rgw {
+struct bucket_index_layout_generation;
+struct bucket_index_normal_layout;
+class SiteConfig;
+}
+
+namespace rgwrados::bucket_index {
+
+/// Format the rados object name for a shard of the index layout generation.
+auto shard_oid(std::string_view prefix, uint64_t gen,
+               const rgw::bucket_index_normal_layout& index, uint32_t shard)
+    -> std::string;
+
+/// Initialize all of the index shard objects using exclusive create.
+///
+/// If judge_support_logrecord is true, issue the cls_rgw_bucket_init_index2()
+/// op to detect whether the OSD supports the reshard log.
+int init(const DoutPrefixProvider* dpp,
+         optional_yield y,
+         librados::Rados& rados,
+         const rgw::SiteConfig& site,
+         const RGWBucketInfo& info,
+         const rgw::bucket_index_layout_generation& index,
+         bool judge_support_logrecord = false);
+
+} // namespace rgwrados::bucket_index

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -2937,6 +2937,7 @@ int RGWMetadataHandlerPut_BucketInstance::put_post(const DoutPrefixProvider *dpp
 
   objv_tracker = bci.info.objv_tracker;
 
+  // XXX: skip this if bucket isn't owned by the local zonegroup
   int ret = bihandler->svc.bi->init_index(dpp, y, bci.info, bci.info.layout.current_index);
   if (ret < 0) {
     return ret;

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -561,7 +561,7 @@ int RGWBucket::check_object_index(const DoutPrefixProvider *dpp,
   }
 
   // use a quicker/shorter tag timeout during this process
-  bucket->set_tag_timeout(dpp, BUCKET_TAG_QUICK_TIMEOUT);
+  bucket->set_tag_timeout(dpp, y, BUCKET_TAG_QUICK_TIMEOUT);
 
   rgw::sal::Bucket::ListResults results;
   results.is_truncated = true;
@@ -589,7 +589,7 @@ int RGWBucket::check_object_index(const DoutPrefixProvider *dpp,
   formatter->close_section();
 
   // restore normal tag timeout for bucket
-  bucket->set_tag_timeout(dpp, 0);
+  bucket->set_tag_timeout(dpp, y, 0);
 
   return 0;
 }

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -2937,7 +2937,7 @@ int RGWMetadataHandlerPut_BucketInstance::put_post(const DoutPrefixProvider *dpp
 
   objv_tracker = bci.info.objv_tracker;
 
-  int ret = bihandler->svc.bi->init_index(dpp, bci.info, bci.info.layout.current_index);
+  int ret = bihandler->svc.bi->init_index(dpp, y, bci.info, bci.info.layout.current_index);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/driver/rados/rgw_d3n_datacache.h
+++ b/src/rgw/driver/rados/rgw_d3n_datacache.h
@@ -209,7 +209,7 @@ int D3nRGWDataCache<T>::get_obj_iterate_cb(const DoutPrefixProvider *dpp, const 
     const uint64_t id = obj_ofs; // use logical object offset for sorting replies
 
     auto completed = d->aio->get(ref.obj, rgw::Aio::librados_op(ref.ioctx, std::move(op), d->yield), cost, id);
-    return d->flush(std::move(completed));
+    return d->flush(dpp, std::move(completed));
   } else {
     ldpp_dout(dpp, 20) << "D3nDataCache::" << __func__ << "(): oid=" << read_obj.oid << ", is_head_obj=" << is_head_obj << ", obj-ofs=" << obj_ofs << ", read_ofs=" << read_ofs << ", len=" << len << dendl;
     int r;
@@ -233,7 +233,7 @@ int D3nRGWDataCache<T>::get_obj_iterate_cb(const DoutPrefixProvider *dpp, const 
       d->d3n_bypass_cache_write = true;
       lsubdout(g_ceph_context, rgw, 5) << "D3nDataCache: " << __func__ << "(): Note - bypassing datacache: oid=" << read_obj.oid << ", read_ofs!=0 = " << read_ofs << ", size=" << astate->size << " != accounted_size=" << astate->accounted_size << ", is_compressed=" << is_compressed << ", is_encrypted=" << is_encrypted  << dendl;
       auto completed = d->aio->get(ref.obj, rgw::Aio::librados_op(ref.ioctx, std::move(op), d->yield), cost, id);
-      r = d->flush(std::move(completed));
+      r = d->flush(dpp, std::move(completed));
       return r;
     }
 
@@ -241,7 +241,7 @@ int D3nRGWDataCache<T>::get_obj_iterate_cb(const DoutPrefixProvider *dpp, const 
       // Read From Cache
       ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): READ FROM CACHE: oid=" << read_obj.oid << ", obj-ofs=" << obj_ofs << ", read_ofs=" << read_ofs << ", len=" << len << dendl;
       auto completed = d->aio->get(ref.obj, rgw::Aio::d3n_cache_op(dpp, d->yield, read_ofs, len, d->rgwrados->d3n_data_cache->cache_location), cost, id);
-      r = d->flush(std::move(completed));
+      r = d->flush(dpp, std::move(completed));
       if (r < 0) {
         lsubdout(g_ceph_context, rgw, 0) << "D3nDataCache: " << __func__ << "(): Error: failed to drain/flush, r= " << r << dendl;
       }
@@ -250,7 +250,7 @@ int D3nRGWDataCache<T>::get_obj_iterate_cb(const DoutPrefixProvider *dpp, const 
       // Write To Cache
       ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): WRITE TO CACHE: oid=" << read_obj.oid << ", obj-ofs=" << obj_ofs << ", read_ofs=" << read_ofs << " len=" << len << dendl;
       auto completed = d->aio->get(ref.obj, rgw::Aio::librados_op(ref.ioctx, std::move(op), d->yield), cost, id);
-      return d->flush(std::move(completed));
+      return d->flush(dpp, std::move(completed));
     }
   }
   lsubdout(g_ceph_context, rgw, 1) << "D3nDataCache: " << __func__ << "(): Warning: Check head object cache handling flow, oid=" << read_obj.oid << dendl;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -23,6 +23,7 @@
 #include "common/BackTrace.h"
 #include "common/ceph_time.h"
 
+#include "rgw_asio_thread.h"
 #include "rgw_cksum.h"
 #include "rgw_sal.h"
 #include "rgw_zone.h"
@@ -5230,6 +5231,7 @@ int RGWRados::delete_bucket(RGWBucketInfo& bucket_info, RGWObjVersionTracker& ob
     }
 
    /* remove bucket index objects asynchronously by best effort */
+    maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
     (void) CLSRGWIssueBucketIndexClean(index_pool,
 				       bucket_objs,
 				       cct->_conf->rgw_bucket_index_max_aio)();
@@ -5436,6 +5438,7 @@ int RGWRados::bucket_check_index(const DoutPrefixProvider *dpp, RGWBucketInfo& b
     bucket_objs_ret.emplace(iter.first, rgw_cls_check_index_ret());
   }
 
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   ret = CLSRGWIssueBucketCheck(index_pool, oids, bucket_objs_ret, cct->_conf->rgw_bucket_index_max_aio)();
   if (ret < 0) {
     return ret;
@@ -5460,6 +5463,7 @@ int RGWRados::bucket_rebuild_index(const DoutPrefixProvider *dpp, RGWBucketInfo&
     return r;
   }
 
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   return CLSRGWIssueBucketRebuild(index_pool, bucket_objs, cct->_conf->rgw_bucket_index_max_aio)();
 }
 
@@ -5611,6 +5615,8 @@ int RGWRados::bucket_set_reshard(const DoutPrefixProvider *dpp,
       cpp_strerror(-r) << ")" << dendl;
     return r;
   }
+
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   r = CLSRGWIssueSetBucketResharding(index_pool, bucket_objs, entry, cct->_conf->rgw_bucket_index_max_aio)();
   if (r < 0) {
     ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
@@ -9527,6 +9533,7 @@ int RGWRados::cls_obj_set_bucket_tag_timeout(const DoutPrefixProvider *dpp, RGWB
   if (r < 0)
     return r;
 
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   return CLSRGWIssueSetTagTimeout(index_pool, bucket_objs, cct->_conf->rgw_bucket_index_max_aio, timeout)();
 }
 
@@ -9658,6 +9665,7 @@ int RGWRados::cls_bucket_list_ordered(const DoutPrefixProvider *dpp,
   auto& ioctx = index_pool;
   std::map<int, rgw_cls_list_ret> shard_list_results;
   cls_rgw_obj_key start_after_key(start_after.name, start_after.instance);
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   r = CLSRGWIssueBucketList(ioctx, start_after_key, prefix, delimiter,
 			    num_entries_per_shard,
 			    list_versions, shard_oids, shard_list_results,
@@ -10438,6 +10446,7 @@ int RGWRados::cls_bucket_head(const DoutPrefixProvider *dpp, const RGWBucketInfo
     return r;
   }
 
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   r = CLSRGWIssueGetDirHeader(index_pool, oids, list_results, cct->_conf->rgw_bucket_index_max_aio)();
   if (r < 0) {
     ldpp_dout(dpp, 20) << "cls_bucket_head: CLSRGWIssueGetDirHeader() returned "

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -23,6 +23,7 @@
 #include "common/BackTrace.h"
 #include "common/ceph_time.h"
 
+#include "bucket_index.h"
 #include "rgw_asio_thread.h"
 #include "rgw_cksum.h"
 #include "rgw_sal.h"
@@ -2359,7 +2360,9 @@ int RGWRados::create_bucket(const DoutPrefixProvider* dpp,
     }
 
     if (zone_placement) {
-      ret = svc.bi->init_index(dpp, y, info, info.layout.current_index);
+      // create the bucket index shards
+      ret = rgwrados::bucket_index::init(dpp, y, *get_rados_handle(), *svc.site,
+                                         info, info.layout.current_index);
       if (ret < 0) {
         return ret;
       }

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -2359,7 +2359,7 @@ int RGWRados::create_bucket(const DoutPrefixProvider* dpp,
     }
 
     if (zone_placement) {
-      ret = svc.bi->init_index(dpp, info, info.layout.current_index);
+      ret = svc.bi->init_index(dpp, y, info, info.layout.current_index);
       if (ret < 0) {
         return ret;
       }

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9518,19 +9518,6 @@ int RGWRados::cls_obj_complete_cancel(BucketShard& bs, string& tag, rgw_obj& obj
 			     zones_trace, log_op);
 }
 
-int RGWRados::cls_obj_set_bucket_tag_timeout(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, uint64_t timeout)
-{
-  librados::IoCtx index_pool;
-  map<int, string> bucket_objs;
-  int r = svc.bi_rados->open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
-  if (r < 0)
-    return r;
-
-  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
-  return CLSRGWIssueSetTagTimeout(index_pool, bucket_objs, cct->_conf->rgw_bucket_index_max_aio, timeout)();
-}
-
-
 // returns 0 if there is an error in calculation
 uint32_t RGWRados::calc_ordered_bucket_list_per_shard(uint32_t num_entries,
 						      uint32_t num_shards)

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1510,11 +1510,6 @@ public:
 				rgw_obj_index_key *last_entry,
                                 optional_yield y,
 				RGWBucketListNameFilter force_check_filter = {});
-  int cls_bucket_head(const DoutPrefixProvider *dpp,
-		      const RGWBucketInfo& bucket_info,
-		      const rgw::bucket_index_layout_generation& idx_layout,
-		      int shard_id, std::vector<rgw_bucket_dir_header>& headers,
-		      std::map<int, std::string> *bucket_instance_ids = NULL);
   int cls_bucket_head_async(const DoutPrefixProvider *dpp,
 			    const RGWBucketInfo& bucket_info,
 			    const rgw::bucket_index_layout_generation& idx_layout,

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1718,23 +1718,23 @@ struct get_obj_data {
   D3nGetObjData d3n_get_data;
   std::atomic_bool d3n_bypass_cache_write{false};
 
-  int flush(rgw::AioResultList&& results);
+  int flush(const DoutPrefixProvider* dpp, rgw::AioResultList&& results);
 
   void cancel() {
     // wait for all completions to drain and ignore the results
     aio->drain();
   }
 
-  int drain() {
+  int drain(const DoutPrefixProvider* dpp) {
     auto c = aio->wait();
     while (!c.empty()) {
-      int r = flush(std::move(c));
+      int r = flush(dpp, std::move(c));
       if (r < 0) {
         cancel();
         return r;
       }
       c = aio->wait();
     }
-    return flush(std::move(c));
+    return flush(dpp, std::move(c));
   }
 };

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1477,7 +1477,6 @@ public:
   int cls_obj_complete_cancel(BucketShard& bs, std::string& tag, rgw_obj& obj,
                               std::list<rgw_obj_index_key> *remove_objs,
                               uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr, bool log_op = true);
-  int cls_obj_set_bucket_tag_timeout(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, uint64_t timeout);
 
   using ent_map_t =
     boost::container::flat_map<std::string, rgw_bucket_dir_entry>;

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -421,7 +421,7 @@ static int remove_old_reshard_instance(rgw::sal::RadosStore* store,
   }
 
   // delete its shard objects (ignore errors)
-  store->svc()->bi->clean_index(dpp, info, info.layout.current_index);
+  store->svc()->bi->clean_index(dpp, y, info, info.layout.current_index);
   // delete the bucket instance metadata
   return store->ctl()->bucket->remove_bucket_instance_info(bucket, info, y, dpp);
 }
@@ -459,7 +459,7 @@ static int init_target_index(rgw::sal::RadosStore* store,
       ldpp_dout(dpp, 0) << "ERROR: " << __func__ << " failed to disable "
           "bucket sync on the target index shard objects: "
           << cpp_strerror(ret) << dendl;
-      store->svc()->bi->clean_index(dpp, bucket_info, index);
+      store->svc()->bi->clean_index(dpp, y, bucket_info, index);
       return ret;
     }
   }
@@ -505,7 +505,7 @@ static int init_target_layout(rgw::sal::RadosStore* store,
     ldpp_dout(dpp, 10) << __func__ << " removing existing target index "
         "objects from a previous reshard attempt" << dendl;
     // delete its existing shard objects (ignore errors)
-    store->svc()->bi->clean_index(dpp, bucket_info, *bucket_info.layout.target_index);
+    store->svc()->bi->clean_index(dpp, y, bucket_info, *bucket_info.layout.target_index);
     // don't reuse this same generation in the new target layout, in case
     // something is still trying to operate on its shard objects
     target.gen = bucket_info.layout.target_index->gen + 1;
@@ -574,7 +574,7 @@ static int init_target_layout(rgw::sal::RadosStore* store,
     bucket_info.layout = std::move(prev);  // restore in-memory layout
 
     // delete the target shard objects (ignore errors)
-    store->svc()->bi->clean_index(dpp, bucket_info, target);
+    store->svc()->bi->clean_index(dpp, y, bucket_info, target);
     return ret;
   }
 
@@ -592,7 +592,7 @@ static int revert_target_layout(rgw::sal::RadosStore* store,
   auto prev = bucket_info.layout; // make a copy for cleanup
 
   // remove target index shard objects
-  int ret = store->svc()->bi->clean_index(dpp, bucket_info, *prev.target_index);
+  int ret = store->svc()->bi->clean_index(dpp, y, bucket_info, *prev.target_index);
   if (ret < 0) {
     ldpp_dout(dpp, 1) << "WARNING: " << __func__ << " failed to remove "
         "target index with: " << cpp_strerror(ret) << dendl;
@@ -947,7 +947,7 @@ static int commit_reshard(rgw::sal::RadosStore* store,
       });
   if (log == logs.end()) {
     // delete the index objects (ignore errors)
-    store->svc()->bi->clean_index(dpp, bucket_info, prev.current_index);
+    store->svc()->bi->clean_index(dpp, y, bucket_info, prev.current_index);
   }
   return 0;
 } // commit_reshard

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -766,9 +766,11 @@ int RadosBucket::rebuild_index(const DoutPrefixProvider *dpp)
   return store->getRados()->bucket_rebuild_index(dpp, info);
 }
 
-int RadosBucket::set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout)
+int RadosBucket::set_tag_timeout(const DoutPrefixProvider *dpp,
+                                 optional_yield y, uint64_t timeout)
 {
-  return store->getRados()->cls_obj_set_bucket_tag_timeout(dpp, info, timeout);
+  return store->getRados()->svc.bi_rados->set_tag_timeout(
+      dpp, y, info, info.layout.current_index, timeout);
 }
 
 int RadosBucket::purge_instance(const DoutPrefixProvider* dpp, optional_yield y)

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -732,7 +732,8 @@ class RadosBucket : public StoreBucket {
     virtual int remove_objs_from_index(const DoutPrefixProvider *dpp, std::list<rgw_obj_index_key>& objs_to_unlink) override;
     virtual int check_index(const DoutPrefixProvider *dpp, std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) override;
     virtual int rebuild_index(const DoutPrefixProvider *dpp) override;
-    virtual int set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout) override;
+    virtual int set_tag_timeout(const DoutPrefixProvider *dpp,
+                                optional_yield y, uint64_t timeout) override;
     virtual int purge_instance(const DoutPrefixProvider* dpp, optional_yield y) override;
     virtual std::unique_ptr<Bucket> clone() override {
       return std::make_unique<RadosBucket>(*this);

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -923,7 +923,8 @@ class Bucket {
     /** Rebuild the bucket index.  May be removed from API */
     virtual int rebuild_index(const DoutPrefixProvider *dpp) = 0;
     /** Set a timeout on the check_index() call.  May be removed from API */
-    virtual int set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout) = 0;
+    virtual int set_tag_timeout(const DoutPrefixProvider *dpp,
+                                optional_yield y, uint64_t timeout) = 0;
     /** Remove this specific bucket instance from the backing store.  May be removed from API */
     virtual int purge_instance(const DoutPrefixProvider* dpp, optional_yield y) = 0;
 

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -319,7 +319,8 @@ namespace rgw::sal {
     return 0;
   }
 
-  int DBBucket::set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout)
+  int DBBucket::set_tag_timeout(const DoutPrefixProvider *dpp,
+                                optional_yield y, uint64_t timeout)
   {
     /* XXX: CHECK: set tag timeout for all the bucket objects? */
     return 0;

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -178,7 +178,8 @@ protected:
       virtual int remove_objs_from_index(const DoutPrefixProvider *dpp, std::list<rgw_obj_index_key>& objs_to_unlink) override;
       virtual int check_index(const DoutPrefixProvider *dpp, std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) override;
       virtual int rebuild_index(const DoutPrefixProvider *dpp) override;
-      virtual int set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout) override;
+      virtual int set_tag_timeout(const DoutPrefixProvider *dpp,
+                                  optional_yield y, uint64_t timeout) override;
       virtual int purge_instance(const DoutPrefixProvider *dpp, optional_yield y) override;
       virtual std::unique_ptr<Bucket> clone() override {
         return std::make_unique<DBBucket>(*this);

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -942,9 +942,10 @@ int FilterBucket::rebuild_index(const DoutPrefixProvider *dpp)
   return next->rebuild_index(dpp);
 }
 
-int FilterBucket::set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout)
+int FilterBucket::set_tag_timeout(const DoutPrefixProvider *dpp,
+                                optional_yield y, uint64_t timeout)
 {
-  return next->set_tag_timeout(dpp, timeout);
+  return next->set_tag_timeout(dpp, y, timeout);
 }
 
 int FilterBucket::purge_instance(const DoutPrefixProvider* dpp, optional_yield y)

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -623,7 +623,8 @@ public:
 			  std::map<RGWObjCategory, RGWStorageStats>&
 			  calculated_stats) override;
   virtual int rebuild_index(const DoutPrefixProvider *dpp) override;
-  virtual int set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout) override;
+  virtual int set_tag_timeout(const DoutPrefixProvider *dpp,
+                              optional_yield y, uint64_t timeout) override;
   virtual int purge_instance(const DoutPrefixProvider* dpp, optional_yield y) override;
   virtual bool empty() const override { return next->empty(); }
   virtual const std::string& get_name() const override { return next->get_name(); }

--- a/src/rgw/services/svc_bi.h
+++ b/src/rgw/services/svc_bi.h
@@ -33,7 +33,9 @@ public:
                          const RGWBucketInfo& bucket_info,
                          const rgw::bucket_index_layout_generation& idx_layout,
                          bool judge_support_logrecord = false) = 0;
-  virtual int clean_index(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout) = 0;
+  virtual int clean_index(const DoutPrefixProvider *dpp, optional_yield y,
+                          const RGWBucketInfo& bucket_info,
+                          const rgw::bucket_index_layout_generation& idx_layout) = 0;
 
   virtual int read_stats(const DoutPrefixProvider *dpp,
                          const RGWBucketInfo& bucket_info,

--- a/src/rgw/services/svc_bi.h
+++ b/src/rgw/services/svc_bi.h
@@ -29,13 +29,11 @@ public:
   RGWSI_BucketIndex(CephContext *cct) : RGWServiceInstance(cct) {}
   virtual ~RGWSI_BucketIndex() {}
 
-  virtual int init_index(const DoutPrefixProvider *dpp,
-                         RGWBucketInfo& bucket_info,
+  virtual int init_index(const DoutPrefixProvider *dpp, optional_yield y,
+                         const RGWBucketInfo& bucket_info,
                          const rgw::bucket_index_layout_generation& idx_layout,
                          bool judge_support_logrecord = false) = 0;
-  virtual int clean_index(const DoutPrefixProvider *dpp,
-                          RGWBucketInfo& bucket_info,
-                          const rgw::bucket_index_layout_generation& idx_layout) = 0;
+  virtual int clean_index(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout) = 0;
 
   virtual int read_stats(const DoutPrefixProvider *dpp,
                          const RGWBucketInfo& bucket_info,

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -1,18 +1,22 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
+#include <concepts>
 #include <fmt/format.h>
 
 #include "svc_bi_rados.h"
 #include "svc_bilog_rados.h"
 #include "svc_zone.h"
 
+#include "rgw_aio_throttle.h"
 #include "rgw_asio_thread.h"
 #include "rgw_bucket.h"
 #include "rgw_zone.h"
 #include "rgw_datalog.h"
 
 #include "cls/rgw/cls_rgw_client.h"
+
+#include "common/errno.h"
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -315,16 +319,17 @@ int RGWSI_BucketIndex_RADOS::cls_bucket_head(const DoutPrefixProvider *dpp,
 }
 
 int RGWSI_BucketIndex_RADOS::init_index(const DoutPrefixProvider *dpp,
-                                        RGWBucketInfo& bucket_info,
+                                        optional_yield y,
+                                        const RGWBucketInfo& bucket_info,
                                         const rgw::bucket_index_layout_generation& idx_layout,
                                         bool judge_support_logrecord)
 {
-  librados::IoCtx index_pool;
+  librados::IoCtx ioctx;
 
   string dir_oid = dir_oid_prefix;
-  int r = open_bucket_index_pool(dpp, bucket_info, &index_pool);
-  if (r < 0) {
-    return r;
+  int ret = open_bucket_index_pool(dpp, bucket_info, &ioctx);
+  if (ret < 0) {
+    return ret;
   }
 
   dir_oid.append(bucket_info.bucket.bucket_id);
@@ -332,16 +337,61 @@ int RGWSI_BucketIndex_RADOS::init_index(const DoutPrefixProvider *dpp,
   map<int, string> bucket_objs;
   get_bucket_index_objects(dir_oid, idx_layout.layout.normal.num_shards, idx_layout.gen, &bucket_objs);
 
-  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
-  if (judge_support_logrecord) {
-    return CLSRGWIssueBucketIndexInit2(index_pool,
-                                       bucket_objs,
-                                       cct->_conf->rgw_bucket_index_max_aio)();
-  } else {
-    return CLSRGWIssueBucketIndexInit(index_pool,
-                                      bucket_objs,
-                                      cct->_conf->rgw_bucket_index_max_aio)();
+  // issue up to max_aio requests in parallel
+  auto aio = rgw::make_throttle(cct->_conf->rgw_bucket_index_max_aio, y);
+  constexpr uint64_t cost = 1; // 1 throttle unit per request
+  constexpr uint64_t id = 0; // ids unused
+
+  // ignore EEXIST errors from exclusive create
+  constexpr auto is_error = [] (int r) { return r < 0 && r != -EEXIST; };
+  constexpr std::string_view error_message =
+      "failed to init index object";
+
+  // track all completions so we can roll back on error
+  rgw::AioResultList completed;
+
+  for (const auto& [_, oid] : bucket_objs) {
+    librados::ObjectWriteOperation op;
+    op.create(true);
+    cls_rgw_bucket_init_index(op);
+
+    rgw_raw_obj obj; // obj.pool is empty and unused
+    obj.oid = oid;
+
+    auto c = aio->get(obj, rgw::Aio::librados_op(ioctx, std::move(op), y), cost, id);
+    ret = rgw::check_for_errors(c, is_error, dpp, error_message);
+
+    completed.splice(completed.end(), c);
+
+    if (ret < 0) {
+      break;
+    }
   }
+
+  auto c = aio->drain();
+  if (ret == 0) {
+    // check for errors from drain()
+    ret = rgw::check_for_errors(c, is_error, dpp, error_message);
+    if (ret == 0) {
+      return 0;
+    }
+  }
+  completed.splice(completed.end(), c);
+
+  // on error, delete any objects that were successfully created
+  for (const rgw::AioResult& e : completed) {
+    if (e.result < 0) {
+      continue;
+    }
+
+    librados::ObjectWriteOperation op;
+    op.remove();
+
+    std::ignore = aio->get(e.obj, rgw::Aio::librados_op(ioctx, std::move(op), y), cost, id);
+  }
+  std::ignore = aio->drain();
+
+  return ret;
 }
 
 int RGWSI_BucketIndex_RADOS::clean_index(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout)

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -5,6 +5,7 @@
 #include "svc_bilog_rados.h"
 #include "svc_zone.h"
 
+#include "rgw_asio_thread.h"
 #include "rgw_bucket.h"
 #include "rgw_zone.h"
 #include "rgw_datalog.h"
@@ -339,6 +340,7 @@ int RGWSI_BucketIndex_RADOS::cls_bucket_head(const DoutPrefixProvider *dpp,
     list_results.emplace(iter.first, rgw_cls_list_ret());
   }
 
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   r = CLSRGWIssueGetDirHeader(index_pool, oids, list_results,
 			      cct->_conf->rgw_bucket_index_max_aio)();
   if (r < 0)
@@ -369,6 +371,7 @@ int RGWSI_BucketIndex_RADOS::init_index(const DoutPrefixProvider *dpp,
   map<int, string> bucket_objs;
   get_bucket_index_objects(dir_oid, idx_layout.layout.normal.num_shards, idx_layout.gen, &bucket_objs);
 
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   if (judge_support_logrecord) {
     return CLSRGWIssueBucketIndexInit2(index_pool,
                                        bucket_objs,
@@ -396,6 +399,7 @@ int RGWSI_BucketIndex_RADOS::clean_index(const DoutPrefixProvider *dpp, RGWBucke
   get_bucket_index_objects(dir_oid, idx_layout.layout.normal.num_shards,
                            idx_layout.gen, &bucket_objs);
 
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   return CLSRGWIssueBucketIndexClean(index_pool,
 				     bucket_objs,
 				     cct->_conf->rgw_bucket_index_max_aio)();

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -121,13 +121,11 @@ public:
     return bucket_shard_index(sharding_key, num_shards);
   }
 
-  int init_index(const DoutPrefixProvider *dpp,
-                 RGWBucketInfo& bucket_info,
+  int init_index(const DoutPrefixProvider *dpp, optional_yield y,
+                 const RGWBucketInfo& bucket_info,
                  const rgw::bucket_index_layout_generation& idx_layout,
                  bool judge_support_logrecord = false) override;
-  int clean_index(const DoutPrefixProvider *dpp,
-                  RGWBucketInfo& bucket_info,
-                  const rgw::bucket_index_layout_generation& idx_layout) override;
+  int clean_index(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout) override;
 
   /* RADOS specific */
 

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -66,14 +66,6 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
                               uint64_t gen_id, const std::string& obj_key,
                               std::string* bucket_obj, int* shard_id);
 
-  int cls_bucket_head(const DoutPrefixProvider *dpp,
-		      const RGWBucketInfo& bucket_info,
-                      const rgw::bucket_index_layout_generation& idx_layout,
-                      int shard_id,
-                      std::vector<rgw_bucket_dir_header> *headers,
-                      std::map<int, std::string> *bucket_instance_ids,
-                      optional_yield y);
-
 public:
 
   librados::Rados* rados{nullptr};
@@ -130,6 +122,14 @@ public:
                   const rgw::bucket_index_layout_generation& idx_layout) override;
 
   /* RADOS specific */
+
+  int cls_bucket_head(const DoutPrefixProvider *dpp,
+		      const RGWBucketInfo& bucket_info,
+                      const rgw::bucket_index_layout_generation& idx_layout,
+                      int shard_id,
+                      std::vector<rgw_bucket_dir_header> *headers,
+                      std::map<int, std::string> *bucket_instance_ids,
+                      optional_yield y);
 
   int read_stats(const DoutPrefixProvider *dpp,
                  const RGWBucketInfo& bucket_info,

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -22,6 +22,7 @@
 
 #include "svc_bi.h"
 #include "svc_tier_rados.h"
+#include "cls/rgw/cls_rgw_ops.h"
 
 struct rgw_bucket_dir_header;
 
@@ -171,4 +172,15 @@ public:
                       const RGWBucketInfo& bucket_info,
                       const rgw::bucket_index_layout_generation& idx_layout,
                       uint64_t timeout);
+
+  int list_objects(const DoutPrefixProvider* dpp,
+                   optional_yield y,
+                   librados::IoCtx& ioctx,
+                   const std::map<int, std::string>& shard_oids,
+                   const cls_rgw_obj_key& start_obj,
+                   const std::string& filter_prefix,
+                   const std::string& delimiter,
+                   uint32_t num_entries,
+                   bool list_versions,
+                   std::map<int, rgw_cls_list_ret>& list_results);
 };

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -166,4 +166,9 @@ public:
                         librados::IoCtx* index_pool,
                         std::map<int, std::string> *bucket_objs,
                         std::map<int, std::string> *bucket_instance_ids);
+
+  int set_tag_timeout(const DoutPrefixProvider* dpp, optional_yield y,
+                      const RGWBucketInfo& bucket_info,
+                      const rgw::bucket_index_layout_generation& idx_layout,
+                      uint64_t timeout);
 };

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -125,7 +125,9 @@ public:
                  const RGWBucketInfo& bucket_info,
                  const rgw::bucket_index_layout_generation& idx_layout,
                  bool judge_support_logrecord = false) override;
-  int clean_index(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout) override;
+  int clean_index(const DoutPrefixProvider *dpp, optional_yield y,
+                  const RGWBucketInfo& bucket_info,
+                  const rgw::bucket_index_layout_generation& idx_layout) override;
 
   /* RADOS specific */
 

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -4,6 +4,7 @@
 #include "svc_bilog_rados.h"
 #include "svc_bi_rados.h"
 
+#include "rgw_asio_thread.h"
 #include "cls/rgw/cls_rgw_client.h"
 
 #define dout_subsys ceph_subsys_rgw
@@ -48,6 +49,7 @@ int RGWSI_BILog_RADOS::log_trim(const DoutPrefixProvider *dpp,
     return r;
   }
 
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   return CLSRGWIssueBILogTrim(index_pool, start_marker_mgr, end_marker_mgr, bucket_objs,
 			      cct->_conf->rgw_bucket_index_max_aio)();
 }
@@ -61,6 +63,7 @@ int RGWSI_BILog_RADOS::log_start(const DoutPrefixProvider *dpp, const RGWBucketI
   if (r < 0)
     return r;
 
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   return CLSRGWIssueResyncBucketBILog(index_pool, bucket_objs, cct->_conf->rgw_bucket_index_max_aio)();
 }
 
@@ -73,6 +76,7 @@ int RGWSI_BILog_RADOS::log_stop(const DoutPrefixProvider *dpp, const RGWBucketIn
   if (r < 0)
     return r;
 
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   return CLSRGWIssueBucketBILogStop(index_pool, bucket_objs, cct->_conf->rgw_bucket_index_max_aio)();
 }
 
@@ -113,6 +117,7 @@ int RGWSI_BILog_RADOS::log_list(const DoutPrefixProvider *dpp,
   if (r < 0)
     return r;
 
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
   r = CLSRGWIssueBILogList(index_pool, marker_mgr, max, oids, bi_log_lists, cct->_conf->rgw_bucket_index_max_aio)();
   if (r < 0)
     return r;

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -261,6 +261,21 @@ TEST_F(cls_rgw, index_remove_object)
 	     total_size);
 }
 
+static int set_tag_timeout(librados::IoCtx& ioctx,
+                           std::map<int, std::string>& bucket_objs,
+                           uint64_t timeout)
+{
+  for (const auto& [_, oid] : bucket_objs) {
+    librados::ObjectWriteOperation op;
+    cls_rgw_bucket_set_tag_timeout(op, timeout);
+
+    if (int r = ioctx.operate(oid, &op); r < 0) {
+      return r;
+    }
+  }
+  return 0;
+}
+
 TEST_F(cls_rgw, index_suggest)
 {
   string bucket_oid = str_int("suggest", 1);
@@ -347,7 +362,7 @@ TEST_F(cls_rgw, index_suggest)
 
   map<int, string> bucket_objs;
   bucket_objs[0] = bucket_oid;
-  int r = CLSRGWIssueSetTagTimeout(ioctx, bucket_objs, 8 /* max aio */, 1)();
+  int r = set_tag_timeout(ioctx, bucket_objs, 1);
   ASSERT_EQ(0, r);
 
   sleep(1);


### PR DESCRIPTION
(includes commits from https://github.com/ceph/ceph/pull/58461 and https://github.com/ceph/ceph/pull/58448)

CLSRGWConcurrentIO in cls_rgw_client.h is used for several bucket index operations that need to send requests to every shard object. it uses ioctx.aio_operate() to send async requests, but blocks on a condition variable waiting for completions

when called from a coroutine, we shouldn't block this way. the rgw::Aio abstraction and concrete Yielding/BlockingAioThrottle classes were built to handle this for PutObject/GetObject. start using them to replace CLSRGWConcurrentIO too

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
