### PR TITLE
rgw: exclude nanosecs on 'LastModified' responses

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -497,8 +497,19 @@ void dump_epoch_header(req_state *s, const char *name, real_time t)
 void dump_time(req_state *s, const char *name, real_time t)
 {
   char buf[TIME_BUF_SIZE];
-  rgw_to_iso8601(t, buf, sizeof(buf));
+  struct tm tmp;
+  utime_t ut(t);
+  time_t secs = (time_t)ut.sec();
+  gmtime_r(&secs, &tmp);
+  strftime(buf, sizeof(buf), "%Y-%m-%dT%T.000Z", &tmp);
 
+  s->formatter->dump_string(name, buf);
+}
+
+void dump_time_iso8601(req_state *s, const char *name, real_time t)
+{
+  char buf[TIME_BUF_SIZE];
+  rgw_to_iso8601(t, buf, sizeof(buf));
   s->formatter->dump_string(name, buf);
 }
 

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -832,6 +832,7 @@ extern void dump_range(req_state* s, uint64_t ofs, uint64_t end,
 extern void dump_continue(req_state *s);
 extern void list_all_buckets_end(req_state *s);
 extern void dump_time(req_state *s, const char *name, real_time t);
+extern void dump_time_iso8601(req_state *s, const char *name, real_time t);
 extern std::string dump_time_to_str(const real_time& t);
 extern void dump_bucket_from_state(req_state *s);
 extern void dump_redirect(req_state *s, const std::string& redirect);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -95,7 +95,7 @@ void dump_bucket(req_state *s, const RGWBucketEnt& ent)
 {
   s->formatter->open_object_section("Bucket");
   s->formatter->dump_string("Name", ent.bucket.name);
-  dump_time(s, "CreationDate", ent.creation_time);
+  dump_time_iso8601(s, "CreationDate", ent.creation_time);
   s->formatter->close_section();
 }
 
@@ -2756,16 +2756,7 @@ void RGWPutObj_ObjStore_S3::send_response()
       }
       end_header(s, this, to_mime_type(s->format));
       dump_start(s);
-      struct tm tmp;
-      utime_t ut(mtime);
-      time_t secs = (time_t)ut.sec();
-      gmtime_r(&secs, &tmp);
-      char buf[TIME_BUF_SIZE];
-      s->formatter->open_object_section_in_ns("CopyPartResult",
-          "http://s3.amazonaws.com/doc/2006-03-01/");
-      if (strftime(buf, sizeof(buf), "%Y-%m-%dT%T.000Z", &tmp) > 0) {
-        s->formatter->dump_string("LastModified", buf);
-      }
+      dump_time(s, "LastModified", mtime);
       s->formatter->dump_string("ETag", etag);
       s->formatter->close_section();
       rgw_flush_formatter_and_reset(s, s->formatter);
@@ -4236,7 +4227,7 @@ void RGWListBucketMultiparts_ObjStore_S3::send_response()
       dump_owner(s, owner.id, owner.display_name, "Initiator");
       dump_owner(s, owner.id, owner.display_name); // Owner
       s->formatter->dump_string("StorageClass", "STANDARD");
-      dump_time(s, "Initiated", upload->get_mtime());
+      dump_time_iso8601(s, "Initiated", upload->get_mtime());
       s->formatter->close_section();
     }
     if (!common_prefixes.empty()) {


### PR DESCRIPTION
Turns out replying with nanoseconds on `LastModified` responses may not be quite according to S3 specification. Furthermore, this leads to inconsistencies between operations like `ListObjectVersions` and `HeadObject`, where the latter does not include nanoseconds, potentially causing clients to be confused.

This patch ensures the `dump_time()` function, mostly used for the `LastModified` field, does not return nanoseconds.
To avoid potential issues with other fields relying on this function, a new function `dump_time_iso8601()` was created, ensuring the previous behavior is maintained.

Fixes: https://tracker.ceph.com/issues/67846

Signed-off-by: Joao Eduardo Luis <joao@clyso.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

<!--
## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>