### PR TITLE
rbd: fix CLI output of `rbd group snap info` command when a group snapshot with no member images

### DIFF
--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -500,9 +500,10 @@ int GroupSnapshot_to_group_snap_info2(
   group_snap->id = cls_group_snap.id;
   group_snap->name = cls_group_snap.name;
   group_snap->state = static_cast<group_snap_state_t>(cls_group_snap.state);
-  group_snap->image_snap_name = calc_ind_image_snap_name(group_ioctx.get_id(),
-                                                         group_id,
-                                                         cls_group_snap.id);
+  if (!image_snaps.empty()) {
+    group_snap->image_snap_name = calc_ind_image_snap_name(
+        group_ioctx.get_id(), group_id, cls_group_snap.id);
+  }
   group_snap->image_snaps = std::move(image_snaps);
 
   return 0;

--- a/src/test/librbd/test_Groups.cc
+++ b/src/test/librbd/test_Groups.cc
@@ -505,8 +505,6 @@ TEST_F(TestGroup, snap_get_info)
 
   const char *gp_name = "gp_snapgetinfo";
   ASSERT_EQ(0, rbd_group_create(ioctx2, gp_name));
-  ASSERT_EQ(0, rbd_group_image_add(ioctx2, gp_name, ioctx,
-                                   m_image_name.c_str()));
 
   const char *gp_snap_name = "snap_snapshot";
   ASSERT_EQ(0, rbd_group_snap_create(ioctx2, gp_name, gp_snap_name));
@@ -516,6 +514,20 @@ TEST_F(TestGroup, snap_get_info)
                                              &gp_snap_info));
   ASSERT_EQ(-ENOENT, rbd_group_snap_get_info(ioctx2, gp_name, "absent",
                                              &gp_snap_info));
+
+  ASSERT_EQ(0, rbd_group_snap_get_info(ioctx2, gp_name, gp_snap_name,
+                                       &gp_snap_info));
+  ASSERT_STREQ(gp_snap_name, gp_snap_info.name);
+  ASSERT_EQ(RBD_GROUP_SNAP_STATE_COMPLETE, gp_snap_info.state);
+  ASSERT_STREQ("", gp_snap_info.image_snap_name);
+  ASSERT_EQ(0U, gp_snap_info.image_snaps_count);
+
+  rbd_group_snap_get_info_cleanup(&gp_snap_info);
+  ASSERT_EQ(0, rbd_group_snap_remove(ioctx2, gp_name, gp_snap_name));
+
+  ASSERT_EQ(0, rbd_group_image_add(ioctx2, gp_name, ioctx,
+                                   m_image_name.c_str()));
+  ASSERT_EQ(0, rbd_group_snap_create(ioctx2, gp_name, gp_snap_name));
 
   ASSERT_EQ(0, rbd_group_snap_get_info(ioctx2, gp_name, gp_snap_name,
                                        &gp_snap_info));
@@ -545,8 +557,6 @@ TEST_F(TestGroup, snap_get_infoPP)
 
   const char *gp_name = "gp_snapgetinfoPP";
   ASSERT_EQ(0, m_rbd.group_create(ioctx2, gp_name));
-  ASSERT_EQ(0, m_rbd.group_image_add(ioctx2, gp_name, m_ioctx,
-                                     m_image_name.c_str()));
 
   const char *gp_snap_name = "snap_snapshot";
   ASSERT_EQ(0, m_rbd.group_snap_create(ioctx2, gp_name, gp_snap_name));
@@ -556,6 +566,19 @@ TEST_F(TestGroup, snap_get_infoPP)
                                                &gp_snap_info));
   ASSERT_EQ(-ENOENT, m_rbd.group_snap_get_info(ioctx2, gp_name, "absent",
                                                &gp_snap_info));
+
+  ASSERT_EQ(0, m_rbd.group_snap_get_info(ioctx2, gp_name, gp_snap_name,
+                                         &gp_snap_info));
+  ASSERT_EQ(gp_snap_name, gp_snap_info.name);
+  ASSERT_EQ(RBD_GROUP_SNAP_STATE_COMPLETE, gp_snap_info.state);
+  ASSERT_EQ("", gp_snap_info.image_snap_name);
+  ASSERT_EQ(0U, gp_snap_info.image_snaps.size());
+
+  ASSERT_EQ(0, m_rbd.group_snap_remove(ioctx2, gp_name, gp_snap_name));
+
+  ASSERT_EQ(0, m_rbd.group_image_add(ioctx2, gp_name, m_ioctx,
+                                     m_image_name.c_str()));
+  ASSERT_EQ(0, m_rbd.group_snap_create(ioctx2, gp_name, gp_snap_name));
 
   ASSERT_EQ(0, m_rbd.group_snap_get_info(ioctx2, gp_name, gp_snap_name,
                                          &gp_snap_info));

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -2918,6 +2918,18 @@ class TestGroups(object):
         self.group.remove_snap(snap_name)
         assert_raises(ObjectNotFound, self.group.get_snap_info, snap_name)
 
+    def test_group_snap_get_info_no_member_images(self):
+        self.group.create_snap(snap_name)
+
+        snap_info_dict = self.group.get_snap_info(snap_name)
+        assert sorted(snap_info_dict.keys()) == self.gp_snap_keys
+        assert snap_info_dict['name'] == snap_name
+        assert snap_info_dict['state'] == RBD_GROUP_SNAP_STATE_COMPLETE
+        assert snap_info_dict['image_snap_name'] == ""
+        assert snap_info_dict['image_snaps'] == []
+
+        self.group.remove_snap(snap_name)
+
     def test_group_snap(self):
         global snap_name
         eq([], list(self.group.list_snaps()))

--- a/src/tools/rbd/action/Group.cc
+++ b/src/tools/rbd/action/Group.cc
@@ -805,9 +805,13 @@ int execute_group_snap_info(const po::variables_map &vm,
   } else {
     std::cout << "rbd group snapshot '" << group_snap.name << "':\n"
               << "\tid: " << group_snap.id << std::endl
-              << "\tstate: " << state_string << std::endl
-              << "\timage snap: " << group_snap.image_snap_name << std::endl
-              << "\timages:" << std::endl;
+              << "\tstate: " << state_string << std::endl;
+    if (!group_snap.image_snaps.empty()) {
+      std::cout << "\timage snap: " << group_snap.image_snap_name << std::endl
+                << "\timages:" << std::endl;
+    } else {
+      ceph_assert(group_snap.image_snap_name.empty());
+    }
   }
 
   std::sort(group_snap.image_snaps.begin(), group_snap.image_snaps.end(),


### PR DESCRIPTION
Before the fix (copied from https://tracker.ceph.com/issues/67436)
```
[root@server1 build]# rbd group snap info data/grp1@snap1
rbd group snapshot 'snap1':
    id: 102c5329c35a
    state: complete
    image snap: .group.2_102a9283e0ec_102c5329c35a
    images:
```

**See below for outputs with the fix**
```
$ rbd group create gp3
$ rbd group snap create gp3@snap3
$ # omitted 'images' and 'image snap' fields from the `rbd group snap info` output
$ rbd group snap info gp3@snap3
rbd group snapshot 'snap3':
	id: 1038d0c5cddc
	state: complete
$ rbd group snap info gp3@snap3 --format=json --pretty-format
{
    "id": "1038d0c5cddc",
    "name": "snap3",
    "state": "complete",
    "image_snap_name": "",
    "images": []
}
$ rbd create -s 10M img3
$ rbd group image add gp3 img3
$ rbd group snap create gp3@snap4
$ rbd group snap info gp3@snap4
rbd group snapshot 'snap4':
	id: 104cf0614061
	state: complete
	image snap: .group.1_103647dab2e1_104cf0614061
	images:
		rbd/img3 (snap id: 3)
```

In the Python interpreter,
```
>>> import rbd; import rados
>>> rc = rados.Rados(conffile='/home/rraja/git/ceph-3/build/ceph.conf'); rc.connect(); ioctx = rc.open_ioctx('rbd'); gc = rbd.Group(ioctx, 'gp3')
>>> print(json.dumps(gc.get_snap_info('snap3'), indent=2))
{
  "id": "1038d0c5cddc",
  "name": "snap3",
  "state": 1,
  "image_snap_name": "",
  "image_snaps": []
}
>>> for gp_snap in gc.list_snaps():
...     print(json.dumps(gp_snap, indent=2))
... 
{
  "id": "1038d0c5cddc",
  "name": "snap3",
  "state": 1,
  "image_snap_name": "",
  "image_snaps": []
}
{
  "id": "104cf0614061",
  "name": "snap4",
  "state": 1,
  "image_snap_name": ".group.1_103647dab2e1_104cf0614061",
  "image_snaps": [
    {
      "pool_id": 1,
      "snap_id": 3,
      "image_name": "img3"
    }
  ]
}
```
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
