### PR TITLE
reef: osd/ECTransaction: Remove incorrect asserts in generate_transactions

### DIFF
--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -204,9 +204,6 @@ void ECTransaction::generate_transactions(
       xattr_rollback[ECUtil::get_hinfo_key()] = old_hinfo;
 
       if (op.is_none() && op.truncate && op.truncate->first == 0) {
-	ceph_assert(op.truncate->first == 0);
-	ceph_assert(op.truncate->first ==
-	       op.truncate->second);
 	ceph_assert(entry);
 	ceph_assert(obc);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67132

---

backport of https://github.com/ceph/ceph/pull/56924
parent tracker: https://tracker.ceph.com/issues/65509

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh