### PR TITLE
squid: qa/suites/upgrade: ignore PG_AVAILABILITY and MON_DOWN for quincy-x and reef-x upgrade suites

### DIFF
--- a/qa/suites/upgrade/quincy-x/parallel/1-tasks.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/1-tasks.yaml
@@ -1,3 +1,11 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - mons down
+      - mon down
+      - MON_DOWN
+      - out of quorum
+      - PG_AVAILABILITY
 tasks:
 - install:
     branch: quincy

--- a/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
@@ -11,6 +11,7 @@ overrides:
       - Reduced data availability
       - Degraded data redundancy
       - OSDMAP_FLAGS
+      - PG_AVAILABILITY
 tasks:
 - install:
     branch: quincy

--- a/qa/suites/upgrade/reef-x/parallel/1-tasks.yaml
+++ b/qa/suites/upgrade/reef-x/parallel/1-tasks.yaml
@@ -5,6 +5,7 @@ overrides:
       - mon down
       - MON_DOWN
       - out of quorum
+      - PG_AVAILABILITY
 tasks:
 - install:
     branch: reef

--- a/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/reef-x/stress-split/1-start.yaml
@@ -1,3 +1,11 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - mons down
+      - mon down
+      - MON_DOWN
+      - out of quorum
+      - PG_AVAILABILITY
 tasks:
 - install:
     branch: reef


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67577

---

backport of https://github.com/ceph/ceph/pull/58415
parent tracker: https://tracker.ceph.com/issues/66809

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh