### PR TITLE
crimson/os/seastore: make laddr_t block aligned

### DIFF
--- a/src/crimson/os/seastore/backref/backref_tree_node.h
+++ b/src/crimson/os/seastore/backref/backref_tree_node.h
@@ -17,7 +17,7 @@ using BackrefNode = FixedKVNode<paddr_t>;
 
 struct backref_map_val_t {
   extent_len_t len = 0;	///< length of extents
-  laddr_t laddr = 0;	///< logical address of extents
+  laddr_t laddr = L_ADDR_MIN; ///< logical address of extents
   extent_types_t type = extent_types_t::ROOT;
 
   backref_map_val_t() = default;
@@ -36,7 +36,7 @@ std::ostream& operator<<(std::ostream &out, const backref_map_val_t& val);
 
 struct backref_map_val_le_t {
   extent_len_le_t len = init_extent_len_le(0);
-  laddr_le_t laddr = laddr_le_t(0);
+  laddr_le_t laddr = laddr_le_t(L_ADDR_MIN);
   extent_types_le_t type = 0;
 
   backref_map_val_le_t() = default;

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -226,12 +226,18 @@ public:
       assert(!is_end());
       auto val = get_val();
       auto key = get_key();
+      node_key_t end{};
+      if constexpr (std::is_same_v<node_key_t, laddr_t>) {
+        end = (key + val.len).checked_to_laddr();
+      } else {
+        end = key + val.len;
+      }
       return std::make_unique<pin_t>(
         ctx,
 	leaf.node,
         leaf.pos,
 	val,
-	fixed_kv_node_meta_t<node_key_t>{ key, key + val.len, 0 });
+	fixed_kv_node_meta_t<node_key_t>{ key, end, 0 });
     }
 
     typename leaf_node_t::Ref get_leaf_node() {

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -977,10 +977,9 @@ public:
     TCachedExtentRef<T> ext;
     if (original_bptr.has_value()) {
       // shallow copy the buffer from original extent
-      auto nbp = ceph::bufferptr(
-        *original_bptr,
-        remap_laddr - original_laddr,
-        remap_length);
+      auto remap_offset = remap_laddr.get_byte_distance<
+	extent_len_t>(original_laddr);
+      auto nbp = ceph::bufferptr(*original_bptr, remap_offset, remap_length);
       // ExtentPlacementManager::alloc_new_extent will make a new
       // (relative/temp) paddr, so make extent directly
       ext = CachedExtent::make_cached_extent_ref<T>(std::move(nbp));

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -1325,7 +1325,7 @@ public:
   void on_rewrite(Transaction&, CachedExtent &extent, extent_len_t off) final {
     assert(get_type() == extent.get_type());
     auto &lextent = (LogicalCachedExtent&)extent;
-    set_laddr(lextent.get_laddr() + off);
+    set_laddr((lextent.get_laddr() + off).checked_to_laddr());
   }
 
   bool has_laddr() const {

--- a/src/crimson/os/seastore/laddr_interval_set.h
+++ b/src/crimson/os/seastore/laddr_interval_set.h
@@ -1,0 +1,758 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "crimson/os/seastore/seastore_types.h"
+
+namespace crimson::os::seastore {
+namespace details {
+
+// this interval_set structure is copied from include/interval_set.h to allow
+// use the different type for length as the laddr_t becomes struct, and avoid
+// changing the behaviors of other components.
+//
+// The latest commit is 58860ce3f60489d258aaa10fd783e68083261937
+
+template<typename T, typename L, template<typename, typename, typename ...> class C = std::map>
+class interval_set {
+ public:
+  using Map = C<T, L>;
+  using value_type = typename Map::value_type;
+  using offset_type = T;
+  using length_type = L;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using size_type = typename Map::size_type;
+
+  class const_iterator;
+
+  class iterator
+  {
+    public:
+        using difference_type = ssize_t;
+        using value_type = typename Map::value_type;
+        using pointer = typename Map::value_type*;
+        using reference = typename Map::value_type&;
+        using iterator_category = std::forward_iterator_tag;
+
+        explicit iterator(typename Map::iterator iter)
+          : _iter(iter)
+        { }
+
+        // For the copy constructor and assignment operator, the compiler-generated functions, which
+        // perform simple bitwise copying, should be fine.
+
+        bool operator==(const iterator& rhs) const {
+          return (_iter == rhs._iter);
+        }
+
+        bool operator!=(const iterator& rhs) const {
+          return (_iter != rhs._iter);
+        }
+
+        // Dereference this iterator to get a pair.
+        reference operator*() const {
+          return *_iter;
+        }
+
+        // Return the interval start.
+        offset_type get_start() const {
+          return _iter->first;
+        }
+
+        // Return the interval length.
+        length_type get_len() const {
+          return _iter->second;
+        }
+
+        offset_type get_end() const {
+          return _iter->first + _iter->second;
+        }
+
+        // Set the interval length.
+        void set_len(const length_type& len) {
+          _iter->second = len;
+        }
+
+        // Preincrement
+        iterator& operator++()
+        {
+          ++_iter;
+          return *this;
+        }
+
+        // Postincrement
+        iterator operator++(int)
+        {
+          iterator prev(_iter);
+          ++_iter;
+          return prev;
+        }
+
+        // Predecrement
+        iterator& operator--()
+        {
+          --_iter;
+          return *this;
+        }
+
+        // Postdecrement
+        iterator operator--(int)
+        {
+          iterator prev(_iter);
+          --_iter;
+          return prev;
+        }
+
+    friend class interval_set::const_iterator;
+
+    protected:
+        typename Map::iterator _iter;
+    friend class interval_set;
+  };
+
+  class const_iterator
+  {
+    public:
+        using difference_type = ssize_t;
+        using value_type = const typename Map::value_type;
+        using pointer = const typename Map::value_type*;
+        using reference = const typename Map::value_type&;
+        using iterator_category = std::forward_iterator_tag;
+
+        explicit const_iterator(typename Map::const_iterator iter)
+          : _iter(iter)
+        { }
+
+        const_iterator(const iterator &i)
+	  : _iter(i._iter)
+        { }
+
+        // For the copy constructor and assignment operator, the compiler-generated functions, which
+        // perform simple bitwise copying, should be fine.
+
+        bool operator==(const const_iterator& rhs) const {
+          return (_iter == rhs._iter);
+        }
+
+        bool operator!=(const const_iterator& rhs) const {
+          return (_iter != rhs._iter);
+        }
+
+        // Dereference this iterator to get a pair.
+        reference operator*() const {
+          return *_iter;
+        }
+
+        // Return the interval start.
+        offset_type get_start() const {
+          return _iter->first;
+        }
+        offset_type get_end() const {
+          return _iter->first + _iter->second;
+        }
+
+        // Return the interval length.
+        length_type get_len() const {
+          return _iter->second;
+        }
+
+        // Preincrement
+        const_iterator& operator++()
+        {
+          ++_iter;
+          return *this;
+        }
+
+        // Postincrement
+        const_iterator operator++(int)
+        {
+          const_iterator prev(_iter);
+          ++_iter;
+          return prev;
+        }
+
+        // Predecrement
+        iterator& operator--()
+        {
+          --_iter;
+          return *this;
+        }
+
+        // Postdecrement
+        iterator operator--(int)
+        {
+          iterator prev(_iter);
+          --_iter;
+          return prev;
+        }
+
+    protected:
+        typename Map::const_iterator _iter;
+  };
+
+  interval_set() = default;
+  interval_set(Map&& other) {
+    m.swap(other);
+    for (const auto& p : m) {
+      _size += p.second;
+    }
+  }
+
+  size_type num_intervals() const
+  {
+    return m.size();
+  }
+
+  iterator begin() {
+    return iterator(m.begin());
+  }
+
+  iterator lower_bound(T start) {
+    return iterator(find_inc_m(start));
+  }
+
+  iterator end() {
+    return iterator(m.end());
+  }
+
+  const_iterator begin() const {
+    return const_iterator(m.begin());
+  }
+
+  const_iterator lower_bound(T start) const {
+    return const_iterator(find_inc(start));
+  }
+
+  const_iterator end() const {
+    return const_iterator(m.end());
+  }
+
+  // helpers
+ private:
+  auto find_inc(T start) const {
+    auto p = m.lower_bound(start);  // p->first >= start
+    if (p != m.begin() &&
+        (p == m.end() || p->first > start)) {
+      --p;   // might overlap?
+      if (p->first + p->second <= start)
+        ++p; // it doesn't.
+    }
+    return p;
+  }
+
+  auto find_inc_m(T start) {
+    auto p = m.lower_bound(start);
+    if (p != m.begin() &&
+        (p == m.end() || p->first > start)) {
+      --p;   // might overlap?
+      if (p->first + p->second <= start)
+        ++p; // it doesn't.
+    }
+    return p;
+  }
+
+  auto find_adj(T start) const {
+    auto p = m.lower_bound(start);
+    if (p != m.begin() &&
+        (p == m.end() || p->first > start)) {
+      --p;   // might touch?
+      if (p->first + p->second < start)
+        ++p; // it doesn't.
+    }
+    return p;
+  }
+
+  auto find_adj_m(T start) {
+    auto p = m.lower_bound(start);
+    if (p != m.begin() &&
+        (p == m.end() || p->first > start)) {
+      --p;   // might touch?
+      if (p->first + p->second < start)
+        ++p; // it doesn't.
+    }
+    return p;
+  }
+
+  void intersection_size_asym(const interval_set &s, const interval_set &l) {
+    auto ps = s.m.begin();
+    ceph_assert(ps != s.m.end());
+    auto offset = ps->first;
+    bool first = true;
+    auto mi = m.begin();
+
+    while (1) {
+      if (first)
+        first = false;
+      auto pl = l.find_inc(offset);
+      if (pl == l.m.end())
+        break;
+      while (ps != s.m.end() && ps->first + ps->second <= pl->first)
+        ++ps;
+      if (ps == s.m.end())
+        break;
+      offset = pl->first + pl->second;
+      if (offset <= ps->first) {
+        offset = ps->first;
+        continue;
+      }
+
+      if (*ps == *pl) {
+        do {
+          mi = m.insert(mi, *ps);
+          _size += ps->second;
+          ++ps;
+          ++pl;
+        } while (ps != s.m.end() && pl != l.m.end() && *ps == *pl);
+        if (ps == s.m.end())
+          break;
+        offset = ps->first;
+        continue;
+      }
+
+      auto start = std::max<T>(ps->first, pl->first);
+      auto en = std::min<T>(ps->first + ps->second, offset);
+      ceph_assert(en > start);
+      mi = m.emplace_hint(mi, start, en - start);
+      _size += mi->second;
+      if (ps->first + ps->second <= offset) {
+        ++ps;
+        if (ps == s.m.end())
+          break;
+        offset = ps->first;
+      }
+    }
+  }
+
+  bool subset_size_sym(const interval_set &b) const {
+    auto pa = m.begin(), pb = b.m.begin();
+    const auto a_end = m.end(), b_end = b.m.end();
+
+    while (pa != a_end && pb != b_end) {
+      while (pb->first + pb->second <= pa->first) {
+        ++pb;
+        if (pb == b_end)
+          return false;
+      }
+
+      if (*pa == *pb) {
+        do {
+          ++pa;
+          ++pb;
+        } while (pa != a_end && pb != b_end && *pa == *pb);
+        continue;
+      }
+
+      // interval begins before other
+      if (pa->first < pb->first)
+        return false;
+      // interval is longer than other
+      if (pa->first + pa->second > pb->first + pb->second)
+        return false;
+
+      ++pa;
+    }
+
+    return pa == a_end;
+  }
+
+ public:
+  bool operator==(const interval_set& other) const {
+    return _size == other._size && m == other.m;
+  }
+
+  uint64_t size() const {
+    return _size;
+  }
+
+  void bound_encode(size_t& p) const {
+    denc_traits<Map>::bound_encode(m, p);
+  }
+  void encode(ceph::buffer::list::contiguous_appender& p) const {
+    denc(m, p);
+  }
+  void decode(ceph::buffer::ptr::const_iterator& p) {
+    denc(m, p);
+    _size = 0;
+    for (const auto& p : m) {
+      _size += p.second;
+    }
+  }
+  void decode(ceph::buffer::list::iterator& p) {
+    denc(m, p);
+    _size = 0;
+    for (const auto& p : m) {
+      _size += p.second;
+    }
+  }
+
+  void encode_nohead(ceph::buffer::list::contiguous_appender& p) const {
+    denc_traits<Map>::encode_nohead(m, p);
+  }
+  void decode_nohead(int n, ceph::buffer::ptr::const_iterator& p) {
+    denc_traits<Map>::decode_nohead(n, m, p);
+    _size = 0;
+    for (const auto& p : m) {
+      _size += p.second;
+    }
+  }
+
+  void clear() {
+    m.clear();
+    _size = 0;
+  }
+
+  bool contains(T i, T *pstart=0, L *plen=0) const {
+    auto p = find_inc(i);
+    if (p == m.end()) return false;
+    if (p->first > i) return false;
+    if (p->first+p->second <= i) return false;
+    ceph_assert(p->first <= i && p->first+p->second > i);
+    if (pstart)
+      *pstart = p->first;
+    if (plen)
+      *plen = p->second;
+    return true;
+  }
+  bool contains(T start, L len) const {
+    auto p = find_inc(start);
+    if (p == m.end()) return false;
+    if (p->first > start) return false;
+    if (p->first+p->second <= start) return false;
+    ceph_assert(p->first <= start && p->first+p->second > start);
+    if (p->first+p->second < start+len) return false;
+    return true;
+  }
+  bool intersects(T start, L len) const {
+    interval_set a;
+    a.insert(start, len);
+    interval_set i;
+    i.intersection_of( *this, a );
+    if (i.empty()) return false;
+    return true;
+  }
+
+  // outer range of set
+  bool empty() const {
+    return m.empty();
+  }
+  offset_type range_start() const {
+    ceph_assert(!empty());
+    auto p = m.begin();
+    return p->first;
+  }
+  offset_type range_end() const {
+    ceph_assert(!empty());
+    auto p = m.rbegin();
+    return p->first + p->second;
+  }
+
+  // interval start after p (where p not in set)
+  bool starts_after(T i) const {
+    ceph_assert(!contains(i));
+    auto p = find_inc(i);
+    if (p == m.end()) return false;
+    return true;
+  }
+  offset_type start_after(T i) const {
+    ceph_assert(!contains(i));
+    auto p = find_inc(i);
+    return p->first;
+  }
+
+  // interval end that contains start
+  offset_type end_after(T start) const {
+    ceph_assert(contains(start));
+    auto p = find_inc(start);
+    return p->first+p->second;
+  }
+
+  void insert(T val) {
+    insert(val, 1);
+  }
+
+  void insert(T start, L len, T *pstart=0, L *plen=0) {
+    //cout << "insert " << start << "~" << len << endl;
+    ceph_assert(len > 0);
+    _size += len;
+    auto p = find_adj_m(start);
+    if (p == m.end()) {
+      m[start] = len;                  // new interval
+      if (pstart)
+	*pstart = start;
+      if (plen)
+	*plen = len;
+    } else {
+      if (p->first < start) {
+
+        if (p->first + p->second != start) {
+          //cout << "p is " << p->first << "~" << p->second << ", start is " << start << ", len is " << len << endl;
+          ceph_abort();
+        }
+
+        p->second += len;               // append to end
+
+        auto n = p;
+        ++n;
+	if (pstart)
+	  *pstart = p->first;
+        if (n != m.end() &&
+            start+len == n->first) {   // combine with next, too!
+          p->second += n->second;
+	  if (plen)
+	    *plen = p->second;
+          m.erase(n);
+        } else {
+	  if (plen)
+	    *plen = p->second;
+	}
+      } else {
+        if (start+len == p->first) {
+	  if (pstart)
+	    *pstart = start;
+	  if (plen)
+	    *plen = len + p->second;
+	  L psecond = p->second;
+          m.erase(p);
+          m[start] = len + psecond;  // append to front
+        } else {
+          ceph_assert(p->first > start+len);
+	  if (pstart)
+	    *pstart = start;
+	  if (plen)
+	    *plen = len;
+          m[start] = len;              // new interval
+        }
+      }
+    }
+  }
+
+  void swap(interval_set& other) {
+    m.swap(other.m);
+    std::swap(_size, other._size);
+  }
+
+  void erase(const iterator &i) {
+    _size -= i.get_len();
+    m.erase(i._iter);
+  }
+
+  void erase(T val) {
+    erase(val, 1);
+  }
+
+  void erase(T start, L len,
+    std::function<bool(T, L)> claim = {}) {
+    auto p = find_inc_m(start);
+
+    _size -= len;
+
+    ceph_assert(p != m.end());
+    ceph_assert(p->first <= start);
+
+    L before = start - p->first;
+    ceph_assert(p->second >= before+len);
+    L after = p->second - before - len;
+    if (before) {
+      if (claim && claim(p->first, before)) {
+	_size -= before;
+	m.erase(p);
+      } else {
+	p->second = before;        // shorten bit before
+      }
+    } else {
+      m.erase(p);
+    }
+    if (after) {
+      if (claim && claim(start + len, after)) {
+	_size -= after;
+      } else {
+	m[start + len] = after;
+      }
+    }
+  }
+
+  void subtract(const interval_set &a) {
+    for (const auto& [start, len] : a.m) {
+      erase(start, len);
+    }
+  }
+
+  void insert(const interval_set &a) {
+    for (const auto& [start, len] : a.m) {
+      insert(start, len);
+    }
+  }
+
+
+  void intersection_of(const interval_set &a, const interval_set &b) {
+    ceph_assert(&a != this);
+    ceph_assert(&b != this);
+    clear();
+
+    const interval_set *s, *l;
+
+    if (a.size() < b.size()) {
+      s = &a;
+      l = &b;
+    } else {
+      s = &b;
+      l = &a;
+    }
+
+    if (!s->size())
+      return;
+
+    /*
+     * Use the lower_bound algorithm for larger size ratios
+     * where it performs better, but not for smaller size
+     * ratios where sequential search performs better.
+     */
+    if (l->size() / s->size() >= 10) {
+      intersection_size_asym(*s, *l);
+      return;
+    }
+
+    auto pa = a.m.begin();
+    auto pb = b.m.begin();
+    auto mi = m.begin();
+
+    while (pa != a.m.end() && pb != b.m.end()) {
+      // passing?
+      if (pa->first + pa->second <= pb->first)
+        { pa++;  continue; }
+      if (pb->first + pb->second <= pa->first)
+        { pb++;  continue; }
+
+      if (*pa == *pb) {
+        do {
+          mi = m.insert(mi, *pa);
+          _size += pa->second;
+          ++pa;
+          ++pb;
+        } while (pa != a.m.end() && pb != b.m.end() && *pa == *pb);
+        continue;
+      }
+
+      T start = std::max(pa->first, pb->first);
+      T en = std::min(pa->first+pa->second, pb->first+pb->second);
+      ceph_assert(en > start);
+      mi = m.emplace_hint(mi, start, en - start);
+      _size += mi->second;
+      if (pa->first+pa->second > pb->first+pb->second)
+        pb++;
+      else
+        pa++;
+    }
+  }
+  void intersection_of(const interval_set& b) {
+    interval_set a;
+    swap(a);
+    intersection_of(a, b);
+  }
+
+  void union_of(const interval_set &a, const interval_set &b) {
+    ceph_assert(&a != this);
+    ceph_assert(&b != this);
+    clear();
+
+    //cout << "union_of" << endl;
+
+    // a
+    m = a.m;
+    _size = a._size;
+
+    // - (a*b)
+    interval_set ab;
+    ab.intersection_of(a, b);
+    subtract(ab);
+
+    // + b
+    insert(b);
+    return;
+  }
+  void union_of(const interval_set &b) {
+    interval_set a;
+    swap(a);
+    union_of(a, b);
+  }
+  void union_insert(T off, L len) {
+    interval_set a;
+    a.insert(off, len);
+    union_of(a);
+  }
+
+  bool subset_of(const interval_set &big) const {
+    if (!size())
+      return true;
+    if (size() > big.size())
+      return false;
+    if (range_end() > big.range_end())
+      return false;
+
+    /*
+     * Use the lower_bound algorithm for larger size ratios
+     * where it performs better, but not for smaller size
+     * ratios where sequential search performs better.
+     */
+    if (big.size() / size() < 10)
+      return subset_size_sym(big);
+
+    for (const auto& [start, len] : m) {
+      if (!big.contains(start, len)) return false;
+    }
+    return true;
+  }
+
+  /*
+   * build a subset of @other, starting at or after @start, and including
+   * @len worth of values, skipping holes.  e.g.,
+   *  span_of([5~10,20~5], 8, 5) -> [8~2,20~3]
+   */
+  void span_of(const interval_set &other, T start, L len) {
+    clear();
+    auto p = other.find_inc(start);
+    if (p == other.m.end())
+      return;
+    if (p->first < start) {
+      if (p->first + p->second < start)
+	return;
+      if (p->first + p->second < start + len) {
+	L howmuch = p->second - (start - p->first);
+	insert(start, howmuch);
+	len -= howmuch;
+	p++;
+      } else {
+	insert(start, len);
+	return;
+      }
+    }
+    while (p != other.m.end() && len > 0) {
+      if (p->second < len) {
+	insert(p->first, p->second);
+	len -= p->second;
+	p++;
+      } else {
+	insert(p->first, len);
+	return;
+      }
+    }
+  }
+
+  /*
+   * Move contents of m into another Map. Use that instead of
+   * encoding interval_set into bufferlist then decoding it back into Map.
+   */
+  Map detach() && {
+    return std::move(m);
+  }
+
+private:
+  // data
+  uint64_t _size = 0;
+  Map m;   // map start -> len
+};
+} // namespace details
+using laddr_interval_set_t = details::interval_set<laddr_t, extent_len_t>;
+} // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -316,7 +316,7 @@ BtreeLBAManager::_alloc_extents(
     assert((info.key == L_ADDR_NULL) == (laddr_null));
     if (!laddr_null) {
       assert(info.key >= last_end);
-      last_end = info.key + info.len;
+      last_end = (info.key + info.len).checked_to_laddr();
     }
   }
 #endif
@@ -381,7 +381,7 @@ BtreeLBAManager::_alloc_extents(
 	    interruptible::ready_future_marker{},
 	    seastar::stop_iteration::yes);
 	} else {
-	  state.last_end = pos.get_key() + pos.get_val().len;
+	  state.last_end = (pos.get_key() + pos.get_val().len).checked_to_laddr();
 	  TRACET("{}~{}, hint={}, state: {}~{}, repeat ... -- {}",
 		 t, addr, total_len, hint,
 		 pos.get_key(), pos.get_val().len,
@@ -431,7 +431,7 @@ BtreeLBAManager::_alloc_extents(
 	    return iter.next(c).si_then([&state, &alloc_info](auto it) {
 	      state.insert_iter = it;
 	      if (alloc_info.key == L_ADDR_NULL) {
-		state.last_end = state.last_end + alloc_info.len;
+		state.last_end = (state.last_end + alloc_info.len).checked_to_laddr();
 	      }
 	    });
 	  });

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -325,7 +325,8 @@ BtreeLBAManager::_alloc_extents(
       total_len += info.len;
     }
   } else {
-    total_len = alloc_infos.back().key + alloc_infos.back().len - hint;
+    auto end = alloc_infos.back().key + alloc_infos.back().len;
+    total_len = end.get_byte_distance<extent_len_t>(hint);
   }
 
   struct state_t {

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -431,7 +431,7 @@ BtreeLBAManager::_alloc_extents(
 	    return iter.next(c).si_then([&state, &alloc_info](auto it) {
 	      state.insert_iter = it;
 	      if (alloc_info.key == L_ADDR_NULL) {
-		state.last_end += alloc_info.len;
+		state.last_end = state.last_end + alloc_info.len;
 	      }
 	    });
 	  });

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -465,7 +465,7 @@ public:
 	      : L_ADDR_NULL;
 	    auto remap_offset = remap.offset;
 	    auto remap_len = remap.len;
-	    auto remap_laddr = orig_laddr + remap_offset;
+	    auto remap_laddr = (orig_laddr + remap_offset).checked_to_laddr();
 	    ceph_assert(intermediate_base != L_ADDR_NULL);
 	    ceph_assert(intermediate_key != L_ADDR_NULL);
 	    ceph_assert(remap_len < orig_len);
@@ -476,7 +476,7 @@ public:
 	      " intermediate_base: {}, intermediate_key: {}", t,
 	      remap_laddr, orig_paddr, remap_len,
 	      intermediate_base, intermediate_key);
-	    auto remapped_intermediate_key = intermediate_key + remap_offset;
+	    auto remapped_intermediate_key = (intermediate_key + remap_offset).checked_to_laddr();
 	    alloc_infos.emplace_back(
 	      alloc_mapping_info_t::create_indirect(
 		remap_laddr,
@@ -485,7 +485,7 @@ public:
 	  }
 	  fut = alloc_cloned_mappings(
 	    t,
-	    remaps.front().offset + orig_laddr,
+	    (remaps.front().offset + orig_laddr).checked_to_laddr(),
 	    std::move(alloc_infos)
 	  ).si_then([&orig_mapping](auto imappings) mutable {
 	    std::vector<LBAMappingRef> mappings;
@@ -504,7 +504,7 @@ public:
 	} else { // !orig_mapping->is_indirect()
 	  fut = alloc_extents(
 	    t,
-	    remaps.front().offset + orig_laddr,
+	    (remaps.front().offset + orig_laddr).checked_to_laddr(),
 	    std::move(extents),
 	    EXTENT_DEFAULT_REF_COUNT);
 	}

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -128,7 +128,7 @@ public:
     assert(intermediate_key >= intermediate_base);
     assert((intermediate_key == L_ADDR_NULL)
       == (intermediate_base == L_ADDR_NULL));
-    return intermediate_key - intermediate_base;
+    return intermediate_key.get_byte_distance<extent_len_t>(intermediate_base);
   }
 
   extent_len_t get_intermediate_length() const final {

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.cc
@@ -83,7 +83,7 @@ BtreeLBAMappingRef LBALeafNode::get_mapping(
     this,
     iter.get_offset(),
     val,
-    lba_node_meta_t{laddr, laddr + val.len, 0});
+    lba_node_meta_t{laddr, (laddr + val.len).checked_to_laddr(), 0});
 }
 
 }

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -520,7 +520,6 @@ ObjectDataHandler::write_ret do_insertions(
     [ctx](auto &region) {
       LOG_PREFIX(object_data_handler.cc::do_insertions);
       if (region.is_data()) {
-	ceph_assert(region.addr.is_aligned(ctx.tm.get_block_size()));
 	assert_aligned(region.len);
 	ceph_assert(region.len == region.bl->length());
 	DEBUGT("allocating extent: {}~{}",
@@ -726,11 +725,6 @@ public:
 private:
   // refer to overwrite_plan_t description
   void validate() const {
-    ceph_assert(pin_begin.is_aligned(block_size));
-    ceph_assert(pin_end.is_aligned(block_size));
-    ceph_assert(aligned_data_begin.is_aligned(block_size));
-    ceph_assert(aligned_data_end.is_aligned(block_size));
-
     ceph_assert(pin_begin <= aligned_data_begin);
     ceph_assert(aligned_data_begin <= data_begin);
     ceph_assert(data_begin <= data_end);
@@ -1208,8 +1202,6 @@ extent_to_write_list_t get_to_writes_with_zero_buffer(
     (!tailptr && (right == zero_right)));
 
   assert(right > left);
-  assert(left.is_aligned(block_size));
-  assert(right.is_aligned(block_size));
 
   // zero region too small for a reserved section,
   // headptr and tailptr in same extent
@@ -1324,7 +1316,6 @@ ObjectDataHandler::write_ret ObjectDataHandler::overwrite(
           if (headptr) {
             write_bl.append(*headptr);
             write_offset = write_offset - headptr->length();
-	    ceph_assert(write_offset.is_aligned(ctx.tm.get_block_size()));
           }
           write_bl.claim_append(*bl);
           if (tailptr) {

--- a/src/crimson/os/seastore/object_data_handler.h
+++ b/src/crimson/os/seastore/object_data_handler.h
@@ -229,7 +229,8 @@ private:
   /// Updates region [_offset, _offset + bl.length) to bl
   write_ret overwrite(
     context_t ctx,        ///< [in] ctx
-    laddr_t offset,       ///< [in] write offset
+    laddr_t data_base,    ///< [in] data base laddr
+    objaddr_t offset,     ///< [in] write offset
     extent_len_t len,     ///< [in] len to write, len == bl->length() if bl
     std::optional<bufferlist> &&bl, ///< [in] buffer to write, empty for zeros
     lba_pin_list_t &&pins ///< [in] set of pins overlapping above region

--- a/src/crimson/os/seastore/omap_manager/btree/omap_types.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_types.h
@@ -46,7 +46,7 @@ struct omap_node_meta_le_t {
 struct omap_inner_key_t {
   uint16_t key_off = 0;
   uint16_t key_len = 0;
-  laddr_t laddr = 0;
+  laddr_t laddr = L_ADDR_MIN;
 
   omap_inner_key_t() = default;
   omap_inner_key_t(uint16_t off, uint16_t len, laddr_t addr)
@@ -70,7 +70,7 @@ struct omap_inner_key_t {
 struct omap_inner_key_le_t {
   ceph_le16 key_off{0};
   ceph_le16 key_len{0};
-  laddr_le_t laddr{0};
+  laddr_le_t laddr{L_ADDR_MIN};
 
   omap_inner_key_le_t() = default;
   omap_inner_key_le_t(const omap_inner_key_le_t &) = default;

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -82,8 +82,9 @@ public:
     assert(default_metadata_offset);
     assert(default_metadata_range);
     uint64_t range_blocks = default_metadata_range / block_size;
-    return get_hint() + default_metadata_offset +
-      (((uint32_t)std::rand() % range_blocks) * block_size);
+    auto random_offset = default_metadata_offset +
+        (((uint32_t)std::rand() % range_blocks) * block_size);
+    return (get_hint() + random_offset).checked_to_laddr();
   }
   laddr_t get_data_hint() const {
     return get_hint();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
@@ -12,7 +12,7 @@ namespace crimson::os::seastore::onode {
 void FLTreeOnode::Recorder::apply_value_delta(
   ceph::bufferlist::const_iterator &bliter,
   NodeExtentMutable &value,
-  laddr_t value_addr)
+  laddr_offset_t value_addr_offset)
 {
   LOG_PREFIX(FLTreeOnode::Recorder::apply_value_delta);
   delta_op_t op;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -66,7 +66,7 @@ struct FLTreeOnode final : Onode, Value {
     void apply_value_delta(
       ceph::bufferlist::const_iterator &bliter,
       NodeExtentMutable &value,
-      laddr_t value_addr) final;
+      laddr_offset_t value_addr_offset) final;
 
     void encode_update(NodeExtentMutable &payload_mut, delta_op_t op);
   };

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -435,7 +435,7 @@ eagain_ifuture<Ref<Node>> Node::load_root(context_t c, RootNodeTracker& root_tra
     assert(_super);
     auto root_addr = _super->get_root_laddr();
     assert(root_addr != L_ADDR_NULL);
-    TRACET("loading root_addr={:x} ...", c.t, root_addr);
+    TRACET("loading root_addr={} ...", c.t, root_addr);
     return Node::load(c, root_addr, true
     ).si_then([c, _super = std::move(_super),
                  &root_tracker, FNAME](auto root) mutable {
@@ -693,22 +693,22 @@ eagain_ifuture<Ref<Node>> Node::load(
     eagain_iertr::pass_further{},
     crimson::ct_error::input_output_error::assert_failure(
         [FNAME, c, addr, expect_is_level_tail] {
-      ERRORT("EIO -- addr={:x}, is_level_tail={}",
+      ERRORT("EIO -- addr={}, is_level_tail={}",
              c.t, addr, expect_is_level_tail);
     }),
     crimson::ct_error::invarg::assert_failure(
         [FNAME, c, addr, expect_is_level_tail] {
-      ERRORT("EINVAL -- addr={:x}, is_level_tail={}",
+      ERRORT("EINVAL -- addr={}, is_level_tail={}",
              c.t, addr, expect_is_level_tail);
     }),
     crimson::ct_error::enoent::assert_failure(
         [FNAME, c, addr, expect_is_level_tail] {
-      ERRORT("ENOENT -- addr={:x}, is_level_tail={}",
+      ERRORT("ENOENT -- addr={}, is_level_tail={}",
              c.t, addr, expect_is_level_tail);
     }),
     crimson::ct_error::erange::assert_failure(
         [FNAME, c, addr, expect_is_level_tail] {
-      ERRORT("ERANGE -- addr={:x}, is_level_tail={}",
+      ERRORT("ERANGE -- addr={}, is_level_tail={}",
              c.t, addr, expect_is_level_tail);
     })
   ).si_then([FNAME, c, addr, expect_is_level_tail](auto extent)
@@ -717,13 +717,13 @@ eagain_ifuture<Ref<Node>> Node::load(
     auto header = extent->get_header();
     auto field_type = header.get_field_type();
     if (!field_type) {
-      ERRORT("load addr={:x}, is_level_tail={} error, "
+      ERRORT("load addr={}, is_level_tail={} error, "
              "got invalid header -- {}",
              c.t, addr, expect_is_level_tail, fmt::ptr(extent));
       ceph_abort("fatal error");
     }
     if (header.get_is_level_tail() != expect_is_level_tail) {
-      ERRORT("load addr={:x}, is_level_tail={} error, "
+      ERRORT("load addr={}, is_level_tail={} error, "
              "is_level_tail mismatch -- {}",
              c.t, addr, expect_is_level_tail, fmt::ptr(extent));
       ceph_abort("fatal error");
@@ -732,7 +732,7 @@ eagain_ifuture<Ref<Node>> Node::load(
     auto node_type = header.get_node_type();
     if (node_type == node_type_t::LEAF) {
       if (extent->get_length() != c.vb.get_leaf_node_size()) {
-        ERRORT("load addr={:x}, is_level_tail={} error, "
+        ERRORT("load addr={}, is_level_tail={} error, "
                "leaf length mismatch -- {}",
                c.t, addr, expect_is_level_tail, fmt::ptr(extent));
         ceph_abort("fatal error");
@@ -743,7 +743,7 @@ eagain_ifuture<Ref<Node>> Node::load(
 	new LeafNode(derived_ptr, std::move(impl)));
     } else if (node_type == node_type_t::INTERNAL) {
       if (extent->get_length() != c.vb.get_internal_node_size()) {
-        ERRORT("load addr={:x}, is_level_tail={} error, "
+        ERRORT("load addr={}, is_level_tail={} error, "
                "internal length mismatch -- {}",
                c.t, addr, expect_is_level_tail, fmt::ptr(extent));
         ceph_abort("fatal error");
@@ -1084,7 +1084,7 @@ eagain_ifuture<> InternalNode::apply_children_merge(
   auto left_addr = left_child->impl->laddr();
   auto& right_pos = right_child->parent_info().position;
   auto right_addr = right_child->impl->laddr();
-  DEBUGT("apply {}'s child {} (was {:#x}) at pos({}), "
+  DEBUGT("apply {}'s child {} (was {}) at pos({}), "
          "to merge with {} at pos({}), update_index={} ...",
          c.t, get_name(), left_child->get_name(), origin_left_addr, left_pos,
          right_child->get_name(), right_pos, update_index);
@@ -1572,12 +1572,12 @@ eagain_ifuture<Ref<Node>> InternalNode::get_or_track_child(
   return [this, position, child_addr, c, FNAME] {
     auto found = tracked_child_nodes.find(position);
     if (found != tracked_child_nodes.end()) {
-      TRACET("loaded child tracked {} at pos({}) addr={:x}",
+      TRACET("loaded child tracked {} at pos({}) addr={}",
               c.t, found->second->get_name(), position, child_addr);
       return eagain_iertr::make_ready_future<Ref<Node>>(found->second);
     }
     // the child is not loaded yet
-    TRACET("loading child at pos({}) addr={:x} ...",
+    TRACET("loading child at pos({}) addr={} ...",
            c.t, position, child_addr);
     bool level_tail = position.is_end();
     return Node::load(c, child_addr, level_tail

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -173,7 +173,7 @@ class DeltaRecorderT final: public DeltaRecorder {
         auto p_addr = reinterpret_cast<laddr_packed_t*>(
             mut.get_write() + update_offset);
         SUBDEBUG(seastore_onode,
-            "apply {:#x} to offset {:#x} ...",
+            "apply {} to offset {:#x} ...",
             new_addr, update_offset);
         layout_t::update_child_addr(mut, new_addr, p_addr);
         break;
@@ -526,12 +526,12 @@ class NodeExtentAccessorT {
       crimson::ct_error::input_output_error::assert_failure(
           [FNAME, c, alloc_size, l_to_discard = extent->get_laddr()] {
         SUBERRORT(seastore_onode,
-            "EIO during allocate -- node_size={}, to_discard={:x}",
+            "EIO during allocate -- node_size={}, to_discard={}",
             c.t, alloc_size, l_to_discard);
       })
     ).si_then([this, c, FNAME] (auto fresh_extent) {
       SUBDEBUGT(seastore_onode,
-          "update addr from {:#x} to {:#x} ...",
+          "update addr from {} to {} ...",
           c.t, extent->get_laddr(), fresh_extent->get_laddr());
       assert(fresh_extent);
       assert(fresh_extent->is_initial_pending());
@@ -555,14 +555,14 @@ class NodeExtentAccessorT {
             [FNAME, c, l_to_discard = to_discard->get_laddr(),
              l_fresh = fresh_extent->get_laddr()] {
           SUBERRORT(seastore_onode,
-              "EIO during retire -- to_disgard={:x}, fresh={:x}",
+              "EIO during retire -- to_disgard={}, fresh={}",
               c.t, l_to_discard, l_fresh);
         }),
         crimson::ct_error::enoent::assert_failure(
             [FNAME, c, l_to_discard = to_discard->get_laddr(),
              l_fresh = fresh_extent->get_laddr()] {
           SUBERRORT(seastore_onode,
-              "ENOENT during retire -- to_disgard={:x}, fresh={:x}",
+              "ENOENT during retire -- to_disgard={}, fresh={}",
               c.t, l_to_discard, l_fresh);
         })
       );
@@ -582,11 +582,11 @@ class NodeExtentAccessorT {
       eagain_iertr::pass_further{},
       crimson::ct_error::input_output_error::assert_failure(
           [FNAME, c, addr] {
-        SUBERRORT(seastore_onode, "EIO -- addr={:x}", c.t, addr);
+        SUBERRORT(seastore_onode, "EIO -- addr={}", c.t, addr);
       }),
       crimson::ct_error::enoent::assert_failure(
           [FNAME, c, addr] {
-        SUBERRORT(seastore_onode, "ENOENT -- addr={:x}", c.t, addr);
+        SUBERRORT(seastore_onode, "ENOENT -- addr={}", c.t, addr);
       })
 #ifndef NDEBUG
     ).si_then([c] {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
@@ -28,7 +28,7 @@ class DummySuper final: public Super {
   laddr_t get_root_laddr() const override { return *p_root_laddr; }
   void write_root_laddr(context_t c, laddr_t addr) override {
     LOG_PREFIX(OTree::Dummy);
-    SUBDEBUGT(seastore_onode, "update root {:#x} ...", c.t, addr);
+    SUBDEBUGT(seastore_onode, "update root {} ...", c.t, addr);
     *p_root_laddr = addr;
   }
  private:
@@ -77,7 +77,7 @@ class DummyNodeExtentManager final: public NodeExtentManager {
 
   read_iertr::future<NodeExtentRef> read_extent(
       Transaction& t, laddr_t addr) override {
-    SUBTRACET(seastore_onode, "reading at {:#x} ...", t, addr);
+    SUBTRACET(seastore_onode, "reading at {} ...", t, addr);
     if constexpr (SYNC) {
       return read_extent_sync(t, addr);
     } else {
@@ -90,7 +90,7 @@ class DummyNodeExtentManager final: public NodeExtentManager {
 
   alloc_iertr::future<NodeExtentRef> alloc_extent(
       Transaction& t, laddr_t hint, extent_len_t len) override {
-    SUBTRACET(seastore_onode, "allocating {}B with hint {:#x} ...", t, len, hint);
+    SUBTRACET(seastore_onode, "allocating {}B with hint {} ...", t, len, hint);
     if constexpr (SYNC) {
       return alloc_extent_sync(t, len);
     } else {
@@ -104,7 +104,7 @@ class DummyNodeExtentManager final: public NodeExtentManager {
   retire_iertr::future<> retire_extent(
       Transaction& t, NodeExtentRef extent) override {
     SUBTRACET(seastore_onode,
-        "retiring {}B at {:#x} -- {} ...",
+        "retiring {}B at {} -- {} ...",
         t, extent->get_length(), extent->get_laddr(), *extent);
     if constexpr (SYNC) {
       return retire_extent_sync(t, extent);
@@ -140,7 +140,7 @@ class DummyNodeExtentManager final: public NodeExtentManager {
     assert(iter != allocate_map.end());
     auto extent = iter->second;
     SUBTRACET(seastore_onode,
-        "read {}B at {:#x} -- {}",
+        "read {}B at {} -- {}",
         t, extent->get_length(), extent->get_laddr(), *extent);
     assert(extent->get_laddr() == addr);
     return read_iertr::make_ready_future<NodeExtentRef>(extent);
@@ -157,7 +157,7 @@ class DummyNodeExtentManager final: public NodeExtentManager {
     assert(allocate_map.find(extent->get_laddr()) == allocate_map.end());
     allocate_map.insert({extent->get_laddr(), extent});
     SUBDEBUGT(seastore_onode,
-        "allocated {}B at {:#x} -- {}",
+        "allocated {}B at {} -- {}",
         t, extent->get_length(), extent->get_laddr(), *extent);
     assert(extent->get_length() == len);
     return alloc_iertr::make_ready_future<NodeExtentRef>(extent);
@@ -172,13 +172,13 @@ class DummyNodeExtentManager final: public NodeExtentManager {
     auto iter = allocate_map.find(addr);
     assert(iter != allocate_map.end());
     allocate_map.erase(iter);
-    SUBDEBUGT(seastore_onode, "retired {}B at {:#x}", t, len, addr);
+    SUBDEBUGT(seastore_onode, "retired {}B at {}", t, len, addr);
     return retire_iertr::now();
   }
 
   getsuper_iertr::future<Super::URef> get_super_sync(
       Transaction& t, RootNodeTracker& tracker) {
-    SUBTRACET(seastore_onode, "got root {:#x}", t, root_laddr);
+    SUBTRACET(seastore_onode, "got root {}", t, root_laddr);
     return getsuper_iertr::make_ready_future<Super::URef>(
         Super::URef(new DummySuper(t, tracker, &root_laddr)));
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
@@ -150,7 +150,7 @@ class DummyNodeExtentManager final: public NodeExtentManager {
       Transaction& t, extent_len_t len) {
     assert(len % ALIGNMENT == 0);
     auto r = ceph::buffer::create_aligned(len, ALIGNMENT);
-    auto addr = reinterpret_cast<laddr_t>(r->get_data());
+    auto addr = laddr_t(reinterpret_cast<laddr_t::Unsigned>(r->get_data()));
     auto bp = ceph::bufferptr(std::move(r));
     auto extent = Ref<DummyNodeExtent>(new DummyNodeExtent(std::move(bp)));
     extent->set_laddr(addr);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
@@ -150,7 +150,8 @@ class DummyNodeExtentManager final: public NodeExtentManager {
       Transaction& t, extent_len_t len) {
     assert(len % ALIGNMENT == 0);
     auto r = ceph::buffer::create_aligned(len, ALIGNMENT);
-    auto addr = laddr_t(reinterpret_cast<laddr_t::Unsigned>(r->get_data()));
+    auto addr = laddr_t::from_byte_offset(
+      reinterpret_cast<laddr_t::Unsigned>(r->get_data()));
     auto bp = ceph::bufferptr(std::move(r));
     auto extent = Ref<DummyNodeExtent>(new DummyNodeExtent(std::move(bp)));
     extent->set_laddr(addr);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -30,7 +30,7 @@ class SeastoreSuper final: public Super {
   }
   void write_root_laddr(context_t c, laddr_t addr) override {
     LOG_PREFIX(OTree::Seastore);
-    SUBDEBUGT(seastore_onode, "update root {:#x} ...", c.t, addr);
+    SUBDEBUGT(seastore_onode, "update root {} ...", c.t, addr);
     root_addr = addr;
     tm.write_onode_root(c.t, addr);
   }
@@ -102,10 +102,10 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
 
   read_iertr::future<NodeExtentRef> read_extent(
       Transaction& t, laddr_t addr) override {
-    SUBTRACET(seastore_onode, "reading at {:#x} ...", t, addr);
+    SUBTRACET(seastore_onode, "reading at {} ...", t, addr);
     if constexpr (INJECT_EAGAIN) {
       if (trigger_eagain()) {
-        SUBDEBUGT(seastore_onode, "reading at {:#x}: trigger eagain", t, addr);
+        SUBDEBUGT(seastore_onode, "reading at {}: trigger eagain", t, addr);
         t.test_set_conflict();
         return read_iertr::make_ready_future<NodeExtentRef>();
       }
@@ -113,7 +113,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
     return tm.read_extent<SeastoreNodeExtent>(t, addr
     ).si_then([addr, &t](auto&& e) -> read_iertr::future<NodeExtentRef> {
       SUBTRACET(seastore_onode,
-          "read {}B at {:#x} -- {}",
+          "read {}B at {} -- {}",
           t, e->get_length(), e->get_laddr(), *e);
       assert(e->get_laddr() == addr);
       std::ignore = addr;
@@ -123,7 +123,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
 
   alloc_iertr::future<NodeExtentRef> alloc_extent(
       Transaction& t, laddr_t hint, extent_len_t len) override {
-    SUBTRACET(seastore_onode, "allocating {}B with hint {:#x} ...", t, len, hint);
+    SUBTRACET(seastore_onode, "allocating {}B with hint {} ...", t, len, hint);
     if constexpr (INJECT_EAGAIN) {
       if (trigger_eagain()) {
         SUBDEBUGT(seastore_onode, "allocating {}B: trigger eagain", t, len);
@@ -134,7 +134,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
     return tm.alloc_non_data_extent<SeastoreNodeExtent>(t, hint, len
     ).si_then([len, &t](auto extent) {
       SUBDEBUGT(seastore_onode,
-          "allocated {}B at {:#x} -- {}",
+          "allocated {}B at {} -- {}",
           t, extent->get_length(), extent->get_laddr(), *extent);
       if (!extent->is_initial_pending()) {
         SUBERRORT(seastore_onode,
@@ -157,12 +157,12 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
     auto addr = extent->get_laddr();
     auto len = extent->get_length();
     SUBDEBUGT(seastore_onode,
-        "retiring {}B at {:#x} -- {} ...",
+        "retiring {}B at {} -- {} ...",
         t, len, addr, *extent);
     if constexpr (INJECT_EAGAIN) {
       if (trigger_eagain()) {
         SUBDEBUGT(seastore_onode,
-            "retiring {}B at {:#x} -- {} : trigger eagain",
+            "retiring {}B at {} -- {} : trigger eagain",
             t, len, addr, *extent);
         t.test_set_conflict();
         return retire_iertr::now();
@@ -170,7 +170,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
     }
     return tm.remove(t, extent).si_then([addr, len, &t] (unsigned cnt) {
       assert(cnt == 0);
-      SUBTRACET(seastore_onode, "retired {}B at {:#x} ...", t, len, addr);
+      SUBTRACET(seastore_onode, "retired {}B at {} ...", t, len, addr);
     });
   }
 
@@ -185,7 +185,7 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
       }
     }
     return tm.read_onode_root(t).si_then([this, &t, &tracker](auto root_addr) {
-      SUBTRACET(seastore_onode, "got root {:#x}", t, root_addr);
+      SUBTRACET(seastore_onode, "got root {}", t, root_addr);
       return Super::URef(new SeastoreSuper(t, tracker, root_addr, tm));
     });
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -374,8 +374,8 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
         size += sizeof(laddr_t);
         auto value_ptr = node_stage.get_end_p_laddr();
         int offset = reinterpret_cast<const char*>(value_ptr) - p_start;
-        os << "\n  tail value: 0x"
-           << std::hex << value_ptr->value << std::dec
+        os << "\n  tail value: "
+           << value_ptr->value
            << " " << size << "B"
            << "  @" << offset << "B";
       }
@@ -845,7 +845,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
       const search_position_t& pos, laddr_t dst, laddr_t src) override {
     if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
       LOG_PREFIX(OTree::Layout::replace_child_addr);
-      SUBDEBUG(seastore_onode, "update from {:#x} to {:#x} at pos({}) ...", src, dst, pos);
+      SUBDEBUG(seastore_onode, "update from {} to {} at pos({}) ...", src, dst, pos);
       const laddr_packed_t* p_value;
       if (pos.is_end()) {
         assert(is_level_tail());
@@ -924,8 +924,8 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     // XXX: maybe also include the extent state
     std::ostringstream sos;
     sos << "Node" << NODE_TYPE << FIELD_TYPE
-        << "@0x" << std::hex << extent.get_laddr()
-        << "+" << extent.get_length() << std::dec
+        << "@" << extent.get_laddr()
+        << "+" << std::hex << extent.get_length() << std::dec
         << "Lv" << (unsigned)level()
         << (is_level_tail() ? "$" : "");
     name = sos.str();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -375,7 +375,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
         auto value_ptr = node_stage.get_end_p_laddr();
         int offset = reinterpret_cast<const char*>(value_ptr) - p_start;
         os << "\n  tail value: "
-           << value_ptr->value
+           << laddr_t(value_ptr->value)
            << " " << size << "B"
            << "  @" << offset << "B";
       }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
@@ -44,10 +44,10 @@ inline std::ostream& operator<<(std::ostream &os, const node_type_t& type) {
 }
 
 struct laddr_packed_t {
-  laddr_t value;
+  laddr_le_t value;
 } __attribute__((packed));
 inline std::ostream& operator<<(std::ostream& os, const laddr_packed_t& laddr) {
-  return os << "laddr_packed(" << laddr.value << ")";
+  return os << "laddr_packed(" << laddr_t(laddr.value) << ")";
 }
 
 using match_stat_t = int8_t;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
@@ -47,7 +47,7 @@ struct laddr_packed_t {
   laddr_t value;
 } __attribute__((packed));
 inline std::ostream& operator<<(std::ostream& os, const laddr_packed_t& laddr) {
-  return os << "laddr_packed(0x" << std::hex << laddr.value << std::dec << ")";
+  return os << "laddr_packed(" << laddr.value << ")";
 }
 
 using match_stat_t = int8_t;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -46,9 +46,9 @@ static laddr_t get_lba_hint(shard_t shard, pool_t pool, crush_hash_t crush) {
   // FIXME: It is possible that PGs from different pools share the same prefix
   // if the mask 0xFF is not long enough, result in unexpected transaction
   // conflicts.
-  return laddr_t((uint64_t)(shard & 0xFF)<<56 |
-                 (uint64_t)(pool  & 0xFF)<<48 |
-                 (uint64_t)(crush       )<<16);
+  return laddr_t::from_raw_uint((uint64_t)(shard & 0xFF)<<56 |
+                                (uint64_t)(pool  & 0xFF)<<48 |
+                                (uint64_t)(crush       )<<16);
 }
 
 struct node_offset_packed_t {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -46,9 +46,9 @@ static laddr_t get_lba_hint(shard_t shard, pool_t pool, crush_hash_t crush) {
   // FIXME: It is possible that PGs from different pools share the same prefix
   // if the mask 0xFF is not long enough, result in unexpected transaction
   // conflicts.
-  return ((uint64_t)(shard & 0XFF)<<56 |
-          (uint64_t)(pool  & 0xFF)<<48 |
-          (uint64_t)(crush       )<<16);
+  return laddr_t((uint64_t)(shard & 0xFF)<<56 |
+                 (uint64_t)(pool  & 0xFF)<<48 |
+                 (uint64_t)(crush       )<<16);
 }
 
 struct node_offset_packed_t {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
@@ -1443,7 +1443,7 @@ struct staged {
         if constexpr (NODE_TYPE == node_type_t::LEAF) {
           os << *value_ptr;
         } else {
-          os << "0x" << std::hex << value_ptr->value << std::dec;
+          os << value_ptr->value;
         }
         os << " " << size << "B"
            << "  @" << offset << "B";

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
@@ -1443,7 +1443,7 @@ struct staged {
         if constexpr (NODE_TYPE == node_type_t::LEAF) {
           os << *value_ptr;
         } else {
-          os << value_ptr->value;
+          os << laddr_t(value_ptr->value);
         }
         os << " " << size << "B"
            << "  @" << offset << "B";

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.cc
@@ -22,7 +22,7 @@ const laddr_packed_t* internal_sub_items_t::insert_at(
 
   auto p_insert = const_cast<char*>(p_shift_end) - size;
   auto item = internal_sub_item_t{
-    snap_gen_t::from_key(key), laddr_packed_t{value}};
+    snap_gen_t::from_key(key), laddr_packed_t{laddr_le_t{value}}};
   mut.copy_in_absolute(p_insert, item);
   return &reinterpret_cast<internal_sub_item_t*>(p_insert)->value;
 }
@@ -79,7 +79,7 @@ void internal_sub_items_t::Appender<KT>::append(
 {
   p_append -= sizeof(internal_sub_item_t);
   auto item = internal_sub_item_t{
-    snap_gen_t::from_key(key), laddr_packed_t{value}};
+    snap_gen_t::from_key(key), laddr_packed_t{laddr_le_t{value}}};
   p_mut->copy_in_absolute(p_append, item);
   p_value = &reinterpret_cast<internal_sub_item_t*>(p_append)->value;
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -138,7 +138,7 @@ void validate_tree_config(const tree_conf_t& conf)
 #define _STAGE_T(NodeType) node_to_stage_t<typename NodeType::node_stage_t>
 #define NXT_T(StageType)  staged<typename StageType::next_param_t>
 
-    laddr_t i_value{0};
+    laddr_t i_value = L_ADDR_MIN;
     auto insert_size_2 =
       _STAGE_T(InternalNode0)::insert_size(key, i_value);
     auto insert_size_0 =

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -141,7 +141,7 @@ class ValueDeltaRecorder {
   /// Called by DeltaRecorderT to apply user-defined value delta.
   virtual void apply_value_delta(ceph::bufferlist::const_iterator&,
                                  NodeExtentMutable&,
-                                 laddr_t) = 0;
+                                 laddr_offset_t) = 0;
 
  protected:
   ValueDeltaRecorder(ceph::bufferlist& encoded) : encoded{encoded} {}

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -96,6 +96,11 @@ std::ostream &operator<<(std::ostream &out, const laddr_t &laddr) {
   return out << 'L' << std::hex << laddr.value << std::dec;
 }
 
+std::ostream &operator<<(std::ostream &out, const laddr_offset_t &laddr_offset) {
+  return out << laddr_offset.get_aligned_laddr()
+	     << "+" << std::hex << laddr_offset.get_offset() << std::dec;
+}
+
 std::ostream &operator<<(std::ostream &out, const pladdr_t &pladdr)
 {
   if (pladdr.is_laddr()) {

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -92,6 +92,10 @@ std::ostream& operator<<(std::ostream& out, segment_seq_printer_t seq)
   }
 }
 
+std::ostream &operator<<(std::ostream &out, const laddr_t &laddr) {
+  return out << 'L' << std::hex << laddr.value << std::dec;
+}
+
 std::ostream &operator<<(std::ostream &out, const pladdr_t &pladdr)
 {
   if (pladdr.is_laddr()) {

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -1006,6 +1006,19 @@ constexpr journal_seq_t JOURNAL_SEQ_MAX{
 // JOURNAL_SEQ_NULL == JOURNAL_SEQ_MAX == journal_seq_t{}
 constexpr journal_seq_t JOURNAL_SEQ_NULL = JOURNAL_SEQ_MAX;
 
+// logical offset between two laddr_t
+using loffset_t = uint64_t;
+
+// logical offset within an extent
+using extent_len_t = uint32_t;
+constexpr extent_len_t EXTENT_LEN_MAX =
+  std::numeric_limits<extent_len_t>::max();
+
+using extent_len_le_t = ceph_le32;
+inline extent_len_le_t init_extent_len_le(extent_len_t len) {
+  return ceph_le32(len);
+}
+
 // logical addr, see LBAManager, TransactionManager
 class laddr_t {
 public:
@@ -1015,24 +1028,19 @@ public:
       std::numeric_limits<Unsigned>::max();
 
   constexpr laddr_t() : laddr_t(RAW_VALUE_MAX) {}
-  constexpr explicit laddr_t(Unsigned value) : value(value) {}
 
-  bool is_aligned(Unsigned alignment) const {
-    assert(alignment != 0);
-    assert((alignment & (alignment - 1)) == 0);
-    return value == p2align(value, alignment);
+  // laddr_t is block aligned, one logical address represents one 4KiB block in disk
+  static constexpr unsigned UNIT_SHIFT = 12;
+  static constexpr unsigned UNIT_SIZE = 1 << UNIT_SHIFT; // 4096
+  static constexpr unsigned UNIT_MASK = UNIT_SIZE - 1;
+
+  static laddr_t from_byte_offset(Unsigned value) {
+    assert((value & UNIT_MASK) == 0);
+    return laddr_t(value >> UNIT_SHIFT);
   }
 
-  laddr_t get_aligned_laddr(Unsigned alignment) const {
-    assert(alignment != 0);
-    assert((alignment & (alignment - 1)) == 0);
-    return laddr_t(p2align(value, alignment));
-  }
-
-  laddr_t get_roundup_laddr(Unsigned alignment) const {
-    assert(alignment != 0);
-    assert((alignment & (alignment - 1)) == 0);
-    return laddr_t(p2roundup(value, alignment));
+  static constexpr laddr_t from_raw_uint(Unsigned v) {
+    return laddr_t(v);
   }
 
   /// laddr_t works like primitive integer type, encode/decode it manually
@@ -1047,38 +1055,178 @@ public:
     memcpy((char *)&value, p.get_pos_add(sizeof(Unsigned)), sizeof(Unsigned));
   }
 
+  // laddr_offset_t contains one base laddr and one block not aligned
+  // offset(< laddr_t::UNIT_SIZE). It is the return type of plus/minus
+  // overloads for laddr_t and loffset_t.
+  struct laddr_offset_t {
+    explicit laddr_offset_t(laddr_t base)
+	: base(base.value), offset(0) {}
+    laddr_offset_t(laddr_t base, extent_len_t offset)
+	: base(base.value), offset(offset) {
+      assert(offset < laddr_t::UNIT_SIZE);
+    }
+
+    laddr_t get_roundup_laddr() const {
+      if (offset == 0) {
+	return laddr_t(base);
+      } else {
+	assert(offset < laddr_t::UNIT_SIZE);
+	return laddr_t(base + 1);
+      }
+    }
+    laddr_t get_aligned_laddr() const { return laddr_t(base); }
+    extent_len_t get_offset() const {
+      assert(offset < laddr_t::UNIT_SIZE);
+      return offset;
+    }
+    laddr_t checked_to_laddr() const {
+      assert(offset == 0);
+      return laddr_t(base);
+    }
+
+    template<std::unsigned_integral U>
+    U get_byte_distance(const laddr_t &l) const {
+      assert(offset < UNIT_SIZE);
+      if (base >= l.value) {
+	Unsigned udiff = base - l.value;
+	assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+	return (static_cast<U>(udiff) << UNIT_SHIFT) + offset;
+      } else { // base < l.value
+	Unsigned udiff = l.value - base;
+	assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+	return (static_cast<U>(udiff) << UNIT_SHIFT) - offset;
+      }
+    }
+
+    template<std::unsigned_integral U>
+    U get_byte_distance(const laddr_offset_t &l) const {
+      assert(offset < UNIT_SIZE);
+      if (*this >= l) {
+	Unsigned udiff = base - l.base;
+	assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+	return ((static_cast<U>(udiff) << UNIT_SHIFT) + offset) - l.offset;
+      } else { // *this < l
+	Unsigned udiff = l.base - base;
+	assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+	return ((static_cast<U>(udiff) << UNIT_SHIFT) + l.offset) - offset;
+      }
+    }
+
+    friend bool operator==(const laddr_offset_t&, const laddr_offset_t&) = default;
+    friend auto operator<=>(const laddr_offset_t&, const laddr_offset_t&) = default;
+    friend std::ostream &operator<<(std::ostream&, const laddr_offset_t&);
+    friend laddr_offset_t operator+(const laddr_offset_t &laddr_offset,
+				    const loffset_t &offset) {
+      // laddr_offset_t could access (laddr_t + loffset_t) overload.
+      return laddr_offset.get_aligned_laddr()
+	  + (laddr_offset.get_offset() + offset);
+    }
+    friend laddr_offset_t operator+(const loffset_t &offset,
+				    const laddr_offset_t &loffset) {
+      return loffset + offset;
+    }
+
+    friend laddr_offset_t operator-(const laddr_offset_t &laddr_offset,
+				    const loffset_t &offset) {
+      if (laddr_offset.get_offset() >= offset) {
+	return laddr_offset_t(
+	  laddr_offset.get_aligned_laddr(),
+	  laddr_offset.get_offset() - offset);
+      } else {
+	// laddr_offset_t could access (laddr_t - loffset_t) overload.
+	return laddr_offset.get_aligned_laddr()
+	    - (offset - laddr_offset.get_offset());
+      }
+    }
+
+    friend class laddr_t;
+  private:
+    // use Unsigned here to avoid incomplete type of laddr_t
+    Unsigned base;
+    extent_len_t offset;
+  };
+
+  template<std::unsigned_integral U>
+  U get_byte_distance(const laddr_offset_t &l) const {
+    if (value <= l.base) {
+      Unsigned udiff = l.base - value;
+      assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+      return (static_cast<U>(udiff) << UNIT_SHIFT) + l.offset;
+    } else { // value > l.base
+      Unsigned udiff = value - l.base;
+      assert(udiff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+      return (static_cast<U>(udiff) << UNIT_SHIFT) - l.offset;
+    }
+  }
+
+  template<std::unsigned_integral U>
+  U get_byte_distance(const laddr_t &l) const {
+    Unsigned diff = value > l.value
+	? value - l.value
+	: l.value - value;
+    assert(diff <= (std::numeric_limits<U>::max() >> UNIT_SHIFT));
+    return static_cast<U>(diff) << UNIT_SHIFT;
+  }
+
   friend std::ostream &operator<<(std::ostream &, const laddr_t &);
-
+  friend bool operator==(const laddr_t&, const laddr_t&) = default;
+  friend bool operator==(const laddr_t &laddr,
+			 const laddr_offset_t &laddr_offset) {
+    return laddr == laddr_offset.get_aligned_laddr()
+	&& 0 == laddr_offset.get_offset();
+  }
+  friend bool operator==(const laddr_offset_t &laddr_offset,
+			 const laddr_t &laddr) {
+    return laddr_offset.get_aligned_laddr() == laddr
+	&& laddr_offset.get_offset() == 0;
+  }
   friend auto operator<=>(const laddr_t&, const laddr_t&) = default;
-
-  friend laddr_t operator+(const laddr_t &laddr, const Unsigned &i) {
-    return laddr_t{laddr.value + i};
+  friend auto operator<=>(const laddr_t &laddr,
+			  const laddr_offset_t &laddr_offset) {
+    return laddr_offset_t(laddr, 0) <=> laddr_offset;
+  }
+  friend auto operator<=>(const laddr_offset_t &laddr_offset,
+			  const laddr_t &laddr) {
+    return laddr_offset <=> laddr_offset_t(laddr, 0);
   }
 
-  friend laddr_t operator+(const Unsigned &i, const laddr_t &laddr) {
-    return laddr_t{laddr.value + i};
+  friend laddr_offset_t operator+(const laddr_t &laddr,
+				  const loffset_t &offset) {
+    auto base = laddr;
+    base.value += offset >> laddr_t::UNIT_SHIFT;
+    assert(base.value >= laddr.value);
+    return laddr_offset_t(base, offset & laddr_t::UNIT_MASK);
+  }
+  friend laddr_offset_t operator+(const loffset_t &offset,
+				  const laddr_t &laddr) {
+    return laddr + offset;
   }
 
-  friend laddr_t operator-(const laddr_t &laddr, const Unsigned &i) {
-    return laddr_t{laddr.value - i};
-  }
-
-  friend Unsigned operator-(const laddr_t &l, const laddr_t &r) {
-    return l.value - r.value;
+  friend laddr_offset_t operator-(const laddr_t &laddr, loffset_t offset) {
+    auto base = laddr;
+    auto diff = (offset + laddr_t::UNIT_SIZE - 1) >> laddr_t::UNIT_SHIFT;
+    base.value -= diff;
+    assert(base.value <= laddr.value);
+    offset = (diff << laddr_t::UNIT_SHIFT) - offset;
+    return laddr_offset_t(base, offset);
   }
 
   friend struct laddr_le_t;
   friend struct pladdr_le_t;
 
 private:
+  // Prevent direct construction of laddr_t with an integer,
+  // always use laddr_t::from_raw_uint instead.
+  constexpr explicit laddr_t(Unsigned value) : value(value) {}
   Unsigned value;
 };
+using laddr_offset_t = laddr_t::laddr_offset_t;
 
-constexpr laddr_t L_ADDR_MAX = laddr_t(laddr_t::RAW_VALUE_MAX);
-constexpr laddr_t L_ADDR_MIN = laddr_t(0);
+constexpr laddr_t L_ADDR_MAX = laddr_t::from_raw_uint(laddr_t::RAW_VALUE_MAX);
+constexpr laddr_t L_ADDR_MIN = laddr_t::from_raw_uint(0);
 constexpr laddr_t L_ADDR_NULL = L_ADDR_MAX;
-constexpr laddr_t L_ADDR_ROOT = laddr_t(laddr_t::RAW_VALUE_MAX - 1);
-constexpr laddr_t L_ADDR_LBAT = laddr_t(laddr_t::RAW_VALUE_MAX - 2);
+constexpr laddr_t L_ADDR_ROOT = laddr_t::from_raw_uint(laddr_t::RAW_VALUE_MAX - 1);
+constexpr laddr_t L_ADDR_LBAT = laddr_t::from_raw_uint(laddr_t::RAW_VALUE_MAX - 2);
 
 struct __attribute__((packed)) laddr_le_t {
   ceph_le64 laddr;
@@ -1199,16 +1347,6 @@ struct min_max_t<paddr_t> {
   static constexpr paddr_t min = P_ADDR_MIN;
   static constexpr paddr_t null = P_ADDR_NULL;
 };
-
-// logical offset, see LBAManager, TransactionManager
-using extent_len_t = uint32_t;
-constexpr extent_len_t EXTENT_LEN_MAX =
-  std::numeric_limits<extent_len_t>::max();
-
-using extent_len_le_t = ceph_le32;
-inline extent_len_le_t init_extent_len_le(extent_len_t len) {
-  return ceph_le32(len);
-}
 
 using extent_ref_count_t = uint32_t;
 constexpr extent_ref_count_t EXTENT_DEFAULT_REF_COUNT = 1;
@@ -2749,6 +2887,7 @@ template <> struct fmt::formatter<crimson::os::seastore::extent_types_t> : fmt::
 template <> struct fmt::formatter<crimson::os::seastore::journal_seq_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::journal_tail_delta_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::laddr_t> : fmt::ostream_formatter {};
+template <> struct fmt::formatter<crimson::os::seastore::laddr_offset_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::laddr_list_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::omap_root_t> : fmt::ostream_formatter {};
 template <> struct fmt::formatter<crimson::os::seastore::paddr_list_t> : fmt::ostream_formatter {};

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -585,7 +585,7 @@ TransactionManager::rewrite_logical_extent(
         if (first_extent) {
           fut = lba_manager->update_mapping(
             t,
-            lextent->get_laddr() + off,
+            (lextent->get_laddr() + off).checked_to_laddr(),
             lextent->get_length(),
             lextent->get_paddr(),
             nlextent->get_length(),
@@ -599,7 +599,7 @@ TransactionManager::rewrite_logical_extent(
 	  ceph_assert(refcount != 0);
           fut = lba_manager->alloc_extent(
             t,
-            lextent->get_laddr() + off,
+            (lextent->get_laddr() + off).checked_to_laddr(),
             *nlextent,
 	    refcount
           ).si_then([lextent, nlextent, off](auto mapping) {

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -348,7 +348,6 @@ public:
     LOG_PREFIX(TransactionManager::alloc_non_data_extent);
     SUBTRACET(seastore_tm, "{} len={}, placement_hint={}, laddr_hint={}",
               t, T::TYPE, len, placement_hint, laddr_hint);
-    ceph_assert(laddr_hint.is_aligned(epm->get_block_size()));
     auto ext = cache->alloc_new_non_data_extent<T>(
       t,
       len,
@@ -388,7 +387,6 @@ public:
     LOG_PREFIX(TransactionManager::alloc_data_extents);
     SUBTRACET(seastore_tm, "{} len={}, placement_hint={}, laddr_hint={}",
               t, T::TYPE, len, placement_hint, laddr_hint);
-    ceph_assert(laddr_hint.is_aligned(epm->get_block_size()));
     auto exts = cache->alloc_new_data_extents<T>(
       t,
       len,
@@ -582,7 +580,6 @@ public:
     extent_len_t len) {
     LOG_PREFIX(TransactionManager::reserve_region);
     SUBDEBUGT(seastore_tm, "len={}, laddr_hint={}", t, len, hint);
-    ceph_assert(hint.is_aligned(epm->get_block_size()));
     return lba_manager->reserve_region(
       t,
       hint,
@@ -615,7 +612,6 @@ public:
     LOG_PREFIX(TransactionManager::clone_pin);
     SUBDEBUGT(seastore_tm, "len={}, laddr_hint={}, clone_offset {}",
       t, mapping.get_length(), hint, intermediate_key);
-    ceph_assert(hint.is_aligned(epm->get_block_size()));
     return lba_manager->clone_mapping(
       t,
       hint,

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -348,7 +348,7 @@ public:
     LOG_PREFIX(TransactionManager::alloc_non_data_extent);
     SUBTRACET(seastore_tm, "{} len={}, placement_hint={}, laddr_hint={}",
               t, T::TYPE, len, placement_hint, laddr_hint);
-    ceph_assert(is_aligned(laddr_hint, epm->get_block_size()));
+    ceph_assert(laddr_hint.is_aligned(epm->get_block_size()));
     auto ext = cache->alloc_new_non_data_extent<T>(
       t,
       len,
@@ -388,7 +388,7 @@ public:
     LOG_PREFIX(TransactionManager::alloc_data_extents);
     SUBTRACET(seastore_tm, "{} len={}, placement_hint={}, laddr_hint={}",
               t, T::TYPE, len, placement_hint, laddr_hint);
-    ceph_assert(is_aligned(laddr_hint, epm->get_block_size()));
+    ceph_assert(laddr_hint.is_aligned(epm->get_block_size()));
     auto exts = cache->alloc_new_data_extents<T>(
       t,
       len,
@@ -582,7 +582,7 @@ public:
     extent_len_t len) {
     LOG_PREFIX(TransactionManager::reserve_region);
     SUBDEBUGT(seastore_tm, "len={}, laddr_hint={}", t, len, hint);
-    ceph_assert(is_aligned(hint, epm->get_block_size()));
+    ceph_assert(hint.is_aligned(epm->get_block_size()));
     return lba_manager->reserve_region(
       t,
       hint,
@@ -615,7 +615,7 @@ public:
     LOG_PREFIX(TransactionManager::clone_pin);
     SUBDEBUGT(seastore_tm, "len={}, laddr_hint={}, clone_offset {}",
       t, mapping.get_length(), hint, intermediate_key);
-    ceph_assert(is_aligned(hint, epm->get_block_size()));
+    ceph_assert(hint.is_aligned(epm->get_block_size()));
     return lba_manager->clone_mapping(
       t,
       hint,

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -532,7 +532,7 @@ public:
 	  for (auto &remap : remaps) {
 	    auto remap_offset = remap.offset;
 	    auto remap_len = remap.len;
-	    auto remap_laddr = original_laddr + remap_offset;
+	    auto remap_laddr = (original_laddr + remap_offset).checked_to_laddr();
 	    auto remap_paddr = original_paddr.add_offset(remap_offset);
 	    ceph_assert(remap_len < original_len);
 	    ceph_assert(remap_offset + remap_len <= original_len);

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -121,7 +121,7 @@ seastar::future<bufferlist> TMDriver::read(
             cur = i.first;
           }
           blret.append(i.second->get_bptr());
-          cur += i.second->get_bptr().length();
+	  cur = (cur + i.second->get_bptr().length()).checked_to_laddr();
         }
         if (blret.length() != size) {
           assert(blret.length() < size);

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -27,20 +27,20 @@ seastar::future<> TMDriver::write(
         "write",
         [this, offset, &ptr](auto& t)
       {
-        return tm->remove(t, offset
+        return tm->remove(t, laddr_t(offset)
         ).discard_result().handle_error_interruptible(
           crimson::ct_error::enoent::handle([](auto) { return seastar::now(); }),
           crimson::ct_error::pass_further_all{}
         ).si_then([this, offset, &t, &ptr] {
           logger().debug("dec_ref complete");
-          return tm->alloc_data_extents<TestBlock>(t, offset, ptr.length());
+          return tm->alloc_data_extents<TestBlock>(t, laddr_t(offset), ptr.length());
         }).si_then([this, offset, &t, &ptr](auto extents) mutable {
 	  boost::ignore_unused(offset);  // avoid clang warning;
 	  auto off = offset;
 	  auto left = ptr.length();
 	  size_t written = 0;
 	  for (auto &ext : extents) {
-	    assert(ext->get_laddr() == (size_t)off);
+	    assert(ext->get_laddr() == laddr_t(off));
 	    assert(ext->get_bptr().length() <= left);
 	    ptr.copy_out(written, ext->get_length(), ext->get_bptr().c_str());
 	    off += ext->get_length();
@@ -111,9 +111,9 @@ seastar::future<bufferlist> TMDriver::read(
       "read",
       [=, &blret, this](auto& t)
     {
-      return read_extents(t, offset, size
+      return read_extents(t, laddr_t(offset), size
       ).si_then([=, &blret](auto ext_list) {
-        size_t cur = offset;
+        laddr_t cur(offset);
         for (auto &i: ext_list) {
           if (cur != i.first) {
             assert(cur < i.first);

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -117,7 +117,7 @@ seastar::future<bufferlist> TMDriver::read(
         for (auto &i: ext_list) {
           if (cur != i.first) {
             assert(cur < i.first);
-            blret.append_zero(i.first - cur);
+            blret.append_zero(i.first.template get_byte_distance<size_t>(cur));
             cur = i.first;
           }
           blret.append(i.second->get_bptr());

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -32,7 +32,7 @@ struct onode_item_t {
   void initialize(Transaction& t, Onode& value) const {
     auto &ftvalue = static_cast<FLTreeOnode&>(value);
     ftvalue.update_onode_size(t, size);
-    auto oroot = omap_root_t(laddr_t(id), cnt_modify,
+    auto oroot = omap_root_t(laddr_t::from_raw_uint(id), cnt_modify,
       value.get_metadata_hint(block_size));
     ftvalue.update_omap_root(t, oroot);
     validate(value);
@@ -40,8 +40,8 @@ struct onode_item_t {
 
   void validate(Onode& value) const {
     auto& layout = value.get_layout();
-    ceph_assert(laddr_t(layout.size) == laddr_t{size});
-    ceph_assert(layout.omap_root.get(value.get_metadata_hint(block_size)).addr == laddr_t(id));
+    ceph_assert(uint64_t(layout.size) == uint64_t{size});
+    ceph_assert(layout.omap_root.get(value.get_metadata_hint(block_size)).addr == laddr_t::from_raw_uint(id));
     ceph_assert(layout.omap_root.get(value.get_metadata_hint(block_size)).depth == cnt_modify);
   }
 

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -32,7 +32,7 @@ struct onode_item_t {
   void initialize(Transaction& t, Onode& value) const {
     auto &ftvalue = static_cast<FLTreeOnode&>(value);
     ftvalue.update_onode_size(t, size);
-    auto oroot = omap_root_t(id, cnt_modify,
+    auto oroot = omap_root_t(laddr_t(id), cnt_modify,
       value.get_metadata_hint(block_size));
     ftvalue.update_omap_root(t, oroot);
     validate(value);
@@ -41,7 +41,7 @@ struct onode_item_t {
   void validate(Onode& value) const {
     auto& layout = value.get_layout();
     ceph_assert(laddr_t(layout.size) == laddr_t{size});
-    ceph_assert(layout.omap_root.get(value.get_metadata_hint(block_size)).addr == id);
+    ceph_assert(layout.omap_root.get(value.get_metadata_hint(block_size)).addr == laddr_t(id));
     ceph_assert(layout.omap_root.get(value.get_metadata_hint(block_size)).depth == cnt_modify);
   }
 

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -127,7 +127,7 @@ TEST_F(a_basic_test_t, 1_basic_sizes)
   value.payload_size = 8;
 #define _STAGE_T(NodeType) node_to_stage_t<typename NodeType::node_stage_t>
 #define NXT_T(StageType)  staged<typename StageType::next_param_t>
-  laddr_t i_value{0};
+  laddr_t i_value = L_ADDR_MIN;
   logger().info("\n"
     "Bytes of a key-value insertion (full-string):\n"
     "  s-p-c, 'n'-'o', s-g => value_payload(8): typically internal 43B, leaf 59B\n"
@@ -1047,8 +1047,8 @@ class DummyChildPool {
 
     static Ref<DummyChild> create_new(
         const std::set<ghobject_t>& keys, bool is_level_tail, DummyChildPool& pool) {
-      static laddr_t seed = 0;
-      return create(keys, is_level_tail, seed++, pool);
+      static uint64_t seed = 0;
+      return create(keys, is_level_tail, laddr_t(seed++), pool);
     }
 
     static eagain_ifuture<Ref<DummyChild>> create_initial(

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1048,7 +1048,7 @@ class DummyChildPool {
     static Ref<DummyChild> create_new(
         const std::set<ghobject_t>& keys, bool is_level_tail, DummyChildPool& pool) {
       static uint64_t seed = 0;
-      return create(keys, is_level_tail, laddr_t(seed++), pool);
+      return create(keys, is_level_tail, laddr_t::from_raw_uint(seed++), pool);
     }
 
     static eagain_ifuture<Ref<DummyChild>> create_initial(

--- a/src/test/crimson/seastore/onode_tree/test_value.h
+++ b/src/test/crimson/seastore/onode_tree/test_value.h
@@ -159,12 +159,12 @@ class TestValue final : public Value {
           break;
         }
         default:
-          logger().error("OTree::TestValue::Replay: got unknown op {} when replay {:#x}+{:#x}",
+          logger().error("OTree::TestValue::Replay: got unknown op {} when replay {}~{:#x}",
                          op, value_addr, payload_mut.get_length());
           ceph_abort();
         }
       } catch (buffer::error& e) {
-        logger().error("OTree::TestValue::Replay: got decode error {} when replay {:#x}+{:#x}",
+        logger().error("OTree::TestValue::Replay: got decode error {} when replay {}~{:#x}",
                        e.what(), value_addr, payload_mut.get_length());
         ceph_abort();
       }

--- a/src/test/crimson/seastore/onode_tree/test_value.h
+++ b/src/test/crimson/seastore/onode_tree/test_value.h
@@ -137,7 +137,7 @@ class TestValue final : public Value {
 
     void apply_value_delta(ceph::bufferlist::const_iterator& delta,
                            NodeExtentMutable& payload_mut,
-                           laddr_t value_addr) override {
+                           laddr_offset_t value_addr_offset) override {
       delta_op_t op;
       try {
         ceph::decode(op, delta);
@@ -160,12 +160,12 @@ class TestValue final : public Value {
         }
         default:
           logger().error("OTree::TestValue::Replay: got unknown op {} when replay {}~{:#x}",
-                         op, value_addr, payload_mut.get_length());
+                         op, value_addr_offset, payload_mut.get_length());
           ceph_abort();
         }
       } catch (buffer::error& e) {
         logger().error("OTree::TestValue::Replay: got decode error {} when replay {}~{:#x}",
-                       e.what(), value_addr, payload_mut.get_length());
+                       e.what(), value_addr_offset, payload_mut.get_length());
         ceph_abort();
       }
     }

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -378,14 +378,14 @@ TEST_F(lba_btree_test, basic)
   run_async([this] {
     constexpr unsigned total = 16<<10;
     for (unsigned i = 0; i < total; i += 16) {
-      insert(laddr_t(i), 8);
+      insert(laddr_t::from_raw_uint(i), 8);
     }
 
     for (unsigned i = 0; i < total; i += 16) {
-      check_lower_bound(laddr_t(i));
-      check_lower_bound(laddr_t(i + 4));
-      check_lower_bound(laddr_t(i + 8));
-      check_lower_bound(laddr_t(i + 12));
+      check_lower_bound(laddr_t::from_raw_uint(i));
+      check_lower_bound(laddr_t::from_raw_uint(i + 4));
+      check_lower_bound(laddr_t::from_raw_uint(i + 8));
+      check_lower_bound(laddr_t::from_raw_uint(i + 12));
     }
   });
 }
@@ -681,7 +681,7 @@ struct btree_lba_manager_test : btree_test_base {
 TEST_F(btree_lba_manager_test, basic)
 {
   run_async([this] {
-    laddr_t laddr = laddr_t(0x12345678 * block_size);
+    laddr_t laddr = laddr_t::from_byte_offset(0x12345678 * block_size);
     {
       // write initial mapping
       auto t = create_transaction();
@@ -831,23 +831,23 @@ TEST_F(btree_lba_manager_test, split_merge_multi)
       }
     };
     iterate([&](auto &t, auto idx) {
-      alloc_mappings(t, laddr_t(idx * block_size), block_size);
+      alloc_mappings(t, laddr_t::from_byte_offset(idx * block_size), block_size);
     });
     check_mappings();
     iterate([&](auto &t, auto idx) {
       if ((idx % 32) > 0) {
-	decref_mapping(t, laddr_t(idx * block_size));
+	decref_mapping(t, laddr_t::from_byte_offset(idx * block_size));
       }
     });
     check_mappings();
     iterate([&](auto &t, auto idx) {
       if ((idx % 32) > 0) {
-	alloc_mappings(t, laddr_t(idx * block_size), block_size);
+	alloc_mappings(t, laddr_t::from_byte_offset(idx * block_size), block_size);
       }
     });
     check_mappings();
     iterate([&](auto &t, auto idx) {
-      decref_mapping(t, laddr_t(idx * block_size));
+      decref_mapping(t, laddr_t::from_byte_offset(idx * block_size));
     });
     check_mappings();
   });

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -378,14 +378,14 @@ TEST_F(lba_btree_test, basic)
   run_async([this] {
     constexpr unsigned total = 16<<10;
     for (unsigned i = 0; i < total; i += 16) {
-      insert(i, 8);
+      insert(laddr_t(i), 8);
     }
 
     for (unsigned i = 0; i < total; i += 16) {
-      check_lower_bound(i);
-      check_lower_bound(i + 4);
-      check_lower_bound(i + 8);
-      check_lower_bound(i + 12);
+      check_lower_bound(laddr_t(i));
+      check_lower_bound(laddr_t(i + 4));
+      check_lower_bound(laddr_t(i + 8));
+      check_lower_bound(laddr_t(i + 12));
     }
   });
 }
@@ -665,7 +665,7 @@ struct btree_lba_manager_test : btree_test_base {
       [=, &t, this](auto &) {
 	return lba_manager->scan_mappings(
 	  *t.t,
-	  0,
+	  L_ADDR_MIN,
 	  L_ADDR_MAX,
 	  [iter=t.mappings.begin(), &t](auto l, auto p, auto len) mutable {
 	    EXPECT_NE(iter, t.mappings.end());
@@ -681,7 +681,7 @@ struct btree_lba_manager_test : btree_test_base {
 TEST_F(btree_lba_manager_test, basic)
 {
   run_async([this] {
-    laddr_t laddr = 0x12345678 * block_size;
+    laddr_t laddr = laddr_t(0x12345678 * block_size);
     {
       // write initial mapping
       auto t = create_transaction();
@@ -701,7 +701,7 @@ TEST_F(btree_lba_manager_test, force_split)
       auto t = create_transaction();
       logger().debug("opened transaction");
       for (unsigned j = 0; j < 5; ++j) {
-	alloc_mappings(t, 0, block_size);
+	alloc_mappings(t, L_ADDR_MIN, block_size);
 	if ((i % 10 == 0) && (j == 3)) {
 	  check_mappings(t);
 	  check_mappings();
@@ -721,7 +721,7 @@ TEST_F(btree_lba_manager_test, force_split_merge)
       auto t = create_transaction();
       logger().debug("opened transaction");
       for (unsigned j = 0; j < 5; ++j) {
-	auto rets = alloc_mappings(t, 0, block_size);
+	auto rets = alloc_mappings(t, L_ADDR_MIN, block_size);
 	// just to speed things up a bit
 	if ((i % 100 == 0) && (j == 3)) {
 	  check_mappings(t);
@@ -780,7 +780,7 @@ TEST_F(btree_lba_manager_test, single_transaction_split_merge)
     {
       auto t = create_transaction();
       for (unsigned i = 0; i < 400; ++i) {
-	alloc_mappings(t, 0, block_size);
+	alloc_mappings(t, L_ADDR_MIN, block_size);
       }
       check_mappings(t);
       submit_test_transaction(std::move(t));
@@ -803,7 +803,7 @@ TEST_F(btree_lba_manager_test, single_transaction_split_merge)
     {
       auto t = create_transaction();
       for (unsigned i = 0; i < 600; ++i) {
-	alloc_mappings(t, 0, block_size);
+	alloc_mappings(t, L_ADDR_MIN, block_size);
       }
       auto addresses = get_mapped_addresses(t);
       for (unsigned i = 0; i != addresses.size(); ++i) {
@@ -831,23 +831,23 @@ TEST_F(btree_lba_manager_test, split_merge_multi)
       }
     };
     iterate([&](auto &t, auto idx) {
-      alloc_mappings(t, idx * block_size, block_size);
+      alloc_mappings(t, laddr_t(idx * block_size), block_size);
     });
     check_mappings();
     iterate([&](auto &t, auto idx) {
       if ((idx % 32) > 0) {
-	decref_mapping(t, idx * block_size);
+	decref_mapping(t, laddr_t(idx * block_size));
       }
     });
     check_mappings();
     iterate([&](auto &t, auto idx) {
       if ((idx % 32) > 0) {
-	alloc_mappings(t, idx * block_size, block_size);
+	alloc_mappings(t, laddr_t(idx * block_size), block_size);
       }
     });
     check_mappings();
     iterate([&](auto &t, auto idx) {
-      decref_mapping(t, idx * block_size);
+      decref_mapping(t, laddr_t(idx * block_size));
     });
     check_mappings();
   });

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -500,7 +500,7 @@ struct btree_lba_manager_test : btree_test_base {
 	bottom->first + bottom->second.len <= addr)
       ++bottom;
 
-    auto top = t.mappings.lower_bound(addr + len);
+    auto top = t.mappings.lower_bound((addr + len).checked_to_laddr());
     return std::make_pair(
       bottom,
       top

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -218,14 +218,14 @@ struct object_data_handler_test_t:
     objaddr_t offset,
     extent_len_t length) {
     auto ret = with_trans_intr(t, [&](auto &t) {
-      return tm->get_pins(t, laddr_t(offset), length);
+      return tm->get_pins(t, laddr_t::from_byte_offset(offset), length);
     }).unsafe_get();
     return ret;
   }
   std::list<LBAMappingRef> get_mappings(objaddr_t offset, extent_len_t length) {
     auto t = create_mutate_transaction();
     auto ret = with_trans_intr(*t, [&](auto &t) {
-      return tm->get_pins(t, laddr_t(offset), length);
+      return tm->get_pins(t, laddr_t::from_byte_offset(offset), length);
     }).unsafe_get();
     return ret;
   }
@@ -798,7 +798,7 @@ TEST_P(object_data_handler_test_t, overwrite_then_read_within_transaction) {
       auto pins = get_mappings(*t, base, len);
       assert(pins.size() == 1);
       auto pin1 = remap_pin(*t, std::move(pins.front()), 4096, 8192);
-      auto ext = get_extent(*t, laddr_t(base + 4096), 4096 * 2);
+      auto ext = get_extent(*t, laddr_t::from_byte_offset(base + 4096), 4096 * 2);
       ASSERT_TRUE(ext->is_exist_clean());
       write(*t, base + 4096, 4096, 'y');
       ASSERT_TRUE(ext->is_exist_mutation_pending());

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -632,7 +632,7 @@ TEST_P(object_data_handler_test_t, remap_left) {
     auto base = pins.front()->get_key();
     int i = 0;
     for (auto &pin : pins) {
-      EXPECT_EQ(pin->get_key() - base, res[i]);
+      EXPECT_EQ(pin->get_key().get_byte_distance<size_t>(base), res[i]);
       i++;
     }
     read(0, 128<<10);
@@ -666,7 +666,7 @@ TEST_P(object_data_handler_test_t, remap_right) {
     auto base = pins.front()->get_key();
     int i = 0;
     for (auto &pin : pins) {
-      EXPECT_EQ(pin->get_key() - base, res[i]);
+      EXPECT_EQ(pin->get_key().get_byte_distance<size_t>(base), res[i]);
       i++;
     }
     read(0, 128<<10);
@@ -699,7 +699,7 @@ TEST_P(object_data_handler_test_t, remap_right_left) {
     auto base = pins.front()->get_key();
     int i = 0;
     for (auto &pin : pins) {
-      EXPECT_EQ(pin->get_key() - base, res[i]);
+      EXPECT_EQ(pin->get_key().get_byte_distance<size_t>(base), res[i]);
       i++;
     }
     enable_max_extent_size();
@@ -730,7 +730,7 @@ TEST_P(object_data_handler_test_t, multiple_remap) {
     auto base = pins.front()->get_key();
     int i = 0;
     for (auto &pin : pins) {
-      EXPECT_EQ(pin->get_key() - base, res[i]);
+      EXPECT_EQ(pin->get_key().get_byte_distance<size_t>(base), res[i]);
       i++;
     }
     read(0, 128<<10);

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -254,7 +254,7 @@ struct transaction_manager_test_t :
 	  EXPECT_EQ(addr, last);
 	  break;
 	}
-	EXPECT_FALSE((iter->first - last).to_byte_offset() > len);
+	EXPECT_FALSE(iter->first.get_byte_distance<extent_len_t>(last) > len);
 	last = (iter->first + iter->second.desc.len).checked_to_laddr();
 	++iter;
       }
@@ -1575,7 +1575,8 @@ struct transaction_manager_test_t :
 	      if (off == 0 || off >= 255) {
 		continue;
 	      }
-              auto new_off = laddr_t(off << 10) - last_pin->get_key();
+              auto new_off = laddr_t::from_byte_offset(off << 10)
+		  .get_byte_distance<extent_len_t>(last_pin->get_key());
               auto new_len = last_pin->get_length() - new_off;
               //always remap right extent at new split_point
 	      auto pin = remap_pin(t, std::move(last_pin), new_off, new_len);
@@ -1674,7 +1675,8 @@ struct transaction_manager_test_t :
                 continue;
               }
               empty_transaction = false;
-              auto new_off = laddr_t(start_off << 10) - last_rpin->get_key();
+              auto new_off = laddr_t::from_byte_offset(start_off << 10)
+		  .get_byte_distance<extent_len_t>(last_rpin->get_key());
               auto new_len = (end_off - start_off) << 10;
               bufferlist bl;
               bl.append(ceph::bufferptr(ceph::buffer::create(new_len, 0)));


### PR DESCRIPTION
This PR converts `laddr_t` to a struct and make it block aligned, as the basic part of static 128-bits laddr design described at https://github.com/ceph/ceph/pull/55291#issuecomment-2196998830 .


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
