### PR TITLE
mgr/dashboard: improve TTL management in multi-cluster

### DIFF
--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -97,7 +97,7 @@ class JwtManager(object):
         return decoded_message
 
     @classmethod
-    def gen_token(cls, username, ttl: Optional[int] = None):
+    def gen_token(cls, username, ttl: Optional[int] = None, payload: Optional[dict] = None):
         if not cls._secret:
             cls.init()
         if ttl is None:
@@ -105,13 +105,14 @@ class JwtManager(object):
         else:
             ttl = int(ttl) * 60 * 60  # convert hours to seconds
         now = int(time.time())
-        payload = {
-            'iss': 'ceph-dashboard',
-            'jti': str(uuid.uuid4()),
-            'exp': now + ttl,
-            'iat': now,
-            'username': username
-        }
+        if payload is None:
+            payload = {
+                'iss': 'ceph-dashboard',
+                'jti': str(uuid.uuid4()),
+                'exp': now + ttl,
+                'iat': now,
+                'username': username
+            }
         return cls.encode(payload, cls._secret)  # type: ignore
 
     @classmethod


### PR DESCRIPTION
* With the introduction to Multi-Cluster management we added a new param to the `api/auth` endpoint i.e `token's ttl`. Since exposing the ttl param in the auth endpoint poses security risk, so we are removing this param in this PR.

* In place of the above mentioned mechanism, now when we are authenticating to the remote cluster from the hub cluster, we send an additional header with the api/auth request i.e. `X-MULTI-CLUSTER-TOKEN`. This header contains another `jwt token` which encodes the `ttl` we want to set in the remote cluster. In the `create` method of the `api/auth` endpoint, we check for this header. If the header is received we decode the ttl from the token received from this header and set the custom ttl for this request. When this header is not received, the default ttl is set for the token everytime. 

Fixes: https://tracker.ceph.com/issues/67066

Signed-off-by: Aashish Sharma <aasharma@redhat.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
