### PR TITLE
squid: rgw: ignore zoneless default realm when not configured

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -79,6 +79,8 @@
   config option. Previously, they would ignore invalid or missing realms and
   go on to load a zone/zonegroup in a different realm. If startup fails with
   a  "failed to load realm" error, fix or remove the ``rgw_realm`` option.
+* rgw: The radosgw-admin commands ``realm create`` and ``realm pull`` no
+  longer set the default realm without ``--default``.
 * CephFS: Running the command "ceph fs authorize" for an existing entity now
   upgrades the entity's capabilities instead of printing an error. It can now
   also change read/write permissions in a capability that the entity already

--- a/src/rgw/driver/rados/rgw_zone.cc
+++ b/src/rgw/driver/rados/rgw_zone.cc
@@ -532,14 +532,6 @@ int create_realm(const DoutPrefixProvider* dpp, optional_yield y,
     return r;
   }
 
-  // try to set as default. may race with another create, so pass exclusive=true
-  // so we don't override an existing default
-  r = set_default_realm(dpp, y, cfgstore, info, true);
-  if (r < 0 && r != -EEXIST) {
-    ldpp_dout(dpp, 0) << "WARNING: failed to set realm as default: "
-        << cpp_strerror(r) << dendl;
-  }
-
   if (writer_out) {
     *writer_out = std::move(writer);
   }

--- a/src/rgw/driver/rados/rgw_zone.cc
+++ b/src/rgw/driver/rados/rgw_zone.cc
@@ -1205,6 +1205,18 @@ int SiteConfig::load(const DoutPrefixProvider* dpp, optional_yield y,
   } else if (realm) {
     // load the realm's default zone
     r = cfgstore->read_default_zone(dpp, y, realm->id, zone_params, nullptr);
+    if (r == -ENOENT) {
+      if (realm_name.empty()) {
+        // rgw_realm was not specified, and we found a default realm that
+        // doesn't have a default zone. ignore the realm and try to load the
+        // global default zone
+        realm = std::nullopt;
+        r = read_or_create_default_zone(dpp, y, cfgstore, zone_params);
+      } else {
+        ldpp_dout(dpp, 0) << "No rgw_zone configured, and the selected realm \""
+            << realm->name << "\" does not have a default zone." << dendl;
+      }
+    }
   } else {
     // load or create the "default" zone
     r = read_or_create_default_zone(dpp, y, cfgstore, zone_params);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -223,6 +223,7 @@ void usage()
   cout << "  realm rename                     rename a realm\n";
   cout << "  realm set                        set realm info (requires infile)\n";
   cout << "  realm default                    set realm as default\n";
+  cout << "  realm default rm                 clear the current default realm\n";
   cout << "  realm pull                       pull a realm and its current period\n";
   cout << "  zonegroup add                    add a zone to a zonegroup\n";
   cout << "  zonegroup create                 create a new zone group info\n";
@@ -815,6 +816,7 @@ enum class OPT {
   REALM_RENAME,
   REALM_SET,
   REALM_DEFAULT,
+  REALM_DEFAULT_RM,
   REALM_PULL,
   PERIOD_DELETE,
   PERIOD_GET,
@@ -1056,6 +1058,7 @@ static SimpleCmd::Commands all_cmds = {
   { "realm rename", OPT::REALM_RENAME },
   { "realm set", OPT::REALM_SET },
   { "realm default", OPT::REALM_DEFAULT },
+  { "realm default rm", OPT::REALM_DEFAULT_RM },
   { "realm pull", OPT::REALM_PULL },
   { "period delete", OPT::PERIOD_DELETE },
   { "period get", OPT::PERIOD_GET },
@@ -4252,7 +4255,7 @@ int main(int argc, const char **argv)
 			 OPT::REALM_LIST_PERIODS,
 			 OPT::REALM_GET_DEFAULT,
 			 OPT::REALM_RENAME, OPT::REALM_SET,
-			 OPT::REALM_DEFAULT, OPT::REALM_PULL};
+			 OPT::REALM_DEFAULT, OPT::REALM_DEFAULT_RM, OPT::REALM_PULL};
 
     std::set<OPT> readonly_ops_list = {
                          OPT::USER_INFO,
@@ -5106,6 +5109,12 @@ int main(int argc, const char **argv)
 	  cerr << "failed to set realm as default: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
+      }
+      break;
+    case OPT::REALM_DEFAULT_RM:
+      if (int ret = cfgstore->delete_default_realm_id(dpp(), null_yield); ret < 0) {
+        cerr << "failed to remove default realm: " << cpp_strerror(-ret) << std::endl;
+        return -ret;
       }
       break;
     case OPT::REALM_PULL:

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -88,6 +88,7 @@
     realm rename                     rename a realm
     realm set                        set realm info (requires infile)
     realm default                    set realm as default
+    realm default rm                 clear the current default realm
     realm pull                       pull a realm and its current period
     zonegroup add                    add a zone to a zonegroup
     zonegroup create                 create a new zone group info

--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -251,7 +251,7 @@ def init(parse_args):
     realm = multisite.Realm('r')
     if bootstrap:
         # create the realm on c1
-        realm.create(c1)
+        realm.create(c1, ['--default'])
     else:
         realm.get(c1)
     period = multisite.Period(realm=realm)
@@ -305,7 +305,7 @@ def init(parse_args):
                     cluster.start()
                     # pull realm configuration from the master's gateway
                     gateway = realm.meta_master_zone().gateways[0]
-                    realm.pull(cluster, gateway, admin_creds)
+                    realm.pull(cluster, gateway, admin_creds, ['--default'])
 
             endpoints = zone_endpoints(zg, z, args.gateways_per_zone)
             if is_master:

--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -382,7 +382,9 @@ def init(parse_args):
                     arg += admin_creds.credential_args()
                     admin_user.create(zone, arg)
                     # create test account/user
-                    cluster.admin(['account', 'create', '--account-id', user.account])
+                    arg = ['--account-id', user.account]
+                    arg += zone.zone_args()
+                    cluster.admin(['account', 'create'] + arg)
                     arg = ['--display-name', 'TestUser']
                     arg += user_creds.credential_args()
                     user.create(zone, arg)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67723

---

backport of https://github.com/ceph/ceph/pull/59422
parent tracker: https://tracker.ceph.com/issues/67697

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh