### PR TITLE
squid: rgw/auth: RemoteApplier respects implicit tenants

### DIFF
--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -621,6 +621,9 @@ protected:
   const rgw::auth::ImplicitTenants& implicit_tenant_context;
   const rgw::auth::ImplicitTenants::implicit_tenant_flag_bits implicit_tenant_bit;
 
+  // AuthInfo::acct_user updated with implicit tenant if necessary
+  mutable rgw_user owner_acct_user;
+
   // account and policies are loaded by load_acct_info()
   mutable std::optional<RGWAccountInfo> account;
   mutable std::vector<IAM::Policy> policies;
@@ -660,7 +663,7 @@ public:
   std::string get_acct_name() const override { return info.acct_name; }
   std::string get_subuser() const override { return {}; }
   const std::string& get_tenant() const override {
-    return info.acct_user.tenant;
+    return owner_acct_user.tenant;
   }
   const std::optional<RGWAccountInfo>& get_account() const override {
     return account;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67267

---

backport of https://github.com/ceph/ceph/pull/58606
parent tracker: https://tracker.ceph.com/issues/66937

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh