### PR TITLE
qa/crontab: update frequency and priority for rados nightlies

### DIFF
--- a/qa/crontab/teuthology-cronjobs
+++ b/qa/crontab/teuthology-cronjobs
@@ -71,7 +71,7 @@ TEUTHOLOGY_SUITE_ARGS="--non-interactive --newest=100 --ceph-repo=https://git.ce
 ## see script in https://github.com/ceph/ceph/tree/main/qa/machine_types
 
 # rados is massive and difficult to bring down to less than 300 jobs, use one higher priority
-00 20 * * 0        $CW $SS 100000 --ceph main --suite      rados -p 951
+00 20 * * 0        $CW $SS 100000 --ceph main --suite      rados -p 101
 08 20 * * 1        $CW $SS     64 --ceph main --suite       orch -p 950
 16 20 * * 2        $CW $SS    128 --ceph main --suite        rbd -p 950
 24 20 1 * *        $CW $SS    512 --ceph main --suite         fs -p 700
@@ -86,7 +86,7 @@ TEUTHOLOGY_SUITE_ARGS="--non-interactive --newest=100 --ceph-repo=https://git.ce
 
 # rados is massive and difficult to bring down to less than 300 jobs, use one higher priority
 #                                                                 -p 94-
-00 21 * * 0,4      $CW $SS 100000 --ceph squid --suite      rados -p 101 --force-priority
+00 21 * * 0        $CW $SS 100000 --ceph squid --suite      rados -p 700 --force-priority
 08 21 * * 1,5      $CW $SS     64 --ceph squid --suite       orch -p 100 --force-priority
 16 21 * * 2,6      $CW $SS    128 --ceph squid --suite        rbd -p 100 --force-priority
 24 21 * * 3,0      $CW $SS    512 --ceph squid --suite         fs -p 100 --force-priority


### PR DESCRIPTION
Although main rados nightlies are scheduled to run weekly, they are so low in the queue that they take weeks to run, and when they finally do, most of the jobs die (likely due to waiting in the queue so long).

This commit increases the priority of main rados runs since these are most important for debugging new failures. To compliment this increase in priority, this commit also decreases the frequency of squid rados runs from twice a week to once a week, since once is more than enough. It also decreases the priority of squid runs.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
