### PR TITLE
qa/cephfs: update ignorelist

### DIFF
--- a/qa/cephfs/overrides/ignorelist_health.yaml
+++ b/qa/cephfs/overrides/ignorelist_health.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     log-ignorelist:
       - FS_DEGRADED
+      - fs.*is degraded
       - FS_INLINE_DATA_DEPRECATED
       - FS_WITH_FAILED_MDS
       - MDS_ALL_DOWN
@@ -9,6 +10,7 @@ overrides:
       - MDS_DEGRADED
       - MDS_FAILED
       - MDS_INSUFFICIENT_STANDBY
+      - insufficient standby MDS daemons available
       - MDS_UP_LESS_THAN_MAX
       - filesystem is online with fewer MDS than max_mds
       - POOL_APP_NOT_ENABLED


### PR DESCRIPTION
In following 2 jobs from a Squid QA run we see cluster errors/warnings
which are expected but not added to ignorelist which causes these jobs
to fail.

From https://pulpito.ceph.com/xiubli-2024-07-29_02:08:56-fs-wip-xiubli-testing-20240726.021939-squid-distro-default-smithi/7823678 -

	"2024-07-29T05:10:00.000118+0000 mon.smithi057 (mon.0) 879 : cluster [WRN] Health detail: HEALTH_WARN insufficient standby MDS daemons available" in cluster log

From https://pulpito.ceph.com/xiubli-2024-07-29_02:08:56-fs-wip-xiubli-testing-20240726.021939-squid-distro-default-smithi/7823724 -

	"2024-07-29T06:00:00.000144+0000 mon.smithi104 (mon.0) 600 : cluster [ERR] fs cephfs is degraded" in cluster log

"FS_DEGRADED" and "MDS_INSUFFICIENT_STANDBY" are already present in the
ignorelist for these jobs bit these are not sufficient catch above
cluster warninings/errors. Therefore, add "fs.*is degraded" and
"insufficient standby MDS daemons available" too.

Fixes: https://tracker.ceph.com/issues/67303






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>