### PR TITLE
logrorate: only reload related daemons by sequentially rotating logs

### DIFF
--- a/src/logrotate.conf
+++ b/src/logrotate.conf
@@ -2,9 +2,26 @@
     rotate 7
     daily
     compress
-    sharedscripts
     postrotate
-        killall -q -1 ceph-mon ceph-mgr ceph-mds ceph-osd ceph-fuse radosgw rbd-mirror cephfs-mirror || pkill -1 -x "ceph-mon|ceph-mgr|ceph-mds|ceph-osd|ceph-fuse|radosgw|rbd-mirror|cephfs-mirror" || true
+        filename=$(basename "${1}")
+        if [[ $filename =~ ^(ceph-(mon|mgr|mds|osd|fuse))\.(.*)\.log$ ]]
+        then
+                service=${BASH_REMATCH[1]}
+                id=${BASH_REMATCH[3]}
+        elif [[ $filename =~ ^(rbd-mirror)\.(.*)\.log$ ]]
+        then
+                service="ceph-${BASH_REMATCH[1]}"
+                id=${BASH_REMATCH[2]}
+        elif [[ $filename =~ ^(ceph-client.rgw)\.(.*)\.log$ ]]
+        then
+                service=ceph-radosgw
+                id=${BASH_REMATCH[2]}
+        elif [[ $filename =~ ^(cephfs-mirror)\.(.*)\.log$ ]]
+        then
+                service=${BASH_REMATCH[1]}
+                id=${BASH_REMATCH[2]}
+        fi
+        systemctl reload "${service}"@"${id}" || true
     endscript
     missingok
     notifempty


### PR DESCRIPTION
We observed that the current logrotate.conf configuration causes all Ceph daemons to receive a SIGHUP whenever any file in /var/log/ceph/ is rotated. This led to issues where booting ceph daemons received a SIGHUP from logrotate before their signal handlers were registered, causing the daemons to stop.

To address this, we modified logrotate.conf to perform rotations sequentially. Each subtask now identifies the corresponding Ceph daemon based on the rotated file name and sends a SIGHUP to request a reload.

Fixes: https://tracker.ceph.com/issues/67566

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
