### PR TITLE
reef: common/TrackedOp: rename and raise prio of slow op perfcounter

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -90,7 +90,7 @@ void OpHistory::_insert_delayed(const utime_t& now, TrackedOpRef op)
   arrived.insert(make_pair(op->get_initiated(), op));
   if (opduration >= history_slow_op_threshold.load()) {
     slow_op.insert(make_pair(op->get_initiated(), op));
-    logger->inc(l_osd_slow_op_count);
+    logger->inc(l_trackedop_slow_op_count);
   }
   cleanup(now);
 }

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -53,9 +53,9 @@ public:
 };
 
 enum {
-  l_osd_slow_op_first = 1000,
-  l_osd_slow_op_count,
-  l_osd_slow_op_last,
+  l_trackedop_slow_op_first = 1000,
+  l_trackedop_slow_op_count,
+  l_trackedop_slow_op_last,
 };
 
 class OpHistory {
@@ -76,9 +76,11 @@ class OpHistory {
 
 public:
   OpHistory(CephContext *c) : cct(c), opsvc(this) {
-    PerfCountersBuilder b(cct, "osd-slow-ops",
-                         l_osd_slow_op_first, l_osd_slow_op_last);
-    b.add_u64_counter(l_osd_slow_op_count, "slow_ops_count",
+    PerfCountersBuilder b(cct, "trackedop",
+                         l_trackedop_slow_op_first, l_trackedop_slow_op_last);
+    b.set_prio_default(PerfCountersBuilder::PRIO_USEFUL);
+
+    b.add_u64_counter(l_trackedop_slow_op_count, "slow_ops_count",
                       "Number of operations taking over ten second");
 
     logger.reset(b.create_perf_counters());


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67458

---

backport of https://github.com/ceph/ceph/pull/52068
parent tracker: https://tracker.ceph.com/issues/67456

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh