### PR TITLE
rbd-mirror: use correct ioctx for namespace

### DIFF
--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -580,10 +580,20 @@ int group_snap_remove(librados::IoCtx *ioctx, const std::string &oid,
 int group_snap_get_by_id(librados::IoCtx *ioctx, const std::string &oid,
                          const std::string &snap_id,
                          cls::rbd::GroupSnapshot *snapshot);
+void group_snap_list_start(librados::ObjectReadOperation *op,
+                           const cls::rbd::GroupSnapshot &start,
+                           uint64_t max_return);
+int group_snap_list_finish(ceph::buffer::list::const_iterator *iter,
+                           std::vector<cls::rbd::GroupSnapshot> *snapshots);
 int group_snap_list(librados::IoCtx *ioctx, const std::string &oid,
                     const cls::rbd::GroupSnapshot &start,
                     uint64_t max_return,
                     std::vector<cls::rbd::GroupSnapshot> *snapshots);
+void group_snap_list_order_start(librados::ObjectReadOperation *op,
+                                 const std::string &start_snap_id,
+                                 uint64_t max_return);
+int group_snap_list_order_finish(ceph::buffer::list::const_iterator *iter,
+                                 std::map<std::string, uint64_t> *snap_order);
 int group_snap_list_order(librados::IoCtx *ioctx, const std::string &oid,
                           const std::string &snap_id, uint64_t max_return,
                           std::map<std::string, uint64_t> *snap_order);

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -77,6 +77,7 @@ set(librbd_internal_srcs
   exclusive_lock/PostAcquireRequest.cc
   exclusive_lock/PreReleaseRequest.cc
   exclusive_lock/StandardPolicy.cc
+  group/ListSnapshotsRequest.cc
   image/AttachChildRequest.cc
   image/AttachParentRequest.cc
   image/CloneRequest.cc

--- a/src/librbd/api/Group.h
+++ b/src/librbd/api/Group.h
@@ -47,6 +47,7 @@ struct Group {
   static int snap_rename(librados::IoCtx& group_ioctx, const char *group_name,
                          const char *old_snap_name, const char *new_snap_name);
   static int snap_list(librados::IoCtx& group_ioctx, const char *group_name,
+                       bool try_to_sort, bool fail_if_not_sorted,
                        std::vector<group_snap_info2_t> *snaps);
   static int snap_get_info(librados::IoCtx& group_ioctx,
                            const char *group_name, const char *snap_name,

--- a/src/librbd/group/ListSnapshotsRequest.cc
+++ b/src/librbd/group/ListSnapshotsRequest.cc
@@ -1,0 +1,187 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/group/ListSnapshotsRequest.h"
+#include "include/ceph_assert.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "common/ceph_context.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "librbd/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::group::ListSnapshotsRequest: " << this \
+                           << " " << __func__ << ": "
+
+namespace librbd {
+namespace group {
+
+namespace {
+
+const uint32_t MAX_RETURN = 1024;
+
+} // anonymous namespace
+
+template <typename I>
+ListSnapshotsRequest<I>::ListSnapshotsRequest(librados::IoCtx &group_io_ctx,
+                                              const std::string &group_id,
+                                              bool try_to_sort,
+                                              bool fail_if_not_sorted,
+                                              std::vector<cls::rbd::GroupSnapshot> *snaps,
+                                              Context *on_finish)
+     : m_group_io_ctx(group_io_ctx), m_group_id(group_id),
+       m_try_to_sort(try_to_sort), m_fail_if_not_sorted(fail_if_not_sorted),
+       m_snaps(snaps), m_on_finish(on_finish) {
+  auto cct = reinterpret_cast<CephContext*>(m_group_io_ctx.cct());
+  ldout(cct, 20) << "group_id=" << m_group_id
+                 << ", try_to_sort=" << m_try_to_sort
+                 << ", fail_if_not_sorted=" << m_fail_if_not_sorted
+                 << dendl;
+}
+
+template <typename I>
+void ListSnapshotsRequest<I>::send() {
+  list_snap_orders();
+}
+
+template <typename I>
+void ListSnapshotsRequest<I>::list_snap_orders() {
+  if (!m_try_to_sort) {
+    list_snaps();
+    return;
+  }
+
+  auto cct = reinterpret_cast<CephContext*>(m_group_io_ctx.cct());
+  ldout(cct, 10) << dendl;
+
+  librados::ObjectReadOperation op;
+  cls_client::group_snap_list_order_start(&op, m_start_after_order, MAX_RETURN);
+  auto comp = util::create_rados_callback<
+      ListSnapshotsRequest<I>,
+      &ListSnapshotsRequest<I>::handle_list_snap_orders>(this);
+  m_out_bl.clear();
+  int r = m_group_io_ctx.aio_operate(util::group_header_name(m_group_id), comp,
+                                     &op, &m_out_bl);
+  ceph_assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+void ListSnapshotsRequest<I>::handle_list_snap_orders(int r) {
+  auto cct = reinterpret_cast<CephContext*>(m_group_io_ctx.cct());
+  ldout(cct, 10) << "r=" << r << dendl;
+
+  std::map<std::string, uint64_t> snap_orders;
+  if (r == 0) {
+    auto iter = m_out_bl.cbegin();
+    r = cls_client::group_snap_list_order_finish(&iter, &snap_orders);
+  }
+
+  if (r < 0) {
+    if (m_fail_if_not_sorted) {
+      ldout(cct, 10) << "failed to get group snapshot orders: " << cpp_strerror(r)
+	         << dendl;
+      finish(r);
+      return;
+    } else {
+      list_snaps();
+      return;
+    }
+  }
+
+  m_snap_orders.insert(snap_orders.begin(), snap_orders.end());
+  if (snap_orders.size() < MAX_RETURN) {
+    list_snaps();
+    return;
+  }
+
+  m_start_after_order = snap_orders.rbegin()->first;
+  list_snap_orders();
+}
+
+
+template <typename I>
+void ListSnapshotsRequest<I>::list_snaps() {
+  auto cct = reinterpret_cast<CephContext*>(m_group_io_ctx.cct());
+  ldout(cct, 10) << dendl;
+
+  librados::ObjectReadOperation op;
+  cls_client::group_snap_list_start(&op, m_start_after, MAX_RETURN);
+  auto comp = util::create_rados_callback<
+      ListSnapshotsRequest<I>,
+      &ListSnapshotsRequest<I>::handle_list_snaps>(this);
+  m_out_bl.clear();
+  int r = m_group_io_ctx.aio_operate(util::group_header_name(m_group_id), comp,
+                                     &op, &m_out_bl);
+  ceph_assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+void ListSnapshotsRequest<I>::handle_list_snaps(int r) {
+  auto cct = reinterpret_cast<CephContext*>(m_group_io_ctx.cct());
+  ldout(cct, 10) << "r=" << r << dendl;
+
+  std::vector<cls::rbd::GroupSnapshot> snaps;
+  if (r == 0) {
+    auto iter = m_out_bl.cbegin();
+    r = cls_client::group_snap_list_finish(&iter, &snaps);
+  }
+
+  if (r < 0) {
+    lderr(cct) << "failed to list group snapshots: " << cpp_strerror(r)
+               << dendl;
+    finish(r);
+    return;
+  }
+
+  m_snaps->insert(m_snaps->end(), snaps.begin(), snaps.end());
+  if (snaps.size() < MAX_RETURN) {
+    sort_snaps();
+    return;
+  }
+
+  m_start_after = *snaps.rbegin();
+  list_snaps();
+}
+
+template <typename I>
+void ListSnapshotsRequest<I>::sort_snaps() {
+  if (!m_try_to_sort) {
+    finish(0);
+    return;
+  }
+
+  auto cct = reinterpret_cast<CephContext*>(m_group_io_ctx.cct());
+  ldout(cct, 10) << dendl;
+
+  for (const auto& snap : *m_snaps) {
+    if (m_snap_orders.find(snap.id) == m_snap_orders.end()) {
+      ldout(cct, 10) << "Missing order for snap_id=" << snap.id << dendl;
+      finish(m_fail_if_not_sorted ? -EINVAL : 0);
+      return;
+    }
+  }
+
+  std::sort(m_snaps->begin(), m_snaps->end(),
+            [this](const cls::rbd::GroupSnapshot &a,
+                   const cls::rbd::GroupSnapshot &b) {
+	       return this->m_snap_orders[a.id] < this->m_snap_orders[b.id];
+	    });
+
+  finish(0);
+}
+
+template <typename I>
+void ListSnapshotsRequest<I>::finish(int r) {
+  auto cct = reinterpret_cast<CephContext*>(m_group_io_ctx.cct());
+  ldout(cct, 10) << "r=" << r << dendl;
+
+  m_on_finish->complete(r);
+}
+
+} // namespace group
+} // namespace librbd
+
+template class librbd::group::ListSnapshotsRequest<librbd::ImageCtx>;

--- a/src/librbd/group/ListSnapshotsRequest.h
+++ b/src/librbd/group/ListSnapshotsRequest.h
@@ -1,0 +1,93 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_GROUP_LIST_SNAPSHOTS_REQUEST_H
+#define CEPH_LIBRBD_GROUP_LIST_SNAPSHOTS_REQUEST_H
+
+#include "include/int_types.h"
+#include "include/types.h"
+#include "include/rados/librados.hpp"
+#include "cls/rbd/cls_rbd_types.h"
+
+#include <string>
+#include <vector>
+
+class Context;
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace group {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class ListSnapshotsRequest {
+public:
+  static ListSnapshotsRequest *create(
+      librados::IoCtx &group_io_ctx, const std::string &group_id,
+      bool try_to_sort, bool fail_if_not_sorted,
+      std::vector<cls::rbd::GroupSnapshot> *snaps, Context *on_finish) {
+    return new ListSnapshotsRequest(group_io_ctx, group_id, try_to_sort,
+                                    fail_if_not_sorted, snaps, on_finish);
+  }
+
+  ListSnapshotsRequest(librados::IoCtx &group_io_ctx,
+                       const std::string &group_id,
+                       bool try_to_sort, bool fail_if_not_sorted,
+                       std::vector<cls::rbd::GroupSnapshot> *snaps,
+                       Context *on_finish);
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>    /--------\
+   *    |       |        | (if required. repeat if more
+   *    v       v        |  entries)
+   *  LIST_SNAP_ORDERS --/
+   *    |       /--------\
+   *    |       |        | (repeat if more
+   *    v       v        |  snapshots)
+   *  LIST_SNAPS ----/
+   *    |
+   *    v
+   *  SORT_SNAPS (if required)  
+   *    |
+   *    v
+   *  <finish>
+   *
+   * @endverbatim
+   */
+
+  librados::IoCtx &m_group_io_ctx;
+  std::string m_group_id;
+  bool m_try_to_sort;
+  //Fail if m_try_to_sort is true and sorting fails. Ignored if m_try_to_sort is false.
+  bool m_fail_if_not_sorted;
+  std::vector<cls::rbd::GroupSnapshot> *m_snaps;
+  std::map<std::string, uint64_t> m_snap_orders;
+  Context *m_on_finish;
+
+  cls::rbd::GroupSnapshot m_start_after;
+  std::string m_start_after_order;
+  bufferlist m_out_bl;
+
+  void list_snaps();
+  void handle_list_snaps(int r);
+
+  void list_snap_orders();
+  void handle_list_snap_orders(int r);
+
+  void sort_snaps();
+
+  void finish(int r);
+};
+
+} // namespace group
+} // namespace librbd
+
+extern template class librbd::group::ListSnapshotsRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_GROUP_LIST_SNAPSHOTS_REQUEST_H

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1456,7 +1456,8 @@ namespace librbd {
     }
 
     std::vector<group_snap_info2_t> snaps2;
-    int r = librbd::api::Group<>::snap_list(group_ioctx, group_name, &snaps2);
+    int r = librbd::api::Group<>::snap_list(group_ioctx, group_name, true,
+                                            false, &snaps2);
 
     for (const auto& snap : snaps2) {
       snaps->push_back(
@@ -1473,7 +1474,8 @@ namespace librbd {
   int RBD::group_snap_list2(IoCtx& group_ioctx, const char *group_name,
                             std::vector<group_snap_info2_t> *snaps)
   {
-    return librbd::api::Group<>::snap_list(group_ioctx, group_name, snaps);
+    return librbd::api::Group<>::snap_list(group_ioctx, group_name, true,
+                                           false, snaps);
   }
 
   int RBD::group_snap_get_info(IoCtx& group_ioctx, const char *group_name,
@@ -7322,7 +7324,8 @@ extern "C" int rbd_group_snap_list(rados_ioctx_t group_p,
   }
 
   std::vector<librbd::group_snap_info2_t> cpp_snaps;
-  int r = librbd::api::Group<>::snap_list(group_ioctx, group_name, &cpp_snaps);
+  int r = librbd::api::Group<>::snap_list(group_ioctx, group_name, true, false,
+                                          &cpp_snaps);
 
   if (r == -ENOENT) {
     *snaps_size = 0;
@@ -7372,7 +7375,8 @@ extern "C" int rbd_group_snap_list2(rados_ioctx_t group_p,
   librados::IoCtx::from_rados_ioctx_t(group_p, group_ioctx);
 
   std::vector<librbd::group_snap_info2_t> cpp_snaps;
-  int r = librbd::api::Group<>::snap_list(group_ioctx, group_name, &cpp_snaps);
+  int r = librbd::api::Group<>::snap_list(group_ioctx, group_name, true, false,
+                                          &cpp_snaps);
   if (r < 0) {
     return r;
   }

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -603,6 +603,13 @@ int IoCtx::omap_get_vals(const std::string& oid,
                      max_return, out_vals));
 }
 
+int IoCtx::omap_rm_keys(const std::string& oid,
+                        const std::set<std::string>& keys) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->execute_operation(
+    oid, std::bind(&TestIoCtxImpl::omap_rm_keys, _1, _2, keys));
+}
+
 int IoCtx::operate(const std::string& oid, ObjectWriteOperation *op) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -747,8 +747,11 @@ int PoolReplayer<I>::list_mirroring_namespaces(
   }
 
   for (auto &name : names) {
+    librados::IoCtx ns_ioctx;
+    ns_ioctx.dup(m_local_io_ctx);
+    ns_ioctx.set_namespace(name);
     cls::rbd::MirrorMode mirror_mode = cls::rbd::MIRROR_MODE_DISABLED;
-    int r = librbd::cls_client::mirror_mode_get(&m_local_io_ctx, &mirror_mode);
+    int r = librbd::cls_client::mirror_mode_get(&ns_ioctx, &mirror_mode);
     if (r < 0 && r != -ENOENT) {
       derr << "failed to get namespace mirror mode: " << cpp_strerror(r)
            << dendl;


### PR DESCRIPTION
The PoolReplayer uses the ioctx for the default namespace to check if other namespaces are mirror enabled. This causes it to incorrectly determine that all namespaces are enabled for mirroring, even if they are not.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
