### PR TITLE
mon [stretch mode]: support disable_stretch_mode

### DIFF
--- a/doc/rados/operations/stretch-mode.rst
+++ b/doc/rados/operations/stretch-mode.rst
@@ -247,6 +247,34 @@ possible, if needed).
 
 .. _Changing Monitor elections: ../change-mon-elections
 
+Exiting Stretch Mode
+=====================
+To exit stretch mode, run the following command:
+
+.. prompt:: bash $
+
+   ceph mon disable_stretch_mode [{crush_rule}] --yes-i-really-mean-it
+
+
+.. describe:: {crush_rule}
+
+   The CRUSH rule that the user wants all pools to move back to. If this
+   is not specified, the pools will move back to the default CRUSH rule.
+
+   :Type: String
+   :Required: No.
+
+The command will move the cluster back to normal mode,
+and the cluster will no longer be in stretch mode.
+All pools will move its ``size`` and ``min_size``
+back to the default values it started with.
+At this point the user is responsible for scaling down the cluster
+to the desired number of OSDs if they choose to operate with less number of OSDs.
+
+Please note that the command will not execute when the cluster is in
+``recovery stretch mode``. The command will only execute when the cluster
+is in ``degraded stretch mode`` or ``healthy stretch mode``.
+
 Limitations of Stretch Mode 
 ===========================
 When using stretch mode, OSDs must be located at exactly two sites. 

--- a/qa/suites/rados/singleton/all/stretch-mode-5-mons-8-osds.yaml
+++ b/qa/suites/rados/singleton/all/stretch-mode-5-mons-8-osds.yaml
@@ -1,0 +1,58 @@
+roles:
+- - mon.a
+  - mon.b
+  - mgr.a
+  - mgr.b
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+- - mon.c
+  - mon.d
+  - mgr.c
+  - mgr.d
+  - osd.4
+  - osd.5
+  - osd.6
+  - osd.7
+- - mon.e
+- - client.0
+
+openstack:
+  - volumes: # attached to each instance
+      count: 3
+      size: 10 # GB
+overrides:
+  ceph:
+    conf:
+      global:
+        mon election default strategy: 3
+        osd pool default size: 3
+        osd pool default min size: 2
+      mon:
+        debug mon: 30
+tasks:
+- install:
+- ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr_pool false --force
+    log-ignorelist:
+      - \(POOL_
+      - \(CACHE_POOL_
+      - overall HEALTH_
+      - \(PG_AVAILABILITY\)
+      - Reduced data availability
+      - \(PG_DEGRADED\)
+      - \(MON_DOWN\)
+      - \(OSD_DATACENTER_DOWN\)
+      - \(OSD_DOWN\)
+      - \(OSD_HOST_DOWN\)
+
+
+- workunit:
+    clients:
+      client.0:
+        - mon/mon-stretch-mode-5-mons-8-osds.sh
+- cephfs_test_runner:
+    modules:
+      - tasks.stretch_mode_disable_enable

--- a/qa/tasks/stretch_mode_disable_enable.py
+++ b/qa/tasks/stretch_mode_disable_enable.py
@@ -1,0 +1,547 @@
+import logging
+from tasks.mgr.mgr_test_case import MgrTestCase
+
+log = logging.getLogger(__name__)
+
+class TestStretchMode(MgrTestCase):
+    """
+    Test the stretch mode feature of Ceph
+    """
+    POOL = 'stretch_pool'
+    CLUSTER = "ceph"
+    WRITE_PERIOD = 10
+    RECOVERY_PERIOD = WRITE_PERIOD * 6
+    SUCCESS_HOLD_TIME = 7
+    STRETCH_CRUSH_RULE = 'stretch_rule'
+    STRETCH_CRUSH_RULE_ID = None
+    STRETCH_BUCKET_TYPE = 'datacenter'
+    TIEBREAKER_MON_NAME = 'e'
+    DEFAULT_POOL_TYPE = 'replicated'
+    DEFAULT_POOL_CRUSH_RULE = 'replicated_rule'
+    DEFAULT_POOL_SIZE = 3
+    DEFAULT_POOL_MIN_SIZE = 2
+    DEFAULT_POOL_CRUSH_RULE_ID = None
+    # This dictionary maps the datacenter to the osd ids and hosts
+    DC_OSDS = {
+        'dc1': {
+            "host01": [0, 1],
+            "host02": [2, 3],
+        },
+        'dc2': {
+            "host03": [4, 5],
+            "host04": [6, 7],
+        },
+    }
+    DC_MONS = {
+        'dc1': {
+            "host01": ['a'],
+            "host02": ['b'],
+        },
+        'dc2': {
+            "host03": ['c'],
+            "host04": ['d'],
+        },
+        'dc3': {
+            "host05": ['e'],
+        }
+    }
+    def _osd_count(self):
+        """
+        Get the number of OSDs in the cluster.
+        """
+        osd_map = self.mgr_cluster.mon_manager.get_osd_dump_json()
+        return len(osd_map['osds'])
+
+    def setUp(self):
+        """
+        Setup the cluster and
+        ensure we have a clean condition before the test.
+        """
+        # Ensure we have at least 6 OSDs
+        super(TestStretchMode, self).setUp()
+        self.DEFAULT_POOL_CRUSH_RULE_ID = self.mgr_cluster.mon_manager.get_crush_rule_id(self.DEFAULT_POOL_CRUSH_RULE)
+        self.STRETCH_CRUSH_RULE_ID = self.mgr_cluster.mon_manager.get_crush_rule_id(self.STRETCH_CRUSH_RULE)
+        if self._osd_count() < 4:
+            self.skipTest("Not enough OSDS!")
+
+        # Remove any filesystems so that we can remove their pools
+        if self.mds_cluster:
+            self.mds_cluster.mds_stop()
+            self.mds_cluster.mds_fail()
+            self.mds_cluster.delete_all_filesystems()
+
+        # Remove all other pools
+        for pool in self.mgr_cluster.mon_manager.get_osd_dump_json()['pools']:
+            try:
+                self.mgr_cluster.mon_manager.remove_pool(pool['pool_name'])
+            except:
+                self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                    'osd', 'pool', 'delete',
+                    pool['pool_name'],
+                    pool['pool_name'],
+                    '--yes-i-really-really-mean-it')
+
+    def _setup_pool(
+            self,
+            pool_name=POOL,
+            pg_num=16,
+            pool_type=DEFAULT_POOL_TYPE,
+            crush_rule=DEFAULT_POOL_CRUSH_RULE,
+            size=None,
+            min_size=None
+        ):
+        """
+        Create a pool, set its size and pool if specified.
+        """
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'osd', 'pool', 'create', pool_name, str(pg_num), pool_type, crush_rule)
+
+        if size is not None:
+            self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                'osd', 'pool', 'set', pool_name, 'size', str(size))
+
+        if min_size is not None:
+            self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                'osd', 'pool', 'set', pool_name, 'min_size', str(min_size))
+
+    def _write_some_data(self, t):
+        """
+        Write some data to the pool to simulate a workload.
+        """
+        args = [
+            "rados", "-p", self.POOL, "bench", str(t), "write", "-t", "16"]
+        self.mgr_cluster.admin_remote.run(args=args, wait=True)
+
+    def _get_all_mons_from_all_dc(self):
+        """
+        Get all mons from all datacenters.
+        """
+        return [mon for dc in self.DC_MONS.values() for mons in dc.values() for mon in mons]
+
+    def _bring_back_mon(self, mon):
+        """
+        Bring back the mon.
+        """
+        try:
+            self.ctx.daemons.get_daemon('mon', mon, self.CLUSTER).restart()
+        except Exception:
+            log.error("Failed to bring back mon.{}".format(str(mon)))
+            pass
+
+    def _get_host(self, osd):
+        """
+        Get the host of the osd.
+        """
+        for dc, nodes in self.DC_OSDS.items():
+            for node, osds in nodes.items():
+                if osd in osds:
+                    return node
+        return None
+
+    def _move_osd_back_to_host(self, osd):
+        """
+        Move the osd back to the host.
+        """
+        host = self._get_host(osd)
+        assert host is not None, "The host of osd {} is not found.".format(osd)
+        log.debug("Moving osd.%d back to %s", osd, host)
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'osd', 'crush', 'move', 'osd.{}'.format(str(osd)),
+            'host={}'.format(host)
+        )
+
+    def tearDown(self):
+        """
+        Clean up the cluster after the test.
+        """
+        # Remove the pool
+        if self.POOL in self.mgr_cluster.mon_manager.pools:
+            self.mgr_cluster.mon_manager.remove_pool(self.POOL)
+
+        osd_map = self.mgr_cluster.mon_manager.get_osd_dump_json()
+        for osd in osd_map['osds']:
+            # mark all the osds in
+            if osd['weight'] == 0.0:
+                self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                    'osd', 'in', str(osd['osd']))
+            # Bring back all the osds and move it back to the host.
+            if osd['up'] == 0:
+                self.mgr_cluster.mon_manager.revive_osd(osd['osd'])
+                self._move_osd_back_to_host(osd['osd'])
+        
+        # Bring back all the mons
+        mons = self._get_all_mons_from_all_dc()
+        for mon in mons:
+            self._bring_back_mon(mon)
+        super(TestStretchMode, self).tearDown()
+
+    def _kill_osd(self, osd):
+        """
+        Kill the osd.
+        """
+        try:
+            self.ctx.daemons.get_daemon('osd', osd, self.CLUSTER).stop()
+        except Exception:
+            log.error("Failed to stop osd.{}".format(str(osd)))
+            pass
+
+    def _get_osds_data(self, want_osds):
+        """
+        Get the osd data
+        """
+        all_osds_data = \
+            self.mgr_cluster.mon_manager.get_osd_dump_json()['osds']
+        return [
+            osd_data for osd_data in all_osds_data
+            if int(osd_data['osd']) in want_osds
+        ]
+
+    def _get_osds_by_dc(self, dc):
+        """
+        Get osds by datacenter.
+        """
+        ret = []
+        for host, osds in self.DC_OSDS[dc].items():
+            ret.extend(osds)
+        return ret
+
+    def _fail_over_all_osds_in_dc(self, dc):
+        """
+        Fail over all osds in specified <datacenter>
+        """
+        if not isinstance(dc, str):
+            raise ValueError("dc must be a string")
+        if dc not in self.DC_OSDS:
+            raise ValueError(
+                "dc must be one of the following: %s" % self.DC_OSDS.keys()
+                )
+        log.debug("Failing over all osds in %s", dc)
+        osds = self._get_osds_by_dc(dc)
+        # fail over all the OSDs in the DC
+        log.debug("OSDs to failed over: %s", osds)
+        for osd_id in osds:
+            self._kill_osd(osd_id)
+        # wait until all the osds are down
+        self.wait_until_true(
+            lambda: all([int(osd['up']) == 0
+                        for osd in self._get_osds_data(osds)]),
+            timeout=self.RECOVERY_PERIOD
+        )
+
+    def _check_mons_out_of_quorum(self, want_mons):
+        """
+        Check if the mons are not in quorum.
+        """
+        quorum_names = self.mgr_cluster.mon_manager.get_mon_quorum_names()
+        return all([mon not in quorum_names for mon in want_mons])
+
+    def _kill_mon(self, mon):
+        """
+        Kill the mon.
+        """
+        try:
+            self.ctx.daemons.get_daemon('mon', mon, self.CLUSTER).stop()
+        except Exception:
+            log.error("Failed to stop mon.{}".format(str(mon)))
+            pass
+
+    def _get_mons_by_dc(self, dc):
+        """
+        Get mons by datacenter.
+        """
+        ret = []
+        for host, mons in self.DC_MONS[dc].items():
+            ret.extend(mons)
+        return ret
+
+    def _fail_over_all_mons_in_dc(self, dc):
+        """
+        Fail over all mons in the specified <datacenter>
+        """
+        if not isinstance(dc, str):
+            raise ValueError("dc must be a string")
+        if dc not in self.DC_MONS:
+            raise ValueError("dc must be one of the following: %s" %
+                             ", ".join(self.DC_MONS.keys()))
+        log.debug("Failing over all mons %s", dc)
+        mons = self._get_mons_by_dc(dc)
+        log.debug("Mons to be failed over: %s", mons)
+        for mon in mons:
+            self._kill_mon(mon)
+        # wait until all the mons are out of quorum
+        self.wait_until_true(
+            lambda: self._check_mons_out_of_quorum(mons),
+            timeout=self.RECOVERY_PERIOD
+        )
+
+    def _stretch_mode_enabled_correctly(self):
+        """
+        Evaluate whether the stretch mode is enabled correctly.
+        by checking the OSDMap and MonMap.
+        """
+        # Checking the OSDMap
+        osdmap = self.mgr_cluster.mon_manager.get_osd_dump_json()
+        for pool in osdmap['pools']:
+            # expects crush_rule to be stretch_rule
+            self.assertEqual(
+                self.STRETCH_CRUSH_RULE_ID,
+                pool['crush_rule']
+            )
+            # expects pool size to be 4
+            self.assertEqual(
+                4,
+                pool['size']
+            )
+            # expects pool min_size to be 2
+            self.assertEqual(
+                2,
+                pool['min_size']
+            )
+            # expects pool is_stretch_pool flag to be true
+            self.assertEqual(
+                True,
+                pool['is_stretch_pool']
+            )
+            # expects peering_crush_bucket_count = 2 (always this value for stretch mode)
+            self.assertEqual(
+                2,
+                pool['peering_crush_bucket_count']
+            )
+            # expects peering_crush_bucket_target = 2 (always this value for stretch mode)
+            self.assertEqual(
+                2,
+                pool['peering_crush_bucket_target']
+            )
+            # expects peering_crush_bucket_barrier = 8 (crush type of datacenter is 8)
+            self.assertEqual(
+                8,
+                pool['peering_crush_bucket_barrier']
+            )
+        # expects stretch_mode_enabled to be True
+        self.assertEqual(
+            True,
+            osdmap['stretch_mode']['stretch_mode_enabled']
+        )
+        # expects stretch_mode_bucket_count to be 2
+        self.assertEqual(
+            2,
+            osdmap['stretch_mode']['stretch_bucket_count']
+        )
+        # expects degraded_stretch_mode to be 0
+        self.assertEqual(
+            0,
+            osdmap['stretch_mode']['degraded_stretch_mode']
+        )
+        # expects recovering_stretch_mode to be 0
+        self.assertEqual(
+            0,
+            osdmap['stretch_mode']['recovering_stretch_mode']
+        )
+        # expects stretch_mode_bucket to be 8 (datacenter crush type = 8)
+        self.assertEqual(
+            8,
+            osdmap['stretch_mode']['stretch_mode_bucket']
+        )
+        # Checking the MonMap
+        monmap = self.mgr_cluster.mon_manager.get_mon_dump_json()
+        # expects stretch_mode to be True
+        self.assertEqual(
+            True,
+            monmap['stretch_mode']
+        )
+        # expects disallowed_leaders to be tiebreaker_mon
+        self.assertEqual(
+            self.TIEBREAKER_MON_NAME,
+            monmap['disallowed_leaders']
+        )
+        # expects tiebreaker_mon to be tiebreaker_mon
+        self.assertEqual(
+            self.TIEBREAKER_MON_NAME,
+            monmap['tiebreaker_mon']
+        )
+
+    def _stretch_mode_disabled_correctly(self):
+        """
+        Evaluate whether the stretch mode is disabled correctly.
+        by checking the OSDMap and MonMap.
+        """
+        # Checking the OSDMap
+        osdmap = self.mgr_cluster.mon_manager.get_osd_dump_json()
+        for pool in osdmap['pools']:
+            # expects crush_rule to be default
+            self.assertEqual(
+                self.DEFAULT_POOL_CRUSH_RULE_ID,
+                pool['crush_rule']
+            )
+            # expects pool size to be default
+            self.assertEqual(
+                self.DEFAULT_POOL_SIZE,
+                pool['size']
+            )
+            # expects pool min_size to be default
+            self.assertEqual(
+                self.DEFAULT_POOL_MIN_SIZE,
+                pool['min_size']
+            )
+            # expects pool is_stretch_pool flag to be false
+            self.assertEqual(
+                False,
+                pool['is_stretch_pool']
+            )
+            # expects peering_crush_bucket_count = 0
+            self.assertEqual(
+                0,
+                pool['peering_crush_bucket_count']
+            )
+            # expects peering_crush_bucket_target = 0
+            self.assertEqual(
+                0,
+                pool['peering_crush_bucket_target']
+            )
+            # expects peering_crush_bucket_barrier = 0
+            self.assertEqual(
+                0,
+                pool['peering_crush_bucket_barrier']
+            )
+        # expects stretch_mode_enabled to be False
+        self.assertEqual(
+            False,
+            osdmap['stretch_mode']['stretch_mode_enabled']
+        )
+        # expects stretch_mode_bucket to be 0
+        self.assertEqual(
+            0,
+            osdmap['stretch_mode']['stretch_bucket_count']
+        )
+        # expects degraded_stretch_mode to be 0
+        self.assertEqual(
+            0,
+            osdmap['stretch_mode']['degraded_stretch_mode']
+        )
+        # expects recovering_stretch_mode to be 0
+        self.assertEqual(
+            0,
+            osdmap['stretch_mode']['recovering_stretch_mode']
+        )
+        # expects stretch_mode_bucket to be 0
+        self.assertEqual(
+            0,
+            osdmap['stretch_mode']['stretch_mode_bucket']
+        )
+        # Checking the MonMap
+        monmap = self.mgr_cluster.mon_manager.get_mon_dump_json()
+        # expects stretch_mode to be False
+        self.assertEqual(
+            False,
+            monmap['stretch_mode']
+        )
+        # expects disallowed_leaders to be empty
+        self.assertEqual(
+            "",
+            monmap['disallowed_leaders']
+        )
+        # expects tiebreaker_mon to be empty
+        self.assertEqual(
+            "",
+            monmap['tiebreaker_mon']
+        )
+
+    def test_disable_stretch_mode(self):
+        """
+        Test disabling stretch mode with the following scenario:
+        1. Healthy Stretch Mode
+        2. Degraded Stretch Mode
+        """
+        # Create a pool
+        self._setup_pool(self.POOL, 16, 'replicated', self.STRETCH_CRUSH_RULE, 4, 2)
+        # Write some data to the pool
+        self._write_some_data(self.WRITE_PERIOD)
+        # disable stretch mode without --yes-i-really-mean-it (expects -EPERM 1)
+        self.assertEqual(
+            1,
+            self.mgr_cluster.mon_manager.raw_cluster_cmd_result(
+                'mon',
+                'disable_stretch_mode'
+            ))
+        # Disable stretch mode with non-existent crush rule (expects -EINVAL 22)
+        self.assertEqual(
+            22,
+            self.mgr_cluster.mon_manager.raw_cluster_cmd_result(
+                'mon',
+                'disable_stretch_mode',
+                'non_existent_rule',
+                '--yes-i-really-mean-it'
+            ))
+        # Disable stretch mode with the current stretch rule (expect -EINVAL 22)
+        self.assertEqual(
+            22,
+            self.mgr_cluster.mon_manager.raw_cluster_cmd_result(
+                'mon',
+                'disable_stretch_mode',
+                self.STRETCH_CRUSH_RULE,
+                '--yes-i-really-mean-it',
+
+            ))
+        # Disable stretch mode without crush rule (expect success 0)
+        self.assertEqual(
+            0,
+            self.mgr_cluster.mon_manager.raw_cluster_cmd_result(
+                'mon',
+                'disable_stretch_mode',
+                '--yes-i-really-mean-it'
+            ))
+        # Check if stretch mode is disabled correctly
+        self._stretch_mode_disabled_correctly()
+        # all PGs are active + clean
+        self.wait_until_true_and_hold(
+            lambda: self.mgr_cluster.mon_manager.pg_all_active_clean(),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+        # write some data to the pool
+        self._write_some_data(self.WRITE_PERIOD)
+        # Enable stretch mode
+        self.assertEqual(
+            0,
+            self.mgr_cluster.mon_manager.raw_cluster_cmd_result(
+                'mon',
+                'enable_stretch_mode',
+                self.TIEBREAKER_MON_NAME,
+                self.STRETCH_CRUSH_RULE,
+                self.STRETCH_BUCKET_TYPE
+            ))
+        self._stretch_mode_enabled_correctly()
+        # all PGs are active + clean
+        self.wait_until_true_and_hold(
+            lambda: self.mgr_cluster.mon_manager.pg_all_active_clean(),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+        # write some data to the pool
+        # self._write_some_data(self.WRITE_PERIOD)
+        # Bring down dc1
+        self._fail_over_all_osds_in_dc('dc1')
+        self._fail_over_all_mons_in_dc('dc1')
+        # should be in degraded stretch mode
+        self.wait_until_true_and_hold(
+            lambda: self.mgr_cluster.mon_manager.is_degraded_stretch_mode(),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+        # Disable stretch mode with valid crush rule (expect success 0)
+        self.assertEqual(
+            0,
+            self.mgr_cluster.mon_manager.raw_cluster_cmd_result(
+                'mon',
+                'disable_stretch_mode',
+                self.DEFAULT_POOL_CRUSH_RULE,
+                '--yes-i-really-mean-it'
+            ))
+        # Check if stretch mode is disabled correctly
+        self._stretch_mode_disabled_correctly()
+        # all PGs are active
+        self.wait_until_true_and_hold(
+            lambda: self.mgr_cluster.mon_manager.pg_all_active(),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )

--- a/qa/workunits/mon/mon-stretch-mode-5-mons-8-osds.sh
+++ b/qa/workunits/mon/mon-stretch-mode-5-mons-8-osds.sh
@@ -1,0 +1,68 @@
+#!/bin/bash -ex
+
+# A bash script for setting up stretch mode with 5 monitors and 8 OSDs.
+
+NUM_OSDS_UP=$(ceph osd df | grep "up" | wc -l)
+
+if [ $NUM_OSDS_UP -lt 8 ]; then
+    echo "test requires at least 8 OSDs up and running"
+    exit 1
+fi
+
+for dc in dc1 dc2
+    do
+      ceph osd crush add-bucket $dc datacenter
+      ceph osd crush move $dc root=default
+    done
+
+ceph osd crush add-bucket host01 host
+ceph osd crush add-bucket host02 host
+ceph osd crush add-bucket host03 host
+ceph osd crush add-bucket host04 host
+
+ceph osd crush move host01 datacenter=dc1
+ceph osd crush move host02 datacenter=dc1
+ceph osd crush move host03 datacenter=dc2
+ceph osd crush move host04 datacenter=dc2
+
+ceph osd crush move osd.0 host=host01
+ceph osd crush move osd.1 host=host01
+ceph osd crush move osd.2 host=host02
+ceph osd crush move osd.3 host=host02
+ceph osd crush move osd.4 host=host03
+ceph osd crush move osd.5 host=host03
+ceph osd crush move osd.6 host=host04
+ceph osd crush move osd.7 host=host04
+
+# set location for monitors
+ceph mon set_location a datacenter=dc1 host=host01
+ceph mon set_location b datacenter=dc1 host=host02
+ceph mon set_location c datacenter=dc2 host=host03
+ceph mon set_location d datacenter=dc2 host=host04
+
+# set location for tiebreaker monitor
+ceph mon set_location e datacenter=dc3 host=host05
+
+# remove the current host from crush map
+hostname=$(hostname -s)
+ceph osd crush remove $hostname
+# create a new crush rule with stretch rule
+ceph osd getcrushmap > crushmap
+crushtool --decompile crushmap > crushmap.txt
+sed 's/^# end crush map$//' crushmap.txt > crushmap_modified.txt
+cat >> crushmap_modified.txt << EOF
+rule stretch_rule {
+       id 2
+       type replicated
+       step take default
+       step choose firstn 2 type datacenter
+       step chooseleaf firstn 2 type host
+       step emit
+}
+# end crush map
+EOF
+
+crushtool --compile crushmap_modified.txt -o crushmap.bin
+ceph osd setcrushmap -i crushmap.bin
+
+ceph mon enable_stretch_mode e stretch_rule datacenter

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -558,6 +558,11 @@ COMMAND("mon enable_stretch_mode " \
 	"as the tiebreaker and setting <dividing_bucket> locations "
 	"as the units for stretching across",
 	"mon", "rw")
+COMMAND("mon disable_stretch_mode " \
+	"name=crush_rule,type=CephString,req=false, "
+	"name=yes_i_really_mean_it,type=CephBool,req=false, ",
+	"disable stretch mode, reverting to normal peering rules",
+	"mon", "rw")
 COMMAND("mon set_new_tiebreaker " \
 	"name=name,type=CephString "
 	"name=yes_i_really_mean_it,type=CephBool,req=false",

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -431,10 +431,10 @@ void MonMap::dump(Formatter *f) const
   f->dump_unsigned("min_mon_release", to_integer<unsigned>(min_mon_release));
   f->dump_string("min_mon_release_name", to_string(min_mon_release));
   f->dump_int ("election_strategy", strategy);
-  f->dump_stream("disallowed_leaders: ") << disallowed_leaders;
+  f->dump_stream("disallowed_leaders") << disallowed_leaders;
   f->dump_bool("stretch_mode", stretch_mode_enabled);
   f->dump_string("tiebreaker_mon", tiebreaker_mon);
-  f->dump_stream("removed_ranks: ") << removed_ranks;
+  f->dump_stream("removed_ranks") << removed_ranks;
   f->open_object_section("features");
   persistent_features.dump(f, "persistent");
   optional_features.dump(f, "optional");

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -6683,6 +6683,8 @@ void Monitor::notify_new_monmap(bool can_change_external_state, bool remove_rank
 
   if (monmap->stretch_mode_enabled) {
     try_engage_stretch_mode();
+  } else {
+    try_disable_stretch_mode();
   }
 
   if (is_stretch_mode()) {
@@ -6741,6 +6743,32 @@ void Monitor::try_engage_stretch_mode()
     disconnect_disallowed_stretch_sessions();
   }
 }
+struct CMonDisableStretchMode : public Context {
+  Monitor *m;
+  CMonDisableStretchMode(Monitor *mon) : m(mon) {}
+  void finish(int r) {
+    m->try_disable_stretch_mode();
+  }
+};
+void Monitor::try_disable_stretch_mode()
+{
+  dout(20) << __func__ << dendl;
+  if (!stretch_mode_engaged) return;
+  if (!osdmon()->is_readable()) {
+    dout(20) << "osdmon is not readable" << dendl;
+    osdmon()->wait_for_readable_ctx(new CMonDisableStretchMode(this));
+    return;
+  }
+  if (!osdmon()->osdmap.stretch_mode_enabled &&
+      !monmap->stretch_mode_enabled) {
+    dout(10) << "Disabling stretch mode!" << dendl;
+    stretch_mode_engaged = false;
+    stretch_bucket_divider.clear();
+    degraded_stretch_mode = false;
+    recovering_stretch_mode = false;
+  }
+
+}
 
 void Monitor::do_stretch_mode_election_work()
 {
@@ -6797,6 +6825,7 @@ struct CMonGoRecovery : public Context {
 void Monitor::go_recovery_stretch_mode()
 {
   dout(20) << __func__ << dendl;
+  if (!is_stretch_mode()) return;
   dout(20) << "is_leader(): " << is_leader() << dendl;
   if (!is_leader()) return;
   dout(20) << "is_degraded_stretch_mode(): " << is_degraded_stretch_mode() << dendl;
@@ -6827,6 +6856,7 @@ void Monitor::go_recovery_stretch_mode()
 
 void Monitor::set_recovery_stretch_mode()
 {
+  if (!is_stretch_mode()) return;
   degraded_stretch_mode = true;
   recovering_stretch_mode = true;
   osdmon()->set_recovery_stretch_mode();
@@ -6835,6 +6865,7 @@ void Monitor::set_recovery_stretch_mode()
 void Monitor::maybe_go_degraded_stretch_mode()
 {
   dout(20) << __func__ << dendl;
+  if (!is_stretch_mode()) return;
   if (is_degraded_stretch_mode()) return;
   if (!is_leader()) return;
   if (dead_mon_buckets.empty()) return;
@@ -6873,6 +6904,7 @@ void Monitor::trigger_degraded_stretch_mode(const set<string>& dead_mons,
 					    const set<int>& dead_buckets)
 {
   dout(20) << __func__ << dendl;
+  if (!is_stretch_mode()) return;
   ceph_assert(osdmon()->is_writeable());
   ceph_assert(monmon()->is_writeable());
 
@@ -6893,6 +6925,7 @@ void Monitor::trigger_degraded_stretch_mode(const set<string>& dead_mons,
 void Monitor::set_degraded_stretch_mode()
 {
   dout(20) << __func__ << dendl;
+  if (!is_stretch_mode()) return;
   degraded_stretch_mode = true;
   recovering_stretch_mode = false;
   osdmon()->set_degraded_stretch_mode();
@@ -6910,6 +6943,7 @@ struct CMonGoHealthy : public Context {
 void Monitor::trigger_healthy_stretch_mode()
 {
   dout(20) << __func__ << dendl;
+  if (!is_stretch_mode()) return;
   if (!is_degraded_stretch_mode()) return;
   if (!is_leader()) return;
   if (!osdmon()->is_writeable()) {
@@ -6930,6 +6964,7 @@ void Monitor::trigger_healthy_stretch_mode()
 
 void Monitor::set_healthy_stretch_mode()
 {
+  if (!is_stretch_mode()) return;
   degraded_stretch_mode = false;
   recovering_stretch_mode = false;
   osdmon()->set_healthy_stretch_mode();

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -293,6 +293,7 @@ public:
    * updates across the entire cluster.
    */
   void try_engage_stretch_mode();
+  void try_disable_stretch_mode();
   void maybe_go_degraded_stretch_mode();
   void trigger_degraded_stretch_mode(const std::set<std::string>& dead_mons,
 				     const std::set<int>& dead_buckets);

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -845,6 +845,20 @@ public:
 			       const std::set<pg_pool_t*>& pools,
 			       const std::string& new_crush_rule);
   /**
+  *
+  * Set all stretch mode values of all pools back to pre-stretch mode values.
+  * Set all stretch mode values of OSDMap back to pre-stretch mode values.
+  * If crush_rule is not empty, set the crush rule to that value, else use
+  * the default replicated crush rule.
+  * @param ss: a stringstream to write errors into
+  * @param errcode: filled with -errno if there's a problem
+  * @param crush_rule: the crush rule that will used after disabling stretch mode
+  */
+  void try_disable_stretch_mode(std::stringstream& ss,
+          bool *okay,
+          int *errcode,
+          const std::string& crush_rule);
+  /**
    * Check the input dead_buckets mapping (buckets->dead monitors) to see
    * if the OSDs are also down. If so, fill in really_down_buckets and
    * really_down_mons and return true; else return false.


### PR DESCRIPTION
Problem:

Currently, Ceph lacks the ability
to exit stretch mode and move back
to normal cluster (non-stretched).

Solution:

Provide a command to allow
the user to exit stretch mode gracefully:

`ceph mon disable_stretch_mode <crush_rule> --yes-i-really-mean-it`

Users can either specify a crush rule that
they want all pools to move to or not specify
a rule and Ceph will use a default replicated crush rule.

Fixes: https://tracker.ceph.com/issues/67467

### TODO
- [x] Code changes
- [x] Test changes that exercises all the case
- [x] Documentation changes

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
