### PR TITLE
rgw/posix: name the lock_guard in BucketCacheEntry::reclaim()

### DIFF
--- a/src/rgw/driver/posix/bucket_cache.h
+++ b/src/rgw/driver/posix/bucket_cache.h
@@ -144,7 +144,7 @@ public:
     { /* anon block */
       /* in this case, we are being called from a context which holds
        * A partition lock, and this may be still in use */
-      lock_guard{mtx};
+      auto lock = lock_guard{mtx};
       if (! deleted()) {
 	flags |= FLAG_DELETED;
 	bc->recycle_count++;


### PR DESCRIPTION
resolves compiler warning:
```
rgw/driver/posix/bucket_cache.h: In instantiation of ‘bool file::listing::BucketCacheEntry<D, B>::reclaim(const cohort::lru::ObjectFactory*) [with D = rgw::sal::POSIXDriver; B = rgw::sal::POSIXBucket]’:
src/rgw/driver/posix/bucket_cache.h:139:8:   required from here
  139 |   bool reclaim(const cohort::lru::ObjectFactory* newobj_fac) {
      |        ^~~~~~~
src/rgw/driver/posix/bucket_cache.h:147:7: warning: ignoring return value of ‘std::lock_guard<_Mutex>::lock_guard(mutex_type&) [with _Mutex = std::mutex; mutex_type = std::mutex]’, declared with attribute ‘nodiscard’ [-Wunused-result]
  147 |       lock_guard{mtx};
      |       ^~~~~~~~~~
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
