### PR TITLE
qa/rgw/multisite: specify realm/zonegroup/zone args for 'account create'

### DIFF
--- a/qa/suites/rgw/multisite/realms/three-zones.yaml.disabled
+++ b/qa/suites/rgw/multisite/realms/three-zones.yaml.disabled
@@ -2,7 +2,7 @@ overrides:
   rgw-multisite:
     realm:
       name: test-realm
-      is default: true
+      is_default: true
     zonegroups:
       - name: test-zonegroup
         is_master: true

--- a/qa/suites/rgw/multisite/realms/two-zonegroup.yaml.disabled
+++ b/qa/suites/rgw/multisite/realms/two-zonegroup.yaml.disabled
@@ -2,7 +2,7 @@ overrides:
   rgw-multisite:
     realm:
       name: test-realm
-      is default: true
+      is_default: true
     zonegroups:
       - name: a
         is_master: true

--- a/qa/suites/rgw/multisite/realms/two-zones.yaml
+++ b/qa/suites/rgw/multisite/realms/two-zones.yaml
@@ -2,7 +2,7 @@ overrides:
   rgw-multisite:
     realm:
       name: test-realm
-      is default: true
+      is_default: true
     zonegroups:
       - name: test-zonegroup
         is_master: true

--- a/qa/tasks/rgw_multisite.py
+++ b/qa/tasks/rgw_multisite.py
@@ -139,7 +139,10 @@ class RGWMultisite(Task):
 
                 if cluster != cluster1: # already created on master cluster
                     log.info('pulling realm configuration to %s', cluster.name)
-                    realm.pull(cluster, master_zone.gateways[0], creds)
+
+                    is_default = self.config['realm'].get('is_default', False)
+                    args = ['--default'] if is_default else []
+                    realm.pull(cluster, master_zone.gateways[0], creds, args)
 
                 # use the first zone's cluster to create the zonegroup
                 if not zonegroup:

--- a/qa/tasks/rgw_multisite_tests.py
+++ b/qa/tasks/rgw_multisite_tests.py
@@ -72,7 +72,9 @@ class RGWMultisiteTests(Task):
         # create test account/user
         log.info('creating test user..')
         user = multisite.User('rgw-multisite-test-user', account='RGW11111111111111111')
-        master_zone.cluster.admin(['account', 'create', '--account-id', user.account])
+        arg = ['--account-id', user.account]
+        arg += master_zone.zone_args()
+        master_zone.cluster.admin(['account', 'create'] + arg)
         user.create(master_zone, ['--display-name', 'TestUser',
                                   '--gen-access-key', '--gen-secret'])
 


### PR DESCRIPTION
in the rgw/multisite suite, jobs fail on user creation:

> radosgw-admin --cluster c1 account create --account-id RGW11111111111111111
> radosgw-admin --cluster c1 user create --uid rgw-multisite-test-user --account-id RGW11111111111111111 --account-root --rgw-zone test-zone1 --rgw-zonegroup test-zonegroup --rgw-realm test-realm --display-name TestUser --gen-access-key --gen-secret
> could not create user: unable to create user, Failed to load account by id

realms/two-zones.yaml misspells `is_default` as `is default` for the realm, so it doesn't get set as default. the `account create` command doesn't specify a realm/zonegroup/zone, so operates on the "default" zone and zonegroup

use `zone_args()` to add the explicit realm/zonegroup/zone arguments

Fixes: https://tracker.ceph.com/issues/67839

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
