### PR TITLE
osd/scrub: add configuration parameters to control delay duration

### DIFF
--- a/qa/standalone/scrub/scrub-helpers.sh
+++ b/qa/standalone/scrub/scrub-helpers.sh
@@ -249,6 +249,9 @@ function standard_scrub_cluster() {
             --osd_pool_default_pg_autoscale_mode=off \
             --osd_pg_stat_report_interval_max_seconds=1 \
             --osd_pg_stat_report_interval_max_epochs=1 \
+            --osd_scrub_retry_after_noscrub=5 \
+            --osd_scrub_retry_pg_state=5 \
+            --osd_scrub_retry_delay=3 \
             $extra_pars"
 
     for osd in $(seq 0 $(expr $OSDS - 1))

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -560,6 +560,17 @@ options:
   see_also:
   - osd_scrub_retry_delay
   with_legacy: false
+- name: osd_scrub_retry_trimming
+  type: int
+  level: advanced
+  desc: Period (in seconds) before retrying to scrub a previously snap-trimming PG
+  long_desc: Minimum delay after a failed attempt to scrub a PG that was performing
+    snap trimming and not available for scrubbing.
+  default: 10
+  min: 1
+  see_also:
+  - osd_scrub_retry_delay
+  with_legacy: false
 - name: osd_scrub_disable_reservation_queuing
   type: bool
   level: advanced

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -535,6 +535,8 @@ options:
   see_also:
   - osd_scrub_retry_pg_state
   - osd_scrub_retry_after_noscrub
+  - osd_scrub_retry_new_interval
+  - osd_scrub_retry_trimming
   with_legacy: false
 - name: osd_scrub_retry_after_noscrub
   type: int
@@ -566,6 +568,17 @@ options:
   desc: Period (in seconds) before retrying to scrub a previously snap-trimming PG
   long_desc: Minimum delay after a failed attempt to scrub a PG that was performing
     snap trimming and not available for scrubbing.
+  default: 10
+  min: 1
+  see_also:
+  - osd_scrub_retry_delay
+  with_legacy: false
+- name: osd_scrub_retry_new_interval
+  type: int
+  level: advanced
+  desc: Period (in seconds) before retrying a scrub aborted on a new interval
+  long_desc: Minimum delay before retrying, after a scrub was aborted as the
+    PG interval changed.
   default: 10
   min: 1
   see_also:

--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -520,6 +520,46 @@ options:
     stats (inc. scrub/block duration) every this many seconds.
   default: 120
   with_legacy: false
+- name: osd_scrub_retry_delay
+  type: int
+  level: advanced
+  desc: Period (in seconds) before retrying a PG that has failed a prior scrub.
+  long_desc: Minimum delay after a failed attempt to scrub a PG. The delay is
+    either applied to one of the scheduled scrubs for the PG (the next shallow
+    scrub or the next deep scrub), or to both.
+    This is a default value, used when the cause of the delay does not have an
+    associated configuration option. See the 'see also' for the configuration
+    options for some delay reasons that have their own configuration.
+  default: 30
+  min: 1
+  see_also:
+  - osd_scrub_retry_pg_state
+  - osd_scrub_retry_after_noscrub
+  with_legacy: false
+- name: osd_scrub_retry_after_noscrub
+  type: int
+  level: advanced
+  desc: Period (in seconds) before retrying to scrub a PG at a specific level
+    after detecting a no-scrub or no-deep-scrub flag
+  long_desc: Minimum delay after a failed attempt to scrub a PG at a level
+    (shallow or deep) that is disabled by cluster or pool no-scrub or no-deep-scrub
+    flags.
+  default: 60
+  min: 1
+  see_also:
+  - osd_scrub_retry_delay
+  with_legacy: false
+- name: osd_scrub_retry_pg_state
+  type: int
+  level: advanced
+  desc: Period (in seconds) before retrying to scrub a previously inactive/not-clean PG
+  long_desc: Minimum delay after a failed attempt to scrub a PG that is not
+    active and clean.
+  default: 60
+  min: 1
+  see_also:
+  - osd_scrub_retry_delay
+  with_legacy: false
 - name: osd_scrub_disable_reservation_queuing
   type: bool
   level: advanced

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2220,7 +2220,7 @@ void PgScrubber::on_mid_scrub_abort(Scrub::delay_cause_t issue)
   // that made any of the targets into a high-priority one. All that's left:
   // delay the specific target that was aborted.
 
-  auto& trgt = m_scrub_job->delay_on_failure(aborted_target.level(), 5s, issue,
+  auto& trgt = m_scrub_job->delay_on_failure(aborted_target.level(), issue,
       scrub_clock_now);
 
   /// \todo complete the merging of the deadline & target for non-hp targets
@@ -2251,8 +2251,7 @@ void PgScrubber::requeue_penalized(
     return;
   }
   /// \todo fix the 5s' to use a cause-specific delay parameter
-  auto& trgt =
-      m_scrub_job->delay_on_failure(s_or_d, 5s, cause, scrub_clock_now);
+  auto& trgt = m_scrub_job->delay_on_failure(s_or_d, cause, scrub_clock_now);
   ceph_assert(!trgt.queued);
   m_osds->get_scrub_services().enqueue_target(trgt);
   trgt.queued = true;
@@ -2274,7 +2273,7 @@ void PgScrubber::requeue_penalized(
       m_osds->get_scrub_services().dequeue_target(m_pg_id, sister_level);
       trgt2.queued = false;
     }
-    m_scrub_job->delay_on_failure(sister_level, 5s, cause, scrub_clock_now);
+    m_scrub_job->delay_on_failure(sister_level, cause, scrub_clock_now);
     m_osds->get_scrub_services().enqueue_target(trgt2);
     trgt2.queued = true;
   }

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2332,7 +2332,8 @@ Scrub::schedule_result_t PgScrubber::start_scrub_session(
     // i.e. some time before setting 'snaptrim'.
     dout(10) << __func__ << ": cannot scrub while snap-trimming" << dendl;
     requeue_penalized(
-	s_or_d, delay_both_targets_t::yes, delay_cause_t::pg_state, clock_now);
+	s_or_d, delay_both_targets_t::yes, delay_cause_t::snap_trimming,
+	clock_now);
     return schedule_result_t::target_specific_failure;
   }
 

--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -313,6 +313,9 @@ SchedTarget& ScrubJob::delay_on_failure(
     case delay_cause_t::pg_state:
       delay = seconds(cct->_conf.get_val<int64_t>("osd_scrub_retry_pg_state"));
       break;
+    case delay_cause_t::snap_trimming:
+      delay = seconds(cct->_conf.get_val<int64_t>("osd_scrub_retry_trimming"));
+      break;
     case delay_cause_t::local_resources:
     default:
       // for all other possible delay causes: use the default delay

--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -301,7 +301,7 @@ void ScrubJob::adjust_deep_schedule(
 
 SchedTarget& ScrubJob::delay_on_failure(
     scrub_level_t level,
-    Scrub::delay_cause_t delay_cause,
+    delay_cause_t delay_cause,
     utime_t scrub_clock_now)
 {
   seconds delay = seconds(cct->_conf.get_val<int64_t>("osd_scrub_retry_delay"));
@@ -316,7 +316,11 @@ SchedTarget& ScrubJob::delay_on_failure(
     case delay_cause_t::snap_trimming:
       delay = seconds(cct->_conf.get_val<int64_t>("osd_scrub_retry_trimming"));
       break;
+    case delay_cause_t::interval:
+      delay = seconds(cct->_conf.get_val<int64_t>("osd_scrub_retry_new_interval"));
+      break;
     case delay_cause_t::local_resources:
+    case delay_cause_t::aborted:
     default:
       // for all other possible delay causes: use the default delay
       break;

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -239,14 +239,14 @@ class ScrubJob {
 
   /**
    * For the level specified, set the 'not-before' time to 'now+delay',
-   * so that this scrub target
-   * would not be retried before 'delay' seconds have passed.
+   * so that this scrub target would not be retried before the required
+   * delay seconds have passed.
+   * The delay is determined based on the 'cause' parameter.
    * The 'last_issue' is updated to the cause of the delay.
    * \returns a reference to the target that was modified.
    */
   [[maybe_unused]] SchedTarget& delay_on_failure(
       scrub_level_t level,
-      std::chrono::seconds delay,
       delay_cause_t delay_cause,
       utime_t scrub_clock_now);
 

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -551,6 +551,10 @@ struct Session : sc::state<Session, PrimaryActive, ReservingReplicas>,
 
   /// the time when the session was initiated
   ScrubTimePoint m_session_started_at{ScrubClock::now()};
+
+  /// abort reason - if known. Determines the delay time imposed on the
+  /// failed scrub target.
+  std::optional<Scrub::delay_cause_t> m_abort_reason{std::nullopt};
 };
 
 struct ReservingReplicas : sc::state<ReservingReplicas, Session>, NamedSimply {

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -229,7 +229,8 @@ enum class delay_cause_t {
   none,		    ///< scrub attempt was successful
   replicas,	    ///< failed to reserve replicas
   flags,	    ///< noscrub or nodeep-scrub
-  pg_state,	    ///< e.g. snap-trimming
+  pg_state,	    ///< not active+clean
+  snap_trimming,    ///< snap-trimming is in progress
   restricted_time,  ///< time restrictions or busy CPU
   local_resources,  ///< too many scrubbing PGs
   aborted,	    ///< scrub was aborted w/ unspecified reason
@@ -252,6 +253,7 @@ struct formatter<Scrub::delay_cause_t> : ::fmt::formatter<std::string_view> {
       case replicas:            desc = "replicas"; break;
       case flags:               desc = "noscrub"; break;
       case pg_state:            desc = "pg-state"; break;
+      case snap_trimming:       desc = "snap-trim"; break;
       case restricted_time:     desc = "time/load"; break;
       case local_resources:     desc = "local-cnt"; break;
       case aborted:             desc = "aborted"; break;


### PR DESCRIPTION
to apply to a scrub target following a scrub failure

Specific configuration parameters are added to control the duration
of the delay to apply to the 'not-before' attribute of the failed scrub
target following a scrub failure.  Some failure causes now have
their own delay values, while others share a common duration.

