### PR TITLE
mgr/dashboard: Increase maximum namespace count to 1024

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nvmeof.py
+++ b/src/pybind/mgr/dashboard/controllers/nvmeof.py
@@ -61,13 +61,13 @@ else:
             "Create a new NVMeoF subsystem",
             parameters={
                 "nqn": Param(str, "NVMeoF subsystem NQN"),
-                "max_namespaces": Param(int, "Maximum number of namespaces", True, 256),
+                "max_namespaces": Param(int, "Maximum number of namespaces", True, 1024),
                 "enable_ha": Param(bool, "Enable high availability"),
             },
         )
         @empty_response
         @handle_nvmeof_error
-        def create(self, nqn: str, enable_ha: bool, max_namespaces: int = 256):
+        def create(self, nqn: str, enable_ha: bool, max_namespaces: int = 1024):
             return NVMeoFClient().stub.create_subsystem(
                 NVMeoFClient.pb2.create_subsystem_req(
                     subsystem_nqn=nqn, max_namespaces=max_namespaces, enable_ha=enable_ha

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.html
@@ -49,16 +49,16 @@
                    type="text"
                    name="max_namespaces"
                    formControlName="max_namespaces">
-            <cd-help-text i18n>The maximum namespaces per subsystem. Default is 256.</cd-help-text>
+            <cd-help-text i18n>The maximum namespaces per subsystem. Default is {{defaultMaxNamespace}}</cd-help-text>
             <span class="invalid-feedback"
                   *ngIf="subsystemForm.showError('max_namespaces', formDir, 'min')"
                   i18n>The value must be at least 1.</span>
             <span class="invalid-feedback"
                   *ngIf="subsystemForm.showError('max_namespaces', formDir, 'max')"
-                  i18n>The value cannot be greated than 256.</span>
+                  i18n>The value cannot be greater than {{defaultMaxNamespace}}.</span>
             <span class="invalid-feedback"
                   *ngIf="subsystemForm.showError('max_namespaces', formDir, 'pattern')"
-                  i18n>The value must be  a positive integer.</span>
+                  i18n>The value must be a positive integer.</span>
           </div>
         </div>
       </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.spec.ts
@@ -11,7 +11,7 @@ import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { SharedModule } from '~/app/shared/shared.module';
 import { NvmeofSubsystemsFormComponent } from './nvmeof-subsystems-form.component';
 import { FormHelper } from '~/testing/unit-test-helper';
-import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { MAX_NAMESPACE, NvmeofService } from '~/app/shared/api/nvmeof.service';
 
 describe('NvmeofSubsystemsFormComponent', () => {
   let component: NvmeofSubsystemsFormComponent;
@@ -59,7 +59,7 @@ describe('NvmeofSubsystemsFormComponent', () => {
       component.onSubmit();
       expect(nvmeofService.createSubsystem).toHaveBeenCalledWith({
         nqn: expectedNqn,
-        max_namespaces: 256,
+        max_namespaces: MAX_NAMESPACE,
         enable_ha: true
       });
     });
@@ -76,8 +76,8 @@ describe('NvmeofSubsystemsFormComponent', () => {
       formHelper.expectError('max_namespaces', 'pattern');
     });
 
-    it('should give error on max_namespaces greater than 256', () => {
-      formHelper.setValue('max_namespaces', 300);
+    it(`should give error on max_namespaces greater than ${MAX_NAMESPACE}`, () => {
+      formHelper.setValue('max_namespaces', 2000);
       component.onSubmit();
       formHelper.expectError('max_namespaces', 'max');
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.ts
@@ -10,7 +10,7 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import { Router } from '@angular/router';
-import { NvmeofService } from '~/app/shared/api/nvmeof.service';
+import { MAX_NAMESPACE, NvmeofService } from '~/app/shared/api/nvmeof.service';
 
 @Component({
   selector: 'cd-nvmeof-subsystems-form',
@@ -23,6 +23,7 @@ export class NvmeofSubsystemsFormComponent implements OnInit {
   action: string;
   resource: string;
   pageURL: string;
+  defaultMaxNamespace: number = MAX_NAMESPACE;
 
   constructor(
     private authStorageService: AuthStorageService,
@@ -68,8 +69,12 @@ export class NvmeofSubsystemsFormComponent implements OnInit {
           CdValidators.unique(this.nvmeofService.isSubsystemPresent, this.nvmeofService)
         ]
       }),
-      max_namespaces: new UntypedFormControl(256, {
-        validators: [CdValidators.number(false), Validators.max(256), Validators.min(1)]
+      max_namespaces: new UntypedFormControl(this.defaultMaxNamespace, {
+        validators: [
+          CdValidators.number(false),
+          Validators.max(this.defaultMaxNamespace),
+          Validators.min(1)
+        ]
       })
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -5,6 +5,8 @@ import _ from 'lodash';
 import { Observable, of as observableOf } from 'rxjs';
 import { catchError, mapTo } from 'rxjs/operators';
 
+export const MAX_NAMESPACE = 1024;
+
 export interface ListenerRequest {
   host_name: string;
   traddr: string;

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -8237,7 +8237,7 @@ paths:
                   description: Enable high availability
                   type: boolean
                 max_namespaces:
-                  default: 256
+                  default: 1024
                   description: Maximum number of namespaces
                   type: integer
                 nqn:


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/67871

The maximum namespace count will be 1024 for subsystems now.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
