### PR TITLE
ceph-volume: pass self.osd_id to create_id() call

### DIFF
--- a/src/ceph-volume/ceph_volume/objectstore/rawbluestore.py
+++ b/src/ceph-volume/ceph_volume/objectstore/rawbluestore.py
@@ -21,7 +21,7 @@ class RawBlueStore(BlueStore):
         super().__init__(args)
         self.method = 'raw'
         self.devices: List[str] = getattr(args, 'devices', [])
-        self.osd_id = getattr(self.args, 'osd_id', '')
+        self.osd_id = getattr(self.args, 'osd_id', None)
         self.osd_fsid = getattr(self.args, 'osd_fsid', '')
         self.block_device_path = getattr(self.args, 'data', '')
         self.db_device_path = getattr(self.args, 'block_db', '')
@@ -95,7 +95,7 @@ class RawBlueStore(BlueStore):
 
         # reuse a given ID if it exists, otherwise create a new ID
         self.osd_id = prepare_utils.create_id(
-            self.osd_fsid, json.dumps(self.secrets))
+            self.osd_fsid, json.dumps(self.secrets), self.osd_id)
 
         if self.encrypted:
             self.prepare_dmcrypt()


### PR DESCRIPTION
This fixes a regression
(most likely introduced with 04c93a1ed42)

Current (broken) behavior:
```
[root@devel1-1 /]# ceph osd tree
ID  CLASS  WEIGHT  TYPE NAME     STATUS     REWEIGHT  PRI-AFF
-1              0  root default
 0              0  osd.0         destroyed         0  1.00000
[root@devel1-1 /]# ceph-volume raw prepare --bluestore --data /dev/vdb --osd-id 0
Running command: /usr/bin/ceph-authtool --gen-print-key
Running command: /usr/bin/ceph-authtool --gen-print-key
Running command: /usr/bin/ceph --cluster ceph --name client.bootstrap-osd --keyring /var/lib/ceph/bootstrap-osd/ceph.keyring -i - osd new 543e0268-ea66-451f-a2f6-95ae60ab6146
Running command: /usr/bin/mount -t tmpfs tmpfs /var/lib/ceph/osd/ceph-1
Running command: /usr/sbin/restorecon /var/lib/ceph/osd/ceph-1
Running command: /usr/bin/chown -R ceph:ceph /dev/vdb
Running command: /usr/bin/ln -s /dev/vdb /var/lib/ceph/osd/ceph-1/block
Running command: /usr/bin/ceph --cluster ceph --name client.bootstrap-osd --keyring /var/lib/ceph/bootstrap-osd/ceph.keyring mon getmap -o /var/lib/ceph/osd/ceph-1/activate.monmap
 stderr: got monmap epoch 1
--> Creating keyring file for osd.1
Running command: /usr/bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-1/keyring
Running command: /usr/bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-1/
Running command: /usr/bin/ceph-osd --cluster ceph --osd-objectstore bluestore --mkfs -i 1 --monmap /var/lib/ceph/osd/ceph-1/activate.monmap --keyfile - --osd-data /var/lib/ceph/osd/ceph-1/ --osd-uuid 543e0268-ea66-451f-a2f6-95ae60ab6146 --setuser ceph --setgroup ceph
 stderr: 2024-09-04T11:46:54.283+0000 7f0027d2b640 -1 bluestore(/var/lib/ceph/osd/ceph-1//block) _read_bdev_label unable to decode label /var/lib/ceph/osd/ceph-1//block at offset 102: void bluestore_bdev_label_t::decode(ceph::buffer::v15_2_0::list::const_iterator&) decode past end of struct encoding: Malformed input [buffer:3]
 stderr: 2024-09-04T11:46:54.283+0000 7f0027d2b640 -1 bluestore(/var/lib/ceph/osd/ceph-1//block) _read_bdev_label unable to decode label /var/lib/ceph/osd/ceph-1//block at offset 102: void bluestore_bdev_label_t::decode(ceph::buffer::v15_2_0::list::const_iterator&) decode past end of struct encoding: Malformed input [buffer:3]
 stderr: 2024-09-04T11:46:54.283+0000 7f0027d2b640 -1 bluestore(/var/lib/ceph/osd/ceph-1//block) _read_bdev_label unable to decode label /var/lib/ceph/osd/ceph-1//block at offset 102: void bluestore_bdev_label_t::decode(ceph::buffer::v15_2_0::list::const_iterator&) decode past end of struct encoding: Malformed input [buffer:3]
 stderr: 2024-09-04T11:46:54.283+0000 7f0027d2b640 -1 bluestore(/var/lib/ceph/osd/ceph-1/) _read_fsid unparsable uuid
--> ceph-volume raw dmcrypt prepare successful for: /dev/vdb
[root@devel1-1 /]# ceph osd tree
ID  CLASS  WEIGHT  TYPE NAME     STATUS     REWEIGHT  PRI-AFF
-1              0  root default
 0              0  osd.0         destroyed         0  1.00000
 1              0  osd.1              down   1.00000  1.00000
```

A new osd id has been generated while we want to reuse the existing one (0 in this case).

Expected (fixed) behavior:

```
[root@devel1-1 /]# ceph osd tree
ID  CLASS  WEIGHT  TYPE NAME     STATUS     REWEIGHT  PRI-AFF
-1              0  root default
 0              0  osd.0         destroyed         0  1.00000
[root@devel1-1 /]# ceph-volume raw prepare --bluestore --data /dev/vdb --osd-id 0
Running command: /usr/bin/ceph-authtool --gen-print-key
Running command: /usr/bin/ceph-authtool --gen-print-key
Running command: /usr/bin/ceph --cluster ceph --name client.bootstrap-osd --keyring /var/lib/ceph/bootstrap-osd/ceph.keyring osd tree -f json
Running command: /usr/bin/ceph --cluster ceph --name client.bootstrap-osd --keyring /var/lib/ceph/bootstrap-osd/ceph.keyring -i - osd new c87841fb-f56f-40a2-a653-62bb092e8e95 0
Running command: /usr/bin/mount -t tmpfs tmpfs /var/lib/ceph/osd/ceph-0
Running command: /usr/sbin/restorecon /var/lib/ceph/osd/ceph-0
Running command: /usr/bin/chown -R ceph:ceph /dev/vdb
Running command: /usr/bin/ln -s /dev/vdb /var/lib/ceph/osd/ceph-0/block
Running command: /usr/bin/ceph --cluster ceph --name client.bootstrap-osd --keyring /var/lib/ceph/bootstrap-osd/ceph.keyring mon getmap -o /var/lib/ceph/osd/ceph-0/activate.monmap
 stderr: got monmap epoch 1
--> Creating keyring file for osd.0
Running command: /usr/bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-0/keyring
Running command: /usr/bin/chown -R ceph:ceph /var/lib/ceph/osd/ceph-0/
Running command: /usr/bin/ceph-osd --cluster ceph --osd-objectstore bluestore --mkfs -i 0 --monmap /var/lib/ceph/osd/ceph-0/activate.monmap --keyfile - --osd-data /var/lib/ceph/osd/ceph-0/ --osd-uuid c87841fb-f56f-40a2-a653-62bb092e8e95 --setuser ceph --setgroup ceph
 stderr: 2024-09-04T13:07:39.125+0000 7ff02baaa640 -1 bluestore(/var/lib/ceph/osd/ceph-0//block) _read_bdev_label unable to decode label /var/lib/ceph/osd/ceph-0//block at offset 102: void bluestore_bdev_label_t::decode(ceph::buffer::v15_2_0::list::const_iterator&) decode past end of struct encoding: Malformed input [buffer:3]
 stderr: 2024-09-04T13:07:39.125+0000 7ff02baaa640 -1 bluestore(/var/lib/ceph/osd/ceph-0//block) _read_bdev_label unable to decode label /var/lib/ceph/osd/ceph-0//block at offset 102: void bluestore_bdev_label_t::decode(ceph::buffer::v15_2_0::list::const_iterator&) decode past end of struct encoding: Malformed input [buffer:3]
 stderr: 2024-09-04T13:07:39.126+0000 7ff02baaa640 -1 bluestore(/var/lib/ceph/osd/ceph-0//block) _read_bdev_label unable to decode label /var/lib/ceph/osd/ceph-0//block at offset 102: void bluestore_bdev_label_t::decode(ceph::buffer::v15_2_0::list::const_iterator&) decode past end of struct encoding: Malformed input [buffer:3]
 stderr: 2024-09-04T13:07:39.126+0000 7ff02baaa640 -1 bluestore(/var/lib/ceph/osd/ceph-0/) _read_fsid unparsable uuid
--> ceph-volume raw dmcrypt prepare successful for: /dev/vdb
[root@devel1-1 /]# ceph osd tree
ID  CLASS  WEIGHT  TYPE NAME     STATUS  REWEIGHT  PRI-AFF
-1              0  root default
 0              0  osd.0           down         0  1.00000
```

Fixes: https://tracker.ceph.com/issues/67898
