### PR TITLE
squid: src/crimson/osd/scrub: fix the null pointer error

### DIFF
--- a/src/crimson/osd/scrub/scrub_validator.cc
+++ b/src/crimson/osd/scrub/scrub_validator.cc
@@ -60,12 +60,14 @@ shard_evaluation_t evaluate_object_shard(
   if (from == policy.primary) {
     ret.shard_info.primary = true;
   }
-  if (!maybe_obj || maybe_obj->negative) {
-    // impossible since chunky scrub was introduced
-    ceph_assert(!maybe_obj->negative);
+
+  if (!maybe_obj) {
     ret.shard_info.set_missing();
     return ret;
   }
+
+  // impossible since chunky scrub was introduced
+  ceph_assert(!maybe_obj->negative);
 
   auto &obj = *maybe_obj;
   /* We are ignoring ScrubMap::object::large_omap_object*, object_omap_* is all the


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/58471

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh