### PR TITLE
quincy: rgw: when there are a large number of multiparts, the unorder list result may miss objects

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9341,7 +9341,6 @@ int RGWRados::cls_bucket_list_unordered(const DoutPrefixProvider *dpp,
 	  ent_list.emplace_back(std::move(dirent));
 	  ++count;
 	} else {
-	  last_added_entry = dirent.key;
 	  *is_truncated = true;
 	  ldpp_dout(dpp, 10) << "INFO: " << __func__ <<
 	    ": reached max entries (" << num_entries << ") to return at \"" <<


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62759

---

backport of https://github.com/ceph/ceph/pull/52866
parent tracker: https://tracker.ceph.com/issues/59400

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh