### PR TITLE
smb: cluster public ip addresses support

### DIFF
--- a/doc/cephadm/services/smb.rst
+++ b/doc/cephadm/services/smb.rst
@@ -105,20 +105,42 @@ custom_dns
     Active Directory even if the Ceph host nodes are not tied into the Active
     Directory DNS domain(s).
 
-include_ceph_users:
+include_ceph_users
     A list of cephx user (aka entity) names that the Samba Containers may use.
     The cephx keys for each user in the list will automatically be added to
     the keyring in the container.
 
-cluster_meta_uri:
+cluster_meta_uri
     A string containing a URI that identifies where the cluster structure
     metadata will be stored. Required if ``clustered`` feature is set. Must be
     a RADOS pseudo-URI.
 
-cluster_lock_uri:
+cluster_lock_uri
     A string containing a URI that identifies where Samba/CTDB will store a
     cluster lock. Required if ``clustered`` feature is set. Must be a RADOS
     pseudo-URI.
+
+cluster_public_addrs
+    List of objects; optional. Supported only when using Samba's clustering.
+    Assign "virtual" IP addresses that will be managed by the clustering
+    subsystem and may automatically move between nodes running Samba
+    containers.
+    Fields:
+
+    address
+        Required string. An IP address with a required prefix length (example:
+        ``192.168.4.51/24``). This address will be assigned to one of the
+        host's network devices and managed automatically.
+    destination
+        Optional. String or list of strings. A ``destination`` defines where
+        the system will assign the managed IPs. Each string value must be a
+        network address (example ``192.168.4.0/24``). One or more destinations
+        may be supplied. The typical case is to use exactly one destination and
+        so the value may be supplied as a string, rather than a list with a
+        single item. Each destination network will be mapped to a device on a
+        host. Run ``cephadm list-networks`` for an example of these mappings.
+        If destination is not supplied the network is automatically determined
+        using the address value supplied and taken as the destination.
 
 
 .. note::

--- a/doc/mgr/smb.rst
+++ b/doc/mgr/smb.rst
@@ -376,6 +376,27 @@ clustering
     enables clustering regardless of the placement count. A value of ``never``
     disables clustering regardless of the placement count. If unspecified,
     ``default`` is assumed.
+public_addrs
+    List of objects; optional. Supported only when using Samba's clustering.
+    Assign "virtual" IP addresses that will be managed by the clustering
+    subsystem and may automatically move between nodes running Samba
+    containers.
+    Fields:
+
+    address
+        Required string. An IP address with a required prefix length (example:
+        ``192.168.4.51/24``). This address will be assigned to one of the
+        host's network devices and managed automatically.
+    destination
+        Optional. String or list of strings. A ``destination`` defines where
+        the system will assign the managed IPs. Each string value must be a
+        network address (example ``192.168.4.0/24``). One or more destinations
+        may be supplied. The typical case is to use exactly one destination and
+        so the value may be supplied as a string, rather than a list with a
+        single item. Each destination network will be mapped to a device on a
+        host. Run ``cephadm list-networks`` for an example of these mappings.
+        If destination is not supplied the network is automatically determined
+        using the address value supplied and taken as the destination.
 custom_smb_global_options
     Optional mapping. Specify key-value pairs that will be directly added to
     the global ``smb.conf`` options (or equivalent) of a Samba server.  Do

--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ips.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_ips.yaml
@@ -1,0 +1,145 @@
+roles:
+# Test is for basic smb deployment & functionality. one node cluster is OK
+- - host.a
+  - mon.a
+  - mgr.x
+  - osd.0
+  - osd.1
+  - client.0
+- - host.b
+  - mon.b
+  - osd.2
+  - osd.3
+- - host.c
+  - mon.c
+  - osd.4
+  - osd.5
+# Reserve a host for acting as a domain controller and smb client
+- - host.d
+  - cephadm.exclude
+overrides:
+  ceph:
+    log-only-match:
+      - CEPHADM_
+tasks:
+- cephadm.deploy_samba_ad_dc:
+    role: host.d
+- vip:
+    count: 2
+- cephadm:
+
+- cephadm.shell:
+    host.a:
+      - ceph fs volume create cephfs
+- cephadm.wait_for_service:
+    service: mds.cephfs
+
+- cephadm.shell:
+    host.a:
+      # add subvolgroup & subvolumes for test
+      - cmd: ceph fs subvolumegroup create cephfs smb
+      - cmd: ceph fs subvolume create cephfs sv1 --group-name=smb --mode=0777
+      - cmd: ceph fs subvolume create cephfs sv2 --group-name=smb --mode=0777
+      # set up smb cluster and shares
+      - cmd: ceph mgr module enable smb
+      # TODO: replace sleep with poll of mgr state?
+      - cmd: sleep 30
+      - cmd: ceph smb apply -i -
+        stdin: |
+          # --- Begin Embedded YAML
+          - resource_type: ceph.smb.cluster
+            cluster_id: adipctdb
+            auth_mode: active-directory
+            domain_settings:
+              realm: DOMAIN1.SINK.TEST
+              join_sources:
+                - source_type: resource
+                  ref: join1-admin
+            custom_dns:
+              - "{{ctx.samba_ad_dc_ip}}"
+            public_addrs:
+              - address: {{VIP0}}/{{VIPPREFIXLEN}}
+              - address: {{VIP1}}/{{VIPPREFIXLEN}}
+            placement:
+              count: 3
+          - resource_type: ceph.smb.join.auth
+            auth_id: join1-admin
+            auth:
+              username: Administrator
+              password: Passw0rd
+          - resource_type: ceph.smb.share
+            cluster_id: adipctdb
+            share_id: share1
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv1
+              path: /
+          - resource_type: ceph.smb.share
+            cluster_id: adipctdb
+            share_id: share2
+            cephfs:
+              volume: cephfs
+              subvolumegroup: smb
+              subvolume: sv2
+              path: /
+          # --- End Embedded YAML
+# Wait for the smb service to start
+- cephadm.wait_for_service:
+    service: smb.adipctdb
+# Since this is a true cluster there should be a clustermeta in rados
+- cephadm.shell:
+    host.a:
+      - cmd: rados --pool=.smb -N adipctdb get cluster.meta.json /dev/stdout
+
+# Check if shares exist
+- cephadm.exec:
+    host.d:
+      - sleep 30
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share1 -c ls"
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{'host.a'|role_to_remote|attr('ip_address')}}/share2 -c ls"
+
+# verify CTDB is healthy, cluster well formed
+- cephadm.exec:
+    host.a:
+      - "{{ctx.cephadm}} ls --no-detail  | {{ctx.cephadm}} shell jq -r 'map(select(.name | startswith(\"smb.adipctdb\")))[-1].name' > /tmp/svcname"
+      - "{{ctx.cephadm}} enter -n $(cat /tmp/svcname) ctdb status > /tmp/ctdb_status"
+      - cat /tmp/ctdb_status
+      - grep 'pnn:0 .*OK' /tmp/ctdb_status
+      - grep 'pnn:1 .*OK' /tmp/ctdb_status
+      - grep 'pnn:2 .*OK' /tmp/ctdb_status
+      - grep 'Number of nodes:3' /tmp/ctdb_status
+      - rm -rf /tmp/svcname /tmp/ctdb_status
+
+# Test the two assigned VIPs
+- cephadm.exec:
+    host.d:
+      - sleep 30
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{VIP0}}/share1 -c ls"
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{VIP1}}/share1 -c ls"
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{VIP0}}/share2 -c ls"
+      - "{{ctx.samba_client_container_cmd|join(' ')}} smbclient -U DOMAIN1\\\\ckent%1115Rose. //{{VIP1}}/share2 -c ls"
+
+- cephadm.shell:
+    host.a:
+      - cmd: ceph smb apply -i -
+        stdin: |
+          # --- Begin Embedded YAML
+          - resource_type: ceph.smb.cluster
+            cluster_id: adipctdb
+            intent: removed
+          - resource_type: ceph.smb.join.auth
+            auth_id: join1-admin
+            intent: removed
+          - resource_type: ceph.smb.share
+            cluster_id: adipctdb
+            share_id: share1
+            intent: removed
+          - resource_type: ceph.smb.share
+            cluster_id: adipctdb
+            share_id: share2
+            intent: removed
+          # --- End Embedded YAML
+# Wait for the smb service to be removed
+- cephadm.wait_for_service_not_present:
+    service: smb.adipctdb

--- a/src/pybind/mgr/cephadm/services/smb.py
+++ b/src/pybind/mgr/cephadm/services/smb.py
@@ -70,6 +70,9 @@ class SMBService(CephService):
             config_blobs['cluster_meta_uri'] = smb_spec.cluster_meta_uri
         if smb_spec.cluster_lock_uri:
             config_blobs['cluster_lock_uri'] = smb_spec.cluster_lock_uri
+        cluster_public_addrs = smb_spec.strict_cluster_ip_specs()
+        if cluster_public_addrs:
+            config_blobs['cluster_public_addrs'] = cluster_public_addrs
         ceph_users = smb_spec.include_ceph_users or []
         config_blobs.update(
             self._ceph_config_and_keyring_for(

--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -1205,6 +1205,7 @@ def _generate_smb_service_spec(
         user_sources=user_sources,
         custom_dns=cluster.custom_dns,
         include_ceph_users=user_entities,
+        cluster_public_addrs=cluster.service_spec_public_addrs(),
     )
 
 

--- a/src/pybind/mgr/smb/resources.py
+++ b/src/pybind/mgr/smb/resources.py
@@ -5,7 +5,11 @@ import json
 
 import yaml
 
-from ceph.deployment.service_spec import PlacementSpec
+from ceph.deployment.service_spec import (
+    PlacementSpec,
+    SMBClusterPublicIPSpec,
+    SpecValidationError,
+)
 from object_format import ErrorResponseBase
 
 from . import resourcelib, validation
@@ -346,6 +350,25 @@ class WrappedPlacementSpec(PlacementSpec):
         return self.to_json()
 
 
+# This class is a near 1:1 mirror of the service spec helper class.
+@resourcelib.component()
+class ClusterPublicIPAssignment(_RBase):
+    address: str
+    destination: Union[List[str], str, None] = None
+
+    def to_spec(self) -> SMBClusterPublicIPSpec:
+        return SMBClusterPublicIPSpec(
+            address=self.address,
+            destination=self.destination,
+        )
+
+    def validate(self) -> None:
+        try:
+            self.to_spec().validate()
+        except SpecValidationError as err:
+            raise ValueError(str(err)) from err
+
+
 @resourcelib.resource('ceph.smb.cluster')
 class Cluster(_RBase):
     """Represents a cluster (instance) that is / should be present."""
@@ -361,6 +384,7 @@ class Cluster(_RBase):
     placement: Optional[WrappedPlacementSpec] = None
     # control if the cluster is really a cluster
     clustering: Optional[SMBClustering] = None
+    public_addrs: Optional[List[ClusterPublicIPAssignment]] = None
 
     def validate(self) -> None:
         if not self.cluster_id:
@@ -414,6 +438,13 @@ class Cluster(_RBase):
             count = self.placement.count
         # clustering enabled unless we're deploying a single instance "cluster"
         return count != 1
+
+    def service_spec_public_addrs(
+        self,
+    ) -> Optional[List[SMBClusterPublicIPSpec]]:
+        if self.public_addrs is None:
+            return None
+        return [a.to_spec() for a in self.public_addrs]
 
 
 @resourcelib.resource('ceph.smb.join.auth')


### PR DESCRIPTION
Depends on: <s>https://github.com/samba-in-kubernetes/sambacc/pull/133</s> pr merged

Add support for IPs managed by Samba's CTDB clustering system that can move due to cluster events. The IPs are configured in "interface form" (with a /<prefixlength>), and these values are passed down to ctdb through sambacc after being converted to device names by cephadm.

The cephadm service and the smb mgr module resource have basically the same YAML/JSON configuration. Example:

```yaml
- resource_type: ceph.smb.cluster
  cluster_id: adipctdb 
  auth_mode: active-directory
  domain_settings:
    realm: DOMAIN1.SINK.TEST
    join_sources:
      - source_type: resource
        ref: join1-admin
  # --> new stuff here:
  public_addrs:
    - address: 192.168.76.50/24
    - address: 192.168.76.51/24
    - address: 192.168.76.51/24
  # <--
  placement:
    count: 3
```

These can also take the form where a 2nd optional field, `destination` is provided with a network. this network is used by cephadm to get matched with a device name on the host.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s>
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
