### PR TITLE
rgw/cls_rgw: integer is being interpreted as a character code when assigning it to a string

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -48,7 +48,7 @@ CLS_NAME(rgw)
 // of a special bucket-index entry for the first byte. Note: although
 // it has no impact, the 2nd, 3rd, or 4th byte of a UTF-8 character
 // may be 0x80.
-#define BI_PREFIX_CHAR 0x80
+constexpr unsigned char BI_PREFIX_CHAR = 0x80;
 
 #define BI_BUCKET_OBJS_INDEX          0
 #define BI_BUCKET_LOG_INDEX           1
@@ -67,11 +67,11 @@ static std::string bucket_index_prefixes[] = { "", /* special handling for the o
 
 // this string is greater than all ascii plain entries and less than
 // all special entries
-static const std::string BI_PREFIX_BEGIN = string(1, BI_PREFIX_CHAR);
+static const std::string BI_PREFIX_BEGIN = string(1, static_cast<char>(BI_PREFIX_CHAR));
 
 // this string is greater than all special entries and less than all
 // non-ascii plain entries
-static const std::string BI_PREFIX_END = string(1, BI_PREFIX_CHAR) +
+static const std::string BI_PREFIX_END = string(1, static_cast<char>(BI_PREFIX_CHAR)) +
     bucket_index_prefixes[BI_BUCKET_LAST_INDEX];
 
 /* Returns whether parameter is not a key for a special entry. Empty
@@ -80,7 +80,7 @@ static const std::string BI_PREFIX_END = string(1, BI_PREFIX_CHAR) +
  * using appropriately.
  */
 static bool bi_is_plain_entry(const std::string& s) {
-  return (s.empty() || (unsigned char)s[0] != BI_PREFIX_CHAR);
+  return (s.empty() || static_cast<unsigned char>(s[0]) != BI_PREFIX_CHAR);
 }
 
 static int bi_entry_type(const string& s)
@@ -209,7 +209,7 @@ static int get_obj_vals(cls_method_context_t hctx,
   }
 
   auto last_element = pkeys->crbegin();
-  if ((unsigned char)last_element->first[0] < BI_PREFIX_CHAR) {
+  if (static_cast<unsigned char>(last_element->first[0]) < BI_PREFIX_CHAR) {
     /* if the first character of the last entry is less than the
      * prefix then all entries must preceed the "ugly namespace" and
      * we're done
@@ -218,7 +218,7 @@ static int get_obj_vals(cls_method_context_t hctx,
   }
 
   auto first_element = pkeys->cbegin();
-  if ((unsigned char)first_element->first[0] > BI_PREFIX_CHAR) {
+  if (static_cast<unsigned char>(first_element->first[0]) > BI_PREFIX_CHAR) {
     /* if the first character of the first entry is after the "ugly
      * namespace" then all entries must follow the "ugly namespace"
      * then all entries do and we're done


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/67780

clang-tidy original warning:

```
src/cls/rgw/cls_rgw.cc: warning: an integer is interpreted as a character code when assigning it to a string; 
if this is intended, cast the integer to the appropriate character type; if you want a string representation, 
use the appropriate conversion facility [bugprone-string-integer-assignment] key = BI_PREFIX_CHAR;
^
/home/suyash/ceph/src/cls/rgw/cls_rgw.cc:51:24: note: expanded from macro 'BI_PREFIX_CHAR' 
#define BI_PREFIX_CHAR 0x80
```

**On the following lines we are getting the warning:**

1. 138
2. 319
3. 342
4. 2875
5. 2966
6. 3294
7. 3304
8. 3307
9. 3418
10. 3421





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
