### PR TITLE
mgr/dashboard: add service management for oauth2-proxy

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/services.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/services.po.ts
@@ -100,6 +100,14 @@ export class ServicesPageHelper extends PageHelper {
           }
           break;
 
+        case 'oauth2-proxy':
+          cy.get('#https_address').type('localhost:8443');
+          cy.get('#provider_display_name').type('provider');
+          cy.get('#client_id').type('foo');
+          cy.get('#client_secret').type('bar');
+          cy.get('#oidc_issuer_url').type('http://127.0.0.0:8080/realms/ceph');
+          break;
+
         default:
           cy.get('#service_id').type('test');
           unmanaged

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/05-services.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/05-services.e2e-spec.ts
@@ -40,5 +40,14 @@ describe('Services page', () => {
 
       services.deleteService('smb.testsmb');
     });
+
+    it('should create and delete an oauth2-proxy service', () => {
+      services.navigateTo('create');
+      services.addService('oauth2-proxy');
+
+      services.checkExist('oauth2-proxy', true);
+
+      services.deleteService('oauth2-proxy');
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -16,6 +16,13 @@
              Click here</a> to create a new Realm/Zone Group/Zone
         </cd-alert-panel>
 
+        <cd-alert-panel *ngIf="serviceForm.controls.service_type.value === 'oauth2-proxy'"
+                        type="info"
+                        spacingClass="mb-3"
+                        i18n>
+          Authentication must be enabled in an active `mgtm-gateway` service to enable Single Sign-On(SSO) with `oauth2-proxy`
+        </cd-alert-panel>
+
         <!-- Service type -->
         <div class="form-group row">
           <label class="cd-col-form-label required"
@@ -907,8 +914,146 @@
             </div>
           </fieldset>
         </ng-container>
-        <!-- RGW, Ingress & iSCSI -->
-        <ng-container *ngIf="!serviceForm.controls.unmanaged.value && ['rgw', 'iscsi', 'ingress'].includes(serviceForm.controls.service_type.value)">
+
+        <!-- oauth2-proxy -->
+        <ng-container *ngIf="serviceForm.controls.service_type.value === 'oauth2-proxy'">
+          <!-- provider_display_name -->
+          <div class="form-group row">
+            <label class="cd-col-form-label required"
+                   for="provider_display_name">
+              <span i18n>Provider display name</span>
+            </label>
+            <div class="cd-col-form-input">
+              <input id="provider_display_name"
+                     class="form-control"
+                     type="text"
+                     formControlName="provider_display_name"
+                     placeholder="My OIDC Provider"
+                     i18n-placeholder>
+              <cd-help-text i18n>The display name for the identity provider (IdP) in the UI.</cd-help-text>
+              <span class="invalid-feedback"
+                    *ngIf="serviceForm.showError('provider_display_name', frm, 'required')"
+                    i18n>This field is required.</span>
+            </div>
+          </div>
+          <!-- client_id -->
+          <div class="form-group row">
+            <label class="cd-col-form-label required"
+                   for="client_id">
+              <span i18n>Client ID</span>
+            </label>
+            <div class="cd-col-form-input">
+              <input id="client_id"
+                     class="form-control"
+                     type="text"
+                     formControlName="client_id"
+                     placeholder="oauth2-client">
+              <cd-help-text i18n>The client ID for authenticating with the IdP.</cd-help-text>
+              <span class="invalid-feedback"
+                    *ngIf="serviceForm.showError('client_id', frm, 'required')"
+                    i18n>This field is required.</span>
+            </div>
+          </div>
+          <!-- client_secret -->
+          <div class="form-group row">
+            <label class="cd-col-form-label required"
+                   for="client_secret">
+              <span i18n>Client secret</span>
+            </label>
+            <div class="cd-col-form-input">
+              <div class="input-group">
+                <input id="client_secret"
+                       class="form-control"
+                       type="password"
+                       formControlName="client_secret">
+                <span class="input-group-append">
+                  <button type="button"
+                          class="btn btn-light"
+                          cdPasswordButton="client_secret">
+                  </button>
+                  <cd-copy-2-clipboard-button source="client_secret">
+                  </cd-copy-2-clipboard-button>
+                </span>
+              </div>
+              <cd-help-text i18n>The client secret for authenticating with the IdP.</cd-help-text>
+              <span class="invalid-feedback"
+                    *ngIf="serviceForm.showError('client_secret', frm, 'required')"
+                    i18n>This field is required.</span>
+            </div>
+          </div>
+          <!-- oidc_issuer_url -->
+          <div class="form-group row">
+            <label class="cd-col-form-label required"
+                   for="oidc_issuer_url">
+              <span i18n>OIDC Issuer URL</span>
+            </label>
+            <div class="cd-col-form-input">
+              <input id="oidc_issuer_url"
+                     class="form-control"
+                     type="text"
+                     formControlName="oidc_issuer_url"
+                     placeholder="https://<IdPs-domain>/realms/<realm-name>">
+              <cd-help-text i18n>The URL of the OpenID Connect (OIDC) issuer.</cd-help-text>
+              <span class="invalid-feedback"
+                    *ngIf="serviceForm.showError('oidc_issuer_url', frm, 'required')"
+                    i18n>This field is required.</span>
+              <span class="invalid-feedback"
+                    *ngIf="serviceForm.showError('oidc_issuer_url', frm, 'validUrl')"
+                    i18n>Invalid url.</span>
+            </div>
+          </div>
+          <!-- https_address -->
+          <div class="form-group row">
+            <label class="cd-col-form-label"
+                   for="https_address">
+              <span i18n>Https address</span>
+            </label>
+            <div class="cd-col-form-input">
+              <input id="https_address"
+                     class="form-control"
+                     type="text"
+                     formControlName="https_address"
+                     placeholder="0.0.0.0:4180">
+              <cd-help-text i18n>The address for HTTPS connections as [IP|Hostname]:port.</cd-help-text>
+              <span class="invalid-feedback"
+                    *ngIf="serviceForm.showError('https_address', frm, 'invalidAddress')"
+                    i18n>Format must be [IP|Hostname]:port and the port between 0 and 65535</span>
+            </div>
+          </div>
+          <!-- redirect_url -->
+          <div class="form-group row">
+            <label class="cd-col-form-label"
+                   for="redirect_url">
+              <span i18n>Redirect URL</span>
+            </label>
+            <div class="cd-col-form-input">
+              <input id="redirect_url"
+                     class="form-control"
+                     type="text"
+                     formControlName="redirect_url"
+                     placeholder="https://<IP|Hostname>:4180/oauth2/callback">
+              <cd-help-text i18n>The URL the oauth2-proxy service will redirect to after a successful login.</cd-help-text>
+            </div>
+          </div>
+          <!-- Allowlist_domains -->
+          <div class="form-group row">
+            <label class="cd-col-form-label"
+                   for="allowlist_domains">
+              <span i18n>Allowlist domains</span>
+            </label>
+            <div class="cd-col-form-input">
+              <input id="allowlist_domains"
+                     class="form-control"
+                     type="text"
+                     formControlName="allowlist_domains"
+                     placeholder="domain1.com,192.168.100.1:8080">
+              <cd-help-text i18n>Comma separated list of domains to be allowed to redirect to, used for login or logout.</cd-help-text>
+            </div>
+          </div>
+        </ng-container>
+
+        <!-- RGW, Ingress, iSCSI & Oauth2-proxy -->
+        <ng-container *ngIf="!serviceForm.controls.unmanaged.value && ['rgw', 'iscsi', 'ingress', 'oauth2-proxy'].includes(serviceForm.controls.service_type.value)">
           <!-- ssl -->
           <div class="form-group row">
             <div class="cd-col-form-offset">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
@@ -666,4 +666,21 @@ export class CdValidators {
       }
     };
   }
+
+  static oauthAddressTest(): ValidatorFn {
+    const OAUTH2_HTTPS_ADDRESS_PATTERN = /^((\d{1,3}\.){3}\d{1,3}|([a-zA-Z0-9-_]+\.)*[a-zA-Z0-9-_]+)/;
+    return (control: AbstractControl): Record<string, boolean> | null => {
+      if (!control.value) {
+        return null;
+      }
+
+      if (!control.value.includes(':')) {
+        return { invalidAddress: true };
+      }
+      const [address, port] = control.value.split(':');
+      const addressTest = OAUTH2_HTTPS_ADDRESS_PATTERN.test(address);
+      const portTest = Number(port) >= 0 && Number(port) <= 65535;
+      return { invalidAddress: !(addressTest && portTest) };
+    };
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
@@ -47,6 +47,11 @@ export interface CephServiceAdditionalSpec {
   custom_dns: string[];
   join_sources: string[];
   include_ceph_users: string[];
+  https_address: string;
+  provider_display_name: string;
+  client_id: string;
+  client_secret: string;
+  oidc_issuer_url: string;
 }
 
 export interface CephServicePlacement {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/67651




[screen-capture (24).webm](https://github.com/user-attachments/assets/a6aefe30-1278-4e52-90c1-30eec4c57137)

Video's spec file:
```
[ceph: root@ceph-node-00 /]# ceph orch ls --service_name oauth2-proxy --export
service_type: oauth2-proxy
service_name: oauth2-proxy
placement:
  count: 1
spec:
  allowlist_domains:
  - domain1.com
  - 192.168.1.1:433
  - 192.168.100.100
  - ceph-node-00
  client_id: clientid
  client_secret: clientsecret
  oidc_issuer_url: https://0.0.0.0
  provider_display_name: My OIDC provider
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
