### PR TITLE
reef: [RGW] Fix the handling of HEAD requests that do not comply with RFC standards

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -394,6 +394,10 @@ void dump_content_length(req_state* const s, const uint64_t len)
 
 static void dump_chunked_encoding(req_state* const s)
 {
+  // omit transfer-encoding for HEAD requests so ChunkingFilter doesn't
+  // try to write the final chunk
+  if(s->op == OP_HEAD)
+    return;
   try {
     RESTFUL_IO(s)->send_chunked_transfer_encoding();
   } catch (rgw::io::Exception& e) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67100

---

backport of https://github.com/ceph/ceph/pull/58572
parent tracker: https://tracker.ceph.com/issues/66938

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh