### PR TITLE
reef: mgr: do not require NOTIFY_TYPES in python modules

### DIFF
--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -515,8 +515,8 @@ int PyModule::load_notify_types()
 {
   PyObject *ls = PyObject_GetAttrString(pClass, "NOTIFY_TYPES");
   if (ls == nullptr) {
-    derr << "Module " << get_name() << " has missing NOTIFY_TYPES member" << dendl;
-    return -EINVAL;
+    dout(10) << "Module " << get_name() << " has no NOTIFY_TYPES member" << dendl;
+    return 0;
   }
   if (!PyObject_TypeCheck(ls, &PyList_Type)) {
     // Relatively easy mistake for human to make, e.g. defining COMMANDS


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66431

---

backport of https://github.com/ceph/ceph/pull/57106
parent tracker: https://tracker.ceph.com/issues/55835

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh