### PR TITLE
rgw/rados: zero-init shard_count in RGWBucket::check_index_unlinked()

### DIFF
--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -953,7 +953,7 @@ int RGWBucket::check_index_unlinked(rgw::sal::RadosStore* const rados_store,
         if (shard >= max_shards) {
           return;
         }
-        uint64_t shard_count;
+        uint64_t shard_count = 0;
         int r = ::check_index_unlinked(rados_store, &*bucket, dpp, op_state, flusher, shard, &shard_count, yield);
         if (r < 0) {
           ldpp_dout(dpp, -1) << "ERROR: error processing shard " << shard << 


### PR DESCRIPTION
> rgw_bucket.cc:962:19: warning: ‘shard_count’ may be used uninitialized [-Wmaybe-uninitialized]

Fixes: https://tracker.ceph.com/issues/67468

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
