### PR TITLE
doc/rgw/notification: persistent notification queue full behavior

### DIFF
--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -61,9 +61,15 @@ Asynchronous Notifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Notifications can be sent asynchronously. They are committed into persistent
-storage and then asynchronously sent to the topic's configured endpoint. In
-this case, the only latency added to the original operation is the latency
+storage and then asynchronously sent to the topic's configured endpoint.
+The notification will be committed to persistent storage only if the triggering
+operation was successful.
+In this case, the only latency added to the original operation is the latency
 added when the notification is committed to persistent storage.
+If the endpoint of the topic to which the notification is sent is not available for a long
+period of time, the persistent storage allocated for this topic will eventually fill up.
+When this happens the triggering operations will fail with ``503 Service Unavailable``, 
+which tells the client that it may retry later.
 
 .. note:: If the notification fails with an error, cannot be delivered, or
    times out, it is retried until it is successfully acknowledged.


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50610

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
