### PR TITLE
mgr/dashboard: alerts module supports setting multiple email recipients

### DIFF
--- a/doc/mgr/alerts.rst
+++ b/doc/mgr/alerts.rst
@@ -23,7 +23,8 @@ The *alerts* module is enabled with::
 Configuration
 -------------
 
-To configure SMTP, all of the following config options must be set::
+To configure SMTP, all of the following config options must be set
+(When setting ``mgr/alerts/smtp_destination``, you can use commas to separate multiple)::
 
   ceph config set mgr mgr/alerts/smtp_host *<smtp-server>*
   ceph config set mgr mgr/alerts/smtp_destination *<email-address-to-send-to>*

--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -28,7 +28,7 @@ class Alerts(MgrModule):
         Option(
             name='smtp_destination',
             default='',
-            desc='Email address to send alerts to',
+            desc='Email address to send alerts to, use commas to separate multiple',
             runtime=True),
         Option(
             name='smtp_port',
@@ -243,7 +243,7 @@ class Alerts(MgrModule):
                 server = smtplib.SMTP(self.smtp_host, self.smtp_port)
             if self.smtp_password:
                 server.login(self.smtp_user, self.smtp_password)
-            server.sendmail(self.smtp_sender, self.smtp_destination, message)
+            server.sendmail(self.smtp_sender, self.smtp_destination.split(','), message)
             server.quit()
         except Exception as e:
             return {


### PR DESCRIPTION
---
This code change involves the alerts module in mgr:

+ **Before the change**: The current alerts can send the cluster's health status to a configured email recipient, but currently, only one recipient can be configured.
+ **After the change**: It supports setting multiple recipients, with each recipient separated by a comma.
---


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
