### PR TITLE
crimson/os/seastore: add const format

### DIFF
--- a/src/crimson/os/seastore/journal/record_submitter.cc
+++ b/src/crimson/os/seastore/journal/record_submitter.cc
@@ -257,7 +257,7 @@ RecordSubmitter::roll_segment()
         wait_available_promise.reset();
       }).handle_error(
         crimson::ct_error::all_same_way([FNAME, this](auto e) {
-          ERROR("{} got error {}, available", get_name(), e);
+          ERROR("{} got error, available", get_name());
           has_io_error = true;
           wait_available_promise->set_value();
           wait_available_promise.reset();
@@ -540,8 +540,8 @@ void RecordSubmitter::flush_current_batch()
     finish_submit_batch(p_batch, write_result);
   }).handle_error(
     crimson::ct_error::all_same_way([this, p_batch, FNAME, num, sizes](auto e) {
-      ERROR("{} {} records, {}, got error {}",
-            get_name(), num, sizes, e);
+      ERROR("{} {} records, {}, got error",
+            get_name(), num, sizes);
       finish_submit_batch(p_batch, std::nullopt);
       return seastar::now();
     })

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
@@ -115,7 +115,7 @@ template <> struct fmt::formatter<crimson::os::seastore::onode::node_delta_op_t>
   using node_delta_op_t =  crimson::os::seastore::onode::node_delta_op_t;
   // parse is inherited from formatter<string_view>.
   template <typename FormatContext>
-  auto format(node_delta_op_t op, FormatContext& ctx) {
+  auto format(node_delta_op_t op, FormatContext& ctx) const {
     std::string_view name = "unknown";
     switch (op) {
     case node_delta_op_t::INSERT:

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
@@ -2485,7 +2485,7 @@ namespace fmt {
 // (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92944).
 template <HasDoFormatTo T> struct formatter<T> : formatter<std::string_view> {
   template <typename FormatContext>
-  auto format(const T& staged_iterator, FormatContext& ctx) {
+  auto format(const T& staged_iterator, FormatContext& ctx) const {
     return staged_iterator.do_format_to(ctx.out(), true);
   }
 };

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -33,7 +33,7 @@ using segment_state_t = crimson::os::seastore::Segment::segment_state_t;
 template <> struct fmt::formatter<segment_state_t>: fmt::formatter<std::string_view> {
   // parse is inherited from formatter<string_view>.
   template <typename FormatContext>
-  auto format(segment_state_t s, FormatContext& ctx) {
+  auto format(segment_state_t s, FormatContext& ctx) const {
     std::string_view name = "unknown";
     switch (s) {
     case segment_state_t::EMPTY:


### PR DESCRIPTION
Spotted when tried to upgrade to fmt 11

Fixes: https://tracker.ceph.com/issues/66887



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
