### PR TITLE
osd/scrub: exempt only operator scrubs from max_scrubs limit

### DIFF
--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -513,6 +513,7 @@ sched_params_t PgScrubber::determine_initial_schedule(
     // Set the smallest time that isn't utime_t()
     res.proposed_time = PgScrubber::scrub_must_stamp();
     res.is_must = Scrub::must_scrub_t::mandatory;
+    res.observes_max_scrubs = false;
 
   } else if (m_pg->info.stats.stats_invalid && app_conf.mandatory_on_invalid) {
     res.proposed_time = scrub_clock_now;
@@ -660,7 +661,7 @@ bool PgScrubber::reserve_local()
   // a wrapper around the actual reservation, and that object releases
   // the local resource automatically when reset.
   m_local_osd_resource = m_osds->get_scrub_services().inc_scrubs_local(
-      m_scrub_job->is_high_priority());
+      !m_scrub_job->observes_max_concurrency);
   if (m_local_osd_resource) {
     dout(15) << __func__ << ": local resources reserved" << dendl;
     return true;

--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -61,6 +61,8 @@ void ScrubJob::adjust_schedule(
 	   << dendl;
 
   high_priority = (suggested.is_must == must_scrub_t::mandatory);
+  observes_max_concurrency = suggested.observes_max_scrubs;
+
   utime_t adj_not_before = suggested.proposed_time;
   utime_t adj_target = suggested.proposed_time;
   schedule.deadline = adj_target;

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -47,6 +47,7 @@ struct scrub_schedule_t {
 struct sched_params_t {
   utime_t proposed_time{};
   must_scrub_t is_must{must_scrub_t::not_mandatory};
+  bool observes_max_scrubs{true};
 };
 
 /**
@@ -143,6 +144,13 @@ class ScrubJob {
   CephContext* cct;
 
   bool high_priority{false};
+
+  /**
+   * If cleared: the scrub can be initiated even if the local OSD has reached
+   * osd_max_scrubs. Only 'false' for those high-priority scrubs that were
+   * operator initiated.
+   */
+  bool observes_max_concurrency{true};
 
   ScrubJob(CephContext* cct, const spg_t& pg, int node_id);
 


### PR DESCRIPTION
Existing code exempts all 'high priority' scrubs, including for example
'after_repair' and 'mandatory on invalid history' scrubs from the limit.

PGs that do not have valid last-scrub data (which is what we have when
a pool is first created) - are set to shallow-scrub immediately.
Unfortunately - with the low granularity implemented 
in existing code - this type of scrub  is 'high priority'.
Which means that a newly created pool will have all its PGs start
scrubbing, regardless of concurrency (or any other) limits.

Fixes: https://tracker.ceph.com/issues/67253
