### PR TITLE
squid: rgwlc: fix typo in getlc (ObjectSizeGreaterThan)

### DIFF
--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -133,7 +133,7 @@ void LCFilter_S3::dump_xml(Formatter *f) const
     }
   }
   if (has_size_gt()) {
-    encode_xml("ObjectSizeGreaterThanw", size_gt, f);
+    encode_xml("ObjectSizeGreaterThan", size_gt, f);
   }
   if (has_size_lt()) {
     encode_xml("ObjectSizeLessThan", size_lt, f);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67557

---

backport of https://github.com/ceph/ceph/pull/58965
parent tracker: https://tracker.ceph.com/issues/67556

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh