### PR TITLE
squid: doc/cephfs: improve "layout fields" text

### DIFF
--- a/doc/cephfs/file-layouts.rst
+++ b/doc/cephfs/file-layouts.rst
@@ -20,7 +20,7 @@ Layout fields
 -------------
 
 pool
-    This is a string and returns either an ID or a name. Strings may contain
+    This is a string and contains either an ID or a name. Strings may contain
     only characters in the set ``[a-zA-Z0-9\_-.]``. This determines the RADOS
     pool that stores a file's data objects.
 
@@ -41,9 +41,9 @@ pool_namespace
 stripe_unit
     This is an integer. The size (in bytes) of a block of data used in the
     distribution of a file. All stripe units for a file have equal size. The
-    last stripe unit is typically incomplete–that is, it represents the data at
-    the end of the file as well as unused “space” beyond the end of the file to
-    the end of the fixed stripe unit size.
+    last stripe unit is typically only partly full of data: it holds file data
+    through EOF as well as padding that fills the balance of the fixed stripe
+    unit size. 
 
 stripe_count
     Integer. The number of consecutive stripe units that constitute a RAID 0


### PR DESCRIPTION
Improve "layout fields" text in doc/cephfs/file-layouts.rst, as suggesed by Anthony D'Atri in these comments:

https://github.com/ceph/ceph/pull/59021#discussion_r1704108581 https://github.com/ceph/ceph/pull/59021#discussion_r1704112320

Co-authored-by: Anthony D'Atri <anthony.datri@gmail.com>
Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 0949b410433837f0509fb73169fa7f22c8f6c256)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

