### PR TITLE
run-make: install libstdc++-12-dev where gcc-12 is installed

### DIFF
--- a/src/script/run-make.sh
+++ b/src/script/run-make.sh
@@ -53,9 +53,23 @@ function prepare() {
         which_pkg="debianutils"
     fi
 
+    INSTALL_EXTRA_PACKAGES="ccache git $which_pkg clang lvm2"
+    source /etc/os-release
+    if [[ "$ID" == "ubuntu" ]]; then
+        case "$VERSION" in
+            *Jammy*)
+                # when g++-12 is installed, clang builds try to use it's
+                # version of libstdc++. but nothing depends specifically
+                # on gcc 12's libstdc++ to install it
+                if command -v g++-12 > /dev/null 2>&1 ; then
+                    INSTALL_EXTRA_PACKAGES+=" libstdc++-12-dev"
+                fi
+                ;;
+        esac
+    fi
+
     if test -f ./install-deps.sh ; then
         ci_debug "Running install-deps.sh"
-        INSTALL_EXTRA_PACKAGES="ccache git $which_pkg clang lvm2"
         $DRY_RUN source ./install-deps.sh || return 1
         trap clean_up_after_myself EXIT
     fi


### PR DESCRIPTION
debian builds don't depend on a specific version of gcc. ubuntu jammy's gcc defaults to gcc-11, but gcc-12 packages are also available

we use clang for 'make check' on pull requests, and clang will use the standard library from the most recent gcc version it finds. if gcc-12 is installed but libstdc++-12-dev is not, the builds fail to link with:

> /usr/bin/ld: cannot find -lstdc++: No such file or directory

we don't want to make debian/control depend on a specific compiler version, so i chose to add this to run-make.sh for run-make-check.sh instead

Fixes: https://tracker.ceph.com/issues/67233

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
