### PR TITLE
squid: crimson/os/seastore/cached_extent: add the "refresh" ability to lba mappings

### DIFF
--- a/src/crimson/os/seastore/btree/btree_range_pin.cc
+++ b/src/crimson/os/seastore/btree/btree_range_pin.cc
@@ -11,7 +11,7 @@ get_child_ret_t<LogicalCachedExtent>
 BtreeNodeMapping<key_t, val_t>::get_logical_extent(
   Transaction &t)
 {
-  ceph_assert(is_parent_valid());
+  ceph_assert(is_parent_viewable());
   assert(pos != std::numeric_limits<uint16_t>::max());
   ceph_assert(t.get_trans_id() == ctx.trans.get_trans_id());
   auto &p = (FixedKVNode<key_t>&)*parent;

--- a/src/crimson/os/seastore/btree/btree_range_pin.h
+++ b/src/crimson/os/seastore/btree/btree_range_pin.h
@@ -225,6 +225,10 @@ public:
     }
     return !is_unviewable_by_trans(*parent, ctx.trans);
   }
+  bool is_parent_valid() const final {
+    ceph_assert(parent);
+    return parent->is_valid();
+  }
 };
 
 }

--- a/src/crimson/os/seastore/btree/btree_range_pin.h
+++ b/src/crimson/os/seastore/btree/btree_range_pin.h
@@ -218,7 +218,7 @@ public:
   get_child_ret_t<LogicalCachedExtent> get_logical_extent(Transaction&) final;
   bool is_stable() const final;
   bool is_data_stable() const final;
-  bool is_parent_valid() const final {
+  bool is_parent_viewable() const final {
     ceph_assert(parent);
     if (!parent->is_valid()) {
       return false;

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -1047,7 +1047,7 @@ public:
         fixed_kv_extent.get_user_hint(),
         // get target rewrite generation
         fixed_kv_extent.get_rewrite_generation());
-      n_fixed_kv_extent->rewrite(fixed_kv_extent, 0);
+      n_fixed_kv_extent->rewrite(c.trans, fixed_kv_extent, 0);
       
       SUBTRACET(
         seastore_fixedkv_tree,

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -1068,7 +1068,6 @@ public:
       });
     };
     
-    CachedExtentRef n_fixed_kv_extent;
     if (e->get_type() == internal_node_t::TYPE) {
       auto lint = e->cast<internal_node_t>();
       return do_rewrite(*lint);

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1154,7 +1154,7 @@ public:
   bool is_zero_reserved() const {
     return !get_val().is_real();
   }
-  virtual bool is_parent_valid() const = 0;
+  virtual bool is_parent_viewable() const = 0;
   virtual bool parent_modified() const {
     ceph_abort("impossible");
     return false;

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -112,6 +112,9 @@ struct trans_spec_view_t {
   // if the extent is pending, contains the id of the owning transaction;
   // TRANS_ID_NULL otherwise
   transaction_id_t pending_for_transaction = TRANS_ID_NULL;
+  trans_spec_view_t() = default;
+  trans_spec_view_t(transaction_id_t id) : pending_for_transaction(id) {}
+  virtual ~trans_spec_view_t() = default;
 
   struct cmp_t {
     bool operator()(
@@ -307,7 +310,7 @@ public:
     return true;
   }
 
-  void rewrite(CachedExtent &e, extent_len_t o) {
+  void rewrite(Transaction &t, CachedExtent &e, extent_len_t o) {
     assert(is_initial_pending());
     if (!e.is_pending()) {
       prior_instance = &e;
@@ -321,7 +324,7 @@ public:
       get_bptr().c_str());
     set_modify_time(e.get_modify_time());
     set_last_committed_crc(e.get_last_committed_crc());
-    on_rewrite(e, o);
+    on_rewrite(t, e, o);
   }
 
   /**
@@ -330,7 +333,7 @@ public:
    * Called when this extent is rewriting another one.
    *
    */
-  virtual void on_rewrite(CachedExtent &, extent_len_t) = 0;
+  virtual void on_rewrite(Transaction &, CachedExtent &, extent_len_t) = 0;
 
   friend std::ostream &operator<<(std::ostream &, extent_state_t);
   virtual std::ostream &print_detail(std::ostream &out) const { return out; }
@@ -1221,7 +1224,7 @@ public:
     return false;
   }
 
-  void on_rewrite(CachedExtent&, extent_len_t) final {}
+  void on_rewrite(Transaction &, CachedExtent&, extent_len_t) final {}
 
   std::ostream &print_detail(std::ostream &out) const final {
     return out << ", RetiredExtentPlaceholder";
@@ -1308,7 +1311,7 @@ public:
     : ChildableCachedExtent(std::forward<T>(t)...)
   {}
 
-  void on_rewrite(CachedExtent &extent, extent_len_t off) final {
+  void on_rewrite(Transaction&, CachedExtent &extent, extent_len_t off) final {
     assert(get_type() == extent.get_type());
     auto &lextent = (LogicalCachedExtent&)extent;
     set_laddr(lextent.get_laddr() + off);

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1121,6 +1121,10 @@ public:
   virtual val_t get_val() const = 0;
   virtual key_t get_key() const = 0;
   virtual PhysicalNodeMappingRef<key_t, val_t> duplicate() const = 0;
+  virtual PhysicalNodeMappingRef<key_t, val_t> refresh_with_pending_parent() {
+    ceph_abort("impossible");
+    return {};
+  }
   virtual bool has_been_invalidated() const = 0;
   virtual CachedExtentRef get_parent() const = 0;
   virtual uint16_t get_pos() const = 0;
@@ -1155,6 +1159,7 @@ public:
     return !get_val().is_real();
   }
   virtual bool is_parent_viewable() const = 0;
+  virtual bool is_parent_valid() const = 0;
   virtual bool parent_modified() const {
     ceph_abort("impossible");
     return false;

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -163,13 +163,13 @@ public:
 
   bool parent_modified() const final {
     ceph_assert(parent);
-    ceph_assert(is_parent_valid());
+    ceph_assert(is_parent_viewable());
     auto &p = static_cast<LBALeafNode&>(*parent);
     return p.modified_since(parent_modifications);
   }
 
   void maybe_fix_pos() final {
-    assert(is_parent_valid());
+    assert(is_parent_viewable());
     if (!parent_modified()) {
       return;
     }

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -176,6 +176,14 @@ public:
     auto &p = static_cast<LBALeafNode&>(*parent);
     p.maybe_fix_mapping_pos(*this);
   }
+
+  LBAMappingRef refresh_with_pending_parent() final {
+    assert(is_parent_valid() && !is_parent_viewable());
+    auto &p = static_cast<LBALeafNode&>(*parent);
+    auto &viewable_p = static_cast<LBALeafNode&>(
+      *p.find_pending_version(ctx.trans, get_key()));
+    return viewable_p.get_mapping(ctx, get_key());
+  }
 protected:
   std::unique_ptr<BtreeNodeMapping<laddr_t, paddr_t>> _duplicate(
     op_context_t<laddr_t> ctx) const final {

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
@@ -72,4 +72,18 @@ void LBALeafNode::maybe_fix_mapping_pos(BtreeLBAMapping &mapping)
   }
 }
 
+BtreeLBAMappingRef LBALeafNode::get_mapping(
+  op_context_t<laddr_t> c, laddr_t laddr)
+{
+  auto iter = lower_bound(laddr);
+  ceph_assert(iter != end() && iter->get_key() == laddr);
+  auto val = iter.get_val();
+  return std::make_unique<BtreeLBAMapping>(
+    c,
+    this,
+    iter.get_offset(),
+    val,
+    lba_node_meta_t{laddr, val.len, 0});
+}
+
 }

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -294,6 +294,7 @@ struct LBALeafNode
   std::ostream &_print_detail(std::ostream &out) const final;
 
   void maybe_fix_mapping_pos(BtreeLBAMapping &mapping);
+  std::unique_ptr<BtreeLBAMapping> get_mapping(op_context_t<laddr_t> c, laddr_t laddr);
 };
 using LBALeafNodeRef = TCachedExtentRef<LBALeafNode>;
 

--- a/src/crimson/os/seastore/root_block.h
+++ b/src/crimson/os/seastore/root_block.h
@@ -50,7 +50,7 @@ struct RootBlock : CachedExtent {
       backref_root_node(nullptr)
   {}
 
-  void on_rewrite(CachedExtent&, extent_len_t) final {}
+  void on_rewrite(Transaction&, CachedExtent&, extent_len_t) final {}
 
   CachedExtentRef duplicate_for_write(Transaction&) final {
     return CachedExtentRef(new RootBlock(*this));

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -494,7 +494,7 @@ TransactionManager::rewrite_logical_extent(
       lextent->get_user_hint(),
       // get target rewrite generation
       lextent->get_rewrite_generation())->cast<LogicalCachedExtent>();
-    nlextent->rewrite(*lextent, 0);
+    nlextent->rewrite(t, *lextent, 0);
 
     DEBUGT("rewriting logical extent -- {} to {}", t, *lextent, *nlextent);
 
@@ -535,7 +535,7 @@ TransactionManager::rewrite_logical_extent(
         bool first_extent = (off == 0);
         ceph_assert(left >= nextent->get_length());
         auto nlextent = nextent->template cast<LogicalCachedExtent>();
-        nlextent->rewrite(*lextent, off);
+        nlextent->rewrite(t, *lextent, off);
         DEBUGT("rewriting logical extent -- {} to {}", t, *lextent, *nlextent);
 
         /* This update_mapping is, strictly speaking, unnecessary for delayed_alloc

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -182,7 +182,7 @@ public:
     LBAMappingRef pin)
   {
     auto fut = base_iertr::make_ready_future<LBAMappingRef>();
-    if (!pin->is_parent_valid()) {
+    if (!pin->is_parent_viewable()) {
       fut = get_pin(t, pin->get_key()
       ).handle_error_interruptible(
 	crimson::ct_error::enoent::assert_failure{"unexpected enoent"},
@@ -210,7 +210,7 @@ public:
     Transaction &t,
     LBAMappingRef pin)
   {
-    ceph_assert(pin->is_parent_valid());
+    ceph_assert(pin->is_parent_viewable());
     // checking the lba child must be atomic with creating
     // and linking the absent child
     auto v = pin->get_logical_extent(t);
@@ -473,7 +473,7 @@ public:
       // The according extent might be stable or pending.
       auto fut = base_iertr::now();
       if (!pin->is_indirect()) {
-	if (!pin->is_parent_valid()) {
+	if (!pin->is_parent_viewable()) {
 	  fut = get_pin(t, pin->get_key()
 	  ).si_then([&pin](auto npin) {
 	    assert(npin);

--- a/src/test/crimson/seastore/test_block.h
+++ b/src/test/crimson/seastore/test_block.h
@@ -111,7 +111,7 @@ struct TestBlockPhysical : crimson::os::seastore::CachedExtent{
 
   std::vector<test_block_delta_t> delta = {};
 
-  void on_rewrite(CachedExtent&, extent_len_t) final {}
+  void on_rewrite(Transaction&, CachedExtent&, extent_len_t) final {}
 
   TestBlockPhysical(ceph::bufferptr &&ptr)
     : CachedExtent(std::move(ptr)) {}

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -2193,12 +2193,12 @@ TEST_P(tm_single_device_test_t, invalid_lba_mapping_detect)
     {
       auto t = create_transaction();
       auto pin = get_pin(t, (LEAF_NODE_CAPACITY - 1) * 4096);
-      assert(pin->is_parent_valid());
+      assert(pin->is_parent_viewable());
       auto extent = alloc_extent(t, LEAF_NODE_CAPACITY * 4096, 4096, 'a');
-      assert(!pin->is_parent_valid());
+      assert(!pin->is_parent_viewable());
       pin = get_pin(t, LEAF_NODE_CAPACITY * 4096);
       std::ignore = alloc_extent(t, (LEAF_NODE_CAPACITY + 1) * 4096, 4096, 'a');
-      assert(pin->is_parent_valid());
+      assert(pin->is_parent_viewable());
       assert(pin->parent_modified());
       pin->maybe_fix_pos();
       auto v = pin->get_logical_extent(*t.t);


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/58367

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh