### PR TITLE
mgr/cephadm: change SPDK RPC fields in nvmeof configuration

### DIFF
--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -53,8 +53,7 @@ class NvmeofService(CephService):
             'addr': host_ip,
             'port': spec.port,
             'spdk_protocol_log_level': 'WARNING',
-            'rpc_socket_dir': '/var/tmp/',
-            'rpc_socket_name': 'spdk.sock',
+            'rpc_socket': '/var/tmp/spdk.sock',
             'transport_tcp_options': transport_tcp_options,
             'rados_id': rados_id
         }

--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -48,8 +48,7 @@ root_ca_cert = /root.ca.cert
 
 [spdk]
 tgt_path = {{ spec.tgt_path }}
-rpc_socket_dir = {{ spec.rpc_socket_dir }}
-rpc_socket_name = {{ spec.rpc_socket_name }}
+rpc_socket = {{ spec.rpc_socket }}
 timeout = {{ spec.spdk_timeout }}
 bdevs_per_cluster = {{ spec.bdevs_per_cluster }}
 log_level={{ spec.spdk_log_level }}

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -437,8 +437,7 @@ root_ca_cert = /root.ca.cert
 
 [spdk]
 tgt_path = /usr/local/bin/nvmf_tgt
-rpc_socket_dir = /var/tmp/
-rpc_socket_name = spdk.sock
+rpc_socket = /var/tmp/spdk.sock
 timeout = 60.0
 bdevs_per_cluster = 32
 log_level=

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1340,8 +1340,7 @@ class NvmeofServiceSpec(ServiceSpec):
                  spdk_timeout: Optional[float] = 60.0,
                  spdk_log_level: Optional[str] = '',
                  spdk_protocol_log_level: Optional[str] = 'WARNING',
-                 rpc_socket_dir: Optional[str] = '/var/tmp/',
-                 rpc_socket_name: Optional[str] = 'spdk.sock',
+                 rpc_socket: Optional[str] = '/var/tmp/spdk.sock',
                  conn_retries: Optional[int] = 10,
                  transports: Optional[str] = 'tcp',
                  transport_tcp_options: Optional[Dict[str, int]] =
@@ -1430,10 +1429,8 @@ class NvmeofServiceSpec(ServiceSpec):
         self.spdk_log_level = spdk_log_level
         #: ``spdk_protocol_log_level`` the SPDK-GW protocol log level
         self.spdk_protocol_log_level = spdk_protocol_log_level or 'WARNING'
-        #: ``rpc_socket_dir`` the SPDK socket file directory
-        self.rpc_socket_dir = rpc_socket_dir or '/var/tmp/'
-        #: ``rpc_socket_name`` the SPDK socket file name
-        self.rpc_socket_name = rpc_socket_name or 'spdk.sock'
+        #: ``rpc_socket`` the SPDK RPC socket file path
+        self.rpc_socket = rpc_socket or '/var/tmp/spdk.sock'
         #: ``conn_retries`` ceph connection retries number
         self.conn_retries = conn_retries
         #: ``transports`` tcp


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->
mgr/cephadm: change SPDK RPC fields in nvmeof configuration
python-common/ceph/deployment: change SPDK RPC fields in nvmeof configuration

    Fixes https://tracker.ceph.com/issues/67629

    Signed-off-by: Gil Bregman <gbregman@il.ibm.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>