### PR TITLE
quincy: rgw/lua: add lib64 to the package search path

### DIFF
--- a/src/rgw/rgw_lua_utils.cc
+++ b/src/rgw/rgw_lua_utils.cc
@@ -50,11 +50,11 @@ void set_package_path(lua_State* L, const std::string& install_dir) {
   if (!lua_istable(L, -1)) {
     return;
   }
-  const auto path = install_dir+"/share/lua/"+CEPH_LUA_VERSION+"/?.lua";  
+  const auto path = install_dir+"/share/lua/"+CEPH_LUA_VERSION+"/?.lua";
   pushstring(L, path);
   lua_setfield(L, -2, "path");
   
-  const auto cpath = install_dir+"/lib/lua/"+CEPH_LUA_VERSION+"/?.so";
+  const auto cpath = install_dir+"/lib/lua/"+CEPH_LUA_VERSION+"/?.so;"+install_dir+"/lib64/lua/"+CEPH_LUA_VERSION+"/?.so";
   pushstring(L, cpath);
   lua_setfield(L, -2, "cpath");
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/61190

---

backport of https://github.com/ceph/ceph/pull/51453
parent tracker: https://tracker.ceph.com/issues/59733

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh