### PR TITLE
squid: crimson/osd/pg: reset the snap mapper's backend when pg interval changes

### DIFF
--- a/src/common/map_cacher.hpp
+++ b/src/common/map_cacher.hpp
@@ -85,6 +85,10 @@ private:
 public:
   MapCacher(StoreDriver<K, V> *driver) : driver(driver) {}
 
+  void reset() {
+    in_progress.reset();
+  }
+
   /// Fetch first key/value std::pair after specified key
   int get_next(
     K key,               ///< [in] key after which to get next

--- a/src/common/sharedptr_registry.hpp
+++ b/src/common/sharedptr_registry.hpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <memory>
 #include "common/ceph_mutex.h"
+#include "include/ceph_assert.h"
 
 /**
  * Provides a registry of shared_ptr<V> indexed by K while
@@ -60,6 +61,11 @@ public:
   SharedPtrRegistry() :
     waiting(0)
   {}
+
+  void reset() {
+    ceph_assert(!waiting);
+    contents.clear();
+  }
 
   bool empty() {
     std::lock_guard l(lock);

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1592,6 +1592,7 @@ void PG::on_change(ceph::os::Transaction &t) {
   // is save and in time.
   peering_state.state_clear(PG_STATE_SNAPTRIM);
   peering_state.state_clear(PG_STATE_SNAPTRIM_ERROR);
+  snap_mapper.reset_backend();
 }
 
 void PG::context_registry_on_change() {

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -357,6 +357,11 @@ private:
     return prefix_itr;
   }
 
+  /// reset the MapCacher backend, this should be called on pg interval change
+  void reset_backend() {
+    backend.reset();
+  }
+
   /// Update snaps for oid, empty new_snaps removes the mapping
   int update_snaps(
     const hobject_t &oid,       ///< [in] oid to update


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57125

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh