### PR TITLE
doc/README.md - add "tip" alert styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,19 +92,20 @@ To build Ceph, follow this procedure:
 
     ``ninja``
 
-   [Ninja](https://ninja-build.org/) is the build system used by the Ceph
-   project to build test builds.  The number of jobs used by `ninja` is 
-   derived from the number of CPU cores of the building host if unspecified. 
-   Use the `-j` option to limit the job number if build jobs are running 
-   out of memory. If you attempt to run `ninja` and receive a message that 
-   reads `g++: fatal error: Killed signal terminated program cc1plus`, then 
-   you have run out of memory.
-
-   Using the `-j` option with an argument appropriate to the hardware on which 
-   the `ninja` command is run is expected to result in a successful build. For
-   example, to limit the job number to 3, run the command `ninja -j 3`. On
-   average, each `ninja` job run in parallel needs approximately 2.5 GiB 
-   of RAM.
+   > [!TIP]
+   > [Ninja](https://ninja-build.org/) is the build system used by the Ceph
+   > project to build test builds.  The number of jobs used by `ninja` is 
+   > derived from the number of CPU cores of the building host if unspecified. 
+   > Use the `-j` option to limit the job number if build jobs are running 
+   > out of memory. If you attempt to run `ninja` and receive a message that 
+   > reads `g++: fatal error: Killed signal terminated program cc1plus`, then 
+   > you have run out of memory.
+   >
+   > Using the `-j` option with an argument appropriate to the hardware on
+   > which the `ninja` command is run is expected to result in a successful
+   > build. For example, to limit the job number to 3, run the command `ninja
+   > -j 3`. On average, each `ninja` job run in parallel needs approximately
+   > 2.5 GiB of RAM.
 
 This documentation assumes that your build directory is a subdirectory of the
 `ceph.git` checkout. If the build directory is located elsewhere, point


### PR DESCRIPTION
Add "tip" alert styling (what in Docbook XML is called "an admonition") to information about Ninja in an ordered list (which is what markdown has here instead of procedures).





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

