### PR TITLE
squid: cephfs_mirror: use snapdiff api for incremental syncing

### DIFF
--- a/src/tools/cephfs_mirror/PeerReplayer.h
+++ b/src/tools/cephfs_mirror/PeerReplayer.h
@@ -301,6 +301,8 @@ private:
   int do_synchronize(const std::string &dir_root, const Snapshot &current,
                      boost::optional<Snapshot> prev);
 
+  int do_synchronize(const std::string &dir_root, const Snapshot &current);
+
   int synchronize(const std::string &dir_root, const Snapshot &current,
                   boost::optional<Snapshot> prev);
   int do_sync_snaps(const std::string &dir_root);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65223

---

backport of https://github.com/ceph/ceph/pull/54633
parent tracker: https://tracker.ceph.com/issues/61334

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh