### PR TITLE
ceph-volume: add "packaging" to install_requires

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -977,7 +977,6 @@ Requires: parted
 Requires: util-linux
 Requires: xfsprogs
 Requires: python%{python3_pkgversion}-setuptools
-Requires: python%{python3_pkgversion}-packaging
 Requires: python%{python3_pkgversion}-ceph-common = %{_epoch_prefix}%{version}-%{release}
 %description volume
 This package contains a tool to deploy OSD with different devices like

--- a/debian/control
+++ b/debian/control
@@ -456,7 +456,6 @@ Depends: ceph-osd (= ${binary:Version}),
          e2fsprogs,
          lvm2,
          parted,
-         python3-packaging,
          xfsprogs,
          ${misc:Depends},
          ${python3:Depends}

--- a/src/ceph-volume/setup.py
+++ b/src/ceph-volume/setup.py
@@ -14,7 +14,10 @@ setup(
     keywords='ceph volume disk devices lvm',
     url="https://github.com/ceph/ceph",
     zip_safe = False,
-    install_requires='ceph',
+    install_requires=[
+        'ceph',
+        'packaging',
+    ],
     dependency_links=[''.join(['file://', os.path.join(os.getcwd(), '../',
                                                        'python-common#egg=ceph-1.0.0')])],
     tests_require=[


### PR DESCRIPTION
in 0985e201, "packaging" was introduced as a runtime dependency of ceph-volume, and `ceph.spec.in` was updated accordingly to note this new dependency. but the debian packaging was not updated.

in 80edcd40, the missing dependency was added to debian/control as one of ceph-volume's runtime dependency.

but dh_python3 is able to figure out the dependencies by reading the egg's metadata of the ceph-volume python module. and as a python project, ceph-volume is using its `setup.py` for tracking its dependencies.

so in order to be more consistent, and keep all of its dependencies in one place, let's move this dependency to setup.py .





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
