### PR TITLE
squid: test/rgw/notification: use real ip address instead of localhost

### DIFF
--- a/qa/tasks/rabbitmq.py
+++ b/qa/tasks/rabbitmq.py
@@ -70,22 +70,25 @@ def run_rabbitmq(ctx, config):
         (remote,) = ctx.cluster.only(client).remotes.keys()
 
         ctx.cluster.only(client).run(args=[
-             'sudo', 'systemctl', 'enable', 'rabbitmq-server.service'
+             'echo', 'loopback_users.guest = false', run.Raw('|'), 'sudo', 'tee', '-a', '/etc/rabbitmq/rabbitmq.conf'
             ],
         )
 
         ctx.cluster.only(client).run(args=[
-             'sudo', '/sbin/service', 'rabbitmq-server', 'start'
+             'sudo', 'systemctl', 'enable', 'rabbitmq-server'
             ],
         )
 
-        '''
+        ctx.cluster.only(client).run(args=[
+             'sudo', 'systemctl', 'start', 'rabbitmq-server'
+            ],
+        )
+
         # To check whether rabbitmq-server is running or not
         ctx.cluster.only(client).run(args=[
-             'sudo', '/sbin/service', 'rabbitmq-server', 'status'
+             'sudo', 'systemctl', 'status', 'rabbitmq-server'
             ],
         )
-        '''
 
     try:
         yield
@@ -96,7 +99,7 @@ def run_rabbitmq(ctx, config):
             (remote,) = ctx.cluster.only(client).remotes.keys()
 
             ctx.cluster.only(client).run(args=[
-                 'sudo', '/sbin/service', 'rabbitmq-server', 'stop'
+                 'sudo', 'systemctl', 'stop', 'rabbitmq-server'
                 ],
             )
 

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -477,10 +477,6 @@ def stop_kafka_receiver(receiver, task):
 
 
 def get_ip():
-    return 'localhost'
-
-
-def get_ip_http():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
         # address should not be reachable
@@ -3953,7 +3949,7 @@ def persistent_notification(endpoint_type, conn, account=None):
     host = get_ip()
     if endpoint_type == 'http':
         # create random port for the http server
-        host = get_ip_http()
+        host = get_ip()
         port = random.randint(10000, 20000)
         # start an http server in a separate thread
         receiver = HTTPServerWithEvents((host, port))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67609

---

backport of https://github.com/ceph/ceph/pull/59239
parent tracker: https://tracker.ceph.com/issues/67206

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh