### PR TITLE
qa/tasks/nvmeof.py: add nvmeof gw-group to deployment

### DIFF
--- a/qa/suites/nvmeof/basic/workloads/nvmeof_initiator.yaml
+++ b/qa/suites/nvmeof/basic/workloads/nvmeof_initiator.yaml
@@ -11,7 +11,7 @@ tasks:
       cli_image: quay.io/ceph/nvmeof-cli:1.2
 
 - cephadm.wait_for_service:
-    service: nvmeof.mypool
+    service: nvmeof.mypool.mygroup0
 
 - workunit:
     no_coverage_and_limits: true

--- a/qa/suites/nvmeof/thrash/gateway-initiator-setup/3-subsys-60-namespace.yaml
+++ b/qa/suites/nvmeof/thrash/gateway-initiator-setup/3-subsys-60-namespace.yaml
@@ -11,7 +11,7 @@ tasks:
       cli_image: quay.io/ceph/nvmeof-cli:1.2
 
 - cephadm.wait_for_service:
-    service: nvmeof.mypool
+    service: nvmeof.mypool.mygroup0
 
 - workunit:
     no_coverage_and_limits: true

--- a/qa/tasks/nvmeof.py
+++ b/qa/tasks/nvmeof.py
@@ -64,6 +64,8 @@ class Nvmeof(Task):
 
         gateway_config = self.config.get('gateway_config', {})
         self.cli_image = gateway_config.get('cli_image', 'quay.io/ceph/nvmeof-cli:latest')
+        self.groups_count = gateway_config.get('groups_count', 1)
+        self.groups_prefix = gateway_config.get('groups_prefix', 'mygroup') 
         self.nqn_prefix = gateway_config.get('subsystem_nqn_prefix', 'nqn.2016-06.io.spdk:cnode')
         self.subsystems_count = gateway_config.get('subsystems_count', 1) 
         self.namespaces_count = gateway_config.get('namespaces_count', 1) # namepsaces per subsystem
@@ -114,11 +116,17 @@ class Nvmeof(Task):
                 'rbd', 'pool', 'init', poolname
             ])
 
-            log.info(f'[nvmeof]: ceph orch apply nvmeof {poolname}')
-            _shell(self.ctx, self.cluster_name, self.remote, [
-                'ceph', 'orch', 'apply', 'nvmeof', poolname, 
-                '--placement', str(len(nodes)) + ';' + ';'.join(nodes)
-            ])
+            group_to_nodes = defaultdict(list)
+            for index, node in enumerate(nodes):
+                group_name = self.groups_prefix + str(index % int(self.groups_count))
+                group_to_nodes[group_name] += [node]
+            for group_name in group_to_nodes:
+                gp_nodes = group_to_nodes[group_name]
+                log.info(f'[nvmeof]: ceph orch apply nvmeof {poolname} {group_name}')
+                _shell(self.ctx, self.cluster_name, self.remote, [
+                    'ceph', 'orch', 'apply', 'nvmeof', poolname, group_name,
+                    '--placement', ';'.join(gp_nodes)
+                ])
 
             total_images = int(self.namespaces_count) * int(self.subsystems_count)
             log.info(f'[nvmeof]: creating {total_images} images')


### PR DESCRIPTION
This PR adds nvmeof gateway groups to it's deployment in "nvmeof" teuthology test. 
Groups was made a required parameter to `ceph orch apply nvmeof <pool> <group>` in https://github.com/ceph/ceph/pull/58860. That broke the `nvmeof` suite so this PR fixes that.

Right now, all gateway are deployed in a single group. Later, this would be changed to have 2 gateway groups for a better test.

Results: 
Thrasher (passed): https://pulpito.ceph.com/vallariag-2024-08-26_08:49:55-nvmeof-wip-sjust-nvmeof-testing-nvmeof-reenable-2024-08-24-distro-default-smithi/
Other tests (queued): https://pulpito.ceph.com/vallariag-2024-08-26_09:57:21-nvmeof-wip-sjust-nvmeof-testing-nvmeof-reenable-2024-08-24-distro-default-smithi/

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
