### PR TITLE
 msg: simplify ProtocolV1 for the sake of buffferlist's const-correctness 

### DIFF
--- a/src/crimson/net/io_handler.cc
+++ b/src/crimson/net/io_handler.cc
@@ -1039,8 +1039,15 @@ IOHandler::read_message(
     ceph_msg_footer footer{ceph_le32(0), ceph_le32(0),
                            ceph_le32(0), ceph_le64(0), current_header.flags};
 
-    Message *message = decode_message(nullptr, 0, header, footer,
-        msg_frame.front(), msg_frame.middle(), msg_frame.data(), nullptr);
+    Message *message = decode_message(
+        nullptr,
+        0,
+        header,
+        footer,
+        std::move(msg_frame.front()),
+        std::move(msg_frame.middle()),
+        std::as_const(msg_frame.data()),
+        nullptr);
     if (!message) {
       logger().warn("{} decode message failed", conn);
       abort_in_fault();

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4831,7 +4831,7 @@ void Monitor::handle_ping(MonOpRequestRef op)
   stringstream ss;
   f->flush(ss);
   encode(ss.str(), payload);
-  reply->set_payload(payload);
+  reply->set_payload(std::move(payload));
   dout(10) << __func__ << " reply payload len " << reply->get_payload().length() << dendl;
   m->get_connection()->send_message(reply);
 }

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -311,9 +311,9 @@ Message *decode_message(CephContext *cct,
                         int crcflags,
                         ceph_msg_header& header,
                         ceph_msg_footer& footer,
-                        ceph::bufferlist& front,
-                        ceph::bufferlist& middle,
-                        ceph::bufferlist& data,
+                        ceph::bufferlist&& front,
+                        ceph::bufferlist&& middle,
+                        const ceph::bufferlist& data,
                         Message::ConnectionRef conn)
 {
 #ifdef WITH_SEASTAR
@@ -980,8 +980,8 @@ Message *decode_message(CephContext *cct,
   m->set_connection(std::move(conn));
   m->set_header(header);
   m->set_footer(footer);
-  m->set_payload(front);
-  m->set_middle(middle);
+  m->set_payload(std::move(front));
+  m->set_middle(std::move(middle));
   m->set_data(data);
 
   try {
@@ -1101,5 +1101,5 @@ Message *decode_message(CephContext *cct, int crcflags, ceph::bufferlist::const_
   decode(fr, p);
   decode(mi, p);
   decode(da, p);
-  return decode_message(cct, crcflags, h, f, fr, mi, da, nullptr);
+  return decode_message(cct, crcflags, h, f, std::move(fr), std::move(mi), std::move(da), nullptr);
 }

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -420,7 +420,7 @@ public:
   bool empty_payload() const { return payload.length() == 0; }
   ceph::buffer::list& get_payload() { return payload; }
   const ceph::buffer::list& get_payload() const { return payload; }
-  void set_payload(ceph::buffer::list& bl) {
+  void set_payload(ceph::buffer::list&& bl) {
     if (byte_throttler)
       byte_throttler->put(payload.length());
     payload = std::move(bl);
@@ -428,7 +428,7 @@ public:
       byte_throttler->take(payload.length());
   }
 
-  void set_middle(ceph::buffer::list& bl) {
+  void set_middle(ceph::buffer::list&& bl) {
     if (byte_throttler)
       byte_throttler->put(middle.length());
     middle = std::move(bl);
@@ -549,9 +549,9 @@ extern Message *decode_message(CephContext *cct,
                                int crcflags,
                                ceph_msg_header& header,
                                ceph_msg_footer& footer,
-                               ceph::buffer::list& front,
-                               ceph::buffer::list& middle,
-                               ceph::buffer::list& data,
+                               ceph::buffer::list&& front,
+                               ceph::buffer::list&& middle,
+                               const ceph::buffer::list& data,
                                Message::ConnectionRef conn);
 inline std::ostream& operator<<(std::ostream& out, const Message& m) {
   m.print(out);

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -931,8 +931,14 @@ CtPtr ProtocolV1::handle_message_footer(char *buffer, int r) {
   ldout(cct, 20) << __func__ << " got " << front.length() << " + "
                  << middle.length() << " + " << data.length() << " byte message"
                  << dendl;
-  Message *message = decode_message(cct, messenger->crcflags, current_header,
-                                    footer, front, middle, data, connection);
+  Message *message = decode_message(cct,
+                                    messenger->crcflags,
+                                    current_header,
+                                    footer,
+                                    std::move(front),
+                                    std::move(middle),
+                                    std::move(data),
+                                    connection);
   if (!message) {
     ldout(cct, 1) << __func__ << " decode message failed " << dendl;
     return _fault();

--- a/src/msg/async/ProtocolV1.h
+++ b/src/msg/async/ProtocolV1.h
@@ -126,18 +126,15 @@ protected:
   // Open state
   ceph_msg_connect connect_msg;
   ceph_msg_connect_reply connect_reply;
-  ceph::buffer::list authorizer_buf;  // auth(orizer) payload read off the wire
+  ceph::buffer::ptr authorizer_buf;  // auth(orizer) payload read off the wire
   ceph::buffer::list authorizer_more;  // connect-side auth retry (we added challenge)
 
   utime_t backoff;  // backoff time
   utime_t recv_stamp;
   utime_t throttle_stamp;
-  unsigned msg_left;
   uint64_t cur_msg_size;
   ceph_msg_header current_header;
-  ceph::buffer::list data_buf;
-  ceph::buffer::list::iterator data_blp;
-  ceph::buffer::list front, middle, data;
+  ceph::buffer::ptr front, middle, data;
 
   bool replacing;  // when replacing process happened, we will reply connect
                    // side with RETRY tag and accept side will clear replaced
@@ -170,7 +167,6 @@ protected:
   CONTINUATION_DECL(ProtocolV1, throttle_dispatch_queue);
   READ_HANDLER_CONTINUATION_DECL(ProtocolV1, handle_message_front);
   READ_HANDLER_CONTINUATION_DECL(ProtocolV1, handle_message_middle);
-  CONTINUATION_DECL(ProtocolV1, read_message_data);
   READ_HANDLER_CONTINUATION_DECL(ProtocolV1, handle_message_data);
   READ_HANDLER_CONTINUATION_DECL(ProtocolV1, handle_message_footer);
 
@@ -191,7 +187,6 @@ protected:
   CtPtr handle_message_front(char *buffer, int r);
   CtPtr read_message_middle();
   CtPtr handle_message_middle(char *buffer, int r);
-  CtPtr read_message_data_prepare();
   CtPtr read_message_data();
   CtPtr handle_message_data(char *buffer, int r);
   CtPtr read_message_footer();

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1398,8 +1398,8 @@ CtPtr ProtocolV2::handle_message() {
 	                 ceph_le32(0), ceph_le64(0), current_header.flags};
 
   Message *message = decode_message(cct, 0, header, footer,
-      msg_frame.front(),
-      msg_frame.middle(),
+      std::move(msg_frame.front()),
+      std::move(msg_frame.middle()),
       msg_frame.data(),
       connection);
   if (!message) {


### PR DESCRIPTION
The patch removes the leftover complexity after abandoning the `rx_buffers` optimization around 2018, particularly the calls to `get_current_ptr()`. This enabled switching out from `bufferlist` to `bufferptr` for message's buffers which is also a part of the commit.

Although simplifying the things, the main rationale is going towards `bufferlist` with tight restrictions on modifying stored data, and thus enabling e.g. deduplication of padding zeros. This in turn can be very interesting for some further optimizations of EC support which have in common increasing the chunk size.

Currently `bufferlist` allows to mess its content and cause crosstalks through at least two mechanisms:

  * the `bufferlist::c_str()` returning non-`const` pointer to `char`,
  * the iterator's `get_current_ptr()` returning a writable bptr,
  * the iterator's `copy_in()`.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
