### PR TITLE
crimson/os/seastore/cache: cleanups and comments

### DIFF
--- a/src/crimson/os/seastore/async_cleaner.h
+++ b/src/crimson/os/seastore/async_cleaner.h
@@ -333,12 +333,12 @@ public:
     sea_time_point modify_time) = 0;
 
   /**
-   * get_extent_if_live
+   * get_extents_if_live
    *
    * Returns extent at specified location if still referenced by
    * lba_manager and not removed by t.
    *
-   * See TransactionManager::get_extent_if_live and
+   * See TransactionManager::get_extents_if_live and
    * LBAManager::get_physical_extent_if_live.
    */
   using get_extents_if_live_iertr = base_iertr;

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -1383,6 +1383,9 @@ private:
       "looking up root on {}",
       c.trans,
       *root_block);
+
+    // checking the lba root node must be atomic with creating
+    // and linking the absent root node
     auto [found, fut] = get_root_node(c);
 
     auto on_found_internal =

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -476,16 +476,45 @@ public:
     CachedExtentRef extent)
   {
     assert(extent->is_valid());
-    auto p_extent = extent->get_transactional_view(t);
-    if (!p_extent->is_pending_in_trans(t.get_trans_id())) {
-      t.add_to_read_set(p_extent);
-      touch_extent(*p_extent);
+    CachedExtent* p_extent;
+    if (extent->is_stable()) {
+      p_extent = extent->get_transactional_view(t);
+      if (p_extent != extent.get()) {
+        assert(!extent->is_stable_writting());
+        assert(p_extent->is_pending_in_trans(t.get_trans_id()));
+        assert(!p_extent->is_stable_writting());
+        if (p_extent->is_mutable()) {
+          assert(p_extent->is_fully_loaded());
+          assert(!p_extent->is_pending_io());
+          return get_extent_ertr::make_ready_future<CachedExtentRef>(
+            CachedExtentRef(p_extent));
+        } else {
+          assert(p_extent->is_exist_clean());
+        }
+      } else {
+        // stable from trans-view
+        assert(!p_extent->is_pending_in_trans(t.get_trans_id()));
+        t.add_to_read_set(p_extent);
+        touch_extent(*p_extent);
+      }
+    } else {
+      assert(!extent->is_stable_writting());
+      assert(extent->is_pending_in_trans(t.get_trans_id()));
+      if (extent->is_mutable()) {
+        assert(extent->is_fully_loaded());
+        assert(!extent->is_pending_io());
+        return get_extent_ertr::make_ready_future<CachedExtentRef>(extent);
+      } else {
+        assert(extent->is_exist_clean());
+        p_extent = extent.get();
+      }
     }
+
+    assert(p_extent->is_stable() || p_extent->is_exist_clean());
     // user should not see RETIRED_PLACEHOLDER extents
     ceph_assert(p_extent->get_type() != extent_types_t::RETIRED_PLACEHOLDER);
     if (!p_extent->is_fully_loaded()) {
       assert(!p_extent->is_mutable());
-      touch_extent(*p_extent);
       LOG_PREFIX(Cache::get_extent_viewable_by_trans);
       SUBDEBUG(seastore_cache,
         "{} {}~{} is present without been fully loaded, reading ... -- {}",

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -479,9 +479,7 @@ public:
     auto p_extent = extent->get_transactional_view(t);
     if (!p_extent->is_pending_in_trans(t.get_trans_id())) {
       t.add_to_read_set(p_extent);
-      if (!p_extent->is_mutation_pending()) {
-	touch_extent(*p_extent);
-      }
+      touch_extent(*p_extent);
     }
     // user should not see RETIRED_PLACEHOLDER extents
     ceph_assert(p_extent->get_type() != extent_types_t::RETIRED_PLACEHOLDER);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -494,8 +494,9 @@ public:
       } else {
         // stable from trans-view
         assert(!p_extent->is_pending_in_trans(t.get_trans_id()));
-        t.add_to_read_set(p_extent);
-        touch_extent(*p_extent);
+        if (t.maybe_add_to_read_set(p_extent)) {
+          touch_extent(*p_extent);
+        }
       }
     } else {
       assert(!extent->is_stable_writting());

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -437,6 +437,11 @@ public:
    * Mostly the same as Cache::get_extent(), with the only difference
    * that get_absent_extent won't search the transaction's context for
    * the specific CachedExtent
+   *
+   * The extent in query is supposed to be absent in Cache.
+   *
+   * User is responsible to call get_extent_viewable_by_trans()
+   * *atomically* prior to call this method.
    */
   template <typename T>
   get_extent_iertr::future<TCachedExtentRef<T>> get_absent_extent(
@@ -784,6 +789,9 @@ public:
    * and read in the extent at location offset~length.
    *
    * The extent in query is supposed to be absent in Cache.
+   *
+   * User is responsible to call get_extent_viewable_by_trans()
+   * *atomically* prior to call this method.
    */
   template <typename Func>
   get_extent_by_type_ret get_absent_extent_by_type(

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -680,7 +680,7 @@ TransactionManager::get_extents_if_live(
   laddr_t laddr,
   extent_len_t len)
 {
-  LOG_PREFIX(TransactionManager::get_extent_if_live);
+  LOG_PREFIX(TransactionManager::get_extents_if_live);
   TRACET("{} {}~{} {}", t, type, laddr, len, paddr);
 
   // This only works with segments to check if alive,


### PR DESCRIPTION
I'm looking at the boundary of Cache component.

This might be a good basis to proceed to fix cache metrics and fine-grained-cache (https://github.com/ceph/ceph/pull/57787)

Manual rough tests looks good. @xxhdx1985126 Does the revised version of `get_extent_viewable_by_trans()` look reasonable to you?


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
