### PR TITLE
squid: crimson/osd/pg_recovery: skip unfound objects when recovering the primary

### DIFF
--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -739,6 +739,10 @@ public:
     // TODO: see PrimaryLogPG::mark_all_unfound_lost()
     return seastar::now();
   }
+  interruptible_future<> find_unfound(epoch_t epoch_started);
+  bool have_unfound() const {
+    return peering_state.have_unfound();
+  }
 
   bool old_peering_msg(epoch_t reply_epoch, epoch_t query_epoch) const;
 
@@ -771,9 +775,6 @@ private:
   friend class SnapTrimEvent;
   friend class SnapTrimObjSubEvent;
 private:
-  seastar::future<bool> find_unfound() {
-    return seastar::make_ready_future<bool>(true);
-  }
 
   bool can_discard_replica_op(const Message& m, epoch_t m_map_epoch) const;
   bool can_discard_op(const MOSDOp& m) const;

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -146,10 +146,22 @@ size_t PGRecovery::start_primary_recovery_ops(
     } else {
       soid = p->second;
     }
-    const pg_missing_item& item = missing.get_items().find(p->second)->second;
-    ++p;
 
     hobject_t head = soid.get_head();
+
+    if (pg->get_peering_state().get_missing_loc().is_unfound(soid)) {
+      logger().debug("{}: object {} unfound", __func__, soid);
+      ++skipped;
+      continue;
+    }
+    if (pg->get_peering_state().get_missing_loc().is_unfound(head)) {
+      logger().debug("{}: head object {} unfound", __func__, soid);
+      ++skipped;
+      continue;
+    }
+
+    const pg_missing_item& item = missing.get_items().find(p->second)->second;
+    ++p;
 
     bool head_missing = missing.is_missing(head);
     logger().info(


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57147

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh