### PR TITLE
quincy: rgw: disable RGWDataChangesLog::add_entry() when log_data is off

### DIFF
--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -603,6 +603,10 @@ std::string RGWDataChangesLog::get_oid(uint64_t gen_id, int i) const {
 }
 
 int RGWDataChangesLog::add_entry(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, int shard_id) {
+  if (!zone->log_data) {
+    return 0;
+  }
+
   auto& bucket = bucket_info.bucket;
 
   if (!filter_bucket(dpp, bucket, null_yield)) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55289

---

backport of https://github.com/ceph/ceph/pull/45357
parent tracker: https://tracker.ceph.com/issues/54531

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh