### PR TITLE
crimson/osd: write require_osd_release only when needed

### DIFF
--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1558,9 +1558,13 @@ seastar::future<> OSD::handle_peering_op(
 seastar::future<> OSD::check_osdmap_features()
 {
   assert(seastar::this_shard_id() == PRIMARY_CORE);
-  return store.write_meta(
-      "require_osd_release",
-      stringify((int)osdmap->require_osd_release));
+  if (osdmap->require_osd_release != last_require_osd_release) {
+    last_require_osd_release = osdmap->require_osd_release;
+    return store.write_meta(
+        "require_osd_release",
+        stringify((int)osdmap->require_osd_release));
+  }
+  return seastar::now();
 }
 
 seastar::future<> OSD::prepare_to_stop()

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1557,8 +1557,12 @@ seastar::future<> OSD::handle_peering_op(
 
 seastar::future<> OSD::check_osdmap_features()
 {
+  LOG_PREFIX(OSD::check_osdmap_features);
   assert(seastar::this_shard_id() == PRIMARY_CORE);
   if (osdmap->require_osd_release != last_require_osd_release) {
+    DEBUG("updating require_osd_release from {} to {}",
+          to_string(last_require_osd_release),
+          to_string(osdmap->require_osd_release));
     last_require_osd_release = osdmap->require_osd_release;
     return store.write_meta(
         "require_osd_release",

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -234,6 +234,8 @@ private:
 private:
   crimson::common::Gated gate;
 
+  ceph_release_t last_require_osd_release{ceph_release_t::unknown};
+
   seastar::promise<> stop_acked;
   void got_stop_ack() {
     stop_acked.set_value();


### PR DESCRIPTION
Otherwise, we would invoke _write_bdev_label on each committed map:
```
DEBUG 2024-08-14 17:12:55,789 [shard 0:main] bluestore - bluestore(/var/lib/ceph/osd/ceph-2/block) _write_bdev_label path /var/lib/ceph/osd/ceph-2/block label bdev(osd_uuid d2ce936a-24b4-415d-9979-c8d75a9ea0f4, size 0x1680000000, btime 2024-08-14T17:10:52.823128+0000, desc main, 16 meta) locations [0,1073741824,10737418240]
DEBUG 2024-08-14 17:12:56,792 [shard 0:main] bluestore - bluestore(/var/lib/ceph/osd/ceph-2/block) _write_bdev_label path /var/lib/ceph/osd/ceph-2/block label bdev(osd_uuid d2ce936a-24b4-415d-9979-c8d75a9ea0f4, size 0x1680000000, btime 2024-08-14T17:10:52.823128+0000, desc main, 16 meta) locations [0,1073741824,10737418240]
DEBUG 2024-08-14 17:12:57,800 [shard 0:main] bluestore - bluestore(/var/lib/ceph/osd/ceph-2/block) _write_bdev_label path /var/lib/ceph/osd/ceph-2/block label bdev(osd_uuid d2ce936a-24b4-415d-9979-c8d75a9ea0f4, size 0x1680000000, btime 2024-08-14T17:10:52.823128+0000, desc main, 16 meta) locations [0,1073741824,10737418240]
DEBUG 2024-08-14 17:12:58,801 [shard 0:main] bluestore - bluestore(/var/lib/ceph/osd/ceph-2/block) _write_bdev_label path /var/lib/ceph/osd/ceph-2/block label bdev(osd_uuid d2ce936a-24b4-415d-9979-c8d75a9ea0f4, size 0x1680000000, btime 2024-08-14T17:10:52.823128+0000, desc main, 16 meta) locations [0,1073741824,10737418240]
DEBUG 2024-08-14 17:12:59,717 [shard 0:main] bluestore - bluestore(/var/lib/ceph/osd/ceph-2/block) _write_bdev_label path /var/lib/ceph/osd/ceph-2/block label bdev(osd_uuid d2ce936a-24b4-415d-9979-c8d75a9ea0f4, size 0x1680000000, btime 2024-08-14T17:10:52.823128+0000, desc main, 16 meta) locations [0,1073741824,10737418240]
DEBUG 2024-08-14 17:13:00,714 [shard 0:main] bluestore - bluestore(/var/lib/ceph/osd/ceph-2/block) _write_bdev_label path /var/lib/ceph/osd/ceph-2/block label bdev(osd_uuid d2ce936a-24b4-415d-9979-c8d75a9ea0f4, size 0x1680000000, btime 2024-08-14T17:10:52.823128+0000, desc main, 16 meta) locations [0,1073741824,10737418240]
DEBUG 2024-08-14 17:13:01,812 [shard 0:main] bluestore - bluestore(/var/lib/ceph/osd/ceph-2/block) _write_bdev_label path /var/lib/ceph/osd/ceph-2/block label bdev(osd_uuid d2ce936a-24b4-415d-9979-c8d75a9ea0f4, size 0x1680000000, btime 2024-08-14T17:10:52.823128+0000, desc main, 16 meta) locations [0,1073741824,10737418240]
```

The continues `write_meta` calls misuse bdev replication.

Fixes: https://tracker.ceph.com/issues/67568


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
