### PR TITLE
script/backport-create-issue: handle ResourceAttrError when getting CF_TAGS

### DIFF
--- a/src/script/backport-create-issue
+++ b/src/script/backport-create-issue
@@ -319,11 +319,13 @@ def mark_as_processed(r, issue):
     logging.debug("custom_fields: %s", list(issue['custom_fields']))
 
     tags_cf = next(filter(lambda x: x['id'] == CF_TAGS, issue['custom_fields']), None)
-
     if tags_cf is None:
         tags = ''
     else:
-        tags = tags_cf.value
+        try:
+            tags = tags_cf.value
+        except ResourceAttrError:
+            tags = None
         if tags is None:
             tags = ''
         else:


### PR DESCRIPTION
Older versions of python-redmine may raise ResourceAttrError here instead of returning None, see [1].  Being prepared for an exception seems like a good idea regardless given how this field recently got recreated.

[1] https://github.com/maxtepkeev/python-redmine/commit/0de5689ef5891c1be263c0b3deb8b03966a9c5bd