### PR TITLE
reef: rgwfile: fix lock_guard decl

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -345,7 +345,7 @@ namespace rgw {
     int rc = g_rgwlib->get_fe()->execute_req(&req);
     if ((rc == 0) &&
         ((rc = req.get_ret()) == 0)) {
-      lock_guard(rgw_fh->mtx);
+      lock_guard guard(rgw_fh->mtx);
       rgw_fh->set_atime(real_clock::to_timespec(real_clock::now()));
       *bytes_read = req.nread;
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63423

---

backport of https://github.com/ceph/ceph/pull/54309
parent tracker: https://tracker.ceph.com/issues/63409

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh