### PR TITLE
mgr/dashboard: mgr/dashboard: Select no device by default in EC profile

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.html
@@ -94,8 +94,6 @@
           <label for="device_class"
                  class="cd-col-form-label">
             <ng-container i18n>Device class</ng-container>
-            <cd-helper [html]="tooltips.device_class">
-            </cd-helper>
           </label>
           <div class="cd-col-form-input">
             <select class="form-select"
@@ -103,12 +101,15 @@
                     name="device_class"
                     formControlName="device_class">
               <option ngValue=""
-                      i18n>Let Ceph decide</option>
+                      i18n>All devices</option>
               <option *ngFor="let deviceClass of devices"
                       [ngValue]="deviceClass">
                 {{ deviceClass }}
               </option>
             </select>
+            <cd-help-text>
+              <span i18n>{{tooltips.device_class}}</span>
+            </cd-help-text>
           </div>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.html
@@ -410,8 +410,6 @@
           <label for="crushDeviceClass"
                  class="cd-col-form-label">
             <ng-container i18n>Crush device class</ng-container>
-            <cd-helper [html]="tooltips.crushDeviceClass">
-            </cd-helper>
           </label>
           <div class="cd-col-form-input">
             <select class="form-select"
@@ -419,12 +417,15 @@
                     name="crushDeviceClass"
                     formControlName="crushDeviceClass">
               <option ngValue=""
-                      i18n>Let Ceph decide</option>
+                      i18n>All devices</option>
               <option *ngFor="let deviceClass of devices"
                       [ngValue]="deviceClass">
                 {{ deviceClass }}
               </option>
             </select>
+            <cd-help-text>
+              <span i18n>{{tooltips.crushDeviceClass}}</span>
+            </cd-help-text>
             <span class="form-text text-muted"
                   i18n>Available OSDs: {{deviceCount}}</span>
           </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.spec.ts
@@ -563,6 +563,7 @@ describe('ErasureCodeProfileFormModalComponent', () => {
         ecpChange('technique', 'cauchy');
         formHelper.setMultipleValues(ecp, true);
         formHelper.setValue('crushFailureDomain', 'osd', true);
+        formHelper.setValue('crushDeviceClass', 'ssd', true);
         submittedEcp['crush-failure-domain'] = 'osd';
         submittedEcp['crush-device-class'] = 'ssd';
         testCreation();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.ts
@@ -383,7 +383,8 @@ export class ErasureCodeProfileFormModalComponent
             nodes,
             this.form.get('crushRoot'),
             this.form.get('crushFailureDomain'),
-            this.form.get('crushDeviceClass')
+            this.form.get('crushDeviceClass'),
+            false
           );
           this.plugins = plugins;
           this.names = names;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/crush-rule.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/crush-rule.service.ts
@@ -13,7 +13,7 @@ export class CrushRuleService {
     // Copied from /doc/rados/operations/crush-map.rst
     root: $localize`The name of the node under which data should be placed.`,
     failure_domain: $localize`The type of CRUSH nodes across which we should separate replicas.`,
-    device_class: $localize`The device class data should be placed on.`
+    device_class: $localize`The device class on which to place data.`
   };
 
   constructor(private http: HttpClient) {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/erasure-code-profile.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/erasure-code-profile.service.ts
@@ -91,8 +91,7 @@ export class ErasureCodeProfileService {
      defaults to 1. Using a value greater than one will cause a CRUSH MSR rule to be created.
       Must be specified if crush-num-failure-domains is specified.`,
 
-    crushDeviceClass: $localize`Restrict placement to devices of a specific class
-      (e.g., ssd or hdd), using the crush device class names in the CRUSH map.`,
+    crushDeviceClass: $localize`The device class on which to place data.`,
 
     directory: $localize`Set the directory name from which the erasure code plugin is loaded.`
   };

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/crush.node.selection.class.ts
@@ -19,6 +19,14 @@ export class CrushNodeSelectionClass {
   failureDomainKeys: string[] = [];
   devices: string[] = [];
   deviceCount = 0;
+  /**
+   * Handles manual or automatic update of device class.
+   *
+   * When set true, the device class form field is automatically
+   * updated with the first device in the list of devices.
+   * Otherwise, user manually selects a device class.
+   */
+  autoDeviceUpdate: boolean = true;
 
   static searchFailureDomains(
     nodes: CrushNode[],
@@ -120,8 +128,10 @@ export class CrushNodeSelectionClass {
     nodes: CrushNode[],
     rootControl: AbstractControl,
     failureControl: AbstractControl,
-    deviceControl: AbstractControl
+    deviceControl: AbstractControl,
+    autoDeviceUpdate: boolean = true
   ) {
+    this.autoDeviceUpdate = autoDeviceUpdate;
     this.nodes = nodes;
     this.idTree = CrushNodeSelectionClass.createIdTreeFromNodes(nodes);
     nodes.forEach((node) => {
@@ -208,7 +218,7 @@ export class CrushNodeSelectionClass {
       this.devices.length === 1
         ? this.devices[0]
         : this.getIncludedCustomValue(this.controls.device, this.devices);
-    this.silentSet(this.controls.device, device);
+    if (this.autoDeviceUpdate) this.silentSet(this.controls.device, device);
     this.onDeviceChange(device);
   }
 


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/67853
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2305949

When EC pools are created with device class specified, the pools are created with just 1 PG and autoscaler does not work. PG autoscaler not working on a cluster where pools have multiple overlapping roots is a known issue, and bug is raised for same 

Issue documented already : https://docs.ceph.com/en/reef/rados/operations/placement-groups/#viewing-pg-scaling-recommendations

Also renames "let ceph decide" option to "All devices" in crush rule and ec profile component.
Updates Unit tests for ec profile modal

### Before
[Screencast from 2024-09-02 15-27-54.webm](https://github.com/user-attachments/assets/6cdaed19-0e7f-4855-aad1-07008c95b1ec)


### After
[Screencast from 2024-09-10 13-19-23.webm](https://github.com/user-attachments/assets/3e42b439-dac3-4244-89e5-97267f07d27c)


config of created EC profile when selecting `None`
```
[ceph: root@ceph-node-00 /]# ceph osd erasure-code-profile get none_profile
crush-device-class=
crush-failure-domain=osd
crush-num-failure-domains=0
crush-osds-per-failure-domain=0
crush-root=default
directory=/usr/lib64/ceph/erasure-code
jerasure-per-chunk-alignment=false
k=4
m=2
packetsize=2048
plugin=jerasure
technique=reed_sol_van
w=8
```


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
