### PR TITLE
squid: rgw/notifications: fixing radosgw-admin notification json

### DIFF
--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -85,6 +85,7 @@ void rgw_s3_key_filter::dump(Formatter *f) const {
     ::encode_json("Value", regex_rule, f);
     f->close_section();
   }
+  f->close_section();
 }
 
 bool rgw_s3_key_filter::decode_xml(XMLObj* obj) {
@@ -151,6 +152,7 @@ void rgw_s3_key_value_filter::dump(Formatter *f) const {
     ::encode_json("Value", key_value.second, f);
     f->close_section();
   }
+  f->close_section();
 }
 
 bool rgw_s3_key_value_filter::decode_xml(XMLObj* obj) {

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -735,18 +735,44 @@ def test_ps_s3_notification_configuration_admin_on_master():
                  'arn:aws:sns:' + zonegroup + '::' + topic_name + '_1')
     # create s3 notification
     notification_name = bucket_name + NOTIFICATION_SUFFIX
-    topic_conf_list = [{'Id': notification_name+'_1',
+    topic_conf_list = [
+                    {
+                        'Id': notification_name+'_1',
                         'TopicArn': topic_arn,
-                        'Events': ['s3:ObjectCreated:*']
-                        },
-                       {'Id': notification_name+'_2',
+                        'Events': ['s3:ObjectCreated:*'],
+                        'Filter': {
+                            'Key': {
+                                'FilterRules': [
+                                    {'Name': 'prefix', 'Value': 'test'},
+                                    {'Name': 'suffix', 'Value': 'txt'}
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        'Id': notification_name+'_2',
                         'TopicArn': topic_arn,
-                        'Events': ['s3:ObjectRemoved:*']
-                        },
-                       {'Id': notification_name+'_3',
+                        'Events': ['s3:ObjectRemoved:*'],
+                        'Filter': {
+                            'Metadata': {
+                                'FilterRules': [
+                                    {'Name': 'x-amz-meta-foo', 'Value': 'bar'},
+                                    {'Name': 'x-amz-meta-hello', 'Value': 'world'}]
+                            },
+                        }
+                    },
+                    {
+                        'Id': notification_name+'_3',
                         'TopicArn': topic_arn,
-                        'Events': []
-                        }]
+                        'Events': [],
+                        'Filter': {
+                            'Tags': {
+                                'FilterRules': [
+                                    {'Name': 'tag1', 'Value': 'value1'},
+                                    {'Name': 'tag2', 'Value': 'value2'}]
+                            }
+                        }
+                    }]
     s3_notification_conf = PSNotificationS3(conn, bucket_name, topic_conf_list)
     _, status = s3_notification_conf.set_config()
     assert_equal(status/100, 2)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67574

---

backport of https://github.com/ceph/ceph/pull/59218
parent tracker: https://tracker.ceph.com/issues/67525

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh