### PR TITLE
squid: qa/rgw/multisite: specify realm/zonegroup/zone args for 'account create'

### DIFF
--- a/qa/suites/rgw/multisite/realms/three-zones.yaml.disabled
+++ b/qa/suites/rgw/multisite/realms/three-zones.yaml.disabled
@@ -2,7 +2,7 @@ overrides:
   rgw-multisite:
     realm:
       name: test-realm
-      is default: true
+      is_default: true
     zonegroups:
       - name: test-zonegroup
         is_master: true

--- a/qa/suites/rgw/multisite/realms/two-zonegroup.yaml.disabled
+++ b/qa/suites/rgw/multisite/realms/two-zonegroup.yaml.disabled
@@ -2,7 +2,7 @@ overrides:
   rgw-multisite:
     realm:
       name: test-realm
-      is default: true
+      is_default: true
     zonegroups:
       - name: a
         is_master: true

--- a/qa/suites/rgw/multisite/realms/two-zones.yaml
+++ b/qa/suites/rgw/multisite/realms/two-zones.yaml
@@ -2,7 +2,7 @@ overrides:
   rgw-multisite:
     realm:
       name: test-realm
-      is default: true
+      is_default: true
     zonegroups:
       - name: test-zonegroup
         is_master: true

--- a/qa/tasks/rgw_multisite.py
+++ b/qa/tasks/rgw_multisite.py
@@ -139,7 +139,10 @@ class RGWMultisite(Task):
 
                 if cluster != cluster1: # already created on master cluster
                     log.info('pulling realm configuration to %s', cluster.name)
-                    realm.pull(cluster, master_zone.gateways[0], creds)
+
+                    is_default = self.config['realm'].get('is_default', False)
+                    args = ['--default'] if is_default else []
+                    realm.pull(cluster, master_zone.gateways[0], creds, args)
 
                 # use the first zone's cluster to create the zonegroup
                 if not zonegroup:

--- a/qa/tasks/rgw_multisite_tests.py
+++ b/qa/tasks/rgw_multisite_tests.py
@@ -72,7 +72,9 @@ class RGWMultisiteTests(Task):
         # create test account/user
         log.info('creating test user..')
         user = multisite.User('rgw-multisite-test-user', account='RGW11111111111111111')
-        master_zone.cluster.admin(['account', 'create', '--account-id', user.account])
+        arg = ['--account-id', user.account]
+        arg += master_zone.zone_args()
+        master_zone.cluster.admin(['account', 'create'] + arg)
         user.create(master_zone, ['--display-name', 'TestUser',
                                   '--gen-access-key', '--gen-secret'])
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67882

---

backport of https://github.com/ceph/ceph/pull/59535
parent tracker: https://tracker.ceph.com/issues/67839

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh