### PR TITLE
reef: rgw-check-policy: remove check for nonempty tenant

### DIFF
--- a/src/rgw/rgw_polparser.cc
+++ b/src/rgw/rgw_polparser.cc
@@ -78,11 +78,6 @@ int main(int argc, const char** argv)
     }
   }
 
-  if (tenant.empty()) {
-    std::cerr << cmdname << ": must specify tenant name" << std::endl;
-    helpful_exit(cmdname);
-  }
-
   bool success = true;
 
   if (args.empty()) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63450

---

backport of https://github.com/ceph/ceph/pull/54213
parent tracker: https://tracker.ceph.com/issues/63333

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh