### PR TITLE
reef: rgw : fix add initialization for RGWGC::process()

### DIFF
--- a/src/rgw/driver/rados/rgw_gc.cc
+++ b/src/rgw/driver/rados/rgw_gc.cc
@@ -578,7 +578,7 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
 
   string marker;
   string next_marker;
-  bool truncated;
+  bool truncated = false;
   IoCtx *ctx = new IoCtx;
   do {
     int max = 100;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61631

---

backport of https://github.com/ceph/ceph/pull/49316
parent tracker: https://tracker.ceph.com/issues/57323

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh