### PR TITLE
rgw: raise default rgw_max_listing_results=5000

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3428,10 +3428,10 @@ options:
 - name: rgw_max_listing_results
   type: uint
   level: advanced
-  desc: Upper bound on results in listing operations, ListBucket max-keys
+  desc: Upper bound on results in listing operations, ListObjects max-keys
   long_desc: This caps the maximum permitted value for listing-like operations in
-    RGW S3. Affects ListBucket(max-keys), ListBucketVersions(max-keys), ListBucketMultipartUploads(max-uploads),
-    ListMultipartUploadParts(max-parts)
+    RGW S3. Affects ListObjects(max-keys), ListObjectsVersions(max-keys),
+    ListMultipartUploads(max-uploads), ListParts(max-parts)
   default: 1000
   services:
   - rgw

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3432,7 +3432,7 @@ options:
   long_desc: This caps the maximum permitted value for listing-like operations in
     RGW S3. Affects ListObjects(max-keys), ListObjectsVersions(max-keys),
     ListMultipartUploads(max-uploads), ListParts(max-parts)
-  default: 1000
+  default: 5000
   services:
   - rgw
   - rgw


### PR DESCRIPTION
allow clients to request more than the default 1000 keys per request

bucket listing of large buckets (with many shards) can be more efficient with larger batches. raising max-keys also improves the balls-into-bins algorithm (see https://github.com/ceph/ceph/pull/30853) which we artificially cap at a minimum of 8 keys per shard

with the default max-keys=1000, we reach this min=8 at around 350 shards. above that shard count, we're always requesting more than the optimal number of entries per shard, so wasting i/o and bandwidth

as we raise the max-keys, we push this minimum to higher shard counts:

| max-keys | shard count |
|----------|-------------|
|     1000 |         350 |
|     2000 |         720 |
|     3000 |        1100 |
|     4000 |        1500 |
|     5000 |        1900 |

this table was calculated with the formula (using various values of max-keys):

> solve 8 = 1 + (1000/x + sqrt(2 * 1000 * log10(1000) / x))

ex. https://www.wolframalpha.com/input?i=solve+8+%3D+1+%2B+%281000%2Fx+%2B+sqrt%282+*+1000+*+log10%281000%29+%2F+x%29%29

raising max-keys does increase the total memory usage of each bucket listing request, which gets into megabytes (tens to hundreds?). so i chose 5000 as a cutoff that covers most of the range up to our current rgw_max_dynamic_shards=1999

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
