### PR TITLE
common/async: spawn_throttle wraps call to asio::spawn()

### DIFF
--- a/src/common/async/max_concurrent_for_each.h
+++ b/src/common/async/max_concurrent_for_each.h
@@ -60,10 +60,9 @@ void max_concurrent_for_each(Iterator begin,
   }
   auto throttle = spawn_throttle{y, max_concurrent, on_error};
   for (Iterator i = begin; i != end; ++i) {
-    boost::asio::spawn(throttle.get_executor(),
-                       [&func, &val = *i] (boost::asio::yield_context yield) {
-                         func(val, yield);
-                       }, throttle);
+    throttle.spawn([&func, &val = *i] (boost::asio::yield_context yield) {
+        func(val, yield);
+      });
   }
   throttle.wait();
 }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7156,10 +7156,9 @@ void RGWDeleteMultiObj::execute(optional_yield y)
   auto group = ceph::async::spawn_throttle{y, max_aio};
 
   for (const auto& key : multi_delete->objects) {
-    boost::asio::spawn(group.get_executor(),
-                       [this, &key] (boost::asio::yield_context yield) {
-                         handle_individual_object(key, yield);
-                       }, group);
+    group.spawn([this, &key] (boost::asio::yield_context yield) {
+                  handle_individual_object(key, yield);
+                });
 
     rgw_flush_formatter(s, s->formatter);
   }


### PR DESCRIPTION
(relates to discussion from https://github.com/ceph/ceph/pull/58348)

cancellation of the parent must immediately cancel its children, which only works if the children are on the same executor as the parent

prohibit child coroutines from being spawned on a different executor by wrapping the call to asio::spawn() in a new spawn_throttle::spawn() interface

expose an overload for asio::spawn()'s optional StackAllocator argument

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
