### PR TITLE
osd: Move erasure code read offset logic to earlier in read

### DIFF
--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -238,15 +238,20 @@ struct ECCommon {
     bool fast_read,
     GenContextURef<ec_extents_t &&> &&func) = 0;
 
+  struct shard_read_t {
+    std::list<ec_align_t> extents;
+    std::vector<std::pair<int, int>> subchunk;
+  };
+  friend std::ostream &operator<<(std::ostream &lhs, const shard_read_t &rhs);
+
   struct read_request_t {
     const std::list<ec_align_t> to_read;
-    std::map<pg_shard_t, std::vector<std::pair<int, int>>> need;
+    std::map<pg_shard_t, shard_read_t> shard_reads;
     bool want_attrs;
     read_request_t(
       const std::list<ec_align_t> &to_read,
-      const std::map<pg_shard_t, std::vector<std::pair<int, int>>> &need,
       bool want_attrs)
-      : to_read(to_read), need(need), want_attrs(want_attrs) {}
+      : to_read(to_read), want_attrs(want_attrs) { }
   };
   friend std::ostream &operator<<(std::ostream &lhs, const read_request_t &rhs);
   struct ReadOp;
@@ -489,7 +494,7 @@ struct ECCommon {
       const std::set<int> &want,      ///< [in] desired shards
       bool for_recovery,         ///< [in] true if we may use non-acting replicas
       bool do_redundant_reads,   ///< [in] true if we want to issue redundant reads to reduce latency
-      std::map<pg_shard_t, std::vector<std::pair<int, int>>> *to_read   ///< [out] shards, corresponding subchunks to read
+      read_request_t *read_request ///< [out] shard_reads, corresponding subchunks / other sub reads to read
       ); ///< @return error code, 0 on success
 
     void schedule_recovery_work();


### PR DESCRIPTION

This PR is some preparation work for further performance work on Erasure Coding.  See https://github.com/bill-scales/CephErasureCodingDesign for details. 

The long-term intention with EC is to grow the chunk size to be much larger (64k-256k). The current partial read implementation will not perform well with such chunk sizes. 

The changes here adapt the read_request_t structure, to allow the shard calculations to specify a set of extents, where an extent is a partial read within an individual chunk. 

As a result of the struct changes, the logic to calculate offsets within the shard reads have been moved much earlier in the process.  The intent being that later optimisations will specify much smaller read ranges. 

Since there is no functional test, I have not added any new tests. 

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
