### PR TITLE
reef: rgw/lua: add more info on package install errors

### DIFF
--- a/src/rgw/rgw_appmain.cc
+++ b/src/rgw/rgw_appmain.cc
@@ -539,7 +539,7 @@ void rgw::AppMain::init_lua()
   r = rgw::lua::install_packages(dpp, driver, null_yield, path,
                                  failed_packages, output);
   if (r < 0) {
-    dout(1) << "WARNING: failed to install lua packages from allowlist"
+    dout(1) << "WARNING: failed to install lua packages from allowlist. error: " << r
             << dendl;
   }
   if (!output.empty()) {

--- a/src/rgw/rgw_lua.cc
+++ b/src/rgw/rgw_lua.cc
@@ -162,7 +162,7 @@ int install_packages(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver,
   if (std::filesystem::remove_all(luarocks_path, ec)
       == static_cast<std::uintmax_t>(-1) &&
       ec != std::errc::no_such_file_or_directory) {
-    output.append("failed to clear luarock directory: ");
+    output.append("failed to clear luarocks directory: ");
     output.append(ec.message());
     output.append("\n");
     return ec.value();
@@ -175,11 +175,13 @@ int install_packages(const DoutPrefixProvider *dpp, rgw::sal::Driver* driver,
     return 0;
   }
   if (ret < 0) {
+    output.append("failed to get lua package list");
     return ret;
   }
   // verify that luarocks exists
   const auto p = bp::search_path("luarocks");
   if (p.empty()) {
+    output.append("failed to find luarocks");
     return -ECHILD;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61191

---

backport of https://github.com/ceph/ceph/pull/51415
parent tracker: https://tracker.ceph.com/issues/59698

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh