### PR TITLE
Change code from non-PIC to PIC for ppc64

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -225,6 +225,7 @@ elseif(HAVE_POWER8)
     list(APPEND crc32_srcs
       crc32c_ppc_asm.S
       crc32c_ppc_fast_zero_asm.S)
+    set_source_files_properties(crc32c_ppc_asm.S PROPERTIES COMPILE_FLAGS -D__ASSEMBLY__)
   endif(HAVE_PPC64LE)
 elseif(HAVE_ARMV8_CRC)
   list(APPEND crc32_srcs

--- a/src/common/crc32c_ppc_fast_zero_asm.S
+++ b/src/common/crc32c_ppc_fast_zero_asm.S
@@ -25,6 +25,23 @@
 #endif
 #include "ppc-opcode.h"
 
+/*
+ * The following line is required because toc is defined as 2 in
+ * ppc-asm.h. This definition will break @toc in the assembly code,
+ * hence toc should be undefined.
+ */
+#undef toc
+
+/* If we do not define r2 as 2, the assembler throws errors.
+ * This is because the assembler has no builtin support for
+ * registers, and we should either define them ourselves or
+ * use their indexes explicitly like:
+ *       addis   4,2,.bit_reflected_constants@toc@ha
+ */
+#ifndef r2
+#define r2 2
+#endif
+
 	.section	.data
 .balign 16
 .constants:
@@ -45,8 +62,8 @@
 
 /* unsigned int barrett_reduction(unsigned long val) */
 FUNC_START(barrett_reduction)
-	lis	r4,.constants@ha
-	la	r4,.constants@l(r4)
+	addis   r4,r2,.constants@toc@ha
+	addi    r4,r4,.constants@toc@l
 
 	li	r5,16
 	vxor	v1,v1,v1	/* zero v1 */
@@ -83,8 +100,8 @@ FUNC_END(barrett_reduction)
 
 /* unsigned int barrett_reduction_reflected(unsigned long val) */
 FUNC_START(barrett_reduction_reflected)
-	lis	r4,.bit_reflected_constants@ha
-	la	r4,.bit_reflected_constants@l(r4)
+	addis   r4,r2,.bit_reflected_constants@toc@ha
+	addi    r4,r4,.bit_reflected_constants@toc@l
 
 	li	r5,16
 	vxor	v1,v1,v1	/* zero v1 */


### PR DESCRIPTION
Building Ceph on IBM Power is failing with the error:
```
[ 46%] Linking CXX executable ../../bin/ceph-authtool
cd /builddir/build/BUILD/ceph-19.0.0-2896-g6f942bab/redhat-linux-build/src/tools && /usr/bin/cmake -E cmake_link_script CMakeFiles/ceph-authtool.dir/link.txt --verbose=1
/usr/bin/c++ -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong   -m64 -mcpu=power9 -mtune=power9 -fasynchronous-unwind-tables -fstack-clash-protection -Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -rdynamic -pie "CMakeFiles/ceph-authtool.dir/ceph_authtool.cc.o" -o ../../bin/ceph-authtool  -Wl,-rpath,/builddir/build/BUILD/ceph-19.0.0-2896-g6f942bab/redhat-linux-build/lib: ../../lib/libglobal.a -ldl /usr/lib64/librt.a -lresolv /usr/lib64/libcrypto.so ../../lib/libceph-common.so.2 -lresolv /usr/lib64/libcrypto.so ../../lib/libjson_spirit.a ../../lib/libcommon_utf8.a ../../lib/liberasure_code.a ../../lib/libextblkdev.a -lcap ../../boost/lib/libboost_thread.a ../../boost/lib/libboost_chrono.a ../../boost/lib/libboost_atomic.a ../../boost/lib/libboost_system.a ../../boost/lib/libboost_random.a ../../boost/lib/libboost_program_options.a ../../boost/lib/libboost_date_time.a ../../boost/lib/libboost_iostreams.a ../../boost/lib/libboost_regex.a /usr/lib64/libblkid.so -ldl /usr/lib64/libudev.so /usr/lib64/libibverbs.so /usr/lib64/librdmacm.so /usr/lib64/libz.so ../opentelemetry-cpp/sdk/src/trace/libopentelemetry_trace.a ../opentelemetry-cpp/sdk/src/resource/libopentelemetry_resources.a ../opentelemetry-cpp/sdk/src/common/libopentelemetry_common.a ../opentelemetry-cpp/exporters/jaeger/libopentelemetry_exporter_jaeger_trace.a ../opentelemetry-cpp/ext/src/http/client/curl/libopentelemetry_http_client_curl.a /usr/lib64/libcurl.so /usr/lib64/libthrift.so 
make[2]: Leaving directory '/builddir/build/BUILD/ceph-19.0.0-2896-g6f942bab/redhat-linux-build'
/usr/bin/ld: ../../lib/libceph-common.so.2: undefined reference to `MAX_SIZE'
/usr/bin/ld: ../../lib/libceph-common.so.2: undefined reference to `.barrett_constants'
/usr/bin/ld: ../../lib/libceph-common.so.2: undefined reference to `.short_constants'
/usr/bin/ld: ../../lib/libceph-common.so.2: undefined reference to `.constants'
collect2: error: ld returned 1 exit status
make[2]: *** [src/tools/CMakeFiles/ceph-authtool.dir/build.make:127: bin/ceph-authtool] Error 1
make[1]: *** [CMakeFiles/Makefile2:8962: src/tools/CMakeFiles/ceph-authtool.dir/all] Error 2
```

These constants are defined in src/common/crc32c_ppc_constants.h but they are included only if `__ASSEMBLY__` is defined.
This can be fixed by passing compiler flag -D__ASSEMBLY__ when building crc32c_ppc_asm.S.

However, this is leading to the following error when running bin/unittest_crc32c :

```
bash$ bin/unittest_crc32c
bin/unittest_crc32c: error while loading shared libraries: …ceph/build/lib/libceph-common.so.2: R_PPC64_ADDR16_HA reloc at 0x00007fff9b0b7298 for symbol `' out of range
```

In libceph-common.so, there are 4 relocations of type R_PPC64_ADDR16_* :
```
0000000000ab7298 R_PPC64_ADDR16_HA  .data+0x0000000000006a20
0000000000ab729c R_PPC64_ADDR16_LO  .data+0x0000000000006a20
0000000000ab72dc R_PPC64_ADDR16_HA  .data+0x0000000000006a40
0000000000ab72e0 R_PPC64_ADDR16_LO  .data+0x0000000000006a40
```

From examination of the .o files and compiler generated relocations, these dynamic relocations are coming from crc32c_ppc_fast_zero_asm.S. The lines in question are:

```
FUNC_START(barrett_reduction)
        lis     r4,.constants@ha
        la      r4,.constants@l(r4)
```

and

```
FUNC_START(barrett_reduction_reflected)
        lis     r4,.bit_reflected_constants@ha
        la      r4,.bit_reflected_constants@l(r4)
```

This code is 32-bit (ie, -m32) non-PIC code and will cause dynamic text relocations, so it is basically invalid for 64-bit binaries (which are always PIC). It can work in some instances, which is probably why we didn't notice it before.

This code can be made PIC by using `@toc` relocations as follows:

```
FUNC_START(barrett_reduction)
	addis   r4,r2,.constants@toc@ha
        addi    r4,r4,.constants@toc@l

```
```
FUNC_START(barrett_reduction_reflected)
	addis   r4,r2,.bit_reflected_constants@toc@ha
        addi    r4,r4,.bit_reflected_constants@toc@l

```

These changes fix the error regarding symbol out of range when loading libceph-common.so

Fixes: https://tracker.ceph.com/issues/66306

Signed-off-by: Surya Kumari Jangala surya.kumari.jangala@ibm.com
