### PR TITLE
crimson/os/seastore: move ool writes from collection lock to concurrent DeviceSubmission phase

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1322,7 +1322,7 @@ record_t Cache::prepare_record(
     }
   }
 
-  for (auto &i: t.written_ool_block_list) {
+  for (auto &i: t.ool_block_list) {
     TRACET("fresh ool extent -- {}", t, *i);
     ceph_assert(i->is_valid());
     assert(!i->is_inline());
@@ -1340,7 +1340,7 @@ record_t Cache::prepare_record(
     }
   }
 
-  for (auto &i: t.written_inplace_ool_block_list) {
+  for (auto &i: t.inplace_ool_block_list) {
     if (!i->is_valid()) {
       continue;
     }
@@ -1422,13 +1422,13 @@ record_t Cache::prepare_record(
 
   ceph_assert(t.get_fresh_block_stats().num ==
               t.inline_block_list.size() +
-              t.written_ool_block_list.size() +
+              t.ool_block_list.size() +
               t.num_delayed_invalid_extents +
 	      t.num_allocated_invalid_extents);
 
   auto& ool_stats = t.get_ool_write_stats();
-  ceph_assert(ool_stats.extents.num == t.written_ool_block_list.size() +
-    t.written_inplace_ool_block_list.size());
+  ceph_assert(ool_stats.extents.num == t.ool_block_list.size() +
+    t.inplace_ool_block_list.size());
 
   if (record.is_empty()) {
     SUBINFOT(seastore_t,

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -498,6 +498,7 @@ ExtentPlacementManager::write_delayed_ool_extents(
       assert(extent->is_valid());
     });
 #endif
+    assert(writer->get_type() == backend_type_t::SEGMENTED);
     return writer->alloc_write_ool_extents(t, extents);
   });
 }
@@ -524,6 +525,7 @@ ExtentPlacementManager::write_preallocated_ool_extents(
     return trans_intr::do_for_each(alloc_map, [&t](auto& p) {
       auto writer = p.first;
       auto& extents = p.second;
+      assert(writer->get_type() == backend_type_t::RANDOM_BLOCK);
       return writer->alloc_write_ool_extents(t, extents);
     });
   });

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -28,8 +28,7 @@ SegmentedOolWriter::SegmentedOolWriter(
 {
 }
 
-SegmentedOolWriter::alloc_write_ertr::future<>
-SegmentedOolWriter::write_record(
+void SegmentedOolWriter::write_record(
   Transaction& t,
   record_t&& record,
   std::list<LogicalCachedExtentRef>&& extents,
@@ -63,15 +62,20 @@ SegmentedOolWriter::write_record(
     extent_addr = extent_addr.as_seg_paddr().add_offset(
         extent->get_length());
   }
-  return std::move(ret.future
-  ).safe_then([this, FNAME, &t,
-               record_base=ret.record_base_regardless_md
-              ](record_locator_t ret) {
-    TRACET("{} finish {}=={}",
-           t, segment_allocator.get_name(), ret, record_base);
-    // ool won't write metadata, so the paddrs must be equal
-    assert(ret.record_block_base == record_base.offset);
+  // t might be destructed inside write_future
+  auto write_future = seastar::with_gate(write_guard,
+    [this, FNAME, tid=t.get_trans_id(),
+     record_base=ret.record_base_regardless_md,
+     submit_fut=std::move(ret.future)]() mutable {
+    return std::move(submit_fut
+    ).safe_then([this, FNAME, tid, record_base](record_locator_t ret) {
+      TRACE("trans.{} {} finish {}=={}",
+            tid, segment_allocator.get_name(), ret, record_base);
+      // ool won't write metadata, so the paddrs must be equal
+      assert(ret.record_block_base == record_base.offset);
+    });
   });
+  t.get_handle().add_write_future(std::move(write_future));
 }
 
 SegmentedOolWriter::alloc_write_iertr::future<>
@@ -108,19 +112,15 @@ SegmentedOolWriter::do_write(
       DEBUGT("{} extents={} submit {} extents and roll, unavailable ...",
              t, segment_allocator.get_name(),
              extents.size(), num_extents);
-      auto fut_write = alloc_write_ertr::now();
       if (num_extents > 0) {
         assert(record_submitter.check_action(record.size) !=
                action_t::ROLL);
-        fut_write = write_record(
+        write_record(
             t, std::move(record), std::move(pending_extents),
             true/* with_atomic_roll_segment */);
       }
       return trans_intr::make_interruptible(
-        record_submitter.roll_segment(
-        ).safe_then([fut_write=std::move(fut_write)]() mutable {
-          return std::move(fut_write);
-        })
+        record_submitter.roll_segment()
       ).si_then([this, &t, &extents] {
         return do_write(t, extents);
       });
@@ -151,15 +151,12 @@ SegmentedOolWriter::do_write(
       DEBUGT("{} extents={} submit {} extents ...",
              t, segment_allocator.get_name(),
              extents.size(), pending_extents.size());
-      return trans_intr::make_interruptible(
-        write_record(t, std::move(record), std::move(pending_extents))
-      ).si_then([this, &t, &extents] {
-        if (!extents.empty()) {
-          return do_write(t, extents);
-        } else {
-          return alloc_write_iertr::now();
-        }
-      });
+      write_record(t, std::move(record), std::move(pending_extents));
+      if (!extents.empty()) {
+        return do_write(t, extents);
+      } else {
+        return alloc_write_iertr::now();
+      }
     }
     // SUBMIT_NOT_FULL: evaluate the next extent
   }
@@ -169,8 +166,8 @@ SegmentedOolWriter::do_write(
          t, segment_allocator.get_name(),
          num_extents);
   assert(num_extents > 0);
-  return trans_intr::make_interruptible(
-    write_record(t, std::move(record), std::move(pending_extents)));
+  write_record(t, std::move(record), std::move(pending_extents));
+  return alloc_write_iertr::now();
 }
 
 SegmentedOolWriter::alloc_write_iertr::future<>
@@ -994,13 +991,11 @@ RandomBlockOolWriter::alloc_write_ool_extents(
   if (extents.empty()) {
     return alloc_write_iertr::now();
   }
-  return seastar::with_gate(write_guard, [this, &t, &extents] {
-    return do_write(t, extents);
-  });
+  do_write(t, extents);
+  return alloc_write_iertr::now();
 }
 
-RandomBlockOolWriter::alloc_write_iertr::future<>
-RandomBlockOolWriter::do_write(
+void RandomBlockOolWriter::do_write(
   Transaction& t,
   std::list<CachedExtentRef>& extents)
 {
@@ -1053,8 +1048,10 @@ RandomBlockOolWriter::do_write(
     }
   }
 
-  return trans_intr::make_interruptible(
-    seastar::do_with(std::move(writes),
+  // t might be destructed inside write_future
+  auto write_future = seastar::with_gate(write_guard,
+    [writes=std::move(writes)]() mutable {
+    return seastar::do_with(std::move(writes),
       [](auto& writes) {
       return crimson::do_for_each(writes,
         [](auto& info) {
@@ -1065,8 +1062,9 @@ RandomBlockOolWriter::do_write(
             "Invalid error when writing record"}
         );
       });
-    })
-  );
+    });
+  });
+  t.get_handle().add_write_future(std::move(write_future));
 }
 
 }

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -1033,7 +1033,7 @@ RandomBlockOolWriter::do_write(
       rbm->write(paddr + offset,
 	bp
       ).handle_error(
-	alloc_write_iertr::pass_further{},
+	alloc_write_ertr::pass_further{},
 	crimson::ct_error::assert_all{
 	  "Invalid error when writing record"}
       )

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -115,7 +115,7 @@ private:
     Transaction& t,
     std::list<CachedExtentRef> &extent);
 
-  alloc_write_ertr::future<> write_record(
+  void write_record(
     Transaction& t,
     record_t&& record,
     std::list<LogicalCachedExtentRef> &&extents,
@@ -195,7 +195,7 @@ private:
     ceph::bufferptr bp;
     RandomBlockManager* rbm;
   };
-  alloc_write_iertr::future<> do_write(
+  void do_write(
     Transaction& t,
     std::list<CachedExtentRef> &extent);
 

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -190,6 +190,11 @@ public:
   }
 #endif
 private:
+  struct write_info_t {
+    paddr_t offset;
+    ceph::bufferptr bp;
+    RandomBlockManager* rbm;
+  };
   alloc_write_iertr::future<> do_write(
     Transaction& t,
     std::list<CachedExtentRef> &extent);

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.cc
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.cc
@@ -94,9 +94,10 @@ CircularBoundedJournal::do_submit_record(
 	(void*)&handle,
 	action == RecordSubmitter::action_t::SUBMIT_FULL ?
 	"FULL" : "NOT_FULL");
-  auto submit_fut = record_submitter.submit(std::move(record));
+  auto submit_ret = record_submitter.submit(std::move(record));
+  // submit_ret.record_base_regardless_md is wrong for journaling
   return handle.enter(write_pipeline->device_submission
-  ).then([submit_fut=std::move(submit_fut)]() mutable {
+  ).then([submit_fut=std::move(submit_ret.future)]() mutable {
     return std::move(submit_fut);
   }).safe_then([FNAME, this, &handle](record_locator_t result) {
     return handle.enter(write_pipeline->finalize

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.cc
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.cc
@@ -97,7 +97,9 @@ CircularBoundedJournal::do_submit_record(
   auto submit_ret = record_submitter.submit(std::move(record));
   // submit_ret.record_base_regardless_md is wrong for journaling
   return handle.enter(write_pipeline->device_submission
-  ).then([submit_fut=std::move(submit_ret.future)]() mutable {
+  ).then([&handle] {
+    return handle.take_write_future();
+  }).safe_then([submit_fut=std::move(submit_ret.future)]() mutable {
     return std::move(submit_fut);
   }).safe_then([FNAME, this, &handle](record_locator_t result) {
     return handle.enter(write_pipeline->finalize

--- a/src/crimson/os/seastore/journal/circular_journal_space.cc
+++ b/src/crimson/os/seastore/journal/circular_journal_space.cc
@@ -84,7 +84,7 @@ CircularJournalSpace::write(ceph::bufferlist&& to_write) {
           target, get_records_used_size(), length);
     return write_result;
   }).handle_error(
-    base_ertr::pass_further{},
+    write_ertr::pass_further{},
     crimson::ct_error::assert_all{ "Invalid error" }
   );
 }
@@ -167,7 +167,8 @@ ceph::bufferlist CircularJournalSpace::encode_header()
   return bl;
 }
 
-CircularJournalSpace::write_ertr::future<> CircularJournalSpace::device_write_bl(
+CircularJournalSpace::submit_ertr::future<>
+CircularJournalSpace::device_write_bl(
     rbm_abs_addr offset, bufferlist &bl)
 {
   LOG_PREFIX(CircularJournalSpace::device_write_bl);
@@ -181,7 +182,7 @@ CircularJournalSpace::write_ertr::future<> CircularJournalSpace::device_write_bl
     length);
   return device->writev(offset, bl
   ).handle_error(
-    write_ertr::pass_further{},
+    submit_ertr::pass_further{},
     crimson::ct_error::assert_all{ "Invalid error device->write" }
   );
 }
@@ -229,7 +230,7 @@ CircularJournalSpace::read_header()
   });
 }
 
-CircularJournalSpace::write_ertr::future<>
+CircularJournalSpace::submit_ertr::future<>
 CircularJournalSpace::write_header()
 {
   LOG_PREFIX(CircularJournalSpace::write_header);
@@ -245,7 +246,7 @@ CircularJournalSpace::write_header()
   iter.copy(bl.length(), bp.c_str());
   return device->write(device->get_shard_journal_start(), std::move(bp)
   ).handle_error(
-    write_ertr::pass_further{},
+    submit_ertr::pass_further{},
     crimson::ct_error::assert_all{ "Invalid error device->write" }
   );
 }

--- a/src/crimson/os/seastore/journal/circular_journal_space.h
+++ b/src/crimson/os/seastore/journal/circular_journal_space.h
@@ -46,7 +46,11 @@ class CircularJournalSpace : public JournalAllocator {
 
   roll_ertr::future<> roll() final;
 
-  write_ret write(ceph::bufferlist&& to_write) final;
+  journal_seq_t get_written_to() const final {
+    return written_to;
+  }
+
+  write_ertr::future<> write(ceph::bufferlist&& to_write) final;
 
   void update_modify_time(record_t& record) final {}
 
@@ -140,9 +144,6 @@ class CircularJournalSpace : public JournalAllocator {
    *
    */
 
-  journal_seq_t get_written_to() const {
-    return written_to;
-  }
   rbm_abs_addr get_rbm_addr(journal_seq_t seq) const {
     return convert_paddr_to_abs_addr(seq.offset);
   }

--- a/src/crimson/os/seastore/journal/circular_journal_space.h
+++ b/src/crimson/os/seastore/journal/circular_journal_space.h
@@ -69,7 +69,7 @@ class CircularJournalSpace : public JournalAllocator {
   CircularJournalSpace(RBMDevice * device);
 
   struct cbj_header_t;
-  using write_ertr = Journal::submit_record_ertr;
+  using submit_ertr = Journal::submit_record_ertr;
   /*
    * device_write_bl
    *
@@ -77,7 +77,8 @@ class CircularJournalSpace : public JournalAllocator {
    * @param bufferlist to write
    *
    */
-  write_ertr::future<> device_write_bl(rbm_abs_addr offset, ceph::bufferlist &bl);
+  submit_ertr::future<>
+  device_write_bl(rbm_abs_addr offset, ceph::bufferlist &bl);
 
   using read_ertr = crimson::errorator<
     crimson::ct_error::input_output_error,
@@ -100,7 +101,7 @@ class CircularJournalSpace : public JournalAllocator {
 
   ceph::bufferlist encode_header();
 
-  write_ertr::future<> write_header();
+  submit_ertr::future<> write_header();
 
 
   /**

--- a/src/crimson/os/seastore/journal/record_submitter.cc
+++ b/src/crimson/os/seastore/journal/record_submitter.cc
@@ -40,11 +40,10 @@ RecordBatch::add_pending(
     assert(maybe_write_base.has_value());
     assert(!write_base.has_value());
     write_base = maybe_write_base;
-  } else {
-    assert(io_promise.has_value());
   }
   state = state_t::PENDING;
   assert(write_base.has_value());
+  assert(io_promise.has_value());
 
   return io_promise->get_shared_future(
   ).then([dlength_offset, FNAME, &name

--- a/src/crimson/os/seastore/journal/record_submitter.h
+++ b/src/crimson/os/seastore/journal/record_submitter.h
@@ -149,9 +149,6 @@ public:
   // Add to the batch, the future will be resolved after the batch is
   // written.
   //
-  // Set write_result_t::write_length to 0 if the record is not the first one
-  // in the batch.
-  //
   // write_base must be assigned when the state is empty
   using add_pending_ertr = JournalAllocator::write_ertr;
   using add_pending_ret = add_pending_ertr::future<record_locator_t>;

--- a/src/crimson/os/seastore/journal/record_submitter.h
+++ b/src/crimson/os/seastore/journal/record_submitter.h
@@ -168,8 +168,8 @@ public:
       segment_nonce_t segment_nonce);
 
   // Set the write result and reset for reuse
-  using maybe_result_t = std::optional<write_result_t>;
-  void set_result(maybe_result_t maybe_write_end_seq);
+  using maybe_result_t = std::optional<extent_len_t>;
+  void set_result(maybe_result_t maybe_write_length);
 
   // The fast path that is equivalent to submit a single record as a batch.
   //
@@ -205,7 +205,7 @@ private:
   extent_len_t submitting_mdlength = 0;
 
   struct promise_result_t {
-    write_result_t write_result;
+    extent_len_t write_length;
     extent_len_t mdlength;
   };
   using maybe_promise_result_t = std::optional<promise_result_t>;

--- a/src/crimson/os/seastore/journal/record_submitter.h
+++ b/src/crimson/os/seastore/journal/record_submitter.h
@@ -36,9 +36,10 @@ public:
 
   virtual segment_nonce_t get_nonce() const  = 0;
 
+  virtual journal_seq_t get_written_to() const = 0;
+
   using write_ertr = base_ertr;
-  using write_ret = write_ertr::future<write_result_t>;
-  virtual write_ret write(ceph::bufferlist&& to_write) = 0;
+  virtual write_ertr::future<> write(ceph::bufferlist&& to_write) = 0;
 
   virtual bool can_write() const = 0;
   

--- a/src/crimson/os/seastore/journal/record_submitter.h
+++ b/src/crimson/os/seastore/journal/record_submitter.h
@@ -151,8 +151,14 @@ public:
   //
   // write_base must be assigned when the state is empty
   using add_pending_ertr = JournalAllocator::write_ertr;
-  using add_pending_ret = add_pending_ertr::future<record_locator_t>;
-  add_pending_ret add_pending(
+  using add_pending_fut = add_pending_ertr::future<record_locator_t>;
+  struct add_pending_ret_t {
+    // The supposed record base if no metadata,
+    // only useful in case of ool.
+    journal_seq_t record_base_regardless_md;
+    add_pending_fut future;
+  };
+  add_pending_ret_t add_pending(
       const std::string& name,
       record_t&&,
       extent_len_t block_size,
@@ -275,8 +281,7 @@ public:
   roll_segment_ertr::future<> roll_segment();
 
   // when available, submit the record if possible
-  using submit_ertr = base_ertr;
-  using submit_ret = submit_ertr::future<record_locator_t>;
+  using submit_ret = RecordBatch::add_pending_ret_t;
   submit_ret submit(record_t&&, bool with_atomic_roll_segment=false);
 
   void update_committed_to(const journal_seq_t& new_committed_to) {

--- a/src/crimson/os/seastore/journal/segment_allocator.h
+++ b/src/crimson/os/seastore/journal/segment_allocator.h
@@ -84,11 +84,13 @@ class SegmentAllocator : public JournalAllocator {
   // close the current segment and initialize next one
   roll_ertr::future<> roll() final;
 
+  journal_seq_t get_written_to() const final;
+
   // write the buffer, return the write result
   //
   // May be called concurrently, but writes may complete in any order.
   // If rolling/opening, no write is allowed.
-  write_ret write(ceph::bufferlist&& to_write) final;
+  write_ertr::future<> write(ceph::bufferlist&& to_write) final;
 
   using close_ertr = base_ertr;
   close_ertr::future<> close() final;

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -393,9 +393,10 @@ SegmentedJournal::do_submit_record(
           (void*)&handle,
           action == RecordSubmitter::action_t::SUBMIT_FULL ?
           "FULL" : "NOT_FULL");
-    auto submit_fut = record_submitter.submit(std::move(record));
+    auto submit_ret = record_submitter.submit(std::move(record));
+    // submit_ret.record_base_regardless_md is wrong for journaling
     return handle.enter(write_pipeline->device_submission
-    ).then([submit_fut=std::move(submit_fut)]() mutable {
+    ).then([submit_fut=std::move(submit_ret.future)]() mutable {
       return std::move(submit_fut);
     }).safe_then([FNAME, this, &handle](record_locator_t result) {
       return handle.enter(write_pipeline->finalize

--- a/src/crimson/os/seastore/journal/segmented_journal.cc
+++ b/src/crimson/os/seastore/journal/segmented_journal.cc
@@ -396,7 +396,9 @@ SegmentedJournal::do_submit_record(
     auto submit_ret = record_submitter.submit(std::move(record));
     // submit_ret.record_base_regardless_md is wrong for journaling
     return handle.enter(write_pipeline->device_submission
-    ).then([submit_fut=std::move(submit_ret.future)]() mutable {
+    ).then([&handle] {
+      return handle.take_write_future();
+    }).safe_then([submit_fut=std::move(submit_ret.future)]() mutable {
       return std::move(submit_fut);
     }).safe_then([FNAME, this, &handle](record_locator_t result) {
       return handle.enter(write_pipeline->finalize

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -668,12 +668,18 @@ seastar::future<> SeaStore::report_stats()
          calc_conflicts(io_total.io_num, io_total.repeat_io_num),
          calc_conflicts(io_total.read_num, io_total.repeat_read_num),
          calc_conflicts(io_total.get_bg_num(), io_total.get_repeat_bg_num()));
-    INFO("trans outstanding: {},{},{},{} per-shard: {:.2f},{:.2f},{:.2f},{:.2f}",
+    INFO("trans outstanding: {},{},{},{} "
+         "per-shard: {:.2f}({:.2f},{:.2f},{:.2f},{:.2f},{:.2f}),{:.2f},{:.2f},{:.2f}",
          io_total.pending_io_num,
          io_total.pending_read_num,
          io_total.pending_bg_num,
          io_total.pending_flush_num,
          (double)io_total.pending_io_num/seastar::smp::count,
+         (double)io_total.starting_io_num/seastar::smp::count,
+         (double)io_total.waiting_collock_io_num/seastar::smp::count,
+         (double)io_total.waiting_throttler_io_num/seastar::smp::count,
+         (double)io_total.processing_inlock_io_num/seastar::smp::count,
+         (double)io_total.processing_postlock_io_num/seastar::smp::count,
          (double)io_total.pending_read_num/seastar::smp::count,
          (double)io_total.pending_bg_num/seastar::smp::count,
          (double)io_total.pending_flush_num/seastar::smp::count);

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -236,7 +236,7 @@ block_sm_superblock_t make_superblock(
        uint64_t(config_segment_size),
        data.block_size);
   for (unsigned int i = 0; i < seastar::smp::count; i++) {
-    INFO("shard {} infos:", i, shard_infos[i]);
+    INFO("shard {} infos: {}", i, shard_infos[i]);
   }
 
   return block_sm_superblock_t{

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -304,18 +304,6 @@ public:
     return inline_block_list;
   }
 
-  const auto &get_mutated_block_list() {
-    return mutated_block_list;
-  }
-
-  const auto &get_existing_block_list() {
-    return existing_block_list;
-  }
-
-  const auto &get_retired_set() {
-    return retired_set;
-  }
-
   bool is_retired(paddr_t paddr, extent_len_t len) {
     auto iter = retired_set.lower_bound(paddr);
     if (iter == retired_set.end()) {

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -198,7 +198,7 @@ public:
   }
 
   void mark_delayed_extent_ool(CachedExtentRef& ref) {
-    written_ool_block_list.push_back(ref);
+    ool_block_list.push_back(ref);
   }
 
   void update_delayed_ool_extent_addr(LogicalCachedExtentRef& ref,
@@ -214,13 +214,13 @@ public:
   void mark_allocated_extent_ool(CachedExtentRef& ref) {
     assert(ref->get_paddr().is_absolute());
     assert(!ref->is_inline());
-    written_ool_block_list.push_back(ref);
+    ool_block_list.push_back(ref);
   }
 
   void mark_inplace_rewrite_extent_ool(LogicalCachedExtentRef ref) {
     assert(ref->get_paddr().is_absolute());
     assert(!ref->is_inline());
-    written_inplace_ool_block_list.push_back(ref);
+    inplace_ool_block_list.push_back(ref);
   }
 
   void add_inplace_rewrite_extent(CachedExtentRef ref) {
@@ -332,7 +332,7 @@ public:
 
   template <typename F>
   auto for_each_finalized_fresh_block(F &&f) const {
-    std::for_each(written_ool_block_list.begin(), written_ool_block_list.end(), f);
+    std::for_each(ool_block_list.begin(), ool_block_list.end(), f);
     std::for_each(inline_block_list.begin(), inline_block_list.end(), f);
   }
 
@@ -410,8 +410,8 @@ public:
     num_allocated_invalid_extents = 0;
     delayed_alloc_list.clear();
     inline_block_list.clear();
-    written_ool_block_list.clear();
-    written_inplace_ool_block_list.clear();
+    ool_block_list.clear();
+    inplace_ool_block_list.clear();
     pre_alloc_list.clear();
     pre_inplace_rewrite_list.clear();
     retired_set.clear();
@@ -555,7 +555,7 @@ private:
    * Contains a reference (without a refcount) to every extent mutated
    * as part of *this.  No contained extent may be referenced outside
    * of *this.  Every contained extent will be in one of inline_block_list,
-   * written_ool_block_list or/and pre_alloc_list, mutated_block_list,
+   * ool_block_list or/and pre_alloc_list, mutated_block_list,
    * or delayed_alloc_list.
    */
   ExtentIndex write_set;
@@ -566,20 +566,23 @@ private:
   io_stat_t fresh_block_stats;
   uint64_t num_delayed_invalid_extents = 0;
   uint64_t num_allocated_invalid_extents = 0;
-  /// fresh blocks with delayed allocation, may become inline or ool below
+  /// fresh blocks with delayed allocation,
+  /// may become inline_block_list or ool_block_list below
   std::list<CachedExtentRef> delayed_alloc_list;
   /// fresh blocks with pre-allocated addresses with RBM,
-  /// should be released upon conflicts, will be added to ool below
+  /// should be released upon conflicts,
+  /// will be added to ool_block_list below
   std::list<CachedExtentRef> pre_alloc_list;
-  /// dirty blocks for inplace rewrite with RBM, will be added to inplace ool below
+  /// dirty blocks for inplace rewrite with RBM,
+  /// will be added to inplace inplace_ool_block_list below
   std::list<LogicalCachedExtentRef> pre_inplace_rewrite_list;
 
   /// fresh blocks that will be committed with inline journal record
   std::list<CachedExtentRef> inline_block_list;
   /// fresh blocks that will be committed with out-of-line record
-  std::list<CachedExtentRef> written_ool_block_list;
+  std::list<CachedExtentRef> ool_block_list;
   /// dirty blocks that will be committed out-of-line with inplace rewrite
-  std::list<LogicalCachedExtentRef> written_inplace_ool_block_list;
+  std::list<LogicalCachedExtentRef> inplace_ool_block_list;
 
   /// list of mutated blocks, holds refcounts, subset of write_set
   std::list<CachedExtentRef> mutated_block_list;


### PR DESCRIPTION
Essential changes:
1. Refactor `RecordSubmitter` to make the write base available upon submitting ool writes.
2. Refactors in ool to move necessary updates before ool writes, see commits:
   * "`RandomBlockOolWriter` to update extents upon submitting writes".
   * "`SegmentedOolWriter` to update ool paddr upon submitting writes".
3. Move ool write futures into the concurrent `DeviceSubmission` phase, see commit:
   * "wait ool writes in `DeviceSubmission` phase".

----

The issue was observed from https://github.com/ceph/ceph/pull/58467, that there are many waiters blocked by the collection lock, and this PR tries to decouple (maybe slow) IO writes out of the lock.

The observed benefits are:
1. The random write end-performance was improved by ~3 ~6% from local fio-rbd tests (1 OSD, 32 cores, fio-rbd).
2. Reactor utilization was improved from ~89% to ~93% [1].
3. The op concurrency (per-shard) outside (after) the collection lock was improved from ~1.4 to ~2.6 [2].

----
(Further analysis, unrelated to this PR)

However, this PR doesn't address the issue of "too many collection lock waiters" very well, my current understandings are:
1. The overall reactor utilization is very high (~93%), meaning that CPU is already busy executing actual tasks (not starving), so making the critical logic efficient would be more benefitial in this case.
2. The collection lock waiters are very unbalanced [3]:
   * They are varying from 0 up to 1400 waiters across the shards.
   * The pattern of the imbalanced waiters won't change during the tests, they are keeping piling up in the same shard.
   * The shards having excessive waiters have higher reactor utilizations (99% vs others 88%) and lower IOPS (4700 vs others 5200), impacting the end-performance.

----

[1] Reactor utilizations
```
Before:
INFO  2024-07-29 14:22:49,878 [shard  0:main] osd - OSD::start: reactor_utilizations: 89(91,99,96,84,89,90,99,99,87,85,88,90,91,82,88,89,91,83,85,96,89,91,90,91,98,82,84,91,90,76,72,73,)
INFO  2024-07-29 14:22:51,878 [shard  0:main] osd - OSD::start: reactor_utilizations: 88(90,99,96,83,89,91,99,99,87,84,87,90,92,81,88,88,91,81,84,95,90,91,89,90,98,81,85,90,90,76,72,74,)
INFO  2024-07-29 14:22:53,879 [shard  0:main] osd - OSD::start: reactor_utilizations: 88(90,99,95,82,88,91,99,99,88,83,87,90,91,81,88,88,90,81,85,96,89,90,89,89,98,81,84,91,88,76,73,73,)
INFO  2024-07-29 14:22:55,878 [shard  0:main] osd - OSD::start: reactor_utilizations: 88(91,99,97,82,87,92,99,99,88,82,86,90,90,82,90,88,90,82,85,96,90,91,89,88,98,82,84,92,89,76,74,74,)
...

After:
INFO  2024-07-29 13:45:22,400 [shard  0:main] osd - OSD::start: reactor_utilizations: 93(86,87,99,99,99,94,99,96,88,94,89,93,87,90,93,96,94,90,97,90,97,87,91,80,96,92,92,93,95,95,94,99,)
INFO  2024-07-29 13:45:24,400 [shard  0:main] osd - OSD::start: reactor_utilizations: 93(87,86,99,99,99,94,99,98,88,95,89,93,87,91,94,96,94,90,97,91,97,87,92,79,96,92,93,93,95,96,94,99,)
INFO  2024-07-29 13:45:26,401 [shard  0:main] osd - OSD::start: reactor_utilizations: 93(86,85,99,99,99,94,99,98,88,95,88,92,85,92,95,95,93,89,95,91,96,88,92,79,96,92,94,93,95,96,93,98,)
INFO  2024-07-29 13:45:28,401 [shard  0:main] osd - OSD::start: reactor_utilizations: 92(84,85,99,99,99,92,99,97,88,93,88,91,85,92,95,94,93,89,92,91,96,88,91,80,93,93,94,92,96,95,91,97,)
...
```

[2] SeaStore outstanding transactions (The 4th colume is outside the collection-lock, see *):
```
Before:
INFO  2024-07-29 14:22:45,879 [shard  0:main] seastore - SeaStore: trans outstanding per-shard: 105.81(0.00,101.59,0.00,2.62,*1.59*)
INFO  2024-07-29 14:22:47,878 [shard  0:main] seastore - SeaStore: trans outstanding per-shard: 100.12(0.00,96.16,0.00,2.44,*1.53*)
INFO  2024-07-29 14:22:49,878 [shard  0:main] seastore - SeaStore: trans outstanding per-shard: 102.81(0.00,99.44,0.00,2.19,*1.19*)
INFO  2024-07-29 14:22:51,878 [shard  0:main] seastore - SeaStore: trans outstanding per-shard: 101.22(0.00,97.50,0.00,2.31,*1.41*)
...

After:
INFO  2024-07-29 13:45:16,400 [shard  0:main] seastore - SeaStore: trans outstanding per-shard: 99.41(0.00,94.31,0.00,2.34,*2.75*)
INFO  2024-07-29 13:45:18,400 [shard  0:main] seastore - SeaStore: trans outstanding per-shard: 101.44(0.00,96.97,0.00,2.03,*2.44*)
INFO  2024-07-29 13:45:20,400 [shard  0:main] seastore - SeaStore: trans outstanding per-shard: 100.41(0.00,95.31,0.00,2.41,*2.69*)
INFO  2024-07-29 13:45:22,400 [shard  0:main] seastore - SeaStore: trans outstanding per-shard: 103.28(0.00,98.00,0.00,2.59,*2.69*)
...
```

[3] Persistent waiter imbalances:
```
The second colume means waiters (see *):
INFO  2024-07-29 13:45:14,400 [shard  0:main] seastore - SeaStore: details: 12(0,9,0,2,1) 3(0,0,0,1,2) 965(0,*958*,0,3,4) 536(0,528,0,4,4) 623(0,615,0,4,4) 2(0,0,0,0,2) ...
INFO  2024-07-29 13:45:16,400 [shard  0:main] seastore - SeaStore: details: 0(0,0,0,0,0) 18(0,11,0,4,3) 999(0,*991*,0,4,4) 521(0,514,0,3,4) 547(0,540,0,4,3) 29(0,21,0,4,4) ...
INFO  2024-07-29 13:45:18,400 [shard  0:main] seastore - SeaStore: details: 0(0,0,0,0,0) 1(0,0,0,0,1) 1159(0,*1152*,0,3,4) 518(0,512,0,4,2) 528(0,521,0,4,3) 23(0,17,0,3,3) ...
INFO  2024-07-29 13:45:20,400 [shard  0:main] seastore - SeaStore: details: 2(0,0,0,0,2) 9(0,5,0,1,3) 1160(0,*1152*,0,4,4) 426(0,418,0,4,4) 519(0,512,0,4,3) 39(0,34,0,3,2) ...

They are consistent with the pattern of reactor utilizations:
INFO  2024-07-29 13:45:14,400 [shard  0:main] osd - OSD::start: reactor_utilizations: 92(83,84,99,99,99,91...)
INFO  2024-07-29 13:45:16,400 [shard  0:main] osd - OSD::start: reactor_utilizations: 93(84,86,99,99,99,93...)
INFO  2024-07-29 13:45:18,400 [shard  0:main] osd - OSD::start: reactor_utilizations: 93(86,88,99,99,99,93...)
INFO  2024-07-29 13:45:20,400 [shard  0:main] osd - OSD::start: reactor_utilizations: 93(86,88,99,99,99,93...)

They are consistent with the pattern of IOPS:
INFO  2024-07-29 13:45:14,400 [shard  0:main] seastore - SeaStore: device IOPS: 166397.74 5199.93(5102.37,5179.87,4908.37,4955.87,4946.37,5347.86...)
INFO  2024-07-29 13:45:16,400 [shard  0:main] seastore - SeaStore: device IOPS: 176248.70 5507.77(5910.40,6137.38,4764.02,4842.51,4805.01,5414.95...)
INFO  2024-07-29 13:45:18,400 [shard  0:main] seastore - SeaStore: device IOPS: 174205.65 5443.93(6037.49,5712.44,4732.28,4734.78,4786.29,5557.91...)
INFO  2024-07-29 13:45:20,400 [shard  0:main] seastore - SeaStore: device IOPS: 170744.17 5335.76(5574.89,5768.39,4798.41,4866.91,4826.41,5468.89...)
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
