### PR TITLE
squid: mgr/dashboard: add restful api for creating crush rule with type of 'erasure'

### DIFF
--- a/qa/tasks/mgr/dashboard/test_crush_rule.py
+++ b/qa/tasks/mgr/dashboard/test_crush_rule.py
@@ -82,3 +82,16 @@ class CrushRuleTest(DashboardTestCase):
             'nodes': JList(JObj({}, allow_unknown=True)),
             'roots': JList(int)
         }))
+
+    @DashboardTestCase.RunAs('test', 'test', ['pool-manager', 'cluster-manager'])
+    def test_create_erasure_with_ssd(self):
+        data = self._get('/api/osd/0')
+        self.assertStatus(200)
+        device_class = data['osd_metadata']['default_device_class']
+        self.create_and_delete_rule({
+            'pool_type': 'erasure',
+            'name': 'some_erasure_crush_rule',
+            'profile': 'default',
+            'failure_domain': 'osd',
+            'device_class': device_class
+        })

--- a/src/pybind/mgr/dashboard/controllers/crush_rule.py
+++ b/src/pybind/mgr/dashboard/controllers/crush_rule.py
@@ -38,14 +38,24 @@ class CrushRule(RESTController):
                 return r
         raise NotFound('No such crush rule')
 
-    def create(self, name, root, failure_domain, device_class=None):
-        rule = {
-            'name': name,
-            'root': root,
-            'type': failure_domain,
-            'class': device_class
-        }
-        CephService.send_command('mon', 'osd crush rule create-replicated', **rule)
+    def create(self, name, failure_domain, device_class=None, root=None, profile=None,
+               pool_type='replication'):
+        if pool_type == 'erasure':
+            rule = {
+                'name': name,
+                'profile': profile,
+                'type': failure_domain,
+                'class': device_class
+            }
+            CephService.send_command('mon', 'osd crush rule create-erasure', **rule)
+        else:
+            rule = {
+                'name': name,
+                'root': root,
+                'type': failure_domain,
+                'class': device_class
+            }
+            CephService.send_command('mon', 'osd crush rule create-replicated', **rule)
 
     def delete(self, name):
         CephService.send_command('mon', 'osd crush rule rm', name=name)

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -4165,11 +4165,15 @@ paths:
                   type: string
                 name:
                   type: string
+                pool_type:
+                  default: replication
+                  type: string
+                profile:
+                  type: string
                 root:
                   type: string
               required:
               - name
-              - root
               - failure_domain
               type: object
       responses:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67123

---

backport of https://github.com/ceph/ceph/pull/58224
parent tracker: https://tracker.ceph.com/issues/66490

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh