### PR TITLE
reef: rgw/multisite: set versioning status in archive zone upon bucket creation

### DIFF
--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -2599,13 +2599,14 @@ int RGWMetadataHandlerPut_BucketInstance::put_check(const DoutPrefixProvider *dp
     }
     bci.info.layout.current_index.layout.type = rule_info.index_type;
   } else {
-    /* always keep bucket versioning enabled on archive zone */
-    if (bihandler->driver->get_zone()->get_tier_type() == "archive") {
-      bci.info.flags = (bci.info.flags & ~BUCKET_VERSIONS_SUSPENDED) | BUCKET_VERSIONED;
-    }
     /* existing bucket, keep its placement */
     bci.info.bucket.explicit_placement = old_bci->info.bucket.explicit_placement;
     bci.info.placement_rule = old_bci->info.placement_rule;
+  }
+
+  //always keep bucket versioning enabled on archive zone
+  if (bihandler->driver->get_zone()->get_tier_type() == "archive") {
+    bci.info.flags = (bci.info.flags & ~BUCKET_VERSIONS_SUSPENDED) | BUCKET_VERSIONED;
   }
 
   /* record the read version (if any), store the new version */


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63454

---

backport of https://github.com/ceph/ceph/pull/54171
parent tracker: https://tracker.ceph.com/issues/63296

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh