### PR TITLE
reef: rgw: add versioning status during `radosgw-admin bucket stats`

### DIFF
--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -1327,6 +1327,7 @@ static int bucket_stats(rgw::sal::Driver* driver,
   formatter->dump_int("num_shards",
 		      bucket->get_info().layout.current_index.layout.normal.num_shards);
   formatter->dump_string("tenant", bucket->get_tenant());
+  formatter->dump_string("versioning", bucket->versioned() ? (bucket->versioning_enabled() ? "enabled" : "suspended") : "off");
   formatter->dump_string("zonegroup", bucket->get_info().zonegroup);
   formatter->dump_string("placement_rule", bucket->get_info().placement_rule.to_str());
   ::encode_json("explicit_placement", bucket->get_key().explicit_placement, formatter);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62748

---

backport of https://github.com/ceph/ceph/pull/53027
parent tracker: https://tracker.ceph.com/issues/62474

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh