### PR TITLE
crush: require non-leaf failure domain in add_multi_osd_per_failure_domain_rule_at

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -2411,7 +2411,19 @@ int CrushWrapper::add_multi_osd_per_failure_domain_rule_at(
       if (err)
 	*err << "unknown type " << failure_domain_name;
       return -EINVAL;
+    } else if (type == 0) {
+      if (err) {
+	*err << "cannot automatically create msr rule with leaf failure domain: "
+	     << failure_domain_name;
+      }
+      return -EINVAL;
     }
+  } else {
+    if (err) {
+      *err << "cannot automatically create msr rule without "
+	   << "failure domain specified";
+    }
+    return -EINVAL;
   }
   if (device_class.size()) {
     if (!class_exists(device_class)) {


### PR DESCRIPTION
Disallows specifying osd as failure domain or failing to specify a failure domain.

Fixes: https://tracker.ceph.com/issues/67756

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
