### PR TITLE
mgr/dashboard: Cloning subvolume not listing _nogroup if no subvolume

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-snapshots-list/cephfs-subvolume-snapshots-list.component.ts
@@ -26,6 +26,7 @@ import moment from 'moment';
 import { Validators } from '@angular/forms';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs';
 
 @Component({
   selector: 'cd-cephfs-subvolume-snapshots-list',
@@ -57,6 +58,7 @@ export class CephfsSubvolumeSnapshotsListComponent implements OnInit, OnChanges 
   isLoading = true;
 
   observables: any = [];
+  allGroups: any = [];
 
   constructor(
     private cephfsSubvolumeGroupService: CephfsSubvolumeGroupService,
@@ -126,8 +128,14 @@ export class CephfsSubvolumeSnapshotsListComponent implements OnInit, OnChanges 
       .pipe(
         switchMap((groups) => {
           // manually adding the group '_nogroup' to the list.
-          groups.unshift({ name: '' });
 
+          groups.unshift({ name: '' });
+          this.allGroups = Array.from(groups).map((group) => {
+            return {
+              value: group.name,
+              text: group.name === '' ? DEFAULT_SUBVOLUME_GROUP : group.name
+            };
+          });
           const observables = groups.map((group) =>
             this.cephfsSubvolumeService.existsInFs(this.fsName, group.name).pipe(
               switchMap((resp) => {
@@ -248,9 +256,6 @@ export class CephfsSubvolumeSnapshotsListComponent implements OnInit, OnChanges 
 
   cloneModal() {
     const cloneName = `clone_${moment().toISOString(true)}`;
-    const allGroups = Array.from(this.subvolumeGroupList).map((group) => {
-      return { value: group, text: group === '' ? '_nogroup' : group };
-    });
     this.modalService.show(FormModalComponent, {
       titleText: $localize`Create clone`,
       fields: [
@@ -284,7 +289,7 @@ export class CephfsSubvolumeSnapshotsListComponent implements OnInit, OnChanges 
           valueChangeListener: true,
           dependsOn: 'cloneName',
           typeConfig: {
-            options: allGroups
+            options: this.allGroups
           }
         }
       ],

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/cephfs.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/cephfs.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_SUBVOLUME_GROUP = '_nogroup';


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/67891

Signed-off-by: Dnyaneshwari talwekar <dtalweka@redhat.com>

Tracker: https://tracker.ceph.com/issues/67891

![Screenshot from 2024-09-10 17-16-15](https://github.com/user-attachments/assets/9bebd709-abcd-43df-a89d-61e2ea9d5505)


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
