### PR TITLE
squid: rgw/rgw_rados: fix server side-copy orphans tail-objects

### DIFF
--- a/qa/workunits/rgw/test_rgw_orphan_list.sh
+++ b/qa/workunits/rgw/test_rgw_orphan_list.sh
@@ -376,6 +376,95 @@ done
 
 mys3cmd rb --recursive s3://$o_bkt
 
+############################################################
+# copy multipart objects and delete destination
+
+o_bkt="orig-mp-bkt-5"
+d_bkt="copy-mp-bkt-5"
+
+mys3cmd mb s3://$o_bkt
+
+for f in $(seq 2) ;do
+    dest_obj="orig-multipart-obj-$f"
+    mys3cmd put -q $huge_obj s3://${o_bkt}/$dest_obj
+done
+
+mys3cmd mb s3://$d_bkt
+
+mys3cmd cp s3://${o_bkt}/orig-multipart-obj-1 \
+	s3://${d_bkt}/copied-multipart-obj-1
+
+for f in $(seq 5 5) ;do
+    dest_obj="orig-multipart-obj-$f"
+    mys3cmd put -q $huge_obj s3://${d_bkt}/$dest_obj
+done
+
+mys3cmd rb --recursive s3://$d_bkt
+
+#####################################################################
+# FORCE GARBAGE COLLECTION
+sleep 6 # since for testing age at which gc can happen is 5 secs
+radosgw-admin gc process --include-all
+#####################################################################
+
+############################################################
+# copy multipart objects and delete original then destination
+
+o_bkt="orig-mp-bkt-6"
+d_bkt="copy-mp-bkt-6"
+
+mys3cmd mb s3://$o_bkt
+
+for f in $(seq 2) ;do
+    dest_obj="orig-multipart-obj-$f"
+    mys3cmd put -q $huge_obj s3://${o_bkt}/$dest_obj
+done
+
+mys3cmd mb s3://$d_bkt
+
+mys3cmd cp s3://${o_bkt}/orig-multipart-obj-1 \
+	s3://${d_bkt}/copied-multipart-obj-1
+
+for f in $(seq 5 5) ;do
+    dest_obj="orig-multipart-obj-$f"
+    mys3cmd put -q $huge_obj s3://${d_bkt}/$dest_obj
+done
+
+mys3cmd rb --recursive s3://$o_bkt
+mys3cmd rb --recursive s3://$d_bkt
+
+############################################################
+# copy multipart objects and delete destination then original
+
+o_bkt="orig-mp-bkt-7"
+d_bkt="copy-mp-bkt-7"
+
+mys3cmd mb s3://$o_bkt
+
+for f in $(seq 2) ;do
+    dest_obj="orig-multipart-obj-$f"
+    mys3cmd put -q $huge_obj s3://${o_bkt}/$dest_obj
+done
+
+mys3cmd mb s3://$d_bkt
+
+mys3cmd cp s3://${o_bkt}/orig-multipart-obj-1 \
+	s3://${d_bkt}/copied-multipart-obj-1
+
+for f in $(seq 5 5) ;do
+    dest_obj="orig-multipart-obj-$f"
+    mys3cmd put -q $huge_obj s3://${d_bkt}/$dest_obj
+done
+
+mys3cmd rb --recursive s3://$d_bkt
+mys3cmd rb --recursive s3://$o_bkt
+
+#####################################################################
+# FORCE GARBAGE COLLECTION
+sleep 6 # since for testing age at which gc can happen is 5 secs
+radosgw-admin gc process --include-all
+#####################################################################
+
 ########################################################################
 # SWIFT TESTS
 

--- a/qa/workunits/rgw/test_rgw_orphan_list.sh
+++ b/qa/workunits/rgw/test_rgw_orphan_list.sh
@@ -6,7 +6,8 @@ set -e
 # if defined, debug messages will be displayed and prepended with the string
 # debug="DEBUG"
 
-huge_size=5100 # in megabytes
+#huge_size=5100 # in megabytes
+huge_size=51 # in megabytes
 big_size=7 # in megabytes
 
 huge_obj=/tmp/huge_obj.temp.$$

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1128,7 +1128,7 @@ public:
                std::string *ptag,
                std::string *petag, optional_yield y);
 
-  int fetch_remote_obj(RGWObjectCtx& obj_ctx,
+  int fetch_remote_obj(RGWObjectCtx& dest_obj_ctx,
                        const rgw_user& user_id,
                        req_info *info,
                        const rgw_zone_id& source_zone,
@@ -1175,7 +1175,8 @@ public:
    *                             are overwritten by values contained in attrs parameter.
    * Returns: 0 on success, -ERR# otherwise.
    */
-  int copy_obj(RGWObjectCtx& obj_ctx,
+  int copy_obj(RGWObjectCtx& src_obj_ctx,
+               RGWObjectCtx& dest_obj_ctx,
                const ACLOwner& owner, // owner of destination object
                const rgw_user& remote_user, // uid for fetch_remote_obj() auth
                req_info *info,

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -2863,6 +2863,7 @@ int RadosObject::copy_object(const ACLOwner& owner,
 				optional_yield y)
 {
   return store->getRados()->copy_obj(*rados_ctx,
+				     *static_cast<RadosObject*>(dest_object)->rados_ctx,
 				     owner,
 				     remote_user,
 				     info,

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -59,6 +59,8 @@
 #include "RadosImport.h"
 
 #include "osd/ECUtil.h"
+#include "objclass/objclass.h"
+#include "cls/refcount/cls_refcount_ops.h"
 
 using namespace std::chrono_literals;
 using namespace librados;
@@ -2750,8 +2752,30 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     }
     else
       ret = 0;
-    string s(bl.c_str(), bl.length());
-    cout << s;
+
+    if (attr_name == "refcount")  {
+      obj_refcount oref;
+      auto p = bl.cbegin();
+      decode(oref, p);
+      for (auto itr = oref.refs.begin(); itr != oref.refs.end(); itr++) {
+	if (!itr->first.empty()) {
+	  cout << itr->first << "::" << itr->second << std::endl;
+	}
+	else {
+	  cout << "wildcard reference::" << itr->second << std::endl;
+	}
+      }
+      if (!oref.retired_refs.empty()) {
+	cout << "--------------------------------------" << std::endl;
+	for (const auto & ref : oref.retired_refs) {
+	  cout << "retired_refs::" << ref << std::endl;
+	}
+      }
+    }
+    else {
+      string s(bl.c_str(), bl.length());
+      cout << s << std::endl;
+    }
   } else if (strcmp(nargs[0], "rmxattr") == 0) {
     if (!pool_name || nargs.size() < (obj_name ? 2 : 3)) {
       usage(cerr);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67269

---

backport of https://github.com/ceph/ceph/pull/58213
parent tracker: https://tracker.ceph.com/issues/66286

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh