### PR TITLE
reef: os/bluestore: allow use BtreeAllocator 

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4149,6 +4149,7 @@ options:
   - bitmap
   - stupid
   - avl
+  - btree
   - hybrid
   with_legacy: true
 - name: bluefs_log_replay_check_allocations
@@ -4928,6 +4929,7 @@ options:
   - bitmap
   - stupid
   - avl
+  - btree
   - hybrid
   - zoned
   with_legacy: true


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67607

---

backport of https://github.com/ceph/ceph/pull/57120
parent tracker: https://tracker.ceph.com/issues/65678

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh