### PR TITLE
mon: increase dns buffer size

### DIFF
--- a/src/common/dns_resolve.cc
+++ b/src/common/dns_resolve.cc
@@ -212,19 +212,19 @@ int DNSResolver::resolve_ip_addr(CephContext *cct, const string& hostname,
 int DNSResolver::resolve_ip_addr(CephContext *cct, res_state *res, const string& hostname, 
     entity_addr_t *addr) {
 
-  u_char nsbuf[NS_PACKETSZ];
+  auto nsbuf = std::make_unique<std::array<u_char, NS_MAXMSG>>();
   int len;
   int family = cct->_conf->ms_bind_ipv6 ? AF_INET6 : AF_INET;
   int type = cct->_conf->ms_bind_ipv6 ? ns_t_aaaa : ns_t_a;
 
 #ifdef HAVE_RES_NQUERY
-  len = resolv_h->res_nquery(*res, hostname.c_str(), ns_c_in, type, nsbuf, sizeof(nsbuf));
+  len = resolv_h->res_nquery(*res, hostname.c_str(), ns_c_in, type, nsbuf->data(), nsbuf->size());
 #else
   {
 # ifndef HAVE_THREAD_SAFE_RES_QUERY
     std::lock_guard l(lock);
 # endif
-    len = resolv_h->res_query(hostname.c_str(), ns_c_in, type, nsbuf, sizeof(nsbuf));
+    len = resolv_h->res_query(hostname.c_str(), ns_c_in, type, nsbuf->data(), nsbuf->size());
   }
 #endif
   if (len < 0) {
@@ -237,7 +237,7 @@ int DNSResolver::resolve_ip_addr(CephContext *cct, res_state *res, const string&
   }
 
   ns_msg handle;
-  ns_initparse(nsbuf, len, &handle);
+  ns_initparse(nsbuf->data(), len, &handle);
 
   if (ns_msg_count(handle, ns_s_an) == 0) {
     ldout(cct, 20) << "no address found for hostname " << hostname << dendl;
@@ -285,7 +285,7 @@ int DNSResolver::resolve_srv_hosts(CephContext *cct, const string& service_name,
     });
 #endif
 
-  u_char nsbuf[NS_PACKETSZ];
+  auto nsbuf = std::make_unique<std::array<u_char, NS_MAXMSG>>();
   int num_hosts;
 
   string proto_str = srv_protocol_to_str(trans_protocol);
@@ -294,15 +294,15 @@ int DNSResolver::resolve_srv_hosts(CephContext *cct, const string& service_name,
   int len;
 
 #ifdef HAVE_RES_NQUERY
-  len = resolv_h->res_nsearch(res, query_str.c_str(), ns_c_in, ns_t_srv, nsbuf,
-      sizeof(nsbuf));
+  len = resolv_h->res_nsearch(res, query_str.c_str(), ns_c_in, ns_t_srv, nsbuf->data(),
+      nsbuf->size());
 #else
   {
 # ifndef HAVE_THREAD_SAFE_RES_QUERY
     std::lock_guard l(lock);
 # endif
-    len = resolv_h->res_search(query_str.c_str(), ns_c_in, ns_t_srv, nsbuf,
-        sizeof(nsbuf));
+    len = resolv_h->res_search(query_str.c_str(), ns_c_in, ns_t_srv, nsbuf->data(),
+        nsbuf->size());
   }
 #endif
   if (len < 0) {
@@ -316,7 +316,7 @@ int DNSResolver::resolve_srv_hosts(CephContext *cct, const string& service_name,
 
   ns_msg handle;
 
-  ns_initparse(nsbuf, len, &handle);
+  ns_initparse(nsbuf->data(), len, &handle);
 
   num_hosts = ns_msg_count (handle, ns_s_an);
   if (num_hosts == 0) {


### PR DESCRIPTION
Increases the buffers used for dns reponses from 512 to 8k bytes. Otherwise [service discovery](https://docs.ceph.com/en/latest/rados/configuration/mon-lookup-dns/) fails, if DNS reponses are larger than 512 bytes.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
