### PR TITLE
client: Prevent race condition when printing Inode in ll_sync_inode

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -16140,7 +16140,7 @@ int Client::ll_sync_inode(Inode *in, bool syncdataonly)
   if (!mref_reader.is_state_satisfied())
     return -CEPHFS_ENOTCONN;
 
-  ldout(cct, 3) << "ll_sync_inode " << *in << " " << dendl;
+  ldout(cct, 3) << "ll_sync_inode " << _get_vino(in) << " " << dendl;
   tout(cct) << "ll_sync_inode" << std::endl;
   tout(cct) << (uintptr_t)in << std::endl;
 


### PR DESCRIPTION
In the ll_sync_inode function, the entire Inode structure is printed without holding a lock. This can lead to a race condition when evaluating the assertion in xlist<ObjectCacher::Object*>::size(), resulting in abnormal behavior.

Fixes: https://tracker.ceph.com/issues/67491