### PR TITLE
quincy: rgw/multisite: fix sync_error_trim command

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8978,12 +8978,15 @@ next:
       return -EINVAL;
     }
     if (!start_marker.empty()) {
-      std::cerr << "end-date not allowed." << std::endl;
+      std::cerr << "start-marker not allowed." << std::endl;
       return -EINVAL;
     }
     if (!end_marker.empty()) {
-      std::cerr << "end-date not allowed." << std::endl;
+      std::cerr << "end_marker not allowed." << std::endl;
       return -EINVAL;
+    }
+    if (marker.empty()) {
+      marker = "9"; // trims everything
     }
 
     if (shard_id < 0) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63404

---

backport of https://github.com/ceph/ceph/pull/53828
parent tracker: https://tracker.ceph.com/issues/62845

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh