### PR TITLE
rgw: send self zonegroup on forward to master

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -148,7 +148,7 @@ int rgw_forward_request_to_master(const DoutPrefixProvider* dpp,
 
   // use the master zone's endpoints
   auto conn = RGWRESTConn{dpp->get_cct(), z->second.id, z->second.endpoints,
-                          creds, zg->second.id, zg->second.api_name};
+                          creds, site.get_zonegroup().id, zg->second.api_name};
   bufferlist outdata;
   constexpr size_t max_response_size = 128 * 1024; // we expect a very small response
   int ret = conn.forward(dpp, effective_owner, req, nullptr,


### PR DESCRIPTION
When creating a bucket in the secondary zonegroup, the `rgwx-zonegroup` is mistakenly set to the master zonegroup when forwarding the request. Instead, it should be set to the secondary zonegroup so that the master zonegroup creates the bucket for the intended zonegroup rather than for itself.

Fixes: https://tracker.ceph.com/issues/67610