### PR TITLE
quincy: docs: removed centos 8 and added squid to the build matrix

### DIFF
--- a/doc/dev/release-process.rst
+++ b/doc/dev/release-process.rst
@@ -97,15 +97,15 @@ We'll use a stable/regular 15.2.17 release of Octopus as an example throughout t
 
 4. Use https://docs.ceph.com/en/latest/start/os-recommendations/?highlight=debian#platforms to determine the ``DISTROS`` parameter.  For example,
 
-    +-------------------+-------------------------------------------+
-    | Release           | Distro Codemap                            |
-    +===================+===========================================+
-    | octopus (15.X.X)  | ``focal bionic centos7 centos8 buster``   |
-    +-------------------+-------------------------------------------+
-    | pacific (16.X.X)  | ``focal bionic centos8 buster bullseye``  |
-    +-------------------+-------------------------------------------+
-    | quincy (17.X.X)   | ``focal centos8 centos9 bullseye``        |
-    +-------------------+-------------------------------------------+
+    +-------------------+--------------------------------------------------+
+    | Release           | Distro Codemap                                   |
+    +===================+==================================================+
+    | octopus (15.X.X)  | ``focal bionic centos7 centos8 buster``          |
+    +-------------------+--------------------------------------------------+
+    | pacific (16.X.X)  | ``focal bionic buster bullseye``                 |
+    +-------------------+--------------------------------------------------+
+    | quincy (17.X.X)   | ``jammy focal centos9 bullseye``                 |
+    +-------------------+--------------------------------------------------+
 
 5. Click ``Build``.
 


### PR DESCRIPTION
Signed-off-by: Yuri Weinstein <yweinste@redhat.com>
(cherry picked from commit 8761bbe16c2a6d19e136254c26d1d67ebe839e3b)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
