### PR TITLE
squid: mon: Remove any pg_upmap_primary mapping during remove a pool

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -14634,6 +14634,25 @@ int OSDMonitor::_prepare_remove_pool(
       }
     }
   }
+  // remove any old pg_upmap_primary mapping for this pool
+  for (auto& p : osdmap.pg_upmap_primaries) {
+    if (p.first.pool() == pool) {
+      dout(10) << __func__ << " " << pool
+               << " removing obsolete pg_upmap_primaries " << p.first
+               << dendl;
+      pending_inc.old_pg_upmap_primary.insert(p.first);
+    }
+  }
+
+  // remove any pending pg_upmap_primary mapping for this pool
+  for (auto& p : osdmap.pg_upmap_primaries) {
+    if (p.first.pool() == pool) {
+      dout(10) << __func__ << " " << pool
+               << " removing pending pg_upmap_primaries " << p.first
+               << dendl;
+      pending_inc.new_pg_upmap_primary.erase(p.first);
+    }
+  }
 
   // remove any choose_args for this pool
   CrushWrapper newcrush = _get_pending_crush();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67245

---

backport of https://github.com/ceph/ceph/pull/58470
parent tracker: https://tracker.ceph.com/issues/66867

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh