### PR TITLE
crimson/os/seastore/cache: report lru usage/in/out with trans and extent type

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -766,14 +766,11 @@ void Cache::add_to_dirty(CachedExtentRef ref)
 
 void Cache::remove_from_dirty(CachedExtentRef ref)
 {
-  if (ref->is_dirty()) {
-    ceph_assert(ref->primary_ref_list_hook.is_linked());
-    stats.dirty_bytes -= ref->get_length();
-    dirty.erase(dirty.s_iterator_to(*ref));
-    intrusive_ptr_release(&*ref);
-  } else {
-    ceph_assert(!ref->primary_ref_list_hook.is_linked());
-  }
+  assert(ref->is_dirty());
+  ceph_assert(ref->primary_ref_list_hook.is_linked());
+  stats.dirty_bytes -= ref->get_length();
+  dirty.erase(dirty.s_iterator_to(*ref));
+  intrusive_ptr_release(&*ref);
 }
 
 void Cache::remove_extent(CachedExtentRef ref)

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1342,7 +1342,7 @@ record_t Cache::prepare_record(
     i->state = CachedExtent::extent_state_t::CLEAN;
     assert(i->is_logical());
     i->clear_modified_region();
-    touch_extent(*i);
+    touch_extent(*i, &trans_src);
     DEBUGT("inplace rewrite ool block is commmitted -- {}", t, *i);
   }
 
@@ -1895,7 +1895,7 @@ Cache::replay_delta(
         nullptr,
         [](CachedExtent &) {},
         [this](CachedExtent &ext) {
-          touch_extent(ext);
+          touch_extent(ext, nullptr);
         }) :
       _get_extent_if_cached(
 	delta.paddr)

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -44,7 +44,7 @@ Cache::Cache(
 	  "seastore_cache_lru_size"))
 {
   LOG_PREFIX(Cache::Cache);
-  INFO("created, lru_size={}", lru.get_capacity());
+  INFO("created, lru_capacity={}B", lru.get_capacity_bytes());
   register_metrics();
   segment_providers_by_device_id.resize(DEVICE_ID_MAX, nullptr);
 }
@@ -509,14 +509,14 @@ void Cache::register_metrics()
       sm::make_counter(
 	"cache_lru_size_bytes",
 	[this] {
-	  return lru.get_current_contents_bytes();
+	  return lru.get_current_size_bytes();
 	},
 	sm::description("total bytes pinned by the lru")
       ),
       sm::make_counter(
-	"cache_lru_size_extents",
+	"cache_lru_num_extents",
 	[this] {
-	  return lru.get_current_contents_extents();
+	  return lru.get_current_num_extents();
 	},
 	sm::description("total extents pinned by the lru")
       ),
@@ -1747,8 +1747,8 @@ Cache::close_ertr::future<> Cache::close()
        stats.dirty_bytes,
        get_oldest_dirty_from().value_or(JOURNAL_SEQ_NULL),
        get_oldest_backref_dirty_from().value_or(JOURNAL_SEQ_NULL),
-       lru.get_current_contents_extents(),
-       lru.get_current_contents_bytes(),
+       lru.get_current_num_extents(),
+       lru.get_current_size_bytes(),
        extents.size(),
        extents.get_bytes());
   root.reset();

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -585,8 +585,8 @@ private:
       SUBDEBUG(seastore_cache,
           "{} {}~{} is absent, add extent and reading ... -- {}",
           T::TYPE, offset, length, *ret);
-      const auto p_src = p_src_ext ? &p_src_ext->first : nullptr;
-      add_extent(ret, p_src);
+      add_extent(ret);
+      // touch_extent() should be included in on_cache
       on_cache(*ret);
       extent_init_func(*ret);
       return read_extent<T>(
@@ -1642,7 +1642,10 @@ private:
     const journal_seq_t &);
 
   /// Add extent to extents handling dirty and refcounting
-  void add_extent(CachedExtentRef ref, const Transaction::src_t* t_src);
+  ///
+  /// Note, it must follows with add_to_dirty() or touch_extent().
+  /// The only exception is RetiredExtentPlaceholder.
+  void add_extent(CachedExtentRef ref);
 
   /// Mark exising extent ref dirty -- mainly for replay
   void mark_dirty(CachedExtentRef ref);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -312,7 +312,7 @@ public:
     if (!ret) {
       SUBDEBUGT(seastore_cache, "{} {} is absent", t, type, offset);
       return get_extent_if_cached_iertr::make_ready_future<CachedExtentRef>();
-    } else if (ret->get_type() == extent_types_t::RETIRED_PLACEHOLDER) {
+    } else if (is_retired_placeholder_type(ret->get_type())) {
       // retired_placeholder is not really cached yet
       SUBDEBUGT(seastore_cache, "{} {} is absent(placeholder)",
                 t, type, offset);
@@ -515,7 +515,7 @@ public:
     }
 
     // user should not see RETIRED_PLACEHOLDER extents
-    ceph_assert(p_extent->get_type() != extent_types_t::RETIRED_PLACEHOLDER);
+    ceph_assert(!is_retired_placeholder_type(p_extent->get_type()));
     if (!p_extent->is_fully_loaded()) {
       assert(!p_extent->is_mutable());
       LOG_PREFIX(Cache::get_extent_viewable_by_trans);
@@ -597,7 +597,7 @@ private:
     }
 
     // extent PRESENT in cache
-    if (cached->get_type() == extent_types_t::RETIRED_PLACEHOLDER) {
+    if (is_retired_placeholder_type(cached->get_type())) {
       auto ret = CachedExtent::make_cached_extent_ref<T>(
         alloc_cache_buf(length));
       ret->init(CachedExtent::extent_state_t::CLEAN_PENDING,
@@ -1736,7 +1736,7 @@ private:
         iter != extents.end()) {
       if (p_metric_key &&
           // retired_placeholder is not really cached yet
-          iter->get_type() != extent_types_t::RETIRED_PLACEHOLDER) {
+          !is_retired_placeholder_type(iter->get_type())) {
         ++p_counters->hit;
       }
       return CachedExtentRef(&*iter);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1507,9 +1507,6 @@ private:
     uint64_t hit = 0;
   };
 
-  template <typename CounterT>
-  using counter_by_extent_t = std::array<CounterT, EXTENT_TYPES_MAX>;
-
   struct invalid_trans_efforts_t {
     io_stat_t read;
     io_stat_t mutate;
@@ -1592,15 +1589,6 @@ private:
     version_stat_t committed_dirty_version;
     version_stat_t committed_reclaim_version;
   } stats;
-
-  template <typename CounterT>
-  CounterT& get_by_ext(
-      counter_by_extent_t<CounterT>& counters_by_ext,
-      extent_types_t ext) {
-    auto index = static_cast<uint8_t>(ext);
-    assert(index < EXTENT_TYPES_MAX);
-    return counters_by_ext[index];
-  }
 
   void account_conflict(Transaction::src_t src1, Transaction::src_t src2) {
     assert(src1 < Transaction::src_t::MAX);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1380,7 +1380,7 @@ private:
    *
    * holds refs to dirty extents.  Ordered by CachedExtent::get_dirty_from().
    */
-  CachedExtent::list dirty;
+  CachedExtent::primary_ref_list dirty;
 
   using backref_extent_entry_query_set_t =
     std::set<
@@ -1428,7 +1428,7 @@ private:
     // current size (bytes)
     size_t contents = 0;
 
-    CachedExtent::list lru;
+    CachedExtent::primary_ref_list lru;
 
     void trim_to_capacity() {
       while (contents > capacity) {

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -371,7 +371,6 @@ public:
         });
       } else {
 	assert(!ret->is_mutable());
-	touch_extent(*ret);
         SUBDEBUGT(seastore_cache, "{} {}~{} is present on t without been \
           fully loaded, reading ... {}", t, T::TYPE, offset, length, *ret);
         auto bp = alloc_cache_buf(ret->get_length());
@@ -712,7 +711,6 @@ private:
         });
       } else {
 	assert(!ret->is_mutable());
-	touch_extent(*ret);
         SUBDEBUGT(seastore_cache, "{} {}~{} {} is present on t without been \
                   fully loaded, reading ...", t, type, offset, length, laddr);
         auto bp = alloc_cache_buf(ret->get_length());

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -685,7 +685,7 @@ private:
     CachedExtent,
     boost::intrusive::list_member_hook<>,
     &CachedExtent::primary_ref_list_hook>;
-  using list = boost::intrusive::list<
+  using primary_ref_list = boost::intrusive::list<
     CachedExtent,
     primary_ref_list_member_options>;
 

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -515,7 +515,7 @@ public:
 
   /// Returns true if extent is a plcaeholder
   bool is_placeholder() const {
-    return get_type() == extent_types_t::RETIRED_PLACEHOLDER;
+    return is_retired_placeholder_type(get_type());
   }
 
   bool is_pending_io() const {

--- a/src/crimson/os/seastore/extent_placement_manager.cc
+++ b/src/crimson/os/seastore/extent_placement_manager.cc
@@ -277,7 +277,8 @@ void ExtentPlacementManager::set_primary_device(Device *device)
 device_stats_t
 ExtentPlacementManager::get_device_stats(
   const writer_stats_t &journal_stats,
-  bool report_detail) const
+  bool report_detail,
+  double seconds) const
 {
   LOG_PREFIX(ExtentPlacementManager::get_device_stats);
 
@@ -345,16 +346,7 @@ ExtentPlacementManager::get_device_stats(
     cold_stats.add(cold_writer_stats.back());
   }
 
-  auto now = seastar::lowres_clock::now();
-  if (last_tp == seastar::lowres_clock::time_point::min()) {
-    last_tp = now;
-    return {};
-  }
-  std::chrono::duration<double> duration_d = now - last_tp;
-  double seconds = duration_d.count();
-  last_tp = now;
-
-  if (report_detail) {
+  if (report_detail && seconds != 0) {
     std::ostringstream oss;
     auto report_writer_stats = [seconds, &oss](
         const char* name,

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -303,7 +303,8 @@ public:
 
   device_stats_t get_device_stats(
     const writer_stats_t &journal_stats,
-    bool report_detail) const;
+    bool report_detail,
+    double seconds) const;
 
   using mount_ertr = crimson::errorator<
       crimson::ct_error::input_output_error>;
@@ -1097,9 +1098,6 @@ private:
   // TODO: drop once paddr->journal_seq_t is introduced
   SegmentSeqAllocatorRef ool_segment_seq_allocator;
   extent_len_t max_data_allocation_size = 0;
-
-  mutable seastar::lowres_clock::time_point last_tp =
-    seastar::lowres_clock::time_point::min();
 
   friend class ::transaction_manager_test_t;
 };

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -177,7 +177,7 @@ public:
       return false;
     }
     assert(t.get_src() == transaction_type_t::TRIM_DIRTY);
-    ceph_assert_always(extent->get_type() == extent_types_t::ROOT ||
+    ceph_assert_always(is_root_type(extent->get_type()) ||
 	extent->get_paddr().is_absolute());
     return crimson::os::seastore::can_inplace_rewrite(extent->get_type());
   }
@@ -571,7 +571,8 @@ private:
       extent_types_t type,
       placement_hint_t hint,
       rewrite_gen_t gen) {
-    if (type == extent_types_t::ROOT) {
+    assert(is_real_type(type));
+    if (is_root_type(type)) {
       gen = INLINE_GENERATION;
     } else if (get_main_backend_type() == backend_type_t::SEGMENTED &&
                is_lba_backref_node(type)) {

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -210,6 +210,8 @@ public:
 
     shard_stats_t get_io_stats(bool report_detail, double seconds) const;
 
+    cache_stats_t get_cache_stats(bool report_detail, double seconds) const;
+
   private:
     struct internal_context_t {
       CollectionRef ch;
@@ -585,6 +587,7 @@ private:
     seastar::lowres_clock::time_point::min();
   mutable std::vector<device_stats_t> shard_device_stats;
   mutable std::vector<shard_stats_t> shard_io_stats;
+  mutable std::vector<cache_stats_t> shard_cache_stats;
 };
 
 std::unique_ptr<SeaStore> make_seastore(

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -204,9 +204,11 @@ public:
 
     void init_managers();
 
-    device_stats_t get_device_stats(bool report_detail) const;
+    double reset_report_interval() const;
 
-    shard_stats_t get_io_stats(bool report_detail) const;
+    device_stats_t get_device_stats(bool report_detail, double seconds) const;
+
+    shard_stats_t get_io_stats(bool report_detail, double seconds) const;
 
   private:
     struct internal_context_t {

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -245,6 +245,10 @@ std::ostream &operator<<(std::ostream &out, extent_types_t t)
     return out << "OBJECT_DATA_BLOCK";
   case extent_types_t::RETIRED_PLACEHOLDER:
     return out << "RETIRED_PLACEHOLDER";
+  case extent_types_t::ALLOC_INFO:
+    return out << "ALLOC_INFO";
+  case extent_types_t::JOURNAL_TAIL:
+    return out << "JOURNAL_TAIL";
   case extent_types_t::TEST_BLOCK:
     return out << "TEST_BLOCK";
   case extent_types_t::TEST_BLOCK_PHYSICAL:
@@ -256,7 +260,7 @@ std::ostream &operator<<(std::ostream &out, extent_types_t t)
   case extent_types_t::NONE:
     return out << "NONE";
   default:
-    return out << "UNKNOWN";
+    return out << "UNKNOWN(" << (unsigned)t << ")";
   }
 }
 
@@ -290,7 +294,7 @@ std::ostream &operator<<(std::ostream &out, data_category_t c)
 }
 
 bool can_inplace_rewrite(extent_types_t type) {
-  return get_extent_category(type) == data_category_t::DATA;
+  return is_data_type(type);
 }
 
 std::ostream &operator<<(std::ostream &out, sea_time_point_printer_t tp)

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -980,4 +980,36 @@ std::ostream& operator<<(std::ostream& out, const writer_stats_printer_t& p)
   return out;
 }
 
+std::ostream& operator<<(std::ostream& out, const cache_io_stats_printer_t& p)
+{
+  constexpr const char* dfmt = "{:.2f}";
+  out << "in("
+      << fmt::format(dfmt, p.stats.get_in_mbs(p.seconds))
+      << "MiB/s,"
+      << fmt::format(dfmt, p.stats.get_in_avg_kb())
+      << "KiB,"
+      << fmt::format(dfmt, p.stats.in_num_extents/p.seconds)
+      << "ps) out("
+      << fmt::format(dfmt, p.stats.get_out_mbs(p.seconds))
+      << "MiB/s,"
+      << fmt::format(dfmt, p.stats.get_out_avg_kb())
+      << "KiB,"
+      << fmt::format(dfmt, p.stats.out_num_extents/p.seconds)
+      << "ps)";
+  return out;
 }
+
+std::ostream& operator<<(std::ostream& out, const cache_size_stats_t& p)
+{
+  constexpr const char* dfmt = "{:.2f}";
+  out << "("
+      << fmt::format(dfmt, p.get_mb())
+      << "MiB,"
+      << fmt::format(dfmt, p.get_avg_kb())
+      << "KiB,"
+      << p.num_extents
+      << ")";
+  return out;
+}
+
+} // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2330,6 +2330,18 @@ void minus_srcs(counter_by_src_t<CounterT>& base,
   }
 }
 
+template <typename CounterT>
+using counter_by_extent_t = std::array<CounterT, EXTENT_TYPES_MAX>;
+
+template <typename CounterT>
+CounterT& get_by_ext(
+    counter_by_extent_t<CounterT>& counters_by_ext,
+    extent_types_t ext) {
+  auto index = static_cast<uint8_t>(ext);
+  assert(index < EXTENT_TYPES_MAX);
+  return counters_by_ext[index];
+}
+
 struct grouped_io_stats {
   uint64_t num_io = 0;
   uint64_t num_io_grouped = 0;

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -101,7 +101,7 @@ public:
       iter != read_set.end()) {
       // placeholder in read-set should be in the retired-set
       // at the same time.
-      assert(iter->ref->get_type() != extent_types_t::RETIRED_PLACEHOLDER);
+      assert(!is_retired_placeholder_type(iter->ref->get_type()));
       if (out)
 	*out = iter->ref;
       SUBTRACET(seastore_cache, "{} is present in read_set -- {}",
@@ -270,9 +270,9 @@ public:
   void replace_placeholder(CachedExtent& placeholder, CachedExtent& extent) {
     ceph_assert(!is_weak());
 
-    assert(placeholder.get_type() == extent_types_t::RETIRED_PLACEHOLDER);
-    assert(extent.get_type() != extent_types_t::RETIRED_PLACEHOLDER);
-    assert(extent.get_type() != extent_types_t::ROOT);
+    assert(is_retired_placeholder_type(placeholder.get_type()));
+    assert(!is_retired_placeholder_type(extent.get_type()));
+    assert(!is_root_type(extent.get_type()));
     assert(extent.get_paddr() == placeholder.get_paddr());
     {
       auto where = read_set.find(placeholder.get_paddr());

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -658,7 +658,7 @@ TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(
     return backref_manager->rewrite_extent(t, extent);
   }
 
-  if (extent->get_type() == extent_types_t::ROOT) {
+  if (is_root_type(extent->get_type())) {
     DEBUGT("rewriting root extent -- {}", t, *extent);
     cache->duplicate_for_write(t, extent);
     return rewrite_extent_iertr::now();

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -86,6 +86,10 @@ public:
     return epm->get_device_stats(journal_stats, report_detail, seconds);
   }
 
+  cache_stats_t get_cache_stats(bool report_detail, double seconds) const {
+    return cache->get_stats(report_detail, seconds);
+  }
+
   /// Resets transaction
   void reset_transaction_preserve_handle(Transaction &t) {
     return cache->reset_transaction_preserve_handle(t);

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -80,9 +80,10 @@ public:
   using close_ertr = base_ertr;
   close_ertr::future<> close();
 
-  device_stats_t get_device_stats(bool report_detail) const {
+  device_stats_t get_device_stats(
+      bool report_detail, double seconds) const {
     writer_stats_t journal_stats = journal->get_writer_stats();
-    return epm->get_device_stats(journal_stats, report_detail);
+    return epm->get_device_stats(journal_stats, report_detail, seconds);
   }
 
   /// Resets transaction


### PR DESCRIPTION
The main change refer to the last commit, the rest are related refactors/cleanups.

The report looks like:
```
INFO  2024-08-14 15:46:35,714 [shard 0:main] seastore_cache - Cache::LRU::get_stats:
lru total(64.00MiB,4.52KiB,14501)
  data(55.79MiB,4.00KiB,14283)
  mdat(7.88MiB,60.63KiB,133)
  phys(0.33MiB,4.00KiB,85)
lru io: trans-in(0.40MiB/s,5.71KiB,72.50ps) out(0.28MiB/s,5.06KiB,56.50ps); other-in(0.00MiB/s,-nanKiB,0.00ps) out(0.12MiB/s,7.76KiB,16.50ps)
  MUTATE: in(0.37MiB/s,5.95KiB,63.50ps) out(0.23MiB/s,4.59KiB,51.00ps)
    data: in(0.22MiB/s,4.00KiB,57.50ps) out(0.20MiB/s,4.00KiB,50.50ps)
    mdat: in(0.13MiB/s,45.33KiB,3.00ps) out(0.03MiB/s,64.00KiB,0.50ps)
    phys: in(0.01MiB/s,4.00KiB,3.00ps) out(0.00MiB/s,-nanKiB,0.00ps)
  TRIM_DIRTY: in(0.02MiB/s,4.00KiB,4.50ps) out(0.02MiB/s,4.00KiB,4.00ps)
    data: in(0.00MiB/s,-nanKiB,0.00ps) out(0.02MiB/s,4.00KiB,4.00ps)
    mdat: in(0.00MiB/s,-nanKiB,0.00ps) out(0.00MiB/s,-nanKiB,0.00ps)
    phys: in(0.02MiB/s,4.00KiB,4.50ps) out(0.00MiB/s,-nanKiB,0.00ps)
  TRIM_ALLOC: in(0.02MiB/s,4.00KiB,4.50ps) out(0.04MiB/s,24.00KiB,1.50ps)
    data: in(0.00MiB/s,-nanKiB,0.00ps) out(0.00MiB/s,4.00KiB,1.00ps)
    mdat: in(0.00MiB/s,-nanKiB,0.00ps) out(0.03MiB/s,64.00KiB,0.50ps)
    phys: in(0.02MiB/s,4.00KiB,4.50ps) out(0.00MiB/s,-nanKiB,0.00ps)
...
INFO  2024-08-14 15:46:35,715 [shard 0:main] seastore - SeaStore: cache lru: total(255.96MiB,4.53KiB,57895) in(1.35MiB/s,4.64KiB,298.38ps) out(1.34MiB/s,4.86KiB,282.86ps); per-shard: total(63.99MiB,4.53KiB,14473) in(0.34MiB/s,4.64KiB,74.59ps) out(0.33MiB/s,4.87KiB,70.59ps)
```
This prints the details of LRU cache in shard 0, and a summary at the seastore level.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
