### PR TITLE
reef: src/ceph-volume/ceph_volume/devices/lvm/listing.py : lvm list filters with vg name

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -153,7 +153,9 @@ class List(object):
         elif arg[0] == '/':
             lv = api.get_lvs_from_path(arg)
         else:
-            lv = [api.get_single_lv(filters={'lv_name': arg.split('/')[1]})]
+            vg_name, lv_name = arg.split('/')
+            lv = [api.get_single_lv(filters={'lv_name': lv_name,
+                                             'vg_name': vg_name})]
 
         report = self.create_report(lv)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/64642

---

backport of https://github.com/ceph/ceph/pull/53841
parent tracker: https://tracker.ceph.com/issues/62320

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh