### PR TITLE
quincy: os/bluestore: allow use BtreeAllocator 

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4124,6 +4124,7 @@ options:
   - bitmap
   - stupid
   - avl
+  - btree
   - hybrid
   with_legacy: true
 - name: bluefs_log_replay_check_allocations
@@ -4903,6 +4904,7 @@ options:
   - bitmap
   - stupid
   - avl
+  - btree
   - hybrid
   - zoned
   with_legacy: true


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67606

---

backport of https://github.com/ceph/ceph/pull/57120
parent tracker: https://tracker.ceph.com/issues/65678

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh