### PR TITLE
mgr/dashboard: cleanup authen + authorz

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/_base_controller.py
+++ b/src/pybind/mgr/dashboard/controllers/_base_controller.py
@@ -191,7 +191,7 @@ class BaseController:
         if scope is None:
             raise Exception("Cannot verify permissions without scope security"
                             " defined")
-        username = JwtManager.LOCAL_USER.username
+        username = cherrypy.request.username
         return AuthManager.authorize(username, scope, permissions)
 
     @classmethod

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -119,7 +119,7 @@ class CherryPyConfig(object):
                       server_addr, server_port)
 
         # Initialize custom handlers.
-        cherrypy.tools.authenticate = AuthManagerTool()
+        cherrypy.tools.authenticate = AuthManagerTool(backend=self.get_module_option('auth_backend'))  # type: ignore
         configure_cors()
         cherrypy.tools.plugin_hooks_filter_request = cherrypy.Tool(
             'before_handler',
@@ -275,6 +275,7 @@ class Module(MgrModule, CherryPyConfig):
                min=400, max=599),
         Option(name='redirect_resolve_ip_addr', type='bool', default=False),
         Option(name='cross_origin_url', type='str', default=''),
+        Option(name='auth_backend', type='str', default='local'),
     ]
     MODULE_OPTIONS.extend(options_schema_list())
     for options in PLUGIN_MANAGER.hook.get_options() or []:


### PR DESCRIPTION
Dashboard authn and authz are messy. This tries to clean that up by:

- Simplifying involved classes and services (there are multiple services, JWTManager, AuthManager, LocalAuthenticator), but there's no clear interface between them.
- Providing abstract interface for implementing new or reimplement the existing authn + authz back-ends (local, SAML2, OAuth2)
- Change security defaults to enforce strictness (e.g.: universal access should require a explicit setting vs. the current "no setting" equals universal access).
- Clean up current JWT implementation, which is non-standard and underperforming (JWT blocklist is checked from the mon DB on every request)

Fixes: https://tracker.ceph.com/issues/67794





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
