### PR TITLE
reef: CephContext: acquire _fork_watchers_lock in notify_post_fork()

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -1042,7 +1042,7 @@ void CephContext::notify_pre_fork()
 
 void CephContext::notify_post_fork()
 {
-  ceph::spin_unlock(&_fork_watchers_lock);
+  std::lock_guard lg(_fork_watchers_lock);
   for (auto &&t : _fork_watchers)
     t->handle_post_fork();
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65924

---

backport of https://github.com/ceph/ceph/pull/54433
parent tracker: https://tracker.ceph.com/issues/63494

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh