### PR TITLE
squid: crimson/osd/recovery_backend: cleanup PGBackend::temp_contents when pg interval changes

### DIFF
--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -486,8 +486,6 @@ private:
   friend class ::crimson::osd::PG;
 
 protected:
-  boost::container::flat_set<hobject_t> temp_contents;
-
   template <class... Args>
   void add_temp_obj(Args&&... args) {
     temp_contents.insert(std::forward<Args>(args)...);
@@ -501,5 +499,15 @@ protected:
       clear_temp_obj(oid);
     }
   }
+  template <typename Func>
+  void for_each_temp_obj(Func &&f) {
+    std::for_each(temp_contents.begin(), temp_contents.end(), f);
+  }
+  void clear_temp_objs() {
+    temp_contents.clear();
+  }
+private:
+  boost::container::flat_set<hobject_t> temp_contents;
+
   friend class RecoveryBackend;
 };

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -45,11 +45,11 @@ void RecoveryBackend::clear_temp_obj(const hobject_t &oid)
 void RecoveryBackend::clean_up(ceph::os::Transaction& t,
 			       std::string_view why)
 {
-  for (auto& soid : temp_contents) {
+  for_each_temp_obj([&](auto &soid) {
     t.remove(pg.get_collection_ref()->get_cid(),
 	      ghobject_t(soid, ghobject_t::NO_GEN, pg.get_pg_whoami().shard));
-  }
-  temp_contents.clear();
+  });
+  clear_temp_objs();
 
   for (auto& [soid, recovery_waiter] : recovering) {
     if ((recovery_waiter->pull_info

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -10,6 +10,7 @@
 #include "crimson/os/futurized_collection.h"
 #include "crimson/osd/pg_interval_interrupt_condition.h"
 #include "crimson/osd/object_context.h"
+#include "crimson/osd/pg_backend.h"
 #include "crimson/osd/shard_services.h"
 
 #include "messages/MOSDPGBackfill.h"
@@ -21,8 +22,6 @@
 namespace crimson::osd{
   class PG;
 }
-
-class PGBackend;
 
 class RecoveryBackend {
 public:
@@ -240,10 +239,15 @@ protected:
     const hobject_t& target,
     eversion_t version) const;
 
-  boost::container::flat_set<hobject_t> temp_contents;
-
   void add_temp_obj(const hobject_t &oid);
   void clear_temp_obj(const hobject_t &oid);
+  template <typename Func>
+  void for_each_temp_obj(Func &&f) {
+    backend->for_each_temp_obj(std::forward<Func>(f));
+  }
+  void clear_temp_objs() {
+    backend->clear_temp_objs();
+  }
 
   void clean_up(ceph::os::Transaction& t, std::string_view why);
   virtual seastar::future<> on_stop() = 0;


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/58694

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh