### PR TITLE
quincy: rgw: cmake configure error on fedora-37/rawhide

### DIFF
--- a/src/rgw/store/dbstore/CMakeLists.txt
+++ b/src/rgw/store/dbstore/CMakeLists.txt
@@ -48,7 +48,7 @@ else()
 endif()
 
 include_directories(${CMAKE_INCLUDE_DIR})
-add_library(dbstore ${dbstore_mgr_srcs})
+add_library(dbstore STATIC ${dbstore_mgr_srcs})
 target_link_libraries(dbstore ${CMAKE_LINK_LIBRARIES})
 
 # testing purpose

--- a/src/rgw/store/dbstore/sqlite/CMakeLists.txt
+++ b/src/rgw/store/dbstore/sqlite/CMakeLists.txt
@@ -12,5 +12,5 @@ include_directories(${CMAKE_INCLUDE_DIR})
 set(SQLITE_COMPILE_FLAGS "-DSQLITE_THREADSAFE=1")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SQLITE_COMPILE_FLAGS}")
 
-add_library(sqlite_db ${sqlite_db_srcs})
+add_library(sqlite_db STATIC ${sqlite_db_srcs})
 target_link_libraries(sqlite_db sqlite3 dbstore_lib rgw_common)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/54464

---

backport of https://github.com/ceph/ceph/pull/45022
parent tracker: https://tracker.ceph.com/issues/54266

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh