### PR TITLE
crush: Updated the algorithm for calculating osd weight

### DIFF
--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1139,7 +1139,9 @@ private:
   float _get_take_weight_osd_map(int root, std::map<int,float> *pmap) const;
   void _normalize_weight_map(float sum, const std::map<int,float>& m,
 			     std::map<int,float> *pmap) const;
-
+  void _normalize_weight_map(float sum, int choose_val, unsigned size,
+					 const std::map<int,float>& m,
+					 std::map<int,float> *pmap) const;
 public:
   /**
    * calculate a map of osds to weights for a given rule
@@ -1149,9 +1151,10 @@ public:
    *
    * @param ruleno [in] rule id
    * @param pmap [out] map of osd to weight
+   * @param size [in] pool size
    * @return 0 for success, or negative error code
    */
-  int get_rule_weight_osd_map(unsigned ruleno, std::map<int,float> *pmap) const;
+  int get_rule_weight_osd_map(unsigned ruleno, std::map<int,float> *pmap, unsigned size) const;
 
   /**
    * calculate a map of osds to weights for a given starting root

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -983,10 +983,13 @@ int64_t PGMapDigest::get_pool_free_space(const OSDMap &osd_map,
   return avail / osd_map.pool_raw_used_rate(poolid);
 }
 
-int64_t PGMap::get_rule_avail(const OSDMap& osdmap, int ruleno) const
+/*
+ *  size: pool size
+ */
+int64_t PGMap::get_rule_avail(const OSDMap& osdmap, int ruleno, unsigned size) const
 {
   map<int,float> wm;
-  int r = osdmap.crush->get_rule_weight_osd_map(ruleno, &wm);
+  int r = osdmap.crush->get_rule_weight_osd_map(ruleno, &wm, size);
   if (r < 0) {
     return r;
   }
@@ -1037,8 +1040,10 @@ void PGMap::get_rules_avail(const OSDMap& osdmap,
       continue;
     const pg_pool_t *pool = osdmap.get_pg_pool(pool_id);
     int ruleno = pool->get_crush_rule();
-    if (avail_map->count(ruleno) == 0)
-      (*avail_map)[ruleno] = get_rule_avail(osdmap, ruleno);
+    if (avail_map->count(ruleno) == 0){
+      unsigned size = pool->get_size();
+      (*avail_map)[ruleno] = get_rule_avail(osdmap, ruleno, size);
+    }
   }
 }
 

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -449,7 +449,7 @@ public:
   void encode_digest(const OSDMap& osdmap,
 		     ceph::buffer::list& bl, uint64_t features);
 
-  int64_t get_rule_avail(const OSDMap& osdmap, int ruleno) const;
+  int64_t get_rule_avail(const OSDMap& osdmap, int ruleno, unsigned size) const;
   void get_rules_avail(const OSDMap& osdmap,
 		       std::map<int,int64_t> *avail_map) const;
   void dump(ceph::Formatter *f, bool with_net = false) const;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2118,7 +2118,8 @@ bool OSDMap::check_pg_upmaps(
     map<int, float> weight_map;
     auto it = rule_weight_map.find(crush_rule);
     if (it == rule_weight_map.end()) {
-      auto r = crush->get_rule_weight_osd_map(crush_rule, &weight_map);
+      unsigned size = pi->get_size();
+      auto r = crush->get_rule_weight_osd_map(crush_rule, &weight_map, size);
       if (r < 0) {
         lderr(cct) << __func__ << " unable to get crush weight_map for "
                    << "crush_rule " << crush_rule
@@ -5900,7 +5901,8 @@ float OSDMap::get_osds_weight(
   map<int,float> pmap;
   ceph_assert(pools.count(pid));
   int ruleno = pools.at(pid).get_crush_rule();
-  tmp_osd_map.crush->get_rule_weight_osd_map(ruleno, &pmap);
+  unsigned size = pools.at(pid).get_size();
+  tmp_osd_map.crush->get_rule_weight_osd_map(ruleno, &pmap, size);
     ldout(cct,20) << __func__ << " pool " << pid
                   << " ruleno " << ruleno
                   << " weight-map " << pmap
@@ -6481,7 +6483,8 @@ int OSDMap::calc_rbs_fair(CephContext *cct, OSDMap& tmp_osd_map, int64_t pool_id
   map<int,float> osds_crush_weight;
   // Set up the OSDMap
   int ruleno = tmp_osd_map.pools.at(pool_id).get_crush_rule();
-  tmp_osd_map.crush->get_rule_weight_osd_map(ruleno, &osds_crush_weight);
+  unsigned size = tmp_osd_map.pools.at(pool_id).get_size();
+  tmp_osd_map.crush->get_rule_weight_osd_map(ruleno, &osds_crush_weight, size);
 
   if (cct != nullptr) {
     ldout(cct,20) << __func__ << " pool " << pool_id

--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -899,6 +899,30 @@ TEST_F(CrushWrapperTest, dump_rules) {
 				"osd.0", loc));
   }
 
+  item = 1;
+  loc = c->get_immediate_parent(item, &ret);
+  EXPECT_EQ(-ENOENT, ret);
+
+  {
+    map<string,string> loc;
+    loc["root"] = root_name;
+
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
+				"osd.1", loc));
+  }
+
+  item = 2;
+  loc = c->get_immediate_parent(item, &ret);
+  EXPECT_EQ(-ENOENT, ret);
+
+  {
+    map<string,string> loc;
+    loc["root"] = root_name;
+
+    EXPECT_EQ(0, c->insert_item(cct, item, 1.0,
+				"osd.2", loc));
+  }
+
   // no rule by default
   {
     auto f = Formatter::create_unique("json-pretty");
@@ -934,9 +958,11 @@ TEST_F(CrushWrapperTest, dump_rules) {
   }
 
   map<int,float> wm;
-  c->get_rule_weight_osd_map(0, &wm);
-  ASSERT_TRUE(wm.size() == 1);
-  ASSERT_TRUE(wm[0] == 1.0);
+  //for erasure pool, k = 2 m = 1
+  unsigned size = 3;
+  c->get_rule_weight_osd_map(0, &wm, size);
+  ASSERT_TRUE(wm.size() == 3);
+  ASSERT_TRUE(wm[0] == 1.0 / 3);
 }
 
 TEST_F(CrushWrapperTest, distance) {


### PR DESCRIPTION
Resolve the issue of the "MAX AVAIL" value being smaller than expected in the ceph df command.

For example， In the following environment:
```
ID   CLASS  WEIGHT   TYPE NAME             STATUS  REWEIGHT  PRI-AFF
 -1         1.57739  root default
 -5         0.39435      rack rack1
-13         0.19716          host ubuntu1
  0    ssd  0.09859              osd.0         up   1.00000  1.00000
  1    ssd  0.09859              osd.1         up   1.00000  1.00000
-14         0.19716          host ubuntu2
  2    ssd  0.09859              osd.2         up   1.00000  1.00000
  3    ssd  0.09859              osd.3         up   1.00000  1.00000
 -6         0.39435      rack rack2
-15         0.19716          host ubuntu3
  4    ssd  0.09859              osd.4         up   1.00000  1.00000
  5    ssd  0.09859              osd.5         up   1.00000  1.00000
-16         0.19716          host ubuntu4
  6    ssd  0.09859              osd.6         up   1.00000  1.00000
  7    ssd  0.09859              osd.7         up   1.00000  1.00000
 -7         0.39435      rack rack3
-17         0.19716          host ubuntu5
  8    ssd  0.09859              osd.8         up   1.00000  1.00000
  9    ssd  0.09859              osd.9         up   1.00000  1.00000
-18         0.19716          host ubuntu6
 10    ssd  0.09859              osd.10        up   1.00000  1.00000
 11    ssd  0.09859              osd.11        up   1.00000  1.00000
 -8         0.39435      rack rack4
-19         0.19716          host ubuntu7
 12    ssd  0.09859              osd.12        up   1.00000  1.00000
 13    ssd  0.09859              osd.13        up   1.00000  1.00000
-20         0.19716          host ubuntu8
 14    ssd  0.09859              osd.14        up   1.00000  1.00000
 15    ssd  0.09859              osd.15        up   1.00000  1.00000
```
create two erasure-coded pools （k=3  m=1）
the crush rule of the pool named ec-pool is ecrule1
the crush rule of the pool named ec-pool2 is ecrule2
```
rule ecrule1 {
        id 1
        type erasure
        step set_chooseleaf_tries 5
        step set_choose_tries 100
        step take default
        step chooseleaf indep 0 type host
        step emit
}
rule ecrule2 {
        id 2
        type erasure
        step set_chooseleaf_tries 5
        step set_choose_tries 100
        step take default
        step take rack1
        step chooseleaf indep 1 type host
        step emit
        step take rack2
        step chooseleaf indep 1 type host
        step emit
        step take rack3
        step chooseleaf indep 1 type host
        step emit
        step take rack4
        step chooseleaf indep 1 type host
        step emit
        step emit
}
```

The expected value of MAX AVAIL in the ceph df output is as follows：
```
--- RAW STORAGE ---
CLASS     SIZE    AVAIL    USED  RAW USED  %RAW USED
ssd    1.6 TiB  1.6 TiB  16 GiB    16 GiB       0.99
TOTAL  1.6 TiB  1.6 TiB  16 GiB    16 GiB       0.99

--- POOLS ---
POOL      ID  PGS  STORED  OBJECTS  USED  %USED  MAX AVAIL
ec-pool    1  128     0 B        0   0 B      0    1.2 TiB
ec-pool2   3  128     0 B        0   0 B      0    1.2 TiB
```
