### PR TITLE
reef: BlueStore: Improve fragmentation score metric

### DIFF
--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -190,8 +190,13 @@ void Allocator::release(const PExtentVector& release_vec)
 double Allocator::get_fragmentation_score()
 {
   // this value represents how much worth is 2X bytes in one chunk then in X + X bytes
-  static const double double_size_worth = 1.1 ;
-  std::vector<double> scales{1};
+  static const double double_size_worth_small = 1.2;
+  // chunks larger then 128MB are large enough that should be counted without penalty
+  static const double double_size_worth_huge = 1;
+  static const size_t small_chunk_p2 = 20; // 1MB
+  static const size_t huge_chunk_p2 = 27; // 128MB
+  // for chunks 1MB - 128MB penalty coeffs are linearly weighted 1.2 (at small) ... 1 (at huge)
+  static std::vector<double> scales{1};
   double score_sum = 0;
   size_t sum = 0;
 
@@ -199,9 +204,17 @@ double Allocator::get_fragmentation_score()
     size_t sc = sizeof(v) * 8 - std::countl_zero(v) - 1; //assign to grade depending on log2(len)
     while (scales.size() <= sc + 1) {
       //unlikely expand scales vector
-      scales.push_back(scales[scales.size() - 1] * double_size_worth);
+      auto ss = scales.size();
+      double scale = double_size_worth_small;
+      if (ss >= huge_chunk_p2) {
+	scale = double_size_worth_huge;
+      } else if (ss > small_chunk_p2) {
+	// linear decrease 1.2 ... 1
+	scale = (double_size_worth_huge * (ss - small_chunk_p2) + double_size_worth_small * (huge_chunk_p2 - ss)) /
+	  (huge_chunk_p2 - small_chunk_p2);
+      }
+      scales.push_back(scales[scales.size() - 1] * scale);
     }
-
     size_t sc_shifted = size_t(1) << sc;
     double x = double(v - sc_shifted) / sc_shifted; //x is <0,1) in its scale grade
     // linear extrapolation in its scale grade

--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -217,8 +217,7 @@ double Allocator::get_fragmentation_score()
   };
   foreach(iterated_allocation);
 
-
   double ideal = get_score(sum);
-  double terrible = sum * get_score(1);
+  double terrible = (sum / block_size) * get_score(block_size);
   return (ideal - score_sum) / (ideal - terrible);
 }

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -301,7 +301,6 @@ TEST_P(AllocTest, test_alloc_fragmentation)
     alloc->release(release_set);
   }
   EXPECT_EQ(1.0, alloc->get_fragmentation());
-  EXPECT_EQ(66u, uint64_t(alloc->get_fragmentation_score() * 100));
 
   for (size_t i = 1; i < allocated.size() / 2; i += 2)
   {
@@ -316,7 +315,6 @@ TEST_P(AllocTest, test_alloc_fragmentation)
     // fragmentation approx = 257 intervals / 768 max intervals
     EXPECT_EQ(33u, uint64_t(alloc->get_fragmentation() * 100));
   }
-  EXPECT_EQ(27u, uint64_t(alloc->get_fragmentation_score() * 100));
 
   for (size_t i = allocated.size() / 2 + 1; i < allocated.size(); i += 2)
   {
@@ -329,11 +327,84 @@ TEST_P(AllocTest, test_alloc_fragmentation)
   // Hence leaving just two 
   // digits after decimal point due to this.
   EXPECT_EQ(0u, uint64_t(alloc->get_fragmentation() * 100));
-  if (bitmap_alloc) {
-    EXPECT_EQ(0u, uint64_t(alloc->get_fragmentation_score() * 100));
-  } else {
-    EXPECT_EQ(11u, uint64_t(alloc->get_fragmentation_score() * 100));
+}
+
+TEST_P(AllocTest, test_fragmentation_score_0)
+{
+  uint64_t capacity = 16LL * 1024 * 1024 * 1024; //16 GB, very small
+  uint64_t alloc_unit = 4096;
+
+  init_alloc(capacity, alloc_unit);
+  alloc->init_add_free(0, capacity);
+  EXPECT_EQ(0, alloc->get_fragmentation_score());
+
+  // alloc every 100M, should get very small score
+  for (uint64_t pos = 0; pos < capacity; pos +=  100 * 1024 * 1024) {
+    alloc->init_rm_free(pos, alloc_unit);
   }
+  EXPECT_LT(alloc->get_fragmentation_score(), 0.0001); // frag < 0.01%
+  for (uint64_t pos = 0; pos < capacity; pos +=  100 * 1024 * 1024) {
+    // put back
+    alloc->init_add_free(pos, alloc_unit);
+  }
+
+  // 10% space is trashed, rest is free, small score
+  for (uint64_t pos = 0; pos < capacity / 10; pos +=  3 * alloc_unit) {
+    alloc->init_rm_free(pos, alloc_unit);
+  }
+  EXPECT_LT(0.01, alloc->get_fragmentation_score()); // 1% < frag < 10%
+  EXPECT_LT(alloc->get_fragmentation_score(), 0.1);
+}
+
+TEST_P(AllocTest, test_fragmentation_score_some)
+{
+  uint64_t capacity = 1024 * 1024 * 1024; //1 GB, very small
+  uint64_t alloc_unit = 4096;
+
+  init_alloc(capacity, alloc_unit);
+  alloc->init_add_free(0, capacity);
+  // half (in 16 chunks) is completely free,
+  // other half completely fragmented, expect less than 50% fragmentation score
+  for (uint64_t chunk = 0; chunk < capacity; chunk += capacity / 16) {
+    for (uint64_t pos = 0; pos < capacity / 32; pos += alloc_unit * 3) {
+      alloc->init_rm_free(chunk + pos, alloc_unit);
+    }
+  }
+  EXPECT_LT(alloc->get_fragmentation_score(), 0.5); // f < 50%
+
+  init_alloc(capacity, alloc_unit);
+  alloc->init_add_free(0, capacity);
+  // half (in 16 chunks) is completely full,
+  // other half completely fragmented, expect really high fragmentation score
+  for (uint64_t chunk = 0; chunk < capacity; chunk += capacity / 16) {
+    alloc->init_rm_free(chunk + capacity / 32, capacity / 32);
+    for (uint64_t pos = 0; pos < capacity / 32; pos += alloc_unit * 3) {
+      alloc->init_rm_free(chunk + pos, alloc_unit);
+    }
+  }
+  EXPECT_LT(0.9, alloc->get_fragmentation_score()); // 50% < f
+}
+
+TEST_P(AllocTest, test_fragmentation_score_1)
+{
+  uint64_t capacity = 1024 * 1024 * 1024; //1 GB, very small
+  uint64_t alloc_unit = 4096;
+
+  init_alloc(capacity, alloc_unit);
+  alloc->init_add_free(0, capacity);
+  // alloc every second AU, max fragmentation
+  for (uint64_t pos = 0; pos < capacity; pos += alloc_unit * 2) {
+    alloc->init_rm_free(pos, alloc_unit);
+  }
+  EXPECT_LT(0.99, alloc->get_fragmentation_score()); // 99% < f
+
+  init_alloc(capacity, alloc_unit);
+  alloc->init_add_free(0, capacity);
+  // 1 allocated, 4 empty; expect very high score
+  for (uint64_t pos = 0; pos < capacity; pos += alloc_unit * 5) {
+    alloc->init_rm_free(pos, alloc_unit);
+  }
+  EXPECT_LT(0.90, alloc->get_fragmentation_score()); // 90% < f
 }
 
 TEST_P(AllocTest, test_dump_fragmentation_score)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61465

---

backport of https://github.com/ceph/ceph/pull/49885
parent tracker: https://tracker.ceph.com/issues/58022

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh