### PR TITLE
mgr/cephadm: reconfig haproxy and rgw when ssl cert/key in spec is updated

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3029,6 +3029,11 @@ Then run the following:
             assert ingress_spec.backend_service
             daemons = self.cache.get_daemons_by_service(ingress_spec.backend_service)
             deps = [d.name() for d in daemons]
+            for attr in ['ssl_cert', 'ssl_key']:
+                ssl_cert_key = getattr(ingress_spec, attr, None)
+                if ssl_cert_key:
+                    assert isinstance(ssl_cert_key, str)
+                    deps.append(str(utils.md5_hash(ssl_cert_key)))
         elif daemon_type == 'keepalived':
             # because cephadm creates new daemon instances whenever
             # port or ip changes, identifying daemons by name is

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -36,7 +36,7 @@ from ceph.deployment.service_spec import \
     ServiceSpec, PlacementSpec, \
     HostPlacementSpec, IngressSpec, \
     TunedProfileSpec, IscsiServiceSpec, \
-    MgmtGatewaySpec
+    MgmtGatewaySpec, RGWSpec
 from ceph.utils import str_to_datetime, datetime_to_str, datetime_now
 from cephadm.serve import CephadmServe
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
@@ -3114,6 +3114,13 @@ Then run the following:
             deps = sorted(deps)
         elif daemon_type == 'mgmt-gateway':
             deps = MgmtGatewayService.get_dependencies(self)
+        elif daemon_type == 'rgw':
+            rgw_spec = cast(RGWSpec, spec)
+            ssl_cert = getattr(rgw_spec, 'rgw_frontend_ssl_certificate', None)
+            if isinstance(ssl_cert, list):
+                ssl_cert = '\n'.join(ssl_cert)
+            if ssl_cert:
+                deps.append(str(utils.md5_hash(ssl_cert)))
         else:
             # this daemon type doesn't need deps mgmt
             pass

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1219,6 +1219,16 @@ class RgwService(CephService):
     def config_dashboard(self, daemon_descrs: List[DaemonDescription]) -> None:
         self.mgr.trigger_connect_dashboard_rgw()
 
+    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
+        config, deps = super().generate_config(daemon_spec)
+        rgw_spec = cast(RGWSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
+        ssl_cert = getattr(rgw_spec, 'rgw_frontend_ssl_certificate', None)
+        if isinstance(ssl_cert, list):
+            ssl_cert = '\n'.join(ssl_cert)
+        if ssl_cert:
+            deps.append(str(utils.md5_hash(ssl_cert)))
+        return config, deps
+
 
 class RbdMirrorService(CephService):
     TYPE = 'rbd-mirror'

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -197,9 +197,10 @@ class IngressService(CephService):
         }
         if spec.ssl_cert:
             ssl_cert = spec.ssl_cert
-            if isinstance(ssl_cert, list):
-                ssl_cert = '\n'.join(ssl_cert)
             config_files['files']['haproxy.pem'] = ssl_cert
+        if spec.ssl_key:
+            ssl_key = spec.ssl_key
+            config_files['files']['haproxy.pem.key'] = ssl_key
 
         return config_files, sorted(deps)
 

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -87,6 +87,11 @@ class IngressService(CephService):
         backend_spec = self.mgr.spec_store[spec.backend_service].spec
         daemons = self.mgr.cache.get_daemons_by_service(spec.backend_service)
         deps = [d.name() for d in daemons]
+        for attr in ['ssl_cert', 'ssl_key']:
+            ssl_cert_key = getattr(spec, attr, None)
+            if ssl_cert_key:
+                assert isinstance(ssl_cert_key, str)
+                deps.append(str(utils.md5_hash(ssl_cert_key)))
 
         # generate password?
         pw_key = f'{spec.service_name()}/monitor_password'


### PR DESCRIPTION
To make it so users do not have to manually trigger a reconfig or redeploy of their rgw or ingress services when they update the cert/key for the service


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
