### PR TITLE
rgw/notify: visit() returns copy of owner string

### DIFF
--- a/src/rgw/driver/rados/rgw_notify.cc
+++ b/src/rgw/driver/rados/rgw_notify.cc
@@ -1111,8 +1111,8 @@ int publish_reserve(const DoutPrefixProvider* dpp,
 
       // reload the topic in case it changed since the notification was added
       const std::string& topic_tenant = std::visit(fu2::overload(
-          [] (const rgw_user& u) -> const std::string& { return u.tenant; },
-          [] (const rgw_account_id& a) -> const std::string& { return a; }
+          [] (const rgw_user& u) -> std::string { return u.tenant; },
+          [] (const rgw_account_id& a) -> std::string { return a; }
           ), topic_cfg.owner);
       const RGWPubSub ps(res.store, topic_tenant, site);
       int ret = ps.get_topic(res.dpp, topic_cfg.dest.arn_topic,


### PR DESCRIPTION
return a copy of the owner string to work around compiler warning:
```
ceph/src/rgw/driver/rados/rgw_notify.cc: In function ‘int rgw::notify::publish_reserve(const DoutPrefixProvider*, const rgw::SiteConfig&, const EventTypeList&, reservation_t&, const RGWObjTags*)’: ceph/src/rgw/driver/rados/rgw_notify.cc:1113:26: warning: possibly dangling reference to a temporary [-Wdangling-reference]
 1113 |       const std::string& topic_tenant = std::visit(fu2::overload(
      |                          ^~~~~~~~~~~~
ceph/src/rgw/driver/rados/rgw_notify.cc:1113:51: note: the temporary was destroyed at the end of the full expression ‘std::visit<fu2::abi_310::detail::overloading::overload_impl<rgw::notify::publish_reserve(const DoutPrefixProvider*, const rgw::SiteConfig&, const EventTypeList&, reservation_t&, const RGWObjTags*)::<lambda(const rgw_user&)>, rgw::notify::publish_reserve(const DoutPrefixProvider*, const rgw::SiteConfig&, const EventTypeList&, reservation_t&, const RGWObjTags*)::<lambda(const rgw_account_id&)> >, variant<rgw_user, rgw_account_id>&>(fu2::overload<rgw::notify::publish_reserve(const DoutPrefixProvider*, const rgw::SiteConfig&, const EventTypeList&, reservation_t&, const RGWObjTags*)::<lambda(const rgw_user&)>, rgw::notify::publish_reserve(const DoutPrefixProvider*, const rgw::SiteConfig&, const EventTypeList&, reservation_t&, const RGWObjTags*)::<lambda(const rgw_account_id&)> >(<lambda closure object>rgw::notify::publish_reserve(const DoutPrefixProvider*, const rgw::SiteConfig&, const EventTypeList&, reservation_t&, const RGWObjTags*)::<lambda(const rgw_user&)>(), <lambda closure object>rgw::notify::publish_reserve(const DoutPrefixProvider*, const rgw::SiteConfig&, const EventTypeList&, reservation_t&, const RGWObjTags*)::<lambda(const rgw_account_id&)>()), topic_cfg.rgw_pubsub_topic::owner)’
 1113 |       const std::string& topic_tenant = std::visit(fu2::overload(
      |                                         ~~~~~~~~~~^~~~~~~~~~~~~~~
 1114 |           [] (const rgw_user& u) -> const std::string& { return u.tenant; },
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1115 |           [] (const rgw_account_id& a) -> const std::string& { return a; }
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1116 |           ), topic_cfg.owner);
      |           ~~~~~~~~~~~~~~~~~~~
```
Fixes: https://tracker.ceph.com/issues/67326

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
