### PR TITLE
quincy: rgw: catches nobjects_begin() exceptions

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1462,10 +1462,21 @@ int RGWRados::log_list_init(const DoutPrefixProvider *dpp, const string& prefix,
     delete state;
     return r;
   }
-  state->prefix = prefix;
-  state->obit = state->io_ctx.nobjects_begin();
-  *handle = (RGWAccessHandle)state;
-  return 0;
+  try {
+    state->prefix = prefix;
+    state->obit = state->io_ctx.nobjects_begin();
+    *handle = (RGWAccessHandle)state;
+    return 0;
+  } catch (const std::system_error& e) {
+    r = -e.code().value();
+    ldpp_dout(dpp, 10) << "nobjects_begin threw " << e.what()
+       << ", returning " << r << dendl;
+    return r;
+  } catch (const std::exception& e) {
+    ldpp_dout(dpp, 10) << "nobjects_begin threw " << e.what()
+       << ", returning -5" << dendl;
+    return -EIO;
+  }
 }
 
 int RGWRados::log_list_next(RGWAccessHandle handle, string *name)

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -329,11 +329,21 @@ int RGWSI_RADOS::Pool::List::init(const DoutPrefixProvider *dpp, const string& m
     return -EINVAL;
   }
 
-  ctx.iter = ctx.ioctx.nobjects_begin(oc);
-  ctx.filter = filter;
-  ctx.initialized = true;
-
-  return 0;
+  try {
+    ctx.iter = ctx.ioctx.nobjects_begin(oc);
+    ctx.filter = filter;
+    ctx.initialized = true;
+    return 0;
+  } catch (const std::system_error& e) {
+    r = -e.code().value();
+    ldpp_dout(dpp, 10) << "nobjects_begin threw " << e.what()
+       << ", returning " << r << dendl;
+    return r;
+  } catch (const std::exception& e) {
+    ldpp_dout(dpp, 10) << "nobjects_begin threw " << e.what()
+       << ", returning -5" << dendl;
+    return -EIO;
+  }
 }
 
 int RGWSI_RADOS::Pool::List::get_next(const DoutPrefixProvider *dpp,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67483

---

backport of https://github.com/ceph/ceph/pull/50016
parent tracker: https://tracker.ceph.com/issues/54802

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh