### PR TITLE
cephfs-top: fix exceptions on small/large sized windows

### DIFF
--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -941,6 +941,15 @@ class FSTop(FSTopBase):
         self.header.addstr(5, 0, help, curses.A_DIM)
         return True
 
+    def handle_header(self, stats_json, help, screen_title, color_id=0):
+        try:
+            return self.create_header(stats_json, help, screen_title, color_id)
+        except curses.error:
+            curses.endwin()
+            sys.stderr.write("Error creating header. Please increase the window width to use "
+                             "cephfs-top.\n")
+            exit()
+
     def run_display(self):
         # clear the pads to have a smooth refresh
         self.header.erase()
@@ -990,7 +999,7 @@ class FSTop(FSTopBase):
                     current_states["limit"] = None
                 self.header.erase()  # erase previous text
                 self.fsstats.erase()
-                self.create_header(stats_json, help, screen_title, 3)
+                self.handle_header(stats_json, help, screen_title, 3)
             else:
                 self.tablehead_y = 0
                 help = "COMMANDS: " + help_commands
@@ -1003,7 +1012,7 @@ class FSTop(FSTopBase):
                 else:
                     num_client = len(client_metadata)
                 vscrollEnd += num_client
-                if self.create_header(stats_json, help, screen_title, 3):
+                if self.handle_header(stats_json, help, screen_title, 3):
                     self.create_table_header()
                     self.create_clients(stats_json, fs)
 
@@ -1122,7 +1131,7 @@ class FSTop(FSTopBase):
                 current_states["limit"] = None
                 self.header.erase()  # erase previous text
                 self.fsstats.erase()
-                self.create_header(stats_json, help, screen_title, 2)
+                self.handle_header(stats_json, help, screen_title, 2)
             else:
                 self.tablehead_y = 0
                 num_client = 0
@@ -1138,7 +1147,7 @@ class FSTop(FSTopBase):
                     else:
                         num_client = len(client_metadata)
                     vscrollEnd += num_client
-                    if self.create_header(stats_json, help, screen_title, 2):
+                    if self.handle_header(stats_json, help, screen_title, 2):
                         if not index:  # do it only for the first fs
                             self.create_table_header()
                         self.create_clients(stats_json, fs)

--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -45,6 +45,7 @@ FS_TOP_SUPPORTED_VER = 2
 ITEMS_PAD_LEN = 3
 ITEMS_PAD = " " * ITEMS_PAD_LEN
 DEFAULT_REFRESH_INTERVAL = 1
+DEFAULT_PAD_WIDTH = 300  # for medium size windows
 
 # metadata provided by mgr/stats
 FS_TOP_MAIN_WINDOW_COL_CLIENT_ID = "client_id"
@@ -290,7 +291,7 @@ class FSTop(FSTopBase):
         self.conffile = args.conffile
         self.refresh_interval_secs = args.delay
         self.PAD_HEIGHT = 10000  # height of the fstop_pad
-        self.PAD_WIDTH = 300  # width of the fstop_pad
+        self.PAD_WIDTH = DEFAULT_PAD_WIDTH  # width of the fstop_pad
         self.exit_ev = threading.Event()
 
     def handle_signal(self, signum, _):
@@ -358,6 +359,12 @@ class FSTop(FSTopBase):
             # If the terminal do not support the visibility
             # requested it will raise an exception
             pass
+
+        # Check the window size before creating the pad. For large windows,
+        # PAD_WIDTH = window width.
+        h, w = self.stdscr.getmaxyx()
+        if (w > DEFAULT_PAD_WIDTH):
+            self.PAD_WIDTH = w
         self.fstop_pad = curses.newpad(self.PAD_HEIGHT, self.PAD_WIDTH)
         self.run_all_display()
 
@@ -1030,7 +1037,10 @@ class FSTop(FSTopBase):
             elif cmd == curses.KEY_END:
                 hscrollOffset = self.PAD_WIDTH - self.viewportWidth - 1
             elif cmd == curses.KEY_RESIZE:
-                # terminal resize event. Update the viewport dimensions
+                # terminal resize event.
+                # Update the pad dimensions
+                self.PAD_WIDTH = DEFAULT_PAD_WIDTH
+                # Update the viewport dimensions
                 windowsize = self.stdscr.getmaxyx()
                 self.viewportHeight, self.viewportWidth = windowsize[0] - 1, windowsize[1] - 1
 
@@ -1163,7 +1173,10 @@ class FSTop(FSTopBase):
             elif cmd == curses.KEY_END:
                 hscrollOffset = self.PAD_WIDTH - self.viewportWidth - 1
             elif cmd == curses.KEY_RESIZE:
-                # terminal resize event. Update the viewport dimensions
+                # terminal resize event.
+                # Update the pad dimensions
+                self.PAD_WIDTH = DEFAULT_PAD_WIDTH
+                # Update the viewport dimensions
                 windowsize = self.stdscr.getmaxyx()
                 self.viewportHeight, self.viewportWidth = windowsize[0] - 1, windowsize[1] - 1
             if cmd:


### PR DESCRIPTION
* Fixes `exception: curses function returned NULL` when the window width is larger than expected.
Reproduced this issue on a 32 inch horizontal monitor. Tested the fix on 32 inch horizontal + 24 inch vertical monitor(s) (dual).
* Fixes `exception: addwstr() returned ERR`  when the window width is smaller than expected.


Fixes: https://tracker.ceph.com/issues/67859






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>