### PR TITLE
quincy: rgw: avoid use-after-move in RGWDataSyncSingleEntryCR ctor

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1280,13 +1280,13 @@ class RGWDataSyncSingleEntryCR : public RGWCoroutine {
   int sync_status = 0;
 public:
   RGWDataSyncSingleEntryCR(RGWDataSyncCtx *_sc, rgw::bucket_sync::Handle state,
-                           rgw_data_sync_obligation obligation,
+                           rgw_data_sync_obligation _obligation,
                            RGWDataSyncShardMarkerTrack *_marker_tracker,
                            const rgw_raw_obj& error_repo,
                            boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
                            const RGWSyncTraceNodeRef& _tn_parent)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env),
-      state(std::move(state)), obligation(std::move(obligation)),
+      state(std::move(state)), obligation(std::move(_obligation)),
       marker_tracker(_marker_tracker), error_repo(error_repo),
       lease_cr(std::move(lease_cr)) {
     set_description() << "data sync single entry (source_zone=" << sc->source_zone << ") " << obligation;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/57421

---

backport of https://github.com/ceph/ceph/pull/47904
parent tracker: https://tracker.ceph.com/issues/57329

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh