### PR TITLE
reef: cephadm: add idmap.conf to nfs sample file

### DIFF
--- a/src/cephadm/samples/nfs.json
+++ b/src/cephadm/samples/nfs.json
@@ -9,6 +9,7 @@
             "",
             "%url    rados://nfs-ganesha/nfs-ns/conf-nfs.a",
             ""
-        ]
+        ],
+        "idmap.conf": ""
     }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/65416

---

backport of https://github.com/ceph/ceph/pull/56481
parent tracker: https://tracker.ceph.com/issues/65155

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh