### PR TITLE
quincy: librgw: teach librgw about rgw_backend_store

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -541,8 +541,44 @@ namespace rgw {
       g_conf()->rgw_run_sync_thread &&
       g_conf()->rgw_nfs_run_sync_thread;
 
+    bool rgw_d3n_datacache_enabled =
+        cct->_conf->rgw_d3n_l1_local_datacache_enabled;
+    if (rgw_d3n_datacache_enabled &&
+        (cct->_conf->rgw_max_chunk_size != cct->_conf->rgw_obj_stripe_size)) {
+      lsubdout(cct, rgw_datacache, 0)
+          << "rgw_d3n:  WARNING: D3N DataCache disabling (D3N requires that "
+             "the chunk_size equals stripe_size)"
+          << dendl;
+      rgw_d3n_datacache_enabled = false;
+    }
+    if (rgw_d3n_datacache_enabled && !cct->_conf->rgw_beast_enable_async) {
+      lsubdout(cct, rgw_datacache, 0)
+          << "rgw_d3n:  WARNING: D3N DataCache disabling (D3N requires yield "
+             "context - rgw_beast_enable_async=true)"
+          << dendl;
+      rgw_d3n_datacache_enabled = false;
+    }
+    lsubdout(cct, rgw, 1) << "D3N datacache enabled: "
+                          << rgw_d3n_datacache_enabled << dendl;
+
+    std::string rgw_store = (!rgw_d3n_datacache_enabled) ? "rados" : "d3n";
+
+    const auto &config_store =
+        g_conf().get_val<std::string>("rgw_backend_store");
+#ifdef WITH_RADOSGW_DBSTORE
+    if (config_store == "dbstore") {
+      rgw_store = "dbstore";
+    }
+#endif
+
+#ifdef WITH_RADOSGW_MOTR
+    if (config_store == "motr") {
+      rgw_store = "motr";
+    }
+#endif
+
     store = StoreManager::get_storage(this, g_ceph_context,
-					 "rados",
+					 rgw_store,
 					 run_gc,
 					 run_lc,
 					 run_quota,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55483

---

backport of https://github.com/ceph/ceph/pull/46022
parent tracker: https://tracker.ceph.com/issues/55430

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh