### PR TITLE
mgr/dashboard: add gw_groups support to nvmeof api

### DIFF
--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -145,7 +145,8 @@ class NvmeofService(CephService):
                         'prefix': 'dashboard nvmeof-gateway-add',
                         'inbuf': service_url,
                         'name': service_name,
-                        'group': spec.group
+                        'group': spec.group,
+                        'daemon_name': dd.name()
                     })
             return cmd_dicts
 

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -144,7 +144,8 @@ class NvmeofService(CephService):
                     cmd_dicts.append({
                         'prefix': 'dashboard nvmeof-gateway-add',
                         'inbuf': service_url,
-                        'name': service_name
+                        'name': service_name,
+                        'group': spec.group
                     })
             return cmd_dicts
 

--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -2,6 +2,8 @@
 import logging
 from typing import Any, Dict, Optional
 
+from orchestrator import OrchestratorError
+
 from .. import mgr
 from ..model import nvmeof as model
 from ..security import Scope
@@ -34,6 +36,19 @@ else:
             return NVMeoFClient(gw_group=gw_group).stub.get_gateway_info(
                 NVMeoFClient.pb2.get_gateway_info_req()
             )
+
+        @ReadPermission
+        @Endpoint('GET')
+        def group(self):
+            try:
+                orch = OrchClient.instance()
+                return orch.services.list(service_type='nvmeof')
+            except OrchestratorError as e:
+                # just return none instead of raising an exception
+                # since we need this to work regardless of the status
+                # of orchestrator in UI
+                logger.error('Failed to fetch the gateway groups: %s', e)
+                return None
 
     @APIRouter("/nvmeof/subsystem", Scope.NVME_OF)
     @APIDoc("NVMe-oF Subsystem Management API", "NVMe-oF Subsystem")

--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -30,8 +30,8 @@ else:
         @EndpointDoc("Get information about the NVMeoF gateway")
         @map_model(model.GatewayInfo)
         @handle_nvmeof_error
-        def list(self):
-            return NVMeoFClient().stub.get_gateway_info(
+        def list(self, gw_group: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group).stub.get_gateway_info(
                 NVMeoFClient.pb2.get_gateway_info_req()
             )
 
@@ -41,8 +41,8 @@ else:
         @EndpointDoc("List all NVMeoF subsystems")
         @map_collection(model.Subsystem, pick="subsystems")
         @handle_nvmeof_error
-        def list(self):
-            return NVMeoFClient().stub.list_subsystems(
+        def list(self, gw_group: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group).stub.list_subsystems(
                 NVMeoFClient.pb2.list_subsystems_req()
             )
 
@@ -52,8 +52,8 @@ else:
         )
         @map_model(model.Subsystem, first="subsystems")
         @handle_nvmeof_error
-        def get(self, nqn: str):
-            return NVMeoFClient().stub.list_subsystems(
+        def get(self, nqn: str, gw_group: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group).stub.list_subsystems(
                 NVMeoFClient.pb2.list_subsystems_req(subsystem_nqn=nqn)
             )
 
@@ -67,8 +67,9 @@ else:
         )
         @empty_response
         @handle_nvmeof_error
-        def create(self, nqn: str, enable_ha: bool, max_namespaces: int = 1024):
-            return NVMeoFClient().stub.create_subsystem(
+        def create(self, nqn: str, enable_ha: bool, max_namespaces: int = 1024,
+                   gw_group: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group).stub.create_subsystem(
                 NVMeoFClient.pb2.create_subsystem_req(
                     subsystem_nqn=nqn, max_namespaces=max_namespaces, enable_ha=enable_ha
                 )
@@ -83,8 +84,8 @@ else:
         )
         @empty_response
         @handle_nvmeof_error
-        def delete(self, nqn: str, force: Optional[str] = "false"):
-            return NVMeoFClient().stub.delete_subsystem(
+        def delete(self, nqn: str, force: Optional[str] = "false", gw_group: Optional[str] = None):
+            return NVMeoFClient(gw_group=gw_group).stub.delete_subsystem(
                 NVMeoFClient.pb2.delete_subsystem_req(
                     subsystem_nqn=nqn, force=str_to_bool(force)
                 )

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -8208,6 +8208,28 @@ paths:
       summary: Get information about the NVMeoF gateway
       tags:
       - NVMe-oF Gateway
+  /api/nvmeof/gateway/group:
+    get:
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: OK
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - NVMe-oF Gateway
   /api/nvmeof/subsystem:
     get:
       parameters:

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -8182,7 +8182,12 @@ paths:
       - NFS-Ganesha
   /api/nvmeof/gateway:
     get:
-      parameters: []
+      parameters:
+      - allowEmptyValue: true
+        in: query
+        name: gw_group
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -8205,7 +8210,12 @@ paths:
       - NVMe-oF Gateway
   /api/nvmeof/subsystem:
     get:
-      parameters: []
+      parameters:
+      - allowEmptyValue: true
+        in: query
+        name: gw_group
+        schema:
+          type: string
       responses:
         '200':
           content:
@@ -8236,6 +8246,8 @@ paths:
                 enable_ha:
                   description: Enable high availability
                   type: boolean
+                gw_group:
+                  type: string
                 max_namespaces:
                   default: 1024
                   description: Maximum number of namespaces
@@ -8287,6 +8299,11 @@ paths:
         name: force
         schema:
           type: boolean
+      - allowEmptyValue: true
+        in: query
+        name: gw_group
+        schema:
+          type: string
       responses:
         '202':
           content:
@@ -8318,6 +8335,11 @@ paths:
         in: path
         name: nqn
         required: true
+        schema:
+          type: string
+      - allowEmptyValue: true
+        in: query
+        name: gw_group
         schema:
           type: string
       responses:

--- a/src/pybind/mgr/dashboard/services/nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_cli.py
@@ -19,13 +19,13 @@ def list_nvmeof_gateways(_):
 
 @CLIWriteCommand('dashboard nvmeof-gateway-add')
 @CLICheckNonemptyFileInput(desc='NVMe-oF gateway configuration')
-def add_nvmeof_gateway(_, inbuf, name: str):
+def add_nvmeof_gateway(_, inbuf, name: str, group: str):
     '''
     Add NVMe-oF gateway configuration. Gateway URL read from -i <file>
     '''
     service_url = inbuf
     try:
-        NvmeofGatewaysConfig.add_gateway(name, service_url)
+        NvmeofGatewaysConfig.add_gateway(name, service_url, group)
         return 0, 'Success', ''
     except NvmeofGatewayAlreadyExists as ex:
         return -errno.EEXIST, '', str(ex)

--- a/src/pybind/mgr/dashboard/services/nvmeof_cli.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_cli.py
@@ -19,13 +19,13 @@ def list_nvmeof_gateways(_):
 
 @CLIWriteCommand('dashboard nvmeof-gateway-add')
 @CLICheckNonemptyFileInput(desc='NVMe-oF gateway configuration')
-def add_nvmeof_gateway(_, inbuf, name: str, group: str):
+def add_nvmeof_gateway(_, inbuf, name: str, group: str, daemon_name: str):
     '''
     Add NVMe-oF gateway configuration. Gateway URL read from -i <file>
     '''
     service_url = inbuf
     try:
-        NvmeofGatewaysConfig.add_gateway(name, service_url, group)
+        NvmeofGatewaysConfig.add_gateway(name, service_url, group, daemon_name)
         return 0, 'Success', ''
     except NvmeofGatewayAlreadyExists as ex:
         return -errno.EEXIST, '', str(ex)

--- a/src/pybind/mgr/dashboard/services/nvmeof_client.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_client.py
@@ -22,13 +22,24 @@ else:
     class NVMeoFClient(object):
         pb2 = pb2
 
-        def __init__(self):
+        def __init__(self, gw_group: Optional[str] = None):
             logger.info("Initiating nvmeof gateway connection...")
-            service_name, self.gateway_addr = NvmeofGatewaysConfig.get_service_info()
+            try:
+                if not gw_group:
+                    service_name, self.gateway_addr = NvmeofGatewaysConfig.get_service_info()
+                else:
+                    service_name, self.gateway_addr = NvmeofGatewaysConfig.get_service_info(
+                        gw_group
+                    )
+            except TypeError as e:
+                raise DashboardException(
+                    f'Unable to retrieve the gateway info: {e}'
+                )
 
             root_ca_cert = NvmeofGatewaysConfig.get_root_ca_cert(service_name)
-            client_key = NvmeofGatewaysConfig.get_client_key(service_name)
-            client_cert = NvmeofGatewaysConfig.get_client_cert(service_name)
+            if root_ca_cert:
+                client_key = NvmeofGatewaysConfig.get_client_key(service_name)
+                client_cert = NvmeofGatewaysConfig.get_client_cert(service_name)
 
             if root_ca_cert and client_key and client_cert:
                 logger.info('Securely connecting to: %s', self.gateway_addr)


### PR DESCRIPTION
Introduces a gw_group query-param to gateway and subsystem requests.

Modified the dashboard config to support adding more than one gateway to the list.

Fixes: https://tracker.ceph.com/issues/67774


API Req with different gw_groups
**group: test2t`**
```
╰─$ curl -kX GET "https://192.168.100.100:8443/api/nvmeof/gateway?gw_group=test2t" \
-H "Accept: application/vnd.ceph.api.v1.0+json" \
-H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   206  100   206    0     0   1065      0 --:--:-- --:--:-- --:--:--  1067
{
  "cli_version": "",
  "version": "1.2.17",
  "name": "client.nvmeof.test2t.ceph-node-00.usrpwk",
  "group": "test2t",
  "addr": "192.168.100.100",
  "port": "5500",
  "load_balancing_group": 1,
  "spdk_version": "24.01"
}
```
**group test**
```
╭─nia@alkatraz-ibm ~/projects/ceph-dev ‹main●› 
╰─$ curl -kX GET "https://192.168.100.100:8443/api/nvmeof/gateway?gw_group=test" \
-H "Accept: application/vnd.ceph.api.v1.0+json" \
-H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   202  100   202    0     0   1559      0 --:--:-- --:--:-- --:--:--  1565
{
  "cli_version": "",
  "version": "1.2.17",
  "name": "client.nvmeof.test.ceph-node-01.dyalpt",
  "group": "test",
  "addr": "192.168.100.101",
  "port": "5500",
  "load_balancing_group": 1,
  "spdk_version": "24.01"
}
```






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
