### PR TITLE
reef: librados: use CEPH_OSD_FLAG_FULL_FORCE for IoCtxImpl::remove

### DIFF
--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -1235,7 +1235,7 @@ int librados::IoCtxImpl::remove(const object_t& oid)
   ::ObjectOperation op;
   prepare_assert_ops(&op);
   op.remove();
-  return operate(oid, &op, nullptr, librados::OPERATION_FULL_FORCE);
+  return operate(oid, &op, nullptr, CEPH_OSD_FLAG_FULL_FORCE);
 }
 
 int librados::IoCtxImpl::remove(const object_t& oid, int flags)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65040

---

backport of https://github.com/ceph/ceph/pull/55348
parent tracker: https://tracker.ceph.com/issues/64558

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh