### PR TITLE
HealthMonitor: Add topology-aware netsplit detection and warning

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -153,6 +153,24 @@ To adjust the warning threshold, run the following command:
 
    ceph config set global mon_data_size_warn <size>
 
+MON_NETSPLIT
+____________
+
+A network partition has occurred among Ceph Monitors. This health check is
+raised when one or more monitors detect that at least two Ceph Monitors have
+lost connectivity or reachability, based on their individual connection scores,
+which are frequently updated. This warning only appears when
+the cluster is provisioned with at least three Ceph Monitors and are using the
+``connectivity`` election strategy.
+
+Network partitions are reported in two ways:
+- As location-level netsplits (e.g., "Netsplit detected between dc1 and dc2") when
+  all monitors in one location cannot communicate with all monitors in another location
+- As individual monitor netsplits (e.g., "Netsplit detected between mon.a and mon.d")
+  when only specific monitors are disconnected across locations
+
+The system prioritizes reporting at the highest topology level (``datacenter``, ``rack``, etc.)
+when possible, to better help operators identify infrastructure-level network issues.
 
 AUTH_INSECURE_GLOBAL_ID_RECLAIM
 _______________________________

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -771,6 +771,11 @@ bool Elector::peer_tracker_is_clean()
   return peer_tracker.is_clean(mon->rank, paxos_size());
 }
 
+std::set<std::pair<unsigned, unsigned>> Elector::get_netsplit_peer_tracker(std::set<unsigned> &mons_down)
+{
+  return peer_tracker.get_netsplit(mons_down);
+}
+
 bool Elector::is_tiebreaker(int rank) const
 {
   return mon->monmap->tiebreaker_mon == mon->monmap->get_name(rank);

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -379,6 +379,9 @@ class Elector : public ElectionOwner, RankProvider {
   * https://tracker.ceph.com/issues/58049
   */
   bool peer_tracker_is_clean();
+
+  std::set<std::pair<unsigned, unsigned>> get_netsplit_peer_tracker(std::set<unsigned> &mons_down);
+
   /**
    * Forget everything about our peers. :(
    */

--- a/src/mon/HealthMonitor.h
+++ b/src/mon/HealthMonitor.h
@@ -64,10 +64,11 @@ private:
   bool prepare_command(MonOpRequestRef op);
   bool prepare_health_checks(MonOpRequestRef op);
   void check_for_older_version(health_check_map_t *checks);
-  void check_for_mon_down(health_check_map_t *checks);
+  void check_for_mon_down(health_check_map_t *checks, std::set<std::string> &mons_down);
   void check_for_clock_skew(health_check_map_t *checks);
   void check_mon_crush_loc_stretch_mode(health_check_map_t *checks);
   void check_if_msgr2_enabled(health_check_map_t *checks);
+  void check_netsplit(health_check_map_t *checks, std::set<std::string> &mons_down);
   bool check_leader_health();
   bool check_member_health();
   bool check_mutes();


### PR DESCRIPTION
### NOTE:
This PR is dependent on https://github.com/ceph/ceph/pull/62416 and should always be tested together.

### Problem:
    Currently, Ceph cannot detect and report network partitions (netsplits)
    between monitors in different topology locations in a consolidated way.
    While stretch mode can handle partitions through monitor elections,
    users lack visibility into the topology-level view of network
    disconnections, making troubleshooting difficult.
    
### Solution:
    This implementation adds a hierarchical netsplit detection mechanism that:
      - Uses DirectedGraph structure for netsplit detection
      - Maps monitor disconnections to relevant CRUSH topology levels
      - Aggregates individual disconnections into location-level reports when appropriate
      - Detects complete location-level netsplits when ALL monitors between locations
        cannot communicate
      - Reports specific topology locations experiencing complete communication failures
      - Falls back to individual monitor-level reporting for partial disconnections
      - Handles monitors with missing location data gracefully
      - Leverages HealthMonitor::check_for_mon_down to receive a set of down monitors,
        efficiently avoiding false netsplit reports for monitors already known to be down
      - Implements smart filtering that correctly excludes down monitors from location-based
        analysis, ensuring accurate netsplit reporting at both individual and topology levels

    The implementation produces user-friendly health warnings:
    1. For complete location netsplits: "Netsplit detected between dc1 and dc2"
    2. For individual monitor disconnections: "Netsplit detected between mon.a and mon.d"
    
### Performance considerations:
     - Time complexity: O(m²) where m is the number of monitors
     - Space complexity: O(m²) for connection tracking
     - Practical impact is minimal as monitor count is typically small (3-7)
    
Fixes: https://tracker.ceph.com/issues/67371
    
Signed-off-by: Kamoltat Sirivadhna <ksirivad@redhat.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
