### PR TITLE
squid: crimson/osd/osd_operations/client_request_common: `PeeringState::needs_recovery()` may fail if the object is under backfill

### DIFF
--- a/src/crimson/osd/osd_operations/client_request_common.cc
+++ b/src/crimson/osd/osd_operations/client_request_common.cc
@@ -19,20 +19,34 @@ CommonClientRequest::do_recover_missing(
   const hobject_t& soid,
   const osd_reqid_t& reqid)
 {
-  eversion_t ver;
-  assert(pg->is_primary());
   logger().debug("{} reqid {} check for recovery, {}",
                  __func__, reqid, soid);
+  assert(pg->is_primary());
+  eversion_t ver;
   auto &peering_state = pg->get_peering_state();
   auto &missing_loc = peering_state.get_missing_loc();
-  bool needs_recovery = missing_loc.needs_recovery(soid, &ver);
-  if (!pg->is_unreadable_object(soid) &&
-      !pg->is_degraded_or_backfilling_object(soid)) {
+  bool needs_recovery_or_backfill = false;
+
+  if (pg->is_unreadable_object(soid)) {
+    logger().debug("{} reqid {}, {} is unreadable",
+                   __func__, reqid, soid);
+    ceph_assert(missing_loc.needs_recovery(soid, &ver));
+    needs_recovery_or_backfill = true;
+  }
+
+  if (pg->is_degraded_or_backfilling_object(soid)) {
+    logger().debug("{} reqid {}, {} is degraded or backfilling",
+                   __func__, reqid, soid);
+    if (missing_loc.needs_recovery(soid, &ver)) {
+      needs_recovery_or_backfill = true;
+    }
+  }
+
+  if (!needs_recovery_or_backfill) {
     logger().debug("{} reqid {} nothing to recover {}",
                    __func__, reqid, soid);
     return seastar::now();
   }
-  ceph_assert(needs_recovery);
 
   logger().debug("{} reqid {} need to wait for recovery, {} version {}",
                  __func__, reqid, soid, ver);


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57691

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh