### PR TITLE
submodule: remove the boost_redis submodule again (again)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -78,9 +78,6 @@
 [submodule "src/BLAKE3"]
 	path = src/BLAKE3
 	url = https://github.com/BLAKE3-team/BLAKE3.git
-[submodule "src/boost_redis"]
-	path = src/boost_redis
-	url = https://github.com/boostorg/redis.git
 [submodule "src/nvmeof/gateway"]
 	path = src/nvmeof/gateway
 	url = https://github.com/ceph/ceph-nvmeof.git


### PR DESCRIPTION
5843c6b04bacf9a7c981fca5d874ab3400f855db accidentally added back to the boost_redis submodule that was last removed in 924f2e9f87f0ee940eff363c26a714a309639d26

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
