### PR TITLE
reef: test/rgw/notification: use real ip address instead of localhost

### DIFF
--- a/qa/tasks/rabbitmq.py
+++ b/qa/tasks/rabbitmq.py
@@ -73,6 +73,11 @@ def run_rabbitmq(ctx, config):
              'sudo', 'chkconfig', 'rabbitmq-server', 'on'
             ],
         )
+        
+        ctx.cluster.only(client).run(args=[
+             'echo', 'loopback_users.guest = false', run.Raw('|'), 'sudo', 'tee', '-a', '/etc/rabbitmq/rabbitmq.conf'
+            ],
+        )
 
         ctx.cluster.only(client).run(args=[
              'sudo', '/sbin/service', 'rabbitmq-server', 'start'

--- a/src/test/rgw/bucket_notification/test_bn.py
+++ b/src/test/rgw/bucket_notification/test_bn.py
@@ -486,10 +486,6 @@ def stop_kafka_receiver(receiver, task):
 
 
 def get_ip():
-    return 'localhost'
-
-
-def get_ip_http():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
         # address should not be reachable
@@ -3600,7 +3596,7 @@ def persistent_notification(endpoint_type):
     host = get_ip()
     if endpoint_type == 'http':
         # create random port for the http server
-        host = get_ip_http()
+        host = get_ip()
         port = random.randint(10000, 20000)
         # start an http server in a separate thread
         receiver = StreamingHTTPServer(host, port, num_workers=10)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67608

---

backport of https://github.com/ceph/ceph/pull/59239
parent tracker: https://tracker.ceph.com/issues/67206

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh