### PR TITLE
Further EC partial stripe read fixes

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -132,7 +132,7 @@ ECBackend::ECBackend(
     rmw_pipeline(cct, ec_impl, this->sinfo, get_parent()->get_eclistener(), *this),
     recovery_backend(cct, this->coll, ec_impl, this->sinfo, read_pipeline, unstable_hashinfo_registry, get_parent(), this),
     ec_impl(ec_impl),
-    sinfo(ec_impl->get_data_chunk_count(), stripe_width),
+    sinfo(ec_impl, stripe_width),
     unstable_hashinfo_registry(cct, ec_impl) {
   ceph_assert((ec_impl->get_data_chunk_count() *
 	  ec_impl->get_chunk_size(stripe_width)) == stripe_width);
@@ -990,8 +990,7 @@ void ECBackend::handle_sub_write(
     async);
 
   if (!get_parent()->pg_is_undersized() &&
-      (unsigned)get_parent()->whoami_shard().shard >=
-      ec_impl->get_data_chunk_count())
+      (unsigned)get_parent()->whoami_shard().shard >= sinfo.get_k())
     op.t.set_fadvise_flag(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
 
   localt.register_on_commit(

--- a/src/osd/ECCommon.cc
+++ b/src/osd/ECCommon.cc
@@ -561,7 +561,8 @@ struct ClientReadCompleter : ECCommon::ReadCompleter {
       uint64_t chunk_size = read_pipeline.sinfo.get_chunk_size();
       uint64_t trim_offset = 0;
       for (auto shard : wanted_to_read) {
-	if (shard * chunk_size < aligned_offset_in_stripe) {
+	if (read_pipeline.sinfo.get_raw_shard(shard) * chunk_size <
+	    aligned_offset_in_stripe) {
 	  trim_offset += chunk_size;
 	} else {
 	  break;

--- a/src/osd/ECCommon.h
+++ b/src/osd/ECCommon.h
@@ -460,7 +460,6 @@ struct ECCommon {
       const uint64_t offset,
       const uint64_t length,
       const ECUtil::stripe_info_t& sinfo,
-      const std::vector<int>& chunk_mapping,
       std::set<int> *want_to_read);
 
     int get_remaining_shards(

--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -13,9 +13,10 @@ using ceph::Formatter;
 
 std::pair<uint64_t, uint64_t> ECUtil::stripe_info_t::chunk_aligned_offset_len_to_chunk(
   std::pair<uint64_t, uint64_t> in) const {
+  pair<uint64_t, uint64_t> tmp = offset_len_to_stripe_bounds(in);
   return std::make_pair(
-    chunk_aligned_logical_offset_to_chunk_offset(in.first),
-    chunk_aligned_logical_size_to_chunk_size(in.second));
+    chunk_aligned_logical_offset_to_chunk_offset(tmp.first),
+    chunk_aligned_logical_size_to_chunk_size(tmp.second));
 }
 
 int ECUtil::decode(

--- a/src/test/crimson/test_crimson_scrub.cc
+++ b/src/test/crimson/test_crimson_scrub.cc
@@ -280,7 +280,7 @@ struct test_obj_t : so_builder_t {
   static test_obj_t make_ec_head(const std::string &desc, Args&&... args) {
     return make(
       desc,
-      ECUtil::stripe_info_t{4, 1<<20},
+      ECUtil::stripe_info_t{4, 2, 1<<20},
       so_builder_t::make_ec_head(std::forward<Args>(args)...));
   }
 
@@ -288,7 +288,7 @@ struct test_obj_t : so_builder_t {
   static test_obj_t make_ec_clone(const std::string &desc, Args&&... args) {
     return make(
       desc,
-      ECUtil::stripe_info_t{4, 1<<20},
+      ECUtil::stripe_info_t{4, 2, 1<<20},
       so_builder_t::make_ec_clone(std::forward<Args>(args)...));
   }
 

--- a/src/test/osd/TestECBackend.cc
+++ b/src/test/osd/TestECBackend.cc
@@ -54,20 +54,32 @@ TEST(ECUtil, stripe_info_t)
   ASSERT_EQ(s.aligned_chunk_offset_to_logical_offset(2*s.get_chunk_size()),
 	    2*s.get_stripe_width());
 
+  // Stripe 1 + 1 chunk for 10 stripes needs to read 11 stripes starting
+  // from 1 because there is a partial stripe at the start and end
   ASSERT_EQ(s.chunk_aligned_offset_len_to_chunk(
 	      make_pair(swidth+s.get_chunk_size(), 10*swidth)),
-	    make_pair(s.get_chunk_size(), 10*s.get_chunk_size()));
+	    make_pair(s.get_chunk_size(), 11*s.get_chunk_size()));
 
+  // Stripe 1 + 0 chunks for 10 stripes needs to read 10 stripes starting
+  // from 1 because there are no partial stripes
   ASSERT_EQ(s.chunk_aligned_offset_len_to_chunk(make_pair(swidth, 10*swidth)),
 	    make_pair(s.get_chunk_size(), 10*s.get_chunk_size()));
 
-  // round down offset if it's under stripe width
+  // Stripe 0 + 1 chunk for 10 stripes needs to read 11 stripes starting
+  // from 0 because there is a partial stripe at the start and end
   ASSERT_EQ(s.chunk_aligned_offset_len_to_chunk(make_pair(s.get_chunk_size(), 10*swidth)),
-	    make_pair<uint64_t>(0, 10*s.get_chunk_size()));
+	    make_pair<uint64_t>(0, 11*s.get_chunk_size()));
 
-  // round up size if above stripe
+  // Stripe 0 + 1 chunk for (10 stripes + 1 chunk) needs to read 11 stripes
+  // starting from 0 because there is a partial stripe at the start and end
   ASSERT_EQ(s.chunk_aligned_offset_len_to_chunk(make_pair(s.get_chunk_size(),
 							  10*swidth + s.get_chunk_size())),
+	    make_pair<uint64_t>(0, 11*s.get_chunk_size()));
+
+  // Stripe 0 + 2 chunks for (10 stripes + 2 chunks) needs to read 11 stripes
+  // starting from 0 because there is a partial stripe at the start
+  ASSERT_EQ(s.chunk_aligned_offset_len_to_chunk(make_pair(2*s.get_chunk_size(),
+							  10*swidth + 2*s.get_chunk_size())),
 	    make_pair<uint64_t>(0, 11*s.get_chunk_size()));
 
   ASSERT_EQ(s.offset_len_to_stripe_bounds(make_pair(swidth-10, (uint64_t)20)),

--- a/src/test/osd/test_ec_transaction.cc
+++ b/src/test/osd/test_ec_transaction.cc
@@ -37,7 +37,7 @@ TEST(ectransaction, two_writes_separated)
   b.append_zero(2437120);
   t->write(h, 669856, b.length(), b, 0);
 
-  ECUtil::stripe_info_t sinfo(2, 8192);
+  ECUtil::stripe_info_t sinfo(2, 2, 8192);
   auto plan = ECTransaction::get_write_plan(
     sinfo,
     *t,
@@ -61,7 +61,7 @@ TEST(ectransaction, two_writes_nearby)
   t->create(h);
 
   // two nearby writes, both partly touching the same 8192-byte stripe
-  ECUtil::stripe_info_t sinfo(2, 8192);
+  ECUtil::stripe_info_t sinfo(2, 2, 8192);
   a.append_zero(565760);
   t->write(h, 0, a.length(), a, 0);
   b.append_zero(2437120);
@@ -91,7 +91,7 @@ TEST(ectransaction, many_writes)
   b.append_zero(4096);
   t->create(h);
 
-  ECUtil::stripe_info_t sinfo(2, 8192);
+  ECUtil::stripe_info_t sinfo(2, 2, 8192);
   // write 2801664~512
   // write 2802176~512
   // write 2802688~512

--- a/src/tools/erasure-code/ceph-erasure-code-tool.cc
+++ b/src/tools/erasure-code/ceph-erasure-code-tool.cc
@@ -96,7 +96,7 @@ int ec_init(const std::string &profile_str,
   uint64_t stripe_size = atoi(profile["k"].c_str());
   ceph_assert(stripe_size > 0);
   uint64_t stripe_width = stripe_size * stripe_unit;
-  sinfo->reset(new ECUtil::stripe_info_t(stripe_size, stripe_width));
+  sinfo->reset(new ECUtil::stripe_info_t(*ec_impl, stripe_width));
 
   return 0;
 }


### PR DESCRIPTION
osd: further EC partial stripe read fixes

* More fixes for multi-region reads
* Enable partial stripe reads that span stripes

ECUtil::stripe_info_t::chunk_aligned_offset_len_to_chunk is fixed to return the correct span of a shard that needs to be read to obtain all the data for a specified range of the object. Previously this did not read enough data if the range was multiple stripes and was not stripe aligned.

finish_single_request is fixed to trim the data that is read. For partial reads of more than one stripe the shards that are read (wanted_to_read) is a union of the requirements for each range. This means there can be excess data that needs to be trimmed.

Example 1: chunksize = 4K, 2+2 profile. read offset 4K for length 8K

* chunk_aligned_offset_len_to_chunk calculates that we need to read offset 0, length 8K (first two stripes) from each shard
* shard 0 and shard 1 need to be read so we end up with 2*8K = 16K of data
* finish_single_request needs to trim the data read to remove the first 4K and last 4K

Example 2: chunksize = 4K, 5+2 profile. read offset 8K for 4K, offset 20K for 4K, offset 56K for 4K

* chunk_aligned_offset_len_to_chunk calculates that we need to read:
** offset 0, length 4K (first stripe) from each shard for 1st read
** offset 4K, length 4K (second stripe) from each shard for 2nd read
** offset 8K, length 4K (third stripe) from each shard for 3rd read
* shards 0, 2 and 4 need to be read so we end up with 3*12K = 36K of data
** stripe 0, shard 0,2 and 4
** stripe 1, shard 0,2 and 4
** stripe 2, shard 0,2 and 4
* finish_single_request needs to trim the data read:
** offset=4K (stripe 0, shard 2), length 4K for 1st read
** offset=12K (stripe 1, shard 0), length 4K for 2nd read
** offset=32K (stripe 2, shard 4), length 4K for 3rd read

Unit tests have been updated. Core has no good test tool for validating multi-region reads, regressions were found by librbd LUKs tests. A new test tool designed to perform better validation of read and write I/O to erasure coded pools will be delivered by another PR, this change has been tested and debugged with an early version of that tool.

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
