### PR TITLE
mgr/dashboard: NFS Export form fixes

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -73,6 +73,7 @@
                       label="Volume"
                       cdRequiredField="Volume"
                       id="fs_name"
+                      (change)="volumeChangeHandler()"
                       [invalid]="nfsForm.controls.fsal.controls.fs_name.invalid && (nfsForm.controls.fsal.controls.fs_name.dirty)"
                       [invalidText]="fsNameError"
                       [skeleton]="allFsNames === null"
@@ -164,12 +165,11 @@
                     i18n>
           <option *ngIf="allsubvolgrps === null"
                   value="">Loading...</option>
-          <option *ngIf="allsubvolgrps !== null && allsubvolgrps.length === 0"
-                  value="">-- No CephFS subvolume group available --</option>
-          <option *ngIf="allsubvolgrps !== null && allsubvolgrps.length > 0"
+          <option *ngIf="allsubvolgrps !== null && allsubvolgrps.length >= 0"
                   value="">-- Select the CephFS subvolume group --</option>
           <option *ngFor="let subvol_grp of allsubvolgrps"
-                  [value]="subvol_grp.name">{{ subvol_grp.name }}</option>
+                  [value]="subvol_grp.name"
+                  [selected]="subvol_grp.name === nfsForm.get('subvolume_group').value">{{ subvol_grp.name }}</option>
           <option [value]="defaultSubVolGroup">{{ defaultSubVolGroup }}</option>
         </cds-select>
       </div>
@@ -183,6 +183,8 @@
                   id="subvolume"
                   [skeleton]="allsubvols === null"
                   (change)="setSubVolPath()"
+                  [invalid]="nfsForm.controls.subvolume.invalid && (nfsForm.controls.subvolume.dirty)"
+                  [invalidText]="subvolumeError"
                   i18n>
         <option *ngIf="allsubvols === null"
                 value="">Loading...</option>
@@ -191,8 +193,17 @@
         <option *ngIf="allsubvols !== null && allsubvols.length > 0"
                 value="">-- Select the CephFS subvolume --</option>
         <option *ngFor="let subvolume of allsubvols"
-                [value]="subvolume.name">{{ subvolume.name }}</option>
+                [value]="subvolume.name"
+                [selected]="subvolume.name === nfsForm.get('subvolume').value">{{ subvolume.name }}</option>
       </cds-select>
+      <ng-template #subvolumeError>
+        <span
+                  *ngIf="nfsForm.getValue('subvolume_group') === defaultSubVolGroup && !nfsForm.getValue('subvolume')"
+                  class="invalid-feedback"
+                  i18n>
+                  This field is required.
+        </span>
+      </ng-template>
     </div>
 
       <!-- Path -->
@@ -220,6 +231,9 @@
           <span class="invalid-feedback"
                 *ngIf="nfsForm.showError('path', formDir, 'required')"
                 i18n>This field is required.</span>
+          <span class="invalid-feedback"
+                *ngIf="nfsForm.get('path').hasError('isIsolatedSlash') && nfsForm.get('path').touched"
+                i18n>Export on CephFS volume "<code>/</code>" not allowed.</span>
           <span class="invalid-feedback"
                 *ngIf="nfsForm.showError('path', formDir, 'pattern')"
                 i18n>Path need to start with a '/' and can be followed by a word</span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -92,7 +92,7 @@ describe('NfsFormComponent', () => {
       clients: [],
       cluster_id: 'mynfs',
       fsal: { fs_name: '', name: 'CEPH', user_id: '' },
-      path: '/',
+      path: '',
       protocolNfsv4: true,
       protocolNfsv3: true,
       pseudo: '',
@@ -101,7 +101,7 @@ describe('NfsFormComponent', () => {
       security_label: false,
       squash: 'no_root_squash',
       subvolume: '',
-      subvolume_group: '',
+      subvolume_group: '_nogroup',
       transportTCP: true,
       transportUDP: true
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/cephfs.constant.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/cephfs.constant.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_SUBVOLUME_GROUP = '_nogroup';


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/67400
           https://tracker.ceph.com/issues/68105


Signed-off-by: Dnyaneshwari talwekar <dtalweka@redhat.com>

Tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2303196
               https://bugzilla.redhat.com/show_bug.cgi?id=2269104
               https://bugzilla.redhat.com/show_bug.cgi?id=2302756

Steps: 
1.Navigate to Dashboard -> File -> NFS
2.Create NFS
3.On Create NFS page we can see "CephFS Path" as non-editable and Pseudo as blank field.

Updated Requirement:-
1. On Create NFS SubVolume selection should be required if SubVolume group is "_nogroup".
2. CephFS path should never be single "/"

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>


https://github.com/user-attachments/assets/d58b8ad5-cc1e-4df5-918b-6363a62b919f

