### PR TITLE
reef: mgr/rest: Trim  requests array and limit size

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -117,6 +117,10 @@
   level storage operator (like Rook) to recreate the missing file system.
   See https://docs.ceph.com/en/latest/cephfs/administration/#file-systems
   docs for more information.
+* mgr/REST: The REST manager module will trim requests based on the 'max_requests' option.
+  Without this feature, and in the absence of manual deletion of old requests,
+  the accumulation of requests in the array can lead to Out Of Memory (OOM) issues, 
+  resulting in the Manager crashing.
 
 * CephFS: The `subvolume snapshot clone` command now depends on the config option
   `snapshot_clone_no_wait` which is used to reject the clone operation when

--- a/doc/mgr/restful.rst
+++ b/doc/mgr/restful.rst
@@ -77,6 +77,19 @@ If the port is not configured, *restful* will bind to port ``8003``.
 If the address it not configured, the *restful* will bind to ``::``,
 which corresponds to all available IPv4 and IPv6 addresses.
 
+Configuring max_request
+---------------------------
+
+The maximum request size can be configured via a central configuration
+option::
+
+  ceph config set mgr mgr/restful/$name/max_requests $NUM
+
+where ``$name`` is the ID of the ceph-mgr daemon (usually the hostname).
+
+.. mgr_module:: restful
+.. confval:: max_requests
+
 .. _creating-an-api-user:
 
 Creating an API User

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -24,7 +24,7 @@ from pecan.rest import RestController
 from werkzeug.serving import make_server, make_ssl_devcert
 
 from .hooks import ErrorHook
-from mgr_module import MgrModule, CommandResult, NotifyType
+from mgr_module import MgrModule, CommandResult, NotifyType, Option
 from mgr_util import build_url
 
 
@@ -194,11 +194,18 @@ class CommandsRequest(object):
 
 class Module(MgrModule):
     MODULE_OPTIONS = [
-        {'name': 'server_addr'},
-        {'name': 'server_port'},
-        {'name': 'key_file'},
-        {'name': 'enable_auth', 'type': 'bool', 'default': True},
-        {'name': 'max_requests', 'type': 'int', 'default': 500},
+        Option(name='server_addr'),
+        Option(name='server_port'),
+        Option(name='key_file'),
+        Option(name='enable_auth',
+               type='bool',
+               default=True),
+        Option(name='max_requests',
+               type='int',
+               default=500,
+               desc='Maximum number of requests to keep in memory. '
+                    ' When new request comes in, the oldest request will be removed if the number of requests exceeds the max request number.'
+                    'if un-finished request is removed, error message will be logged in the ceph-mgr log.'),
     ]
 
     COMMANDS = [


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67644

---

backport of https://github.com/ceph/ceph/pull/54984
parent tracker: https://tracker.ceph.com/issues/67642

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh