### PR TITLE
squid: mgr/client: validate connection before sending

### DIFF
--- a/qa/config/crimson_qa_overrides.yaml
+++ b/qa/config/crimson_qa_overrides.yaml
@@ -9,8 +9,6 @@ overrides:
         osd pool default crimson: true
       osd:
         crimson osd obc lru size: 10
-      mgr:
-        mgr stats period: 30
     flavor: crimson
   workunit:
     env:

--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -165,6 +165,10 @@ void Client::report()
     }
     return with_stats.get_stats(
     ).then([this](auto &&pg_stats) {
+      if (!conn) {
+        logger().warn("report: no conn available; before sending stats, report skipped");
+        return seastar::now();
+      }
       return conn->send(std::move(pg_stats));
     });
   });


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/58592

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh