### PR TITLE
debian pkg: record python3-packaging dependency for ceph-volume

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -456,6 +456,7 @@ Depends: ceph-osd (= ${binary:Version}),
          e2fsprogs,
          lvm2,
          parted,
+         python3-packaging,
          xfsprogs,
          ${misc:Depends},
          ${python3:Depends}


### PR DESCRIPTION
Since commit 0985e201342 ("ceph-volume: use 'no workqueue' options with dmcrypt") the python "packaging" module is used to parse the cryptsetup version output, but the debian packaging was not updated to record that new dependency.

Simply record this in the d/control file, adding a <pkg>.requires file could be also an option, but not really sure if that wins us anything here. But if that's preferred I can change to that quite quickly, so just holler at me if I should do so.

Fixes: https://tracker.ceph.com/issues/67290 and do well with getting backported once applied, as the patch causing this got backported to (at least) squid and reef too.
