### PR TITLE
squid: RADOS: Generalize stretch mode pg temp handling to be usable without stretch mode

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -737,6 +737,117 @@ Managing pools that are flagged with ``--bulk``
 ===============================================
 See :ref:`managing_bulk_flagged_pools`.
 
+Setting values for a stretch pool
+=================================
+To set values for a stretch pool, run a command of the following form:
+
+.. prompt:: bash $
+
+   ceph osd pool stretch set {pool-name} {peering_crush_bucket_count} {peering_crush_bucket_target} {peering_crush_bucket_barrier} {crush_rule} {size} {min_size} [--yes-i-really-mean-it]
+
+Here are the break downs of the arguments:
+
+.. describe:: {pool-name}
+
+   The name of the pool. It must be an existing pool, this command doesn't create a new pool.
+
+   :Type: String
+   :Required: Yes.
+
+.. describe:: {peering_crush_bucket_count}
+
+   The value is used along with peering_crush_bucket_barrier to determined whether the set of
+   OSDs in the chosen acting set can peer with each other, based on the number of distinct
+   buckets there are in the acting set.
+
+   :Type: Integer
+   :Required: Yes.
+
+.. describe:: {peering_crush_bucket_target}
+   
+   This value is used along with peering_crush_bucket_barrier and size to calculate
+   the value bucket_max which limits the number of OSDs in the same bucket from getting chose to be in the acting set of a PG.
+   
+   :Type: Integer
+   :Required: Yes.
+
+.. describe:: {peering_crush_bucket_barrier}
+      
+   The type of bucket a pool is stretched across, e.g., rack, row, or datacenter.
+
+   :Type: String
+   :Required: Yes.
+
+.. describe:: {crush_rule}
+      
+   The crush rule to use for the stretch pool. The type of pool must match the type of crush_rule
+   (replicated or erasure).
+
+   :Type: String
+   :Required: Yes.
+
+.. describe:: {size}
+         
+   The number of replicas for objects in the stretch pool.
+   
+   :Type: Integer
+   :Required: Yes.
+
+.. describe:: {min_size}
+            
+   The minimum number of replicas required for I/O in the stretch pool.
+
+   :Type: Integer
+   :Required: Yes.
+
+.. describe:: {--yes-i-really-mean-it}
+   
+      This flag is required to confirm that you really want to by-pass
+      the safety checks and set the values for a stretch pool, e.g,
+      when you are trying to set ``peering_crush_bucket_count`` or 
+      ``peering_crush_bucket_target`` to be more than the number of buckets in the crush map.
+   
+      :Type: Flag
+      :Required: No.
+
+.. _setting_values_for_a_stretch_pool:
+
+Unsetting values for a stretch pool
+===================================
+To move the pool back to non-stretch, run a command of the following form:
+
+.. prompt:: bash $
+
+   ceph osd pool stretch unset {pool-name}
+
+Here are the break downs of the argument:
+
+.. describe:: {pool-name}
+
+   The name of the pool. It must be an existing pool that is stretched,
+   i.e., it has already been set with the command `ceph osd pool stretch set`.
+
+   :Type: String
+   :Required: Yes.
+
+Showing values of a stretch pool
+================================
+To show values for a stretch pool, run a command of the following form:
+
+.. prompt:: bash $
+
+   ceph osd pool stretch show {pool-name}
+
+Here are the break downs of the argument:
+
+.. describe:: {pool-name}
+
+   The name of the pool. It must be an existing pool that is stretched,
+   i.e., it has already been set with the command `ceph osd pool stretch set`.
+
+   :Type: String
+   :Required: Yes.
+
 .. _Pool, PG and CRUSH Config Reference: ../../configuration/pool-pg-config-ref
 .. _Bloom Filter: https://en.wikipedia.org/wiki/Bloom_filter
 .. _setting the number of placement groups: ../placement-groups#set-the-number-of-placement-groups

--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -81,6 +81,18 @@ Data Center B. In a situation of this kind, the loss of Data Center A means
 that the data is lost and Ceph will not be able to operate on it. This
 situation is surprisingly difficult to avoid using only standard CRUSH rules.
 
+Individual Stretch Pools
+========================
+Setting individual ``stretch pool`` is an option that allows for the configuration
+of specific pools to be distributed across ``two or more data centers``.
+This is achieved by executing the ``ceph osd pool stretch set`` command on each desired pool,
+as opposed to applying a cluster-wide configuration ``with stretch mode``.
+See :ref:`setting_values_for_a_stretch_pool`
+
+Use ``stretch mode`` when you have exactly ``two data centers`` and require a uniform
+configuration across the entire cluster. Conversely, opt for a ``stretch pool``
+when you need a particular pool to be replicated across ``more than two data centers``,
+providing a more granular level of control and a larger cluster size.
 
 Stretch Mode
 ============

--- a/qa/suites/rados/singleton/all/3-az-stretch-cluster-netsplit.yaml
+++ b/qa/suites/rados/singleton/all/3-az-stretch-cluster-netsplit.yaml
@@ -1,0 +1,73 @@
+roles:
+- - mon.a
+  - mon.b
+  - mon.c
+  - osd.0
+  - osd.1
+  - osd.2
+  - mgr.a
+  - mgr.b
+- - mon.d
+  - mon.e
+  - mon.f
+  - osd.3
+  - osd.4
+  - osd.5
+  - mgr.c
+  - mgr.d
+- - mon.g
+  - mon.h
+  - mon.i
+  - osd.6
+  - osd.7
+  - osd.8
+  - mgr.e
+  - mgr.f
+- - client.0
+
+openstack:
+  - volumes: # attached to each instance
+      count: 3
+      size: 10 # GB
+overrides:
+  ceph:
+    conf:
+      global:
+        mon election default strategy: 3
+      mon:
+        client mount timeout: 60
+        osd pool default size: 6
+        osd_pool_default_min_size: 3
+        osd_pool_default_pg_autoscale_mode: off
+        debug mon: 30
+tasks:
+- install:
+- ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr_pool false --force
+    log-ignorelist:
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(OBJECT_
+      - \(SLOW_OPS\)
+      - \(REQUEST_SLOW\)
+      - \(TOO_FEW_PGS\)
+      - slow request
+      - \(POOL_APP_NOT_ENABLED\)
+      - overall HEALTH_
+      - \(MGR_DOWN\)
+      - \(MON_DOWN\)
+      - \(PG_AVAILABILITY\)
+      - \(SLOW_OPS\)
+      - \[WRN\]
+- workunit:
+    clients:
+      client.0:
+        - mon/mon-stretch-pool.sh
+- cephfs_test_runner:
+    modules:
+      - tasks.test_netsplit_3az_stretch_pool

--- a/qa/suites/rados/singleton/all/mon-stretch-pool.yaml
+++ b/qa/suites/rados/singleton/all/mon-stretch-pool.yaml
@@ -1,0 +1,67 @@
+roles:
+- - mon.a
+  - mon.b
+  - mon.c
+  - osd.0
+  - osd.1
+  - osd.2
+  - mgr.x
+  - client.0
+  - mon.d
+  - mon.e
+  - mon.f
+  - osd.3
+  - osd.4
+  - osd.5
+  - mon.g
+  - mon.h
+  - mon.i
+  - osd.6
+  - osd.7
+  - osd.8
+
+openstack:
+  - volumes: # attached to each instance
+      count: 3
+      size: 10 # GB
+overrides:
+  ceph:
+    conf:
+      global:
+        mon election default strategy: 3
+      mon:
+        client mount timeout: 60
+        osd pool default size: 6
+        osd_pool_default_min_size: 3
+        osd_pool_default_pg_autoscale_mode: off
+        debug mon: 30
+tasks:
+- install:
+- ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr_pool false --force
+    log-ignorelist:
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(OBJECT_
+      - \(SLOW_OPS\)
+      - \(REQUEST_SLOW\)
+      - \(TOO_FEW_PGS\)
+      - slow request
+      - \(POOL_APP_NOT_ENABLED\)
+      - overall HEALTH_
+      - \(MGR_DOWN\)
+      - \(MON_DOWN\)
+      - \(PG_AVAILABILITY\)
+      - \(SLOW_OPS\)
+- workunit:
+    clients:
+      client.0:
+        - mon/mon-stretch-pool.sh
+- cephfs_test_runner:
+    modules:
+      - tasks.stretch_cluster

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -3163,6 +3163,14 @@ class CephManager:
         j = json.loads(out)
         return j['quorum']
 
+    def get_mon_quorum_names(self):
+        """
+        Extract monitor quorum names from the cluster
+        """
+        out = self.raw_cluster_cmd('quorum_status')
+        j = json.loads(out)
+        return j['quorum_names']
+
     def wait_for_mon_quorum_size(self, size, timeout=300):
         """
         Loop until quorum size is reached.

--- a/qa/tasks/ceph_test_case.py
+++ b/qa/tasks/ceph_test_case.py
@@ -369,8 +369,8 @@ class CephTestCase(unittest.TestCase, RunCephCmd):
                     else:
                         break
                 if success_time_elapsed == success_hold_time:
-                    log.debug("wait_until_true_and_hold: success for {0}s".format(success_hold_time))
-                    return
+                   log.debug("wait_until_true_and_hold: success for {0}s".format(success_hold_time))
+                   return
             else:
                 if elapsed >= timeout:
                     if check_fn and check_fn() and retry_count < 5:

--- a/qa/tasks/stretch_cluster.py
+++ b/qa/tasks/stretch_cluster.py
@@ -1,0 +1,695 @@
+import json
+import logging
+import random
+from tasks.mgr.mgr_test_case import MgrTestCase
+from time import sleep
+
+log = logging.getLogger(__name__)
+
+
+class TestStretchCluster(MgrTestCase):
+    """
+    Test the stretch cluster feature.
+    """
+    # Define some constants
+    POOL = 'pool_stretch'
+    CLUSTER = "ceph"
+    WRITE_PERIOD = 10
+    RECOVERY_PERIOD = WRITE_PERIOD * 6
+    SUCCESS_HOLD_TIME = 7
+    # This dictionary maps the datacenter to the osd ids and hosts
+    DC_OSDS = {
+        'dc1': {
+            "node-1": 0,
+            "node-2": 1,
+            "node-3": 2,
+        },
+        'dc2': {
+            "node-4": 3,
+            "node-5": 4,
+            "node-6": 5,
+        },
+        'dc3': {
+            "node-7": 6,
+            "node-8": 7,
+            "node-9": 8,
+        }
+    }
+
+    # This dictionary maps the datacenter to the mon ids and hosts
+    DC_MONS = {
+        'dc1': {
+            "node-1": 'a',
+            "node-2": 'b',
+            "node-3": 'c',
+        },
+        'dc2': {
+            "node-4": 'd',
+            "node-5": 'e',
+            "node-6": 'f',
+        },
+        'dc3': {
+            "node-7": 'g',
+            "node-8": 'h',
+            "node-9": 'i',
+        }
+    }
+    PEERING_CRUSH_BUCKET_COUNT = 2
+    PEERING_CRUSH_BUCKET_TARGET = 3
+    PEERING_CRUSH_BUCKET_BARRIER = 'datacenter'
+    CRUSH_RULE = 'replicated_rule_custom'
+    SIZE = 6
+    MIN_SIZE = 3
+    BUCKET_MAX = SIZE // PEERING_CRUSH_BUCKET_TARGET
+    if (BUCKET_MAX * PEERING_CRUSH_BUCKET_TARGET) < SIZE:
+        BUCKET_MAX += 1
+
+    def setUp(self):
+        """
+        Setup the cluster and
+        ensure we have a clean condition before the test.
+        """
+        # Ensure we have at least 6 OSDs
+        super(TestStretchCluster, self).setUp()
+        if self._osd_count() < 6:
+            self.skipTest("Not enough OSDS!")
+
+        # Remove any filesystems so that we can remove their pools
+        if self.mds_cluster:
+            self.mds_cluster.mds_stop()
+            self.mds_cluster.mds_fail()
+            self.mds_cluster.delete_all_filesystems()
+
+        # Remove all other pools
+        for pool in self.mgr_cluster.mon_manager.get_osd_dump_json()['pools']:
+            self.mgr_cluster.mon_manager.remove_pool(pool['pool_name'])
+
+    def tearDown(self):
+        """
+        Clean up the cluster after the test.
+        """
+        # Remove the pool
+        if self.POOL in self.mgr_cluster.mon_manager.pools:
+            self.mgr_cluster.mon_manager.remove_pool(self.POOL)
+
+        osd_map = self.mgr_cluster.mon_manager.get_osd_dump_json()
+        for osd in osd_map['osds']:
+            # mark all the osds in
+            if osd['weight'] == 0.0:
+                self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                    'osd', 'in', str(osd['osd']))
+            # Bring back all the osds and move it back to the host.
+            if osd['up'] == 0:
+                self._bring_back_osd(osd['osd'])
+                self._move_osd_back_to_host(osd['osd'])
+
+        # Bring back all the MONS
+        mons = self._get_all_mons_from_all_dc()
+        for mon in mons:
+            self._bring_back_mon(mon)
+        super(TestStretchCluster, self).tearDown()
+
+    def _setup_pool(self, size=None, min_size=None, rule=None):
+        """
+        Create a pool and set its size.
+        """
+        self.mgr_cluster.mon_manager.create_pool(self.POOL, min_size=min_size)
+        if size is not None:
+            self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                'osd', 'pool', 'set', self.POOL, 'size', str(size))
+        if rule is not None:
+            self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                'osd', 'pool', 'set', self.POOL, 'crush_rule', rule)
+
+    def _osd_count(self):
+        """
+        Get the number of OSDs in the cluster.
+        """
+        osd_map = self.mgr_cluster.mon_manager.get_osd_dump_json()
+        return len(osd_map['osds'])
+
+    def _write_some_data(self, t):
+        """
+        Write some data to the pool to simulate a workload.
+        """
+
+        args = [
+            "rados", "-p", self.POOL, "bench", str(t), "write", "-t", "16"]
+
+        self.mgr_cluster.admin_remote.run(args=args, wait=True)
+
+    def _get_pg_stats(self):
+        """
+        Dump the cluster and get pg stats
+        """
+        out = self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                'pg', 'dump', '--format=json')
+        j = json.loads('\n'.join(out.split('\n')[1:]))
+        try:
+            return j['pg_map']['pg_stats']
+        except KeyError:
+            return j['pg_stats']
+
+    def _get_active_pg(self, pgs):
+        """
+        Get the number of active PGs
+        """
+        num_active = 0
+        for pg in pgs:
+            if pg['state'].count('active') and not pg['state'].count('stale'):
+                num_active += 1
+        return num_active
+
+    def _get_active_clean_pg(self, pgs):
+        """
+        Get the number of active+clean PGs
+        """
+        num_active_clean = 0
+        for pg in pgs:
+            if (pg['state'].count('active') and
+                pg['state'].count('clean') and
+                    not pg['state'].count('stale')):
+                num_active_clean += 1
+        return num_active_clean
+
+    def _get_acting_set(self, pgs):
+        """
+        Get the acting set of the PGs
+        """
+        acting_set = []
+        for pg in pgs:
+            acting_set.append(pg['acting'])
+        return acting_set
+
+    def _surviving_osds_in_acting_set_dont_exceed(self, n, osds):
+        """
+        Check if the acting set of the PGs doesn't contain more
+        than n OSDs of the surviving DC.
+        NOTE: Only call this function after we set the pool to stretch.
+        """
+        pgs = self._get_pg_stats()
+        acting_set = self._get_acting_set(pgs)
+        for acting in acting_set:
+            log.debug("Acting set: %s", acting)
+            intersect = list(set(acting) & set(osds))
+            if len(intersect) > n:
+                log.error(
+                    "Acting set: %s contains more than %d \
+                    OSDs from the same %s which are: %s",
+                    acting, n, self.PEERING_CRUSH_BUCKET_BARRIER,
+                    intersect
+                )
+                return False
+        return True
+
+    def _print_not_active_clean_pg(self, pgs):
+        """
+        Print the PGs that are not active+clean.
+        """
+        for pg in pgs:
+            if not (pg['state'].count('active') and
+                    pg['state'].count('clean') and
+                    not pg['state'].count('stale')):
+                log.debug(
+                    "PG %s is not active+clean, but %s",
+                    pg['pgid'], pg['state']
+                )
+
+    def _print_not_active_pg(self, pgs):
+        """
+        Print the PGs that are not active.
+        """
+        for pg in pgs:
+            if not (pg['state'].count('active') and
+                    not pg['state'].count('stale')):
+                log.debug(
+                    "PG %s is not active, but %s",
+                    pg['pgid'], pg['state']
+                )
+
+    def _pg_all_active_clean(self):
+        """
+        Check if all pgs are active and clean.
+        """
+        pgs = self._get_pg_stats()
+        result = self._get_active_clean_pg(pgs) == len(pgs)
+        if result:
+            log.debug("All PGs are active+clean")
+        else:
+            log.debug("Not all PGs are active+clean")
+            self._print_not_active_clean_pg(pgs)
+        return result
+
+    def _pg_all_active(self):
+        """
+        Check if all pgs are active.
+        """
+        pgs = self._get_pg_stats()
+        result = self._get_active_pg(pgs) == len(pgs)
+        if result:
+            log.debug("All PGs are active")
+        else:
+            log.debug("Not all PGs are active")
+            self._print_not_active_pg(pgs)
+        return result
+
+    def _pg_all_unavailable(self):
+        """
+        Check if all pgs are unavailable.
+        """
+        pgs = self._get_pg_stats()
+        return self._get_active_pg(pgs) == 0
+
+    def _pg_partial_active(self):
+        """
+        Check if some pgs are active.
+        """
+        pgs = self._get_pg_stats()
+        return 0 < self._get_active_pg(pgs) <= len(pgs)
+
+    def _kill_osd(self, osd):
+        """
+        Kill the osd.
+        """
+        try:
+            self.ctx.daemons.get_daemon('osd', osd, self.CLUSTER).stop()
+        except Exception:
+            log.error("Failed to stop osd.{}".format(str(osd)))
+            pass
+
+    def _get_osds_by_dc(self, dc):
+        """
+        Get osds by datacenter.
+        """
+        return [osd for _, osd in self.DC_OSDS[dc].items()]
+
+    def _get_all_osds_from_all_dc(self):
+        """
+        Get all osds from all datacenters.
+        """
+        return [osd for nodes in self.DC_OSDS.values()
+                for osd in nodes.values()]
+
+    def _get_osds_data(self, want_osds):
+        """
+        Get the osd data
+        """
+        all_osds_data = \
+            self.mgr_cluster.mon_manager.get_osd_dump_json()['osds']
+        return [
+            osd_data for osd_data in all_osds_data
+            if int(osd_data['osd']) in want_osds
+        ]
+
+    def _get_host(self, osd):
+        """
+        Get the host of the osd.
+        """
+        for dc, nodes in self.DC_OSDS.items():
+            for node, osd_id in nodes.items():
+                if osd_id == osd:
+                    return node
+        return None
+
+    def _move_osd_back_to_host(self, osd):
+        """
+        Move the osd back to the host.
+        """
+        host = self._get_host(osd)
+        assert host is not None, "The host of osd {} is not found.".format(osd)
+        log.debug("Moving osd.%d back to %s", osd, host)
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'osd', 'crush', 'move', 'osd.{}'.format(str(osd)),
+            'host={}'.format(host)
+        )
+
+    def _bring_back_osd(self, osd):
+        """
+        Bring back the osd.
+        """
+        try:
+            self.ctx.daemons.get_daemon('osd', osd, self.CLUSTER).restart()
+        except Exception:
+            log.error("Failed to bring back osd.{}".format(str(osd)))
+            pass
+
+    def _bring_back_all_osds_in_dc(self, dc):
+        """
+        Bring back all osds in the specified <datacenter>
+        """
+        if not isinstance(dc, str):
+            raise ValueError("dc must be a string")
+        if dc not in self.DC_OSDS:
+            raise ValueError("dc must be one of the following: %s" %
+                             self.DC_OSDS.keys())
+        log.debug("Bringing back %s", dc)
+        osds = self._get_osds_by_dc(dc)
+        # Bring back all the osds in the DC and move it back to the host.
+        for osd_id in osds:
+            # Bring back the osd
+            self._bring_back_osd(osd_id)
+            # Wait until the osd is up since we need it to be up before we can
+            # move it back to the host
+            self.wait_until_true(
+                lambda: all([int(osd['up']) == 1
+                            for osd in self._get_osds_data([osd_id])]),
+                timeout=self.RECOVERY_PERIOD
+            )
+            # Move the osd back to the host
+            self._move_osd_back_to_host(osd_id)
+
+    def _fail_over_all_osds_in_dc(self, dc):
+        """
+        Fail over all osds in specified <datacenter>
+        """
+        if not isinstance(dc, str):
+            raise ValueError("dc must be a string")
+        if dc not in self.DC_OSDS:
+            raise ValueError(
+                "dc must be one of the following: %s" % self.DC_OSDS.keys()
+                )
+        log.debug("Failing over %s", dc)
+        osds = self._get_osds_by_dc(dc)
+        # fail over all the OSDs in the DC
+        for osd_id in osds:
+            self._kill_osd(osd_id)
+        # wait until all the osds are down
+        self.wait_until_true(
+            lambda: all([int(osd['up']) == 0
+                        for osd in self._get_osds_data(osds)]),
+            timeout=self.RECOVERY_PERIOD
+        )
+
+    def _fail_over_one_osd_from_dc(self, dc):
+        """
+        Fail over one random OSD from the specified <datacenter>
+        """
+        if not isinstance(dc, str):
+            raise ValueError("dc must be a string")
+        if dc not in self.DC_OSDS:
+            raise ValueError("dc must be one of the following: %s" %
+                             self.DC_OSDS.keys())
+        log.debug("Failing over one random OSD from %s", dc)
+        # filter out failed osds
+        osds_data = self._get_osds_data(self._get_osds_by_dc(dc))
+        osds = [int(osd['osd']) for osd in osds_data if int(osd['up']) == 1]
+        # fail over one random OSD in the DC
+        osd_id = random.choice(osds)
+        self._kill_osd(osd_id)
+        # wait until the osd is down
+        self.wait_until_true(
+            lambda: int(self._get_osds_data([osd_id])[0]['up']) == 0,
+            timeout=self.RECOVERY_PERIOD
+        )
+
+    def _fail_over_one_mon_from_dc(self, dc, no_wait=False):
+        """
+        Fail over one random mon from the specified <datacenter>
+        no_wait: if True, don't wait for the mon to be out of quorum
+        """
+        if not isinstance(dc, str):
+            raise ValueError("dc must be a string")
+        if dc not in self.DC_MONS:
+            raise ValueError("dc must be one of the following: %s" %
+                             ", ".join(self.DC_MONS.keys()))
+        log.debug("Failing over one random mon from %s", dc)
+        mons = self._get_mons_by_dc(dc)
+        # filter out failed mons
+        mon_quorum = self.mgr_cluster.mon_manager.get_mon_quorum_names()
+        mons = [mon for mon in mons if mon in mon_quorum]
+        # fail over one random mon in the DC
+        mon = random.choice(mons)
+        self._kill_mon(mon)
+        if no_wait:
+            return
+        else:
+            # wait until the mon is out of quorum
+            self.wait_until_true(
+                lambda: self._check_mons_out_of_quorum([mon]),
+                timeout=self.RECOVERY_PERIOD
+            )
+
+    def _fail_over_all_mons_in_dc(self, dc):
+        """
+        Fail over all mons in the specified <datacenter>
+        """
+        if not isinstance(dc, str):
+            raise ValueError("dc must be a string")
+        if dc not in self.DC_MONS:
+            raise ValueError("dc must be one of the following: %s" %
+                             ", ".join(self.DC_MONS.keys()))
+        log.debug("Failing over %s", dc)
+        mons = self._get_mons_by_dc(dc)
+        for mon in mons:
+            self._kill_mon(mon)
+        # wait until all the mons are out of quorum
+        self.wait_until_true(
+            lambda: self._check_mons_out_of_quorum(mons),
+            timeout=self.RECOVERY_PERIOD
+        )
+
+    def _kill_mon(self, mon):
+        """
+        Kill the mon.
+        """
+        try:
+            self.ctx.daemons.get_daemon('mon', mon, self.CLUSTER).stop()
+        except Exception:
+            log.error("Failed to stop mon.{}".format(str(mon)))
+            pass
+
+    def _get_mons_by_dc(self, dc):
+        """
+        Get mons by datacenter.
+        """
+        return [mon for _, mon in self.DC_MONS[dc].items()]
+
+    def _get_all_mons_from_all_dc(self):
+        """
+        Get all mons from all datacenters.
+        """
+        return [mon for nodes in self.DC_MONS.values()
+                for mon in nodes.values()]
+
+    def _check_mons_out_of_quorum(self, want_mons):
+        """
+        Check if the mons are not in quorum.
+        """
+        quorum_names = self.mgr_cluster.mon_manager.get_mon_quorum_names()
+        return all([mon not in quorum_names for mon in want_mons])
+
+    def _check_mons_in_quorum(self, want_mons):
+        """
+        Check if the mons are in quorum.
+        """
+        quorum_names = self.mgr_cluster.mon_manager.get_mon_quorum_names()
+        return all([mon in quorum_names for mon in want_mons])
+
+    def _check_mon_quorum_size(self, size):
+        """
+        Check if the mon quorum size is equal to <size>
+        """
+        return len(self.mgr_cluster.mon_manager.get_mon_quorum_names()) == size
+
+    def _bring_back_mon(self, mon):
+        """
+        Bring back the mon.
+        """
+        try:
+            self.ctx.daemons.get_daemon('mon', mon, self.CLUSTER).restart()
+        except Exception:
+            log.error("Failed to bring back mon.{}".format(str(mon)))
+            pass
+
+    def _bring_back_all_mons_in_dc(self, dc):
+        """
+        Bring back all mons in the specified <datacenter>
+        """
+        if not isinstance(dc, str):
+            raise ValueError("dc must be a string")
+        if dc not in self.DC_MONS:
+            raise ValueError("dc must be one of the following: %s" %
+                             ", ".join(self.DC_MONS.keys()))
+        log.debug("Bringing back %s", dc)
+        mons = self._get_mons_by_dc(dc)
+        for mon in mons:
+            self._bring_back_mon(mon)
+        # wait until all the mons are up
+        self.wait_until_true(
+            lambda: self._check_mons_in_quorum(mons),
+            timeout=self.RECOVERY_PERIOD
+        )
+
+    def _no_reply_to_mon_command(self):
+        """
+        Check if the cluster is inaccessible.
+        """
+        try:
+            self.mgr_cluster.mon_manager.raw_cluster_cmd('status')
+            return False
+        except Exception:
+            return True
+
+    def test_mon_failures_in_stretch_pool(self):
+        """
+        Test mon failures in stretch pool.
+        """
+        self._setup_pool(
+            self.SIZE,
+            min_size=self.MIN_SIZE,
+            rule=self.CRUSH_RULE
+        )
+        self._write_some_data(self.WRITE_PERIOD)
+        # Set the pool to stretch
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'osd', 'pool', 'stretch', 'set',
+            self.POOL, str(self.PEERING_CRUSH_BUCKET_COUNT),
+            str(self.PEERING_CRUSH_BUCKET_TARGET),
+            self.PEERING_CRUSH_BUCKET_BARRIER,
+            self.CRUSH_RULE, str(self.SIZE), str(self.MIN_SIZE))
+
+        # SCENARIO 1: MONS in DC1 down
+
+        # Fail over mons in DC1
+        self._fail_over_all_mons_in_dc('dc1')
+        # Expects mons in DC2 and DC3 to be in quorum
+        mons_dc2_dc3 = (
+            self._get_mons_by_dc('dc2') +
+            self._get_mons_by_dc('dc3')
+        )
+        self.wait_until_true_and_hold(
+            lambda: self._check_mons_in_quorum(mons_dc2_dc3),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+
+        # SCENARIO 2: MONS in DC1 down + 1 MON in DC2 down
+
+        # Fail over 1 random MON from DC2
+        self._fail_over_one_mon_from_dc('dc2')
+        # Expects quorum size to be 5
+        self.wait_until_true_and_hold(
+            lambda: self._check_mon_quorum_size(5),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+
+        # SCENARIO 3: MONS in DC1 down + 2 MONS in DC2 down
+
+        # Fail over 1 random MON from DC2
+        self._fail_over_one_mon_from_dc('dc2', no_wait=True)
+        # sleep for 30 seconds to allow the mon to be out of quorum
+        sleep(30)
+        # Expects cluster to be inaccesible
+        self.wait_until_true(
+            lambda: self._no_reply_to_mon_command(),
+            timeout=self.RECOVERY_PERIOD,
+        )
+        # Bring back all mons in DC2 to unblock the cluster
+        self._bring_back_all_mons_in_dc('dc2')
+        # Expects mons in DC2 and DC3 to be in quorum
+        self.wait_until_true_and_hold(
+            lambda: self._check_mons_in_quorum(mons_dc2_dc3),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+
+    def test_set_stretch_pool_no_active_pgs(self):
+        """
+        Test setting a pool to stretch cluster and checks whether
+        it prevents PGs from the going active when there is not
+        enough buckets available in the acting set of PGs to
+        go active.
+        """
+        self._setup_pool(
+            self.SIZE,
+            min_size=self.MIN_SIZE,
+            rule=self.CRUSH_RULE
+        )
+        self._write_some_data(self.WRITE_PERIOD)
+        # 1. We test the case where we didn't make the pool stretch
+        #   and we expect the PGs to go active even when there is only
+        #   one bucket available in the acting set of PGs.
+
+        # Fail over osds in DC1 expects PGs to be 100% active
+        self._fail_over_all_osds_in_dc('dc1')
+        self.wait_until_true_and_hold(
+            lambda: self._pg_all_active(),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+        # Fail over osds in DC2 expects PGs to be partially active
+        self._fail_over_all_osds_in_dc('dc2')
+        self.wait_until_true_and_hold(
+            lambda: self._pg_partial_active,
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+
+        # Bring back osds in DC1 expects PGs to be 100% active
+        self._bring_back_all_osds_in_dc('dc1')
+        self.wait_until_true_and_hold(
+            lambda: self._pg_all_active(),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+        # Bring back osds DC2 expects PGs to be 100% active+clean
+        self._bring_back_all_osds_in_dc('dc2')
+        self.wait_until_true_and_hold(
+            lambda: self._pg_all_active_clean(),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+        # 2. We test the case where we make the pool stretch
+        #   and we expect the PGs to not go active even when there is only
+        #   one bucket available in the acting set of PGs.
+
+        # Set the pool to stretch
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'osd', 'pool', 'stretch', 'set',
+            self.POOL, str(self.PEERING_CRUSH_BUCKET_COUNT),
+            str(self.PEERING_CRUSH_BUCKET_TARGET),
+            self.PEERING_CRUSH_BUCKET_BARRIER,
+            self.CRUSH_RULE, str(self.SIZE), str(self.MIN_SIZE))
+
+        # Fail over osds in DC1 expects PGs to be 100% active
+        self._fail_over_all_osds_in_dc('dc1')
+        self.wait_until_true_and_hold(lambda: self._pg_all_active(),
+                                      timeout=self.RECOVERY_PERIOD,
+                                      success_hold_time=self.SUCCESS_HOLD_TIME)
+
+        # Fail over 1 random OSD from DC2 expects PGs to be 100% active
+        self._fail_over_one_osd_from_dc('dc2')
+        self.wait_until_true_and_hold(lambda: self._pg_all_active(),
+                                      timeout=self.RECOVERY_PERIOD,
+                                      success_hold_time=self.SUCCESS_HOLD_TIME)
+
+        # Fail over osds in DC2 completely expects PGs to be 100% inactive
+        self._fail_over_all_osds_in_dc('dc2')
+        self.wait_until_true_and_hold(lambda: self._pg_all_unavailable,
+                                      timeout=self.RECOVERY_PERIOD,
+                                      success_hold_time=self.SUCCESS_HOLD_TIME)
+
+        # We expect that there will be no more than BUCKET_MAX osds from DC3
+        # in the acting set of the PGs.
+        self.wait_until_true(
+            lambda: self._surviving_osds_in_acting_set_dont_exceed(
+                        self.BUCKET_MAX,
+                        self._get_osds_by_dc('dc3')
+                    ),
+            timeout=self.RECOVERY_PERIOD)
+
+        # Bring back osds in DC1 expects PGs to be 100% active
+        self._bring_back_all_osds_in_dc('dc1')
+        self.wait_until_true_and_hold(
+            lambda: self._pg_all_active(),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME)
+
+        # Bring back osds iin DC2 expects PGs to be 100% active+clean
+        self._bring_back_all_osds_in_dc('dc2')
+        self.wait_until_true_and_hold(
+            lambda: self._pg_all_active_clean(),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )

--- a/qa/tasks/test_netsplit_3az_stretch_pool.py
+++ b/qa/tasks/test_netsplit_3az_stretch_pool.py
@@ -1,0 +1,281 @@
+from tasks.ceph_test_case import CephTestCase
+import logging
+import json
+from tasks.netsplit import disconnect, reconnect, get_ip_and_ports
+import itertools
+import time
+from io import StringIO
+log = logging.getLogger(__name__)
+
+
+class TestNetSplit(CephTestCase):
+    MON_LIST = ["mon.a", "mon.d", "mon.g"]
+    CLIENT = "client.0"
+    CLUSTER = "ceph"
+    WRITE_PERIOD = 10
+    READ_PERIOD = 10
+    RECOVERY_PERIOD = WRITE_PERIOD * 6
+    SUCCESS_HOLD_TIME = 10
+    PEERING_CRUSH_BUCKET_COUNT = 2
+    PEERING_CRUSH_BUCKET_TARGET = 3
+    PEERING_CRUSH_BUCKET_BARRIER = 'datacenter'
+    POOL = 'pool_stretch'
+    CRUSH_RULE = 'replicated_rule_custom'
+    SIZE = 6
+    MIN_SIZE = 3
+    BUCKET_MAX = SIZE // PEERING_CRUSH_BUCKET_TARGET
+    if (BUCKET_MAX * PEERING_CRUSH_BUCKET_TARGET) < SIZE:
+        BUCKET_MAX += 1
+
+    def setUp(self):
+        """
+        Set up the cluster for the test.
+        """
+        super(TestNetSplit, self).setUp()
+
+    def tearDown(self):
+        """
+        Clean up the cluter after the test.
+        """
+        super(TestNetSplit, self).tearDown()
+
+    def _setup_pool(self, size=None, min_size=None, rule=None):
+        """
+        Create a pool and set its size.
+        """
+        self.mgr_cluster.mon_manager.create_pool(self.POOL, min_size=min_size)
+        if size is not None:
+            self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                'osd', 'pool', 'set', self.POOL, 'size', str(size))
+        if rule is not None:
+            self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                'osd', 'pool', 'set', self.POOL, 'crush_rule', rule)
+
+    def _get_pg_stats(self):
+        """
+        Dump the cluster and get pg stats
+        """
+        (client,) = self.ctx.cluster.only(self.CLIENT).remotes.keys()
+        arg = ['ceph', 'pg', 'dump', '--format=json']
+        proc = client.run(args=arg, wait=True, stdout=StringIO(), timeout=30)
+        if proc.exitstatus != 0:
+            log.error("pg dump failed")
+            raise Exception("pg dump failed")
+        out = proc.stdout.getvalue()
+        j = json.loads('\n'.join(out.split('\n')[1:]))
+        try:
+            return j['pg_map']['pg_stats']
+        except KeyError:
+            return j['pg_stats']
+
+    def _get_active_pg(self, pgs):
+        """
+        Get the number of active PGs
+        """
+        num_active = 0
+        for pg in pgs:
+            if pg['state'].count('active') and not pg['state'].count('stale'):
+                num_active += 1
+        return num_active
+
+    def _print_not_active_clean_pg(self, pgs):
+        """
+        Print the PGs that are not active+clean.
+        """
+        for pg in pgs:
+            if not (pg['state'].count('active') and
+                    pg['state'].count('clean') and
+                    not pg['state'].count('stale')):
+                log.debug(
+                    "PG %s is not active+clean, but %s",
+                    pg['pgid'], pg['state']
+                )
+
+    def _print_not_active_pg(self, pgs):
+        """
+        Print the PGs that are not active.
+        """
+        for pg in pgs:
+            if not (pg['state'].count('active') and
+                    not pg['state'].count('stale')):
+                log.debug(
+                    "PG %s is not active, but %s",
+                    pg['pgid'], pg['state']
+                )
+
+    def _pg_all_active(self):
+        """
+        Check if all pgs are active.
+        """
+        pgs = self._get_pg_stats()
+        result = self._get_active_pg(pgs) == len(pgs)
+        if result:
+            log.debug("All PGs are active")
+        else:
+            log.debug("Not all PGs are active")
+            self._print_not_active_pg(pgs)
+        return result
+
+    def _get_active_clean_pg(self, pgs):
+        """
+        Get the number of active+clean PGs
+        """
+        num_active_clean = 0
+        for pg in pgs:
+            if (pg['state'].count('active') and
+                pg['state'].count('clean') and
+                    not pg['state'].count('stale') and
+                    not pg['state'].count('laggy')):
+                num_active_clean += 1
+        return num_active_clean
+
+    def _pg_all_active_clean(self):
+        """
+        Check if all pgs are active and clean.
+        """
+        pgs = self._get_pg_stats()
+        result = self._get_active_clean_pg(pgs) == len(pgs)
+        if result:
+            log.debug("All PGs are active+clean")
+        else:
+            log.debug("Not all PGs are active+clean")
+            self._print_not_active_clean_pg(pgs)
+        return result
+
+    def _disconnect_mons(self, config):
+        """
+        Disconnect the mons in the <config> list.
+        """
+        disconnect(self.ctx, config)
+
+    def _reconnect_mons(self, config):
+        """
+        Reconnect the mons in the <config> list.
+        """
+        reconnect(self.ctx, config)
+
+    def _reply_to_mon_command(self):
+        """
+        Check if the cluster is accessible.
+        """
+        try:
+            self.mgr_cluster.mon_manager.raw_cluster_cmd('status')
+            return True
+        except Exception:
+            return False
+
+    def _check_if_disconnect(self, config):
+        """
+        Check if the mons in the <config> list are disconnected.
+        """
+        assert config[0].startswith('mon.')
+        assert config[1].startswith('mon.')
+        log.info("Checking if the {} and {} are disconnected".format(
+            config[0], config[1]))
+        (ip1, _) = get_ip_and_ports(self.ctx, config[0])
+        (ip2, _) = get_ip_and_ports(self.ctx, config[1])
+        (host1,) = self.ctx.cluster.only(config[0]).remotes.keys()
+        (host2,) = self.ctx.cluster.only(config[1]).remotes.keys()
+        assert host1 is not None
+        assert host2 is not None
+        # if the mons are disconnected, the ping should fail (exitstatus = 1)
+        try:
+            if (host1.run(args=["ping", "-c", "1", ip2]).exitstatus == 0 or
+                    host2.run(args=["ping", "-c", "1", ip1]).exitstatus == 0):
+                return False
+        except Exception:
+            return True
+
+    def _check_if_connect(self, config):
+        """
+        Check if the mons in the <config> list are connected.
+        """
+        assert config[0].startswith('mon.')
+        assert config[1].startswith('mon.')
+        log.info("Checking if {} and {} are connected".format(
+                config[0], config[1]))
+        (ip1, _) = get_ip_and_ports(self.ctx, config[0])
+        (ip2, _) = get_ip_and_ports(self.ctx, config[1])
+        (host1,) = self.ctx.cluster.only(config[0]).remotes.keys()
+        (host2,) = self.ctx.cluster.only(config[1]).remotes.keys()
+        assert host1 is not None
+        assert host2 is not None
+        # if the mons are connected, the ping should succeed (exitstatus = 0)
+        try:
+            if (host1.run(args=["ping", "-c", "1", ip2]).exitstatus == 0 and
+                    host2.run(args=["ping", "-c", "1", ip1]).exitstatus == 0):
+                return True
+        except Exception:
+            return False
+
+    def test_mon_netsplit(self):
+        """
+        Test the mon netsplit scenario, if cluster is actually accessible.
+        """
+        log.info("Running test_mon_netsplit")
+        self._setup_pool(
+            self.SIZE,
+            min_size=self.MIN_SIZE,
+            rule=self.CRUSH_RULE
+        )
+        # set the pool to stretch
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'osd', 'pool', 'stretch', 'set',
+            self.POOL, str(self.PEERING_CRUSH_BUCKET_COUNT),
+            str(self.PEERING_CRUSH_BUCKET_TARGET),
+            self.PEERING_CRUSH_BUCKET_BARRIER,
+            self.CRUSH_RULE, str(self.SIZE), str(self.MIN_SIZE))
+        # check if all the mons are connected
+        self.wait_until_true(
+            lambda: all(
+                [
+                    self._check_if_connect([mon1, mon2])
+                    for mon1, mon2 in itertools.combinations(self.MON_LIST, 2)
+                ]
+            ),
+            timeout=self.RECOVERY_PERIOD,
+        )
+
+        # wait for all PGs to become active
+        self.wait_until_true_and_hold(
+            lambda: self._pg_all_active(),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+
+        # Scenario 1: disconnect Site 1 and Site 2
+        # Site 3 is still connected to both Site 1 and Site 2
+        config = ["mon.a", "mon.d"]
+        # disconnect the mons
+        self._disconnect_mons(config)
+        # wait for the mons to be disconnected
+        time.sleep(self.RECOVERY_PERIOD)
+        # check if the mons are disconnected
+        self.wait_until_true(
+            lambda: self._check_if_disconnect(config),
+            timeout=self.RECOVERY_PERIOD,
+        )
+        # check the cluster is accessible
+        self.wait_until_true_and_hold(
+            lambda: self._reply_to_mon_command(),
+            timeout=self.RECOVERY_PERIOD * 5,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+        # reconnect the mons
+        self._reconnect_mons(config)
+        # wait for the mons to be reconnected
+        time.sleep(self.RECOVERY_PERIOD)
+        # check if the mons are reconnected
+        self.wait_until_true(
+            lambda: self._check_if_connect(config),
+            timeout=self.RECOVERY_PERIOD,
+        )
+        # wait for the PGs to recover
+        time.sleep(self.RECOVERY_PERIOD)
+        # check if all PGs are active+clean
+        self.wait_until_true_and_hold(
+            lambda: self._pg_all_active_clean(),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+        log.info("test_mon_netsplit passed!")

--- a/qa/workunits/mon/mon-stretch-pool.sh
+++ b/qa/workunits/mon/mon-stretch-pool.sh
@@ -1,0 +1,148 @@
+#!/bin/bash -ex
+
+# A CLI test for ceph osd pool stretch set and ceph osd pool stretch show.
+# Sets up the cluster with 3 datacenters and 3 hosts in each datacenter
+
+NUM_OSDS_UP=$(ceph osd df | grep "up" | wc -l)
+
+if [ $NUM_OSDS_UP -lt 6 ]; then
+    echo "test requires at least 6 OSDs up and running"
+    exit 1
+fi
+
+function expect_false()
+{
+  # expect the command to return false
+	if "$@"; then return 1; else return 0; fi
+}
+
+function expect_true()
+{
+    # expect the command to return true
+    if "$@"; then return 0; else return 1; fi
+}
+
+function teardown()
+{
+    # cleanup
+    for pool in `ceph osd pool ls`
+    do
+      ceph osd pool rm $pool $pool --yes-i-really-really-mean-it
+    done
+}
+
+for dc in dc1 dc2 dc3
+    do
+      ceph osd crush add-bucket $dc datacenter
+      ceph osd crush move $dc root=default
+    done
+
+ceph osd crush add-bucket node-1 host
+ceph osd crush add-bucket node-2 host
+ceph osd crush add-bucket node-3 host
+ceph osd crush add-bucket node-4 host
+ceph osd crush add-bucket node-5 host
+ceph osd crush add-bucket node-6 host
+ceph osd crush add-bucket node-7 host
+ceph osd crush add-bucket node-8 host
+ceph osd crush add-bucket node-9 host
+
+ceph osd crush move node-1 datacenter=dc1
+ceph osd crush move node-2 datacenter=dc1
+ceph osd crush move node-3 datacenter=dc1
+ceph osd crush move node-4 datacenter=dc2
+ceph osd crush move node-5 datacenter=dc2
+ceph osd crush move node-6 datacenter=dc2
+ceph osd crush move node-7 datacenter=dc3
+ceph osd crush move node-8 datacenter=dc3
+ceph osd crush move node-9 datacenter=dc3
+
+ceph osd crush move osd.0 host=node-1
+ceph osd crush move osd.1 host=node-2
+ceph osd crush move osd.2 host=node-3
+ceph osd crush move osd.3 host=node-4
+ceph osd crush move osd.4 host=node-5
+ceph osd crush move osd.5 host=node-6
+ceph osd crush move osd.6 host=node-7
+ceph osd crush move osd.7 host=node-8
+ceph osd crush move osd.8 host=node-9
+
+ceph mon set_location a datacenter=dc1 host=node-1
+ceph mon set_location b datacenter=dc1 host=node-2
+ceph mon set_location c datacenter=dc1 host=node-3
+ceph mon set_location d datacenter=dc2 host=node-4
+ceph mon set_location e datacenter=dc2 host=node-5
+ceph mon set_location f datacenter=dc2 host=node-6
+ceph mon set_location g datacenter=dc3 host=node-7
+ceph mon set_location h datacenter=dc3 host=node-8
+ceph mon set_location i datacenter=dc3 host=node-9
+
+
+TEST_POOL_STRETCH=pool_stretch
+TEST_CRUSH_RULE=replicated_rule_custom
+
+# Non existence pool should return error
+expect_false ceph osd pool stretch show $TEST_POOL_STRETCH
+
+ceph osd pool create $TEST_POOL_STRETCH 1
+
+# pool must be a stretch pool for this command to show anything.
+expect_false ceph osd pool stretch show $TEST_POOL_STRETCH
+
+# All Argument must present
+expect_false ceph osd pool stretch set $TEST_POOL_STRETCH 2 3 datacenter $TEST_CRUSH_RULE
+# Non existence pool should return error
+expect_false ceph osd pool stretch set non_exist_pool 2 3 datacenter $TEST_CRUSH_RULE 6 3
+# Non existence barrier should return appropriate error
+expect_false ceph osd pool stretch set $TEST_POOL_STRETCH 2 3 non_exist_barrier $TEST_CRUSH_RULE 6 3
+# Non existence crush_rule should return appropriate error
+expect_false ceph osd pool stretch set $TEST_POOL_STRETCH 2 3 datacenter $TEST_CRUSH_RULE 6 3
+# Unsetting a non existence pool should return error
+expect_false ceph osd pool stretch unset non_exist_pool
+# Unsetting a non-stretch pool should return error
+expect_false ceph osd pool stretch unset $TEST_POOL_STRETCH
+
+# Create a custom crush rule
+ceph osd getcrushmap > crushmap
+crushtool --decompile crushmap > crushmap.txt
+sed 's/^# end crush map$//' crushmap.txt > crushmap_modified.txt
+cat >> crushmap_modified.txt << EOF
+rule replicated_rule_custom {
+        id 1
+        type replicated
+        step take default
+        step choose firstn 3 type datacenter
+        step chooseleaf firstn 2 type host
+        step emit
+}
+# end crush map
+EOF
+
+# compile the modified crushmap and set it
+crushtool --compile crushmap_modified.txt -o crushmap.bin
+ceph osd setcrushmap -i crushmap.bin
+
+# Set the election strategy to connectivity
+ceph mon set election_strategy connectivity
+
+# peer_crush_bucket_count > 3 datacenters throws Error EPERM
+expect_false ceph osd pool stretch set $TEST_POOL_STRETCH 4 3 datacenter $TEST_CRUSH_RULE 6 3
+
+# peer_crush_bucket_target > 3 datacenters throws Error EPERM
+expect_false ceph osd pool stretch set $TEST_POOL_STRETCH 2 4 datacenter $TEST_CRUSH_RULE 6 3
+
+# peer_crush_bucket_target > 3 datacenters success when add --yes-i-really-mean-it flag
+expect_true ceph osd pool stretch set $TEST_POOL_STRETCH 2 4 datacenter $TEST_CRUSH_RULE 6 3 --yes-i-really-mean-it
+
+# pool must be a stretch pool for this command to show anything.
+expect_true ceph osd pool stretch set $TEST_POOL_STRETCH 2 3 datacenter $TEST_CRUSH_RULE 6 3
+expect_true ceph osd pool stretch show $TEST_POOL_STRETCH
+
+# Unset the stretch pool and expects it to work
+expect_true ceph osd pool stretch unset $TEST_POOL_STRETCH
+# try to show the stretch pool values again, should return error since
+# the pool is not a stretch pool anymore.
+expect_false ceph osd pool stretch show $TEST_POOL_STRETCH
+
+# cleanup
+teardown

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1194,6 +1194,25 @@ COMMAND("osd pool application get "
         "name=key,type=CephString,req=false",
         "get value of key <key> of application <app> on pool <poolname>",
         "osd", "r")
+COMMAND("osd pool stretch show "
+        "name=pool,type=CephPoolname",
+        "show all the stretch related information for the pool",
+        "osd", "r")
+COMMAND("osd pool stretch set "
+        "name=pool,type=CephPoolname "
+		"name=peering_crush_bucket_count,type=CephInt,range=0 "
+		"name=peering_crush_bucket_target,type=CephInt,range=0 "
+		"name=peering_crush_bucket_barrier,type=CephString "
+		"name=crush_rule,type=CephString "
+		"name=size,type=CephInt,range=0 "
+		"name=min_size,type=CephInt,range=0 "
+		"name=yes_i_really_mean_it,type=CephBool,req=false",
+        "make the pool stretched across the specified number of CRUSH buckets",
+        "osd", "rw")
+COMMAND("osd pool stretch unset "
+		"name=pool,type=CephPoolname",
+		"unset the stretch mode for the pool",
+		"osd", "rw")
 COMMAND("osd utilization",
 	"get basic pg distribution stats",
 	"osd", "r")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6093,6 +6093,62 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
     }
     r = 0;
 
+  } else if (prefix == "osd pool stretch show") {
+    string poolstr;
+    cmd_getval(cmdmap, "pool", poolstr);
+    int64_t pool = osdmap.lookup_pg_pool_name(poolstr);
+    if (pool < 0) {
+      ss << "unrecognized pool '" << poolstr << "'";
+      r = -ENOENT;
+      goto reply;
+    }
+    const pg_pool_t *p = osdmap.get_pg_pool(pool);
+
+    if (!p->is_stretch_pool()) {
+      ss << poolstr << " " << " is not a stretch pool.";
+      r = -ENOENT;
+      goto reply;
+    } else {
+      if (f) {
+        f->open_object_section("pool");
+        f->dump_string("pool", poolstr);
+        f->dump_int("pool_id", pool);
+        f->dump_bool("is_stretch_pool", p->is_stretch_pool());
+        f->dump_int("peering_crush_bucket_count", p->peering_crush_bucket_count);
+        f->dump_int("peering_crush_bucket_target", p->peering_crush_bucket_target);
+        f->dump_string("peering_crush_bucket_barrier", stringify(osdmap.crush->get_type_name(p->peering_crush_bucket_barrier)));
+        if (osdmap.crush->rule_exists(p->get_crush_rule())) {
+          f->dump_string("crush_rule", osdmap.crush->get_rule_name(p->get_crush_rule()));
+        } else {
+          f->dump_string("crush_rule", stringify(p->get_crush_rule()));
+          // warn if the rule does not exist
+          mon.clog->warn() << __func__ << " pool " << poolstr << " crush rule " << stringify(p->get_crush_rule()) << " does not exist";
+        }
+        f->dump_int("size", p->get_size());
+        f->dump_int("min_size", p->get_min_size());
+        f->close_section();
+        f->flush(rdata);
+      } else {
+        stringstream ss;
+        ss << "pool: " << poolstr << "\n";
+        ss << "pool_id: " << pool << "\n";
+        ss << "is_stretch_pool: " << p->is_stretch_pool() << "\n";
+        ss << "peering_crush_bucket_count: " << p->peering_crush_bucket_count << "\n";
+        ss << "peering_crush_bucket_target: " << p->peering_crush_bucket_target << "\n";
+        ss << "peering_crush_bucket_barrier: " << osdmap.crush->get_type_name(p->peering_crush_bucket_barrier) << "\n";
+        if (osdmap.crush->rule_exists(p->get_crush_rule())) {
+          ss << "crush_rule: " << osdmap.crush->get_rule_name(p->get_crush_rule()) << "\n";
+        } else {
+          ss << "crush_rule: " << p->get_crush_rule() << "\n";
+          // warn if the rule does not exist
+          mon.clog->warn() << __func__ << " pool " << poolstr << " crush rule " << stringify(p->get_crush_rule()) << " does not exist";
+        }
+        ss << "size: " << p->get_size() << "\n";
+        ss << "min_size: " << p->get_min_size() << "\n";
+        rdata.append(ss.str());
+      }
+    }
+    r = 0;
   } else if (prefix == "osd pool get") {
     string poolstr;
     cmd_getval(cmdmap, "pool", poolstr);
@@ -9044,6 +9100,149 @@ int OSDMonitor::prepare_command_pool_application(const string &prefix,
                                                  stringstream& ss)
 {
   return _command_pool_application(prefix, cmdmap, ss, nullptr, true);
+}
+
+int OSDMonitor::prepare_command_pool_stretch_set(const cmdmap_t& cmdmap,
+                                                    stringstream& ss)
+{
+  string pool_name;
+  cmd_getval(cmdmap, "pool", pool_name);
+  int64_t pool = osdmap.lookup_pg_pool_name(pool_name);
+  if (pool < 0) {
+    ss << "unrecognized pool '" << pool_name << "'";
+    return -ENOENT;
+  }
+
+  pg_pool_t p = *osdmap.get_pg_pool(pool);
+  if (pending_inc.new_pools.count(pool))
+    p = pending_inc.new_pools[pool];
+
+  int64_t bucket_count = cmd_getval_or<int64_t>(cmdmap, "peering_crush_bucket_count", 0);
+  if (bucket_count <= 0) {
+    ss << "peering_crush_bucket_count must be >= 0! FYI use 'ceph osd pool stretch unset' to unset the stretch values";
+    return -EINVAL;
+  }
+
+  int64_t bucket_target = cmd_getval_or<int64_t>(cmdmap, "peering_crush_bucket_target", 0);
+  if (bucket_target <= 0) {
+    ss << "peering_crush_bucket_target must be >= 0! FYI use 'ceph osd pool stretch unset' to unset the stretch values";
+    return -EINVAL;
+  }
+
+  int bucket_barrier = 0;
+  string bucket_barrier_str;
+  cmd_getval(cmdmap, "peering_crush_bucket_barrier", bucket_barrier_str);
+  CrushWrapper& crush = _get_stable_crush();
+  if (bucket_barrier_str.empty()) {
+    ss << "peering_crush_bucket_barrier must be provided";
+    return -EINVAL;
+  } else {
+    bucket_barrier = crush.get_type_id(bucket_barrier_str);
+    if (bucket_barrier < 0) {
+      ss << "peering_crush_bucket_barrier " << bucket_barrier_str << " does not exist";
+      return -EINVAL;
+    } else if (bucket_barrier == 0) {
+      ss << "peering_crush_bucket_barrier " << bucket_barrier_str << " is not a bucket type";
+      return -EINVAL;
+    }
+  }
+  // Check if the number of peering_crush_bucket_count and peering_crush_bucket_target
+  // exceeds the number of subtrees of the specified bucket_barrier in the cluster.
+  vector<int> subtrees;
+  bool sure = false;
+  crush.get_subtree_of_type(bucket_barrier, &subtrees);
+  cmd_getval(cmdmap, "yes_i_really_mean_it", sure);
+  if (static_cast<uint32_t>(bucket_count) > subtrees.size()) {
+    if (!sure) {
+      ss << "peering_crush_bucket_count=" << bucket_count
+        << " > " << bucket_barrier_str << "=" <<  subtrees.size()
+        << " can lead to data unavailability, pass --yes-i-really-mean-it to proceed";
+      return -EPERM;
+    }
+  } else if (static_cast<uint32_t>(bucket_target) > subtrees.size()) {
+    if (!sure) {
+      ss << "peering_crush_bucket_target=" << bucket_target
+        << " > " << bucket_barrier_str << "=" <<  subtrees.size()
+        << " can lead to data unavailability, pass --yes-i-really-mean-it to proceed";
+      return -EPERM;
+    }
+  }
+
+  string crush_rule_str;
+  cmd_getval(cmdmap, "crush_rule", crush_rule_str);
+  if (crush_rule_str.empty()) {
+    ss << "crush_rule must be provided";
+    return -EINVAL;
+  }
+  int crush_rule = crush.get_rule_id(crush_rule_str);
+  if (crush_rule < 0) {
+    ss << "crush rule " << crush_rule_str << " does not exist";
+    return -ENOENT;
+  }
+  if (!crush.rule_valid_for_pool_type(crush_rule, p.get_type())) {
+    ss << "crush rule " << crush_rule << " type does not match pool";
+    return -EINVAL;
+  }
+  int64_t pool_size = cmd_getval_or<int64_t>(cmdmap, "size", 0);
+  if (pool_size < 0) {
+    ss << "pool size must be non-negative";
+    return -EINVAL;
+  }
+
+  int64_t pool_min_size = cmd_getval_or<int64_t>(cmdmap, "min_size", 0);
+  if (pool_min_size < 0) {
+    ss << "pool min_size must be non-negative";
+    return -EINVAL;
+  }
+
+  p.peering_crush_bucket_count = static_cast<uint32_t>(bucket_count);
+  p.peering_crush_bucket_target = static_cast<uint32_t>(bucket_target);
+  p.peering_crush_bucket_barrier = static_cast<uint32_t>(bucket_barrier);
+  p.crush_rule = static_cast<__u8>(crush_rule);
+  p.size = static_cast<__u8>(pool_size);
+  p.min_size = static_cast<__u8>(pool_min_size);
+  p.last_change = pending_inc.epoch;
+  pending_inc.new_pools[pool] = p;
+  ss << "pool " << pool_name << " stretch values are set successfully";
+  return 0;
+}
+
+int OSDMonitor::prepare_command_pool_stretch_unset(const cmdmap_t& cmdmap,
+                                                    stringstream& ss)
+{
+  /**
+  * Command syntax:
+  *   ceph osd pool stretch unset <pool>
+  */
+  string pool_name;
+  cmd_getval(cmdmap, "pool", pool_name);
+  int64_t pool = osdmap.lookup_pg_pool_name(pool_name);
+  // check if pool exists
+  if (pool < 0) {
+    ss << "unrecognized pool '" << pool_name << "'";
+    return -ENOENT;
+  }
+
+  // get pool
+  pg_pool_t p = *osdmap.get_pg_pool(pool);
+  if (pending_inc.new_pools.count(pool))
+    p = pending_inc.new_pools[pool];
+  
+  // check if pool is a stretch pool
+  if (!p.is_stretch_pool()) {
+    ss << "pool " << pool_name << " is not a stretch pool";
+    return -ENOENT;
+  }
+
+  // unset stretch values
+  p.peering_crush_bucket_count = 0;
+  p.peering_crush_bucket_target = 0;
+  p.peering_crush_bucket_barrier = 0;
+  p.last_change = pending_inc.epoch;
+  pending_inc.new_pools[pool] = p;
+  ss << "pool " << pool_name
+    << " is no longer a stretch pool, all stretch values are unset successfully";
+  return 0;
 }
 
 int OSDMonitor::preprocess_command_pool_application(const string &prefix,
@@ -13902,6 +14101,28 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     } else {
       goto update;
     }
+  } else if (prefix == "osd pool stretch set") {
+    err = prepare_command_pool_stretch_set(cmdmap, ss);
+    if (err == -EAGAIN)
+      goto wait;
+    if (err < 0)
+      goto reply_no_propose;
+
+    getline(ss, rs);
+    wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
+						   get_last_committed() + 1));
+    return true;
+  } else if (prefix == "osd pool stretch unset") {
+    err = prepare_command_pool_stretch_unset(cmdmap, ss);
+    if (err == -EAGAIN)
+      goto wait;
+    if (err < 0)
+      goto reply_no_propose;
+
+    getline(ss, rs);
+    wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
+						   get_last_committed() + 1));
+    return true;
   } else if (prefix == "osd force-create-pg") {
     pg_t pgid;
     string pgidstr;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -735,6 +735,10 @@ public:
                                           const cmdmap_t& cmdmap,
                                           std::stringstream& ss,
                                           bool *modified);
+  int prepare_command_pool_stretch_set(const cmdmap_t& cmdmap,
+                               std::stringstream& ss);
+  int prepare_command_pool_stretch_unset(const cmdmap_t& cmdmap,
+                                std::stringstream& ss);
   int _command_pool_application(const std::string &prefix,
 				const cmdmap_t& cmdmap,
 				std::stringstream& ss,

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1568,6 +1568,7 @@ void pg_pool_t::dump(Formatter *f) const
   f->dump_int("peering_crush_bucket_target", peering_crush_bucket_target);
   f->dump_int("peering_crush_bucket_barrier", peering_crush_bucket_barrier);
   f->dump_int("peering_crush_bucket_mandatory_member", peering_crush_mandatory_member);
+  f->dump_bool("is_stretch_pool", is_stretch_pool());
   f->dump_int("object_hash", get_object_hash());
   f->dump_string("pg_autoscale_mode",
 		 get_pg_autoscale_mode_name(pg_autoscale_mode));


### PR DESCRIPTION
### ATTENTION:
THIS PR SHOULD BE TESTED IN CONJUNCTION WITH https://github.com/ceph/ceph/pull/57381
Recommend merging https://github.com/ceph/ceph/pull/57381 before this PR.



In the command `ceph osd pool stretch set`

```
<pool> <peering_crush_bucket_count>
<peering_crush_bucket_target> <peering_crush_bucket_barrier> <crush_rule> <size> <min_size>
```

user has the option of setting the value of `peering_crush_bucket_{count|target|barrier}`.
This will then allow the utilization `calc_replicated_acting_stretch`,
since with `peering_crush_bucket_count != 0`
the pool is now a stretch_pool and we can handle pg_temp
better by setting barriers and limits to how much OSDs
should be in a `pg_temp`.

This will enable the specify pool to
handle `pg_temp` properly during `create_acting`, as a stretch pool
should.

Users can also use the command:
`osd pool stretch show <pool> `

to show all the stretch related information for the pool

pool: cephfs.a.data
pool_id: 3
is_stretch_pool: 1
peering_crush_bucket_count: 3
peering_crush_bucket_target: 3
peering_crush_bucket_barrier: 8
crush_rule: replicated_rule_custom
size: 3
min_size: 2

Users can also unset the stretch pool with the command:
`osd pool stretch unset <pool>`

However, the pool must be a stretch pool.

Backporting relevant commit(s) from main PR(s):

https://github.com/ceph/ceph/pull/56233

Fixes: https://tracker.ceph.com/issues/64802


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
