### PR TITLE
reef: rgw: fix user.rgw.user-policy attr remove by modify user

### DIFF
--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -295,6 +295,15 @@ void RGWUserAdminOpState::set_user_version_tracker(RGWObjVersionTracker& objv_tr
   user->get_version_tracker() = objv_tracker;
 }
 
+void RGWUserAdminOpState::set_attrs(rgw::sal::Attrs& attrs)
+{
+  user->get_attrs() = attrs;
+}
+
+rgw::sal::Attrs RGWUserAdminOpState::get_attrs() {
+  return user->get_attrs();
+}
+
 const rgw_user& RGWUserAdminOpState::get_user_id()
 {
   return user->get_id();
@@ -1386,6 +1395,7 @@ int RGWUser::init(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state, 
   
   op_state.set_existing_user(found);
   if (found) {
+    op_state.set_attrs(user->get_attrs());
     op_state.set_user_info(user->get_info());
     op_state.set_populated();
     op_state.objv = user->get_version_tracker();

--- a/src/rgw/driver/rados/rgw_user.h
+++ b/src/rgw/driver/rados/rgw_user.h
@@ -305,6 +305,10 @@ struct RGWUserAdminOpState {
     max_buckets_specified = true;
   }
 
+  rgw::sal::Attrs get_attrs();
+
+  void set_attrs(rgw::sal::Attrs& attrs);
+
   void set_gen_access() {
     gen_access = true;
     key_op = true;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63250

---

backport of https://github.com/ceph/ceph/pull/53750
parent tracker: https://tracker.ceph.com/issues/63134

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh