### PR TITLE
squid: common/dout: fix FTBFS on GCC 14

### DIFF
--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -156,17 +156,27 @@ struct is_dynamic<dynamic_marker_t<T>> : public std::true_type {};
 #else
 #define dout_impl(cct, sub, v)						\
   do {									\
-  const bool should_gather = [&](const auto cctX) {			\
-    if constexpr (ceph::dout::is_dynamic<decltype(sub)>::value ||	\
-		  ceph::dout::is_dynamic<decltype(v)>::value) {		\
+  const bool should_gather = [&](const auto cctX, auto sub_, auto v_) {	\
+    /* The check is performed on `sub_` and `v_` to leverage the C++'s 	\
+     * guarantee on _discarding_ one of blocks of `if constexpr`, which	\
+     * includes also the checks for ill-formed code (`should_gather<>`	\
+     * must not be feed with non-const expresions), BUT ONLY within	\
+     * a template (thus the generic lambda) and under the restriction	\
+     * it's dependant on a parameter of this template).			\
+     * GCC prior to v14 was not enforcing these restrictions. */	\
+    if constexpr (ceph::dout::is_dynamic<decltype(sub_)>::value ||	\
+		  ceph::dout::is_dynamic<decltype(v_)>::value) {	\
       return cctX->_conf->subsys.should_gather(sub, v);			\
     } else {								\
+      constexpr auto sub_helper = static_cast<decltype(sub_)>(sub);	\
+      constexpr auto v_helper = static_cast<decltype(v_)>(v);		\
       /* The parentheses are **essential** because commas in angle	\
        * brackets are NOT ignored on macro expansion! A language's	\
        * limitation, sorry. */						\
-      return (cctX->_conf->subsys.template should_gather<sub, v>());	\
+      return (cctX->_conf->subsys.template should_gather<sub_helper,	\
+							 v_helper>());	\
     }									\
-  }(cct);								\
+  }(cct, sub, v);							\
 									\
   if (should_gather) {							\
     ceph::logging::MutableEntry _dout_e(v, sub);                        \


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67364

---

backport of https://github.com/ceph/ceph/pull/55306
parent tracker: https://tracker.ceph.com/issues/64050

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh