### PR TITLE
include/interval_set: allow the length use different types from the offset

### DIFF
--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -23,7 +23,7 @@ class StupidAllocator : public Allocator {
     mempool::bluestore_alloc::pool_allocator<std::pair<const K, V>>;
   template <typename K, typename V> using btree_map_t =
     btree::btree_map<K, V, std::less<K>, allocator_t<K, V>>;
-  using interval_set_t = interval_set<uint64_t, btree_map_t>;
+  using interval_set_t = interval_set<uint64_t, uint64_t, btree_map_t>;
   std::vector<interval_set_t> free;  ///< leading-edge copy
 
   uint64_t last_alloc = 0;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -143,6 +143,7 @@ void dump(ceph::Formatter* f, const osd_alerts_t& alerts);
 
 typedef interval_set<
   snapid_t,
+  snapid_t,
   mempool::osdmap::flat_map> snap_interval_set_t;
 
 

--- a/src/test/common/test_interval_set.cc
+++ b/src/test/common/test_interval_set.cc
@@ -23,6 +23,19 @@ using namespace ceph;
 
 typedef uint64_t IntervalValueType;
 
+struct IntType {
+  IntType() : value(0) {}
+  IntType(uint64_t value) : value(value) {}
+  IntType &operator+=(IntType o) { value += o.value; return *this; }
+  IntType &operator+=(uint64_t v) { value += v; return *this; }
+  IntType &operator-=(IntType o) { value -= o.value; return *this; }
+  IntType &operator-=(uint64_t v) { value -= v; return *this; }
+  uint64_t value;
+  operator uint64_t() const {
+    return value;
+  }
+};
+
 template<typename T>  // tuple<type to test on, test array size>
 class IntervalSetTest : public ::testing::Test {
 
@@ -32,8 +45,11 @@ class IntervalSetTest : public ::testing::Test {
 
 typedef ::testing::Types<
   interval_set<IntervalValueType>,
-  interval_set<IntervalValueType, btree::btree_map>,
-  interval_set<IntervalValueType, boost::container::flat_map>
+  interval_set<IntervalValueType, IntervalValueType, btree::btree_map>,
+  interval_set<IntervalValueType, IntervalValueType, boost::container::flat_map>,
+  interval_set<IntType>,
+  interval_set<IntType, IntervalValueType, btree::btree_map>,
+  interval_set<IntType, IntervalValueType, boost::container::flat_map>
   > IntervalSetTypes;
 
 TYPED_TEST_SUITE(IntervalSetTest, IntervalSetTypes);
@@ -216,7 +232,8 @@ TYPED_TEST(IntervalSetTest, intersects) {
 TYPED_TEST(IntervalSetTest, insert_erase) {
   typedef typename TestFixture::ISet ISet;
   ISet iset1, iset2;
-  IntervalValueType start, len;
+  typename ISet::offset_type start;
+  typename ISet::length_type len;
   
   iset1.insert(3, 5, &start, &len);
   ASSERT_EQ(3, start);


### PR DESCRIPTION
This PR adds another template parameter for length to `interval_set`.

This change is extracted from https://github.com/ceph/ceph/pull/59182 which introduces a struct `laddr_t` that inhibits the implicit casting to the integer.

The serialization and deserialization for `laddr_t` interval_set is not requried for seastore, so the `denc_traits` for interval_set still requires the types of key and length should be same, there should be no break changes to other components.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
