### PR TITLE
reef: qa/distros: reinstall nvme-cli on centos 9 nodes

### DIFF
--- a/qa/distros/container-hosts/centos_9.stream.yaml
+++ b/qa/distros/container-hosts/centos_9.stream.yaml
@@ -8,4 +8,7 @@ overrides:
 tasks:
 - pexec:
     all:
+    # in order to work around a possible nvme-cli <-> libnvme linking issue
+    # See https://tracker.ceph.com/issues/67684
+    - sudo dnf remove nvme-cli -y
     - sudo dnf install nvmetcli nvme-cli -y

--- a/qa/distros/container-hosts/centos_9.stream_runc.yaml
+++ b/qa/distros/container-hosts/centos_9.stream_runc.yaml
@@ -8,6 +8,9 @@ overrides:
 tasks:
 - pexec:
     all:
+    # in order to work around a possible nvme-cli <-> libnvme linking issue
+    # See https://tracker.ceph.com/issues/67684
+    - sudo dnf remove nvme-cli -y
     - sudo dnf install runc nvmetcli nvme-cli -y
     - sudo sed -i 's/^#runtime = "crun"/runtime = "runc"/g' /usr/share/containers/containers.conf
     - sudo sed -i 's/runtime = "crun"/#runtime = "crun"/g' /usr/share/containers/containers.conf


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67733

---

backport of https://github.com/ceph/ceph/pull/59409
parent tracker: https://tracker.ceph.com/issues/67684

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh