### PR TITLE
squid: crimson/osd: adding osdmap subscribe

### DIFF
--- a/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
+++ b/qa/suites/crimson-rados/basic/tasks/rados_python.yaml
@@ -17,4 +17,4 @@ tasks:
     timeout: 1h
     clients:
       client.0:
-        - rados/test_python.sh -m 'not (wait or tier or ec or bench)'
+        - rados/test_python.sh -m 'not (tier or ec or bench)'

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1178,6 +1178,13 @@ seastar::future<> OSD::committed_osd_maps(
       }
       if (should_restart()) {
         return restart();
+      } else if (!pg_shard_manager.is_stopping()) {
+        /* 
+         * TODO: Missing start_waiting_for_healthy() counterpart.
+         * Only subscribe to the next map until implemented.
+         * See https://tracker.ceph.com/issues/66832 
+        */
+	return get_shard_services().osdmap_subscribe(osdmap->get_epoch() + 1, false);
       } else {
         return seastar::now();
       }


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/58256

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh