### PR TITLE
reef: ceph-volume: Fix unbound var in disk.get_devices()

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -865,6 +865,7 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         for key, file_ in facts:
             metadata[key] = get_file_contents(os.path.join(sysdir, file_))
 
+        device_slaves = []
         if block[2] != 'part':
             device_slaves = os.listdir(os.path.join(sysdir, 'slaves'))
             metadata['partitions'] = get_partitions_facts(sysdir)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63920

---

backport of https://github.com/ceph/ceph/pull/53327
parent tracker: https://tracker.ceph.com/issues/63918

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh