### PR TITLE
reef: qa: load all dirfrags before testing altname recovery

### DIFF
--- a/qa/tasks/cephfs/test_fscrypt.py
+++ b/qa/tasks/cephfs/test_fscrypt.py
@@ -83,9 +83,11 @@ class TestFSCryptRecovery(FSCryptTestCase):
         self.fs.set_joinable()
         self.fs.wait_for_daemons()
 
+        # load all inodes into cache (may be cleared by journal reset)
+        self.mount_a.run_shell_payload(f"cd {self.path} && find")
+
         verify_alternate_name()
 
-        self.mount_a.run_shell_payload(f"cd {self.path} && find")
         self.mount_a.run_shell_payload(f"cd {self.path} && stat {file}")
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67807

---

backport of https://github.com/ceph/ceph/pull/59310
parent tracker: https://tracker.ceph.com/issues/67511

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh