### PR TITLE
qa: correct daemon for warning conf 

### DIFF
--- a/qa/cephfs/conf/mgr.yaml
+++ b/qa/cephfs/conf/mgr.yaml
@@ -1,8 +1,9 @@
 overrides:
   ceph:
-    conf:
+    cluster-conf:
       mgr:
         client mount timeout: 30
         debug client: 20
         debug mgr: 20
         debug ms: 1
+        mon warn on pool no app: false

--- a/qa/cephfs/conf/mon.yaml
+++ b/qa/cephfs/conf/mon.yaml
@@ -3,7 +3,6 @@ overrides:
     cluster-conf:
       mon:
         mon op complaint time: 120
-        mon warn on pool no app: false
     # cephadm can take up to 5 minutes to bring up remaining mons
     # This needs to be set before cluster-conf configs are applied.
     conf:

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -414,6 +414,15 @@ def conf_setup(ctx, config):
     for p in procs:
         log.debug("waiting for %s", p)
         p.wait()
+    cmd = [
+        'sudo',
+        'ceph',
+        '--cluster',
+        cluster_name,
+        'config',
+        'dump',
+    ]
+    mon_remote.run(args=cmd)
     yield
 
 @contextlib.contextmanager

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1849,6 +1849,12 @@ def conf_setup(ctx, config):
     for p in procs:
         log.debug("waiting for %s", p)
         p.wait()
+    cmd = [
+        'ceph',
+        'config',
+        'dump',
+    ]
+    _shell(ctx, cluster_name, remote, args=cmd)
     yield
 
 @contextlib.contextmanager


### PR DESCRIPTION
The mgr emits this health check instead of the mons.

Fixes: https://tracker.ceph.com/issues/67737





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
