### PR TITLE
crimson/os/seastore/cache: report dirty cache usage and rewrite stats

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1954,6 +1954,7 @@ Cache::replay_delta(
     root->apply_delta_and_adjust_crc(record_base, delta.bl);
     root->dirty_from_or_retired_at = journal_seq;
     root->state = CachedExtent::extent_state_t::DIRTY;
+    root->version = 1; // shouldn't be 0 as a dirty extent
     DEBUG("replayed root delta at {} {}, add extent -- {}, root={}",
           journal_seq, record_base, delta, *root);
     root->set_modify_time(modify_time);

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -705,22 +705,22 @@ void Cache::register_metrics()
     {
       sm::make_counter(
         "version_count_dirty",
-        stats.committed_dirty_version.num,
+        stats.trim_rewrites.num,
         sm::description("total number of rewrite-dirty extents")
       ),
       sm::make_counter(
         "version_sum_dirty",
-        stats.committed_dirty_version.version,
+        stats.trim_rewrites.version,
         sm::description("sum of the version from rewrite-dirty extents")
       ),
       sm::make_counter(
         "version_count_reclaim",
-        stats.committed_reclaim_version.num,
+        stats.reclaim_rewrites.num,
         sm::description("total number of rewrite-reclaim extents")
       ),
       sm::make_counter(
         "version_sum_reclaim",
-        stats.committed_reclaim_version.version,
+        stats.reclaim_rewrites.version,
         sm::description("sum of the version from rewrite-reclaim extents")
       ),
     }
@@ -1586,14 +1586,14 @@ record_t Cache::prepare_record(
   efforts.inline_record_metadata_bytes +=
     (record.size.get_raw_mdlength() - record.get_delta_size());
 
-  auto &rewrite_version_stats = t.get_rewrite_version_stats();
+  auto &rewrite_stats = t.get_rewrite_stats();
   if (trans_src == Transaction::src_t::TRIM_DIRTY) {
-    stats.committed_dirty_version.increment_stat(rewrite_version_stats);
+    stats.trim_rewrites.add(rewrite_stats);
   } else if (trans_src == Transaction::src_t::CLEANER_MAIN ||
              trans_src == Transaction::src_t::CLEANER_COLD) {
-    stats.committed_reclaim_version.increment_stat(rewrite_version_stats);
+    stats.reclaim_rewrites.add(rewrite_stats);
   } else {
-    assert(rewrite_version_stats.is_clear());
+    assert(rewrite_stats.is_clear());
   }
 
   return record;

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -750,6 +750,7 @@ void Cache::add_to_dirty(CachedExtentRef ref)
   assert(ref->is_dirty());
   assert(!ref->primary_ref_list_hook.is_linked());
   ceph_assert(ref->get_modify_time() != NULL_TIME);
+  assert(ref->is_fully_loaded());
 
   // Note: next might not be at extent_state_t::DIRTY,
   // also see CachedExtent::is_stable_writting()
@@ -762,6 +763,7 @@ void Cache::remove_from_dirty(CachedExtentRef ref)
 {
   assert(ref->is_dirty());
   ceph_assert(ref->primary_ref_list_hook.is_linked());
+  assert(ref->is_fully_loaded());
 
   stats.dirty_bytes -= ref->get_length();
   dirty.erase(dirty.s_iterator_to(*ref));
@@ -774,12 +776,14 @@ void Cache::replace_dirty(
 {
   assert(prev->is_dirty());
   ceph_assert(prev->primary_ref_list_hook.is_linked());
+  assert(prev->is_fully_loaded());
 
   // Note: next might not be at extent_state_t::DIRTY,
   // also see CachedExtent::is_stable_writting()
   assert(next->is_dirty());
   assert(!next->primary_ref_list_hook.is_linked());
   ceph_assert(next->get_modify_time() != NULL_TIME);
+  assert(next->is_fully_loaded());
 
   assert(prev->get_dirty_from() == next->get_dirty_from());
   assert(prev->get_length() == next->get_length());
@@ -799,6 +803,7 @@ void Cache::clear_dirty()
     auto ptr = &*i;
     assert(ptr->is_dirty());
     ceph_assert(ptr->primary_ref_list_hook.is_linked());
+    assert(ptr->is_fully_loaded());
 
     stats.dirty_bytes -= ptr->get_length();
     dirty.erase(i++);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1687,8 +1687,13 @@ private:
   /// Add dirty extent to dirty list
   void add_to_dirty(CachedExtentRef ref);
 
+  /// Replace the prev dirty extent by next
+  void replace_dirty(CachedExtentRef next, CachedExtentRef prev);
+
   /// Remove from dirty list
   void remove_from_dirty(CachedExtentRef ref);
+
+  void clear_dirty();
 
   /// Remove extent from extents handling dirty and refcounting
   void remove_extent(CachedExtentRef ref);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1631,8 +1631,8 @@ private:
     std::array<uint64_t, NUM_SRC_COMB> trans_conflicts_by_srcs;
     counter_by_src_t<uint64_t> trans_conflicts_by_unknown;
 
-    version_stat_t committed_dirty_version;
-    version_stat_t committed_reclaim_version;
+    rewrite_stats_t trim_rewrites;
+    rewrite_stats_t reclaim_rewrites;
   } stats;
 
   mutable dirty_io_stats_t last_dirty_io;

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1605,6 +1605,7 @@ private:
 
     uint64_t dirty_bytes = 0;
     counter_by_extent_t<cache_size_stats_t> dirty_sizes_by_ext;
+    dirty_io_stats_t dirty_io;
     counter_by_src_t<counter_by_extent_t<dirty_io_stats_t> >
       dirty_io_by_src_ext;
 
@@ -1634,6 +1635,10 @@ private:
     version_stat_t committed_dirty_version;
     version_stat_t committed_reclaim_version;
   } stats;
+
+  mutable dirty_io_stats_t last_dirty_io;
+  mutable counter_by_src_t<counter_by_extent_t<dirty_io_stats_t> >
+    last_dirty_io_by_src_ext;
 
   void account_conflict(Transaction::src_t src1, Transaction::src_t src2) {
     assert(src1 < Transaction::src_t::MAX);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1638,6 +1638,8 @@ private:
   mutable dirty_io_stats_t last_dirty_io;
   mutable counter_by_src_t<counter_by_extent_t<dirty_io_stats_t> >
     last_dirty_io_by_src_ext;
+  mutable rewrite_stats_t last_trim_rewrites;
+  mutable rewrite_stats_t last_reclaim_rewrites;
 
   void account_conflict(Transaction::src_t src1, Transaction::src_t src2) {
     assert(src1 < Transaction::src_t::MAX);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1169,7 +1169,7 @@ public:
         ).si_then([this, FNAME, &t, e](bool is_alive) {
           if (!is_alive) {
             SUBDEBUGT(seastore_cache, "extent is not alive, remove extent -- {}", t, *e);
-            remove_extent(e);
+            remove_extent(e, nullptr);
 	    e->set_invalid(t);
           } else {
             SUBDEBUGT(seastore_cache, "extent is alive -- {}", t, *e);
@@ -1602,7 +1602,11 @@ private:
     counter_by_src_t<invalid_trans_efforts_t> invalidated_efforts_by_src;
     counter_by_src_t<query_counters_t> cache_query_by_src;
     success_read_trans_efforts_t success_read_efforts;
+
     uint64_t dirty_bytes = 0;
+    counter_by_extent_t<cache_size_stats_t> dirty_sizes_by_ext;
+    counter_by_src_t<counter_by_extent_t<dirty_io_stats_t> >
+      dirty_io_by_src_ext;
 
     uint64_t onode_tree_depth = 0;
     int64_t onode_tree_extents_num = 0;
@@ -1685,18 +1689,27 @@ private:
   void mark_dirty(CachedExtentRef ref);
 
   /// Add dirty extent to dirty list
-  void add_to_dirty(CachedExtentRef ref);
+  void add_to_dirty(
+      CachedExtentRef ref,
+      const Transaction::src_t* p_src);
 
   /// Replace the prev dirty extent by next
-  void replace_dirty(CachedExtentRef next, CachedExtentRef prev);
+  void replace_dirty(
+      CachedExtentRef next,
+      CachedExtentRef prev,
+      const Transaction::src_t& src);
 
   /// Remove from dirty list
-  void remove_from_dirty(CachedExtentRef ref);
+  void remove_from_dirty(
+      CachedExtentRef ref,
+      const Transaction::src_t* p_src);
 
   void clear_dirty();
 
   /// Remove extent from extents handling dirty and refcounting
-  void remove_extent(CachedExtentRef ref);
+  void remove_extent(
+      CachedExtentRef ref,
+      const Transaction::src_t* p_src);
 
   /// Retire extent
   void commit_retire_extent(Transaction& t, CachedExtentRef ref);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1436,7 +1436,6 @@ private:
 
     counter_by_extent_t<cache_size_stats_t> sizes_by_ext;
     cache_io_stats_t overall_io;
-    cache_io_stats_t trans_io;
     counter_by_src_t<counter_by_extent_t<cache_io_stats_t> >
       trans_io_by_src_ext;
 
@@ -1459,12 +1458,12 @@ private:
       lru.erase(lru.s_iterator_to(extent));
       current_size -= extent_length;
       get_by_ext(sizes_by_ext, extent.get_type()).account_out(extent_length);
-      overall_io.account_out(extent_length);
+      overall_io.out_sizes.account_in(extent_length);
       if (p_src) {
-        trans_io.account_out(extent_length);
         get_by_ext(
           get_by_src(trans_io_by_src_ext, *p_src),
-          extent.get_type()).account_out(extent_length);
+          extent.get_type()
+        ).out_sizes.account_in(extent_length);
       }
       intrusive_ptr_release(&extent);
     }
@@ -1513,12 +1512,12 @@ private:
         // absent, add to top (back)
         current_size += extent_length;
         get_by_ext(sizes_by_ext, extent.get_type()).account_in(extent_length);
-        overall_io.account_in(extent_length);
+        overall_io.in_sizes.account_in(extent_length);
         if (p_src) {
-          trans_io.account_in(extent_length);
           get_by_ext(
             get_by_src(trans_io_by_src_ext, *p_src),
-            extent.get_type()).account_in(extent_length);
+            extent.get_type()
+          ).in_sizes.account_in(extent_length);
         }
         intrusive_ptr_add_ref(&extent);
         lru.push_back(extent);

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -710,10 +710,10 @@ seastar::future<> SeaStore::report_stats()
     lru_sizes_ps.size /= seastar::smp::count;
     lru_sizes_ps.num_extents /= seastar::smp::count;
     cache_io_stats_t lru_io_ps = cache_total.lru_io;
-    lru_io_ps.in_size /= seastar::smp::count;
-    lru_io_ps.in_num_extents /= seastar::smp::count;
-    lru_io_ps.out_size /= seastar::smp::count;
-    lru_io_ps.out_num_extents /= seastar::smp::count;
+    lru_io_ps.in_sizes.size /= seastar::smp::count;
+    lru_io_ps.in_sizes.num_extents /= seastar::smp::count;
+    lru_io_ps.out_sizes.size /= seastar::smp::count;
+    lru_io_ps.out_sizes.num_extents /= seastar::smp::count;
     INFO("cache lru: total{} {}; per-shard: total{} {}",
          cache_total.lru_sizes,
          cache_io_stats_printer_t{seconds, cache_total.lru_io},

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -705,6 +705,7 @@ seastar::future<> SeaStore::report_stats()
     for (const auto& s : shard_cache_stats) {
       cache_total.add(s);
     }
+
     cache_size_stats_t lru_sizes_ps = cache_total.lru_sizes;
     lru_sizes_ps.size /= seastar::smp::count;
     lru_sizes_ps.num_extents /= seastar::smp::count;
@@ -718,6 +719,23 @@ seastar::future<> SeaStore::report_stats()
          cache_io_stats_printer_t{seconds, cache_total.lru_io},
          lru_sizes_ps,
          cache_io_stats_printer_t{seconds, lru_io_ps});
+
+    cache_size_stats_t dirty_sizes_ps = cache_total.dirty_sizes;
+    dirty_sizes_ps.size /= seastar::smp::count;
+    dirty_sizes_ps.num_extents /= seastar::smp::count;
+    dirty_io_stats_t dirty_io_ps = cache_total.dirty_io;
+    dirty_io_ps.in_sizes.size /= seastar::smp::count;
+    dirty_io_ps.in_sizes.num_extents /= seastar::smp::count;
+    dirty_io_ps.num_replace /= seastar::smp::count;
+    dirty_io_ps.out_sizes.size /= seastar::smp::count;
+    dirty_io_ps.out_sizes.num_extents /= seastar::smp::count;
+    dirty_io_ps.out_versions /= seastar::smp::count;
+    INFO("cache dirty: total{} {}; per-shard: total{} {}",
+         cache_total.dirty_sizes,
+         dirty_io_stats_printer_t{seconds, cache_total.dirty_io},
+         dirty_sizes_ps,
+         dirty_io_stats_printer_t{seconds, dirty_io_ps});
+
     return seastar::now();
   });
 }

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -1012,4 +1012,31 @@ std::ostream& operator<<(std::ostream& out, const cache_size_stats_t& p)
   return out;
 }
 
+std::ostream& operator<<(std::ostream& out, const cache_size_stats_printer_t& p)
+{
+  constexpr const char* dfmt = "{:.2f}";
+  out << "("
+      << fmt::format(dfmt, p.stats.get_mb()/p.seconds)
+      << "MiB/s,"
+      << fmt::format(dfmt, p.stats.get_avg_kb())
+      << "KiB,"
+      << fmt::format(dfmt, p.stats.num_extents/p.seconds)
+      << "ps)";
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const dirty_io_stats_printer_t& p)
+{
+  constexpr const char* dfmt = "{:.2f}";
+  out << "in"
+      << cache_size_stats_printer_t{p.seconds, p.stats.in_sizes}
+      << " replaces="
+      << fmt::format(dfmt, p.stats.num_replace/p.seconds)
+      << "ps out"
+      << cache_size_stats_printer_t{p.seconds, p.stats.out_sizes}
+      << " outv="
+      << fmt::format(dfmt, p.stats.get_avg_out_version());
+  return out;
+}
+
 } // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -980,25 +980,6 @@ std::ostream& operator<<(std::ostream& out, const writer_stats_printer_t& p)
   return out;
 }
 
-std::ostream& operator<<(std::ostream& out, const cache_io_stats_printer_t& p)
-{
-  constexpr const char* dfmt = "{:.2f}";
-  out << "in("
-      << fmt::format(dfmt, p.stats.get_in_mbs(p.seconds))
-      << "MiB/s,"
-      << fmt::format(dfmt, p.stats.get_in_avg_kb())
-      << "KiB,"
-      << fmt::format(dfmt, p.stats.in_num_extents/p.seconds)
-      << "ps) out("
-      << fmt::format(dfmt, p.stats.get_out_mbs(p.seconds))
-      << "MiB/s,"
-      << fmt::format(dfmt, p.stats.get_out_avg_kb())
-      << "KiB,"
-      << fmt::format(dfmt, p.stats.out_num_extents/p.seconds)
-      << "ps)";
-  return out;
-}
-
 std::ostream& operator<<(std::ostream& out, const cache_size_stats_t& p)
 {
   constexpr const char* dfmt = "{:.2f}";
@@ -1022,6 +1003,15 @@ std::ostream& operator<<(std::ostream& out, const cache_size_stats_printer_t& p)
       << "KiB,"
       << fmt::format(dfmt, p.stats.num_extents/p.seconds)
       << "ps)";
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const cache_io_stats_printer_t& p)
+{
+  out << "in"
+      << cache_size_stats_printer_t{p.seconds, p.stats.in_sizes}
+      << " out"
+      << cache_size_stats_printer_t{p.seconds, p.stats.out_sizes};
   return out;
 }
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2557,62 +2557,6 @@ struct shard_stats_t {
   }
 };
 
-struct cache_io_stats_t {
-  uint64_t in_size = 0;
-  uint64_t in_num_extents = 0;
-  uint64_t out_size = 0;
-  uint64_t out_num_extents = 0;
-
-  bool is_empty() const {
-    return in_num_extents == 0 && out_num_extents == 0;
-  }
-
-  double get_in_mbs(double seconds) const {
-    return (in_size>>12)/(seconds*256);
-  }
-
-  double get_in_avg_kb() const {
-    return (in_size>>10)/static_cast<double>(in_num_extents);
-  }
-
-  double get_out_mbs(double seconds) const {
-    return (out_size>>12)/(seconds*256);
-  }
-
-  double get_out_avg_kb() const {
-    return (out_size>>10)/static_cast<double>(out_num_extents);
-  }
-
-  void account_in(extent_len_t size) {
-    in_size += size;
-    ++in_num_extents;
-  }
-
-  void account_out(extent_len_t size) {
-    out_size += size;
-    ++out_num_extents;
-  }
-
-  void minus(const cache_io_stats_t& o) {
-    in_size -= o.in_size;
-    in_num_extents -= o.in_num_extents;
-    out_size -= o.out_size;
-    out_num_extents -= o.out_num_extents;
-  }
-
-  void add(const cache_io_stats_t& o) {
-    in_size += o.in_size;
-    in_num_extents += o.in_num_extents;
-    out_size += o.out_size;
-    out_num_extents += o.out_num_extents;
-  }
-};
-struct cache_io_stats_printer_t {
-  double seconds;
-  const cache_io_stats_t &stats;
-};
-std::ostream& operator<<(std::ostream&, const cache_io_stats_printer_t&);
-
 struct cache_size_stats_t {
   uint64_t size = 0;
   uint64_t num_extents = 0;
@@ -2657,6 +2601,30 @@ struct cache_size_stats_printer_t {
   const cache_size_stats_t& stats;
 };
 std::ostream& operator<<(std::ostream&, const cache_size_stats_printer_t&);
+
+struct cache_io_stats_t {
+  cache_size_stats_t in_sizes;
+  cache_size_stats_t out_sizes;
+
+  bool is_empty() const {
+    return in_sizes.is_empty() && out_sizes.is_empty();
+  }
+
+  void add(const cache_io_stats_t& o) {
+    in_sizes.add(o.in_sizes);
+    out_sizes.add(o.out_sizes);
+  }
+
+  void minus(const cache_io_stats_t& o) {
+    in_sizes.minus(o.in_sizes);
+    out_sizes.minus(o.out_sizes);
+  }
+};
+struct cache_io_stats_printer_t {
+  double seconds;
+  const cache_io_stats_t& stats;
+};
+std::ostream& operator<<(std::ostream&, const cache_io_stats_printer_t&);
 
 struct dirty_io_stats_t {
   cache_size_stats_t in_sizes;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2654,6 +2654,13 @@ struct cache_stats_t {
   }
 };
 
+struct dirty_io_stats_t {
+  cache_size_stats_t in_sizes;
+  uint64_t num_replace = 0;
+  cache_size_stats_t out_sizes;
+  uint64_t out_versions = 0;
+};
+
 }
 
 WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::seastore_meta_t)

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -41,22 +41,22 @@ inline std::ostream& operator<<(std::ostream& out, const io_stat_t& stat) {
   return out << stat.num << "(" << stat.bytes << "B)";
 }
 
-struct version_stat_t {
+struct rewrite_stats_t {
   uint64_t num = 0;
   uint64_t version = 0;
 
   bool is_clear() const {
-    return (num == 0 && version == 0);
+    return num == 0;
   }
 
-  void increment(extent_version_t v) {
+  void account(extent_version_t v) {
     ++num;
     version += v;
   }
 
-  void increment_stat(const version_stat_t& stat) {
-    num += stat.num;
-    version += stat.version;
+  void add(const rewrite_stats_t& o) {
+    num += o.num;
+    version += o.version;
   }
 };
 
@@ -433,7 +433,7 @@ public:
     lba_tree_stats = {};
     backref_tree_stats = {};
     ool_write_stats = {};
-    rewrite_version_stats = {};
+    rewrite_stats = {};
     conflicted = false;
     if (!has_reset) {
       has_reset = true;
@@ -492,8 +492,8 @@ public:
   ool_write_stats_t& get_ool_write_stats() {
     return ool_write_stats;
   }
-  version_stat_t& get_rewrite_version_stats() {
-    return rewrite_version_stats;
+  rewrite_stats_t& get_rewrite_stats() {
+    return rewrite_stats;
   }
 
   struct existing_block_stats_t {
@@ -617,7 +617,7 @@ private:
   tree_stats_t lba_tree_stats;
   tree_stats_t backref_tree_stats;
   ool_write_stats_t ool_write_stats;
-  version_stat_t rewrite_version_stats;
+  rewrite_stats_t rewrite_stats;
 
   bool conflicted = false;
 

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -42,21 +42,41 @@ inline std::ostream& operator<<(std::ostream& out, const io_stat_t& stat) {
 }
 
 struct rewrite_stats_t {
-  uint64_t num = 0;
-  uint64_t version = 0;
+  uint64_t num_n_dirty = 0;
+  uint64_t num_dirty = 0;
+  uint64_t dirty_version = 0;
 
   bool is_clear() const {
-    return num == 0;
+    return (num_n_dirty == 0 && num_dirty == 0);
   }
 
-  void account(extent_version_t v) {
-    ++num;
-    version += v;
+  uint64_t get_num_rewrites() const {
+    return num_n_dirty + num_dirty;
+  }
+
+  double get_avg_version() const {
+    return static_cast<double>(dirty_version)/num_dirty;
+  }
+
+  void account_n_dirty() {
+    ++num_n_dirty;
+  }
+
+  void account_dirty(extent_version_t v) {
+    ++num_dirty;
+    dirty_version += v;
   }
 
   void add(const rewrite_stats_t& o) {
-    num += o.num;
-    version += o.version;
+    num_n_dirty += o.num_n_dirty;
+    num_dirty += o.num_dirty;
+    dirty_version += o.dirty_version;
+  }
+
+  void minus(const rewrite_stats_t& o) {
+    num_n_dirty -= o.num_n_dirty;
+    num_dirty -= o.num_dirty;
+    dirty_version -= o.dirty_version;
   }
 };
 

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -639,6 +639,13 @@ TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(
   assert(extent->is_valid() && !extent->is_initial_pending());
   if (extent->is_dirty()) {
     assert(extent->get_version() > 0);
+    if (is_root_type(extent->get_type())) {
+      // pass
+    } else if (extent->get_version() == 1 && extent->is_mutation_pending()) {
+      t.get_rewrite_stats().account_n_dirty();
+    } else {
+      t.get_rewrite_stats().account_dirty(extent->get_version());
+    }
     if (epm->can_inplace_rewrite(t, extent)) {
       DEBUGT("delta overwriting extent -- {}", t, *extent);
       t.add_inplace_rewrite_extent(extent);
@@ -647,13 +654,13 @@ TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(
     }
     extent->set_target_rewrite_generation(INIT_GENERATION);
   } else {
+    assert(!is_root_type(extent->get_type()));
     extent->set_target_rewrite_generation(target_generation);
     ceph_assert(modify_time != NULL_TIME);
     extent->set_modify_time(modify_time);
     assert(extent->get_version() == 0);
+    t.get_rewrite_stats().account_n_dirty();
   }
-
-  t.get_rewrite_stats().account(extent->get_version());
 
   if (is_backref_node(extent->get_type())) {
     DEBUGT("rewriting backref extent -- {}", t, *extent);

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -638,6 +638,7 @@ TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(
 
   assert(extent->is_valid() && !extent->is_initial_pending());
   if (extent->is_dirty()) {
+    assert(extent->get_version() > 0);
     if (epm->can_inplace_rewrite(t, extent)) {
       DEBUGT("delta overwriting extent -- {}", t, *extent);
       t.add_inplace_rewrite_extent(extent);
@@ -649,9 +650,10 @@ TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(
     extent->set_target_rewrite_generation(target_generation);
     ceph_assert(modify_time != NULL_TIME);
     extent->set_modify_time(modify_time);
+    assert(extent->get_version() == 0);
   }
 
-  t.get_rewrite_version_stats().increment(extent->get_version());
+  t.get_rewrite_stats().account(extent->get_version());
 
   if (is_backref_node(extent->get_type())) {
     DEBUGT("rewriting backref extent -- {}", t, *extent);


### PR DESCRIPTION
Example output:
```
INFO  2024-08-22 11:02:40,358 [shard 0:main] seastore_cache - Cache::get_stats:
dirty total(34.21MiB,36.27KiB,966)
  data(0.00MiB,-nanKiB,0)
  mdat(32.64MiB,59.47KiB,562)
  phys(1.57MiB,3.99KiB,404)
dirty io: in(0.23MiB/s,43.64KiB,5.50ps) replaces=448.46ps out(0.26MiB/s,48.73KiB,5.50ps) outv=209.45
  MUTATE: in(0.23MiB/s,47.60KiB,5.00ps) replaces=423.46ps out(0.07MiB/s,34.00KiB,2.00ps) outv=79.00
    data: in(0.00MiB/s,-nanKiB,0.00ps) replaces=0.00ps out(0.00MiB/s,-nanKiB,0.00ps) outv=-nan
    mdat: in(0.23MiB/s,52.44KiB,4.50ps) replaces=316.47ps out(0.06MiB/s,64.00KiB,1.00ps) outv=119.00
    phys: in(0.00MiB/s,4.00KiB,0.50ps) replaces=106.99ps out(0.00MiB/s,4.00KiB,1.00ps) outv=39.00
  TRIM_DIRTY: in(0.00MiB/s,4.00KiB,0.50ps) replaces=3.00ps out(0.20MiB/s,57.14KiB,3.50ps) outv=284.00
    data: in(0.00MiB/s,-nanKiB,0.00ps) replaces=0.00ps out(0.00MiB/s,-nanKiB,0.00ps) outv=-nan
    mdat: in(0.00MiB/s,-nanKiB,0.00ps) replaces=0.00ps out(0.20MiB/s,57.14KiB,3.50ps) outv=284.00
    phys: in(0.00MiB/s,4.00KiB,0.50ps) replaces=3.00ps out(0.00MiB/s,-nanKiB,0.00ps) outv=-nan
  TRIM_ALLOC: in(0.00MiB/s,-nanKiB,0.00ps) replaces=22.00ps out(0.00MiB/s,-nanKiB,0.00ps) outv=-nan
    data: in(0.00MiB/s,-nanKiB,0.00ps) replaces=0.00ps out(0.00MiB/s,-nanKiB,0.00ps) outv=-nan
    mdat: in(0.00MiB/s,-nanKiB,0.00ps) replaces=0.00ps out(0.00MiB/s,-nanKiB,0.00ps) outv=-nan
    phys: in(0.00MiB/s,-nanKiB,0.00ps) replaces=22.00ps out(0.00MiB/s,-nanKiB,0.00ps) outv=-nan
rewrite trim ndirty=0.00ps, dirty=3.50ps, dversion=284.00; reclaim ndirty=0.00ps, dirty=0.00ps, dversion=-nan
...
INFO  2024-08-22 11:02:40,359 [shard 0:main] seastore - SeaStore: cache dirty: total(132.07MiB,34.32KiB,3941) in(4.18MiB/s,45.03KiB,95.05ps) replaces=2146.68ps out(0.88MiB/s,28.97KiB,31.02ps) outv=140.26; per-shard: total(33.02MiB,34.33KiB,985) in(1.04MiB/s,45.51KiB,23.51ps) replaces=536.29ps out(0.22MiB/s,29.93KiB,7.50ps) outv=144.93
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
