### PR TITLE
mgr/cephadm: add ability for cephadm to generate frontend cert for rgw

### DIFF
--- a/src/pybind/mgr/cephadm/cert_mgr.py
+++ b/src/pybind/mgr/cephadm/cert_mgr.py
@@ -21,7 +21,7 @@ class CertMgr:
             except SSLConfigException:
                 raise Exception("Cannot load cephadm root CA certificates.")
         else:
-            self.ssl_certs.generate_root_cert(ip)
+            self.ssl_certs.generate_root_cert(addr=ip)
             mgr.cert_key_store.save_cert(self.CEPHADM_ROOT_CA_CERT, self.ssl_certs.get_root_cert())
             mgr.cert_key_store.save_key(self.CEPHADM_ROOT_CA_KEY, self.ssl_certs.get_root_key())
 

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -1000,6 +1000,12 @@ class RgwService(CephService):
                 'value': spec.rgw_zone,
             })
 
+        if spec.generate_cert and not spec.rgw_frontend_ssl_certificate:
+            # generate a self-signed cert for the rgw service
+            cert, key = self.mgr.cert_mgr.ssl_certs.generate_root_cert(custom_san_list=spec.zonegroup_hostnames)
+            spec.rgw_frontend_ssl_certificate = ''.join([key, cert])
+            self.mgr.spec_store.save(spec)
+
         if spec.rgw_frontend_ssl_certificate:
             if isinstance(spec.rgw_frontend_ssl_certificate, list):
                 cert_data = '\n'.join(spec.rgw_frontend_ssl_certificate)

--- a/src/pybind/mgr/cephadm/tests/test_node_proxy.py
+++ b/src/pybind/mgr/cephadm/tests/test_node_proxy.py
@@ -37,7 +37,7 @@ class FakeMgr:
         self.http_server = MagicMock()
         self.http_server.agent = MagicMock()
         self.http_server.agent.ssl_certs = SSLCerts()
-        self.http_server.agent.ssl_certs.generate_root_cert(self.get_mgr_ip())
+        self.http_server.agent.ssl_certs.generate_root_cert(addr=self.get_mgr_ip())
         self.cert_mgr = FakeCertMgr()
 
     def get_mgr_ip(self) -> str:

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1206,7 +1206,7 @@ class RGWSpec(ServiceSpec):
                  rgw_zonegroup: Optional[str] = None,
                  rgw_zone: Optional[str] = None,
                  rgw_frontend_port: Optional[int] = None,
-                 rgw_frontend_ssl_certificate: Optional[List[str]] = None,
+                 rgw_frontend_ssl_certificate: Optional[Union[str, List[str]]] = None,
                  rgw_frontend_type: Optional[str] = None,
                  rgw_frontend_extra_args: Optional[List[str]] = None,
                  unmanaged: bool = False,
@@ -1226,6 +1226,7 @@ class RGWSpec(ServiceSpec):
                  rgw_user_counters_cache_size: Optional[int] = None,
                  rgw_bucket_counters_cache: Optional[bool] = False,
                  rgw_bucket_counters_cache_size: Optional[int] = None,
+                 generate_cert: bool = False,
                  ):
         assert service_type == 'rgw', service_type
 
@@ -1255,7 +1256,8 @@ class RGWSpec(ServiceSpec):
         #: Port of the RGW daemons
         self.rgw_frontend_port: Optional[int] = rgw_frontend_port
         #: List of SSL certificates
-        self.rgw_frontend_ssl_certificate: Optional[List[str]] = rgw_frontend_ssl_certificate
+        self.rgw_frontend_ssl_certificate: Optional[Union[str, List[str]]] \
+            = rgw_frontend_ssl_certificate
         #: civetweb or beast (default: beast). See :ref:`rgw_frontends`
         self.rgw_frontend_type: Optional[str] = rgw_frontend_type
         #: List of extra arguments for rgw_frontend in the form opt=value. See :ref:`rgw_frontends`
@@ -1275,6 +1277,8 @@ class RGWSpec(ServiceSpec):
         self.rgw_bucket_counters_cache = rgw_bucket_counters_cache
         #: Used to set number of entries in each cache of bucket counters
         self.rgw_bucket_counters_cache_size = rgw_bucket_counters_cache_size
+        #: Whether we should generate a cert/key for the user if not provided
+        self.generate_cert = generate_cert
 
     def get_port_start(self) -> List[int]:
         return [self.get_port()]
@@ -1302,6 +1306,10 @@ class RGWSpec(ServiceSpec):
                     'Invalid rgw_frontend_type value. Valid values are: beast, civetweb.\n'
                     'Additional rgw type parameters can be passed using rgw_frontend_extra_args.'
                 )
+
+        if self.generate_cert and not self.ssl:
+            raise SpecValidationError('"ssl" field must be set to true when "generate_cert" '
+                                      'is set to true')
 
 
 yaml.add_representer(RGWSpec, ServiceSpec.yaml_representer)

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1221,7 +1221,7 @@ class RGWSpec(ServiceSpec):
                  rgw_realm_token: Optional[str] = None,
                  update_endpoints: Optional[bool] = False,
                  zone_endpoints: Optional[str] = None,  # comma separated endpoints list
-                 zonegroup_hostnames: Optional[str] = None,
+                 zonegroup_hostnames: Optional[List[str]] = None,
                  rgw_user_counters_cache: Optional[bool] = False,
                  rgw_user_counters_cache_size: Optional[int] = None,
                  rgw_bucket_counters_cache: Optional[bool] = False,


### PR DESCRIPTION
If users are okay with a self-signed cert and would prefer to
just let cephadm generate it for them rather than creating it
themselves. Additionally, if the zonegroup_hostnames field is
set, add those entries to the SANs entries for the cert in
order to facilitate virtual host bucket access

Docs and Teuthology test TODO after initial testing

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
