### PR TITLE
qa: drop XMLSTARLET variable, use xmlstarlet directly

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -25,15 +25,6 @@ TMPDIR=${TMPDIR:-/tmp}
 CEPH_BUILD_VIRTUALENV=${TMPDIR}
 TESTDIR=${TESTDIR:-${TMPDIR}}
 
-if type xmlstarlet > /dev/null 2>&1; then
-    XMLSTARLET=xmlstarlet
-elif type xml > /dev/null 2>&1; then
-    XMLSTARLET=xml
-else
-	echo "Missing xmlstarlet binary!"
-	exit 1
-fi
-
 if [ `uname` = FreeBSD ]; then
     SED=gsed
     AWK=gawk

--- a/qa/standalone/crush/crush-classes.sh
+++ b/qa/standalone/crush/crush-classes.sh
@@ -52,7 +52,7 @@ function get_osds_up() {
     local objectname=$2
 
     local osds=$(ceph --format xml osd map $poolname $objectname 2>/dev/null | \
-        $XMLSTARLET sel -t -m "//up/osd" -v . -o ' ')
+        xmlstarlet sel -t -m "//up/osd" -v . -o ' ')
     # get rid of the trailing space
     echo $osds
 }

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 
-. $(dirname $0)/../../standalone/ceph-helpers.sh
-
 export RBD_FORCE_ALLOW_V1=1
 
 # make sure rbd pool is EMPTY.. this is a test script!!
@@ -935,7 +933,7 @@ get_migration_state() {
     local image=$1
 
     rbd --format xml status $image |
-        $XMLSTARLET sel -t -v '//status/migration/state'
+        xmlstarlet sel -t -v '//status/migration/state'
 }
 
 test_migration() {
@@ -1175,14 +1173,14 @@ test_trash_purge_schedule() {
 
     for i in `seq 12`; do
         test "$(rbd trash purge schedule status --format xml |
-            $XMLSTARLET sel -t -v '//scheduled/item/pool')" = 'rbd' && break
+            xmlstarlet sel -t -v '//scheduled/item/pool')" = 'rbd' && break
         sleep 10
     done
     rbd trash purge schedule status
     test "$(rbd trash purge schedule status --format xml |
-        $XMLSTARLET sel -t -v '//scheduled/item/pool')" = 'rbd'
+        xmlstarlet sel -t -v '//scheduled/item/pool')" = 'rbd'
     test "$(rbd trash purge schedule status -p rbd --format xml |
-        $XMLSTARLET sel -t -v '//scheduled/item/pool')" = 'rbd'
+        xmlstarlet sel -t -v '//scheduled/item/pool')" = 'rbd'
 
     rbd trash purge schedule add 2d 00:17
     rbd trash purge schedule ls | grep 'every 2d starting at 00:17'
@@ -1191,36 +1189,36 @@ test_trash_purge_schedule() {
     rbd trash purge schedule ls -p rbd2 -R | grep 'every 2d starting at 00:17'
     rbd trash purge schedule ls -p rbd2/ns1 -R | grep 'every 2d starting at 00:17'
     test "$(rbd trash purge schedule ls -R -p rbd2/ns1 --format xml |
-        $XMLSTARLET sel -t -v '//schedules/schedule/pool')" = "-"
+        xmlstarlet sel -t -v '//schedules/schedule/pool')" = "-"
     test "$(rbd trash purge schedule ls -R -p rbd2/ns1 --format xml |
-        $XMLSTARLET sel -t -v '//schedules/schedule/namespace')" = "-"
+        xmlstarlet sel -t -v '//schedules/schedule/namespace')" = "-"
     test "$(rbd trash purge schedule ls -R -p rbd2/ns1 --format xml |
-        $XMLSTARLET sel -t -v '//schedules/schedule/items/item/start_time')" = "00:17:00"
+        xmlstarlet sel -t -v '//schedules/schedule/items/item/start_time')" = "00:17:00"
 
     for i in `seq 12`; do
         rbd trash purge schedule status --format xml |
-            $XMLSTARLET sel -t -v '//scheduled/item/pool' | grep 'rbd2' && break
+            xmlstarlet sel -t -v '//scheduled/item/pool' | grep 'rbd2' && break
         sleep 10
     done
     rbd trash purge schedule status
     rbd trash purge schedule status --format xml |
-        $XMLSTARLET sel -t -v '//scheduled/item/pool' | grep 'rbd2'
+        xmlstarlet sel -t -v '//scheduled/item/pool' | grep 'rbd2'
     echo $(rbd trash purge schedule status --format xml |
-        $XMLSTARLET sel -t -v '//scheduled/item/pool') | grep 'rbd rbd2 rbd2'
+        xmlstarlet sel -t -v '//scheduled/item/pool') | grep 'rbd rbd2 rbd2'
     test "$(rbd trash purge schedule status -p rbd --format xml |
-        $XMLSTARLET sel -t -v '//scheduled/item/pool')" = 'rbd'
+        xmlstarlet sel -t -v '//scheduled/item/pool')" = 'rbd'
     test "$(echo $(rbd trash purge schedule status -p rbd2 --format xml |
-        $XMLSTARLET sel -t -v '//scheduled/item/pool'))" = 'rbd2 rbd2'
+        xmlstarlet sel -t -v '//scheduled/item/pool'))" = 'rbd2 rbd2'
 
     test "$(echo $(rbd trash purge schedule ls -R --format xml |
-        $XMLSTARLET sel -t -v '//schedules/schedule/items'))" = "2d00:17:00 1d01:30:00"
+        xmlstarlet sel -t -v '//schedules/schedule/items'))" = "2d00:17:00 1d01:30:00"
 
     rbd trash purge schedule add 1d
     rbd trash purge schedule ls | grep 'every 2d starting at 00:17'
     rbd trash purge schedule ls | grep 'every 1d'
 
     rbd trash purge schedule ls -R --format xml |
-        $XMLSTARLET sel -t -v '//schedules/schedule/items' | grep '2d00:17'
+        xmlstarlet sel -t -v '//schedules/schedule/items' | grep '2d00:17'
 
     rbd trash purge schedule rm 1d
     rbd trash purge schedule ls | grep 'every 2d starting at 00:17'
@@ -1362,13 +1360,13 @@ test_mirror_snapshot_schedule() {
 
     rbd mirror snapshot schedule status
     test "$(rbd mirror snapshot schedule status --format xml |
-        $XMLSTARLET sel -t -v '//scheduled_images/image/image')" = 'rbd2/ns1/test1'
+        xmlstarlet sel -t -v '//scheduled_images/image/image')" = 'rbd2/ns1/test1'
     test "$(rbd mirror snapshot schedule status -p rbd2 --format xml |
-        $XMLSTARLET sel -t -v '//scheduled_images/image/image')" = 'rbd2/ns1/test1'
+        xmlstarlet sel -t -v '//scheduled_images/image/image')" = 'rbd2/ns1/test1'
     test "$(rbd mirror snapshot schedule status -p rbd2/ns1 --format xml |
-        $XMLSTARLET sel -t -v '//scheduled_images/image/image')" = 'rbd2/ns1/test1'
+        xmlstarlet sel -t -v '//scheduled_images/image/image')" = 'rbd2/ns1/test1'
     test "$(rbd mirror snapshot schedule status -p rbd2/ns1 --image test1 --format xml |
-        $XMLSTARLET sel -t -v '//scheduled_images/image/image')" = 'rbd2/ns1/test1'
+        xmlstarlet sel -t -v '//scheduled_images/image/image')" = 'rbd2/ns1/test1'
 
     rbd mirror image demote rbd2/ns1/test1
     for i in `seq 12`; do

--- a/qa/workunits/rbd/cli_migration.sh
+++ b/qa/workunits/rbd/cli_migration.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 
-. $(dirname $0)/../../standalone/ceph-helpers.sh
-
 TEMPDIR=
 IMAGE1=image1
 IMAGE2=image2

--- a/qa/workunits/rbd/journal.sh
+++ b/qa/workunits/rbd/journal.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-. $(dirname $0)/../../standalone/ceph-helpers.sh
-
 function list_tests()
 {
   echo "AVAILABLE TESTS"
@@ -45,7 +43,7 @@ test_rbd_journal()
     rbd create --image-feature exclusive-lock --image-feature journaling \
 	--size 128 ${image}
     local journal=$(rbd info ${image} --format=xml 2>/dev/null |
-			   $XMLSTARLET sel -t -v "//image/journal")
+			   xmlstarlet sel -t -v "//image/journal")
     test -n "${journal}"
     rbd journal info ${journal}
     rbd journal info --journal ${journal}
@@ -54,14 +52,14 @@ test_rbd_journal()
     rbd feature disable ${image} journaling
 
     rbd info ${image} --format=xml 2>/dev/null |
-	expect_false $XMLSTARLET sel -t -v "//image/journal"
+	expect_false xmlstarlet sel -t -v "//image/journal"
     expect_false rbd journal info ${journal}
     expect_false rbd journal info --image ${image}
 
     rbd feature enable ${image} journaling
 
     local journal1=$(rbd info ${image} --format=xml 2>/dev/null |
-			    $XMLSTARLET sel -t -v "//image/journal")
+			    xmlstarlet sel -t -v "//image/journal")
     test "${journal}" = "${journal1}"
 
     rbd journal info ${journal}
@@ -89,7 +87,7 @@ test_rbd_journal()
     rbd create --image-feature exclusive-lock --image-feature journaling \
 	--size 128 ${image1}
     journal1=$(rbd info ${image1} --format=xml 2>/dev/null |
-		      $XMLSTARLET sel -t -v "//image/journal")
+		      xmlstarlet sel -t -v "//image/journal")
 
     save_commit_position ${journal1}
     rbd journal import --dest ${image1} $TMPDIR/journal.export
@@ -130,7 +128,7 @@ rbd_assert_eq() {
     local expected_val=$4
 
     local val=$(rbd --format xml ${cmd} --image ${image} |
-		       $XMLSTARLET sel -t -v "${param}")
+		       xmlstarlet sel -t -v "${param}")
     test "${val}" = "${expected_val}"
 }
 

--- a/qa/workunits/rbd/rbd-ggate.sh
+++ b/qa/workunits/rbd/rbd-ggate.sh
@@ -7,15 +7,6 @@ SIZE=64
 DATA=
 DEV=
 
-if which xmlstarlet > /dev/null 2>&1; then
-  XMLSTARLET=xmlstarlet
-elif which xml > /dev/null 2>&1; then
-  XMLSTARLET=xml
-else
-  echo "Missing xmlstarlet binary!"
-  exit 1
-fi
-
 if [ `uname -K` -ge 1200078 ] ; then
     RBD_GGATE_RESIZE_SUPPORTED=1
 fi
@@ -148,16 +139,16 @@ _sudo sync
 
 echo  trim test
 provisioned=`rbd -p ${POOL} --format xml du ${IMAGE} |
-  $XMLSTARLET sel -t -m "//stats/images/image/provisioned_size" -v .`
+  xmlstarlet sel -t -m "//stats/images/image/provisioned_size" -v .`
 used=`rbd -p ${POOL} --format xml du ${IMAGE} |
-  $XMLSTARLET sel -t -m "//stats/images/image/used_size" -v .`
+  xmlstarlet sel -t -m "//stats/images/image/used_size" -v .`
 [ "${used}" -eq "${provisioned}" ]
 _sudo newfs -E ${DEV}
 _sudo sync
 provisioned=`rbd -p ${POOL} --format xml du ${IMAGE} |
-  $XMLSTARLET sel -t -m "//stats/images/image/provisioned_size" -v .`
+  xmlstarlet sel -t -m "//stats/images/image/provisioned_size" -v .`
 used=`rbd -p ${POOL} --format xml du ${IMAGE} |
-  $XMLSTARLET sel -t -m "//stats/images/image/used_size" -v .`
+  xmlstarlet sel -t -m "//stats/images/image/used_size" -v .`
 [ "${used}" -lt "${provisioned}" ]
 
 echo  resize test

--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 
-. $(dirname $0)/../../standalone/ceph-helpers.sh
-
 POOL=rbd
 ANOTHER_POOL=new_default_pool$$
 NS=ns
@@ -105,7 +103,7 @@ function get_pid()
     local pool=$1
     local ns=$2
 
-    PID=$(rbd device --device-type nbd --format xml list | $XMLSTARLET sel -t -v \
+    PID=$(rbd device --device-type nbd --format xml list | xmlstarlet sel -t -v \
       "//devices/device[pool='${pool}'][namespace='${ns}'][image='${IMAGE}'][device='${DEV}']/id")
     test -n "${PID}" || return 1
     ps -p ${PID} -C rbd-nbd
@@ -172,17 +170,17 @@ unmap_device ${DEV} ${PID}
 DEV=`_sudo rbd device --device-type nbd --options notrim map ${POOL}/${IMAGE}`
 get_pid ${POOL}
 provisioned=`rbd -p ${POOL} --format xml du ${IMAGE} |
-  $XMLSTARLET sel -t -m "//stats/images/image/provisioned_size" -v .`
+  xmlstarlet sel -t -m "//stats/images/image/provisioned_size" -v .`
 used=`rbd -p ${POOL} --format xml du ${IMAGE} |
-  $XMLSTARLET sel -t -m "//stats/images/image/used_size" -v .`
+  xmlstarlet sel -t -m "//stats/images/image/used_size" -v .`
 [ "${used}" -eq "${provisioned}" ]
 # should fail discard as at time of mapping notrim was used
 expect_false _sudo blkdiscard ${DEV}
 sync
 provisioned=`rbd -p ${POOL} --format xml du ${IMAGE} |
-  $XMLSTARLET sel -t -m "//stats/images/image/provisioned_size" -v .`
+  xmlstarlet sel -t -m "//stats/images/image/provisioned_size" -v .`
 used=`rbd -p ${POOL} --format xml du ${IMAGE} |
-  $XMLSTARLET sel -t -m "//stats/images/image/used_size" -v .`
+  xmlstarlet sel -t -m "//stats/images/image/used_size" -v .`
 [ "${used}" -eq "${provisioned}" ]
 unmap_device ${DEV} ${PID}
 
@@ -190,17 +188,17 @@ unmap_device ${DEV} ${PID}
 DEV=`_sudo rbd device --device-type nbd map ${POOL}/${IMAGE}`
 get_pid ${POOL}
 provisioned=`rbd -p ${POOL} --format xml du ${IMAGE} |
-  $XMLSTARLET sel -t -m "//stats/images/image/provisioned_size" -v .`
+  xmlstarlet sel -t -m "//stats/images/image/provisioned_size" -v .`
 used=`rbd -p ${POOL} --format xml du ${IMAGE} |
-  $XMLSTARLET sel -t -m "//stats/images/image/used_size" -v .`
+  xmlstarlet sel -t -m "//stats/images/image/used_size" -v .`
 [ "${used}" -eq "${provisioned}" ]
 # should honor discard as at time of mapping trim was considered by default
 _sudo blkdiscard ${DEV}
 sync
 provisioned=`rbd -p ${POOL} --format xml du ${IMAGE} |
-  $XMLSTARLET sel -t -m "//stats/images/image/provisioned_size" -v .`
+  xmlstarlet sel -t -m "//stats/images/image/provisioned_size" -v .`
 used=`rbd -p ${POOL} --format xml du ${IMAGE} |
-  $XMLSTARLET sel -t -m "//stats/images/image/used_size" -v .`
+  xmlstarlet sel -t -m "//stats/images/image/used_size" -v .`
 [ "${used}" -lt "${provisioned}" ]
 unmap_device ${DEV} ${PID}
 

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -72,15 +72,6 @@
 #     ../qa/workunits/rbd/rbd_mirror_helpers.sh cleanup
 #
 
-if type xmlstarlet > /dev/null 2>&1; then
-    XMLSTARLET=xmlstarlet
-elif type xml > /dev/null 2>&1; then
-    XMLSTARLET=xml
-else
-    echo "Missing xmlstarlet binary!"
-    exit 1
-fi
-
 RBD_MIRROR_INSTANCES=${RBD_MIRROR_INSTANCES:-2}
 
 CLUSTER1=cluster1
@@ -894,9 +885,9 @@ test_mirror_pool_status_verbose()
                  --verbose --format xml)
 
     local last_update state
-    last_update=$($XMLSTARLET sel -t -v \
+    last_update=$(xmlstarlet sel -t -v \
         "//images/image[name='${image}']/last_update" <<< "$status")
-    state=$($XMLSTARLET sel -t -v \
+    state=$(xmlstarlet sel -t -v \
         "//images/image[name='${image}']/state" <<< "$status")
 
     echo "${state}" | grep "${state_pattern}" ||
@@ -1337,7 +1328,7 @@ compare_image_snapshots()
 
     for snap_name in $(rbd --cluster ${CLUSTER1} --format xml \
                            snap list ${pool}/${image} | \
-                           $XMLSTARLET sel -t -v "//snapshot/name" | \
+                           xmlstarlet sel -t -v "//snapshot/name" | \
                            grep -E -v "^\.rbd-mirror\."); do
         rm -f ${rmt_export} ${loc_export}
         rbd --cluster ${CLUSTER2} export ${pool}/${image}@${snap_name} ${rmt_export}

--- a/qa/workunits/rbd/test_admin_socket.sh
+++ b/qa/workunits/rbd/test_admin_socket.sh
@@ -5,8 +5,6 @@ TMPDIR=/tmp/rbd_test_admin_socket$$
 mkdir $TMPDIR
 trap "rm -fr $TMPDIR" 0
 
-. $(dirname $0)/../../standalone/ceph-helpers.sh
-
 function expect_false()
 {
     set -x
@@ -40,12 +38,12 @@ function rbd_get_perfcounter()
     local name
 
     name=$(ceph --format xml --admin-daemon $(rbd_watch_asok ${image}) \
-		perf schema | $XMLSTARLET el -d3 |
+		perf schema | xmlstarlet el -d3 |
 		  grep "/librbd-.*-${image}/${counter}\$")
     test -n "${name}" || return 1
 
     ceph --format xml --admin-daemon $(rbd_watch_asok ${image}) perf dump |
-	$XMLSTARLET sel -t -m "${name}" -v .
+	xmlstarlet sel -t -m "${name}" -v .
 }
 
 function rbd_check_perfcounter()


### PR DESCRIPTION
The variable was added in commit 9b6b7c35d03f ("Handle differently-named xmlstarlet binary for *suse") but this compatibility business is long outdated:

  Mon Oct 13 08:52:37 UTC 2014 - toms@opensuse.org

  - SPEC file changes
    - Added link from /usr/bin/xml to /usr/bin/xmlstarlet as other distributions do the same
    - Did the same for the manpage





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
