### PR TITLE
squid: crimson/os/seastore: add writer level stats to RBM

### DIFF
--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -1027,7 +1027,7 @@ RandomBlockOolWriter::do_write(
       auto& trans_stats = get_by_src(w_stats.stats_by_src, t.get_src());
       ++(trans_stats.num_records);
       trans_stats.data_bytes += ex->get_length();
-      w_stats.record_group_data_bytes += ex->get_length();
+      w_stats.data_bytes += ex->get_length();
     }
     return trans_intr::make_interruptible(
       rbm->write(paddr + offset,

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -311,7 +311,12 @@ ExtentPlacementManager::get_device_stats(
     }
     main_stats.add(main_writer_stats.back());
   } else { // RBM
-    // TODO stats from RandomBlockOolWriter
+    ceph_assert(get_main_backend_type() == backend_type_t::RANDOM_BLOCK);
+    // In RBM, md_writer and data_wrtier share a single writer, so we only register
+    // md_writer's writer here.
+    main_writer_stats.emplace_back(
+        get_writer(METADATA, OOL_GENERATION)->get_stats());
+    main_stats.add(main_writer_stats.back());
   }
 
   writer_stats_t cold_stats = {};
@@ -360,7 +365,7 @@ ExtentPlacementManager::get_device_stats(
       report_writer_stats("  mainmdat", main_writer_stats[2]);
       report_writer_stats("  maindata", main_writer_stats[3]);
     } else { // RBM
-      // TODO stats from RandomBlockOolWriter
+      report_writer_stats("  ool", main_writer_stats[0]);
     }
     if (has_cold_tier) {
       report_writer_stats("tier-cold", cold_stats);
@@ -1019,6 +1024,10 @@ RandomBlockOolWriter::do_write(
       bp = ceph::bufferptr(ex->get_bptr(), offset, len);
     } else {
       bp = ex->get_bptr();
+      auto& trans_stats = get_by_src(w_stats.stats_by_src, t.get_src());
+      ++(trans_stats.num_records);
+      trans_stats.data_bytes += ex->get_length();
+      w_stats.record_group_data_bytes += ex->get_length();
     }
     return trans_intr::make_interruptible(
       rbm->write(paddr + offset,

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -137,12 +137,16 @@ public:
   }
 
   writer_stats_t get_stats() const final {
-    // TODO: collect stats
-    return {};
+    writer_stats_t ret = w_stats;
+    ret.minus(last_w_stats);
+    last_w_stats = w_stats;
+    return ret;
   }
 
   using open_ertr = ExtentOolWriter::open_ertr;
   open_ertr::future<> open() final {
+    w_stats = {};
+    last_w_stats = {};
     return open_ertr::now();
   }
 
@@ -192,6 +196,8 @@ private:
 
   RBMCleaner* rb_cleaner;
   seastar::gate write_guard;
+  writer_stats_t w_stats;
+  mutable writer_stats_t last_w_stats;
 };
 
 struct cleaner_usage_t {

--- a/src/crimson/os/seastore/journal/record_submitter.cc
+++ b/src/crimson/os/seastore/journal/record_submitter.cc
@@ -411,7 +411,7 @@ RecordSubmitter::open(bool is_mkfs)
         ),
         sm::make_counter(
           "record_group_data_bytes",
-          stats.record_group_data_bytes,
+          stats.data_bytes,
           sm::description("bytes of data when write record groups"),
           label_instances
         ),
@@ -489,7 +489,7 @@ void RecordSubmitter::account_submission(
   stats.record_group_padding_bytes +=
     (rg.size.get_mdlength() - rg.size.get_raw_mdlength());
   stats.record_group_metadata_bytes += rg.size.get_raw_mdlength();
-  stats.record_group_data_bytes += rg.size.dlength;
+  stats.data_bytes += rg.size.dlength;
   stats.record_batch_stats.increment(rg.get_size());
 
   for (const record_t& r : rg.records) {

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -911,7 +911,7 @@ std::ostream& operator<<(std::ostream& out, const writer_stats_printer_t& p)
       << ",sizeB="
       << fmt::format(dfmt, p.stats.get_total_bytes()/d_num_io)
       << "("
-      << fmt::format(dfmt, p.stats.record_group_data_bytes/d_num_io)
+      << fmt::format(dfmt, p.stats.data_bytes/d_num_io)
       << ","
       << fmt::format(dfmt, p.stats.record_group_metadata_bytes/d_num_io)
       << ","

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2330,7 +2330,7 @@ struct writer_stats_t {
   grouped_io_stats io_depth_stats;
   uint64_t record_group_padding_bytes = 0;
   uint64_t record_group_metadata_bytes = 0;
-  uint64_t record_group_data_bytes = 0;
+  uint64_t data_bytes = 0;
   counter_by_src_t<trans_writer_stats_t> stats_by_src;
 
   bool is_empty() const {
@@ -2340,7 +2340,7 @@ struct writer_stats_t {
   uint64_t get_total_bytes() const {
     return record_group_padding_bytes +
            record_group_metadata_bytes +
-           record_group_data_bytes;
+           data_bytes;
   }
 
   void add(const writer_stats_t &o) {
@@ -2348,7 +2348,7 @@ struct writer_stats_t {
     io_depth_stats.add(o.io_depth_stats);
     record_group_padding_bytes += o.record_group_padding_bytes;
     record_group_metadata_bytes += o.record_group_metadata_bytes;
-    record_group_data_bytes += o.record_group_data_bytes;
+    data_bytes += o.data_bytes;
     add_srcs(stats_by_src, o.stats_by_src);
   }
 
@@ -2357,7 +2357,7 @@ struct writer_stats_t {
     io_depth_stats.minus(o.io_depth_stats);
     record_group_padding_bytes -= o.record_group_padding_bytes;
     record_group_metadata_bytes -= o.record_group_metadata_bytes;
-    record_group_data_bytes -= o.record_group_data_bytes;
+    data_bytes -= o.data_bytes;
     minus_srcs(stats_by_src, o.stats_by_src);
   }
 };


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/58083

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh