### PR TITLE
squid: crimson: simplify obc loading by locking excl for load and demoting to needed lock

### DIFF
--- a/src/crimson/common/tri_mutex.cc
+++ b/src/crimson/common/tri_mutex.cc
@@ -41,26 +41,6 @@ void excl_lock::unlock()
   static_cast<tri_mutex*>(this)->unlock_for_excl();
 }
 
-void excl_lock_from_read::lock()
-{
-  static_cast<tri_mutex*>(this)->promote_from_read();
-}
-
-void excl_lock_from_read::unlock()
-{
-  static_cast<tri_mutex*>(this)->demote_to_read();
-}
-
-void excl_lock_from_write::lock()
-{
-  static_cast<tri_mutex*>(this)->promote_from_write();
-}
-
-void excl_lock_from_write::unlock()
-{
-  static_cast<tri_mutex*>(this)->demote_to_write();
-}
-
 tri_mutex::~tri_mutex()
 {
   LOG_PREFIX(tri_mutex::~tri_mutex());
@@ -101,15 +81,6 @@ void tri_mutex::unlock_for_read()
   if (--readers == 0) {
     wake();
   }
-}
-
-void tri_mutex::promote_from_read()
-{
-  LOG_PREFIX(tri_mutex::promote_from_read());
-  DEBUGDPP("", *this);
-  assert(readers == 1);
-  --readers;
-  exclusively_used = true;
 }
 
 void tri_mutex::demote_to_read()
@@ -154,15 +125,6 @@ void tri_mutex::unlock_for_write()
   if (--writers == 0) {
     wake();
   }
-}
-
-void tri_mutex::promote_from_write()
-{
-  LOG_PREFIX(tri_mutex::promote_from_write());
-  DEBUGDPP("", *this);
-  assert(writers == 1);
-  --writers;
-  exclusively_used = true;
 }
 
 void tri_mutex::demote_to_write()

--- a/src/crimson/common/tri_mutex.cc
+++ b/src/crimson/common/tri_mutex.cc
@@ -54,7 +54,7 @@ seastar::future<> tri_mutex::lock_for_read()
     return seastar::now();
   }
   DEBUGDPP("can't lock_for_read, adding to waiters", *this);
-  waiters.emplace_back(seastar::promise<>(), type_t::read, name);
+  waiters.emplace_back(seastar::promise<>(), type_t::read);
   return waiters.back().pr.get_future();
 }
 
@@ -97,7 +97,7 @@ seastar::future<> tri_mutex::lock_for_write()
     return seastar::now();
   }
   DEBUGDPP("can't lock_for_write, adding to waiters", *this);
-  waiters.emplace_back(seastar::promise<>(), type_t::write, name);
+  waiters.emplace_back(seastar::promise<>(), type_t::write);
   return waiters.back().pr.get_future();
 }
 
@@ -141,7 +141,7 @@ seastar::future<> tri_mutex::lock_for_excl()
     return seastar::now();
   }
   DEBUGDPP("can't lock_for_excl, adding to waiters", *this);
-  waiters.emplace_back(seastar::promise<>(), type_t::exclusive, name);
+  waiters.emplace_back(seastar::promise<>(), type_t::exclusive);
   return waiters.back().pr.get_future();
 }
 
@@ -210,7 +210,7 @@ void tri_mutex::wake()
     default:
       assert(0);
     }
-    DEBUGDPP("waking up {}", *this, waiter.waiter_name);
+    DEBUGDPP("waking up", *this);
     waiter.pr.set_value();
     waiters.pop_front();
   }

--- a/src/crimson/common/tri_mutex.h
+++ b/src/crimson/common/tri_mutex.h
@@ -3,27 +3,25 @@
 
 #pragma once
 
-#include <optional>
-
 #include <seastar/core/future.hh>
 #include <seastar/core/circular_buffer.hh>
 #include "crimson/common/log.h"
 
 class read_lock {
 public:
-  std::optional<seastar::future<>> lock();
+  seastar::future<> lock();
   void unlock();
 };
 
 class write_lock {
 public:
-  std::optional<seastar::future<>> lock();
+  seastar::future<> lock();
   void unlock();
 };
 
 class excl_lock {
 public:
-  std::optional<seastar::future<>> lock();
+  seastar::future<> lock();
   void unlock();
 };
 
@@ -64,7 +62,7 @@ public:
   }
 
   // for shared readers
-  std::optional<seastar::future<>> lock_for_read();
+  seastar::future<> lock_for_read();
   bool try_lock_for_read() noexcept;
   void unlock_for_read();
   void demote_to_read();
@@ -73,7 +71,7 @@ public:
   }
 
   // for shared writers
-  std::optional<seastar::future<>> lock_for_write();
+  seastar::future<> lock_for_write();
   bool try_lock_for_write() noexcept;
   void unlock_for_write();
   void demote_to_write();
@@ -82,7 +80,7 @@ public:
   }
 
   // for exclusive users
-  std::optional<seastar::future<>> lock_for_excl();
+  seastar::future<> lock_for_excl();
   bool try_lock_for_excl() noexcept;
   void unlock_for_excl();
   bool is_excl_acquired() const {

--- a/src/crimson/common/tri_mutex.h
+++ b/src/crimson/common/tri_mutex.h
@@ -101,8 +101,8 @@ public:
     }
   }
 
-  const hobject_t &get_name() const{
-    return name;
+  std::string get_name() const{
+    return name.to_str();
   }
 
 private:

--- a/src/crimson/common/tri_mutex.h
+++ b/src/crimson/common/tri_mutex.h
@@ -5,6 +5,8 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/circular_buffer.hh>
+
+#include "common/hobject.h"
 #include "crimson/common/log.h"
 
 class read_lock {
@@ -45,9 +47,9 @@ class tri_mutex : private read_lock,
 public:
   tri_mutex() = default;
 #ifdef NDEBUG
-  tri_mutex(const std::string obj_name) : name() {}
+  tri_mutex(const hobject_t &obj_name) : name() {}
 #else
-  tri_mutex(const std::string obj_name) : name(obj_name) {}
+  tri_mutex(const hobject_t &obj_name) : name(obj_name) {}
 #endif
   ~tri_mutex();
 
@@ -99,7 +101,7 @@ public:
     }
   }
 
-  std::string_view get_name() const{
+  const hobject_t &get_name() const{
     return name;
   }
 
@@ -122,7 +124,7 @@ private:
     type_t type;
   };
   seastar::circular_buffer<waiter_t> waiters;
-  const std::string name;
+  const hobject_t name;
   friend class read_lock;
   friend class write_lock;
   friend class excl_lock;

--- a/src/crimson/common/tri_mutex.h
+++ b/src/crimson/common/tri_mutex.h
@@ -115,12 +115,11 @@ private:
     none,
   };
   struct waiter_t {
-    waiter_t(seastar::promise<>&& pr, type_t type, std::string_view waiter_name)
+    waiter_t(seastar::promise<>&& pr, type_t type)
       : pr(std::move(pr)), type(type)
     {}
     seastar::promise<> pr;
     type_t type;
-    std::string_view waiter_name;
   };
   seastar::circular_buffer<waiter_t> waiters;
   const std::string name;

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -74,10 +74,6 @@ public:
   using watch_key_t = std::pair<uint64_t, entity_name_t>;
   std::map<watch_key_t, seastar::shared_ptr<crimson::osd::Watch>> watchers;
 
-  // obc loading is a concurrent phase. In case this obc is being loaded,
-  // make other users of this obc to await for the loading to complete.
-  seastar::shared_mutex loading_mutex;
-
   ObjectContext(hobject_t hoid) : lock(hoid.oid.name),
                                   obs(std::move(hoid)) {}
 

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -63,7 +63,6 @@ class ObjectContext : public ceph::common::intrusive_lru_base<
 {
 private:
   tri_mutex lock;
-  bool recovery_read_marker = false;
 
 public:
   ObjectState obs;
@@ -117,9 +116,6 @@ public:
   template<typename Exception>
   void interrupt(Exception ex) {
     lock.abort(std::move(ex));
-    if (recovery_read_marker) {
-      drop_recovery_read();
-    }
   }
 
   bool is_loaded() const {
@@ -292,23 +288,6 @@ public:
   }
   bool is_request_pending() const {
     return lock.is_acquired();
-  }
-
-  bool get_recovery_read() {
-    if (lock.try_lock_for_read()) {
-      recovery_read_marker = true;
-      return true;
-    } else {
-      return false;
-    }
-  }
-  void wait_recovery_read() {
-    assert(lock.get_readers() > 0);
-    recovery_read_marker = true;
-  }
-  void drop_recovery_read() {
-    assert(recovery_read_marker);
-    recovery_read_marker = false;
   }
 };
 using ObjectContextRef = ObjectContext::Ref;

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -137,34 +137,17 @@ public:
 private:
   template <typename Lock, typename Func>
   auto _with_lock(Lock& lock, Func&& func) {
-    auto maybe_fut = lock.lock();
-    return seastar::futurize_invoke([
-        maybe_fut=std::move(maybe_fut),
-        func=std::forward<Func>(func),
-	obc=Ref(this),
-	&lock]() mutable {
-      if (maybe_fut) {
-        return std::move(*maybe_fut
-        ).then([func=std::forward<Func>(func), obc, &lock]() mutable {
-          return seastar::futurize_invoke(
-	    func
-	  ).finally([&lock, obc] {
-	    /* We chain the finally block here because it's possible for
-	     * *maybe_fut from lock.lock() above to fail due to a call to
-	     * ObjectContext::interrupt, which calls tri_mutex::abort.
-	     * In the event of such an error, the lock isn't actually taken
-	     * and calling unlock() would be incorrect. */
-	    lock.unlock();
-	  });
-        });
-      } else {
-        // atomically calling func upon locking
-        return seastar::futurize_invoke(
-	  func
-	).finally([&lock, obc] {
-	  lock.unlock();
-	});
-      }
+    return lock.lock(
+    ).then([&lock, func=std::forward<Func>(func), obc=Ref(this)]() mutable {
+      return seastar::futurize_invoke(
+	func
+      ).finally([&lock, obc=std::move(obc)] {
+	/* We chain the finally block here because it's possible for lock.lock()
+	 * above to fail due to a call to ObjectContext::interrupt, which calls
+	 * tri_mutex::abort.  In the event of such an error, the lock isn't
+	 * actually taken and calling unlock() would be incorrect. */
+	lock.unlock();
+      });
     });
   }
 

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -73,7 +73,7 @@ public:
   using watch_key_t = std::pair<uint64_t, entity_name_t>;
   std::map<watch_key_t, seastar::shared_ptr<crimson::osd::Watch>> watchers;
 
-  ObjectContext(hobject_t hoid) : lock(hoid.oid.name),
+  ObjectContext(hobject_t hoid) : lock(hoid),
                                   obs(std::move(hoid)) {}
 
   const hobject_t &get_oid() const {

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -310,9 +310,6 @@ public:
     assert(recovery_read_marker);
     recovery_read_marker = false;
   }
-  bool maybe_get_excl() {
-    return lock.try_lock_for_excl();
-  }
 };
 using ObjectContextRef = ObjectContext::Ref;
 

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -56,7 +56,7 @@ using crimson::common::local_conf;
                                            bool resolve_clone)
   {
     LOG_PREFIX(ObjectContextLoader::with_clone_obc_only);
-    DEBUGDPP("{}", clone_oid);
+    DEBUGDPP("{}", dpp, clone_oid);
     assert(!clone_oid.is_head());
     if (resolve_clone) {
       auto resolved_oid = resolve_oid(head->get_head_ss(), clone_oid);

--- a/src/crimson/osd/object_context_loader.cc
+++ b/src/crimson/osd/object_context_loader.cc
@@ -158,20 +158,11 @@ using crimson::common::local_conf;
     // See ObjectContext::_with_lock(),
     // this function must be able to support atomicity before
     // acquiring the lock
-    if (obc->loading_mutex.try_lock()) {
-      return _get_or_load_obc<State>(obc, existed
-      ).finally([obc]{
-        obc->loading_mutex.unlock();
-      });
-    } else {
-      return interruptor::with_lock(obc->loading_mutex,
-      [this, obc, existed, FNAME] {
-        // Previous user already loaded the obc
-        DEBUGDPP("{} finished waiting for loader, cache hit on {}",
-                 dpp, FNAME, obc->get_oid());
-        return get_obc(obc, existed);
-      });
-    }
+    ceph_assert(obc->loading_mutex.try_lock());
+    return _get_or_load_obc<State>(obc, existed
+    ).finally([obc]{
+      obc->loading_mutex.unlock();
+    });
   }
 
   template<RWState::State State>

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -75,6 +75,10 @@ private:
   load_obc_iertr::future<> with_head_obc(const hobject_t& oid,
                                          with_obc_func_t&& func);
 
+  template<RWState::State State, bool track, typename Func>
+  load_obc_iertr::future<> with_locked_obc(const hobject_t& oid,
+					   Func&& func);
+
   template<RWState::State State>
   load_obc_iertr::future<ObjectContextRef>
   get_or_load_obc(ObjectContextRef obc,

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -96,7 +96,6 @@ private:
     return load_obc_iertr::make_ready_future<ObjectContextRef>(obc);
   }
 
-  load_obc_iertr::future<ObjectContextRef>
-  load_obc(ObjectContextRef obc);
+  load_obc_iertr::future<> load_obc(ObjectContextRef obc);
 };
 }

--- a/src/crimson/osd/object_context_loader.h
+++ b/src/crimson/osd/object_context_loader.h
@@ -84,18 +84,6 @@ private:
   get_or_load_obc(ObjectContextRef obc,
                   bool existed);
 
-  template<RWState::State State>
-  load_obc_iertr::future<ObjectContextRef>
-  _get_or_load_obc(ObjectContextRef obc,
-                  bool existed);
-
-  static inline load_obc_iertr::future<ObjectContextRef>
-  get_obc(ObjectContextRef obc,
-          bool existed) {
-    ceph_assert(existed && obc->is_valid() && obc->is_loaded());
-    return load_obc_iertr::make_ready_future<ObjectContextRef>(obc);
-  }
-
   load_obc_iertr::future<> load_obc(ObjectContextRef obc);
 };
 }

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -429,8 +429,6 @@ void PGRecovery::on_global_recover (
   pg->get_peering_state().object_recovered(soid, stat_diff);
   pg->publish_stats_to_osd();
   auto& recovery_waiter = pg->get_recovery_backend()->get_recovering(soid);
-  if (!is_delete)
-    recovery_waiter.obc->drop_recovery_read();
   recovery_waiter.set_recovered();
   pg->get_recovery_backend()->remove_recovering(soid);
 }

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -38,7 +38,6 @@ ReplicatedRecoveryBackend::recover_object(
       logger().debug("recover_object: loaded obc: {}", obc->obs.oi.soid);
       auto& recovery_waiter = get_recovering(soid);
       recovery_waiter.obc = obc;
-      recovery_waiter.obc->wait_recovery_read();
       return maybe_push_shards(head, soid, need);
     }, false).handle_error_interruptible(
       crimson::osd::PG::load_obc_ertr::all_same_way([soid](auto& code) {
@@ -98,10 +97,6 @@ ReplicatedRecoveryBackend::maybe_push_shards(
     }
     return seastar::make_ready_future<>();
   }).handle_exception_interruptible([this, soid](auto e) {
-    auto &recovery = get_recovering(soid);
-    if (recovery.obc) {
-      recovery.obc->drop_recovery_read();
-    }
     recovering.erase(soid);
     return seastar::make_exception_future<>(e);
   });


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57977

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh