### PR TITLE
reef: mon, qa: suites override ec profiles with --yes_i_really_mean_it; monitors accept that

### DIFF
--- a/qa/standalone/mon/osd-erasure-code-profile.sh
+++ b/qa/standalone/mon/osd-erasure-code-profile.sh
@@ -56,11 +56,12 @@ function TEST_set() {
     ceph osd erasure-code-profile get $profile | \
         grep -e key=value -e plugin=isa || return 1
     #
-    # --force is required to override an existing profile
+    # --force & --yes-i-really-mean-it are required to override
+    # an existing profile
     #
     ! ceph osd erasure-code-profile set $profile > $dir/out 2>&1 || return 1
     grep 'will not override' $dir/out || return 1
-    ceph osd erasure-code-profile set $profile key=other --force || return 1
+    ceph osd erasure-code-profile set $profile key=other --force --yes-i-really-mean-it || return 1
     ceph osd erasure-code-profile get $profile | \
         grep key=other || return 1
 

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -2490,7 +2490,7 @@ function test_mon_osd_erasure_code()
   ceph osd erasure-code-profile set fooprofile a=b c=d
   ceph osd erasure-code-profile set fooprofile a=b c=d
   expect_false ceph osd erasure-code-profile set fooprofile a=b c=d e=f
-  ceph osd erasure-code-profile set fooprofile a=b c=d e=f --force
+  ceph osd erasure-code-profile set fooprofile a=b c=d e=f --force --yes-i-really-mean-it
   ceph osd erasure-code-profile set fooprofile a=b c=d e=f
   expect_false ceph osd erasure-code-profile set fooprofile a=b c=d e=f g=h
   # make sure rule-foo doesn't work anymore

--- a/qa/workunits/rados/test_rados_tool.sh
+++ b/qa/workunits/rados/test_rados_tool.sh
@@ -89,7 +89,7 @@ run_expect_nosignal "$RADOS_TOOL" --object-locator "asdf" ls
 run_expect_nosignal "$RADOS_TOOL" --namespace "asdf" ls
 
 run_expect_succ "$CEPH_TOOL" osd pool create "$POOL" 8
-run_expect_succ "$CEPH_TOOL" osd erasure-code-profile set myprofile k=2 m=1 stripe_unit=2K crush-failure-domain=osd --force
+run_expect_succ "$CEPH_TOOL" osd erasure-code-profile set myprofile k=2 m=1 stripe_unit=2K crush-failure-domain=osd --force --yes-i-really-mean-it
 run_expect_succ "$CEPH_TOOL" osd pool create "$POOL_EC" 100 100 erasure myprofile
 
 
@@ -779,7 +779,7 @@ function test_stat()
   ############ rados df test (EC pool): ##############
   $RADOS_TOOL purge $POOL_EC --yes-i-really-really-mean-it
   $CEPH_TOOL osd pool rm $POOL_EC $POOL_EC --yes-i-really-really-mean-it
-  $CEPH_TOOL osd erasure-code-profile set myprofile k=2 m=1 stripe_unit=2K crush-failure-domain=osd --force
+  $CEPH_TOOL osd erasure-code-profile set myprofile k=2 m=1 stripe_unit=2K crush-failure-domain=osd --force --yes-i-really-mean-it
   $CEPH_TOOL osd pool create $POOL_EC 8 8 erasure
 
   # put object

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -851,7 +851,8 @@ COMMAND("osd unpause", "unpause osd", "osd", "rw")
 COMMAND("osd erasure-code-profile set "
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] "
 	"name=profile,type=CephString,n=N,req=false "
-	"name=force,type=CephBool,req=false",
+	"name=force,type=CephBool,req=false "
+	"name=yes_i_really_mean_it,type=CephBool,req=false",
 	"create erasure code profile <name> with [<key[=value]> ...] pairs. Add a --force at the end to override an existing profile (VERY DANGEROUS)",
 	"osd", "rw")
 COMMAND("osd erasure-code-profile get "


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66691

---

backport of https://github.com/ceph/ceph/pull/56531
parent tracker: https://tracker.ceph.com/issues/65183

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh