### PR TITLE
mgr/dashboard: RGW multisite sync remove zones fix

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -200,9 +200,9 @@ class RgwMultisiteController(RESTController):
     @EndpointDoc("Create or update the sync flow")
     @CreatePermission
     def create_sync_flow(self, flow_id: str, flow_type: str, group_id: str,
-                         source_zone: Optional[List[str]] = None,
-                         destination_zone: Optional[List[str]] = None,
-                         zones: Optional[List[str]] = None,
+                         source_zone: Optional[str] = None,
+                         destination_zone: Optional[str] = None,
+                         zones: Optional[Dict[str, List]] = None,
                          bucket_name=''):
         multisite_instance = RgwMultisite()
         return multisite_instance.create_sync_flow(group_id, flow_id, flow_type, zones,
@@ -222,11 +222,10 @@ class RgwMultisiteController(RESTController):
     @EndpointDoc("Create or update the sync pipe")
     @CreatePermission
     def create_sync_pipe(self, group_id: str, pipe_id: str,
+                         source_zones: Dict[str, Any],
+                         destination_zones: Dict[str, Any],
                          source_bucket: str = '',
-                         source_zones: Optional[List[str]] = None,
-                         destination_zones: Optional[List[str]] = None,
-                         destination_bucket: str = '',
-                         bucket_name: str = ''):
+                         destination_bucket: str = '', bucket_name: str = ''):
         multisite_instance = RgwMultisite()
         return multisite_instance.create_sync_pipe(group_id, pipe_id, source_zones,
                                                    destination_zones, source_bucket,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-multisite.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-multisite.ts
@@ -61,3 +61,8 @@ export enum FlowType {
   directional = 'directional',
   symmetrical = 'symmetrical'
 }
+
+export interface Zone {
+  added: string[];
+  removed: string[];
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-flow-modal/rgw-multisite-sync-flow-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-flow-modal/rgw-multisite-sync-flow-modal.component.html
@@ -59,7 +59,23 @@
                      i18n>Source Zone
               </label>
               <div class="cd-col-form-input">
-                <ng-container *ngTemplateOutlet="zoneMultiSelect;context: { name: 'source_zone', zone: sourceZones }"></ng-container>
+                <select id="sourceZone"
+                        name="sourceZone"
+                        class="form-select"
+                        formControlName="source_zone"
+                        [autofocus]="editing">
+                <option i18n
+                        *ngIf="zones.data.available.length == 0"
+                        [ngValue]="null">Loading...</option>
+                <option i18n
+                        *ngIf="zones.data.available.length > 0"
+                        [ngValue]="null">-- Select source zone --</option>
+                <option *ngFor="let sourceZone of zones.data.available"
+                        [value]="sourceZone.name">{{ sourceZone.name }}</option>
+              </select>
+              <span class="invalid-feedback"
+                    *ngIf="currentFormGroupContext.showError('source_zone', frm, 'required')"
+                    i18n>This field is required.</span>
               </div>
             </div>
             <div class="form-group row">
@@ -67,7 +83,16 @@
                      for="destination_zone"
                      i18n>Destination Zone</label>
               <div class="cd-col-form-input">
-                <ng-container *ngTemplateOutlet="zoneMultiSelect;context: { name: 'destination_zone', zone: destinationZones }"></ng-container>
+                <input id="destination_zone"
+                       name="destination_zone"
+                       class="form-control"
+                       type="text"
+                       i18n-placeholder
+                       placeholder="Destination Zone..."
+                       formControlName="destination_zone"/>
+                <span class="invalid-feedback"
+                      *ngIf="currentFormGroupContext.showError('destination_zone', frm, 'required')"
+                      i18n>This field is required.</span>
               </div>
             </div>
           </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-details/rgw-multisite-sync-policy-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-details/rgw-multisite-sync-policy-details.component.html
@@ -69,14 +69,6 @@
             </cd-table-actions>
           </div>
         </cd-table>
-        <cd-alert-panel
-          *ngIf="dirFlowSelection.hasSelection"
-          type="info"
-          title="Directional Flow 'edit' & 'delete' actions disabled"
-          i18n-title
-          i18n>
-          Due to some internal dependencies these actions are disabled, it will get enabled once the issue gets resolved.
-        </cd-alert-panel>
       </ng-template>
     </ng-container>
     <ng-container ngbNavItem="pipe">
@@ -118,6 +110,6 @@
 <ng-template #deleteTpl>
   <cd-alert-panel type="danger"
                   i18n>
-    Are you sure you want to delete these Flow?
+    Deleting {{ resourceType | upperFirst }} may disrupt data synchronization
   </cd-alert-panel>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-details/rgw-multisite-sync-policy-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-sync-policy-details/rgw-multisite-sync-policy-details.component.ts
@@ -17,6 +17,12 @@ import { RgwMultisiteSyncFlowModalComponent } from '../rgw-multisite-sync-flow-m
 import { FlowType } from '../models/rgw-multisite';
 import { RgwMultisiteSyncPipeModalComponent } from '../rgw-multisite-sync-pipe-modal/rgw-multisite-sync-pipe-modal.component';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+import { NotificationType } from '~/app/shared/enum/notification-type.enum';
+
+enum MultisiteResourceType {
+  flow = 'flow',
+  pipe = 'pipe'
+}
 
 @Component({
   selector: 'cd-rgw-multisite-sync-policy-details',
@@ -34,6 +40,7 @@ export class RgwMultisiteSyncPolicyDetailsComponent implements OnChanges {
   @ViewChild('deleteTpl', { static: true })
   deleteTpl: TemplateRef<any>;
 
+  resourceType: MultisiteResourceType = MultisiteResourceType.flow;
   flowType = FlowType;
   modalRef: NgbModalRef;
   symmetricalFlowData: any = [];
@@ -136,22 +143,17 @@ export class RgwMultisiteSyncPolicyDetailsComponent implements OnChanges {
       click: () => this.openModal(FlowType.directional),
       canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
     };
-    const dirEditAction: CdTableAction = {
-      permission: 'update',
-      icon: Icons.edit,
-      name: this.actionLabels.EDIT,
-      click: () => this.openModal(FlowType.directional, true),
-      disable: () => true // TODO: disabling 'edit' as we are not getting flow ID from backend which is needed for edit
-    };
     const dirDeleteAction: CdTableAction = {
       permission: 'delete',
       icon: Icons.destroy,
-      disable: () => true, // TODO: disabling 'delete' as we are not getting flow ID from backend which is needed for deletion
+      // TODO: disabling 'delete' as we are not getting flow_id from backend which is needed for deletion
+      disable: () =>
+        'Deleting the directional flow is disabled in the UI. Please use CLI to delete the directional flow',
       name: this.actionLabels.DELETE,
       click: () => this.deleteFlow(FlowType.directional),
-      canBePrimary: (selection: CdTableSelection) => selection.hasMultiSelection
+      canBePrimary: (selection: CdTableSelection) => selection.hasSelection
     };
-    this.dirFlowTableActions = [dirAddAction, dirEditAction, dirDeleteAction];
+    this.dirFlowTableActions = [dirAddAction, dirDeleteAction];
     const pipeAddAction: CdTableAction = {
       permission: 'create',
       icon: Icons.add,
@@ -229,13 +231,14 @@ export class RgwMultisiteSyncPolicyDetailsComponent implements OnChanges {
 
     try {
       const res = await this.modalRef.result;
-      if (res === 'success') {
+      if (res === NotificationType.success) {
         this.loadData();
       }
     } catch (err) {}
   }
 
   deleteFlow(flowType: FlowType) {
+    this.resourceType = MultisiteResourceType.flow;
     let selection = this.symFlowSelection;
     if (flowType === FlowType.directional) {
       selection = this.dirFlowSelection;
@@ -297,13 +300,14 @@ export class RgwMultisiteSyncPolicyDetailsComponent implements OnChanges {
 
     try {
       const res = await this.modalRef.result;
-      if (res === 'success') {
+      if (res === NotificationType.success) {
         this.loadData();
       }
     } catch (err) {}
   }
 
   deletePipe() {
+    this.resourceType = MultisiteResourceType.pipe;
     const pipeIds = this.pipeSelection.selected.map((pipe: any) => pipe.id);
     this.cdsModalService.show(CriticalConfirmationModalComponent, {
       itemDescription: this.pipeSelection.hasSingleSelection ? $localize`Pipe` : $localize`Pipes`,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw.module.ts
@@ -227,6 +227,7 @@ const routes: Routes = [
       {
         path: 'configuration',
         component: RgwMultisiteDetailsComponent,
+        data: { breadcrumbs: 'Configuration' },
         children: [
           {
             path: 'setup-multisite-replication',
@@ -238,6 +239,7 @@ const routes: Routes = [
       {
         path: 'sync-policy',
         component: RgwMultisiteSyncPolicyComponent,
+        data: { breadcrumbs: 'Sync-policy' },
         children: [
           {
             path: `${URLVerbs.CREATE}`,

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -11370,6 +11370,8 @@ paths:
               required:
               - group_id
               - pipe_id
+              - source_zones
+              - destination_zones
               type: object
       responses:
         '200':


### PR DESCRIPTION
This PR fixes the issue of removing/editing zones from symmetrical flow and Pipe. Previously we were not able to remove zones from either flow & pipe, but after this PR we will be able to do so.

Fixes: https://tracker.ceph.com/issues/66945

Signed-off-by: Naman Munet <nmunet@redhat.com>

https://github.com/user-attachments/assets/222d2e9c-768a-4469-a958-ac20a7e55a54

**NOTE:** removed 'edit' button from the directional flow as we can't edit the zones, so everytime we need to create a new zone or either delete it, its the functionality set from core backend.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
