### PR TITLE
quincy: librbd/crypto: fix issue when live-migrating from encrypted export

### DIFF
--- a/qa/workunits/rbd/luks-encryption.sh
+++ b/qa/workunits/rbd/luks-encryption.sh
@@ -2,7 +2,7 @@
 set -ex
 
 CEPH_ID=${CEPH_ID:-admin}
-TMP_FILES="/tmp/passphrase /tmp/testdata1 /tmp/testdata2 /tmp/cmpdata"
+TMP_FILES="/tmp/passphrase /tmp/testdata1 /tmp/testdata2 /tmp/cmpdata /tmp/rawexport /tmp/export.qcow2"
 
 _sudo()
 {
@@ -53,6 +53,103 @@ function test_encryption_format() {
   sudo cryptsetup close cryptsetupdev
 }
 
+function test_migration_read_and_copyup() {
+  local format=$1
+
+  cp /tmp/testdata2 /tmp/cmpdata
+
+  # test reading
+  LIBRBD_DEV=$(_sudo rbd -p rbd map testimg1 -t nbd -o encryption-format=$format,encryption-passphrase-file=/tmp/passphrase)
+  cmp $LIBRBD_DEV /tmp/cmpdata
+
+  # trigger copyup at the beginning and at the end
+  xfs_io -c 'pwrite -S 0xab -W 0 4k' $LIBRBD_DEV /tmp/cmpdata
+  xfs_io -c 'pwrite -S 0xba -W 4095k 4k' $LIBRBD_DEV /tmp/cmpdata
+
+  cmp $LIBRBD_DEV /tmp/cmpdata
+  _sudo rbd device unmap -t nbd $LIBRBD_DEV
+
+  # test reading on a fresh mapping
+  LIBRBD_DEV=$(_sudo rbd -p rbd map testimg1 -t nbd -o encryption-format=$format,encryption-passphrase-file=/tmp/passphrase)
+  cmp $LIBRBD_DEV /tmp/cmpdata
+  _sudo rbd device unmap -t nbd $LIBRBD_DEV
+
+  # test reading on a fresh mapping after migration is executed
+  rbd migration execute testimg1
+  LIBRBD_DEV=$(_sudo rbd -p rbd map testimg1 -t nbd -o encryption-format=$format,encryption-passphrase-file=/tmp/passphrase)
+  cmp $LIBRBD_DEV /tmp/cmpdata
+  _sudo rbd device unmap -t nbd $LIBRBD_DEV
+
+  # test reading on a fresh mapping after migration is committed
+  rbd migration commit testimg1
+  LIBRBD_DEV=$(_sudo rbd -p rbd map testimg1 -t nbd -o encryption-format=$format,encryption-passphrase-file=/tmp/passphrase)
+  cmp $LIBRBD_DEV /tmp/cmpdata
+  _sudo rbd device unmap -t nbd $LIBRBD_DEV
+}
+
+function test_migration_native_with_snaps() {
+  local format=$1
+
+  LIBRBD_DEV=$(_sudo rbd -p rbd map testimg1@snap1 -t nbd -o encryption-format=$format,encryption-passphrase-file=/tmp/passphrase)
+  cmp $LIBRBD_DEV /tmp/testdata1
+  _sudo rbd device unmap -t nbd $LIBRBD_DEV
+  LIBRBD_DEV=$(_sudo rbd -p rbd map testimg1@snap2 -t nbd -o encryption-format=$format,encryption-passphrase-file=/tmp/passphrase)
+  cmp $LIBRBD_DEV /tmp/testdata2
+  _sudo rbd device unmap -t nbd $LIBRBD_DEV
+
+  test_migration_read_and_copyup $format
+
+  # check that snapshots aren't affected by copyups
+  LIBRBD_DEV=$(_sudo rbd -p rbd map testimg1@snap1 -t nbd -o encryption-format=$format,encryption-passphrase-file=/tmp/passphrase)
+  cmp $LIBRBD_DEV /tmp/testdata1
+  _sudo rbd device unmap -t nbd $LIBRBD_DEV
+  LIBRBD_DEV=$(_sudo rbd -p rbd map testimg1@snap2 -t nbd -o encryption-format=$format,encryption-passphrase-file=/tmp/passphrase)
+  cmp $LIBRBD_DEV /tmp/testdata2
+  _sudo rbd device unmap -t nbd $LIBRBD_DEV
+
+  rbd snap rm testimg1@snap2
+  rbd snap rm testimg1@snap1
+  rbd rm testimg1
+}
+
+function test_migration() {
+  local format=$1
+
+  rbd encryption format testimg $format /tmp/passphrase
+
+  LIBRBD_DEV=$(_sudo rbd -p rbd map testimg -t nbd -o encryption-format=$format,encryption-passphrase-file=/tmp/passphrase)
+  dd if=/tmp/testdata1 of=$LIBRBD_DEV conv=fsync bs=1M
+  rbd snap create testimg@snap1
+  dd if=/tmp/testdata2 of=$LIBRBD_DEV conv=fsync bs=1M
+  rbd snap create testimg@snap2
+  # FIXME: https://tracker.ceph.com/issues/67401
+  # leave HEAD with the same data as snap2 as a workaround
+  # dd if=/tmp/testdata3 of=$LIBRBD_DEV conv=fsync bs=1M
+  _sudo rbd device unmap -t nbd $LIBRBD_DEV
+
+  # live import a raw image
+  rbd export testimg /tmp/rawexport
+  rbd migration prepare --import-only --source-spec '{"type": "raw", "stream": {"type": "file", "file_path": "/tmp/rawexport"}}' testimg1
+  test_migration_read_and_copyup $format
+  rbd rm testimg1
+
+  # live import a qcow image
+  qemu-img convert -f raw -O qcow2 /tmp/rawexport /tmp/export.qcow2
+  rbd migration prepare --import-only --source-spec '{"type": "qcow", "stream": {"type": "file", "file_path": "/tmp/export.qcow2"}}' testimg1
+  test_migration_read_and_copyup $format
+  rbd rm testimg1
+
+  # live import a native image
+  rbd migration prepare --import-only testimg@snap2 testimg1
+  test_migration_native_with_snaps $format
+
+  # live migrate a native image (removes testimg)
+  rbd migration prepare testimg testimg1
+  test_migration_native_with_snaps $format
+
+  rm /tmp/rawexport /tmp/export.qcow2
+}
+
 function get_nbd_device_paths {
   rbd device list -t nbd | tail -n +2 | egrep "\s+rbd\s+testimg" | awk '{print $5;}'
 }
@@ -67,7 +164,14 @@ function clean_up {
   for device in $(get_nbd_device_paths); do
     _sudo rbd device unmap -t nbd $device
   done
-	rbd ls | grep testimg > /dev/null && rbd rm testimg || true
+
+  rbd migration abort testimg1 || true
+  rbd snap remove testimg1@snap2 || true
+  rbd snap remove testimg1@snap1 || true
+  rbd remove testimg1 || true
+  rbd snap remove testimg@snap2 || true
+  rbd snap remove testimg@snap1 || true
+  rbd remove testimg || true
 }
 
 if [[ $(uname) != "Linux" ]]; then
@@ -103,5 +207,11 @@ test_encryption_format luks2
 
 _sudo rbd device unmap -t nbd $RAW_DEV
 rbd rm testimg
+
+rbd create --size 20M testimg
+test_migration luks1
+
+rbd create --size 32M testimg
+test_migration luks2
 
 echo OK

--- a/qa/workunits/rbd/luks-encryption.sh
+++ b/qa/workunits/rbd/luks-encryption.sh
@@ -36,11 +36,9 @@ function test_encryption_format() {
 
   # open encryption with cryptsetup
   sudo cryptsetup open $RAW_DEV --type $format cryptsetupdev -d /tmp/passphrase
-  sudo chmod 666 /dev/mapper/cryptsetupdev
 
   # open encryption with librbd
   LIBRBD_DEV=$(_sudo rbd -p rbd map testimg -t nbd -o encryption-format=$format,encryption-passphrase-file=/tmp/passphrase)
-  sudo chmod 666 $LIBRBD_DEV
 
   # write via librbd && compare
   dd if=/tmp/testdata1 of=$LIBRBD_DEV conv=fsync bs=1M

--- a/src/librbd/api/Migration.cc
+++ b/src/librbd/api/Migration.cc
@@ -540,7 +540,6 @@ int Migration<I>::prepare_import(
     return r;
   }
 
-  auto asio_engine = src_image_ctx->asio_engine;
   BOOST_SCOPE_EXIT_TPL(src_image_ctx) {
     src_image_ctx->state->close();
   } BOOST_SCOPE_EXIT_END;
@@ -581,11 +580,6 @@ int Migration<I>::prepare_import(
   Migration migration(src_image_ctx, dst_image_ctx, dst_migration_spec,
                       opts, nullptr);
   return migration.prepare_import();
-  if (r < 0) {
-    return r;
-  }
-
-  return 0;
 }
 
 template <typename I>

--- a/src/librbd/io/ReadResult.cc
+++ b/src/librbd/io/ReadResult.cc
@@ -143,7 +143,7 @@ struct ReadResult::AssembleResultVisitor : public boost::static_visitor<void> {
 
 ReadResult::C_ImageReadRequest::C_ImageReadRequest(
     AioCompletion *aio_completion, uint64_t buffer_offset,
-    const Extents image_extents)
+    const Extents& image_extents)
   : aio_completion(aio_completion), buffer_offset(buffer_offset),
     image_extents(image_extents) {
   aio_completion->add_request();

--- a/src/librbd/io/ReadResult.h
+++ b/src/librbd/io/ReadResult.h
@@ -34,7 +34,7 @@ public:
 
     C_ImageReadRequest(AioCompletion *aio_completion,
                        uint64_t buffer_offset,
-                       const Extents image_extents);
+                       const Extents& image_extents);
 
     void finish(int r) override;
   };

--- a/src/librbd/migration/FileStream.cc
+++ b/src/librbd/migration/FileStream.cc
@@ -74,7 +74,7 @@ struct FileStream<I>::ReadRequest {
     auto offset = lseek64(file_stream->m_file_no, byte_extent.first, SEEK_SET);
     if (offset == -1) {
       r = -errno;
-      lderr(cct) << "failed to seek file stream: " << cpp_strerror(r) << dendl;
+      lderr(cct) << "failed to seek file: " << cpp_strerror(r) << dendl;
       finish(r);
       return;
     }
@@ -149,7 +149,7 @@ void FileStream<I>::open(Context* on_finish) {
   m_file_no = ::open(file_path.c_str(), O_RDONLY);
   if (m_file_no < 0) {
     int r = -errno;
-    lderr(m_cct) << "failed to open file stream '" << file_path << "': "
+    lderr(m_cct) << "failed to open file '" << file_path << "': "
                  << cpp_strerror(r) << dendl;
     on_finish->complete(r);
     return;

--- a/src/librbd/migration/FormatInterface.h
+++ b/src/librbd/migration/FormatInterface.h
@@ -35,7 +35,7 @@ struct FormatInterface {
   virtual void get_image_size(uint64_t snap_id, uint64_t* size,
                               Context* on_finish) = 0;
 
-  virtual bool read(io::AioCompletion* aio_comp, uint64_t snap_id,
+  virtual void read(io::AioCompletion* aio_comp, uint64_t snap_id,
                     io::Extents&& image_extents, io::ReadResult&& read_result,
                     int op_flags, int read_flags,
                     const ZTracer::Trace &parent_trace) = 0;

--- a/src/librbd/migration/HttpClient.cc
+++ b/src/librbd/migration/HttpClient.cc
@@ -283,7 +283,7 @@ private:
     ldout(cct, 15) << "r=" << r << dendl;
 
     if (r < 0) {
-      lderr(cct) << "failed to disconnect stream: '" << cpp_strerror(r)
+      lderr(cct) << "failed to disconnect stream: " << cpp_strerror(r)
                  << dendl;
     }
 
@@ -350,7 +350,7 @@ private:
     ldout(cct, 15) << "r=" << r << dendl;
 
     if (r < 0) {
-      lderr(cct) << "failed to disconnect stream: '" << cpp_strerror(r)
+      lderr(cct) << "failed to disconnect stream: " << cpp_strerror(r)
                  << dendl;
     }
 

--- a/src/librbd/migration/ImageDispatch.cc
+++ b/src/librbd/migration/ImageDispatch.cc
@@ -5,8 +5,13 @@
 #include "include/neorados/RADOS.hpp"
 #include "common/dout.h"
 #include "librbd/ImageCtx.h"
+#include "librbd/crypto/CryptoInterface.h"
+#include "librbd/crypto/EncryptionFormat.h"
 #include "librbd/io/AioCompletion.h"
+#include "librbd/io/ImageDispatcherInterface.h"
+#include "librbd/io/Utils.h"
 #include "librbd/migration/FormatInterface.h"
+#include "librbd/Utils.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -15,6 +20,72 @@
 
 namespace librbd {
 namespace migration {
+
+namespace {
+
+struct C_DecryptData : public io::ReadResult::C_ImageReadRequest {
+  crypto::CryptoInterface* crypto;
+
+  C_DecryptData(io::AioCompletion* aio_comp, const io::Extents& image_extents,
+                crypto::CryptoInterface* crypto)
+      : C_ImageReadRequest(aio_comp, 0, image_extents), crypto(crypto) {}
+
+  void finish(int r) override {
+    if (r < 0) {
+      C_ImageReadRequest::finish(r);
+      return;
+    }
+
+    auto ciphertext_bl = std::move(bl);
+    for (const auto& extent : image_extents) {
+      ceph::bufferlist tmp;
+      ciphertext_bl.splice(0, extent.second, &tmp);
+      int r = crypto->decrypt(&tmp, extent.first);
+      if (r < 0) {
+        C_ImageReadRequest::finish(r);
+        return;
+      }
+      bl.claim_append(tmp);
+    }
+
+    C_ImageReadRequest::finish(0);
+  }
+};
+
+template <typename I>
+struct C_MapSnapshotDelta : public io::C_AioRequest {
+  io::SnapshotDelta* snapshot_delta;
+  I* image_ctx;
+
+  C_MapSnapshotDelta(io::AioCompletion* aio_comp,
+                     io::SnapshotDelta* snapshot_delta, I* image_ctx)
+      : C_AioRequest(aio_comp), snapshot_delta(snapshot_delta),
+        image_ctx(image_ctx) {}
+
+  void finish(int r) override {
+    if (r < 0) {
+      C_AioRequest::finish(r);
+      return;
+    }
+
+    auto raw_snapshot_delta = std::move(*snapshot_delta);
+    for (const auto& [key, raw_sparse_extents] : raw_snapshot_delta) {
+      auto& sparse_extents = (*snapshot_delta)[key];
+      for (const auto& raw_sparse_extent : raw_sparse_extents) {
+        io::Extents extents = {{raw_sparse_extent.get_off(), 0}};
+        image_ctx->io_image_dispatcher->remap_extents(
+            extents, io::IMAGE_EXTENTS_MAP_TYPE_PHYSICAL_TO_LOGICAL);
+        sparse_extents.insert(extents[0].first, raw_sparse_extent.get_len(),
+                              {raw_sparse_extent.get_val().state,
+                               raw_sparse_extent.get_len()});
+      }
+    }
+
+    C_AioRequest::finish(0);
+  }
+};
+
+} // anonymous namespace
 
 template <typename I>
 ImageDispatch<I>::ImageDispatch(I* image_ctx,
@@ -50,6 +121,30 @@ bool ImageDispatch<I>::read(
   }
 
   *dispatch_result = io::DISPATCH_RESULT_COMPLETE;
+
+  if (m_image_ctx->crypto != nullptr) {
+    auto crypto = m_image_ctx->crypto;
+
+    // alignment should be performed on the destination image (see
+    // C_UnalignedObjectReadRequest in CryptoObjectDispatch)
+    for (const auto& extent : image_extents) {
+      ceph_assert(crypto->is_aligned(extent.first, extent.second));
+    }
+
+    aio_comp->read_result = std::move(read_result);
+    aio_comp->read_result.set_image_extents(image_extents);
+
+    aio_comp->set_request_count(1);
+    auto ctx = new C_DecryptData(aio_comp, image_extents, crypto);
+    aio_comp = io::AioCompletion::create_and_start<Context>(
+        ctx, util::get_image_ctx(m_image_ctx), io::AIO_TYPE_READ);
+    read_result = io::ReadResult(&ctx->bl);
+
+    // map to raw image extents _after_ DATA area extents are captured
+    m_image_ctx->io_image_dispatcher->remap_extents(
+        image_extents, io::IMAGE_EXTENTS_MAP_TYPE_LOGICAL_TO_PHYSICAL);
+  }
+
   m_format->read(aio_comp, io_context->read_snap().value_or(CEPH_NOSNAP),
                  std::move(image_extents), std::move(read_result),
                  op_flags, read_flags, parent_trace);
@@ -148,7 +243,17 @@ bool ImageDispatch<I>::list_snaps(
   *dispatch_result = io::DISPATCH_RESULT_COMPLETE;
 
   aio_comp->set_request_count(1);
-  auto ctx = new io::C_AioRequest(aio_comp);
+  Context* ctx;
+
+  if (m_image_ctx->crypto != nullptr) {
+    // map to raw image extents
+    m_image_ctx->io_image_dispatcher->remap_extents(
+        image_extents, io::IMAGE_EXTENTS_MAP_TYPE_LOGICAL_TO_PHYSICAL);
+    // ... and back on completion
+    ctx = new C_MapSnapshotDelta(aio_comp, snapshot_delta, m_image_ctx);
+  } else {
+    ctx = new io::C_AioRequest(aio_comp);
+  }
 
   m_format->list_snaps(std::move(image_extents), std::move(snap_ids),
                        list_snaps_flags, snapshot_delta, parent_trace,

--- a/src/librbd/migration/ImageDispatch.cc
+++ b/src/librbd/migration/ImageDispatch.cc
@@ -43,6 +43,12 @@ bool ImageDispatch<I>::read(
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << dendl;
 
+  // let io::ImageDispatch layer (IMAGE_DISPATCH_LAYER_CORE) handle
+  // native format
+  if (!m_format) {
+    return false;
+  }
+
   *dispatch_result = io::DISPATCH_RESULT_COMPLETE;
   return m_format->read(aio_comp, io_context->read_snap().value_or(CEPH_NOSNAP),
                         std::move(image_extents), std::move(read_result),
@@ -131,6 +137,12 @@ bool ImageDispatch<I>::list_snaps(
     Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << dendl;
+
+  // let io::ImageDispatch layer (IMAGE_DISPATCH_LAYER_CORE) handle
+  // native format
+  if (!m_format) {
+    return false;
+  }
 
   *dispatch_result = io::DISPATCH_RESULT_COMPLETE;
 

--- a/src/librbd/migration/ImageDispatch.cc
+++ b/src/librbd/migration/ImageDispatch.cc
@@ -50,9 +50,10 @@ bool ImageDispatch<I>::read(
   }
 
   *dispatch_result = io::DISPATCH_RESULT_COMPLETE;
-  return m_format->read(aio_comp, io_context->read_snap().value_or(CEPH_NOSNAP),
-                        std::move(image_extents), std::move(read_result),
-                        op_flags, read_flags, parent_trace);
+  m_format->read(aio_comp, io_context->read_snap().value_or(CEPH_NOSNAP),
+                 std::move(image_extents), std::move(read_result),
+                 op_flags, read_flags, parent_trace);
+  return true;
 }
 
 template <typename I>

--- a/src/librbd/migration/ImageDispatch.h
+++ b/src/librbd/migration/ImageDispatch.h
@@ -86,6 +86,8 @@ public:
 
 private:
   ImageCtxT* m_image_ctx;
+
+  // empty (nullptr) for native format
   std::unique_ptr<FormatInterface> m_format;
 
   void fail_io(int r, io::AioCompletion* aio_comp,

--- a/src/librbd/migration/NativeFormat.cc
+++ b/src/librbd/migration/NativeFormat.cc
@@ -16,8 +16,8 @@
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
-#define dout_prefix *_dout << "librbd::migration::NativeFormat: " << this \
-                           << " " << __func__ << ": "
+#define dout_prefix *_dout << "librbd::migration::NativeFormat: " << __func__ \
+                           << ": "
 
 namespace librbd {
 namespace migration {
@@ -51,45 +51,47 @@ std::string NativeFormat<I>::build_source_spec(
 }
 
 template <typename I>
-NativeFormat<I>::NativeFormat(
-    I* image_ctx, const json_spirit::mObject& json_object, bool import_only)
-  : m_image_ctx(image_ctx), m_json_object(json_object),
-    m_import_only(import_only) {
+bool NativeFormat<I>::is_source_spec(
+    const json_spirit::mObject& source_spec_object) {
+  auto it = source_spec_object.find(TYPE_KEY);
+  return it != source_spec_object.end() &&
+         it->second.type() == json_spirit::str_type &&
+         it->second.get_str() == "native";
 }
 
 template <typename I>
-void NativeFormat<I>::open(Context* on_finish) {
-  auto cct = m_image_ctx->cct;
-  ldout(cct, 10) << dendl;
-
+int NativeFormat<I>::create_image_ctx(
+    librados::IoCtx& dst_io_ctx,
+    const json_spirit::mObject& source_spec_object,
+    bool import_only, uint64_t src_snap_id, I** src_image_ctx) {
+  auto cct = reinterpret_cast<CephContext*>(dst_io_ctx.cct());
   int64_t pool_id = -1;
   std::string pool_namespace;
   std::string image_name;
   std::string image_id;
+  std::string snap_name;
+  uint64_t snap_id = CEPH_NOSNAP;
 
-  if (auto it = m_json_object.find(POOL_NAME_KEY);
-      it != m_json_object.end()) {
+  if (auto it = source_spec_object.find(POOL_NAME_KEY);
+      it != source_spec_object.end()) {
     if (it->second.type() == json_spirit::str_type) {
-      librados::Rados rados(m_image_ctx->md_ctx);
+      librados::Rados rados(dst_io_ctx);
       pool_id = rados.pool_lookup(it->second.get_str().c_str());
       if (pool_id < 0) {
         lderr(cct) << "failed to lookup pool" << dendl;
-        on_finish->complete(static_cast<int>(pool_id));
-        return;
+        return static_cast<int>(pool_id);
       }
     } else {
       lderr(cct) << "invalid pool name" << dendl;
-      on_finish->complete(-EINVAL);
-      return;
+      return -EINVAL;
     }
   }
 
-  if (auto it = m_json_object.find(POOL_ID_KEY);
-      it != m_json_object.end()) {
+  if (auto it = source_spec_object.find(POOL_ID_KEY);
+      it != source_spec_object.end()) {
     if (pool_id != -1) {
       lderr(cct) << "cannot specify both pool name and pool id" << dendl;
-      on_finish->complete(-EINVAL);
-      return;
+      return -EINVAL;
     }
     if (it->second.type() == json_spirit::int_type) {
       pool_id = it->second.get_int64();
@@ -101,232 +103,107 @@ void NativeFormat<I>::open(Context* on_finish) {
     }
     if (pool_id == -1) {
       lderr(cct) << "invalid pool id" << dendl;
-      on_finish->complete(-EINVAL);
-      return;
+      return -EINVAL;
     }
   }
 
   if (pool_id == -1) {
     lderr(cct) << "missing pool name or pool id" << dendl;
-    on_finish->complete(-EINVAL);
-    return;
+    return -EINVAL;
   }
 
-  if (auto it = m_json_object.find(POOL_NAMESPACE_KEY);
-      it != m_json_object.end()) {
+  if (auto it = source_spec_object.find(POOL_NAMESPACE_KEY);
+      it != source_spec_object.end()) {
     if (it->second.type() == json_spirit::str_type) {
       pool_namespace = it->second.get_str();
     } else {
       lderr(cct) << "invalid pool namespace" << dendl;
-      on_finish->complete(-EINVAL);
-      return;
+      return -EINVAL;
     }
   }
 
-  if (auto it = m_json_object.find(IMAGE_NAME_KEY);
-      it != m_json_object.end()) {
+  if (auto it = source_spec_object.find(IMAGE_NAME_KEY);
+      it != source_spec_object.end()) {
     if (it->second.type() == json_spirit::str_type) {
       image_name = it->second.get_str();
     } else {
       lderr(cct) << "invalid image name" << dendl;
-      on_finish->complete(-EINVAL);
-      return;
+      return -EINVAL;
     }
   } else {
     lderr(cct) << "missing image name" << dendl;
-    on_finish->complete(-EINVAL);
-    return;
+    return -EINVAL;
   }
 
-  if (auto it = m_json_object.find(IMAGE_ID_KEY);
-      it != m_json_object.end()) {
+  if (auto it = source_spec_object.find(IMAGE_ID_KEY);
+      it != source_spec_object.end()) {
     if (it->second.type() == json_spirit::str_type) {
       image_id = it->second.get_str();
     } else {
       lderr(cct) << "invalid image id" << dendl;
-      on_finish->complete(-EINVAL);
-      return;
+      return -EINVAL;
     }
   }
 
-  if (auto it = m_json_object.find(SNAP_NAME_KEY);
-      it != m_json_object.end()) {
+  if (auto it = source_spec_object.find(SNAP_NAME_KEY);
+      it != source_spec_object.end()) {
     if (it->second.type() == json_spirit::str_type) {
-      m_snap_name = it->second.get_str();
+      snap_name = it->second.get_str();
     } else {
       lderr(cct) << "invalid snap name" << dendl;
-      on_finish->complete(-EINVAL);
-      return;
+      return -EINVAL;
     }
   }
 
-  if (auto it = m_json_object.find(SNAP_ID_KEY);
-      it != m_json_object.end()) {
-    if (!m_snap_name.empty()) {
+  if (auto it = source_spec_object.find(SNAP_ID_KEY);
+      it != source_spec_object.end()) {
+    if (!snap_name.empty()) {
       lderr(cct) << "cannot specify both snap name and snap id" << dendl;
-      on_finish->complete(-EINVAL);
-      return;
+      return -EINVAL;
     }
     if (it->second.type() == json_spirit::int_type) {
-      m_snap_id = it->second.get_uint64();
+      snap_id = it->second.get_uint64();
     } else if (it->second.type() == json_spirit::str_type) {
       try {
-        m_snap_id = boost::lexical_cast<uint64_t>(it->second.get_str());
+        snap_id = boost::lexical_cast<uint64_t>(it->second.get_str());
       } catch (boost::bad_lexical_cast&) {
       }
     }
-    if (m_snap_id == CEPH_NOSNAP) {
+    if (snap_id == CEPH_NOSNAP) {
       lderr(cct) << "invalid snap id" << dendl;
-      on_finish->complete(-EINVAL);
-      return;
+      return -EINVAL;
     }
   }
 
   // snapshot is required for import to keep source read-only
-  if (m_import_only && m_snap_name.empty() && m_snap_id == CEPH_NOSNAP) {
+  if (import_only && snap_name.empty() && snap_id == CEPH_NOSNAP) {
     lderr(cct) << "snapshot required for import" << dendl;
-    on_finish->complete(-EINVAL);
-    return;
+    return -EINVAL;
+  }
+
+  // import snapshot is used only for destination image HEAD
+  // otherwise, src_snap_id corresponds to destination image "opened at"
+  // snap_id
+  if (src_snap_id != CEPH_NOSNAP) {
+    snap_id = src_snap_id;
   }
 
   // TODO add support for external clusters
-  librados::IoCtx io_ctx;
-  int r = util::create_ioctx(m_image_ctx->md_ctx, "source image",
-                             pool_id, pool_namespace, &io_ctx);
+  librados::IoCtx src_io_ctx;
+  int r = util::create_ioctx(dst_io_ctx, "source image", pool_id,
+                             pool_namespace, &src_io_ctx);
   if (r < 0) {
-    on_finish->complete(r);
-    return;
+    return r;
   }
 
-  m_image_ctx->md_ctx.dup(io_ctx);
-  m_image_ctx->data_ctx.dup(io_ctx);
-  m_image_ctx->name = image_name;
-
-  uint64_t flags = 0;
-  if (image_id.empty() && !m_import_only) {
-    flags |= OPEN_FLAG_OLD_FORMAT;
+  if (!snap_name.empty() && snap_id == CEPH_NOSNAP) {
+    *src_image_ctx = I::create(image_name, image_id, snap_name.c_str(),
+                               src_io_ctx, true);
   } else {
-    m_image_ctx->id = image_id;
+    *src_image_ctx = I::create(image_name, image_id, snap_id, src_io_ctx,
+                               true);
   }
-
-  if (m_image_ctx->child != nullptr) {
-    // set rados flags for reading the parent image
-    if (m_image_ctx->child->config.template get_val<bool>("rbd_balance_parent_reads")) {
-      m_image_ctx->set_read_flag(librados::OPERATION_BALANCE_READS);
-    } else if (m_image_ctx->child->config.template get_val<bool>("rbd_localize_parent_reads")) {
-      m_image_ctx->set_read_flag(librados::OPERATION_LOCALIZE_READS);
-    }
-  }
-
-  // open the source RBD image
-  on_finish = new LambdaContext([this, on_finish](int r) {
-    handle_open(r, on_finish); });
-  m_image_ctx->state->open(flags, on_finish);
-}
-
-template <typename I>
-void NativeFormat<I>::handle_open(int r, Context* on_finish) {
-  auto cct = m_image_ctx->cct;
-  ldout(cct, 10) << "r=" << r << dendl;
-
-  if (r < 0) {
-    lderr(cct) << "failed to open image: " << cpp_strerror(r) << dendl;
-    on_finish->complete(r);
-    return;
-  }
-
-  if (m_snap_id == CEPH_NOSNAP && m_snap_name.empty()) {
-    on_finish->complete(0);
-    return;
-  }
-
-  if (!m_snap_name.empty()) {
-    std::shared_lock image_locker{m_image_ctx->image_lock};
-    m_snap_id = m_image_ctx->get_snap_id(cls::rbd::UserSnapshotNamespace{},
-                                         m_snap_name);
-  }
-
-  if (m_snap_id == CEPH_NOSNAP) {
-    lderr(cct) << "failed to locate snapshot " << m_snap_name << dendl;
-    on_finish = new LambdaContext([on_finish](int) {
-      on_finish->complete(-ENOENT); });
-    m_image_ctx->state->close(on_finish);
-    return;
-  }
-
-  on_finish = new LambdaContext([this, on_finish](int r) {
-    handle_snap_set(r, on_finish); });
-  m_image_ctx->state->snap_set(m_snap_id, on_finish);
-}
-
-template <typename I>
-void NativeFormat<I>::handle_snap_set(int r, Context* on_finish) {
-  auto cct = m_image_ctx->cct;
-  ldout(cct, 10) << "r=" << r << dendl;
-
-  if (r < 0) {
-    lderr(cct) << "failed to set snapshot " << m_snap_id << ": "
-               << cpp_strerror(r) << dendl;
-    on_finish = new LambdaContext([r, on_finish](int) {
-      on_finish->complete(r); });
-    m_image_ctx->state->close(on_finish);
-    return;
-  }
-
-  on_finish->complete(0);
-}
-
-template <typename I>
-void NativeFormat<I>::close(Context* on_finish) {
-  auto cct = m_image_ctx->cct;
-  ldout(cct, 10) << dendl;
-
-  // the native librbd::image::CloseRequest handles all cleanup
-  on_finish->complete(0);
-}
-
-template <typename I>
-void NativeFormat<I>::get_snapshots(SnapInfos* snap_infos, Context* on_finish) {
-  auto cct = m_image_ctx->cct;
-  ldout(cct, 10) << dendl;
-
-  m_image_ctx->image_lock.lock_shared();
-  *snap_infos = m_image_ctx->snap_info;
-  m_image_ctx->image_lock.unlock_shared();
-
-  on_finish->complete(0);
-}
-
-template <typename I>
-void NativeFormat<I>::get_image_size(uint64_t snap_id, uint64_t* size,
-                                     Context* on_finish) {
-  auto cct = m_image_ctx->cct;
-  ldout(cct, 10) << dendl;
-
-  m_image_ctx->image_lock.lock_shared();
-  *size = m_image_ctx->get_image_size(snap_id);
-  m_image_ctx->image_lock.unlock_shared();
-
-
-  on_finish->complete(0);
-}
-
-template <typename I>
-void NativeFormat<I>::list_snaps(io::Extents&& image_extents,
-                                 io::SnapIds&& snap_ids, int list_snaps_flags,
-                                 io::SnapshotDelta* snapshot_delta,
-                                 const ZTracer::Trace &parent_trace,
-                                 Context* on_finish) {
-  auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << "image_extents=" << image_extents << dendl;
-
-  auto aio_comp = io::AioCompletion::create_and_start(
-    on_finish, util::get_image_ctx(m_image_ctx), io::AIO_TYPE_GENERIC);
-  auto req = io::ImageDispatchSpec::create_list_snaps(
-    *m_image_ctx, io::IMAGE_DISPATCH_LAYER_MIGRATION, aio_comp,
-    std::move(image_extents), std::move(snap_ids), list_snaps_flags,
-    snapshot_delta, {});
-  req->send();
+  return 0;
 }
 
 } // namespace migration

--- a/src/librbd/migration/NativeFormat.h
+++ b/src/librbd/migration/NativeFormat.h
@@ -62,10 +62,6 @@ private:
   json_spirit::mObject m_json_object;
   bool m_import_only;
 
-  int64_t m_pool_id = -1;
-  std::string m_pool_namespace;
-  std::string m_image_name;
-  std::string m_image_id;
   std::string m_snap_name;
   uint64_t m_snap_id = CEPH_NOSNAP;
 

--- a/src/librbd/migration/NativeFormat.h
+++ b/src/librbd/migration/NativeFormat.h
@@ -5,69 +5,30 @@
 #define CEPH_LIBRBD_MIGRATION_NATIVE_FORMAT_H
 
 #include "include/int_types.h"
-#include "librbd/Types.h"
-#include "librbd/migration/FormatInterface.h"
+#include "include/rados/librados_fwd.hpp"
 #include "json_spirit/json_spirit.h"
-#include <memory>
-
-struct Context;
+#include <string>
 
 namespace librbd {
 
-struct AsioEngine;
 struct ImageCtx;
 
 namespace migration {
 
 template <typename ImageCtxT>
-class NativeFormat : public FormatInterface {
+class NativeFormat {
 public:
   static std::string build_source_spec(int64_t pool_id,
                                        const std::string& pool_namespace,
                                        const std::string& image_name,
                                        const std::string& image_id);
 
-  static NativeFormat* create(ImageCtxT* image_ctx,
-                              const json_spirit::mObject& json_object,
-                              bool import_only) {
-    return new NativeFormat(image_ctx, json_object, import_only);
-  }
+  static bool is_source_spec(const json_spirit::mObject& source_spec_object);
 
-  NativeFormat(ImageCtxT* image_ctx, const json_spirit::mObject& json_object,
-               bool import_only);
-  NativeFormat(const NativeFormat&) = delete;
-  NativeFormat& operator=(const NativeFormat&) = delete;
-
-  void open(Context* on_finish) override;
-  void close(Context* on_finish) override;
-
-  void get_snapshots(SnapInfos* snap_infos, Context* on_finish) override;
-  void get_image_size(uint64_t snap_id, uint64_t* size,
-                      Context* on_finish) override;
-
-  bool read(io::AioCompletion* aio_comp, uint64_t snap_id,
-            io::Extents&& image_extents, io::ReadResult&& read_result,
-            int op_flags, int read_flags,
-            const ZTracer::Trace &parent_trace) override {
-    return false;
-  }
-
-  void list_snaps(io::Extents&& image_extents, io::SnapIds&& snap_ids,
-                  int list_snaps_flags, io::SnapshotDelta* snapshot_delta,
-                  const ZTracer::Trace &parent_trace,
-                  Context* on_finish) override;
-
-private:
-  ImageCtxT* m_image_ctx;
-  json_spirit::mObject m_json_object;
-  bool m_import_only;
-
-  std::string m_snap_name;
-  uint64_t m_snap_id = CEPH_NOSNAP;
-
-  void handle_open(int r, Context* on_finish);
-  void handle_snap_set(int r, Context* on_finish);
-
+  static int create_image_ctx(librados::IoCtx& dst_io_ctx,
+                              const json_spirit::mObject& source_spec_object,
+                              bool import_only, uint64_t src_snap_id,
+                              ImageCtxT** src_image_ctx);
 };
 
 } // namespace migration

--- a/src/librbd/migration/OpenSourceImageRequest.cc
+++ b/src/librbd/migration/OpenSourceImageRequest.cc
@@ -132,11 +132,11 @@ void OpenSourceImageRequest<I>::open_format(
 
   // use default layout values (can be overridden by migration formats later)
   src_image_ctx->order = 22;
-  src_image_ctx->layout = file_layout_t();
-  src_image_ctx->layout.stripe_count = 1;
-  src_image_ctx->layout.stripe_unit = 1ULL << src_image_ctx->order;
-  src_image_ctx->layout.object_size = 1Ull << src_image_ctx->order;
-  src_image_ctx->layout.pool_id = -1;
+  src_image_ctx->stripe_unit = 1ULL << src_image_ctx->order;
+  src_image_ctx->stripe_count = 1;
+  src_image_ctx->layout = file_layout_t(src_image_ctx->stripe_unit,
+                                        src_image_ctx->stripe_count,
+                                        src_image_ctx->stripe_unit);
 
   SourceSpecBuilder<I> source_spec_builder{src_image_ctx};
   int r = source_spec_builder.build_format(source_spec_object, &m_format);

--- a/src/librbd/migration/OpenSourceImageRequest.cc
+++ b/src/librbd/migration/OpenSourceImageRequest.cc
@@ -72,8 +72,8 @@ void OpenSourceImageRequest<I>::open_source() {
   int r = source_spec_builder.parse_source_spec(source_spec,
                                                 &source_spec_object);
   if (r < 0) {
-    lderr(m_cct) << "failed to parse migration source-spec:" << cpp_strerror(r)
-                 << dendl;
+    lderr(m_cct) << "failed to parse migration source-spec: "
+                 << cpp_strerror(r) << dendl;
     (*m_src_image_ctx)->state->close();
     finish(r);
     return;

--- a/src/librbd/migration/OpenSourceImageRequest.cc
+++ b/src/librbd/migration/OpenSourceImageRequest.cc
@@ -22,12 +22,12 @@ namespace migration {
 
 template <typename I>
 OpenSourceImageRequest<I>::OpenSourceImageRequest(
-    librados::IoCtx& io_ctx, I* dst_image_ctx, uint64_t src_snap_id,
+    librados::IoCtx& dst_io_ctx, I* dst_image_ctx, uint64_t src_snap_id,
     const MigrationInfo &migration_info, I** src_image_ctx, Context* on_finish)
-  : m_cct(reinterpret_cast<CephContext*>(io_ctx.cct())), m_io_ctx(io_ctx),
-    m_dst_image_ctx(dst_image_ctx), m_src_snap_id(src_snap_id),
-    m_migration_info(migration_info), m_src_image_ctx(src_image_ctx),
-    m_on_finish(on_finish) {
+  : m_cct(reinterpret_cast<CephContext*>(dst_io_ctx.cct())),
+    m_dst_io_ctx(dst_io_ctx), m_dst_image_ctx(dst_image_ctx),
+    m_src_snap_id(src_snap_id), m_migration_info(migration_info),
+    m_src_image_ctx(src_image_ctx), m_on_finish(on_finish) {
   ldout(m_cct, 10) << dendl;
 }
 
@@ -41,7 +41,7 @@ void OpenSourceImageRequest<I>::open_source() {
   ldout(m_cct, 10) << dendl;
 
   // note that all source image ctx properties are placeholders
-  *m_src_image_ctx = I::create("", "", CEPH_NOSNAP, m_io_ctx, true);
+  *m_src_image_ctx = I::create("", "", CEPH_NOSNAP, m_dst_io_ctx, true);
   auto src_image_ctx = *m_src_image_ctx;
   src_image_ctx->child = m_dst_image_ctx;
 

--- a/src/librbd/migration/OpenSourceImageRequest.cc
+++ b/src/librbd/migration/OpenSourceImageRequest.cc
@@ -143,8 +143,7 @@ void OpenSourceImageRequest<I>::open_format(
   if (r < 0) {
     lderr(m_cct) << "failed to build migration format handler: "
                  << cpp_strerror(r) << dendl;
-    (*m_src_image_ctx)->state->close();
-    finish(r);
+    close_image(r);
     return;
   }
 
@@ -161,7 +160,7 @@ void OpenSourceImageRequest<I>::handle_open_format(int r) {
   if (r < 0) {
     lderr(m_cct) << "failed to open migration format: " << cpp_strerror(r)
                  << dendl;
-    finish(r);
+    close_image(r);
     return;
   }
 

--- a/src/librbd/migration/OpenSourceImageRequest.cc
+++ b/src/librbd/migration/OpenSourceImageRequest.cc
@@ -8,6 +8,7 @@
 #include "librbd/ImageState.h"
 #include "librbd/Utils.h"
 #include "librbd/io/ImageDispatcher.h"
+#include "librbd/migration/FormatInterface.h"
 #include "librbd/migration/ImageDispatch.h"
 #include "librbd/migration/NativeFormat.h"
 #include "librbd/migration/SourceSpecBuilder.h"
@@ -59,12 +60,69 @@ void OpenSourceImageRequest<I>::send() {
     return;
   }
 
-  open_source(source_spec_object, import_only);
+  if (NativeFormat<I>::is_source_spec(source_spec_object)) {
+    open_native(source_spec_object, import_only);
+  } else {
+    open_format(source_spec_object);
+  }
 }
 
 template <typename I>
-void OpenSourceImageRequest<I>::open_source(
+void OpenSourceImageRequest<I>::open_native(
     const json_spirit::mObject& source_spec_object, bool import_only) {
+  ldout(m_cct, 10) << dendl;
+
+  int r = NativeFormat<I>::create_image_ctx(m_dst_io_ctx, source_spec_object,
+                                            import_only, m_src_snap_id,
+                                            m_src_image_ctx);
+  if (r < 0) {
+    lderr(m_cct) << "failed to create native image context: "
+                 << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  auto src_image_ctx = *m_src_image_ctx;
+  src_image_ctx->child = m_dst_image_ctx;
+
+  if (m_dst_image_ctx != nullptr) {
+    // set rados flags for reading the source image
+    if (m_dst_image_ctx->config.template get_val<bool>("rbd_balance_parent_reads")) {
+      src_image_ctx->set_read_flag(librados::OPERATION_BALANCE_READS);
+    } else if (m_dst_image_ctx->config.template get_val<bool>("rbd_localize_parent_reads")) {
+      src_image_ctx->set_read_flag(librados::OPERATION_LOCALIZE_READS);
+    }
+  }
+
+  uint64_t flags = 0;
+  if (src_image_ctx->id.empty() && !import_only) {
+    flags |= OPEN_FLAG_OLD_FORMAT;
+  }
+
+  // open the source image
+  auto ctx = util::create_context_callback<
+    OpenSourceImageRequest<I>,
+    &OpenSourceImageRequest<I>::handle_open_native>(this);
+  src_image_ctx->state->open(flags, ctx);
+}
+
+template <typename I>
+void OpenSourceImageRequest<I>::handle_open_native(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to open native image: " << cpp_strerror(r)
+                 << dendl;
+    finish(r);
+    return;
+  }
+
+  finish(0);
+}
+
+template <typename I>
+void OpenSourceImageRequest<I>::open_format(
+    const json_spirit::mObject& source_spec_object) {
   ldout(m_cct, 10) << dendl;
 
   // note that all source image ctx properties are placeholders
@@ -72,7 +130,7 @@ void OpenSourceImageRequest<I>::open_source(
   auto src_image_ctx = *m_src_image_ctx;
   src_image_ctx->child = m_dst_image_ctx;
 
-  // use default layout values (can be overridden by source layers later)
+  // use default layout values (can be overridden by migration formats later)
   src_image_ctx->order = 22;
   src_image_ctx->layout = file_layout_t();
   src_image_ctx->layout.stripe_count = 1;
@@ -81,8 +139,7 @@ void OpenSourceImageRequest<I>::open_source(
   src_image_ctx->layout.pool_id = -1;
 
   SourceSpecBuilder<I> source_spec_builder{src_image_ctx};
-  int r = source_spec_builder.build_format(source_spec_object, import_only,
-                                           &m_format);
+  int r = source_spec_builder.build_format(source_spec_object, &m_format);
   if (r < 0) {
     lderr(m_cct) << "failed to build migration format handler: "
                  << cpp_strerror(r) << dendl;
@@ -93,16 +150,16 @@ void OpenSourceImageRequest<I>::open_source(
 
   auto ctx = util::create_context_callback<
     OpenSourceImageRequest<I>,
-    &OpenSourceImageRequest<I>::handle_open_source>(this);
+    &OpenSourceImageRequest<I>::handle_open_format>(this);
   m_format->open(ctx);
 }
 
 template <typename I>
-void OpenSourceImageRequest<I>::handle_open_source(int r) {
+void OpenSourceImageRequest<I>::handle_open_format(int r) {
   ldout(m_cct, 10) << "r=" << r << dendl;
 
   if (r < 0) {
-    lderr(m_cct) << "failed to open migration source: " << cpp_strerror(r)
+    lderr(m_cct) << "failed to open migration format: " << cpp_strerror(r)
                  << dendl;
     finish(r);
     return;

--- a/src/librbd/migration/OpenSourceImageRequest.h
+++ b/src/librbd/migration/OpenSourceImageRequest.h
@@ -22,18 +22,18 @@ struct FormatInterface;
 template <typename ImageCtxT>
 class OpenSourceImageRequest {
 public:
-  static OpenSourceImageRequest* create(librados::IoCtx& io_ctx,
+  static OpenSourceImageRequest* create(librados::IoCtx& dst_io_ctx,
                                         ImageCtxT* destination_image_ctx,
                                         uint64_t src_snap_id,
                                         const MigrationInfo &migration_info,
                                         ImageCtxT** source_image_ctx,
                                         Context* on_finish) {
-    return new OpenSourceImageRequest(io_ctx, destination_image_ctx,
+    return new OpenSourceImageRequest(dst_io_ctx, destination_image_ctx,
                                       src_snap_id, migration_info,
                                       source_image_ctx, on_finish);
   }
 
-  OpenSourceImageRequest(librados::IoCtx& io_ctx,
+  OpenSourceImageRequest(librados::IoCtx& dst_io_ctx,
                          ImageCtxT* destination_image_ctx,
                          uint64_t src_snap_id,
                          const MigrationInfo &migration_info,
@@ -66,7 +66,7 @@ private:
   typedef std::map<uint64_t, SnapInfo> SnapInfos;
 
   CephContext* m_cct;
-  librados::IoCtx& m_io_ctx;
+  librados::IoCtx& m_dst_io_ctx;
   ImageCtxT* m_dst_image_ctx;
   uint64_t m_src_snap_id;
   MigrationInfo m_migration_info;

--- a/src/librbd/migration/OpenSourceImageRequest.h
+++ b/src/librbd/migration/OpenSourceImageRequest.h
@@ -6,6 +6,7 @@
 
 #include "include/rados/librados_fwd.hpp"
 #include "librbd/Types.h"
+#include "json_spirit/json_spirit.h"
 #include <map>
 #include <memory>
 
@@ -78,7 +79,8 @@ private:
   uint64_t m_image_size = 0;
   SnapInfos m_snap_infos;
 
-  void open_source();
+  void open_source(const json_spirit::mObject& source_spec_object,
+                   bool import_only);
   void handle_open_source(int r);
 
   void get_image_size();

--- a/src/librbd/migration/OpenSourceImageRequest.h
+++ b/src/librbd/migration/OpenSourceImageRequest.h
@@ -47,19 +47,26 @@ private:
   /**
    * @verbatim
    *
-   * <start>
-   *    |
-   *    v
-   * OPEN_SOURCE
-   *    |
-   *    v
-   * GET_IMAGE_SIZE  * * * * * * *
-   *    |                        *
-   *    v                        v
-   * GET_SNAPSHOTS * * * * > CLOSE_IMAGE
-   *    |                        |
-   *    v                        |
-   * <finish> <------------------/
+   *                  <start>
+   *                     |
+   *                     v
+   *             PARSE_SOURCE_SPEC
+   *   (native)          |          (raw or qcow)
+   *     /--------------/ \-------------------\
+   *     |                                    |
+   *     v                                    v
+   * OPEN_NATIVE          * * * * * * * * OPEN_FORMAT
+   *     |               *                    |
+   *     |               *                    v
+   *     |               * * * * * * * GET_IMAGE_SIZE
+   *     |               *                    |
+   *     |               v                    v
+   *     |          CLOSE_IMAGE < * * * GET_SNAPSHOTS
+   *     |               |                    |
+   *     |/--------------/--------------------/
+   *     |
+   *     v
+   *  <finish>
    *
    * @endverbatim
    */
@@ -79,9 +86,12 @@ private:
   uint64_t m_image_size = 0;
   SnapInfos m_snap_infos;
 
-  void open_source(const json_spirit::mObject& source_spec_object,
+  void open_native(const json_spirit::mObject& source_spec_object,
                    bool import_only);
-  void handle_open_source(int r);
+  void handle_open_native(int r);
+
+  void open_format(const json_spirit::mObject& source_spec_object);
+  void handle_open_format(int r);
 
   void get_image_size();
   void handle_get_image_size(int r);

--- a/src/librbd/migration/QCOWFormat.cc
+++ b/src/librbd/migration/QCOWFormat.cc
@@ -1436,7 +1436,7 @@ void QCOWFormat<I>::get_image_size(uint64_t snap_id, uint64_t* size,
 }
 
 template <typename I>
-bool QCOWFormat<I>::read(
+void QCOWFormat<I>::read(
     io::AioCompletion* aio_comp, uint64_t snap_id, io::Extents&& image_extents,
     io::ReadResult&& read_result, int op_flags, int read_flags,
     const ZTracer::Trace &parent_trace) {
@@ -1451,7 +1451,7 @@ bool QCOWFormat<I>::read(
     auto snapshot_it = m_snapshots.find(snap_id);
     if (snapshot_it == m_snapshots.end()) {
       aio_comp->fail(-ENOENT);
-      return true;
+      return;
     }
 
     auto& snapshot = snapshot_it->second;
@@ -1464,8 +1464,6 @@ bool QCOWFormat<I>::read(
   auto read_request = new ReadRequest(this, aio_comp, l1_table,
                                       std::move(image_extents));
   read_request->send();
-
-  return true;
 }
 
 template <typename I>

--- a/src/librbd/migration/QCOWFormat.cc
+++ b/src/librbd/migration/QCOWFormat.cc
@@ -842,8 +842,8 @@ void QCOWFormat<I>::open(Context* on_finish) {
 
   int r = m_source_spec_builder->build_stream(m_json_object, &m_stream);
   if (r < 0) {
-    lderr(cct) << "failed to build migration stream handler" << cpp_strerror(r)
-               << dendl;
+    lderr(cct) << "failed to build migration stream handler: "
+               << cpp_strerror(r) << dendl;
     on_finish->complete(r);
     return;
   }

--- a/src/librbd/migration/QCOWFormat.h
+++ b/src/librbd/migration/QCOWFormat.h
@@ -66,7 +66,7 @@ public:
   void get_image_size(uint64_t snap_id, uint64_t* size,
                       Context* on_finish) override;
 
-  bool read(io::AioCompletion* aio_comp, uint64_t snap_id,
+  void read(io::AioCompletion* aio_comp, uint64_t snap_id,
             io::Extents&& image_extents, io::ReadResult&& read_result,
             int op_flags, int read_flags,
             const ZTracer::Trace &parent_trace) override;

--- a/src/librbd/migration/RawFormat.cc
+++ b/src/librbd/migration/RawFormat.cc
@@ -108,8 +108,8 @@ void RawFormat<I>::handle_open(int r, Context* on_finish) {
       snapshot->close(gather_ctx->new_sub());
     }
 
-    m_image_ctx->state->close(new LambdaContext(
-      [r, on_finish=gather_ctx->new_sub()](int _) { on_finish->complete(r); }));
+    auto ctx = gather_ctx->new_sub();
+    ctx->complete(r);
 
     gather_ctx->activate();
     return;

--- a/src/librbd/migration/RawFormat.cc
+++ b/src/librbd/migration/RawFormat.cc
@@ -163,7 +163,7 @@ void RawFormat<I>::get_image_size(uint64_t snap_id, uint64_t* size,
 }
 
 template <typename I>
-bool RawFormat<I>::read(
+void RawFormat<I>::read(
     io::AioCompletion* aio_comp, uint64_t snap_id, io::Extents&& image_extents,
     io::ReadResult&& read_result, int op_flags, int read_flags,
     const ZTracer::Trace &parent_trace) {
@@ -174,13 +174,12 @@ bool RawFormat<I>::read(
   auto snapshot_it = m_snapshots.find(snap_id);
   if (snapshot_it == m_snapshots.end()) {
     aio_comp->fail(-ENOENT);
-    return true;
+    return;
   }
 
   snapshot_it->second->read(aio_comp, std::move(image_extents),
                             std::move(read_result), op_flags, read_flags,
                             parent_trace);
-  return true;
 }
 
 template <typename I>

--- a/src/librbd/migration/RawFormat.h
+++ b/src/librbd/migration/RawFormat.h
@@ -44,7 +44,7 @@ public:
   void get_image_size(uint64_t snap_id, uint64_t* size,
                       Context* on_finish) override;
 
-  bool read(io::AioCompletion* aio_comp, uint64_t snap_id,
+  void read(io::AioCompletion* aio_comp, uint64_t snap_id,
             io::Extents&& image_extents, io::ReadResult&& read_result,
             int op_flags, int read_flags,
             const ZTracer::Trace &parent_trace) override;

--- a/src/librbd/migration/RawSnapshot.cc
+++ b/src/librbd/migration/RawSnapshot.cc
@@ -153,8 +153,8 @@ void RawSnapshot<I>::open(SnapshotInterface* previous_snapshot,
 
   int r = m_source_spec_builder->build_stream(m_json_object, &m_stream);
   if (r < 0) {
-    lderr(cct) << "failed to build migration stream handler" << cpp_strerror(r)
-               << dendl;
+    lderr(cct) << "failed to build migration stream handler: "
+               << cpp_strerror(r) << dendl;
     on_finish->complete(r);
     return;
   }

--- a/src/librbd/migration/SourceSpecBuilder.cc
+++ b/src/librbd/migration/SourceSpecBuilder.cc
@@ -96,7 +96,7 @@ int SourceSpecBuilder<I>::build_snapshot(
     snapshot->reset(RawSnapshot<I>::create(m_image_ctx, source_spec_object,
                                            this, index));
   } else {
-    lderr(cct) << "unknown or unsupported format type '" << type << "'"
+    lderr(cct) << "unknown or unsupported snapshot type '" << type << "'"
                << dendl;
     return -ENOSYS;
   }

--- a/src/librbd/migration/SourceSpecBuilder.cc
+++ b/src/librbd/migration/SourceSpecBuilder.cc
@@ -45,7 +45,7 @@ int SourceSpecBuilder<I>::parse_source_spec(
 
 template <typename I>
 int SourceSpecBuilder<I>::build_format(
-    const json_spirit::mObject& source_spec_object, bool import_only,
+    const json_spirit::mObject& source_spec_object,
     std::unique_ptr<FormatInterface>* format) const {
   auto cct = m_image_ctx->cct;
   ldout(cct, 10) << dendl;
@@ -58,10 +58,7 @@ int SourceSpecBuilder<I>::build_format(
   }
 
   auto& type = type_value_it->second.get_str();
-  if (type == "native") {
-    format->reset(NativeFormat<I>::create(m_image_ctx, source_spec_object,
-                                          import_only));
-  } else if (type == "qcow") {
+  if (type == "qcow") {
     format->reset(QCOWFormat<I>::create(m_image_ctx, source_spec_object, this));
   } else if (type == "raw") {
     format->reset(RawFormat<I>::create(m_image_ctx, source_spec_object, this));

--- a/src/librbd/migration/SourceSpecBuilder.cc
+++ b/src/librbd/migration/SourceSpecBuilder.cc
@@ -30,12 +30,9 @@ const std::string TYPE_KEY{"type"};
 template <typename I>
 int SourceSpecBuilder<I>::parse_source_spec(
     const std::string& source_spec,
-    json_spirit::mObject* source_spec_object) const {
-  auto cct = m_image_ctx->cct;
-  ldout(cct, 10) << dendl;
-
+    json_spirit::mObject* source_spec_object) {
   json_spirit::mValue json_root;
-  if(json_spirit::read(source_spec, json_root)) {
+  if (json_spirit::read(source_spec, json_root)) {
     try {
       *source_spec_object = json_root.get_obj();
       return 0;
@@ -43,7 +40,6 @@ int SourceSpecBuilder<I>::parse_source_spec(
     }
   }
 
-  lderr(cct) << "invalid source-spec JSON" << dendl;
   return -EBADMSG;
 }
 

--- a/src/librbd/migration/SourceSpecBuilder.h
+++ b/src/librbd/migration/SourceSpecBuilder.h
@@ -7,7 +7,6 @@
 #include "include/int_types.h"
 #include <json_spirit/json_spirit.h>
 #include <memory>
-#include <optional>
 #include <string>
 
 struct Context;
@@ -25,11 +24,11 @@ struct StreamInterface;
 template <typename ImageCtxT>
 class SourceSpecBuilder {
 public:
+  static int parse_source_spec(const std::string& source_spec,
+                               json_spirit::mObject* source_spec_object);
+
   SourceSpecBuilder(ImageCtxT* image_ctx) : m_image_ctx(image_ctx) {
   }
-
-  int parse_source_spec(const std::string& source_spec,
-                        json_spirit::mObject* source_spec_object) const;
 
   int build_format(const json_spirit::mObject& format_object, bool import_only,
                    std::unique_ptr<FormatInterface>* format) const;
@@ -43,7 +42,6 @@ public:
 
 private:
   ImageCtxT* m_image_ctx;
-
 };
 
 } // namespace migration

--- a/src/librbd/migration/SourceSpecBuilder.h
+++ b/src/librbd/migration/SourceSpecBuilder.h
@@ -30,7 +30,7 @@ public:
   SourceSpecBuilder(ImageCtxT* image_ctx) : m_image_ctx(image_ctx) {
   }
 
-  int build_format(const json_spirit::mObject& format_object, bool import_only,
+  int build_format(const json_spirit::mObject& format_object,
                    std::unique_ptr<FormatInterface>* format) const;
 
   int build_snapshot(const json_spirit::mObject& source_spec_object,

--- a/src/test/librbd/migration/test_mock_QCOWFormat.cc
+++ b/src/test/librbd/migration/test_mock_QCOWFormat.cc
@@ -835,8 +835,8 @@ TEST_F(TestMockMigrationQCOWFormat, Read) {
     &ctx2, m_image_ctx, io::AIO_TYPE_READ);
   bufferlist bl;
   io::ReadResult read_result{&bl};
-  ASSERT_TRUE(mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{65659, 123}},
-                                    std::move(read_result), 0, 0, {}));
+  mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{65659, 123}},
+                        std::move(read_result), 0, 0, {});
   ASSERT_EQ(123, ctx2.wait());
   ASSERT_EQ(expect_bl, bl);
 
@@ -870,8 +870,8 @@ TEST_F(TestMockMigrationQCOWFormat, ReadL1DNE) {
     &ctx2, m_image_ctx, io::AIO_TYPE_READ);
   bufferlist bl;
   io::ReadResult read_result{&bl};
-  ASSERT_TRUE(mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{234, 123}},
-                                    std::move(read_result), 0, 0, {}));
+  mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{234, 123}},
+                        std::move(read_result), 0, 0, {});
   ASSERT_EQ(123, ctx2.wait());
   bufferlist expect_bl;
   expect_bl.append_zero(123);
@@ -910,8 +910,8 @@ TEST_F(TestMockMigrationQCOWFormat, ReadL2DNE) {
     &ctx2, m_image_ctx, io::AIO_TYPE_READ);
   bufferlist bl;
   io::ReadResult read_result{&bl};
-  ASSERT_TRUE(mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{234, 123}},
-                                    std::move(read_result), 0, 0, {}));
+  mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{234, 123}},
+                        std::move(read_result), 0, 0, {});
   ASSERT_EQ(123, ctx2.wait());
   bufferlist expect_bl;
   expect_bl.append_zero(123);
@@ -950,8 +950,8 @@ TEST_F(TestMockMigrationQCOWFormat, ReadZero) {
     &ctx2, m_image_ctx, io::AIO_TYPE_READ);
   bufferlist bl;
   io::ReadResult read_result{&bl};
-  ASSERT_TRUE(mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{65659, 123}},
-                                    std::move(read_result), 0, 0, {}));
+  mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{65659, 123}},
+                        std::move(read_result), 0, 0, {});
   ASSERT_EQ(123, ctx2.wait());
   bufferlist expect_bl;
   expect_bl.append_zero(123);
@@ -1004,8 +1004,8 @@ TEST_F(TestMockMigrationQCOWFormat, ReadSnap) {
     &ctx2, m_image_ctx, io::AIO_TYPE_READ);
   bufferlist bl;
   io::ReadResult read_result{&bl};
-  ASSERT_TRUE(mock_qcow_format.read(aio_comp, 1, {{65659, 123}},
-                                    std::move(read_result), 0, 0, {}));
+  mock_qcow_format.read(aio_comp, 1, {{65659, 123}},
+                        std::move(read_result), 0, 0, {});
   ASSERT_EQ(123, ctx2.wait());
   ASSERT_EQ(expect_bl, bl);
 
@@ -1039,8 +1039,8 @@ TEST_F(TestMockMigrationQCOWFormat, ReadSnapDNE) {
     &ctx2, m_image_ctx, io::AIO_TYPE_READ);
   bufferlist bl;
   io::ReadResult read_result{&bl};
-  ASSERT_TRUE(mock_qcow_format.read(aio_comp, 1, {{65659, 123}},
-                                    std::move(read_result), 0, 0, {}));
+  mock_qcow_format.read(aio_comp, 1, {{65659, 123}},
+                        std::move(read_result), 0, 0, {});
   ASSERT_EQ(-ENOENT, ctx2.wait());
 
   C_SaferCond ctx3;
@@ -1090,8 +1090,8 @@ TEST_F(TestMockMigrationQCOWFormat, ReadClusterCacheHit) {
     &ctx2, m_image_ctx, io::AIO_TYPE_READ);
   bufferlist bl1;
   io::ReadResult read_result1{&bl1};
-  ASSERT_TRUE(mock_qcow_format.read(aio_comp1, CEPH_NOSNAP, {{65659, 123}},
-                                    std::move(read_result1), 0, 0, {}));
+  mock_qcow_format.read(aio_comp1, CEPH_NOSNAP, {{65659, 123}},
+                        std::move(read_result1), 0, 0, {});
   ASSERT_EQ(123, ctx2.wait());
   ASSERT_EQ(expect_bl1, bl1);
 
@@ -1100,8 +1100,8 @@ TEST_F(TestMockMigrationQCOWFormat, ReadClusterCacheHit) {
     &ctx3, m_image_ctx, io::AIO_TYPE_READ);
   bufferlist bl2;
   io::ReadResult read_result2{&bl2};
-  ASSERT_TRUE(mock_qcow_format.read(aio_comp2, CEPH_NOSNAP, {{66016, 234}},
-                                    std::move(read_result2), 0, 0, {}));
+  mock_qcow_format.read(aio_comp2, CEPH_NOSNAP, {{66016, 234}},
+                        std::move(read_result2), 0, 0, {});
   ASSERT_EQ(234, ctx3.wait());
   ASSERT_EQ(expect_bl2, bl2);
 
@@ -1142,8 +1142,8 @@ TEST_F(TestMockMigrationQCOWFormat, ReadClusterError) {
     &ctx2, m_image_ctx, io::AIO_TYPE_READ);
   bufferlist bl;
   io::ReadResult read_result{&bl};
-  ASSERT_TRUE(mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{65659, 123}},
-                                    std::move(read_result), 0, 0, {}));
+  mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{65659, 123}},
+                        std::move(read_result), 0, 0, {});
   ASSERT_EQ(-EIO, ctx2.wait());
 
   C_SaferCond ctx3;
@@ -1179,8 +1179,8 @@ TEST_F(TestMockMigrationQCOWFormat, ReadL2TableError) {
     &ctx2, m_image_ctx, io::AIO_TYPE_READ);
   bufferlist bl;
   io::ReadResult read_result{&bl};
-  ASSERT_TRUE(mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{65659, 123}},
-                                    std::move(read_result), 0, 0, {}));
+  mock_qcow_format.read(aio_comp, CEPH_NOSNAP, {{65659, 123}},
+                        std::move(read_result), 0, 0, {});
   ASSERT_EQ(-EIO, ctx2.wait());
 
   C_SaferCond ctx3;

--- a/src/test/librbd/migration/test_mock_RawFormat.cc
+++ b/src/test/librbd/migration/test_mock_RawFormat.cc
@@ -336,8 +336,8 @@ TEST_F(TestMockMigrationRawFormat, Read) {
     &ctx2, m_image_ctx, io::AIO_TYPE_READ);
   bufferlist bl;
   io::ReadResult read_result{&bl};
-  ASSERT_TRUE(mock_raw_format.read(aio_comp, CEPH_NOSNAP, {{123, 123}},
-                                   std::move(read_result), 0, 0, {}));
+  mock_raw_format.read(aio_comp, CEPH_NOSNAP, {{123, 123}},
+                       std::move(read_result), 0, 0, {});
   ASSERT_EQ(123, ctx2.wait());
   ASSERT_EQ(expect_bl, bl);
 

--- a/src/test/librbd/migration/test_mock_RawFormat.cc
+++ b/src/test/librbd/migration/test_mock_RawFormat.cc
@@ -125,13 +125,6 @@ public:
         })));
   }
 
-  void expect_close(MockTestImageCtx &mock_image_ctx, int r) {
-    EXPECT_CALL(*mock_image_ctx.state, close(_))
-      .WillOnce(Invoke([r](Context* ctx) {
-                  ctx->complete(r);
-                }));
-  }
-
   json_spirit::mObject json_object;
 };
 
@@ -174,7 +167,6 @@ TEST_F(TestMockMigrationRawFormat, OpenError) {
   expect_snapshot_open(*mock_snapshot_interface, -ENOENT);
 
   expect_snapshot_close(*mock_snapshot_interface, 0);
-  expect_close(mock_image_ctx, 0);
 
   MockRawFormat mock_raw_format(&mock_image_ctx, json_object,
                                 &mock_source_spec_builder);
@@ -203,7 +195,6 @@ TEST_F(TestMockMigrationRawFormat, OpenSnapshotError) {
 
   expect_snapshot_close(*mock_snapshot_interface_1, 0);
   expect_snapshot_close(*mock_snapshot_interface_head, 0);
-  expect_close(mock_image_ctx, 0);
 
   json_spirit::mArray snapshots;
   snapshots.push_back(json_spirit::mObject{});


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67442

---

backport of https://github.com/ceph/ceph/pull/58882 and https://github.com/ceph/ceph/pull/44366
parent tracker: https://tracker.ceph.com/issues/53674