### PR TITLE
squid: crimson/os/seastore: add checksum offload to RBM

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -154,3 +154,10 @@ options:
   level: dev
   desc: overwrite the existing data block based on delta if the overwrite size is equal to or less than the value, otherwise do overwrite based on remapping, set to 0 to enforce the remap-based overwrite.
   default: 0
+- name: seastore_disable_end_to_end_data_protection 
+  type: bool
+  level: dev
+  desc: When false, upon mkfs, try to discover whether the nvme device supports
+        internal checksum feature without using sever CPU then enable if available,
+        set to true to disable unconditionally.
+  default: true

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1562,7 +1562,13 @@ void Cache::complete_commit(
       is_inline = true;
       i->set_paddr(final_block_start.add_relative(i->get_paddr()));
     }
-    assert(i->get_last_committed_crc() == i->calc_crc32c());
+#ifndef NDEBUG
+    if (i->get_paddr().is_root() || epm.get_checksum_needed(i->get_paddr())) {
+      assert(i->get_last_committed_crc() == i->calc_crc32c());
+    } else {
+      assert(i->get_last_committed_crc() == CRC_NULL);
+    }
+#endif
     i->pending_for_transaction = TRANS_ID_NULL;
     i->on_initial_write();
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1651,7 +1651,7 @@ private:
       extent->get_length(),
       extent->get_bptr()
     ).safe_then(
-      [extent=std::move(extent)]() mutable {
+      [extent=std::move(extent), this]() mutable {
         LOG_PREFIX(Cache::read_extent);
 	if (likely(extent->state == CachedExtent::extent_state_t::CLEAN_PENDING)) {
 	  extent->state = CachedExtent::extent_state_t::CLEAN;
@@ -1662,7 +1662,11 @@ private:
 	if (extent->is_valid()) {
 	  // crc will be checked against LBA leaf entry for logical extents,
 	  // or check against in-extent crc for physical extents.
-	  extent->last_committed_crc = extent->calc_crc32c();
+	  if (epm.get_checksum_needed(extent->get_paddr())) {
+	    extent->last_committed_crc = extent->calc_crc32c();
+	  } else {
+	    extent->last_committed_crc = CRC_NULL;
+	  }
 	  extent->on_clean_read();
 	}
         extent->complete_io();

--- a/src/crimson/os/seastore/device.h
+++ b/src/crimson/os/seastore/device.h
@@ -137,6 +137,10 @@ public:
 
   virtual secondary_device_set_t& get_secondary_devices() = 0;
 
+  virtual bool is_end_to_end_data_protection() const {
+    return false;
+  }
+
   using close_ertr = crimson::errorator<
     crimson::ct_error::input_output_error>;
   virtual close_ertr::future<> close() = 0;

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -551,6 +551,15 @@ public:
     return background_process.run_until_halt();
   }
 
+  bool get_checksum_needed(paddr_t addr) {
+    // checksum offloading only for blocks physically stored in the device
+    if (addr.is_fake()) {
+      return true;
+    }
+    assert(addr.is_absolute());
+    return !devices_by_id[addr.get_device_id()]->is_end_to_end_data_protection();
+  }
+
 private:
   rewrite_gen_t adjust_generation(
       data_category_t category,

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -107,6 +107,8 @@ public:
   virtual ~Journal() {}
 
   virtual backend_type_t get_type() = 0;
+
+  virtual bool is_checksum_needed() = 0; 
 };
 using JournalRef = std::unique_ptr<Journal>;
 

--- a/src/crimson/os/seastore/journal/circular_bounded_journal.h
+++ b/src/crimson/os/seastore/journal/circular_bounded_journal.h
@@ -186,6 +186,10 @@ public:
     return get_journal_end();
   }
 
+  bool is_checksum_needed() final {
+    return cjs.is_checksum_needed();
+  }
+
   // Test interfaces
   
   CircularJournalSpace& get_cjs() {

--- a/src/crimson/os/seastore/journal/circular_journal_space.h
+++ b/src/crimson/os/seastore/journal/circular_journal_space.h
@@ -242,6 +242,10 @@ class CircularJournalSpace : public JournalAllocator {
     return header;
   }
 
+  bool is_checksum_needed() {
+    return !device->is_end_to_end_data_protection();
+  }
+
  private:
   std::string print_name;
   cbj_header_t header;

--- a/src/crimson/os/seastore/journal/segmented_journal.h
+++ b/src/crimson/os/seastore/journal/segmented_journal.h
@@ -63,6 +63,11 @@ public:
     return seastar::now();
   }
 
+  bool is_checksum_needed() final {
+    // segmented journal always requires checksum
+    return true;
+  }
+
 private:
   submit_record_ret do_submit_record(
     record_t &&record,

--- a/src/crimson/os/seastore/lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager.cc
@@ -13,7 +13,6 @@ LBAManager::update_mappings(
 {
   return trans_intr::do_for_each(extents,
 				 [this, &t](auto &extent) {
-    assert(extent->get_last_committed_crc());
     return update_mapping(
       t,
       extent->get_laddr(),

--- a/src/crimson/os/seastore/random_block_manager.h
+++ b/src/crimson/os/seastore/random_block_manager.h
@@ -39,7 +39,7 @@ struct rbm_shard_info_t {
   }
 };
 
-struct rbm_metadata_header_t {
+struct rbm_superblock_t {
   size_t size = 0;
   size_t block_size = 0;
   uint64_t feature = 0;
@@ -49,7 +49,7 @@ struct rbm_metadata_header_t {
   unsigned int shard_num = 0;
   std::vector<rbm_shard_info_t> shard_infos;
 
-  DENC(rbm_metadata_header_t, v, p) {
+  DENC(rbm_superblock_t, v, p) {
     DENC_START(1, 1, p);
     denc(v.size, p);
     denc(v.block_size, p);
@@ -171,7 +171,7 @@ namespace random_block_device {
 seastar::future<std::unique_ptr<random_block_device::RBMDevice>> 
   get_rb_device(const std::string &device);
 
-std::ostream &operator<<(std::ostream &out, const rbm_metadata_header_t &header);
+std::ostream &operator<<(std::ostream &out, const rbm_superblock_t &header);
 std::ostream &operator<<(std::ostream &out, const rbm_shard_info_t &shard);
 }
 
@@ -179,10 +179,10 @@ WRITE_CLASS_DENC_BOUNDED(
   crimson::os::seastore::rbm_shard_info_t
 )
 WRITE_CLASS_DENC_BOUNDED(
-  crimson::os::seastore::rbm_metadata_header_t
+  crimson::os::seastore::rbm_superblock_t
 )
 
 #if FMT_VERSION >= 90000
-template<> struct fmt::formatter<crimson::os::seastore::rbm_metadata_header_t> : fmt::ostream_formatter {};
+template<> struct fmt::formatter<crimson::os::seastore::rbm_superblock_t> : fmt::ostream_formatter {};
 template<> struct fmt::formatter<crimson::os::seastore::rbm_shard_info_t> : fmt::ostream_formatter {};
 #endif

--- a/src/crimson/os/seastore/random_block_manager.h
+++ b/src/crimson/os/seastore/random_block_manager.h
@@ -51,6 +51,8 @@ struct rbm_superblock_t {
   checksum_t crc = 0;
   device_config_t config;
   unsigned int shard_num = 0;
+  // Must be assigned if ent-to-end-data-protection features is enabled
+  uint32_t nvme_block_size = 0;
   std::vector<rbm_shard_info_t> shard_infos;
 
   DENC(rbm_superblock_t, v, p) {
@@ -63,6 +65,7 @@ struct rbm_superblock_t {
     denc(v.crc, p);
     denc(v.config, p);
     denc(v.shard_num, p);
+    denc(v.nvme_block_size, p);
     denc(v.shard_infos, p);
     DENC_FINISH(p);
   }

--- a/src/crimson/os/seastore/random_block_manager.h
+++ b/src/crimson/os/seastore/random_block_manager.h
@@ -39,6 +39,10 @@ struct rbm_shard_info_t {
   }
 };
 
+enum class rbm_feature_t : uint64_t {
+  RBM_NVME_END_TO_END_PROTECTION = 1,
+};
+
 struct rbm_superblock_t {
   size_t size = 0;
   size_t block_size = 0;
@@ -79,6 +83,13 @@ struct rbm_superblock_t {
     ceph_assert(get_default_backend_of_device(config.spec.dtype) ==
 		backend_type_t::RANDOM_BLOCK);
     ceph_assert(config.spec.id <= DEVICE_ID_MAX_VALID);
+  }
+
+  bool is_end_to_end_data_protection() const {
+    return (feature & (uint64_t)rbm_feature_t::RBM_NVME_END_TO_END_PROTECTION);
+  }
+  void set_end_to_end_data_protection() {
+    feature |= (uint64_t)rbm_feature_t::RBM_NVME_END_TO_END_PROTECTION;
   }
 };
 

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
@@ -209,7 +209,8 @@ std::ostream &operator<<(std::ostream &out, const rbm_superblock_t &header)
        << ", journal_size=" << header.journal_size
        << ", crc=" << header.crc
        << ", config=" << header.config
-       << ", shard_num=" << header.shard_num;
+       << ", shard_num=" << header.shard_num
+       << ", end_to_end_data_protection=" << header.is_end_to_end_data_protection();
   for (auto p : header.shard_infos) {
     out << p;
   }

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
@@ -201,9 +201,9 @@ void BlockRBManager::prefill_fragmented_device()
 }
 #endif
 
-std::ostream &operator<<(std::ostream &out, const rbm_metadata_header_t &header)
+std::ostream &operator<<(std::ostream &out, const rbm_superblock_t &header)
 {
-  out << " rbm_metadata_header_t(size=" << header.size
+  out << " rbm_superblock_t(size=" << header.size
        << ", block_size=" << header.block_size
        << ", feature=" << header.feature
        << ", journal_size=" << header.journal_size

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
@@ -210,7 +210,8 @@ std::ostream &operator<<(std::ostream &out, const rbm_superblock_t &header)
        << ", crc=" << header.crc
        << ", config=" << header.config
        << ", shard_num=" << header.shard_num
-       << ", end_to_end_data_protection=" << header.is_end_to_end_data_protection();
+       << ", end_to_end_data_protection=" << header.is_end_to_end_data_protection()
+       << ", device_block_size=" << header.nvme_block_size;
   for (auto p : header.shard_infos) {
     out << p;
   }

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
@@ -38,7 +38,7 @@ public:
    * Ondisk layout (TODO)
    *
    * ---------------------------------------------------------------------------
-   * | rbm_metadata_header_t | metadatas |        ...      |    data blocks    |
+   * | rbm_superblock_t | metadatas |        ...      |    data blocks    |
    * ---------------------------------------------------------------------------
    */
 

--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
@@ -306,7 +306,11 @@ nvme_command_ertr::future<int> NVMeBlockDevice::pass_admin(
 
 nvme_command_ertr::future<int> NVMeBlockDevice::pass_through_io(
   nvme_io_command_t& io_cmd) {
-  return device.ioctl(NVME_IOCTL_IO_CMD, &io_cmd);
+  return device.ioctl(NVME_IOCTL_IO_CMD, &io_cmd
+  ).handle_exception([](auto e)->nvme_command_ertr::future<int> {
+    logger().error("pass_through_io: ioctl failed {}", e);
+    return crimson::ct_error::input_output_error::make();
+  });
 }
 
 nvme_command_ertr::future<> NVMeBlockDevice::try_enable_end_to_end_protection() {

--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
@@ -42,10 +42,7 @@ open_ertr::future<> NVMeBlockDevice::open(
         // Do identify_controller first, and then identify_namespace.
         return identify_controller(device).safe_then([this, in_path, mode](
           auto id_controller_data) {
-          support_multistream = id_controller_data.oacs.support_directives;
-          if (support_multistream) {
-            stream_id_count = WRITE_LIFE_MAX;
-          }
+	  // TODO: enable multi-stream if the nvme device supports
           awupf = id_controller_data.awupf + 1;
           return identify_namespace(device).safe_then([this, in_path, mode] (
             auto id_namespace_data) {
@@ -75,12 +72,7 @@ open_ertr::future<> NVMeBlockDevice::open_for_io(
       auto file) {
       assert(io_device.size() > stream_index_to_open);
       io_device[stream_index_to_open] = std::move(file);
-      return io_device[stream_index_to_open].fcntl(
-        F_SET_FILE_RW_HINT,
-        (uintptr_t)&stream_index_to_open).then([this](auto ret) {
-        stream_index_to_open++;
-        return seastar::now();
-      });
+      return seastar::now();
     });
   });
 }

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.cc
@@ -59,19 +59,19 @@ RBMDevice::mkfs_ret RBMDevice::do_primary_mkfs(device_config_t config,
       crimson::ct_error::assert_all{
       "Invalid error open in RBMDevice::do_primary_mkfs"}
     ).safe_then([this] {
-      return write_rbm_header(
+      return write_rbm_superblock(
       ).safe_then([this] {
 	return close();
       }).handle_error(
 	mkfs_ertr::pass_further{},
 	crimson::ct_error::assert_all{
-	"Invalid error write_rbm_header in RBMDevice::do_primary_mkfs"
+	"Invalid error write_rbm_superblock in RBMDevice::do_primary_mkfs"
       });
     });
   });
 }
 
-write_ertr::future<> RBMDevice::write_rbm_header()
+write_ertr::future<> RBMDevice::write_rbm_superblock()
 {
   bufferlist meta_b_header;
   super.crc = 0;
@@ -94,10 +94,10 @@ write_ertr::future<> RBMDevice::write_rbm_header()
   return write(RBM_START_ADDRESS, std::move(bp));
 }
 
-read_ertr::future<rbm_metadata_header_t> RBMDevice::read_rbm_header(
+read_ertr::future<rbm_superblock_t> RBMDevice::read_rbm_superblock(
   rbm_abs_addr addr)
 {
-  LOG_PREFIX(RBMDevice::read_rbm_header);
+  LOG_PREFIX(RBMDevice::read_rbm_superblock);
   assert(super.block_size > 0);
   return seastar::do_with(
     bufferptr(ceph::buffer::create_page_aligned(super.block_size)),
@@ -106,16 +106,16 @@ read_ertr::future<rbm_metadata_header_t> RBMDevice::read_rbm_header(
       addr,
       bptr
     ).safe_then([length=bptr.length(), this, bptr, FNAME]()
-      -> read_ertr::future<rbm_metadata_header_t> {
+      -> read_ertr::future<rbm_superblock_t> {
       bufferlist bl;
       bl.append(bptr);
       auto p = bl.cbegin();
-      rbm_metadata_header_t super_block;
+      rbm_superblock_t super_block;
       try {
 	decode(super_block, p);
       }
       catch (ceph::buffer::error& e) {
-	DEBUG("read_rbm_header: unable to decode rbm super block {}",
+	DEBUG("read_rbm_superblock: unable to decode rbm super block {}",
 	      e.what());
 	return crimson::ct_error::enoent::make();
       }
@@ -123,7 +123,7 @@ read_ertr::future<rbm_metadata_header_t> RBMDevice::read_rbm_header(
       bufferlist meta_b_header;
       super_block.crc = 0;
       encode(super_block, meta_b_header);
-      assert(ceph::encoded_sizeof<rbm_metadata_header_t>(super_block) <
+      assert(ceph::encoded_sizeof<rbm_superblock_t>(super_block) <
 	  super_block.block_size);
 
       // Do CRC verification only if data protection is not supported.
@@ -139,7 +139,7 @@ read_ertr::future<rbm_metadata_header_t> RBMDevice::read_rbm_header(
       super_block.crc = crc;
       super = super_block;
       DEBUG("got {} ", super);
-      return read_ertr::future<rbm_metadata_header_t>(
+      return read_ertr::future<rbm_superblock_t>(
 	read_ertr::ready_future_marker{},
 	super_block
       );
@@ -160,7 +160,7 @@ RBMDevice::mount_ret RBMDevice::do_shard_mount()
     ).safe_then([this](auto st) {
       assert(st.block_size > 0);
       super.block_size = st.block_size;
-      return read_rbm_header(RBM_START_ADDRESS
+      return read_rbm_superblock(RBM_START_ADDRESS
       ).safe_then([this](auto s) {
 	LOG_PREFIX(RBMDevice::do_shard_mount);
 	shard_info = s.shard_infos[seastar::this_shard_id()];

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.h
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.h
@@ -66,11 +66,6 @@ using discard_ertr = crimson::errorator<
   crimson::ct_error::input_output_error>;
 
 constexpr uint32_t RBM_SUPERBLOCK_SIZE = 4096;
-enum {
-  // TODO: This allows the device to manage crc on a block by itself
-  RBM_NVME_END_TO_END_PROTECTION = 1,
-  RBM_BITMAP_BLOCK_CRC = 2,
-};
 
 class RBMDevice : public Device {
 public:
@@ -149,7 +144,13 @@ public:
     ceph::bufferlist bl,
     uint16_t stream = 0) = 0;
 
-  bool is_data_protection_enabled() const { return false; }
+  bool is_end_to_end_data_protection() const final {
+    return super.is_end_to_end_data_protection();
+  }
+
+  virtual nvme_command_ertr::future<> initialize_nvme_features() { 
+    return nvme_command_ertr::now(); 
+  }
 
   mkfs_ret do_mkfs(device_config_t);
 

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.h
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.h
@@ -83,7 +83,7 @@ public:
     return read(rbm_addr, out);
   }
 protected:
-  rbm_metadata_header_t super;
+  rbm_superblock_t super;
   rbm_shard_info_t shard_info;
 public:
   RBMDevice() {}
@@ -160,9 +160,9 @@ public:
 
   mount_ret do_shard_mount();
 
-  write_ertr::future<> write_rbm_header();
+  write_ertr::future<> write_rbm_superblock();
 
-  read_ertr::future<rbm_metadata_header_t> read_rbm_header(rbm_abs_addr addr);
+  read_ertr::future<rbm_superblock_t> read_rbm_superblock(rbm_abs_addr addr);
 
   using stat_device_ret =
     read_ertr::future<seastar::stat_data>;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -39,6 +39,7 @@ inline depth_le_t init_depth_le(uint32_t i) {
 }
 
 using checksum_t = uint32_t;
+constexpr checksum_t CRC_NULL = 0;
 
 // Immutable metadata for seastore to set at mkfs time
 struct seastore_meta_t {

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -331,7 +331,7 @@ TransactionManager::update_lba_mappings(
     std::list<LogicalCachedExtentRef>(),
     std::list<CachedExtentRef>(),
     [this, &t, &pre_allocated_extents](auto &lextents, auto &pextents) {
-    auto chksum_func = [&lextents, &pextents](auto &extent) {
+    auto chksum_func = [&lextents, &pextents, this](auto &extent) {
       if (!extent->is_valid() ||
           !extent->is_fully_loaded() ||
           // EXIST_MUTATION_PENDING extents' crc will be calculated when
@@ -343,10 +343,20 @@ TransactionManager::update_lba_mappings(
         // for rewritten extents, last_committed_crc should have been set
         // because the crc of the original extent may be reused.
         // also see rewrite_logical_extent()
-        if (!extent->get_last_committed_crc()) {
-          extent->set_last_committed_crc(extent->calc_crc32c());
-        }
-        assert(extent->calc_crc32c() == extent->get_last_committed_crc());
+	if (!extent->get_last_committed_crc()) {
+	  if (get_checksum_needed(extent->get_paddr())) {
+	    extent->set_last_committed_crc(extent->calc_crc32c());
+	  } else {
+	    extent->set_last_committed_crc(CRC_NULL);
+	  }
+	}
+#ifndef NDEBUG
+	if (get_checksum_needed(extent->get_paddr())) {
+	  assert(extent->get_last_committed_crc() == extent->calc_crc32c());
+	} else {
+	  assert(extent->get_last_committed_crc() == CRC_NULL);
+	}
+#endif
         lextents.emplace_back(extent->template cast<LogicalCachedExtent>());
       } else {
         pextents.emplace_back(extent);
@@ -367,15 +377,20 @@ TransactionManager::update_lba_mappings(
 
     return lba_manager->update_mappings(
       t, lextents
-    ).si_then([&pextents] {
+    ).si_then([&pextents, this] {
       for (auto &extent : pextents) {
         assert(!extent->is_logical() && extent->is_valid());
         // for non-logical extents, we update its last_committed_crc
         // and in-extent checksum fields
         // For pre-allocated fresh physical extents, update in-extent crc.
-        auto crc = extent->calc_crc32c();
-        extent->set_last_committed_crc(crc);
-        extent->update_in_extent_chksum_field(crc);
+	checksum_t crc;
+	if (get_checksum_needed(extent->get_paddr())) {
+	  crc = extent->calc_crc32c();
+	} else {
+	  crc = CRC_NULL;
+	}
+	extent->set_last_committed_crc(crc);
+	extent->update_in_extent_chksum_field(crc);
       }
     });
   });
@@ -516,7 +531,13 @@ TransactionManager::rewrite_logical_extent(
 
     DEBUGT("rewriting logical extent -- {} to {}", t, *lextent, *nlextent);
 
-    assert(lextent->get_last_committed_crc() == lextent->calc_crc32c());
+#ifndef NDEBUG
+    if (get_checksum_needed(lextent->get_paddr())) {
+      assert(lextent->get_last_committed_crc() == lextent->calc_crc32c());
+    } else {
+      assert(lextent->get_last_committed_crc() == CRC_NULL);
+    }
+#endif
     nlextent->set_last_committed_crc(lextent->get_last_committed_crc());
     /* This update_mapping is, strictly speaking, unnecessary for delayed_alloc
      * extents since we're going to do it again once we either do the ool write

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -1000,6 +1000,13 @@ private:
     });
   }
 
+  bool get_checksum_needed(paddr_t paddr) {
+    if (paddr.is_record_relative()) {
+      return journal->is_checksum_needed();
+    }
+    return epm->get_checksum_needed(paddr);
+  }
+
 public:
   // Testing interfaces
   auto get_epm() {

--- a/src/test/crimson/seastore/test_randomblock_manager.cc
+++ b/src/test/crimson/seastore/test_randomblock_manager.cc
@@ -78,8 +78,8 @@ struct rbm_test_t :
     return device->mkfs(config).unsafe_get();
   }
 
-  auto read_rbm_header() {
-    return device->read_rbm_header(RBM_START_ADDRESS).unsafe_get();
+  auto read_rbm_superblock() {
+    return device->read_rbm_superblock(RBM_START_ADDRESS).unsafe_get();
   }
 
   auto open() {
@@ -120,14 +120,14 @@ struct rbm_test_t :
 TEST_F(rbm_test_t, mkfs_test)
 {
  run_async([this] {
-   auto super = read_rbm_header();
+   auto super = read_rbm_superblock();
    ASSERT_TRUE(
        super.block_size == block_size &&
        super.size == size
    );
    config.spec.id = DEVICE_ID_NULL;
    mkfs();
-   super = read_rbm_header();
+   super = read_rbm_superblock();
    ASSERT_TRUE(
        super.config.spec.id == DEVICE_ID_NULL &&
        super.size == size 


### PR DESCRIPTION

backport of https://github.com/ceph/ceph/pull/57782

this backport was staged using crimson-backport.sh which is based on ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh