### PR TITLE
squid: bluestore/bluestore_types: avoid heap-buffer-overflow in another way to keep code uniformity

### DIFF
--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -1377,7 +1377,7 @@ struct sb_info_space_efficient_map_t {
       if (aux_items.size() != 0) {
 	auto it = std::lower_bound(
 	  aux_items.begin(),
-	  aux_items.end(),
+	  aux_items.end() - 1,
 	  id,
 	  [](const sb_info_t& a, const uint64_t& b) {
 	    return a < b;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67134

---

backport of https://github.com/ceph/ceph/pull/56937
parent tracker: https://tracker.ceph.com/issues/65482

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh