### PR TITLE
squid: common: fix string creation from '0' in LogEntry

### DIFF
--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -183,7 +183,6 @@ string clog_type_to_string(clog_type t)
       return "crit";
     default:
       ceph_abort();
-      return 0;
   }
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67272

---

backport of https://github.com/ceph/ceph/pull/55905
parent tracker: https://tracker.ceph.com/issues/67271

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh