### PR TITLE
reef: cmake: BuildFIO.cmake should not introduce -std=gnu++17

### DIFF
--- a/cmake/modules/BuildFIO.cmake
+++ b/cmake/modules/BuildFIO.cmake
@@ -37,6 +37,7 @@ function(build_fio)
   add_library(fio INTERFACE IMPORTED)
   add_dependencies(fio fio_ext)
   set_target_properties(fio PROPERTIES
+    CXX_EXTENSIONS ON
     INTERFACE_INCLUDE_DIRECTORIES ${source_dir}
-    INTERFACE_COMPILE_OPTIONS "-include;${source_dir}/config-host.h;$<$<COMPILE_LANGUAGE:C>:-std=gnu99>$<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>")
+    INTERFACE_COMPILE_OPTIONS "-include;${source_dir}/config-host.h;$<$<COMPILE_LANGUAGE:C>:-std=gnu99>")
 endfunction()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63392

---

backport of https://github.com/ceph/ceph/pull/53346
parent tracker: https://tracker.ceph.com/issues/62778

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh