### PR TITLE
squid: os/bluestore: Multiple bdev labels on main block device

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4330,6 +4330,30 @@ options:
   flags:
   - create
   with_legacy: true
+- name: bluestore_bdev_label_multi
+  type: bool
+  level: advanced
+  desc: Keep multiple copies of block device label.
+  long_desc: Having multiple labels is only useful in error conditions.
+    The label located at offset 0 has been known to be sometimes overwritten by unknown causes,
+    but without it OSD cannot run.
+  default: true
+  flags:
+  - create
+  with_legacy: false
+- name: bluestore_bdev_label_require_all
+  type: bool
+  level: advanced
+  desc: Require all copies to match.
+  long_desc: Under normal conditions, all copies should be the same.
+    Clearing this flag allows to run OSD if at least one of labels
+    could be properly read.
+  default: true
+  see_also:
+  - bluestore_bdev_label_multi
+  flags:
+  - runtime
+  with_legacy: false
 # whether preallocate space if block/db_path/wal_path is file rather that block device.
 - name: bluestore_block_preallocate_file
   type: bool

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4354,6 +4354,16 @@ options:
   flags:
   - runtime
   with_legacy: false
+- name: bluestore_bdev_label_multi_upgrade
+  type: bool
+  level: advanced
+  desc: Let repair upgrade to multi label.
+  long_desc: By default single label is preserved.
+    Setting this variable before running fsck-repair upgrades single label into multi label.
+  default: false
+  flags:
+  - startup
+  with_legacy: false
 # whether preallocate space if block/db_path/wal_path is file rather that block device.
 - name: bluestore_block_preallocate_file
   type: bool

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5229,12 +5229,6 @@ options:
   level: dev
   default: false
   with_legacy: true
-- name: bluestore_debug_prefill
-  type: float
-  level: dev
-  desc: simulate fragmentation
-  default: 0
-  with_legacy: true
 - name: bluestore_debug_prefragment_max
   type: size
   level: dev

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -546,6 +546,13 @@ uint64_t BlueFS::get_block_device_size(unsigned id) const
   return 0;
 }
 
+BlockDevice* BlueFS::get_block_device(unsigned id) const
+{
+  if (id < bdev.size() && bdev[id])
+    return bdev[id];
+  return nullptr;
+}
+
 void BlueFS::handle_discard(unsigned id, interval_set<uint64_t>& to_release)
 {
   dout(10) << __func__ << " bdev " << id << dendl;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -490,7 +490,7 @@ int BlueFS::add_block_device(unsigned id, const string& path, bool trim,
       break;
     case BDEV_DB:
     case BDEV_NEWDB:
-      reserved = DB_SUPER_RESERVED;
+      reserved = SUPER_RESERVED;
       break;
     case BDEV_SLOW:
       reserved = 0;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -743,6 +743,7 @@ public:
 		       bluefs_shared_alloc_context_t* _shared_alloc = nullptr);
   bool bdev_support_label(unsigned id);
   uint64_t get_block_device_size(unsigned bdev) const;
+  BlockDevice* get_block_device(unsigned bdev) const;
 
   // handler for discard event
   void handle_discard(unsigned dev, interval_set<uint64_t>& to_release);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6838,6 +6838,36 @@ int BlueStore::_check_main_bdev_label()
   return 0;
 }
 
+int BlueStore::read_bdev_label(
+  CephContext* cct, const std::string &path,
+  bluestore_bdev_label_t *label, uint64_t disk_position)
+{
+  unique_ptr<BlockDevice> bdev(BlockDevice::create(
+    cct, path, nullptr, nullptr, nullptr, nullptr));
+  int r = bdev->open(path);
+  if (r < 0)
+    return r;
+  r = BlueStore::_read_bdev_label(
+    cct, bdev.get(), path, label, disk_position);
+  bdev->close();
+  return r;
+}
+int BlueStore::write_bdev_label(
+  CephContext* cct, const std::string &path,
+  const bluestore_bdev_label_t& label, uint64_t disk_position)
+{
+  unique_ptr<BlockDevice> bdev(BlockDevice::create(
+    cct, path, nullptr, nullptr, nullptr, nullptr));
+  int r = bdev->open(path);
+  if (r < 0)
+    return r;
+  r = BlueStore::_write_bdev_label(
+    cct, bdev.get(), path, label, {disk_position});
+  bdev->close();
+  return r;
+}
+
+
 void BlueStore::_set_alloc_sizes(void)
 {
   max_alloc_size = cct->_conf->bluestore_max_alloc_size;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6007,16 +6007,15 @@ int BlueStore::write_meta(const std::string& key, const std::string& value)
 {
   string p = path + "/block";
   if (bdev_label_valid_locations.empty()) {
-    int r = _read_main_bdev_label(cct, p, &bdev_label,
+    _read_main_bdev_label(cct, p, &bdev_label,
       &bdev_label_valid_locations, &bdev_label_multi, &bdev_label_epoch);
-    ceph_assert(r == 0);
   }
   if (!bdev_label_valid_locations.empty()) {
     bdev_label.meta[key] = value;
     if (bdev_label_multi) {
       bdev_label.meta["epoch"] = std::to_string(bdev_label_epoch);
     }
-    int r = _write_bdev_label(cct, p, bdev_label);
+    int r = _write_bdev_label(cct, p, bdev_label, bdev_label_valid_locations);
     ceph_assert(r == 0);
   }
   return ObjectStore::write_meta(key, value);
@@ -6026,9 +6025,8 @@ int BlueStore::read_meta(const std::string& key, std::string *value)
 {
   string p = path + "/block";
   if (bdev_label_valid_locations.empty()) {
-    int r = _read_main_bdev_label(cct, p, &bdev_label,
+    _read_main_bdev_label(cct, p, &bdev_label,
       &bdev_label_valid_locations, &bdev_label_multi, &bdev_label_epoch);
-    ceph_assert(r == 0);
   }
   if (!bdev_label_valid_locations.empty()) {
     auto i = bdev_label.meta.find(key);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6509,10 +6509,7 @@ int BlueStore::_write_bdev_label(
   }
   bl.rebuild_aligned_size_and_memory(BDEV_LABEL_BLOCK_SIZE, BDEV_LABEL_BLOCK_SIZE, IOV_MAX);
   int r = 0;
-  if (std::find(locations.begin(), locations.end(), BDEV_LABEL_POSITION) ==
-      locations.end()) {
-    locations.push_back(BDEV_LABEL_POSITION);
-  }
+  ceph_assert(locations.size() > 0);
   struct stat st;
   r = ::fstat(fd, &st);
   if (r < 0) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7114,9 +7114,6 @@ int BlueStore::_init_alloc(std::map<uint64_t, uint64_t> *zone_adjustments)
       }
     }
   }
-  if (bdev_label_multi) {
-    _main_bdev_label_try_reserve();
-  }
   dout(1) << __func__
           << " loaded " << byte_u_t(bytes) << " in " << num << " extents"
           << std::hex
@@ -7612,6 +7609,10 @@ int BlueStore::_open_db_and_around(bool read_only, bool to_repair)
 
   if (!read_only) {
     _post_init_alloc(zone_adjustments);
+  }
+
+  if (bdev_label_multi) {
+    _main_bdev_label_try_reserve();
   }
 
   // when function is called in repair mode (to_repair=true) we skip db->open()/create()

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6733,7 +6733,6 @@ void BlueStore::_main_bdev_label_try_reserve()
   alloc->foreach(look_for_bdev);
   for (auto& location : accepted_positions) {
     alloc->init_rm_free(location, lsize);
-    bdev_label_valid_locations.push_back(location);
   }
 
   for (size_t i = 0; i < candidate_positions.size(); i++) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6735,6 +6735,7 @@ void BlueStore::_main_bdev_label_try_reserve()
   alloc->foreach(look_for_bdev);
   for (auto& location : accepted_positions) {
     alloc->init_rm_free(location, lsize);
+    bdev_label_valid_locations.push_back(location);
   }
 
   for (size_t i = 0; i < candidate_positions.size(); i++) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6759,7 +6759,7 @@ void BlueStore::_main_bdev_label_remove(Allocator* an_alloc)
 }
 
 int BlueStore::_check_or_set_bdev_label(
-  string path, uint64_t size, string desc, bool create)
+  const string& path, uint64_t size, string desc, bool create)
 {
   bluestore_bdev_label_t label;
   if (create) {
@@ -6787,7 +6787,7 @@ int BlueStore::_check_or_set_bdev_label(
 }
 
 int BlueStore::_check_or_set_main_bdev_label(
-  string path, uint64_t size, bool create)
+  const string& path, uint64_t size, bool create)
 {
   if (create) {
     bdev_label_valid_locations.clear();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6678,8 +6678,12 @@ int BlueStore::_read_main_bdev_label(
             *out_is_multi = true;
           }
           if(out_valid_positions) {
-            out_valid_positions->push_back(position);
+            // clear out old versions
+            out_valid_positions->clear();
           }
+        }
+        if(v == epoch && out_valid_positions) {
+          out_valid_positions->push_back(position);
         }
       }
     } else if (r == 1) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6013,6 +6013,7 @@ int BlueStore::write_meta(const std::string& key, const std::string& value)
   if (!bdev_label_valid_locations.empty()) {
     bdev_label.meta[key] = value;
     if (bdev_label_multi) {
+      bdev_label_epoch++;
       bdev_label.meta["epoch"] = std::to_string(bdev_label_epoch);
     }
     int r = _write_bdev_label(cct, p, bdev_label, bdev_label_valid_locations);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6787,8 +6787,8 @@ int BlueStore::_check_or_set_bdev_label(
 int BlueStore::_check_or_set_main_bdev_label(
   string path, uint64_t size, bool create)
 {
-  bluestore_bdev_label_t label;
   if (create) {
+    bluestore_bdev_label_t label;
     label.osd_uuid = fsid;
     label.size = size;
     label.btime = ceph_clock_now();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11095,7 +11095,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     repaired = repairer.apply(db);
     dout(5) << __func__ << " repair applied" << dendl;
   }
-  if (repair) {
+  if (repair && bdev_labels_in_repair.size() > 0) {
     // Now fix bdev_labels that were detected to be broken & repairable.
     string p = path + "/block";
     _write_bdev_label(cct, p, bdev_label, bdev_labels_in_repair);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10359,6 +10359,15 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
   auto alloc_size = fm->get_alloc_size();
 
   // Delayed action, we could not do it in _fsck().
+  if (repair && !bdev_label_multi &&
+    cct->_conf.get_val<bool>("bluestore_bdev_label_multi_upgrade")) {
+    // upgrade to multi
+    bdev_label.meta["multi"] = "yes";
+    bdev_label.meta["epoch"] = "1";
+    bdev_label_multi = true;
+    bdev_labels_broken.push_back(BDEV_LABEL_POSITION);
+    errors++;
+  }
   if (bdev_label_multi) {
     for (size_t i = 0; i < bdev_label_positions.size(); i++) {
       uint64_t location = bdev_label_positions[i];

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10358,7 +10358,7 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
   if (bdev_label_multi) {
     for (size_t i = 0; i < bdev_label_positions.size(); i++) {
       uint64_t location = bdev_label_positions[i];
-      if (location > bdev->get_size()) {
+      if (location + BDEV_LABEL_BLOCK_SIZE > bdev->get_size()) {
         continue;
       }
       if (std::find(
@@ -10427,11 +10427,13 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
     for (size_t i = 0; i < bdev_label_positions.size(); i++) {
       uint64_t position = bdev_label_positions[i];
       uint64_t length = std::max<uint64_t>(BDEV_LABEL_BLOCK_SIZE, alloc_size);
-      apply_for_bitset_range(position, length, alloc_size, used_blocks,
-        [&](uint64_t pos, mempool_dynamic_bitset& bs) {
-          bs.set(pos);
-        }
-      );
+      if (position + length <= bdev->get_size()) {
+        apply_for_bitset_range(position, length, alloc_size, used_blocks,
+          [&](uint64_t pos, mempool_dynamic_bitset& bs) {
+            bs.set(pos);
+          }
+        );
+      }
     }
   }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6583,7 +6583,7 @@ int BlueStore::_read_bdev_label(
   dout(10) << __func__ << " position=0x" << std::hex << disk_position << std::dec << dendl;
   ceph_assert(bdev);
   bufferlist bl;
-  unique_ptr<char> buf(new char[BDEV_LABEL_BLOCK_SIZE]);
+  unique_ptr<char[]> buf(new char[BDEV_LABEL_BLOCK_SIZE]);
   uint64_t dev_size = bdev->get_size();
   if (dev_size < disk_position + BDEV_LABEL_BLOCK_SIZE) {
     dout(10) << __func__ << " position=0x" << std::hex << disk_position

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8287,22 +8287,6 @@ int BlueStore::mkfs()
       return r; // idempotent
     }
   }
-
-  {
-    string type;
-    r = read_meta("type", &type);
-    if (r == 0) {
-      if (type != "bluestore") {
-	derr << __func__ << " expected bluestore, but type is " << type << dendl;
-	return -EIO;
-      }
-    } else {
-      r = write_meta("type", "bluestore");
-      if (r < 0)
-        return r;
-    }
-  }
-
   r = _open_path();
   if (r < 0)
     return r;
@@ -8355,6 +8339,20 @@ int BlueStore::mkfs()
   r = _open_bdev(true);
   if (r < 0)
     goto out_close_fsid;
+  {
+    string type;
+    r = read_meta("type", &type);
+    if (r == 0) {
+      if (type != "bluestore") {
+	derr << __func__ << " expected bluestore, but type is " << type << dendl;
+	return -EIO;
+      }
+    } else {
+      r = write_meta("type", "bluestore");
+      if (r < 0)
+        return r;
+    }
+  }
 
   freelist_type = "bitmap";
   dout(10) << " freelist_type " << freelist_type << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11388,7 +11388,7 @@ void BlueStore::inject_bluefs_file(std::string_view dir, std::string_view name, 
   auto ret = bluefs->open_for_write(dir, name, &p_handle, false);
   ceph_assert(ret == 0);
 
-  std::string s('0', new_size);
+  std::string s(new_size, '0');
   bufferlist bl;
   bl.append(s);
   p_handle->append(bl);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6006,7 +6006,7 @@ int BlueStore::_set_cache_sizes()
 
 int BlueStore::write_meta(const std::string& key, const std::string& value)
 {
-    if (bdev && !bdev->supported_bdev_label()) {
+  if (!bdev || !bdev->supported_bdev_label()) {
     // skip bdev label section if not supported
     return ObjectStore::write_meta(key, value);
   }
@@ -6029,7 +6029,7 @@ int BlueStore::write_meta(const std::string& key, const std::string& value)
 
 int BlueStore::read_meta(const std::string& key, std::string *value)
 {
-  if (bdev && !bdev->supported_bdev_label()) {
+  if (!bdev || !bdev->supported_bdev_label()) {
     // skip bdev label section if not supported
     return ObjectStore::read_meta(key, value);
   }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2763,10 +2763,14 @@ public:
     return deferred_last_submitted;
   }
 
-  static int _write_bdev_label(CephContext* cct,
-			       const std::string &path, bluestore_bdev_label_t label);
-  static int _read_bdev_label(CephContext* cct, const std::string &path,
-			      bluestore_bdev_label_t *label);
+  static int _write_bdev_label(
+    CephContext* cct,
+    const std::string &path,
+    bluestore_bdev_label_t label,
+    std::vector<uint64_t> locations = std::vector<uint64_t>(BDEV_LABEL_POSITION));
+  static int _read_bdev_label(
+    CephContext* cct, const std::string &path,
+    bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_LABEL_POSITION);
 private:
   int _check_or_set_bdev_label(std::string path, uint64_t size, std::string desc,
 			       bool create);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2766,7 +2766,7 @@ public:
     std::lock_guard l(deferred_lock);
     return deferred_last_submitted;
   }
-
+private:
   static int _write_bdev_label(
     CephContext* cct,
     BlockDevice* bdev,
@@ -2776,7 +2776,6 @@ public:
   static int _read_bdev_label(
     CephContext* cct, BlockDevice* bdev, const std::string &path,
     bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_FIRST_LABEL_POSITION);
-private:
   int _check_or_set_bdev_label(const std::string& path, BlockDevice* bdev, uint64_t size,
                                const std::string& desc, bool create);
   int _set_main_bdev_label();
@@ -3428,6 +3427,12 @@ public:
       return _write_bdev_label(cct, bdev, path, label,
         std::vector<uint64_t>({disk_position}));
     }
+  static int read_bdev_label(
+    CephContext* cct, const std::string &path,
+    bluestore_bdev_label_t *label, uint64_t disk_position = 0);
+  static int write_bdev_label(
+    CephContext* cct, const std::string &path,
+    const bluestore_bdev_label_t& label, uint64_t disk_position = 0);
 
   inline void log_latency(const char* name,
     int idx,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2769,18 +2769,23 @@ public:
 
   static int _write_bdev_label(
     CephContext* cct,
+    BlockDevice* bdev,
     const std::string &path,
     bluestore_bdev_label_t label,
     std::vector<uint64_t> locations = std::vector<uint64_t>({BDEV_FIRST_LABEL_POSITION}));
   static int _read_bdev_label(
-    CephContext* cct, const std::string &path,
+    CephContext* cct, BlockDevice* bdev, const std::string &path,
     bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_FIRST_LABEL_POSITION);
 private:
-  int _check_or_set_bdev_label(const std::string& path, uint64_t size, const std::string& desc,
-			       bool create);
+  int _check_or_set_bdev_label(const std::string& path, BlockDevice* bdev, uint64_t size,
+                               const std::string& desc, bool create);
   int _set_main_bdev_label();
   int _check_main_bdev_label();
-  int _read_main_bdev_label(
+  static int _read_main_bdev_label(
+    CephContext* cct,
+    BlockDevice* bdev,
+    const std::string& path,
+    uuid_d fsid,
     bluestore_bdev_label_t *out_label,
     std::vector<uint64_t>* out_valid_positions = nullptr,
     bool* out_is_cloned = nullptr,
@@ -3413,14 +3418,14 @@ public:
   }
 
   static int debug_read_bdev_label(
-    CephContext* cct, const std::string &path,
+    CephContext* cct, BlockDevice* bdev, const std::string &path,
     bluestore_bdev_label_t *label, uint64_t disk_position) {
-      return _read_bdev_label(cct, path, label, disk_position);
+      return _read_bdev_label(cct, bdev, path, label, disk_position);
     }
   static int debug_write_bdev_label(
-    CephContext* cct, const std::string &path,
+    CephContext* cct, BlockDevice* bdev, const std::string &path,
     const bluestore_bdev_label_t& label, uint64_t disk_position) {
-      return _write_bdev_label(cct, path, label,
+      return _write_bdev_label(cct, bdev, path, label,
         std::vector<uint64_t>({disk_position}));
     }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2440,8 +2440,10 @@ private:
   std::atomic<uint32_t> config_changed = {0}; ///< Counter to determine if there is a configuration change.
 
   // caching of bdev_label
-  bool                   bdev_label_valid = false; // indicator if
-  bluestore_bdev_label_t bdev_label;               // this value is valid
+  bluestore_bdev_label_t bdev_label;                 // this value is valid if
+  std::vector<uint64_t>  bdev_label_valid_locations; // this has any elements
+  bool bdev_label_multi = false;
+  int64_t bdev_label_epoch = -1;
 
   typedef std::map<uint64_t, volatile_statfs> osd_pools_map;
 
@@ -2774,6 +2776,17 @@ public:
 private:
   int _check_or_set_bdev_label(std::string path, uint64_t size, std::string desc,
 			       bool create);
+  int _check_or_set_main_bdev_label(
+    std::string path,
+    uint64_t size,
+    bool create);
+  static int _read_main_bdev_label(
+    CephContext* cct,
+    const std::string &path,
+    bluestore_bdev_label_t *out_label,
+    std::vector<uint64_t>* out_valid_positions = nullptr,
+    bool* out_is_cloned = nullptr,
+    int64_t* out_epoch = nullptr);
   int _set_bdev_label_size(const std::string& path, uint64_t size);
 
   int _open_super_meta();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2780,14 +2780,14 @@ private:
                                const std::string& desc, bool create);
   int _set_main_bdev_label();
   int _check_main_bdev_label();
-  static int _read_main_bdev_label(
+  static int _read_multi_bdev_label(
     CephContext* cct,
     BlockDevice* bdev,
     const std::string& path,
     uuid_d fsid,
     bluestore_bdev_label_t *out_label,
     std::vector<uint64_t>* out_valid_positions = nullptr,
-    bool* out_is_cloned = nullptr,
+    bool* out_is_multi = nullptr,
     int64_t* out_epoch = nullptr);
   int _set_bdev_label_size(const std::string& path, uint64_t size);
   void _main_bdev_label_try_reserve();
@@ -3428,8 +3428,12 @@ public:
         std::vector<uint64_t>({disk_position}));
     }
   static int read_bdev_label(
-    CephContext* cct, const std::string &path,
-    bluestore_bdev_label_t *label, uint64_t disk_position = 0);
+    CephContext* cct,
+    const std::string &path,
+    bluestore_bdev_label_t *out_label,
+    std::vector<uint64_t>* out_valid_positions = nullptr,
+    bool* out_is_cloned = nullptr,
+    int64_t* out_epoch = nullptr);
   static int write_bdev_label(
     CephContext* cct, const std::string &path,
     const bluestore_bdev_label_t& label, uint64_t disk_position = 0);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2770,7 +2770,7 @@ public:
     CephContext* cct,
     const std::string &path,
     bluestore_bdev_label_t label,
-    std::vector<uint64_t> locations = std::vector<uint64_t>(BDEV_LABEL_POSITION));
+    std::vector<uint64_t> locations = std::vector<uint64_t>({BDEV_LABEL_POSITION}));
   static int _read_bdev_label(
     CephContext* cct, const std::string &path,
     bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_LABEL_POSITION);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2771,12 +2771,12 @@ public:
     CephContext* cct,
     const std::string &path,
     bluestore_bdev_label_t label,
-    std::vector<uint64_t> locations = std::vector<uint64_t>({BDEV_LABEL_POSITION}));
+    std::vector<uint64_t> locations = std::vector<uint64_t>({BDEV_FIRST_LABEL_POSITION}));
   static int _read_bdev_label(
     CephContext* cct, const std::string &path,
-    bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_LABEL_POSITION);
+    bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_FIRST_LABEL_POSITION);
 private:
-  int _check_or_set_bdev_label(const std::string& path, uint64_t size, std::string desc,
+  int _check_or_set_bdev_label(const std::string& path, uint64_t size, const std::string& desc,
 			       bool create);
   int _set_main_bdev_label();
   int _check_main_bdev_label();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2778,13 +2778,9 @@ public:
 private:
   int _check_or_set_bdev_label(const std::string& path, uint64_t size, std::string desc,
 			       bool create);
-  int _check_or_set_main_bdev_label(
-    const std::string& path,
-    uint64_t size,
-    bool create);
-  static int _read_main_bdev_label(
-    CephContext* cct,
-    const std::string &path,
+  int _set_main_bdev_label();
+  int _check_main_bdev_label();
+  int _read_main_bdev_label(
     bluestore_bdev_label_t *out_label,
     std::vector<uint64_t>* out_valid_positions = nullptr,
     bool* out_is_cloned = nullptr,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3412,6 +3412,18 @@ public:
     _wctx_finish(&txc, c, o, &wctx, nullptr);
   }
 
+  static int debug_read_bdev_label(
+    CephContext* cct, const std::string &path,
+    bluestore_bdev_label_t *label, uint64_t disk_position) {
+      return _read_bdev_label(cct, path, label, disk_position);
+    }
+  static int debug_write_bdev_label(
+    CephContext* cct, const std::string &path,
+    const bluestore_bdev_label_t& label, uint64_t disk_position) {
+      return _write_bdev_label(cct, path, label,
+        std::vector<uint64_t>({disk_position}));
+    }
+
   inline void log_latency(const char* name,
     int idx,
     const ceph::timespan& lat,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2445,6 +2445,7 @@ private:
   std::vector<uint64_t>  bdev_label_valid_locations; // this has any elements
   bool bdev_label_multi = false;
   int64_t bdev_label_epoch = -1;
+  bool bluestore_bdev_label_require_all = false;
 
   typedef std::map<uint64_t, volatile_statfs> osd_pools_map;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2775,10 +2775,10 @@ public:
     CephContext* cct, const std::string &path,
     bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_LABEL_POSITION);
 private:
-  int _check_or_set_bdev_label(std::string path, uint64_t size, std::string desc,
+  int _check_or_set_bdev_label(const std::string& path, uint64_t size, std::string desc,
 			       bool create);
   int _check_or_set_main_bdev_label(
-    std::string path,
+    const std::string& path,
     uint64_t size,
     bool create);
   static int _read_main_bdev_label(

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2439,6 +2439,10 @@ private:
   double max_defer_interval = 0; ///< Time to wait between last deferred submit
   std::atomic<uint32_t> config_changed = {0}; ///< Counter to determine if there is a configuration change.
 
+  // caching of bdev_label
+  bool                   bdev_label_valid = false; // indicator if
+  bluestore_bdev_label_t bdev_label;               // this value is valid
+
   typedef std::map<uint64_t, volatile_statfs> osd_pools_map;
 
   ceph::mutex vstatfs_lock = ceph::make_mutex("BlueStore::vstatfs_lock");

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -52,6 +52,7 @@
 #include "os/ObjectStore.h"
 
 #include "bluestore_types.h"
+#include "bluestore_common.h"
 #include "BlueFS.h"
 #include "common/EventTrace.h"
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3352,6 +3352,9 @@ public:
   KeyValueDB* get_kv() {
     return db;
   }
+  BlockDevice* get_bdev() {
+    return bdev;
+  }
 
   int queue_transactions(
     CollectionHandle& ch,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2776,7 +2776,7 @@ private:
   static int _read_bdev_label(
     CephContext* cct, BlockDevice* bdev, const std::string &path,
     bluestore_bdev_label_t *label, uint64_t disk_position = BDEV_FIRST_LABEL_POSITION);
-  int _check_or_set_bdev_label(const std::string& path, BlockDevice* bdev, uint64_t size,
+  int _check_or_set_bdev_label(BlockDevice* bdev, const std::string& path,
                                const std::string& desc, bool create);
   int _set_main_bdev_label();
   int _check_main_bdev_label();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2788,6 +2788,8 @@ private:
     bool* out_is_cloned = nullptr,
     int64_t* out_epoch = nullptr);
   int _set_bdev_label_size(const std::string& path, uint64_t size);
+  void _main_bdev_label_try_reserve();
+  void _main_bdev_label_remove(Allocator* alloc);
 
   int _open_super_meta();
 

--- a/src/os/bluestore/bluestore_common.h
+++ b/src/os/bluestore/bluestore_common.h
@@ -65,7 +65,8 @@ struct Int64ArrayMergeOperator : public KeyValueDB::MergeOperator {
 // write a label in the first block.  always use this size.  note that
 // bluefs makes a matching assumption about the location of its
 // superblock (always the second block of the device).
-#define BDEV_LABEL_BLOCK_SIZE  4096
+static constexpr uint64_t BDEV_LABEL_POSITION = 0;
+static constexpr uint64_t BDEV_LABEL_BLOCK_SIZE = 4096;
 
 // reserved for standalone DB volume:
 // label (4k) + bluefs super (4k), which means we start at 8k.

--- a/src/os/bluestore/bluestore_common.h
+++ b/src/os/bluestore/bluestore_common.h
@@ -65,7 +65,7 @@ struct Int64ArrayMergeOperator : public KeyValueDB::MergeOperator {
 // write a label in the first block.  always use this size.  note that
 // bluefs makes a matching assumption about the location of its
 // superblock (always the second block of the device).
-static constexpr uint64_t BDEV_LABEL_POSITION = 0;
+static constexpr uint64_t BDEV_FIRST_LABEL_POSITION = 0;
 static constexpr uint64_t BDEV_LABEL_BLOCK_SIZE = 4096;
 
 // reserved for standalone DB volume:

--- a/src/os/bluestore/bluestore_common.h
+++ b/src/os/bluestore/bluestore_common.h
@@ -70,7 +70,9 @@ static constexpr uint64_t BDEV_LABEL_BLOCK_SIZE = 4096;
 
 // reserved for standalone DB volume:
 // label (4k) + bluefs super (4k), which means we start at 8k.
-#define DB_SUPER_RESERVED  (BDEV_LABEL_BLOCK_SIZE + 4096)
+static constexpr uint64_t BLUEFS_SUPER_POSITION = 4096;
+static constexpr uint64_t BLUEFS_SUPER_BLOCK_SIZE = 4096;
+static constexpr uint64_t SUPER_RESERVED = BDEV_LABEL_BLOCK_SIZE + BLUEFS_SUPER_BLOCK_SIZE;
 
 
 #endif

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -79,7 +79,7 @@ const char* find_device_path(
 {
   for (auto& i : devs) {
     bluestore_bdev_label_t label;
-    int r = BlueStore::_read_bdev_label(cct, i, &label);
+    int r = BlueStore::read_bdev_label(cct, i, &label);
     if (r < 0) {
       cerr << "unable to read label for " << i << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -111,7 +111,7 @@ void parse_devices(
   }
   for (auto& d : devs) {
     bluestore_bdev_label_t label;
-    int r = BlueStore::_read_bdev_label(cct, d, &label);
+    int r = BlueStore::read_bdev_label(cct, d, &label);
     if (r < 0) {
       cerr << "unable to read label for " << d << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -625,7 +625,7 @@ int main(int argc, char **argv)
   }
   else if (action == "prime-osd-dir") {
     bluestore_bdev_label_t label;
-    int r = BlueStore::_read_bdev_label(cct.get(), devs.front(), &label);
+    int r = BlueStore::read_bdev_label(cct.get(), devs.front(), &label);
     if (r < 0) {
       cerr << "failed to read label for " << devs.front() << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -679,7 +679,7 @@ int main(int argc, char **argv)
     jf.open_object_section("devices");
     for (auto& i : devs) {
       bluestore_bdev_label_t label;
-      int r = BlueStore::_read_bdev_label(cct.get(), i, &label);
+      int r = BlueStore::read_bdev_label(cct.get(), i, &label);
       if (r < 0) {
 	cerr << "unable to read label for " << i << ": "
 	     << cpp_strerror(r) << std::endl;
@@ -694,7 +694,7 @@ int main(int argc, char **argv)
   }
   else if (action == "set-label-key") {
     bluestore_bdev_label_t label;
-    int r = BlueStore::_read_bdev_label(cct.get(), devs.front(), &label);
+    int r = BlueStore::read_bdev_label(cct.get(), devs.front(), &label);
     if (r < 0) {
       cerr << "unable to read label for " << devs.front() << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -716,7 +716,7 @@ int main(int argc, char **argv)
     } else {
       label.meta[key] = value;
     }
-    r = BlueStore::_write_bdev_label(cct.get(), devs.front(), label);
+    r = BlueStore::write_bdev_label(cct.get(), devs.front(), label);
     if (r < 0) {
       cerr << "unable to write label for " << devs.front() << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -725,7 +725,7 @@ int main(int argc, char **argv)
   }
   else if (action == "rm-label-key") {
     bluestore_bdev_label_t label;
-    int r = BlueStore::_read_bdev_label(cct.get(), devs.front(), &label);
+    int r = BlueStore::read_bdev_label(cct.get(), devs.front(), &label);
     if (r < 0) {
       cerr << "unable to read label for " << devs.front() << ": "
 	   << cpp_strerror(r) << std::endl;
@@ -736,7 +736,7 @@ int main(int argc, char **argv)
       exit(EXIT_FAILURE);
     }
     label.meta.erase(key);
-    r = BlueStore::_write_bdev_label(cct.get(), devs.front(), label);
+    r = BlueStore::write_bdev_label(cct.get(), devs.front(), label);
     if (r < 0) {
       cerr << "unable to write label for " << devs.front() << ": "
 	   << cpp_strerror(r) << std::endl;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -10693,6 +10693,10 @@ TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionWithObjects) {
     }
   }
   umount();
+  // Need to do 2 passes of repair:
+  // - the first one moves offending objects away
+  // - the second can then fix bdev labels
+  store->repair(false);
   ASSERT_EQ(store->repair(false), 0);
   ASSERT_EQ(store->fsck(false), 0);
   bluestore_bdev_label_t label;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -221,12 +221,24 @@ class MultiLabelTest : public StoreTestDeferredSetup {
   }
   bool read_bdev_label(bluestore_bdev_label_t* label, uint64_t position) {
     string bdev_path = get_data_dir() + "/block";
-    int r = BlueStore::read_bdev_label(g_ceph_context, bdev_path, label, position);
+    unique_ptr<BlockDevice> bdev(BlockDevice::create(
+      g_ceph_context, bdev_path, nullptr, nullptr, nullptr, nullptr));
+    int r = bdev->open(bdev_path);
+    if (r < 0)
+      return r;
+    r = BlueStore::debug_read_bdev_label(g_ceph_context, bdev.get(), bdev_path, label, position);
+    bdev->close();
     return r;
   }
   bool write_bdev_label(const bluestore_bdev_label_t& label, uint64_t position) {
     string bdev_path = get_data_dir() + "/block";
-    int r = BlueStore::write_bdev_label(g_ceph_context, bdev_path, label, position);
+    unique_ptr<BlockDevice> bdev(BlockDevice::create(
+      g_ceph_context, bdev_path, nullptr, nullptr, nullptr, nullptr));
+    int r = bdev->open(bdev_path);
+    if (r < 0)
+      return r;
+    r = BlueStore::debug_write_bdev_label(g_ceph_context, bdev.get(), bdev_path, label, position);
+    bdev->close();
     return r;
   }
   protected:

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -10647,7 +10647,7 @@ TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionWithBlueFS) {
   ASSERT_EQ(label.meta["multi"], "yes");
 }
 
-TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionObjects) {
+TEST_P(MultiLabelTest, UpgradeToMultiLabelCollisionWithObjects) {
   static constexpr uint64_t _1G = uint64_t(1024)*1024*1024;
   static constexpr uint64_t _1M = uint64_t(1)*1024*1024;
   SetVal(g_conf(), "bluestore_block_db_create", "true");

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -10398,7 +10398,6 @@ TEST_P(MultiLabelTest, MultiSelectableOff) {
   int r = read_bdev_label(&label, 0);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(label.meta.end(), label.meta.find("multi"));
-  mount();
 }
 
 TEST_P(MultiLabelTest, MultiSelectableOn) {
@@ -10415,7 +10414,6 @@ TEST_P(MultiLabelTest, MultiSelectableOn) {
   auto it = label.meta.find("multi");
   ASSERT_NE(label.meta.end(), it);
   ASSERT_EQ(it->second, "yes");
-  mount();
 }
 
 TEST_P(MultiLabelTest, DetectCorruptedFirst) {
@@ -10447,7 +10445,7 @@ TEST_P(MultiLabelTest, FixCorruptedFirst) {
   ASSERT_EQ(corrupt, true);
   ASSERT_EQ(store->fsck(false), 1);
   ASSERT_EQ(store->repair(false), 0);
-  mount();
+  ASSERT_EQ(store->fsck(false), 0);
 }
 
 TEST_P(MultiLabelTest, FixCorruptedTwo) {
@@ -10467,7 +10465,7 @@ TEST_P(MultiLabelTest, FixCorruptedTwo) {
   ASSERT_EQ(corrupt, true);
   ASSERT_EQ(store->fsck(false), 2);
   ASSERT_EQ(store->repair(false), 0);
-  mount();
+  ASSERT_EQ(store->fsck(false), 0);
 }
 
 TEST_P(MultiLabelTest, FixCorruptedThree) {
@@ -10489,7 +10487,7 @@ TEST_P(MultiLabelTest, FixCorruptedThree) {
   ASSERT_EQ(corrupt, true);
   ASSERT_EQ(store->fsck(false), 3);
   ASSERT_EQ(store->repair(false), 0);
-  mount();
+  ASSERT_EQ(store->fsck(false), 0);
 }
 
 TEST_P(MultiLabelTest, CantFixCorruptedAll) {
@@ -10513,6 +10511,7 @@ TEST_P(MultiLabelTest, CantFixCorruptedAll) {
   ASSERT_EQ(corrupt, true);
   ASSERT_NE(store->fsck(false), 0);
   ASSERT_NE(store->repair(false), 0);
+  ASSERT_NE(store->fsck(false), 0);
 }
 
 TEST_P(MultiLabelTest, SkipInvalidUUID) {
@@ -10539,6 +10538,7 @@ TEST_P(MultiLabelTest, SkipInvalidUUID) {
 
   ASSERT_EQ(store->fsck(false), 1);
   ASSERT_EQ(store->repair(false), 0);
+  ASSERT_EQ(store->fsck(false), 0);
   mount();
 }
 

--- a/src/test/objectstore/store_test_fixture.cc
+++ b/src/test/objectstore/store_test_fixture.cc
@@ -129,3 +129,7 @@ void StoreTestFixture::CloseAndReopen() {
   ASSERT_EQ(0, store->mount());
   g_conf().set_safe_to_start_threads();
 }
+
+void StoreTestFixture::RemoveTestObjectStore() {
+  rm_r(data_dir);
+}

--- a/src/test/objectstore/store_test_fixture.h
+++ b/src/test/objectstore/store_test_fixture.h
@@ -8,10 +8,12 @@ class ObjectStore;
 
 class StoreTestFixture : virtual public ::testing::Test {
   const std::string type;
-  const std::string data_dir;
 
   std::stack<std::pair<std::string, std::string>> saved_settings;
   ConfigProxy* conf = nullptr;
+
+protected:
+  const std::string data_dir;
 
 public:
   std::unique_ptr<ObjectStore> store;
@@ -41,4 +43,11 @@ public:
   }
   void PopSettings(size_t);
   void CloseAndReopen();
+  void RemoveTestObjectStore();
+  const std::string get_type() const {
+    return type;
+  }
+  const std::string get_data_dir() const {
+    return data_dir;
+  }
 };

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -107,8 +107,8 @@ TEST(BlueFS, mkfs_mount) {
   ASSERT_EQ(0, fs.mkfs(fsid, { BlueFS::BDEV_DB, false, false }));
   ASSERT_EQ(0, fs.mount());
   ASSERT_EQ(0, fs.maybe_verify_layout({ BlueFS::BDEV_DB, false, false }));
-  ASSERT_EQ(fs.get_total(BlueFS::BDEV_DB), size - DB_SUPER_RESERVED);
-  ASSERT_LT(fs.get_free(BlueFS::BDEV_DB), size - DB_SUPER_RESERVED);
+  ASSERT_EQ(fs.get_total(BlueFS::BDEV_DB), size - SUPER_RESERVED);
+  ASSERT_LT(fs.get_free(BlueFS::BDEV_DB), size - SUPER_RESERVED);
   fs.umount();
 }
 


### PR DESCRIPTION

backport tracker: https://tracker.ceph.com/issues/67454

backport of #55374
parent tracker: https://tracker.ceph.com/issues/67451

This backport was manually created.
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
