### PR TITLE
ceph-volume: fix generic activation with raw osds

### DIFF
--- a/src/ceph-volume/ceph_volume/activate/main.py
+++ b/src/ceph-volume/ceph_volume/activate/main.py
@@ -27,7 +27,8 @@ class Activate(object):
         )
         parser.add_argument(
             '--osd-uuid',
-            help='OSD UUID to activate'
+            help='OSD UUID to activate',
+            dest='osd_fsid'
         )
         parser.add_argument(
             '--no-systemd',
@@ -44,11 +45,8 @@ class Activate(object):
 
         # first try raw
         try:
-            raw_activate = RAWActivate([])
-            raw_activate.activate(None,
-                                  self.args.osd_id,
-                                  self.args.osd_uuid,
-                                  not self.args.no_tmpfs)
+            raw_activate = RAWActivate(self.args)
+            raw_activate.activate()
             return
         except Exception as e:
             terminal.info(f'Failed to activate via raw: {e}')
@@ -58,10 +56,10 @@ class Activate(object):
             lvm_activate = LVMActivate(argparse.Namespace(
                 no_tmpfs=self.args.no_tmpfs,
                 no_systemd=self.args.no_systemd,
-                osd_fsid=self.args.osd_uuid))
+                osd_fsid=self.args.osd_fsid))
             lvm_activate.activate(None,
                                   self.args.osd_id,
-                                  self.args.osd_uuid)
+                                  self.args.osd_fsid)
             return
         except Exception as e:
             terminal.info(f'Failed to activate via LVM: {e}')
@@ -71,7 +69,7 @@ class Activate(object):
             SimpleActivate([]).activate(
                 argparse.Namespace(
                     osd_id=self.args.osd_id,
-                    osd_fsid=self.args.osd_uuid,
+                    osd_fsid=self.args.osd_fsid,
                     no_systemd=self.args.no_systemd,
                 )
             )


### PR DESCRIPTION
Typical failure:

```
Running command: /usr/bin/ceph-authtool --gen-print-key
Running command: /usr/bin/ceph-authtool --gen-print-key
--> Failed to activate via raw: activate() takes 1 positional argument but 5 were given
Running command: /usr/bin/ceph-authtool --gen-print-key
Running command: /usr/bin/ceph-authtool --gen-print-key
--> Failed to activate via LVM: could not find osd.0 with osd_fsid 1e764f4a-db4b-4b41-86eb-468efe4c3f44
--> Failed to activate via simple: 'Namespace' object has no attribute 'json_config'
--> Failed to activate any OSD(s)
```

04c93a1ed42 seems to have broken it.
This commit fixes it.

Fixes: https://tracker.ceph.com/issues/67873
