### PR TITLE
rgw: list all the shards!

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -188,7 +188,7 @@ options:
   type: uint
   level: advanced
   desc: Max number of concurrent RADOS requests when handling bucket shards.
-  default: 128
+  default: 4_K
   services:
   - rgw
   with_legacy: true


### PR DESCRIPTION
to produce ordered bucket listings, each call must visit every shard of the bucket index. this means that bucket listing performance degrades as the shard count grows. at extreme values, the latency of a single bucket listing request will eventually exceed the client's timeout value. once clients start retrying these requests, it further increases the latency of each request and results in even more timeouts/retries. at this point, the bucket becomes effectively unlistable

even at the conservative shard count of rgw_max_dynamic_shards=1999, the default value of rgw_bucket_index_max_aio=128 means that the ordered listing has a minimum latency of (1999/128) = 15.6 osd round trips

in contrast, the rados cluster itself has available parallelism up to the pg count of its bucket index pool, which could be in the thousands. if there's cluster capacity to handle all of these shards at once, let's use it!

i chose the value of 4k because it's higher than the current default rgw_max_dynamic_shards=1999 while still being a small enough fraction of rgw's default objecter_inflight_ops=24576 to avoid the starvation of other requests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
