### PR TITLE
quincy: osd/TrackedOp: Fix TrackedOp event order

### DIFF
--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -191,8 +191,8 @@ public:
     typename T::Ref retval(new T(params, this));
     retval->tracking_start();
     if (is_tracking()) {
-      retval->mark_event("throttled", params->get_throttle_stamp());
       retval->mark_event("header_read", params->get_recv_stamp());
+      retval->mark_event("throttled", params->get_throttle_stamp());
       retval->mark_event("all_read", params->get_recv_complete_stamp());
       retval->mark_event("dispatched", params->get_dispatch_stamp());
     }

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -31,7 +31,7 @@ using std::stringstream;
 using ceph::Formatter;
 
 OpRequest::OpRequest(Message* req, OpTracker* tracker)
-    : TrackedOp(tracker, req->get_throttle_stamp()),
+    : TrackedOp(tracker, req->get_recv_stamp()),
       request(req),
       hit_flag_points(0),
       latest_flag_point(0),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61396

---

backport of https://github.com/ceph/ceph/pull/51668
parent tracker: https://tracker.ceph.com/issues/61388

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh