### PR TITLE
rbd: amend "rbd {group,} rename" and "rbd mirror pool" command descriptions

### DIFF
--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -51,7 +51,8 @@
       group info                        Show information about a group.
       group list (group ls)             List rbd groups.
       group remove (group rm)           Delete a group.
-      group rename                      Rename a group within pool.
+      group rename                      Rename a group within its pool or
+                                        namespace.
       group snap create                 Make a snapshot of a group.
       group snap info                   Show information about a group snapshot.
       group snap list (... ls)          List snapshots of a group.
@@ -133,7 +134,8 @@
       pool init                         Initialize pool for use by RBD.
       pool stats                        Display pool statistics.
       remove (rm)                       Delete an image.
-      rename (mv)                       Rename image within pool.
+      rename (mv)                       Rename an image within its pool or
+                                        namespace.
       resize                            Resize (expand or shrink) image.
       snap create (snap add)            Create a snapshot.
       snap limit clear                  Remove snapshot limit.
@@ -1034,7 +1036,7 @@
                           [--dest-group <dest-group>] 
                           <source-group-spec> <dest-group-spec> 
   
-  Rename a group within pool.
+  Rename a group within its pool or namespace.
   
   Positional arguments
     <source-group-spec>  source group specification
@@ -2262,7 +2264,7 @@
                     [--dest-namespace <dest-namespace>] [--dest <dest>] 
                     <source-image-spec> <dest-image-spec> 
   
-  Rename image within pool.
+  Rename an image within its pool or namespace.
   
   Positional arguments
     <source-image-spec>  source image specification

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -97,13 +97,14 @@
                                         mirroring.
       mirror image snapshot             Create RBD mirroring image snapshot.
       mirror image status               Show RBD mirroring status for an image.
-      mirror pool demote                Demote all primary images in the pool.
-      mirror pool disable               Disable RBD mirroring by default within a
-                                        pool.
-      mirror pool enable                Enable RBD mirroring by default within a
-                                        pool.
-      mirror pool info                  Show information about the pool mirroring
-                                        configuration.
+      mirror pool demote                Demote all primary images in a pool or
+                                        namespace.
+      mirror pool disable               Disable RBD mirroring in a pool or
+                                        namespace.
+      mirror pool enable                Enable RBD mirroring in a pool or
+                                        namespace.
+      mirror pool info                  Show mirroring configuration for a pool
+                                        or namespace.
       mirror pool peer add              Add a mirroring peer to a pool.
       mirror pool peer bootstrap create Create a peer bootstrap token to import
                                         in a remote cluster
@@ -111,10 +112,10 @@
                                         from a remote cluster
       mirror pool peer remove           Remove a mirroring peer from a pool.
       mirror pool peer set              Update mirroring peer settings.
-      mirror pool promote               Promote all non-primary images in the
-                                        pool.
-      mirror pool status                Show status for all mirrored images in
-                                        the pool.
+      mirror pool promote               Promote all non-primary images in a pool
+                                        or namespace.
+      mirror pool status                Show status for all mirrored images in a
+                                        pool or namespace.
       mirror snapshot schedule add      Add mirror snapshot schedule.
       mirror snapshot schedule list (... ls)
                                         List mirror snapshot schedule.
@@ -1804,7 +1805,7 @@
   usage: rbd mirror pool demote [--pool <pool>] [--namespace <namespace>] 
                                 <pool-spec> 
   
-  Demote all primary images in the pool.
+  Demote all primary images in a pool or namespace.
   
   Positional arguments
     <pool-spec>          pool specification
@@ -1818,7 +1819,7 @@
   usage: rbd mirror pool disable [--pool <pool>] [--namespace <namespace>] 
                                  <pool-spec> 
   
-  Disable RBD mirroring by default within a pool.
+  Disable RBD mirroring in a pool or namespace.
   
   Positional arguments
     <pool-spec>          pool specification
@@ -1833,7 +1834,7 @@
                                 [--site-name <site-name>] 
                                 <pool-spec> <mode> 
   
-  Enable RBD mirroring by default within a pool.
+  Enable RBD mirroring in a pool or namespace.
   
   Positional arguments
     <pool-spec>          pool specification
@@ -1850,7 +1851,7 @@
                               [--format <format>] [--pretty-format] [--all] 
                               <pool-spec> 
   
-  Show information about the pool mirroring configuration.
+  Show mirroring configuration for a pool or namespace.
   
   Positional arguments
     <pool-spec>          pool specification
@@ -1958,7 +1959,7 @@
                                  [--namespace <namespace>] 
                                  <pool-spec> 
   
-  Promote all non-primary images in the pool.
+  Promote all non-primary images in a pool or namespace.
   
   Positional arguments
     <pool-spec>          pool specification
@@ -1974,7 +1975,7 @@
                                 [--format <format>] [--pretty-format] [--verbose] 
                                 <pool-spec> 
   
-  Show status for all mirrored images in the pool.
+  Show status for all mirrored images in a pool or namespace.
   
   Positional arguments
     <pool-spec>          pool specification

--- a/src/tools/rbd/action/Group.cc
+++ b/src/tools/rbd/action/Group.cc
@@ -1046,7 +1046,7 @@ Shell::Action action_list(
   {"group", "list"}, {"group", "ls"}, "List rbd groups.",
   "", &get_list_arguments, &execute_list);
 Shell::Action action_rename(
-  {"group", "rename"}, {}, "Rename a group within pool.",
+  {"group", "rename"}, {}, "Rename a group within its pool or namespace.",
   "", &get_rename_arguments, &execute_rename);
 Shell::Action action_info(
   {"group", "info"}, {}, "Show information about a group.",

--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -1744,27 +1744,27 @@ Shell::Action action_set(
 
 Shell::Action action_disable(
   {"mirror", "pool", "disable"}, {},
-  "Disable RBD mirroring by default within a pool.", "",
+  "Disable RBD mirroring in a pool or namespace.", "",
   &get_disable_arguments, &execute_disable);
 Shell::Action action_enable(
   {"mirror", "pool", "enable"}, {},
-  "Enable RBD mirroring by default within a pool.", "",
+  "Enable RBD mirroring in a pool or namespace.", "",
   &get_enable_arguments, &execute_enable);
 Shell::Action action_info(
   {"mirror", "pool", "info"}, {},
-  "Show information about the pool mirroring configuration.", {},
+  "Show mirroring configuration for a pool or namespace.", {},
   &get_info_arguments, &execute_info);
 Shell::Action action_status(
   {"mirror", "pool", "status"}, {},
-  "Show status for all mirrored images in the pool.", {},
+  "Show status for all mirrored images in a pool or namespace.", {},
   &get_status_arguments, &execute_status);
 Shell::Action action_promote(
   {"mirror", "pool", "promote"}, {},
-  "Promote all non-primary images in the pool.", {},
+  "Promote all non-primary images in a pool or namespace.", {},
   &get_promote_arguments, &execute_promote);
 Shell::Action action_demote(
   {"mirror", "pool", "demote"}, {},
-  "Demote all primary images in the pool.", {},
+  "Demote all primary images in a pool or namespace.", {},
   &get_demote_arguments, &execute_demote);
 
 } // namespace mirror_pool

--- a/src/tools/rbd/action/Rename.cc
+++ b/src/tools/rbd/action/Rename.cc
@@ -86,8 +86,8 @@ int execute(const po::variables_map &vm,
 }
 
 Shell::Action action(
-  {"rename"}, {"mv"}, "Rename image within pool.", "", &get_arguments,
-  &execute);
+  {"rename"}, {"mv"}, "Rename an image within its pool or namespace.", "",
+  &get_arguments, &execute);
 
 } // namespace rename
 } // namespace action


### PR DESCRIPTION
Make it clearer that, despite a full image or group spec being taken for source and destination, an image or a group can be renamed only within its pool or namespace.

Rename across pools or namespaces within the same pool is unsupported.

Fixes: https://tracker.ceph.com/issues/67752





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
