### PR TITLE
remove it->lower_bound(head);

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5519,7 +5519,6 @@ BlueStore::OmapIteratorImpl::OmapIteratorImpl(
   if (o->onode.has_omap()) {
     o->get_omap_key(string(), &head);
     o->get_omap_tail(&tail);
-    it->lower_bound(head);
   }
 }
 BlueStore::OmapIteratorImpl::~OmapIteratorImpl()


### PR DESCRIPTION
I don't think it makes sense to call it->lower_bound(head) in OmapIteratorImpl

All external calls to the OmapIteratorImpl constructor then have their own seek logic

So the call here is redundant and has additional performance costs