### PR TITLE
reef: client: Fix leading / issue with mds_check_access

### DIFF
--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -227,10 +227,13 @@ class MdsCapTester:
         """
         # CephFS mount where read/write test will be conducted.
         self.mount = mount
+        # Set new file creation path
+        self.new_file = os_path_join(self.mount.hostfs_mntpt, path.lstrip('/'), 'new_file')
         # Path where out test file located.
         self.path = self._gen_test_file_path(path)
         # Data that out test file will contain.
         self.data = self._gen_test_file_data()
+
 
         self.mount.write_file(self.path, self.data)
         log.info(f'Test file has been created on FS '
@@ -265,7 +268,8 @@ class MdsCapTester:
             self.path = {self.path}
             cephfs_name = {self.mount.cephfs_name}
             cephfs_mntpt = {self.mount.cephfs_mntpt}
-            hostfs_mntpt = {self.mount.hostfs_mntpt}''')
+            hostfs_mntpt = {self.mount.hostfs_mntpt}
+            self.new_file_path = {self.new_file}''')
 
     def run_mds_cap_tests(self, perm, mntpt=None):
         """
@@ -283,11 +287,13 @@ class MdsCapTester:
             #   cephfs dir serving as root for current mnt: /dir1/dir2
             #   therefore, final path: /mnt/cephfs_x/testdir
             self.path = self.path.replace(mntpt, '')
+            self.new_file = self.new_file.replace(mntpt, '')
 
         self.conduct_pos_test_for_read_caps()
 
         if perm == 'rw':
             self.conduct_pos_test_for_write_caps()
+            self.conduct_pos_test_for_new_file_creation()
         elif perm == 'r':
             self.conduct_neg_test_for_write_caps()
         else:
@@ -324,6 +330,12 @@ class MdsCapTester:
         cmdargs.pop(-1)
         log.info('absence of write perm was tested successfully: '
                  f'failed to be write data to file {self.path}.')
+
+    def conduct_pos_test_for_new_file_creation(self, sudo_write=False):
+        log.info(f'test write perm: try creating a new "{self.new_file}"')
+        self.mount.create_file(self.new_file)
+        log.info(f'write perm was tested successfully: new file "{self.new_file}" '
+                  'created successfully')
 
 
 class CapTester(MonCapTester, MdsCapTester):

--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -272,7 +272,7 @@ class MdsCapTester:
         Run test for read perm and, for write perm, run positive test if it
         is present and run negative test if not.
         """
-        if mntpt:
+        if mntpt and mntpt != '/':
             # beacaue we want to value of mntpt from test_set.path along with
             # slash that precedes it.
             mntpt = '/' + mntpt if mntpt[0] != '/' else mntpt

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1553,6 +1553,28 @@ class TestFsAuthorize(CephFSTestCase):
         self._remount(keyring)
         self.captester.run_mds_cap_tests(PERM)
 
+    def test_fs_read_and_single_path_rw(self):
+        """
+        Tests the file creation using 'touch' cmd on a specific path
+        which has 'rw' caps and 'r' caps on the rest of the fs.
+
+        The mds auth caps with 'rw' caps on a specific path and 'r' caps
+        on the rest of the fs has an issue. The file creation using 'touch'
+        cmd on the fuse client used to fail while doing setattr.
+        Please see https://tracker.ceph.com/issues/67212
+
+        The new file creation test using 'touch' cmd is added to
+        'MdsCapTester.run_mds_cap_tests' which eventually gets
+        called by '_remount_and_run_tests'
+        """
+        FS_AUTH_CAPS = (('/', 'r'), ('/dir2', 'rw'))
+        self.mount_a.run_shell('mkdir -p ./dir2')
+        self.captesters = (CapTester(self.mount_a, '/'),
+                           CapTester(self.mount_a, '/dir2'))
+        keyring = self.fs.authorize(self.client_id, FS_AUTH_CAPS)
+
+        self._remount_and_run_tests(FS_AUTH_CAPS, keyring)
+
     def test_multiple_path_r(self):
         PERM = 'r'
         FS_AUTH_CAPS = (('/dir1/dir12', PERM), ('/dir2/dir22', PERM))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67294

---

backport of https://github.com/ceph/ceph/pull/58878
parent tracker: https://tracker.ceph.com/issues/67212

Also backported a required qa fix https://github.com/ceph/ceph/commit/7626bd5d37b6f24fe60840c225ef917356f8dfc4

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh