### PR TITLE
squid: client: Fix leading / issue with mds_check_access

### DIFF
--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -249,7 +249,7 @@ class MdsCapTester:
         Run test for read perm and, for write perm, run positive test if it
         is present and run negative test if not.
         """
-        if mntpt:
+        if mntpt and mntpt != '/':
             # beacaue we want to value of mntpt from test_set.path along with
             # slash that precedes it.
             mntpt = '/' + mntpt if mntpt[0] != '/' else mntpt

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5933,6 +5933,11 @@ int Client::mds_check_access(std::string& path, const UserPerm& perms, int mask)
     }
   }
 
+  // drop any leading /
+  while (path.length() && path[0] == '/') {
+    path = path.substr(1);
+  }
+
   for (auto& s: cap_auths) {
     ldout(cct, 20) << __func__ << " auth match path " << s.match.path << " r: " << s.readable
                    << " w: " << s.writeable << dendl;
@@ -8032,6 +8037,10 @@ bool Client::make_absolute_path_string(Inode *in, std::string& path)
     return false;
   }
 
+  // Make sure this function returns path with single leading '/'
+  if (path.length() && path[0] == '/' && path[1] == '/')
+    path = path.substr(1);
+
   return true;
 }
 
@@ -8079,8 +8088,6 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
     std::string path;
     if (make_absolute_path_string(in, path)) {
       ldout(cct, 20) << " absolute path: " << path << dendl;
-      if (path.length())
-        path = path.substr(1);    // drop leading /
       res = mds_check_access(path, perms, MAY_WRITE);
       if (res) {
         goto out;
@@ -10322,8 +10329,6 @@ int Client::_open(Inode *in, int flags, mode_t mode, Fh **fhp,
     std::string path;
     if (make_absolute_path_string(in, path)) {
       ldout(cct, 20) << __func__ << " absolute path: " << path << dendl;
-      if (path.length())
-        path = path.substr(1);    // drop leading /
       result = mds_check_access(path, perms, mask);
       if (result) {
         return result;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67293

---

backport of https://github.com/ceph/ceph/pull/58878
parent tracker: https://tracker.ceph.com/issues/67212

Also backported a required qa fix 7626bd5d37b6f24fe60840c225ef917356f8dfc4

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh