### PR TITLE
quincy: rgw: Use STANDARD storage class in objects appending operation when the

### DIFF
--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -646,6 +646,8 @@ int AppendObjectProcessor::prepare(optional_yield y)
     iter = astate->attrset.find(RGW_ATTR_STORAGE_CLASS);
     if (iter != astate->attrset.end()) {
       tail_placement_rule.storage_class = iter->second.to_str();
+    } else {
+      tail_placement_rule.storage_class = RGW_STORAGE_CLASS_STANDARD;
     }
     cur_manifest = &(*astate->manifest);
     manifest.set_prefix(cur_manifest->get_prefix());


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57415

---

backport of https://github.com/ceph/ceph/pull/44610
parent tracker: https://tracker.ceph.com/issues/53902

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh