### PR TITLE
squid: crimson: PG stats are not synced between osds after object update

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1332,6 +1332,15 @@ PG::with_locked_obc(const hobject_t &hobj,
   };
 }
 
+void PG::update_stats(const pg_stat_t &stat) {
+  peering_state.update_stats(
+    [&stat] (auto& history, auto& stats) {
+      stats = stat;
+      return false;
+    }
+  );
+}
+
 PG::interruptible_future<> PG::handle_rep_op(Ref<MOSDRepOp> req)
 {
   if (__builtin_expect(stopping, false)) {
@@ -1350,6 +1359,7 @@ PG::interruptible_future<> PG::handle_rep_op(Ref<MOSDRepOp> req)
   auto p = req->logbl.cbegin();
   std::vector<pg_log_entry_t> log_entries;
   decode(log_entries, p);
+  update_stats(req->pg_stats);
   log_operation(std::move(log_entries),
                 req->pg_trim_to,
                 req->version,

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -514,6 +514,7 @@ public:
     with_obc_func_t&& f);
 
   interruptible_future<> handle_rep_op(Ref<MOSDRepOp> m);
+  void update_stats(const pg_stat_t &stat);
   void log_operation(
     std::vector<pg_log_entry_t>&& logv,
     const eversion_t &trim_to,

--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -70,6 +70,7 @@ ReplicatedBackend::_submit_transaction(std::set<pg_shard_t>&& pg_shards,
       encode(log_entries, m->logbl);
       m->pg_trim_to = osd_op_p.pg_trim_to;
       m->min_last_complete_ondisk = osd_op_p.min_last_complete_ondisk;
+      m->pg_stats = pg.get_info().stats;
       // TODO: set more stuff. e.g., pg_states
       sends->emplace_back(
 	shard_services.send_to_osd(


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/58510

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh