### PR TITLE
quincy: mds: cephx path restriction incorrectly rejects snapshots of deleted directory

### DIFF
--- a/qa/tasks/cephfs/test_snapshots.py
+++ b/qa/tasks/cephfs/test_snapshots.py
@@ -360,6 +360,32 @@ class TestSnapshots(CephFSTestCase):
 
         self.mount_a.run_shell(["rmdir", Raw("d0/d2/dir/.snap/*")])
 
+    def test_snapshot_check_access(self):
+        """
+        """
+
+        self.mount_a.run_shell_payload("mkdir -p dir1/dir2")
+        self.mount_a.umount_wait(require_clean=True)
+
+        newid = 'foo'
+        keyring = self.fs.authorize(newid, ('/dir1', 'rws'))
+        keyring_path = self.mount_a.client_remote.mktemp(data=keyring)
+        self.mount_a.remount(client_id=newid, client_keyring_path=keyring_path, cephfs_mntpt='/dir1')
+
+        self.mount_a.run_shell_payload("pushd dir2; dd if=/dev/urandom of=file bs=4k count=1;")
+        self.mount_a.run_shell_payload("mkdir .snap/one")
+        self.mount_a.run_shell_payload("rm -rf dir2")
+        # ???
+        # Session check_access path ~mds0/stray3/10000000001/file
+        # 2024-07-04T02:05:07.884+0000 7f319ce86640 20 Session check_access: [inode 0x10000000002 [2,2] ~mds0/stray2/10000000001/file ...] caller_uid=1141 caller_gid=1141 caller_gid_list=[1000,1141]
+        # 2024-07-04T02:05:07.884+0000 7f319ce86640 20 Session check_access path ~mds0/stray2/10000000001/file
+        # should be
+        # 2024-07-04T02:11:26.990+0000 7f6b14e71640 20 Session check_access: [inode 0x10000000002 [2,2] ~mds0/stray2/10000000001/file ...] caller_uid=1141 caller_gid=1141 caller_gid_list=[1000,1141]
+        # 2024-07-04T02:11:26.990+0000 7f6b14e71640 20 Session check_access stray_prior_path /dir1/dir2
+        # 2024-07-04T02:11:26.990+0000 7f6b14e71640 10 MDSAuthCap is_capable inode(path /dir1/dir2 owner 1141:1141 mode 0100644) by caller 1141:1141 mask 1 new 0:0 cap: MDSAuthCaps[allow rws fsname=cephfs path="/dir1"]
+        self.mount_a.run_shell_payload("stat .snap/one/dir2/file")
+
+
     def test_multimds_mksnap(self):
         """
         check if snapshot takes effect across authority subtrees

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -8140,6 +8140,7 @@ void Server::_unlink_local(MDRequestRef& mdr, CDentry *dn, CDentry *straydn)
   {
     std::string t;
     dn->make_path_string(t, true);
+    dout(20) << " stray_prior_path = " << t << dendl;
     pi.inode->stray_prior_path = std::move(t);
   }
   pi.inode->version = in->pre_dirty();
@@ -9460,6 +9461,7 @@ void Server::_rename_prepare(MDRequestRef& mdr,
       {
         std::string t;
         destdn->make_path_string(t, true);
+        dout(20) << " stray_prior_path = " << t << dendl;
         tpi->stray_prior_path = std::move(t);
       }
       tpi->nlink--;

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1046,11 +1046,28 @@ int Session::check_access(CInode *in, unsigned mask,
            << dendl;
 
   string path;
-  CInode *diri = NULL;
-  if (!in->is_base())
-    diri = in->get_projected_parent_dn()->get_dir()->get_inode();
-  if (diri && diri->is_stray()){
-    path = in->get_projected_inode()->stray_prior_path;
+  if (!in->is_base()) {
+    auto* dn = in->get_projected_parent_dn();
+    auto* pdiri = dn->get_dir()->get_inode();
+    if (pdiri) {
+      if (pdiri->is_stray()) {
+        path = in->get_projected_inode()->stray_prior_path;
+      } else if (!pdiri->is_base()) {
+        /* is the pdiri in the stray (is this inode in a snapshotted deleted directory?) */
+        auto* gpdiri = pdiri->get_projected_parent_dn()->get_dir()->get_inode();
+        /* stray_prior_path will not necessarily be part of the inode because
+         * it's set on unlink but that happens after the snapshot, naturally.
+         * We need to construct it manually.
+         */
+        if (gpdiri->is_stray()) {
+          /* just check access on the parent dir */
+          path = pdiri->get_projected_inode()->stray_prior_path;
+        }
+      }
+    }
+  }
+
+  if (!path.empty()) {
     dout(20) << __func__ << " stray_prior_path " << path << dendl;
   } else {
     in->make_path_string(path, true);

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1039,6 +1039,12 @@ int Session::check_access(CInode *in, unsigned mask,
 			  const vector<uint64_t> *caller_gid_list,
 			  int new_uid, int new_gid)
 {
+  dout(20) << __func__ << ": " << *in
+           << " caller_uid=" << caller_uid
+           << " caller_gid=" << caller_gid
+           << " caller_gid_list=" << *caller_gid_list
+           << dendl;
+
   string path;
   CInode *diri = NULL;
   if (!in->is_base())


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67749

---

backport of https://github.com/ceph/ceph/pull/58419
parent tracker: https://tracker.ceph.com/issues/66828

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh