### PR TITLE
test/erasure-code: increase ceph_erasure_code_benchmark default buffe…

### DIFF
--- a/qa/workunits/erasure-code/bench.sh
+++ b/qa/workunits/erasure-code/bench.sh
@@ -17,7 +17,8 @@
 #
 # Test that it works from sources with:
 #
-#  CEPH_ERASURE_CODE_BENCHMARK=src/ceph_erasure_code_benchmark  \
+#  TOTAL_SIZE=$((4 * 1024 * 1024)) SIZE=4096 \
+#  CEPH_ERASURE_CODE_BENCHMARK=build/bin/ceph_erasure_code_benchmark  \
 #  PLUGIN_DIRECTORY=build/lib \
 #      qa/workunits/erasure-code/bench.sh fplot jerasure |
 #      tee qa/workunits/erasure-code/bench.js
@@ -34,10 +35,14 @@
 #  firefox qa/workunits/erasure-code/bench.html
 #
 # Once it is confirmed to work, it can be run with a more significant
-# volume of data so that the measures are more reliable:
+# volume of data so that the measures are more reliable. Ideally the size
+# of the buffers (SIZE) should be larger than the L3 cache to avoid cache hits.
+# The following example uses an 80MB (80 * 1024 * 1024) buffer.
+# A larger buffer with fewer iterations (iterations = TOTAL SIZE / SIZE) should result in
+# more time spent encoding/decoding and less time allocating/aligning buffers:
 #
-#  TOTAL_SIZE=$((4 * 1024 * 1024 * 1024)) \
-#  CEPH_ERASURE_CODE_BENCHMARK=src/ceph_erasure_code_benchmark  \
+#  TOTAL_SIZE=$((100 * 80 * 1024 * 1024)) SIZE=$((80 * 1024 * 1024)) \
+#  CEPH_ERASURE_CODE_BENCHMARK=build/bin/ceph_erasure_code_benchmark  \
 #  PLUGIN_DIRECTORY=build/lib \
 #      qa/workunits/erasure-code/bench.sh fplot jerasure |
 #      tee qa/workunits/erasure-code/bench.js
@@ -51,8 +56,8 @@ export PATH=/sbin:$PATH
 : ${PLUGIN_DIRECTORY:=/usr/lib/ceph/erasure-code}
 : ${PLUGINS:=isa jerasure}
 : ${TECHNIQUES:=vandermonde cauchy liberation reed_sol_r6_op blaum_roth liber8tion}
-: ${TOTAL_SIZE:=$((1024 * 1024))}
-: ${SIZE:=4096}
+: ${TOTAL_SIZE:=$((100 * 80 * 1024 * 1024))} #TOTAL_SIZE / SIZE = number of encode or decode iterations to run
+: ${SIZE:=$((80 * 1024 * 1024))} #size of buffer to encode/decode
 : ${PARAMETERS:=--parameter jerasure-per-chunk-alignment=true}
 
 declare -rA isa_techniques=(

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -52,9 +52,9 @@ int ErasureCodeBench::setup(int argc, char** argv) {
   desc.add_options()
     ("help,h", "produce help message")
     ("verbose,v", "explain what happens")
-    ("size,s", po::value<int>()->default_value(1024 * 1024),
+    ("size,s", po::value<int>()->default_value(80 * 1024 * 1024),
      "size of the buffer to be encoded")
-    ("iterations,i", po::value<int>()->default_value(1),
+    ("iterations,i", po::value<int>()->default_value(100),
      "number of encode/decode runs")
     ("plugin,p", po::value<string>()->default_value("jerasure"),
      "erasure code plugin name")


### PR DESCRIPTION
…r size

The ceph_erasure_code_benchmark tool and bench.sh scripts use small default buffer sizes, and also contain comments that suggest running the tool with a buffer size that is too small. It can be observed from flame graphs captured while using the tool that a majority of CPU time is spent allocating, freeing and aligning buffers, rather than testing the performance of the erasure code plugin.

This PR updates the default settings and comments to suggest a far larger buffer size and far fewer number of encode/decode iterations. Flame graphs show that the vast majority of CPU time is now spent encoding and decoding, rather than aligning buffers.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
