### PR TITLE
squid: crimson/os/seastore/onode: add hobject_t into Onode

### DIFF
--- a/src/crimson/os/seastore/onode.cc
+++ b/src/crimson/os/seastore/onode.cc
@@ -10,6 +10,7 @@ std::ostream& operator<<(std::ostream &out, const Onode &rhs)
 {
   auto &layout = rhs.get_layout();
   return out << "Onode("
+	     << "hobj=" << rhs.hobj << ", "
              << "size=" << static_cast<uint32_t>(layout.size)
              << ")";
 }

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -8,6 +8,7 @@
 #include <boost/intrusive_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
+#include "common/hobject.h"
 #include "include/byteorder.h"
 #include "seastore_types.h"
 
@@ -56,10 +57,12 @@ protected:
   virtual laddr_t get_hint() const = 0;
   const uint32_t default_metadata_offset = 0;
   const uint32_t default_metadata_range = 0;
+  const hobject_t hobj;
 public:
-  Onode(uint32_t ddr, uint32_t dmr)
+  Onode(uint32_t ddr, uint32_t dmr, const hobject_t &hobj)
     : default_metadata_offset(ddr),
-      default_metadata_range(dmr)
+      default_metadata_range(dmr),
+      hobj(hobj)
   {}
 
   virtual bool is_alive() const = 0;
@@ -85,6 +88,7 @@ public:
   laddr_t get_data_hint() const {
     return get_hint();
   }
+  friend std::ostream& operator<<(std::ostream &out, const Onode &rhs);
 };
 
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
@@ -151,6 +151,7 @@ FLTreeOnodeManager::get_onode_ret FLTreeOnodeManager::get_onode(
     auto val = OnodeRef(new FLTreeOnode(
 	default_data_reservation,
 	default_metadata_range,
+	hoid.hobj,
 	cursor.value()));
     return get_onode_iertr::make_ready_future<OnodeRef>(
       val
@@ -173,6 +174,7 @@ FLTreeOnodeManager::get_or_create_onode(
     auto onode = new FLTreeOnode(
 	default_data_reservation,
 	default_metadata_range,
+	hoid.hobj,
 	cursor.value());
     if (created) {
       DEBUGT("created onode for entry for {}", trans, hoid);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -36,13 +36,13 @@ struct FLTreeOnode final : Onode, Value {
   FLTreeOnode& operator=(const FLTreeOnode&) = delete;
 
   template <typename... T>
-  FLTreeOnode(uint32_t ddr, uint32_t dmr, T&&... args)
-    : Onode(ddr, dmr),
+  FLTreeOnode(uint32_t ddr, uint32_t dmr, const hobject_t &hobj, T&&... args)
+    : Onode(ddr, dmr, hobj),
       Value(std::forward<T>(args)...) {}
 
   template <typename... T>
-  FLTreeOnode(T&&... args)
-    : Onode(0, 0),
+  FLTreeOnode(const hobject_t &hobj, T&&... args)
+    : Onode(0, 0, hobj),
       Value(std::forward<T>(args)...) {}
 
   struct Recorder : public ValueDeltaRecorder {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
@@ -92,7 +92,7 @@ class Btree {
     ValueImpl value() {
       assert(!is_end());
       return p_tree->value_builder.build_value(
-          *p_tree->nm, p_tree->value_builder, p_cursor);
+        get_ghobj().hobj, *p_tree->nm, p_tree->value_builder, p_cursor);
     }
 
     bool operator==(const Cursor& o) const { return operator<=>(o) == 0; }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -312,11 +312,12 @@ struct ValueBuilderImpl final : public ValueBuilder {
     return ret;
   }
 
-  ValueImpl build_value(NodeExtentManager& nm,
+  ValueImpl build_value(const hobject_t &hobj,
+			NodeExtentManager& nm,
                         const ValueBuilder& vb,
                         Ref<tree_cursor_t>& p_cursor) const {
     assert(vb.get_header_magic() == get_header_magic());
-    return ValueImpl(nm, vb, p_cursor);
+    return ValueImpl(hobj, nm, vb, p_cursor);
   }
 };
 

--- a/src/test/crimson/seastore/onode_tree/test_value.h
+++ b/src/test/crimson/seastore/onode_tree/test_value.h
@@ -176,7 +176,11 @@ class TestValue final : public Value {
     }
   };
 
-  TestValue(NodeExtentManager& nm, const ValueBuilder& vb, Ref<tree_cursor_t>& p_cursor)
+  TestValue(
+    const hobject_t &hobj,
+    NodeExtentManager& nm,
+    const ValueBuilder& vb,
+    Ref<tree_cursor_t>& p_cursor)
     : Value(nm, vb, p_cursor) {}
   ~TestValue() override = default;
 

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -26,7 +26,7 @@ class TestOnode final : public Onode {
   bool dirty = false;
 
 public:
-  TestOnode(uint32_t ddr, uint32_t dmr) : Onode(ddr, dmr) {}
+  TestOnode(uint32_t ddr, uint32_t dmr) : Onode(ddr, dmr, hobject_t()) {}
   const onode_layout_t &get_layout() const final {
     return layout;
   }


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/58356

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh