### PR TITLE
squid: test: Create ParallelPGMapper object before start threadpool

### DIFF
--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -308,8 +308,8 @@ public:
     int cpu_num = 8;
     int pgs_per_chunk = 256;
     ThreadPool tp(cct, "BUG_40104::clean_upmap_tp", "clean_upmap_tp", cpu_num);
-    tp.start();
     ParallelPGMapper mapper(cct, &tp);
+    tp.start();
     vector<pg_t> pgs_to_check;
     om.get_upmap_pgs(&pgs_to_check);
     OSDMonitor::CleanUpmapJob job(cct, om, pending_inc);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67237

---

backport of https://github.com/ceph/ceph/pull/58406
parent tracker: https://tracker.ceph.com/issues/42884

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh