### PR TITLE
squid: suites: test should ignore osd_down warnings

### DIFF
--- a/qa/suites/rados/dashboard/tasks/e2e.yaml
+++ b/qa/suites/rados/dashboard/tasks/e2e.yaml
@@ -13,6 +13,9 @@ roles:
 tasks:
 - install:
 - cephadm:
+- ceph:
+    log-ignorelist:
+      - \(OSD_DOWN\)
 - workunit:
     clients:
       client.1:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67473

---

backport of https://github.com/ceph/ceph/pull/58205
parent tracker: https://tracker.ceph.com/issues/64870

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh