### PR TITLE
test/rgw/notification: use real ip address instead of localhost

### DIFF
--- a/qa/tasks/rabbitmq.py
+++ b/qa/tasks/rabbitmq.py
@@ -70,22 +70,25 @@ def run_rabbitmq(ctx, config):
         (remote,) = ctx.cluster.only(client).remotes.keys()
 
         ctx.cluster.only(client).run(args=[
-             'sudo', 'systemctl', 'enable', 'rabbitmq-server.service'
+             'echo', 'loopback_users.guest = false', run.Raw('|'), 'sudo', 'tee', '-a', '/etc/rabbitmq/rabbitmq.conf'
             ],
         )
 
         ctx.cluster.only(client).run(args=[
-             'sudo', '/sbin/service', 'rabbitmq-server', 'start'
+             'sudo', 'systemctl', 'enable', 'rabbitmq-server'
             ],
         )
 
-        '''
+        ctx.cluster.only(client).run(args=[
+             'sudo', 'systemctl', 'start', 'rabbitmq-server'
+            ],
+        )
+
         # To check whether rabbitmq-server is running or not
         ctx.cluster.only(client).run(args=[
-             'sudo', '/sbin/service', 'rabbitmq-server', 'status'
+             'sudo', 'systemctl', 'status', 'rabbitmq-server'
             ],
         )
-        '''
 
     try:
         yield
@@ -96,7 +99,7 @@ def run_rabbitmq(ctx, config):
             (remote,) = ctx.cluster.only(client).remotes.keys()
 
             ctx.cluster.only(client).run(args=[
-                 'sudo', '/sbin/service', 'rabbitmq-server', 'stop'
+                 'sudo', 'systemctl', 'stop', 'rabbitmq-server'
                 ],
             )
 

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -487,10 +487,6 @@ def stop_kafka_receiver(receiver, task):
 
 
 def get_ip():
-    return 'localhost'
-
-
-def get_ip_http():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
         # address should not be reachable
@@ -1297,7 +1293,7 @@ def notification_push(endpoint_type, conn, account=None, cloudevents=False):
     task = None
     if endpoint_type == 'http':
         # create random port for the http server
-        host = get_ip_http()
+        host = get_ip()
         port = random.randint(10000, 20000)
         # start an http server in a separate thread
         receiver = HTTPServerWithEvents((host, port), cloudevents=cloudevents)
@@ -3833,7 +3829,7 @@ def persistent_notification(endpoint_type, conn, account=None):
     task = None
     if endpoint_type == 'http':
         # create random port for the http server
-        host = get_ip_http()
+        host = get_ip()
         port = random.randint(10000, 20000)
         # start an http server in a separate thread
         receiver = HTTPServerWithEvents((host, port))


### PR DESCRIPTION
based on that comment:
https://tracker.ceph.com/issues/67206#note-6
the address used by the endpoint is taken as the real IP address of the host where the test script is running and not localhost.

Fixes: https://tracker.ceph.com/issues/67206

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
