### PR TITLE
mgr/dashboard: Wrong capitalization of image and pool variables for embedded rbd-details dashboard

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -121,6 +121,7 @@ s0nea Tatjana Dehler <tdehler@suse.com>
 Sarthak0702 Sarthak Gupta <sarthak.dev.0702@gmail.com>
 saschagrunert Sascha Grunert <sgrunert@suse.com>
 sebastian-philipp Sebastian Wagner <sewagner@redhat.com>
+shraddhaag Shraddha Agrawal <shraddhaag@ibm.com>
 ShyamsundarR Shyamsundar R <srangana@redhat.com>
 sidharthanup Sidharth Anupkrishnan <sanupkri@redhat.com>
 smithfarm Nathan Cutler <ncutler@suse.com>

--- a/.mailmap
+++ b/.mailmap
@@ -672,6 +672,7 @@ Shiqi <m13913886148@gmail.com>
 Shiqi <m13913886148@gmail.com> <1454927420@qq.com>
 Shishir Gowda <shishir.gowda@sandisk.com>
 Shotaro Kawaguchi <kawaguchi.s@jp.fujitsu.com>
+Shraddha Agrawal <shraddhaag@ibm.com>
 Shreyansh Sancheti <ssanchet@redhat.com> shreyanshjain7174 <ssanchet@redhat.com>
 Shu, Xinxin <xinxin.shu@intel.com>
 Shuai Yong <yongshuai@sangfor.com.cn>

--- a/.organizationmap
+++ b/.organizationmap
@@ -357,6 +357,7 @@ IBM <contact@IBM.com> Neeraj Pratap Singh <Neeraj.Pratap.Singh1@ibm.com>
 IBM <contact@IBM.com> Or Ozeri <oro@il.ibm.com>
 IBM <contact@IBM.com> Paul Cuzner <pcuzner@ibm.com>
 IBM <contact@IBM.com> Samuel Matzek <smatzek@us.ibm.com>
+IBM <contact@IBM.com> Shraddha Agrawal <shraddhaag@ibm.com>
 IBM <contact@IBM.com> Sunil Angadi <Sunil.Angadi@ibm.com>
 IBM <contact@IBM.com> Teoman Onay <tonay@ibm.com>
 IBM <contact@ibm.com> Ulrich Weigand <ulrich.weigand@de.ibm.com>

--- a/doc/ceph-volume/lvm/newdb.rst
+++ b/doc/ceph-volume/lvm/newdb.rst
@@ -9,3 +9,48 @@ Logical volume name format is vg/lv. Fails if OSD has already got attached DB.
 Attach vgname/lvname as a DB volume to OSD 1::
 
     ceph-volume lvm new-db --osd-id 1 --osd-fsid 55BD4219-16A7-4037-BC20-0F158EFCC83D --target vgname/new_db
+
+Reversing BlueFS Spillover to Slow Devices
+------------------------------------------
+
+Under certain circumstances, OSD RocksDB databases spill onto slow storage and
+the Ceph cluster returns specifics regarding BlueFS spillover warnings. ``ceph
+health detail`` returns these spillover warnings.  Here is an example of a
+spillover warning::
+
+   osd.76 spilled over 128 KiB metadata from 'db' device (56 GiB used of 60 GiB) to slow device
+
+To move this DB metadata from the slower device to the faster device, take the
+following steps:
+
+#. Expand the database's logical volume (LV):
+
+   .. prompt:: bash #
+
+      lvextend -l ${size} ${lv}/${db} ${ssd_dev}
+
+#. Stop the OSD:
+
+   .. prompt:: bash #
+
+      cephadm unit --fsid $cid --name osd.${osd} stop
+
+#. Run the ``bluefs-bdev-expand`` command:
+
+   .. prompt:: bash #
+
+      cephadm shell --fsid $cid --name osd.${osd} -- ceph-bluestore-tool bluefs-bdev-expand --path /var/lib/ceph/osd/ceph-${osd}
+
+#. Run the ``bluefs-bdev-migrate`` command:
+
+   .. prompt:: bash #
+
+      cephadm shell --fsid $cid --name osd.${osd} -- ceph-bluestore-tool bluefs-bdev-migrate --path /var/lib/ceph/osd/ceph-${osd} --devs-source /var/lib/ceph/osd/ceph-${osd}/block --dev-target /var/lib/ceph/osd/ceph-${osd}/block.db 
+
+#. Restart the OSD:
+
+   .. prompt:: bash #
+
+      cephadm unit --fsid $cid --name osd.${osd} start
+
+.. note:: *The above procedure was developed by Chris Dunlop on the [ceph-users] mailing list, and can be seen in its original context here:* `[ceph-users] Re: Fixing BlueFS spillover (pacific 16.2.14) <https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/message/POPUFSZGXR3P2RPYPJ4WJ4HGHZ3QESF6/>`_

--- a/doc/mgr/alerts.rst
+++ b/doc/mgr/alerts.rst
@@ -23,7 +23,8 @@ The *alerts* module is enabled with::
 Configuration
 -------------
 
-To configure SMTP, all of the following config options must be set::
+To configure SMTP, all of the following config options must be set
+(When setting ``mgr/alerts/smtp_destination``, you can use commas to separate multiple)::
 
   ceph config set mgr mgr/alerts/smtp_host *<smtp-server>*
   ceph config set mgr mgr/alerts/smtp_destination *<email-address-to-send-to>*

--- a/examples/rgw/boto3/README.md
+++ b/examples/rgw/boto3/README.md
@@ -3,7 +3,7 @@ This directory contains examples on how to use AWS CLI/boto3 to exercise the Rad
 This is an extension to the [AWS SDK](https://github.com/boto/botocore/blob/develop/botocore/data/s3/2006-03-01/service-2.json).
 
 # Users
-For the standard client to support these extensions, the: ``service-2.sdk-extras.json`` file should be placed under: ``~/.aws/models/s3/2006-03-01/`` directory.
+For the standard client to support these extensions, the ``service-2.sdk-extras.json`` file should be added. You can place it under the default folder ``~/.aws/models/s3/2006-03-01/`` or create a custom one ``/path/to/custom/folder/models/s3/2006-03-01/`` and add it to ``AWS_DATA_PATH`` environment variable.
 For more information see [here](https://github.com/boto/botocore/blob/develop/botocore/loaders.py#L33).
 ## Python
 The [boto3 client](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) could be used with the extensions, code samples exists in this directory.

--- a/qa/cephfs/conf/mgr.yaml
+++ b/qa/cephfs/conf/mgr.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     conf:
       mgr:
+        client mount timeout: 30
         debug client: 20
         debug mgr: 20
         debug ms: 1

--- a/qa/cephfs/overrides/ignorelist_health.yaml
+++ b/qa/cephfs/overrides/ignorelist_health.yaml
@@ -3,9 +3,11 @@ overrides:
     log-ignorelist:
       - FS_DEGRADED
       - fs.*is degraded
+      - filesystem is degraded
       - FS_INLINE_DATA_DEPRECATED
       - FS_WITH_FAILED_MDS
       - MDS_ALL_DOWN
+      - filesystem is offline
       - MDS_DAMAGE
       - MDS_DEGRADED
       - MDS_FAILED

--- a/qa/suites/fs/functional/tasks/snap-schedule.yaml
+++ b/qa/suites/fs/functional/tasks/snap-schedule.yaml
@@ -15,6 +15,7 @@ overrides:
       - is full \(reached quota
       - POOL_FULL
       - POOL_BACKFILLFULL
+      - cluster \[WRN\] evicting unresponsive client
 
 tasks:
   - cephfs_test_runner:

--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -28,7 +28,7 @@ class Alerts(MgrModule):
         Option(
             name='smtp_destination',
             default='',
-            desc='Email address to send alerts to',
+            desc='Email address to send alerts to, use commas to separate multiple',
             runtime=True),
         Option(
             name='smtp_port',
@@ -243,7 +243,7 @@ class Alerts(MgrModule):
                 server = smtplib.SMTP(self.smtp_host, self.smtp_port)
             if self.smtp_password:
                 server.login(self.smtp_user, self.smtp_password)
-            server.sendmail(self.smtp_sender, self.smtp_destination, message)
+            server.sendmail(self.smtp_sender, self.smtp_destination.split(','), message)
             server.quit()
         except Exception as e:
             return {

--- a/src/pybind/mgr/cephadm/services/nvmeof.py
+++ b/src/pybind/mgr/cephadm/services/nvmeof.py
@@ -52,8 +52,9 @@ class NvmeofService(CephService):
             'name': name,
             'addr': host_ip,
             'port': spec.port,
-            'spdk_protocol_log_level': 'WARNING',
-            'rpc_socket': '/var/tmp/spdk.sock',
+            'spdk_log_level': 'WARNING',
+            'rpc_socket_dir': '/var/tmp/',
+            'rpc_socket_name': 'spdk.sock',
             'transport_tcp_options': transport_tcp_options,
             'rados_id': rados_id
         }

--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -18,6 +18,7 @@ omap_file_lock_retry_sleep_interval = {{ spec.omap_file_lock_retry_sleep_interva
 omap_file_update_reloads = {{ spec.omap_file_update_reloads }}
 allowed_consecutive_spdk_ping_failures = {{ spec.allowed_consecutive_spdk_ping_failures }}
 spdk_ping_interval_in_seconds = {{ spec.spdk_ping_interval_in_seconds }}
+ping_spdk_under_lock = {{ spec.ping_spdk_under_lock }}
 enable_monitor_client = {{ spec.enable_monitor_client }}
 
 [gateway-logs]
@@ -48,11 +49,11 @@ root_ca_cert = /root.ca.cert
 
 [spdk]
 tgt_path = {{ spec.tgt_path }}
-rpc_socket = {{ spec.rpc_socket }}
+rpc_socket_dir = {{ spec.rpc_socket_dir }}
+rpc_socket_name = {{ spec.rpc_socket_name }}
 timeout = {{ spec.spdk_timeout }}
 bdevs_per_cluster = {{ spec.bdevs_per_cluster }}
-log_level={{ spec.spdk_log_level }}
-protocol_log_level = {{ spec.spdk_protocol_log_level }}
+log_level = {{ spec.spdk_log_level }}
 conn_retries = {{ spec.conn_retries }}
 transports = {{ spec.transports }}
 {% if transport_tcp_options %}

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -407,6 +407,7 @@ omap_file_lock_retry_sleep_interval = 1.0
 omap_file_update_reloads = 10
 allowed_consecutive_spdk_ping_failures = 1
 spdk_ping_interval_in_seconds = 2.0
+ping_spdk_under_lock = False
 enable_monitor_client = True
 
 [gateway-logs]
@@ -437,11 +438,11 @@ root_ca_cert = /root.ca.cert
 
 [spdk]
 tgt_path = /usr/local/bin/nvmf_tgt
-rpc_socket = /var/tmp/spdk.sock
+rpc_socket_dir = /var/tmp/
+rpc_socket_name = spdk.sock
 timeout = 60.0
 bdevs_per_cluster = 32
-log_level=
-protocol_log_level = WARNING
+log_level = WARNING
 conn_retries = 10
 transports = tcp
 transport_tcp_options = {{"in_capsule_data_size": 8192, "max_io_qpairs_per_ctrlr": 7}}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.ts
@@ -25,7 +25,7 @@ export class RbdDetailsComponent implements OnChanges {
 
   ngOnChanges() {
     if (this.selection) {
-      this.rbdDashboardUrl = `rbd-details?var-Pool=${this.selection['pool_name']}&var-Image=${this.selection['name']}`;
+      this.rbdDashboardUrl = `rbd-details?var-pool=${this.selection['pool_name']}&var-image=${this.selection['name']}`;
     }
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster.component.ts
@@ -433,5 +433,6 @@ export class MultiClusterComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.subs.unsubscribe();
     clearInterval(this.interval);
+    this.prometheusService.unsubscribe();
   }
 }

--- a/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
@@ -364,7 +364,7 @@ public:
 
   void expect_is_linked(MockStateBuilder& mock_state_builder, bool is_linked) {
     EXPECT_CALL(mock_state_builder, is_linked())
-      .WillOnce(Return(is_linked));
+      .WillRepeatedly(Return(is_linked));
   }
 
   void expect_is_disconnected(MockStateBuilder& mock_state_builder,

--- a/src/test/rgw/bucket_notification/README.rst
+++ b/src/test/rgw/bucket_notification/README.rst
@@ -133,6 +133,10 @@ Then you need to run the following command::
 
         sudo chkconfig rabbitmq-server on
 
+Update rabbitmq-server configuration to allow access to the guest user from anywhere on the network. Uncomment or add line to rabbirmq configuration, usually `/etc/rabbitmq/rabbirmq.comf`::
+
+        loopback_user.guest = false
+
 Finally, to start the RabbitMQ server you need to run the following command::
 
         sudo /sbin/service rabbitmq-server start
@@ -140,6 +144,18 @@ Finally, to start the RabbitMQ server you need to run the following command::
 To confirm that the RabbitMQ server is running you can run the following command to check the status of the server::
 
         sudo /sbin/service rabbitmq-server status
+
+Add [boto3 extension](https://github.com/ceph/ceph/tree/main/examples/rgw/boto3#introduction) as it's required for bucket notification tests. You can use the default folder or create a custom one, more information [here](https://github.com/boto/botocore/blob/develop/botocore/loaders.py#L33).
+Default folder::
+
+        mkdir -p ~/.aws/models/s3/2006-03-01/
+        cp /path/to/ceph/examples/rgw/boto3/service-2.sdk-extras.json ~/.aws/models/s3/2006-03-01/
+
+Custom folder::
+
+        mkdir -p /path/to/custom/folder/models/s3/2006-03-01/
+        cp /path/to/ceph/examples/rgw/boto3/service-2.sdk-extras.json /path/to/custom/folder/models/s3/2006-03-01/
+        export AWS_DATA_PATH=/path/to/custom/folder/
 
 After running `vstart.sh` and RabbitMQ server you're ready to run the AMQP tests::
 
@@ -156,4 +172,3 @@ To run the RabbitMQ SSL security tests use the following::
 During these tests, the test script will restart the RabbitMQ server with the correct security configuration (``sudo`` privileges will be needed).
 For that reason it is not recommended to run the `amqp_ssl_test` tests, that assumes a manually configured rabbirmq server, in the same run as `amqp_test` tests, 
 that assume the rabbitmq daemon running on the host as a service.
-

--- a/src/test/rgw/bucket_notification/README.rst
+++ b/src/test/rgw/bucket_notification/README.rst
@@ -25,6 +25,7 @@ we would need the following configuration file::
 				access_key = 1234567890
 				secret_key = pencil
 
+Add boto3 extension to the standard client: https://github.com/ceph/ceph/tree/main/examples/rgw/boto3#introduction.
 
 ===========
 Kafka Tests
@@ -125,7 +126,7 @@ To run the Kafka security test, you also need to provide the test with the locat
 RabbitMQ Tests
 ==============
 
-You need to install RabbitMQ in the following way::
+You need to install RabbitMQ, check supported platforms: https://www.rabbitmq.com/docs/platforms. For example, for Fedora::
 
         sudo dnf install rabbitmq-server
 
@@ -139,23 +140,11 @@ Update rabbitmq-server configuration to allow access to the guest user from anyw
 
 Finally, to start the RabbitMQ server you need to run the following command::
 
-        sudo /sbin/service rabbitmq-server start
+        sudo systemctl start rabbitmq-server
 
 To confirm that the RabbitMQ server is running you can run the following command to check the status of the server::
 
-        sudo /sbin/service rabbitmq-server status
-
-Add [boto3 extension](https://github.com/ceph/ceph/tree/main/examples/rgw/boto3#introduction) as it's required for bucket notification tests. You can use the default folder or create a custom one, more information [here](https://github.com/boto/botocore/blob/develop/botocore/loaders.py#L33).
-Default folder::
-
-        mkdir -p ~/.aws/models/s3/2006-03-01/
-        cp /path/to/ceph/examples/rgw/boto3/service-2.sdk-extras.json ~/.aws/models/s3/2006-03-01/
-
-Custom folder::
-
-        mkdir -p /path/to/custom/folder/models/s3/2006-03-01/
-        cp /path/to/ceph/examples/rgw/boto3/service-2.sdk-extras.json /path/to/custom/folder/models/s3/2006-03-01/
-        export AWS_DATA_PATH=/path/to/custom/folder/
+        sudo systemctl status rabbitmq-server
 
 After running `vstart.sh` and RabbitMQ server you're ready to run the AMQP tests::
 
@@ -163,7 +152,7 @@ After running `vstart.sh` and RabbitMQ server you're ready to run the AMQP tests
 
 After running the tests you need to stop the vstart cluster (``/path/to/ceph/src/stop.sh``) and the RabbitMQ server by running the following command::
 
-        sudo /sbin/service rabbitmq-server stop
+        sudo systemctl stop rabbitmq-server
 
 To run the RabbitMQ SSL security tests use the following::
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/67849

The Performance tab of the dashboard is passing the `pool` and `image` variables to the Grafana iframe with the first letter in uppercase, but in the `monitoring/ceph-mixin/dashboards_out/rbd-details.json` dashboard file they are defined in lowercase, this causes them not to be recognized and the graphics display _No data_.

Example of current (wrong) generated URL:

`https://mycephdashboard.com/d/eRtdGrFfgT/rbd-details?var-Pool=pve_rbd_ssd&var-Image=base-501-disk-0 &refresh=5s&var-datasource=Dashboard1&kiosk&from=now-1h&to=now&orgId=1`

It should be:

`https://mycephdashboard.com/d/eRtdGrFfgT/rbd-details?var-pool=pve_rbd_ssd&var-image=base-501-disk-0 &refresh=5s&var-datasource=Dashboard1&kiosk&from=now-1h&to=now&orgId=1`

_Note that the `var-Image` and `var-Pool` URL variables have the first letter capitalized._

This is happening in all versions of ceph.

![image](https://github.com/user-attachments/assets/2c4d58be-03b7-483b-809f-59dc25cd2e86)

A workaround for this bug for a running production cluster could be rename the variables in the corresponding dashboard file.

```
sed -i \
    -e 's/\$image/\$Image/g' \
    -e 's/"name": "image"/"name": "Image"/g' \
    -e 's/\$pool/\$Pool/g' \
    -e 's/"name": "pool"/"name": "Pool"/g' \
    monitoring/ceph-mixin/dashboards_out/rbd-details.json
```
