### PR TITLE
squid: qa/suites: drop --show-reachable=yes from fs:valgrind tests

### DIFF
--- a/qa/suites/fs/valgrind/mirror/cephfs-mirror/one-per-cluster.yaml
+++ b/qa/suites/fs/valgrind/mirror/cephfs-mirror/one-per-cluster.yaml
@@ -4,4 +4,4 @@ meta:
 tasks:
 - cephfs-mirror:
     client: client.mirror
-    valgrind: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
+    valgrind: [--tool=memcheck, --leak-check=full]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67382

---

backport of https://github.com/ceph/ceph/pull/57987
parent tracker: https://tracker.ceph.com/issues/64752

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh