### PR TITLE
squid: crimson/os/seastore/btree: interrupt transactions immediately when getting children

### DIFF
--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -1491,9 +1491,9 @@ private:
     // checking the lba child must be atomic with creating
     // and linking the absent child
     if (v.has_child()) {
-      return v.get_child_fut().safe_then(
-        [on_found=std::move(on_found), node_iter, c,
-        parent_entry](auto child) mutable {
+      return trans_intr::make_interruptible(std::move(v.get_child_fut())
+      ).si_then([on_found=std::move(on_found), node_iter, c,
+                parent_entry](auto child) {
         LOG_PREFIX(FixedKVBtree::lookup_internal_level);
         SUBTRACET(seastore_fixedkv_tree,
           "got child on {}, pos: {}, res: {}",
@@ -1561,9 +1561,9 @@ private:
     // checking the lba child must be atomic with creating
     // and linking the absent child
     if (v.has_child()) {
-      return v.get_child_fut().safe_then(
-        [on_found=std::move(on_found), node_iter, c,
-        parent_entry](auto child) mutable {
+      return trans_intr::make_interruptible(std::move(v.get_child_fut())
+      ).si_then([on_found=std::move(on_found), node_iter, c,
+                parent_entry](auto child) {
         LOG_PREFIX(FixedKVBtree::lookup_leaf);
         SUBTRACET(seastore_fixedkv_tree,
           "got child on {}, pos: {}, res: {}",
@@ -2116,9 +2116,9 @@ private:
     // checking the lba child must be atomic with creating
     // and linking the absent child
     if (v.has_child()) {
-      return v.get_child_fut().safe_then(
-        [do_merge=std::move(do_merge), &pos,
-        donor_iter, donor_is_left, c, parent_pos](auto child) mutable {
+      return trans_intr::make_interruptible(std::move(v.get_child_fut())
+      ).si_then([do_merge=std::move(do_merge), &pos,
+                donor_iter, donor_is_left, c, parent_pos](auto child) {
         LOG_PREFIX(FixedKVBtree::merge_level);
         SUBTRACET(seastore_fixedkv_tree,
           "got child on {}, pos: {}, res: {}",


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/58357

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh