### PR TITLE
reef: cls/cas/cls_cas_internal: Initialize 'hash' value before decoding

### DIFF
--- a/src/cls/cas/cls_cas_internal.h
+++ b/src/cls/cas/cls_cas_internal.h
@@ -238,7 +238,7 @@ struct chunk_refs_by_hash_t : public chunk_refs_t::refs_t {
     int hash_bytes = (hash_bits + 7) / 8;
     while (n--) {
       int64_t poolid;
-      ceph_le32 hash;
+      ceph_le32 hash{0};
       uint64_t count;
       denc_signed_varint(poolid, p);
       memcpy(&hash, p.get_pos_add(hash_bytes), hash_bytes);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67572

---

backport of https://github.com/ceph/ceph/pull/56136
parent tracker: https://tracker.ceph.com/issues/64854

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh