### PR TITLE
squid: debian pkg: record python3-packaging dependency for ceph-volume

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -927,7 +927,6 @@ Requires: parted
 Requires: util-linux
 Requires: xfsprogs
 Requires: python%{python3_pkgversion}-setuptools
-Requires: python%{python3_pkgversion}-packaging
 Requires: python%{python3_pkgversion}-ceph-common = %{_epoch_prefix}%{version}-%{release}
 %description volume
 This package contains a tool to deploy OSD with different devices like

--- a/debian/control
+++ b/debian/control
@@ -432,6 +432,7 @@ Depends: ceph-osd (= ${binary:Version}),
          e2fsprogs,
          lvm2,
          parted,
+         python3-packaging,
          xfsprogs,
          ${misc:Depends},
          ${python3:Depends}

--- a/debian/control
+++ b/debian/control
@@ -432,7 +432,6 @@ Depends: ceph-osd (= ${binary:Version}),
          e2fsprogs,
          lvm2,
          parted,
-         python3-packaging,
          xfsprogs,
          ${misc:Depends},
          ${python3:Depends}

--- a/src/ceph-volume/setup.py
+++ b/src/ceph-volume/setup.py
@@ -14,7 +14,10 @@ setup(
     keywords='ceph volume disk devices lvm',
     url="https://github.com/ceph/ceph",
     zip_safe = False,
-    install_requires='ceph',
+    install_requires=[
+        'ceph',
+        'packaging',
+    ],
     dependency_links=[''.join(['file://', os.path.join(os.getcwd(), '../',
                                                        'python-common#egg=ceph-1.0.0')])],
     tests_require=[


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67529

---

backport of https://github.com/ceph/ceph/pull/58956
parent tracker: https://tracker.ceph.com/issues/67290

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh