### PR TITLE
quincy: doc/cephfs: s/mountpoint/mount point/

### DIFF
--- a/doc/cephfs/ceph-dokan.rst
+++ b/doc/cephfs/ceph-dokan.rst
@@ -24,7 +24,7 @@ This will mount the default ceph filesystem using the drive letter ``x``.
 If ``ceph.conf`` is placed at the default location, which is
 ``%ProgramData%\ceph\ceph.conf``, then this argument becomes optional.
 
-The ``-l`` argument also allows using an empty folder as a mountpoint
+The ``-l`` argument also allows using an empty folder as a mount point
 instead of a drive letter.
 
 The uid and gid used for mounting the filesystem default to 0 and may be
@@ -75,7 +75,7 @@ like so::
 
     ceph-dokan.exe unmap -l x
 
-Note that when unmapping Ceph filesystems, the exact same mountpoint argument
+Note that when unmapping Ceph filesystems, the exact same mount point argument
 must be used as when the mapping was created.
 
 Limitations


### PR DESCRIPTION
Change the string "mountpoint" to "mount point" in English-language strings (as opposed to in commands, where the string "mountpoint" sometimes appears and is correct).

cf. https://github.com/ceph/ceph/pull/58908#discussion_r1697715486 in which page 345 of The IBM Style Guide is referenced to back up this change.

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 57ed73eaa6945c69059d299ea5310eaac57e2299)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

