### PR TITLE
reef: qa/tasks: watchdog should terminate thrasher

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -815,11 +815,16 @@ class OSDThrasher(Thrasher):
             self.ceph_manager.raw_cluster_cmd('osd', 'primary-affinity',
                                               str(osd), str(1))
 
-    def do_join(self):
+    def stop(self):
+        """
+        Stop the thrasher
+        """
+        self.stopping = True
+
+    def join(self):
         """
         Break out of this Ceph loop
         """
-        self.stopping = True
         self.thread.get()
         if self.sighup_delay:
             self.log("joining the do_sighup greenlet")
@@ -833,6 +838,13 @@ class OSDThrasher(Thrasher):
         if self.noscrub_toggle_delay:
             self.log("joining the do_noscrub_toggle greenlet")
             self.noscrub_toggle_thread.join()
+
+    def stop_and_join(self):
+        """
+        Stop and join the thrasher
+        """
+        self.stop()
+        return self.join()
 
     def grow_pool(self):
         """

--- a/qa/tasks/daemonwatchdog.py
+++ b/qa/tasks/daemonwatchdog.py
@@ -117,6 +117,7 @@ class DaemonWatchdog(Greenlet):
             for thrasher in self.thrashers:
                 if thrasher.exception is not None:
                     self.log("{name} failed".format(name=thrasher.name))
+                    thrasher.stop_and_join()
                     bark = True
 
             if bark:

--- a/qa/tasks/mon_thrash.py
+++ b/qa/tasks/mon_thrash.py
@@ -149,12 +149,25 @@ class MonitorThrasher(Thrasher):
         """
         self.logger.info(x)
 
-    def do_join(self):
+    def stop(self):
+        """
+        Stop the thrashing process.
+        """
+        self.stopping = True
+
+    def join(self):
         """
         Break out of this processes thrashing loop.
         """
         self.stopping = True
         self.thread.get()
+
+    def stop_and_join(self):
+        """
+        Stop the thrashing process and join the thread.
+        """
+        self.stop()
+        return self.join()
 
     def should_thrash_store(self):
         """
@@ -415,6 +428,6 @@ def task(ctx, config):
         yield
     finally:
         log.info('joining mon_thrasher')
-        thrash_proc.do_join()
+        thrash_proc.stop_and_join()
         mons = _get_mons(ctx)
         manager.wait_for_mon_quorum_size(len(mons))

--- a/qa/tasks/scrub.py
+++ b/qa/tasks/scrub.py
@@ -59,7 +59,7 @@ def task(ctx, config):
         yield
     finally:
         log.info('joining scrub')
-        scrub_proc.do_join()
+        scrub_proc.stop_and_join()
 
 class Scrubber:
     """
@@ -91,10 +91,18 @@ class Scrubber:
 
         self.thread = gevent.spawn(self.do_scrub)
 
-    def do_join(self):
-        """Scrubbing thread finished"""
+    def stop(self):
+        """Stop scrubbing"""
         self.stopping = True
+
+    def join(self):
+        """Scrubbing thread finished"""
         self.thread.get()
+
+    def stop_and_join(self):
+        """Stop scrubbing thread"""
+        self.stop()
+        return self.join()
 
     def do_scrub(self):
         """Perform the scrub operation"""

--- a/qa/tasks/thrasher.py
+++ b/qa/tasks/thrasher.py
@@ -1,6 +1,8 @@
 """
 Thrasher base class
 """
+
+
 class Thrasher(object):
 
     def __init__(self):
@@ -13,3 +15,6 @@ class Thrasher(object):
 
     def set_thrasher_exception(self, e):
         self._exception = e
+
+    def stop(self):
+        raise NotImplementedError("Subclasses didn't implement this method.")

--- a/qa/tasks/thrashosds.py
+++ b/qa/tasks/thrashosds.py
@@ -211,7 +211,7 @@ def task(ctx, config):
         yield
     finally:
         log.info('joining thrashosds')
-        thrash_proc.do_join()
+        thrash_proc.stop_and_join()
         cluster_manager.wait_for_all_osds_up()
         cluster_manager.flush_all_pg_stats()
         cluster_manager.wait_for_recovery(config.get('timeout', 360))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67502

---

backport of https://github.com/ceph/ceph/pull/58282
parent tracker: https://tracker.ceph.com/issues/66698

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh