### PR TITLE
rgw: remove rgw_data_log_obj_prefix

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -149,7 +149,6 @@ file under each ``[client.radosgw.{instance-name}]`` instance.
 .. confval:: rgw_run_sync_thread
 .. confval:: rgw_data_log_window
 .. confval:: rgw_data_log_changes_size
-.. confval:: rgw_data_log_obj_prefix
 .. confval:: rgw_data_log_num_shards
 .. confval:: rgw_md_log_max_shards
 .. confval:: rgw_data_sync_poll_interval

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2066,14 +2066,6 @@ options:
   services:
   - rgw
   with_legacy: true
-- name: rgw_data_log_obj_prefix
-  type: str
-  level: dev
-  default: data_log
-  fmt_desc: The object name prefix for the data log.
-  services:
-  - rgw
-  with_legacy: true
 - name: rgw_data_sync_poll_interval
   type: int
   level: dev

--- a/src/rgw/driver/rados/rgw_datalog.h
+++ b/src/rgw/driver/rados/rgw_datalog.h
@@ -241,10 +241,7 @@ class RGWDataChangesLog {
   std::unique_ptr<DataLogBackends> bes;
 
   const int num_shards;
-  std::string get_prefix() {
-    auto prefix = cct->_conf->rgw_data_log_obj_prefix;
-    return prefix.empty() ? prefix : "data_log";
-  }
+  std::string get_prefix() { return "data_log"; }
   std::string metadata_log_oid() {
     return get_prefix() + "generations_metadata";
   }


### PR DESCRIPTION
The evaluation based on rgw_data_log_obj_prefix had a logical error not considering the value and always was returning "data_log". As the config had the dev level and apparently it was useless and fixing the logic could break the existing clusters (if they don't adopt before the upgrade), it was decided to remove the config.

Fixes: https://tracker.ceph.com/issues/67861