### PR TITLE
mon/OSDMonitor: add warning when deploying crimson OSDs without enabling flags

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -986,11 +986,11 @@ $CMONDEBUG
         auth allow insecure global id reclaim = false
 EOF
 
-    if [ "$crimson" -eq 1 ]; then
-        wconf <<EOF
-        osd pool default crimson = true
-EOF
-    fi
+#   if [ "$crimson" -eq 1 ]; then
+#       wconf <<EOF
+#       osd pool default crimson = true
+#EOF
+#   fi
 
     # this is most probably a bug in ceph_mon
     # but public_bind_addr set in [global] doesn't work
@@ -1124,9 +1124,9 @@ EOF
         run 'mon' $f $CEPH_BIN/ceph-mon -i $f $ARGS $CMON_ARGS
     done
 
-    if [ "$crimson" -eq 1 ]; then
-        $CEPH_BIN/ceph osd set-allow-crimson --yes-i-really-mean-it
-    fi
+#      if [ "$crimson" -eq 1 ]; then
+#          $CEPH_BIN/ceph osd set-allow-crimson --yes-i-really-mean-it
+#      fi
 
     if [ -n "$require_osd_and_client_version" ]; then
         $CEPH_BIN/ceph osd set-require-min-compat-client $require_osd_and_client_version


### PR DESCRIPTION
This is just a partial attempt for review at the moment. 

----------------------------------


Attempt at first PR which adds to the code for a good-first-issue enhancement mentioned here: https://tracker.ceph.com/issues/66610 ... I'm expecting to have missed a lot here or made errors so any cc is appreciated!

In essence, the idea is to print a warning when OSDs are deployed on a Crimson build without the necessary flags set; in particular, the flag related to osds.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
