### PR TITLE
librbd: Reduce use of atomics in librbd throttling

### DIFF
--- a/src/librbd/io/QosImageDispatch.h
+++ b/src/librbd/io/QosImageDispatch.h
@@ -117,8 +117,8 @@ private:
 
   void handle_finished(int r, uint64_t tid);
 
-  bool set_throttle_flag(std::atomic<uint32_t>* image_dispatch_flags,
-                         uint32_t flag);
+  bool set_throttle_flags(std::atomic<uint32_t>* image_dispatch_flags,
+                          uint32_t flags);
   bool needs_throttle(bool read_op, const Extents& image_extents, uint64_t tid,
                       std::atomic<uint32_t>* image_dispatch_flags,
                       DispatchResult* dispatch_result, Context** on_finish,


### PR DESCRIPTION
The function `QosImageDispatch::set_throttle_flag` performs 2 atomic operations (`load` and `compare_exchange_weak`) and may be called up to 6 times per I/O by `QosImageDispatch::needs_throttle`  for each of the QOS limits documented here: https://docs.ceph.com/en/quincy/rbd/rbd-config-ref/#qos-settings. 

The end result is up to 12 atomic operations per I/O to process throttling, which seems quite excessive considering that this happens even in the default case where all the QOS limits are disabled.

This PR proposes the following improvements:

1. Skip calling `needs_throttle` in the default case where no QOS limits are enabled (reduces atomic ops per I/O from 12 to 0).
2. If QOS limits are enabled, modify `needs_throttle` to set all of the flags in a single call to `set_throttle_flag` rather than calling it 6 times (reduces atomic ops per I/O from 12 to 2).

Flame graph measurements indicate a 1-2% performance improvement in the first case from eliminating unncessary calls to `needs_throttle`.

Before (calls to `needs_throttle` highlighted in pink):
<img width="1196" alt="Screenshot 2024-07-29 at 16 34 48" src="https://github.com/user-attachments/assets/b6ab92eb-d33c-4928-a40a-2e128a4c98c6">
After:
<img width="1198" alt="Screenshot 2024-07-29 at 16 35 13" src="https://github.com/user-attachments/assets/8c8be08e-a46f-4918-9143-211157186c4a">

In the second case there is around a 0.5% performance improvement from reducing calls to `set_throttle_flag` (now named `set_throttle_flags`).

Before:
<img width="1389" alt="Screenshot 2024-07-29 at 16 28 29" src="https://github.com/user-attachments/assets/53404385-2594-4eb2-91f3-c5b097f8a04c">
After:
<img width="1398" alt="Screenshot 2024-07-29 at 16 28 13" src="https://github.com/user-attachments/assets/96c4af95-08ed-439b-8302-9ad245448909">

This data was captured by running a workload of 4K sequential writes to a 200G volume.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
