### PR TITLE
ceph-crash: fix auth name usage and startup log noise

### DIFF
--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -19,6 +19,7 @@ log = logging.getLogger('ceph-crash')
 auth_names = ['client.crash.%s' % socket.gethostname(),
               'client.crash',
               'client.admin']
+auth_name = None
 
 
 def parse_args():
@@ -43,23 +44,20 @@ def parse_args():
 
 def post_crash(path):
     rc = 0
-    for n in auth_names:
-        pr = subprocess.Popen(
-            args=['timeout', '30', 'ceph',
-                  '-n', n,
-                  'crash', 'post', '-i', '-'],
-            stdin=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        f = open(os.path.join(path, 'meta'), 'rb')
-        (_, stderr) = pr.communicate(input=f.read())
-        stderr = stderr.decode()
-        rc = pr.wait()
-        f.close()
-        if rc != 0 or stderr != "":
-            log.warning('post %s as %s failed: %s' % (path, n, stderr))
-        if rc == 0:
-            break
+    pr = subprocess.Popen(
+        args=['timeout', '30', 'ceph',
+              '-n', auth_name,
+              'crash', 'post', '-i', '-'],
+        stdin=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    f = open(os.path.join(path, 'meta'), 'rb')
+    (_, stderr) = pr.communicate(input=f.read())
+    stderr = stderr.decode()
+    rc = pr.wait()
+    f.close()
+    if rc != 0 or stderr != "":
+        log.warning('post %s as %s failed: %s' % (path, auth_name, stderr))
     return rc
 
 
@@ -108,6 +106,7 @@ def drop_privs():
 
 def main():
     global auth_names
+    global auth_name
 
     # run as unprivileged ceph user
     drop_privs()
@@ -129,10 +128,20 @@ def main():
         time.sleep(30)
 
     log.info("pinging cluster to exercise our key")
-    pr = subprocess.Popen(args=['timeout', '30', 'ceph', '-s'])
-    pr.wait()
+    for n in auth_names:
+        pr = subprocess.Popen(args=['timeout', '30', 'ceph', '-s', '-n', n],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        rc = pr.wait()
+        if rc == 0:
+            auth_name = n
+            break
 
-    log.info("monitoring path %s, delay %ds" % (args.path, args.delay * 60.0))
+    if auth_name is None:
+        log.error("Unable to connect to cluster, no keyring available for any of the configured names")
+        sys.exit(1)
+
+    log.info("monitoring path %s, delay %ds, name %s"
+        % (args.path, args.delay * 60.0, auth_name))
     while True:
         try:
             scrape_path(args.path)


### PR DESCRIPTION
At startup ceph-crash ignored the predefined authentication names and --name parameter at startup connect test, it only used the default admin authentication.
This was not fatal because crash upload tried to find a working name and only moved the crash file to the posted dir when the upload was successful (potentially generating log spam in the process).

This commit changes this behaviour so ceph-crash will first try to find a working authentication name from the predefined list or command line switch (without log spam) and then use the first working one to upload crash files (so this commit basically restores documented behaviour).

Fixes: https://tracker.ceph.com/issues/64102
Signed-off-by: Balazs Kalmar <kalmar15@gmail.com>


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
