### PR TITLE
reef: ceph.spec.in: ceph-mgr-dashboard does not require werkzeug

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -619,7 +619,6 @@ Requires:       python%{python3_pkgversion}-setuptools
 %if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
 Requires:       python%{python3_pkgversion}-cherrypy
 Requires:       python%{python3_pkgversion}-routes
-Requires:       python%{python3_pkgversion}-werkzeug
 %if 0%{?weak_deps}
 Recommends:     python%{python3_pkgversion}-saml
 %endif


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65776

---

backport of https://github.com/ceph/ceph/pull/57145
parent tracker: https://tracker.ceph.com/issues/65693

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh