### PR TITLE
quincy: pybind/ceph_argparse: Fix error message for ceph tell command

### DIFF
--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -402,6 +402,11 @@ class TestMisc(CephFSTestCase):
     def test_client_ls(self):
         self._session_client_ls(['client', 'ls'])
 
+    def test_ceph_tell_for_unknown_cephname_type(self):
+        with self.assertRaises(CommandFailedError) as ce:
+            self.run_ceph_cmd('tell', 'cephfs.c', 'something')
+        self.assertEqual(ce.exception.exitstatus, 1)
+
 
 @classhook('_add_session_client_evictions')
 class TestSessionClientEvict(CephFSTestCase):

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -502,13 +502,13 @@ class CephPgid(CephArgtype):
         try:
             poolid = int(poolid_s)
         except ValueError:
-            raise ArgumentFormat('pool {0} not integer'.format(poolid))
+            raise ArgumentFormat('pool {0} not integer'.format(poolid_s))
         if poolid < 0:
             raise ArgumentFormat('pool {0} < 0'.format(poolid))
         try:
             pgnum = int(pgnum_s, 16)
         except ValueError:
-            raise ArgumentFormat('pgnum {0} not hex integer'.format(pgnum))
+            raise ArgumentFormat('pgnum {0} not hex integer'.format(pgnum_s))
         self.val = s
 
     def __str__(self):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67299

---

backport of https://github.com/ceph/ceph/pull/51332
parent tracker: https://tracker.ceph.com/issues/59624

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh