### PR TITLE
reef: mds: cephx path restriction incorrectly rejects snapshots of deleted directory

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -8159,6 +8159,7 @@ void Server::_unlink_local(MDRequestRef& mdr, CDentry *dn, CDentry *straydn)
   {
     std::string t;
     dn->make_path_string(t, true);
+    dout(20) << " stray_prior_path = " << t << dendl;
     pi.inode->stray_prior_path = std::move(t);
   }
   pi.inode->version = in->pre_dirty();
@@ -9458,6 +9459,7 @@ void Server::_rename_prepare(MDRequestRef& mdr,
       {
         std::string t;
         destdn->make_path_string(t, true);
+        dout(20) << " stray_prior_path = " << t << dendl;
         tpi->stray_prior_path = std::move(t);
       }
       tpi->nlink--;

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1047,11 +1047,28 @@ int Session::check_access(CInode *in, unsigned mask,
            << dendl;
 
   string path;
-  CInode *diri = NULL;
-  if (!in->is_base())
-    diri = in->get_projected_parent_dn()->get_dir()->get_inode();
-  if (diri && diri->is_stray()){
-    path = in->get_projected_inode()->stray_prior_path;
+  if (!in->is_base()) {
+    auto* dn = in->get_projected_parent_dn();
+    auto* pdiri = dn->get_dir()->get_inode();
+    if (pdiri) {
+      if (pdiri->is_stray()) {
+        path = in->get_projected_inode()->stray_prior_path;
+      } else if (!pdiri->is_base()) {
+        /* is the pdiri in the stray (is this inode in a snapshotted deleted directory?) */
+        auto* gpdiri = pdiri->get_projected_parent_dn()->get_dir()->get_inode();
+        /* stray_prior_path will not necessarily be part of the inode because
+         * it's set on unlink but that happens after the snapshot, naturally.
+         * We need to construct it manually.
+         */
+        if (gpdiri->is_stray()) {
+          /* just check access on the parent dir */
+          path = pdiri->get_projected_inode()->stray_prior_path;
+        }
+      }
+    }
+  }
+
+  if (!path.empty()) {
     dout(20) << __func__ << " stray_prior_path " << path << dendl;
   } else {
     in->make_path_string(path, true);

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1040,6 +1040,12 @@ int Session::check_access(CInode *in, unsigned mask,
 			  const vector<uint64_t> *caller_gid_list,
 			  int new_uid, int new_gid)
 {
+  dout(20) << __func__ << ": " << *in
+           << " caller_uid=" << caller_uid
+           << " caller_gid=" << caller_gid
+           << " caller_gid_list=" << *caller_gid_list
+           << dendl;
+
   string path;
   CInode *diri = NULL;
   if (!in->is_base())


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67750

---

backport of https://github.com/ceph/ceph/pull/58419
parent tracker: https://tracker.ceph.com/issues/66828

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh