### PR TITLE
crimson: use gate per shard for AlienStore and OSD

### DIFF
--- a/src/crimson/common/gated.h
+++ b/src/crimson/common/gated.h
@@ -31,13 +31,13 @@ class Gated {
 
   template <typename Func, typename T>
   inline void dispatch_in_background(const char* what, T& who, Func&& func) {
-    ceph_assert(seastar::this_shard_id() == sid);
+    //ceph_assert(seastar::this_shard_id() == sid);
     (void) dispatch(what, who, std::forward<Func>(func));
   }
 
   template <typename Func, typename T>
   inline seastar::future<> dispatch(const char* what, T& who, Func&& func) {
-    ceph_assert(seastar::this_shard_id() == sid);
+    //ceph_assert(seastar::this_shard_id() == sid);
     return seastar::with_gate(pending_dispatch, std::forward<Func>(func)
     ).handle_exception([what, &who] (std::exception_ptr eptr) {
       if (*eptr.__cxa_exception_type() == typeid(system_shutdown_exception)) {
@@ -58,7 +58,7 @@ class Gated {
 
   template <typename Func>
   auto simple_dispatch(const char* what, Func&& func) {
-    ceph_assert(seastar::this_shard_id() == sid);
+    //ceph_assert(seastar::this_shard_id() == sid);
     return seastar::with_gate(pending_dispatch, std::forward<Func>(func));
   }
 

--- a/src/crimson/common/gated.h
+++ b/src/crimson/common/gated.h
@@ -18,6 +18,7 @@ namespace crimson::common {
 class Gated {
  public:
   Gated() : sid(seastar::this_shard_id()) {}
+  Gated(const seastar::shard_id sid) : sid(sid) {}
   Gated(const Gated&) = delete;
   Gated& operator=(const Gated&) = delete;
   Gated(Gated&&) = default;

--- a/src/crimson/common/gated.h
+++ b/src/crimson/common/gated.h
@@ -6,6 +6,8 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/future-util.hh>
+#include <type_traits>
+#include <vector>
 
 #include "crimson/common/exception.h"
 #include "crimson/common/log.h"
@@ -15,15 +17,26 @@ namespace crimson::common {
 
 class Gated {
  public:
+  Gated() : sid(seastar::this_shard_id()) {}
+  Gated(const Gated&) = delete;
+  Gated& operator=(const Gated&) = delete;
+  Gated(Gated&&) = default;
+  Gated& operator=(Gated&&) = delete;
+  virtual ~Gated() = default;
+  
   static seastar::logger& gated_logger() {
     return crimson::get_logger(ceph_subsys_osd);
   }
+
   template <typename Func, typename T>
   inline void dispatch_in_background(const char* what, T& who, Func&& func) {
-    (void) dispatch(what, who, func);
+    ceph_assert(seastar::this_shard_id() == sid);
+    (void) dispatch(what, who, std::forward<Func>(func));
   }
+
   template <typename Func, typename T>
   inline seastar::future<> dispatch(const char* what, T& who, Func&& func) {
+    ceph_assert(seastar::this_shard_id() == sid);
     return seastar::with_gate(pending_dispatch, std::forward<Func>(func)
     ).handle_exception([what, &who] (std::exception_ptr eptr) {
       if (*eptr.__cxa_exception_type() == typeid(system_shutdown_exception)) {
@@ -42,14 +55,81 @@ class Gated {
     });
   }
 
+  template <typename Func>
+  auto simple_dispatch(const char* what, Func&& func) {
+    ceph_assert(seastar::this_shard_id() == sid);
+    return seastar::with_gate(pending_dispatch, std::forward<Func>(func));
+  }
+
   seastar::future<> close() {
+    ceph_assert(seastar::this_shard_id() == sid);
     return pending_dispatch.close();
   }
+
   bool is_closed() const {
     return pending_dispatch.is_closed();
   }
+
+  seastar::shard_id get_shard_id() const {
+    return sid;
+  }
  private:
   seastar::gate pending_dispatch;
+  const seastar::shard_id sid;
 };
 
-}// namespace crimson::common
+// gate_per_shard is a class that provides a gate for each shard.
+// It was introduced to provide a way to have gate for each shard
+// in a seastar application since gates are not supposed to be shared
+// across shards. ( https://tracker.ceph.com/issues/64332 )
+class gate_per_shard {
+ public:
+  gate_per_shard() : gates(seastar::smp::count) {
+    std::vector<seastar::future<>> futures;
+    for (unsigned shard = 0; shard < seastar::smp::count; ++shard) {
+      futures.push_back(seastar::smp::submit_to(shard, [this, shard] {
+        gates[shard] = std::make_unique<Gated>();
+      }));
+    }
+    seastar::when_all_succeed(futures.begin(), futures.end()).get();
+  }
+  //explicit gate_per_shard(size_t shard_count) : gates(shard_count) {}
+  gate_per_shard(const gate_per_shard&) = delete;
+  gate_per_shard& operator=(const gate_per_shard&) = delete;
+  gate_per_shard(gate_per_shard&&) = default;
+  gate_per_shard& operator=(gate_per_shard&&) = default;
+  ~gate_per_shard() = default;
+
+  template <typename Func, typename T>
+  inline void dispatch_in_background(const char* what, T& who, Func&& func) {
+    (void) dispatch(what, who, std::forward<Func>(func));
+  }
+
+  template <typename Func, typename T>
+  inline auto dispatch(const char* what, T& who, Func&& func) {
+    return gates[seastar::this_shard_id()]->dispatch(what, who, std::forward<Func>(func));
+  }
+
+  template <typename Func>
+  auto simple_dispatch(const char* what, Func&& func) {
+    return gates[seastar::this_shard_id()]->simple_dispatch(what, std::forward<Func>(func));
+  }
+
+  bool is_closed() const {
+    return gates[seastar::this_shard_id()]->is_closed();
+  }
+
+  seastar::future<> close_all() {
+    ceph_assert(gates.size() == seastar::smp::count);
+    return seastar::parallel_for_each(gates.begin(), gates.end(), [] (std::unique_ptr<Gated>& gate_ptr) {
+      return seastar::smp::submit_to(gate_ptr->get_shard_id(), [gate = gate_ptr.get()] {
+        return gate->close();
+      });
+    });
+  }
+
+ private:
+  std::vector<std::unique_ptr<Gated>> gates;
+};
+
+} // namespace crimson::common

--- a/src/crimson/net/io_handler.h
+++ b/src/crimson/net/io_handler.h
@@ -255,7 +255,7 @@ public:
   class shard_states_t {
   public:
     shard_states_t(seastar::shard_id _sid, io_state_t state)
-      : sid{_sid}, io_state{state} {}
+      : sid{_sid}, io_state{state}, gate{_sid} {}
 
     seastar::shard_id get_shard_id() const {
       return sid;

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -717,7 +717,7 @@ seastar::future<> OSD::stop()
     DEBUG("prepared to stop");
     public_msgr->stop();
     cluster_msgr->stop();
-    auto gate_close_fut = gate.close();
+    auto gate_close_fut = gate.close_all();
     return asok->stop().then([this] {
       return heartbeat->stop();
     }).then([this] {

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -232,7 +232,7 @@ private:
     Ref<MOSDPGUpdateLogMissingReply> m);
 
 private:
-  crimson::common::Gated gate;
+  crimson::common::gate_per_shard gate;
 
   seastar::promise<> stop_acked;
   void got_stop_ack() {


### PR DESCRIPTION
This change modifies AlienStore and OSD to use a gate per seastar
shard instead of a shared gate.
It introduces a new `gate_per_shard` class in `Gated` to manage
a vector of gates, ensuring proper gate handling across shards.

Fixes: https://tracker.ceph.com/issues/64332
Signed-off-by: NitzanMordhai <nmordech@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
