### PR TITLE
reef: qa/cephfs: fix caps_helper._conduct_neg_test_for_root_squash_caps

### DIFF
--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -344,22 +344,25 @@ class CapTester(MonCapTester, MdsCapTester):
         self.run_mon_cap_tests(fs, client_id)
         self.run_mds_cap_tests(perm, mntpt)
 
+
     def _conduct_neg_test_for_root_squash_caps(self, _cmdargs, sudo_write=False):
         possible_errmsgs = ('permission denied', 'operation not permitted')
         cmdargs = ['sudo'] if sudo_write else ['']
         cmdargs += _cmdargs
 
-        for mount, path, data in self.test_set:
-            log.info(f'test absence of {_cmdargs[0]} perm: expect failure {path}.')
+        log.info(f'test absence of {_cmdargs[0]} perm: expect failure {self.path}.')
 
-            # open the file and hold it. The MDS will issue CEPH_CAP_EXCL_*
-            # to mount
-            proc = mount.open_background(path)
-            cmdargs.append(path)
-            mount.negtestcmd(args=cmdargs, retval=1, errmsgs=possible_errmsgs)
-            cmdargs.pop(-1)
-            mount._kill_background(proc)
-            log.info(f'absence of {_cmdargs[0]} perm was tested successfully')
+        # open the file and hold it. The MDS will issue CEPH_CAP_EXCL_*
+        # to mount
+        proc = self.mount.open_background(self.path)
+
+        cmdargs.append(self.path)
+        self.mount.negtestcmd(args=cmdargs, retval=1, errmsgs=possible_errmsgs)
+        cmdargs.pop(-1)
+
+        self.mount._kill_background(proc)
+
+        log.info(f'absence of {_cmdargs[0]} perm was tested successfully')
 
     def conduct_neg_test_for_chown_caps(self, sudo_write=True):
         # flip ownership to nobody. assumption: nobody's id is 65534


### PR DESCRIPTION
Method _conduct_neg_test_for_root_squash_caps() of caps_helper.py needs
to be same as version in main branch.

Fixes: https://tracker.ceph.com/issues/65970






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>