### PR TITLE
squid: mds: encode quiesce payload on demand

### DIFF
--- a/src/mds/MDSRankQuiesce.cc
+++ b/src/mds/MDSRankQuiesce.cc
@@ -283,9 +283,8 @@ void MDSRank::quiesce_cluster_update() {
         }
         auto addrs = mdsmap->get_info_gid(membership.leader).addrs;
 
-        auto ack_msg = make_message<MMDSQuiesceDbAck>();
+        auto ack_msg = make_message<MMDSQuiesceDbAck>(QuiesceDbPeerAck{me, std::move(ack)});
         dout(10) << "sending ack " << ack << " to the leader " << membership.leader << dendl;
-        ack_msg->encode_payload_from({me, std::move(ack)});
         return send_message_mds(ack_msg, addrs);
       }
     };
@@ -297,9 +296,8 @@ void MDSRank::quiesce_cluster_update() {
         return -ENOENT;
       }
       auto addrs = mdsmap->get_info_gid(to).addrs;
-      auto listing_msg = make_message<MMDSQuiesceDbListing>();
+      auto listing_msg = make_message<MMDSQuiesceDbListing>(QuiesceDbPeerListing{me, std::move(db)});
       dout(10) << "sending listing " << db << " to the peer " << to << dendl;
-      listing_msg->encode_payload_from({me, std::move(db)});
       return send_message_mds(listing_msg, addrs);
     };
   }

--- a/src/messages/MMDSQuiesceDbAck.h
+++ b/src/messages/MMDSQuiesceDbAck.h
@@ -21,6 +21,10 @@
 class MMDSQuiesceDbAck final : public MMDSOp {
 protected:
   MMDSQuiesceDbAck() : MMDSOp{MSG_MDS_QUIESCE_DB_ACK} {}
+  MMDSQuiesceDbAck(auto&& _ack)
+    : MMDSOp{MSG_MDS_QUIESCE_DB_ACK}
+    , ack(std::forward<decltype(_ack)>(_ack))
+    {}
   ~MMDSQuiesceDbAck() final {}
 
 public:
@@ -31,11 +35,6 @@ public:
 
   void encode_payload(uint64_t features) override
   {
-    // noop to prevent unnecessary overheads
-  }
-
-  void encode_payload_from(QuiesceDbPeerAck const& ack)
-  {
     ::encode(ack, payload);
   }
 
@@ -43,10 +42,10 @@ public:
     // noop to prevent unnecessary overheads
   }
 
-  void decode_payload_into(QuiesceDbPeerAck &ack) const
+  void decode_payload_into(QuiesceDbPeerAck &_ack) const
   {
     auto p = payload.cbegin();
-    ::decode(ack, p);
+    ::decode(_ack, p);
   }
 
 private:
@@ -54,4 +53,6 @@ private:
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
   friend MURef<T> crimson::make_message(Args&&... args);
+
+  QuiesceDbPeerAck ack;
 };

--- a/src/messages/MMDSQuiesceDbAck.h
+++ b/src/messages/MMDSQuiesceDbAck.h
@@ -26,7 +26,7 @@ protected:
 public:
   std::string_view get_type_name() const override { return "mds_quiesce_db_ack"; }
   void print(std::ostream& o) const override {
-
+    o << get_type_name();
   }
 
   void encode_payload(uint64_t features) override

--- a/src/messages/MMDSQuiesceDbListing.h
+++ b/src/messages/MMDSQuiesceDbListing.h
@@ -26,7 +26,7 @@ protected:
 public:
   std::string_view get_type_name() const override { return "mds_quiesce_db_listing"; }
   void print(std::ostream& o) const override {
-
+    o << get_type_name();
   }
 
   void encode_payload(uint64_t features) override { 

--- a/src/messages/MMDSQuiesceDbListing.h
+++ b/src/messages/MMDSQuiesceDbListing.h
@@ -21,6 +21,10 @@
 class MMDSQuiesceDbListing final : public MMDSOp {
 protected:
   MMDSQuiesceDbListing() : MMDSOp{MSG_MDS_QUIESCE_DB_LISTING} {}
+  MMDSQuiesceDbListing(auto&& _pl)
+    : MMDSOp{MSG_MDS_QUIESCE_DB_LISTING}
+    , peer_listing(std::forward<decltype(_pl)>(_pl))
+    {}
   ~MMDSQuiesceDbListing() final {}
 
 public:
@@ -30,11 +34,6 @@ public:
   }
 
   void encode_payload(uint64_t features) override { 
-    // noop to prevent unnecessary overheads
-  }
-
-  void encode_payload_from(QuiesceDbPeerListing const& peer_listing)
-  {
     ::encode(peer_listing, payload);
   }
 
@@ -42,10 +41,10 @@ public:
     // noop to prevent unnecessary overheads
   }
 
-  void decode_payload_into(QuiesceDbPeerListing &peer_listing) const
+  void decode_payload_into(QuiesceDbPeerListing &pl) const
   {
     auto p = payload.cbegin();
-    ::decode(peer_listing, p);
+    ::decode(pl, p);
   }
 
 private:
@@ -53,4 +52,6 @@ private:
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
   template<class T, typename... Args>
   friend MURef<T> crimson::make_message(Args&&... args);
+
+  QuiesceDbPeerListing peer_listing;
 };


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67745

---

backport of https://github.com/ceph/ceph/pull/59176
parent tracker: https://tracker.ceph.com/issues/67406

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh