### PR TITLE
quincy: doc/cephfs: improve cache-configuration.rst

### DIFF
--- a/doc/cephfs/cache-configuration.rst
+++ b/doc/cephfs/cache-configuration.rst
@@ -237,12 +237,11 @@ all cached caps (the actual recall value is ``num_caps -
 mds_min_caps_per_client(100)``).
 
 Under certain circumstances, many "recall caps" requests can be sent so quickly
-that the "mon warning limit" exceeded, and the "clients failing to respond to
-cache pressure" message can be triggered. If the client does not release the
-caps fast enough, the MDS repeats the "recall caps" request one second later.
-This means that the MDS will send "recall caps" again and again. The "total"
-counter of "recall caps" for the session will grow and grow, and will
-eventually exceed the "mon warning limit".
+that the health warning is generated: "clients failing to respond to cache
+pressure". If the client does not release the caps fast enough, the MDS repeats
+the "recall caps" request one second later.  This means that the MDS will send
+"recall caps" again and again. The "total" counter of "recall caps" for the
+session will grow and grow, and will eventually exceed the "mon warning limit".
 
 A throttling mechanism, controlled by the ``mds_recall_max_decay_threshold``
 parameter (126K by default), is available for reducing the rate of "recall
@@ -258,7 +257,7 @@ Example Scenario
 Here is an example. A client is having 20k caps cached. At some moment the
 server decides the client is inactive (because the session's ``cache_liveness``
 value is low). It starts to ask the client to release caps down to
-``mds_min_caps_per_client`` value (100 by default). For this every seconds it
+``mds_min_caps_per_client`` value (100 by default). Every second, it
 sends recall_caps asking to release ``caps_num - mds_min_caps_per_client`` caps
 (but not more than ``mds_recall_max_caps``, which is 30k by default). A client
 is starting to release, but is releasing with a rate of (for example) only 100


### PR DESCRIPTION
Improve the text in the section about dealing with cache-pressure alerts that was added in https://github.com/ceph/ceph/pull/59077. The changes in this commit were suggested by Anthony D'Atri.

Co-authored-by: Patrick Donnelly <pdonnelly@redhat.com>
Co-authored-by: Anthony D'Atri <anthony.datri@gmail.com>
Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit aa3bdae2314fef2fca8fc12dca006af657235e17)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
