### PR TITLE
squid: suite/crimson: enable stats tests

### DIFF
--- a/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
+++ b/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
@@ -17,4 +17,4 @@ tasks:
     timeout: 1h
     clients:
       client.0:
-        - rados/test_python.sh -m 'not (wait or tier or ec or bench or stats)'
+        - rados/test_python.sh -m 'not (wait or tier or ec or bench)'


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/58396

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh