### PR TITLE
mgr/smb: earmark resolver for subvolume

### DIFF
--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -299,6 +299,24 @@ The earmarking mechanism ensures that subvolumes are correctly tagged and manage
 helping to avoid conflicts and ensuring that each subvolume is associated
 with the intended service or use case.
 
+Valid Earmarks
+~~~~~~~~~~~~~~~~~~~~
+
+- **For NFS:**
+   - The valid earmark format is the top-level scope: ``'nfs'``.
+
+- **For SMB:**
+   - The valid earmark formats are:
+      - The top-level scope: ``'smb'``.
+      - The top-level scope with an intra-module level scope: ``'smb.cluster.{cluster_id}'``, where ``cluster_id`` is a short string uniquely identifying the cluster.
+      - Example without intra-module scope: ``smb``
+      - Example with intra-module scope: ``smb.cluster.cluster_1``
+
+.. note:: If you are changing an earmark from one scope to another (e.g., from nfs to smb or vice versa),
+   be aware that user permissions and ACLs associated with the previous scope might still apply. Ensure that
+   any necessary permissions are updated as needed to maintain proper access control.
+
+
 Removing a subvolume
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -18,6 +18,7 @@ import operator
 import time
 
 from ceph.deployment.service_spec import SMBSpec
+from ceph.fs.earmarking import EarmarkTopScope
 
 from . import config_store, external, resources
 from .enums import (
@@ -43,6 +44,7 @@ from .proto import (
     AccessAuthorizer,
     ConfigEntry,
     ConfigStore,
+    EarmarkResolver,
     EntryKey,
     OrchSubmitter,
     PathResolver,
@@ -110,6 +112,22 @@ class _FakePathResolver:
         return f'/{path}'
 
     resolve_exists = resolve
+
+
+class _FakeEarmarkResolver:
+    """A stub EarmarkResolver for unit testing."""
+
+    def __init__(self) -> None:
+        self._earmarks: Dict[Tuple[str, str], str] = {}
+
+    def get_earmark(self, path: str, volume: str) -> Optional[str]:
+        return None
+
+    def set_earmark(self, path: str, volume: str, earmark: str) -> None:
+        pass
+
+    def check_earmark(self, earmark: str, top_level_scope: str) -> bool:
+        return True
 
 
 class _FakeAuthorizer:
@@ -325,6 +343,7 @@ class ClusterConfigHandler:
         path_resolver: Optional[PathResolver] = None,
         authorizer: Optional[AccessAuthorizer] = None,
         orch: Optional[OrchSubmitter] = None,
+        earmark_resolver: Optional[EarmarkResolver] = None,
     ) -> None:
         self.internal_store = internal_store
         self.public_store = public_store
@@ -336,6 +355,9 @@ class ClusterConfigHandler:
             authorizer = _FakeAuthorizer()
         self._authorizer: AccessAuthorizer = authorizer
         self._orch = orch  # if None, disables updating the spec via orch
+        if earmark_resolver is None:
+            earmark_resolver = cast(EarmarkResolver, _FakeEarmarkResolver())
+        self._earmark_resolver = earmark_resolver
         log.info(
             'Initialized new ClusterConfigHandler with'
             f' internal store {self.internal_store!r},'
@@ -343,7 +365,8 @@ class ClusterConfigHandler:
             f' priv store {self.priv_store!r},'
             f' path resolver {self._path_resolver!r},'
             f' authorizer {self._authorizer!r},'
-            f' orch {self._orch!r}'
+            f' orch {self._orch!r},'
+            f' earmark resolver {self._earmark_resolver!r}'
         )
 
     def apply(
@@ -474,7 +497,12 @@ class ClusterConfigHandler:
             elif isinstance(
                 resource, (resources.Share, resources.RemovedShare)
             ):
-                _check_share(resource, staging, self._path_resolver)
+                _check_share(
+                    resource,
+                    staging,
+                    self._path_resolver,
+                    self._earmark_resolver,
+                )
             elif isinstance(resource, resources.JoinAuth):
                 _check_join_auths(resource, staging)
             elif isinstance(resource, resources.UsersAndGroups):
@@ -807,7 +835,10 @@ def _check_cluster(cluster: ClusterRef, staging: _Staging) -> None:
 
 
 def _check_share(
-    share: ShareRef, staging: _Staging, resolver: PathResolver
+    share: ShareRef,
+    staging: _Staging,
+    resolver: PathResolver,
+    earmark_resolver: EarmarkResolver,
 ) -> None:
     """Check that the share resource can be updated."""
     if share.intent == Intent.REMOVED:
@@ -822,7 +853,7 @@ def _check_share(
         )
     assert share.cephfs is not None
     try:
-        resolver.resolve_exists(
+        volpath = resolver.resolve_exists(
             share.cephfs.volume,
             share.cephfs.subvolumegroup,
             share.cephfs.subvolume,
@@ -832,6 +863,34 @@ def _check_share(
         raise ErrorResult(
             share, msg="path is not a valid directory in volume"
         )
+    if earmark_resolver:
+        earmark = earmark_resolver.get_earmark(
+            volpath,
+            share.cephfs.volume,
+        )
+        if not earmark:
+            smb_earmark = (
+                f"{EarmarkTopScope.SMB.value}.cluster.{share.cluster_id}"
+            )
+            earmark_resolver.set_earmark(
+                volpath,
+                share.cephfs.volume,
+                smb_earmark,
+            )
+        else:
+            if not earmark_resolver.check_earmark(
+                earmark, EarmarkTopScope.SMB
+            ):
+                raise ErrorResult(
+                    share,
+                    msg=f"earmark has already been set by {earmark.split('.')[0]}",
+                )
+            # Check if earmark is set by same cluster
+            if earmark.split('.')[2] != share.cluster_id:
+                raise ErrorResult(
+                    share,
+                    msg=f"earmark has already been set by smb cluster {earmark.split('.')[2]}",
+                )
     name_used_by = _share_name_in_use(staging, share)
     if name_used_by:
         raise ErrorResult(

--- a/src/pybind/mgr/smb/module.py
+++ b/src/pybind/mgr/smb/module.py
@@ -5,6 +5,7 @@ import logging
 import orchestrator
 from ceph.deployment.service_spec import PlacementSpec, SMBSpec
 from mgr_module import MgrModule, Option, OptionLevel
+from mgr_util import CephFSEarmarkResolver
 
 from . import (
     cli,
@@ -55,6 +56,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         path_resolver = kwargs.pop('path_resolver', None)
         authorizer = kwargs.pop('authorizer', None)
         uo = kwargs.pop('update_orchestration', None)
+        earmark_resolver = kwargs.pop('earmark_resolver', None)
         super().__init__(*args, **kwargs)
         if internal_store is not None:
             self._internal_store = internal_store
@@ -69,6 +71,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             public_store or rados_store.RADOSConfigStore.init(self)
         )
         path_resolver = path_resolver or fs.CachingCephFSPathResolver(self)
+        earmark_resolver = earmark_resolver or CephFSEarmarkResolver(self)
         # Why the honk is the cast needed but path_resolver doesn't need it??
         # Sometimes mypy drives me batty.
         authorizer = cast(
@@ -81,6 +84,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             path_resolver=path_resolver,
             authorizer=authorizer,
             orch=self._orch_backend(enable_orch=uo),
+            earmark_resolver=earmark_resolver,
         )
 
     def _backend_store(self, store_conf: str = '') -> ConfigStore:

--- a/src/pybind/mgr/smb/proto.py
+++ b/src/pybind/mgr/smb/proto.py
@@ -15,6 +15,7 @@ from typing import (
 import sys
 
 from ceph.deployment.service_spec import SMBSpec
+from ceph.fs.earmarking import EarmarkTopScope
 
 # this uses a version check as opposed to a try/except because this
 # form makes mypy happy and try/except doesn't.
@@ -184,4 +185,19 @@ class AccessAuthorizer(Protocol):
     def authorize_entity(
         self, volume: str, entity: str, caps: str = ''
     ) -> None:
+        ...  # pragma: no cover
+
+
+class EarmarkResolver(Protocol):
+    """A protocol for a type that can resolve earmarks for subvolumes."""
+
+    def get_earmark(self, path: str, volume: str) -> Optional[str]:
+        ...  # pragma: no cover
+
+    def set_earmark(self, path: str, volume: str, earmark: str) -> None:
+        ...  # pragma: no cover
+
+    def check_earmark(
+        self, earmark: str, top_level_scope: EarmarkTopScope
+    ) -> bool:
         ...  # pragma: no cover

--- a/src/pybind/mgr/smb/tests/test_handler.py
+++ b/src/pybind/mgr/smb/tests/test_handler.py
@@ -1,6 +1,7 @@
 import pytest
 
 import smb
+from smb.handler import _FakeEarmarkResolver
 
 
 def _cluster(**kwargs):
@@ -880,6 +881,7 @@ def test_apply_remove_all_clusters(thandler):
             self.deployed.remove(service_name)
 
     thandler._orch = FakeOrch()
+    thandler._earmark_resolver = _FakeEarmarkResolver()
     test_apply_full_cluster_create(thandler)
 
     to_apply = [

--- a/src/pybind/mgr/smb/tests/test_smb.py
+++ b/src/pybind/mgr/smb/tests/test_smb.py
@@ -26,6 +26,7 @@ def tmodule():
         path_resolver=smb.handler._FakePathResolver(),
         authorizer=smb.handler._FakeAuthorizer(),
         update_orchestration=False,
+        earmark_resolver=smb.handler._FakeEarmarkResolver(),
     )
 
 

--- a/src/pybind/mgr/tests/test_mgr_util.py
+++ b/src/pybind/mgr/tests/test_mgr_util.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import MagicMock, patch
 import mgr_util
 
 import pytest
@@ -17,3 +18,70 @@ import pytest
 )
 def test_pretty_timedelta(delta: datetime.timedelta, out: str):
     assert mgr_util.to_pretty_timedelta(delta) == out
+
+
+class TestCephFsEarmarkResolver:
+
+    @pytest.fixture
+    def mock_mgr(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_cephfs_client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def resolver(self, mock_mgr, mock_cephfs_client):
+        return mgr_util.CephFSEarmarkResolver(mgr=mock_mgr, client=mock_cephfs_client)
+
+    @patch('mgr_util.open_filesystem')
+    def test_get_earmark(self, mock_open_filesystem, resolver):
+        path = "/volumes/group1/subvol1"
+
+        mock_fs_handle = MagicMock()
+        mock_open_filesystem.return_value.__enter__.return_value = mock_fs_handle
+        mock_open_filesystem.return_value.__exit__.return_value = False
+
+        mock_earmarking = MagicMock()
+        mock_earmarking.get_earmark.return_value = "smb.test"
+        with patch('mgr_util.CephFSVolumeEarmarking', return_value=mock_earmarking):
+            result = resolver.get_earmark(path, "test_volume")
+
+        assert result == "smb.test"
+
+    @patch('mgr_util.open_filesystem')
+    def test_set_earmark(self, mock_open_filesystem, resolver):
+        path = "/volumes/group1/subvol1"
+
+        mock_fs_handle = MagicMock()
+        mock_open_filesystem.return_value.__enter__.return_value = mock_fs_handle
+        mock_open_filesystem.return_value.__exit__.return_value = False
+
+        mock_earmarking = MagicMock()
+        mock_open_filesystem.return_value.__enter__.return_value = mock_fs_handle
+        with patch('mgr_util.CephFSVolumeEarmarking', return_value=mock_earmarking):
+            resolver.set_earmark(path, "test_volume", "smb.test2")
+
+        mock_earmarking.set_earmark.assert_called_once_with("smb.test2")
+
+    @patch('mgr_util.CephFSVolumeEarmarking.parse_earmark')
+    def test_check_earmark(self, mock_parse_earmark, resolver):
+        # Test that an earmark with the 'smb' top-level scope is correctly identified
+        mock_parse_earmark.return_value = MagicMock(top=mgr_util.EarmarkTopScope.SMB)
+        result = resolver.check_earmark("smb.cluster.cluster1", mgr_util.EarmarkTopScope.SMB)
+        assert result is True
+
+        # Test with a different top-level scope, should return False
+        mock_parse_earmark.return_value = MagicMock(top=mgr_util.EarmarkTopScope.SMB)
+        result = resolver.check_earmark("smb.cluster.cluster1", mgr_util.EarmarkTopScope.NFS)
+        assert result is False
+
+        # Test with an invalid earmark (parse_earmark returns None), should return False
+        mock_parse_earmark.return_value = None
+        result = resolver.check_earmark("invalid.test", mgr_util.EarmarkTopScope.SMB)
+        assert result is False
+
+        # Test with an exception raised by parse_earmark, should return False
+        mock_parse_earmark.side_effect = mgr_util.EarmarkParseError
+        result = resolver.check_earmark("error.test", mgr_util.EarmarkTopScope.SMB)
+        assert result is False

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_base.py
@@ -18,7 +18,7 @@ from ...exception import MetadataMgrException, VolumeException
 from .auth_metadata import AuthMetadataManager
 from .subvolume_attrs import SubvolumeStates
 
-from ceph.fs.earmarking import CephFSVolumeEarmarking, EarmarkException  # type: ignore
+from ceph.fs.earmarking import CephFSVolumeEarmarking, EarmarkException
 
 log = logging.getLogger(__name__)
 

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -9,7 +9,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 import cephfs
 
-from ceph.fs.earmarking import CephFSVolumeEarmarking, EarmarkException  # type: ignore
+from ceph.fs.earmarking import CephFSVolumeEarmarking, EarmarkException
 
 from mgr_util import CephfsClient
 


### PR DESCRIPTION
Depends on https://github.com/ceph/ceph/pull/59111/

- Inter module level scope handling: 
```
[ceph: root@ceph-node-00 /]# ceph smb share create  cls1 shr7 fs1  / --subvolume sv1
{
  "resource": {
    "resource_type": "ceph.smb.share",
    "cluster_id": "cls1",
    "share_id": "shr7",
    "intent": "present",
    "name": "shr7",
    "readonly": false,
    "browseable": true,
    "cephfs": {
      "volume": "fs1",
      "path": "/",
      "subvolume": "sv1",
      "provider": "samba-vfs"
    }
  },
  "msg": "earmark has already been set by nfs",
  "success": false
}
Error EAGAIN: resource failed to apply (see response data for details)

```

- Intra module level scope handling: 

```
[ceph: root@ceph-node-00 /]# ceph smb share create  cls2 shr6 fs1  / --subvolume sv1
{
  "resource": {
    "resource_type": "ceph.smb.share",
    "cluster_id": "cls2",
    "share_id": "shr6",
    "intent": "present",
    "name": "shr6",
    "readonly": false,
    "browseable": true,
    "cephfs": {
      "volume": "fs1",
      "path": "/",
      "subvolume": "sv1",
      "provider": "samba-vfs"
    }
  },
  "msg": "earmark has already been set by smb cluster cls1",
  "success": false
}
Error EAGAIN: resource failed to apply (see response data for details)

```
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
