### PR TITLE
crimson/os/seastore/cache: report cache access stats

### DIFF
--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -38,12 +38,14 @@ const get_phy_tree_root_node_ret get_phy_tree_root_node<
 	      trans_intr::make_interruptible(
 		c.cache.get_extent_viewable_by_trans(c.trans, backref_root))};
     } else {
+      c.cache.account_absent_access(c.trans.get_src());
       return {false,
 	      trans_intr::make_interruptible(
 		Cache::get_extent_ertr::make_ready_future<
 		  CachedExtentRef>())};
     }
   } else {
+    c.cache.account_absent_access(c.trans.get_src());
     return {false,
 	    trans_intr::make_interruptible(
 	      Cache::get_extent_ertr::make_ready_future<

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -370,9 +370,11 @@ struct FixedKVNode : ChildableCachedExtent {
       if (is_valid_child_ptr(child)) {
 	return c.cache.template get_extent_viewable_by_trans<T>(c.trans, (T*)child);
       } else {
+        c.cache.account_absent_access(c.trans.get_src());
 	return child_pos_t(&sparent, spos);
       }
     } else {
+      c.cache.account_absent_access(c.trans.get_src());
       return child_pos_t(this, pos);
     }
   }

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -204,25 +204,25 @@ void Cache::register_metrics()
   /*
    * cache_query: cache_access and cache_hit
    */
-  for (auto& [src, src_label] : labels_by_src) {
-    metrics.add_group(
-      "cache",
-      {
-        sm::make_counter(
-          "cache_access",
-          get_by_src(stats.cache_query_by_src, src).access,
-          sm::description("total number of cache accesses"),
-          {src_label}
-        ),
-        sm::make_counter(
-          "cache_hit",
-          get_by_src(stats.cache_query_by_src, src).hit,
-          sm::description("total number of cache hits"),
-          {src_label}
-        ),
-      }
-    );
-  }
+  metrics.add_group(
+    "cache",
+    {
+      sm::make_counter(
+        "cache_access",
+        [this] {
+          return stats.access.get_cache_access();
+        },
+        sm::description("total number of cache accesses")
+      ),
+      sm::make_counter(
+        "cache_hit",
+        [this] {
+          return stats.access.s.get_cache_hit();
+        },
+        sm::description("total number of cache hits")
+      ),
+    }
+  );
 
   {
     /*

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -2317,7 +2317,7 @@ cache_stats_t Cache::get_stats(
       const auto& io_by_ext = get_by_src(_trans_io_by_src_ext, src);
       for (uint8_t _ext=0; _ext<EXTENT_TYPES_MAX; ++_ext) {
         auto ext = static_cast<extent_types_t>(_ext);
-        const auto extent_io = get_by_ext(io_by_ext, ext);
+        const auto& extent_io = get_by_ext(io_by_ext, ext);
         if (is_data_type(ext)) {
           data_io.add(extent_io);
         } else if (is_logical_metadata_type(ext)) {

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -423,6 +423,10 @@ public:
     SUBTRACET(seastore_cache, "{} {}~{} is absent on t, query cache ...",
 	      t, T::TYPE, offset, length);
     auto f = [&t, this](CachedExtent &ext) {
+      // FIXME: assert(ext.is_stable_clean());
+      assert(ext.is_stable());
+      assert(T::TYPE == ext.get_type());
+
       t.add_to_read_set(CachedExtentRef(&ext));
       const auto t_src = t.get_src();
       touch_extent(ext, &t_src);
@@ -762,6 +766,9 @@ private:
     SUBTRACET(seastore_cache, "{} {}~{} {} is absent on t, query cache ...",
 	      t, type, offset, length, laddr);
     auto f = [&t, this](CachedExtent &ext) {
+      // FIXME: assert(ext.is_stable_clean());
+      assert(ext.is_stable());
+
       t.add_to_read_set(CachedExtentRef(&ext));
       const auto t_src = t.get_src();
       touch_extent(ext, &t_src);
@@ -1791,6 +1798,7 @@ private:
           !is_retired_placeholder_type(iter->get_type())) {
         ++p_counters->hit;
       }
+      assert(iter->is_stable());
       return CachedExtentRef(&*iter);
     } else {
       return CachedExtentRef();

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1722,6 +1722,10 @@ private:
     last_dirty_io_by_src_ext;
   mutable rewrite_stats_t last_trim_rewrites;
   mutable rewrite_stats_t last_reclaim_rewrites;
+  mutable cache_access_stats_t last_access;
+  mutable counter_by_src_t<uint64_t> last_cache_absent_by_src;
+  mutable counter_by_src_t<counter_by_extent_t<extent_access_stats_t> >
+    last_access_by_src_ext;
 
   void account_conflict(Transaction::src_t src1, Transaction::src_t src2) {
     assert(src1 < Transaction::src_t::MAX);

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -786,7 +786,7 @@ protected:
 
   struct retired_placeholder_t{};
   CachedExtent(retired_placeholder_t, extent_len_t _length)
-    : state(extent_state_t::INVALID),
+    : state(extent_state_t::CLEAN),
       length(_length) {
     assert(length > 0);
   }

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -62,12 +62,14 @@ const get_phy_tree_root_node_ret get_phy_tree_root_node<
 	      trans_intr::make_interruptible(
 		c.cache.get_extent_viewable_by_trans(c.trans, lba_root))};
     } else {
+      c.cache.account_absent_access(c.trans.get_src());
       return {false,
 	      trans_intr::make_interruptible(
 		Cache::get_extent_ertr::make_ready_future<
 		  CachedExtentRef>())};
     }
   } else {
+    c.cache.account_absent_access(c.trans.get_src());
     return {false,
 	    trans_intr::make_interruptible(
 	      Cache::get_extent_ertr::make_ready_future<

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -740,6 +740,19 @@ seastar::future<> SeaStore::report_stats()
          dirty_sizes_ps,
          dirty_io_stats_printer_t{seconds, dirty_io_ps});
 
+    cache_access_stats_t access_ps = cache_total.access;
+    access_ps.cache_absent /= seastar::smp::count;
+    access_ps.s.trans_pending /= seastar::smp::count;
+    access_ps.s.trans_dirty /= seastar::smp::count;
+    access_ps.s.trans_lru /= seastar::smp::count;
+    access_ps.s.cache_dirty /= seastar::smp::count;
+    access_ps.s.cache_lru /= seastar::smp::count;
+    access_ps.s.load_absent /= seastar::smp::count;
+    access_ps.s.load_present /= seastar::smp::count;
+    INFO("cache_access: total{}; per-shard{}",
+         cache_access_stats_printer_t{seconds, cache_total.access},
+         cache_access_stats_printer_t{seconds, access_ps});
+
     return seastar::now();
   });
 }

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -711,13 +711,9 @@ seastar::future<> SeaStore::report_stats()
     }
 
     cache_size_stats_t lru_sizes_ps = cache_total.lru_sizes;
-    lru_sizes_ps.size /= seastar::smp::count;
-    lru_sizes_ps.num_extents /= seastar::smp::count;
+    lru_sizes_ps.divide_by(seastar::smp::count);
     cache_io_stats_t lru_io_ps = cache_total.lru_io;
-    lru_io_ps.in_sizes.size /= seastar::smp::count;
-    lru_io_ps.in_sizes.num_extents /= seastar::smp::count;
-    lru_io_ps.out_sizes.size /= seastar::smp::count;
-    lru_io_ps.out_sizes.num_extents /= seastar::smp::count;
+    lru_io_ps.divide_by(seastar::smp::count);
     INFO("cache lru: total{} {}; per-shard: total{} {}",
          cache_total.lru_sizes,
          cache_io_stats_printer_t{seconds, cache_total.lru_io},
@@ -725,15 +721,9 @@ seastar::future<> SeaStore::report_stats()
          cache_io_stats_printer_t{seconds, lru_io_ps});
 
     cache_size_stats_t dirty_sizes_ps = cache_total.dirty_sizes;
-    dirty_sizes_ps.size /= seastar::smp::count;
-    dirty_sizes_ps.num_extents /= seastar::smp::count;
+    dirty_sizes_ps.divide_by(seastar::smp::count);
     dirty_io_stats_t dirty_io_ps = cache_total.dirty_io;
-    dirty_io_ps.in_sizes.size /= seastar::smp::count;
-    dirty_io_ps.in_sizes.num_extents /= seastar::smp::count;
-    dirty_io_ps.num_replace /= seastar::smp::count;
-    dirty_io_ps.out_sizes.size /= seastar::smp::count;
-    dirty_io_ps.out_sizes.num_extents /= seastar::smp::count;
-    dirty_io_ps.out_versions /= seastar::smp::count;
+    dirty_io_ps.divide_by(seastar::smp::count);
     INFO("cache dirty: total{} {}; per-shard: total{} {}",
          cache_total.dirty_sizes,
          dirty_io_stats_printer_t{seconds, cache_total.dirty_io},
@@ -741,14 +731,7 @@ seastar::future<> SeaStore::report_stats()
          dirty_io_stats_printer_t{seconds, dirty_io_ps});
 
     cache_access_stats_t access_ps = cache_total.access;
-    access_ps.cache_absent /= seastar::smp::count;
-    access_ps.s.trans_pending /= seastar::smp::count;
-    access_ps.s.trans_dirty /= seastar::smp::count;
-    access_ps.s.trans_lru /= seastar::smp::count;
-    access_ps.s.cache_dirty /= seastar::smp::count;
-    access_ps.s.cache_lru /= seastar::smp::count;
-    access_ps.s.load_absent /= seastar::smp::count;
-    access_ps.s.load_present /= seastar::smp::count;
+    access_ps.divide_by(seastar::smp::count);
     INFO("cache_access: total{}; per-shard{}",
          cache_access_stats_printer_t{seconds, cache_total.access},
          cache_access_stats_printer_t{seconds, access_ps});

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -1038,4 +1038,78 @@ std::ostream& operator<<(std::ostream& out, const dirty_io_stats_printer_t& p)
   return out;
 }
 
+std::ostream& operator<<(std::ostream& out, const extent_access_stats_printer_t& p)
+{
+  constexpr const char* dfmt = "{:.2f}";
+  double est_total_access = static_cast<double>(p.stats.get_estimated_total_access());
+  out << "(~";
+  if (est_total_access > 1000000) {
+    out << fmt::format(dfmt, est_total_access/1000000)
+        << "M, ";
+  } else {
+    out << fmt::format(dfmt, est_total_access/1000)
+        << "K, ";
+  }
+  double trans_hit = static_cast<double>(p.stats.get_trans_hit());
+  double cache_hit = static_cast<double>(p.stats.get_cache_hit());
+  double est_cache_access = static_cast<double>(p.stats.get_estimated_cache_access());
+  double load_absent = static_cast<double>(p.stats.load_absent);
+  out << "trans-hit=~"
+      << fmt::format(dfmt, trans_hit/est_total_access*100)
+      << "%(p"
+      << fmt::format(dfmt, p.stats.trans_pending/trans_hit)
+      << ",d"
+      << fmt::format(dfmt, p.stats.trans_dirty/trans_hit)
+      << ",l"
+      << fmt::format(dfmt, p.stats.trans_lru/trans_hit)
+      << "), cache-hit=~"
+      << fmt::format(dfmt, cache_hit/est_cache_access*100)
+      << "%(d"
+      << fmt::format(dfmt, p.stats.cache_dirty/cache_hit)
+      << ",l"
+      << fmt::format(dfmt, p.stats.cache_lru/cache_hit)
+      <<"), load-present/absent="
+      << fmt::format(dfmt, p.stats.load_present/load_absent)
+      << ")";
+  return out;
+}
+
+std::ostream& operator<<(std::ostream& out, const cache_access_stats_printer_t& p)
+{
+  constexpr const char* dfmt = "{:.2f}";
+  double total_access = static_cast<double>(p.stats.get_total_access());
+  out << "(";
+  if (total_access > 1000000) {
+    out << fmt::format(dfmt, total_access/1000000)
+        << "M, ";
+  } else {
+    out << fmt::format(dfmt, total_access/1000)
+        << "K, ";
+  }
+  double trans_hit = static_cast<double>(p.stats.s.get_trans_hit());
+  double cache_hit = static_cast<double>(p.stats.s.get_cache_hit());
+  double cache_access = static_cast<double>(p.stats.get_cache_access());
+  double load_absent = static_cast<double>(p.stats.s.load_absent);
+  out << "trans-hit="
+      << fmt::format(dfmt, trans_hit/total_access*100)
+      << "%(p"
+      << fmt::format(dfmt, p.stats.s.trans_pending/trans_hit)
+      << ",d"
+      << fmt::format(dfmt, p.stats.s.trans_dirty/trans_hit)
+      << ",l"
+      << fmt::format(dfmt, p.stats.s.trans_lru/trans_hit)
+      << "), cache-hit="
+      << fmt::format(dfmt, cache_hit/cache_access*100)
+      << "%(d"
+      << fmt::format(dfmt, p.stats.s.cache_dirty/cache_hit)
+      << ",l"
+      << fmt::format(dfmt, p.stats.s.cache_lru/cache_hit)
+      <<"), load/absent="
+      << fmt::format(dfmt, load_absent/p.stats.cache_absent*100)
+      << "%, load-present/absent="
+      << fmt::format(dfmt, p.stats.s.load_present/load_absent)
+      << ")";
+  return out;
+}
+
 } // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2868,6 +2868,38 @@ struct dirty_io_stats_printer_t {
 };
 std::ostream& operator<<(std::ostream&, const dirty_io_stats_printer_t&);
 
+/*
+ * Doesn't account:
+ *   replay
+ *   rewrite
+ *   retiring/placeholder
+ *   get_caching_extent() -- test only
+ *   get_caching_extent_by_type() -- test only
+ */
+struct extent_access_stats_t {
+  uint64_t trans_pending = 0;
+  uint64_t trans_dirty = 0;
+  uint64_t trans_lru = 0;
+  uint64_t cache_dirty = 0;
+  uint64_t cache_lru = 0;
+
+  uint64_t load_absent = 0;
+  uint64_t load_present = 0;
+
+  uint64_t get_cache_hit() const {
+    return cache_dirty + cache_lru;
+  }
+};
+
+struct cache_access_stats_t {
+  extent_access_stats_t s;
+  uint64_t cache_absent = 0;
+
+  uint64_t get_cache_access() const {
+    return s.get_cache_hit() + cache_absent;
+  }
+};
+
 struct cache_stats_t {
   cache_size_stats_t lru_sizes;
   cache_io_stats_t lru_io;

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -2800,6 +2800,11 @@ struct cache_size_stats_t {
     size -= o.size;
     num_extents -= o.num_extents;
   }
+
+  void divide_by(unsigned d) {
+    size /= d;
+    num_extents /= d;
+  }
 };
 std::ostream& operator<<(std::ostream&, const cache_size_stats_t&);
 struct cache_size_stats_printer_t {
@@ -2824,6 +2829,11 @@ struct cache_io_stats_t {
   void minus(const cache_io_stats_t& o) {
     in_sizes.minus(o.in_sizes);
     out_sizes.minus(o.out_sizes);
+  }
+
+  void divide_by(unsigned d) {
+    in_sizes.divide_by(d);
+    out_sizes.divide_by(d);
   }
 };
 struct cache_io_stats_printer_t {
@@ -2860,6 +2870,13 @@ struct dirty_io_stats_t {
     num_replace -= o.num_replace;
     out_sizes.minus(o.out_sizes);
     out_versions -= o.out_versions;
+  }
+
+  void divide_by(unsigned d) {
+    in_sizes.divide_by(d);
+    num_replace /= d;
+    out_sizes.divide_by(d);
+    out_versions /= d;
   }
 };
 struct dirty_io_stats_printer_t {
@@ -2925,6 +2942,16 @@ struct extent_access_stats_t {
     load_absent -= o.load_absent;
     load_present -= o.load_present;
   }
+
+  void divide_by(unsigned d) {
+    trans_pending /= d;
+    trans_dirty /= d;
+    trans_lru /= d;
+    cache_dirty /= d;
+    cache_lru /= d;
+    load_absent /= d;
+    load_present /= d;
+  }
 };
 struct extent_access_stats_printer_t {
   double seconds;
@@ -2956,6 +2983,11 @@ struct cache_access_stats_t {
   void minus(const cache_access_stats_t& o) {
     s.minus(o.s);
     cache_absent -= o.cache_absent;
+  }
+
+  void divide_by(unsigned d) {
+    s.divide_by(d);
+    cache_absent /= d;
   }
 };
 struct cache_access_stats_printer_t {

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -508,9 +508,11 @@ public:
 	    auto ret = get_extent_if_linked<T>(t, pin->duplicate());
 	    if (ret.index() == 1) {
 	      return std::move(std::get<1>(ret));
+	    } else {
+	      // absent
+	      return base_iertr::make_ready_future<TCachedExtentRef<T>>();
 	    }
 	  }
-	  return base_iertr::make_ready_future<TCachedExtentRef<T>>();
 	}).si_then([this, &t, &remaps, original_paddr,
 			    original_laddr, original_len,
 			    &extents, FNAME](auto ext) mutable {


### PR DESCRIPTION
* Report stats from the cache index.
* Cache hit stats: hit as pending extents, hit from dirty/lru, get from dirty/lru, absent&load from lru, access by transactions and extent types, etc.
```

The report looks like:
...
cache total(100.41MiB,6.57KiB,15653)
access: total(13.34K, trans-hit=70.04%(p0.18,d0.80,l0.02), cache-hit=99.97%(d0.89,l0.11), load/absent=100.00%, load-present/absent=0.00)
  MUTATE: (12.21K, trans-hit=72.38%(p0.16,d0.82,l0.02), cache-hit=99.97%(d0.87,l0.13), load/absent=100.00%, load-present/absent=0.00)
    data(~0.00K, trans-hit=~-nan%(p-nan,d-nan,l-nan), cache-hit=~-nan%(d-nan,l-nan), load-present/absent=-nan)
    mdat(~1.91K, trans-hit=~26.76%(p0.50,d0.36,l0.13), cache-hit=~99.93%(d0.76,l0.24), load-present/absent=0.00)
    phys(~10.30K, trans-hit=~80.82%(p0.14,d0.85,l0.01), cache-hit=~100.00%(d0.95,l0.05), load-present/absent=-nan)
  TRIM_DIRTY: (0.02K, trans-hit=16.67%(p0.25,d0.75,l0.00), cache-hit=100.00%(d1.00,l0.00), load/absent=-nan%, load-present/absent=-nan)
    data(~0.00K, trans-hit=~-nan%(p-nan,d-nan,l-nan), cache-hit=~-nan%(d-nan,l-nan), load-present/absent=-nan)
    mdat(~0.00K, trans-hit=~-nan%(p-nan,d-nan,l-nan), cache-hit=~-nan%(d-nan,l-nan), load-present/absent=-nan)
    phys(~0.02K, trans-hit=~16.67%(p0.25,d0.75,l0.00), cache-hit=~100.00%(d1.00,l0.00), load-present/absent=-nan)
  TRIM_ALLOC: (1.11K, trans-hit=45.49%(p0.53,d0.47,l0.00), cache-hit=100.00%(d0.96,l0.04), load/absent=-nan%, load-present/absent=-nan)
    data(~0.00K, trans-hit=~-nan%(p-nan,d-nan,l-nan), cache-hit=~-nan%(d-nan,l-nan), load-present/absent=-nan)
    mdat(~0.00K, trans-hit=~-nan%(p-nan,d-nan,l-nan), cache-hit=~-nan%(d-nan,l-nan), load-present/absent=-nan)
    phys(~1.11K, trans-hit=~45.49%(p0.53,d0.47,l0.00), cache-hit=~100.00%(d0.96,l0.04), load-present/absent=-nan)
...
INFO  2024-09-02 10:52:05,461 [shard 0:main] seastore - SeaStore: cache_access: total(59.62K, trans-hit=69.77%(p0.18,d0.80,l0.02), cache-hit=99.98%(d0.89,l0.11), load/absent=100.00%, load-present/absent=0.00); per-shard(14.90K, trans-hit=69.76%(p0.18,d0.80,l0.02), cache-hit=99.98%(d0.89,l0.11), load/absent=100.00%, load-present/absent=0.00)
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
