### PR TITLE
reef: mon/Elector: make paxos_size() an int

### DIFF
--- a/src/mon/ElectionLogic.h
+++ b/src/mon/ElectionLogic.h
@@ -90,7 +90,7 @@ public:
    * by making a paxos commit, but not by injecting values while
    * an election is ongoing.)
    */
-  virtual unsigned paxos_size() const = 0;
+  virtual int paxos_size() const = 0;
   /**
    * Retrieve a set of ranks which are not allowed to become the leader.
    * Like paxos_size(), This set can change between elections, but not

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -131,7 +131,7 @@ bool Elector::ever_participated() const
   return mon->has_ever_joined;
 }
 
-unsigned Elector::paxos_size() const
+int Elector::paxos_size() const
 {
   return mon->monmap->size();
 }

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -240,7 +240,7 @@ class Elector : public ElectionOwner, RankProvider {
   /* Retrieve the Monitor::has_ever_joined member */
   bool ever_participated() const;
   /* Retrieve monmap->size() */
-  unsigned paxos_size() const;
+  int paxos_size() const;
   /* Right now we don't disallow anybody */
   std::set<int> disallowed_leaders;
   const std::set<int>& get_disallowed_leaders() const { return disallowed_leaders; }

--- a/src/test/mon/test_election.cc
+++ b/src/test/mon/test_election.cc
@@ -151,7 +151,7 @@ struct Owner : public ElectionOwner, RankProvider {
     logic.start();
   }
   bool ever_participated() const { return ever_joined; }
-  unsigned paxos_size() const { return parent->get_paxos_size(); }
+  int paxos_size() const { return parent->get_paxos_size(); }
   const set<int>& get_disallowed_leaders() const {
     return parent->get_disallowed_leaders();
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67146

---

backport of https://github.com/ceph/ceph/pull/46862
parent tracker: https://tracker.ceph.com/issues/56392

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh