### PR TITLE
squid: crimson: audit and correct epoch captured by IOInterruptCondition

### DIFF
--- a/src/crimson/admin/pg_commands.cc
+++ b/src/crimson/admin/pg_commands.cc
@@ -174,7 +174,7 @@ public:
       return PG::interruptor::now();
     }, [FNAME, pg](std::exception_ptr ep) {
       DEBUGDPP("interrupted with {}", *pg, ep);
-    }, pg).then([format] {
+    }, pg, pg->get_osdmap_epoch()).then([format] {
       std::unique_ptr<Formatter> f{
 	Formatter::create(format, "json-pretty", "json-pretty")
       };

--- a/src/crimson/osd/osd_operations/background_recovery.cc
+++ b/src/crimson/osd/osd_operations/background_recovery.cc
@@ -86,7 +86,7 @@ seastar::future<> BackgroundRecoveryT<T>::start()
             return do_recovery();
           }, [](std::exception_ptr) {
             return seastar::make_ready_future<bool>(false);
-          }, pg);
+          }, pg, epoch_started);
         }).handle_exception_type([ref, this](const std::system_error& err) {
 	  LOG_PREFIX(BackgroundRecoveryT<T>::start);
           if (err.code() == std::make_error_code(std::errc::interrupted)) {

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -222,7 +222,7 @@ seastar::future<> ClientRequest::with_pg_process(
     }, [FNAME, this, this_instance_id, pgref](std::exception_ptr eptr) {
       DEBUGDPP("{}.{}: interrupted due to {}",
 	       *pgref, *this, this_instance_id, eptr);
-    }, pgref).finally(
+    }, pgref, pgref->get_osdmap_epoch()).finally(
       [this, FNAME, opref=std::move(opref), pgref,
        this_instance_id, instance_handle=std::move(instance_handle), &ihref] {
 	DEBUGDPP("{}.{}: exit", *pgref, *this, this_instance_id);

--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -25,7 +25,7 @@ SET_SUBSYS(osd);
 namespace crimson::osd {
 
 InternalClientRequest::InternalClientRequest(Ref<PG> pg)
-  : pg(std::move(pg))
+  : pg(pg), start_epoch(pg->get_osdmap_epoch())
 {
   assert(bool(this->pg));
   assert(this->pg->is_primary());
@@ -125,7 +125,7 @@ seastar::future<> InternalClientRequest::start()
         } else {
           return seastar::stop_iteration::no;
         }
-      }, pg);
+      }, pg, start_epoch);
     }).then([this] {
       track_event<CompletionEvent>();
     }).finally([this] {

--- a/src/crimson/osd/osd_operations/internal_client_request.h
+++ b/src/crimson/osd/osd_operations/internal_client_request.h
@@ -44,6 +44,7 @@ private:
   seastar::future<> do_process();
 
   Ref<PG> pg;
+  epoch_t start_epoch;
   OpInfo op_info;
   PipelineHandle handle;
 

--- a/src/crimson/osd/osd_operations/logmissing_request.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request.cc
@@ -89,7 +89,7 @@ seastar::future<> LogMissingRequest::with_pg(
     });
   }, [](std::exception_ptr) {
     return seastar::now();
-  }, pg).finally([this, ref=std::move(ref)] {
+  }, pg, pg->get_osdmap_epoch()).finally([this, ref=std::move(ref)] {
     logger().debug("{}: exit", *this);
     handle.exit();
   });

--- a/src/crimson/osd/osd_operations/logmissing_request_reply.cc
+++ b/src/crimson/osd/osd_operations/logmissing_request_reply.cc
@@ -75,7 +75,7 @@ seastar::future<> LogMissingRequestReply::with_pg(
     });
   }, [](std::exception_ptr) {
     return seastar::now();
-  }, pg).finally([this, ref=std::move(ref)] {
+  }, pg, pg->get_osdmap_epoch()).finally([this, ref=std::move(ref)] {
     logger().debug("{}: exit", *this);
     handle.exit();
   });

--- a/src/crimson/osd/osd_operations/peering_event.cc
+++ b/src/crimson/osd/osd_operations/peering_event.cc
@@ -107,7 +107,7 @@ seastar::future<> PeeringEvent<T>::with_pg(
   }, [this](std::exception_ptr ep) {
     LOG_PREFIX(PeeringEvent<T>::with_pg);
     DEBUGI("{}: interrupted with {}", *this, ep);
-  }, pg).finally([this] {
+  }, pg, evt.get_epoch_sent()).finally([this] {
     logger().debug("{}: exit", *this);
     that()->get_handle().exit();
   });

--- a/src/crimson/osd/osd_operations/recovery_subrequest.cc
+++ b/src/crimson/osd/osd_operations/recovery_subrequest.cc
@@ -43,7 +43,7 @@ seastar::future<> RecoverySubRequest::with_pg(
     });
   }, [](std::exception_ptr) {
     return seastar::now();
-  }, pgref).finally([this, opref=std::move(opref), pgref] {
+  }, pgref, pgref->get_osdmap_epoch()).finally([this, opref=std::move(opref), pgref] {
     logger().debug("{}: exit", *this);
     track_event<CompletionEvent>();
     handle.exit();

--- a/src/crimson/osd/osd_operations/replicated_request.cc
+++ b/src/crimson/osd/osd_operations/replicated_request.cc
@@ -88,7 +88,7 @@ seastar::future<> RepRequest::with_pg(
     });
   }, [](std::exception_ptr) {
     return seastar::now();
-  }, pg).finally([this, ref=std::move(ref)] {
+  }, pg, pg->get_osdmap_epoch()).finally([this, ref=std::move(ref)] {
     logger().debug("{}: exit", *this);
     handle.exit();
   });

--- a/src/crimson/osd/osd_operations/scrub_events.cc
+++ b/src/crimson/osd/osd_operations/scrub_events.cc
@@ -56,7 +56,7 @@ seastar::future<> RemoteScrubEventBaseT<T>::with_pg(
     });
   }, [FNAME, pg, this](std::exception_ptr ep) {
     DEBUGDPP("{} interrupted with {}", *pg, *that(), ep);
-  }, pg);
+  }, pg, epoch);
 }
 
 ScrubRequested::ifut<> ScrubRequested::handle_event(PG &pg)

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -544,7 +544,7 @@ void PG::on_active_actmap()
     }, [this](std::exception_ptr eptr) {
       logger().debug("{}: snap trimming interrupted", *this);
       ceph_assert(!peering_state.state_test(PG_STATE_SNAPTRIM));
-    }, pg_ref).finally([pg_ref, this] {
+    }, pg_ref, pg_ref->get_osdmap_epoch()).finally([pg_ref, this] {
       publish_stats_to_osd();
     });
   } else {

--- a/src/crimson/osd/pg_interval_interrupt_condition.cc
+++ b/src/crimson/osd/pg_interval_interrupt_condition.cc
@@ -17,8 +17,6 @@ namespace crimson::osd {
 
 IOInterruptCondition::IOInterruptCondition(Ref<PG>& pg, epoch_t e)
   : pg(pg), e(e) {}
-IOInterruptCondition::IOInterruptCondition(Ref<PG>& pg)
-  : pg(pg), e(pg->get_osdmap_epoch()) {}
 
 IOInterruptCondition::~IOInterruptCondition() {
   // for the sake of forward declaring PG (which is a detivate of

--- a/src/crimson/osd/pg_interval_interrupt_condition.cc
+++ b/src/crimson/osd/pg_interval_interrupt_condition.cc
@@ -15,8 +15,8 @@ interrupt_cond<crimson::osd::IOInterruptCondition>;
 
 namespace crimson::osd {
 
-IOInterruptCondition::IOInterruptCondition(Ref<PG>& pg, epoch_t e)
-  : pg(pg), e(e) {}
+IOInterruptCondition::IOInterruptCondition(Ref<PG>& pg, epoch_t epoch_started)
+  : pg(pg), epoch_started(epoch_started) {}
 
 IOInterruptCondition::~IOInterruptCondition() {
   // for the sake of forward declaring PG (which is a detivate of
@@ -26,9 +26,9 @@ IOInterruptCondition::~IOInterruptCondition() {
 bool IOInterruptCondition::new_interval_created() {
   LOG_PREFIX(IOInterruptCondition::new_interval_created);
   const epoch_t interval_start = pg->get_interval_start_epoch();
-  bool ret = e < interval_start;
+  bool ret = epoch_started < interval_start;
   if (ret) {
-    DEBUGDPP("stored interval e{} < interval_start e{}", *pg, e, interval_start);
+    DEBUGDPP("stored epoch_started e{} < interval_start e{}", *pg, epoch_started, interval_start);
   }
   return ret;
 }

--- a/src/crimson/osd/pg_interval_interrupt_condition.cc
+++ b/src/crimson/osd/pg_interval_interrupt_condition.cc
@@ -15,6 +15,8 @@ interrupt_cond<crimson::osd::IOInterruptCondition>;
 
 namespace crimson::osd {
 
+IOInterruptCondition::IOInterruptCondition(Ref<PG>& pg, epoch_t e)
+  : pg(pg), e(e) {}
 IOInterruptCondition::IOInterruptCondition(Ref<PG>& pg)
   : pg(pg), e(pg->get_osdmap_epoch()) {}
 

--- a/src/crimson/osd/pg_interval_interrupt_condition.h
+++ b/src/crimson/osd/pg_interval_interrupt_condition.h
@@ -14,6 +14,7 @@ class PG;
 
 class IOInterruptCondition {
 public:
+  IOInterruptCondition(Ref<PG>& pg, epoch_t e);
   IOInterruptCondition(Ref<PG>& pg);
   ~IOInterruptCondition();
 

--- a/src/crimson/osd/pg_interval_interrupt_condition.h
+++ b/src/crimson/osd/pg_interval_interrupt_condition.h
@@ -12,15 +12,41 @@ namespace crimson::osd {
 
 class PG;
 
+/**
+ * IOInterruptCondition
+ *
+ * Encapsulates logic for determining whether a continuation chain
+ * started at <epoch_started> should be halted for once of two reasons:
+ * 1. PG instance is stopping (includes if OSD is shutting down)
+ * 2. A map advance has caused an interval change since <epoch_started>
+ *
+ * <epoch_started> should be the epoch at which the operation was logically
+ * started, which may or may not pg->get_osdmap_epoch() at the time at which
+ * with_interruption is actually invoked.
+ */
 class IOInterruptCondition {
 public:
-  IOInterruptCondition(Ref<PG>& pg, epoch_t e);
+  IOInterruptCondition(Ref<PG>& pg, epoch_t epoch_started);
   ~IOInterruptCondition();
 
+  /**
+   * new_interval_created()
+   *
+   * Returns true iff the pg has entered a new interval since <epoch_started>
+   * (<epoch_started> < pg->get_interval_start_epoch())
+   */
   bool new_interval_created();
 
+  /// true iff pg->stopping
   bool is_stopping();
 
+  /**
+   * is_primary
+   *
+   * True iff the pg is still primary.  Used to populate
+   * ::crimson::common::actingset_changed upon interval change
+   * to indicate whether client IOs should be requeued.
+   */
   bool is_primary();
 
   template <typename Fut>
@@ -50,7 +76,7 @@ public:
 
 private:
   Ref<PG> pg;
-  epoch_t e;
+  epoch_t epoch_started;
 };
 
 } // namespace crimson::osd

--- a/src/crimson/osd/pg_interval_interrupt_condition.h
+++ b/src/crimson/osd/pg_interval_interrupt_condition.h
@@ -15,7 +15,6 @@ class PG;
 class IOInterruptCondition {
 public:
   IOInterruptCondition(Ref<PG>& pg, epoch_t e);
-  IOInterruptCondition(Ref<PG>& pg);
   ~IOInterruptCondition();
 
   bool new_interval_created();


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/58463

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh