### PR TITLE
squid: crimson/os/seastore/btree: improve lba pointer related UT checks

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -511,6 +511,8 @@ public:
           &child_node);
       } else {
         if (i->get_val().pladdr.is_laddr()) {
+          assert(!node->children[i->get_offset()] ||
+                  is_reserved_ptr(node->children[i->get_offset()]));
           continue;
         }
         ret = c.trans.get_extent(
@@ -586,7 +588,7 @@ public:
                 : true);
             }
           }
-          if (child == get_reserved_ptr()) {
+          if (is_reserved_ptr(child)) {
             if constexpr(
               !std::is_base_of_v<typename internal_node_t::base_t,
                                  child_node_t>) {

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -130,7 +130,7 @@ struct FixedKVNode : ChildableCachedExtent {
       children[offset] = child;
       set_child_ptracker(child);
     } else {
-      // this can only happen when reserving lba spaces
+      // this can happen when reserving lba spaces and cloning mappings
       ceph_assert(is_leaf_and_has_children());
       // this is to avoid mistakenly copying pointers from
       // copy sources when committing this lba node, because


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57828

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh