### PR TITLE
squid: crimson/osd/pg_recovery: push the iteration forward after finding unfound objects when starting primary recoveries

### DIFF
--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -152,11 +152,13 @@ size_t PGRecovery::start_primary_recovery_ops(
     if (pg->get_peering_state().get_missing_loc().is_unfound(soid)) {
       logger().debug("{}: object {} unfound", __func__, soid);
       ++skipped;
+      ++p;
       continue;
     }
     if (pg->get_peering_state().get_missing_loc().is_unfound(head)) {
       logger().debug("{}: head object {} unfound", __func__, soid);
       ++skipped;
+      ++p;
       continue;
     }
 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/58504

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh