### PR TITLE
mds: allow floating values for ceph.quota.max_bytes

### DIFF
--- a/src/common/strtol.cc
+++ b/src/common/strtol.cc
@@ -172,7 +172,9 @@ T strict_iec_cast(std::string_view str, std::string *err)
     // handling cases when prefixes entered as KB, MB, ...
     // and KiB, MiB, ....
     if (unit.length() > 1 && unit.back() == 'B') {
+      if (unit.front() != 'B')  {
       unit = unit.substr(0, unit.length() - 1);
+      }
     }
     // we accept both old si prefixes as well as the proper iec prefixes
     // i.e. K, M, ... and Ki, Mi, ...

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -6110,6 +6110,49 @@ int Server::parse_layout_vxattr(string name, string value, const OSDMap& osdmap,
   return 0;
 }
 
+int64_t Server::make_quota_max_byte_parseable(string val)
+{
+  string before_decimal;
+  string after_decimal;
+  int64_t dec_len;
+  int64_t q;
+  string cast_err;
+  
+  size_t dec_index = val.find_first_of(".");
+  size_t unit_index = val.find_first_not_of("0123456789-+.");
+  unit = str.substr(unit_index, val.length() - unit_index);
+  if (dec_index != std::string::npos) {
+    if ((unit_index == std::string::npos) || (unit == 'B'))  {
+    dout(10) << __func__ << ":  failed to parse quota.max_bytes: "
+    << "Invalid Byte value" << dendl;
+    return -CEPHFS_EINVAL;
+    }
+  }
+  dec_len = unit_index - dec_index - 1;
+  if ((dec_len == 0) || (dec_index == val.length() - 1)) {
+    dout(10) << __func__ << ":  failed to parse quota.max_bytes: "
+    << "Invalid Float value" << dendl;
+    return -CEPHFS_EINVAL;
+  }  
+  
+  if (dec_index != std::string::npos) {
+    before_decimal = val.substr(0, dec_index);
+    after_decimal = val.substr(dec_index + 1, val.length() - dec_index - 1);
+    before_decimal.append(after_decimal);
+    q = strict_iec_cast<int64_t>(before_decimal, &cast_err);
+    q = q / (std::pow(10, dec_len));
+  }
+  else {
+    q = strict_iec_cast<int64_t>(val, &cast_err);
+  }
+  if(!cast_err.empty()) {
+    dout(10) << __func__ << ":  failed to parse quota.max_bytes: "
+    << cast_err << dendl;
+    q = -CEPHFS_EINVAL;
+  }
+  return q;
+}
+
 int Server::parse_quota_vxattr(string name, string value, quota_info_t *quota)
 {
   dout(20) << "parse_quota_vxattr name " << name << " value '" << value << "'" << dendl;
@@ -6136,14 +6179,11 @@ int Server::parse_quota_vxattr(string name, string value, quota_info_t *quota)
           return r;
       }
     } else if (name == "quota.max_bytes") {
-      string cast_err;
-      int64_t q = strict_iec_cast<int64_t>(value, &cast_err);
-      if(!cast_err.empty()) {
-        dout(10) << __func__ << ":  failed to parse quota.max_bytes: "
-        << cast_err << dendl;
-        return -EINVAL;
+      int64_t res = make_quota_max_byte_parseable(value);
+      if(res == -CEPHFS_EINVAL) {
+        return -CEPHFS_EINVAL;
       }
-      quota->max_bytes = q;
+      quota->max_bytes = res;
     } else if (name == "quota.max_files") {
       int64_t q = boost::lexical_cast<int64_t>(value);
       if (q < 0)

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -6117,23 +6117,32 @@ int64_t Server::make_quota_max_byte_parseable(string val)
   int64_t dec_len;
   int64_t q;
   string cast_err;
+  string unit;
   
   size_t dec_index = val.find_first_of(".");
-  size_t unit_index = val.find_first_not_of("0123456789-+.");
-  unit = str.substr(unit_index, val.length() - unit_index);
+  size_t unit_index = val.find_first_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
   if (dec_index != std::string::npos) {
-    if ((unit_index == std::string::npos) || (unit == 'B'))  {
+    if (unit_index == std::string::npos) {
     dout(10) << __func__ << ":  failed to parse quota.max_bytes: "
     << "Invalid Byte value" << dendl;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
+    }
+    unit = val.substr(unit_index, val.length() - unit_index);
+    if (unit == "B") {
+      dout(10) << __func__ << ":  failed to parse quota.max_bytes: "
+    << "Invalid Byte value" << dendl;
+    return -EINVAL;
     }
   }
+
   dec_len = unit_index - dec_index - 1;
-  if ((dec_len == 0) || (dec_index == val.length() - 1)) {
+  if ((dec_len == 0) || (dec_index == val.length() - 1) ||
+       (dec_index != val.find_last_of("."))) {
     dout(10) << __func__ << ":  failed to parse quota.max_bytes: "
     << "Invalid Float value" << dendl;
-    return -CEPHFS_EINVAL;
-  }  
+    return -EINVAL;
+  }    
   
   if (dec_index != std::string::npos) {
     before_decimal = val.substr(0, dec_index);
@@ -6148,7 +6157,7 @@ int64_t Server::make_quota_max_byte_parseable(string val)
   if(!cast_err.empty()) {
     dout(10) << __func__ << ":  failed to parse quota.max_bytes: "
     << cast_err << dendl;
-    q = -CEPHFS_EINVAL;
+    q = -EINVAL;
   }
   return q;
 }
@@ -6179,9 +6188,15 @@ int Server::parse_quota_vxattr(string name, string value, quota_info_t *quota)
           return r;
       }
     } else if (name == "quota.max_bytes") {
+      std::string *err;
       int64_t res = make_quota_max_byte_parseable(value);
-      if(res == -CEPHFS_EINVAL) {
-        return -CEPHFS_EINVAL;
+      if(res == -EINVAL) {
+        ostringstream oss;
+        oss << "Invalid Input/Suffix '";
+        *err = oss.str();
+        //respond_to_request(mdr, "Invalid input/suffix");
+        //derr << __func__ << "Invalid input" << value << dendl;
+        return 0;
       }
       quota->max_bytes = res;
     } else if (name == "quota.max_files") {

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -265,6 +265,7 @@ public:
   void handle_client_setlayout(const MDRequestRef& mdr);
   void handle_client_setdirlayout(const MDRequestRef& mdr);
 
+  int64_t make_quota_max_byte_parseable(std::string val);
   int parse_quota_vxattr(std::string name, std::string value, quota_info_t *quota);
   void create_quota_realm(CInode *in);
   int parse_layout_vxattr_json(std::string name, std::string value,


### PR DESCRIPTION
floating values were not accepted for ceph.quota.max_bytes
`# setfattr -n ceph.quota.max_bytes -v 2.5G /mnt/ceph-fuse/test_quota/`
setfattr: /mnt/ceph-fuse/test_quota/: Invalid argument

Fixes: https://tracker.ceph.com/issues/66845
Signed-off-by: Neeraj Pratap Singh <neesingh@redhat.com>




<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
