### PR TITLE
.gitmodules: remove shallow=true config from nvmeof/gateway

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,4 +82,3 @@
 	path = src/nvmeof/gateway
 	url = https://github.com/ceph/ceph-nvmeof.git
 	fetchRecurseSubmodules = false
-	shallow = true


### PR DESCRIPTION
shallow=true seems to prevent the checkout from actually finding the correct sha1.

Fixes: https://tracker.ceph.com/issues/67640

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
