### PR TITLE
quincy: test/multisite: dont use path when mrun outside of src tree

### DIFF
--- a/src/mrun
+++ b/src/mrun
@@ -5,26 +5,25 @@
 root=`dirname $0`
 run_name=$1
 command=$2
-CEPH_BIN=$root
-
-[[ "$run_name" == "noname" ]] && CEPH_CONF_PATH=$root || CEPH_CONF_PATH=$root/run/$run_name
+CEPH_BIN=""
+CEPH_CONF_PATH="/etc/ceph/"
 
 [ -z "$BUILD_DIR" ] && BUILD_DIR=build
 
 if [ -e CMakeCache.txt ]; then
-    CEPH_BIN=$PWD/bin
-    [[ "$run_name" == "noname" ]] && CEPH_CONF_PATH=$PWD || CEPH_CONF_PATH=$PWD/run/$run_name
+    CEPH_BIN=$PWD/bin/
+    [[ "$run_name" == "noname" ]] && CEPH_CONF_PATH=$PWD/ || CEPH_CONF_PATH=$PWD/run/$run_name/
 elif [ -e $root/../${BUILD_DIR}/CMakeCache.txt ]; then
     cd $root/../${BUILD_DIR}
-    CEPH_BIN=$PWD/bin
-    [[ "$run_name" == "noname" ]] && CEPH_CONF_PATH=$PWD || CEPH_CONF_PATH=$PWD/run/$run_name
+    CEPH_BIN=$PWD/bin/
+    [[ "$run_name" == "noname" ]] && CEPH_CONF_PATH=$PWD/ || CEPH_CONF_PATH=$PWD/run/$run_name/
 fi
 
 shift 2
 
 if [ "$RGW_VALGRIND" = "yes" ] && [ "$command" = "radosgw" ]; then
-    valgrind --trace-children=yes --tool=memcheck --max-threads=1024 $CEPH_BIN/$command -c $CEPH_CONF_PATH/ceph.conf "$@"
+    valgrind --trace-children=yes --tool=memcheck --max-threads=1024 "$CEPH_BIN""$command" -c "$CEPH_CONF_PATH"ceph.conf "$@"
     sleep 10
 else
-    $CEPH_BIN/$command -c $CEPH_CONF_PATH/ceph.conf "$@"
+    "$CEPH_BIN""$command" -c "$CEPH_CONF_PATH"ceph.conf "$@"
 fi


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/55268

---

backport of https://github.com/ceph/ceph/pull/45770
parent tracker: https://tracker.ceph.com/issues/54416

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh