### PR TITLE
quincy: osd: avoid watcher remains after "rados watch" is interrupted

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8770,15 +8770,14 @@ void PrimaryLogPG::do_osd_op_effects(OpContext *ctx, const ConnectionRef& conn)
   ceph_assert(conn);
 
   auto session = conn->get_priv();
-  if (!session)
-    return;
 
   for (list<pair<watch_info_t,bool> >::iterator i = ctx->watch_connects.begin();
        i != ctx->watch_connects.end();
        ++i) {
     pair<uint64_t, entity_name_t> watcher(i->first.cookie, entity);
     dout(15) << "do_osd_op_effects applying watch connect on session "
-	     << session.get() << " watcher " << watcher << dendl;
+	     << (session ? session.get() : nullptr) << " watcher " << watcher
+	     << dendl;
     WatchRef watch;
     if (ctx->obc->watchers.count(watcher)) {
       dout(15) << "do_osd_op_effects found existing watch watcher " << watcher
@@ -8802,7 +8801,6 @@ void PrimaryLogPG::do_osd_op_effects(OpContext *ctx, const ConnectionRef& conn)
        p != ctx->notifies.end();
        ++p) {
     dout(10) << "do_osd_op_effects, notify " << *p << dendl;
-    ConnectionRef conn(ctx->op->get_req()->get_connection());
     NotifyRef notif(
       Notify::makeNotifyRef(
 	conn,

--- a/src/osd/Watch.cc
+++ b/src/osd/Watch.cc
@@ -393,7 +393,14 @@ void Watch::connect(ConnectionRef con, bool _will_ping)
     last_ping = ceph_clock_now();
     register_cb();
   } else {
-    unregister_cb();
+    if (!con->get_priv()) {
+      // if session is already nullptr
+      // !will_ping should also register WatchTimeout
+      conn = ConnectionRef();
+      register_cb();
+    } else {
+      unregister_cb();
+    }
   }
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67165

---

backport of https://github.com/ceph/ceph/pull/50861
parent tracker: https://tracker.ceph.com/issues/58120