### PR TITLE
quincy: Test: osd-recovery-space.sh extends the wait time for "recovery toofull"

### DIFF
--- a/qa/standalone/osd/osd-recovery-space.sh
+++ b/qa/standalone/osd/osd-recovery-space.sh
@@ -76,6 +76,10 @@ function wait_for_state() {
 function wait_for_recovery_toofull() {
     local timeout=$1
     wait_for_state recovery_toofull $timeout
+    if [ $ret -ne 0 ]; then
+      echo "Error: Recovery toofull timeout"
+      return 1
+    fi
 }
 
 
@@ -131,7 +135,11 @@ function TEST_recovery_test_simple() {
     done
 
     # If this times out, we'll detected errors below
-    wait_for_recovery_toofull 30
+    wait_for_recovery_toofull 120
+    if [ $? -ne 0 ]; then
+      echo "Error: Recovery toofull timeout"
+      return 1
+    fi
 
     ERRORS=0
     if [ "$(ceph pg dump pgs | grep +recovery_toofull | wc -l)" != "1" ];


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67350

---

backport of https://github.com/ceph/ceph/pull/57193
parent tracker: https://tracker.ceph.com/issues/44510

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh