### PR TITLE
reef: mgr/cephadm: make SMB and NVMEoF upgrade last in staggered upgrade

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -9,7 +9,7 @@ from cephadm.registry import Registry
 from cephadm.serve import CephadmServe
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 from cephadm.utils import ceph_release_to_major, name_to_config_section, CEPH_UPGRADE_ORDER, \
-    CEPH_TYPES, NON_CEPH_IMAGE_TYPES, GATEWAY_TYPES
+    CEPH_TYPES, CEPH_IMAGE_TYPES, NON_CEPH_IMAGE_TYPES, MONITORING_STACK_TYPES, GATEWAY_TYPES
 from cephadm.ssh import HostConnectionError
 from orchestrator import OrchestratorError, DaemonDescription, DaemonDescriptionStatus, daemon_type_to_service
 
@@ -1187,8 +1187,10 @@ class CephadmUpgrade:
             upgraded_daemon_count += done
             self._update_upgrade_progress(upgraded_daemon_count / len(daemons))
 
-            # make sure mgr and non-ceph-image daemons are properly redeployed in staggered upgrade scenarios
-            if daemon_type == 'mgr' or daemon_type in NON_CEPH_IMAGE_TYPES:
+            # make sure mgr and monitoring stack daemons are properly redeployed in staggered upgrade scenarios
+            # The idea here is to upgrade the mointoring daemons after the mgr is done upgrading as
+            # that means cephadm and the dashboard modules themselves have been upgraded
+            if daemon_type == 'mgr' or daemon_type in MONITORING_STACK_TYPES:
                 if any(d in target_digests for d in self.mgr.get_active_mgr_digests()):
                     need_upgrade_names = [d[0].name() for d in need_upgrade] + \
                         [d[0].name() for d in need_upgrade_deployer]
@@ -1202,6 +1204,20 @@ class CephadmUpgrade:
                 else:
                     # no point in trying to redeploy with new version if active mgr is not on the new version
                     need_upgrade_deployer = []
+            elif daemon_type in NON_CEPH_IMAGE_TYPES:
+                # Also handle daemons that are not on the ceph image but aren't monitoring daemons.
+                # This needs to be handled differently than the monitoring daemons as the nvmeof daemon,
+                # which falls in this category, relies on the mons being upgraded as well. This block
+                # sets these daemon types to be upgraded only when all ceph image daemons have been upgraded
+                if any(d in target_digests for d in self.mgr.get_active_mgr_digests()):
+                    ceph_daemons = [d for d in self.mgr.cache.get_daemons() if d.daemon_type in CEPH_IMAGE_TYPES]
+                    _, n1, n2, __ = self._detect_need_upgrade(ceph_daemons, target_digests, target_image)
+                    if not n1 and not n2:
+                        # no ceph daemons need upgrade
+                        dds = [d for d in self.mgr.cache.get_daemons_by_type(
+                            daemon_type) if d.name() not in need_upgrade_names]
+                        _, ___, n2, ____ = self._detect_need_upgrade(dds, target_digests, target_image)
+                        need_upgrade_deployer += n2
 
             if any(d in target_digests for d in self.mgr.get_active_mgr_digests()):
                 # only after the mgr itself is upgraded can we expect daemons to have


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/66428

---

backport of https://github.com/ceph/ceph/pull/57292
parent tracker: https://tracker.ceph.com/issues/65809

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh