### PR TITLE
ceph-volume: switch over to new disk sorting behavior

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -224,7 +224,6 @@ class Batch(object):
             action='store_true',
             help=('deploy multi-device OSDs if rotational and non-rotational drives '
                   'are passed in DEVICES'),
-            default=True
         )
         parser.add_argument(
             '--no-auto',
@@ -377,7 +376,6 @@ class Batch(object):
         '''
         mlogger.warning('DEPRECATION NOTICE')
         mlogger.warning('You are using the legacy automatic disk sorting behavior')
-        mlogger.warning('The Pacific release will change the default to --no-auto')
         rotating = []
         ssd = []
         for d in self.args.devices:


### PR DESCRIPTION
The automatic disk sorting behavior is deprecated. The new behavior should be the default since Ceph Pacific but it got pushed back multiple times.

Fixes: https://tracker.ceph.com/issues/67497
