### PR TITLE
crimson/osd/recovery_backend: always set the primary osd's BackfillInterval::version to the last_update before the backfill scan

### DIFF
--- a/src/crimson/osd/backfill_facades.h
+++ b/src/crimson/osd/backfill_facades.h
@@ -28,8 +28,8 @@ struct PeeringFacade final : BackfillState::PeeringFacade {
     return peering_state.get_peer_info(peer).last_backfill;
   }
 
-  const eversion_t& get_last_update() const override {
-    return peering_state.get_info().last_update;
+  eversion_t get_pg_committed_to() const override {
+    return peering_state.get_pg_committed_to();
   }
 
   const eversion_t& get_log_tail() const override {

--- a/src/crimson/osd/backfill_state.cc
+++ b/src/crimson/osd/backfill_state.cc
@@ -406,7 +406,7 @@ BackfillState::Enqueuing::Enqueuing(my_context ctx)
 BackfillState::PrimaryScanning::PrimaryScanning(my_context ctx)
   : my_base(ctx)
 {
-  backfill_state().backfill_info.version = peering_state().get_last_update();
+  backfill_state().backfill_info.version = peering_state().get_pg_committed_to();
   backfill_listener().request_primary_scan(
     backfill_state().backfill_info.begin);
 }
@@ -416,6 +416,7 @@ BackfillState::PrimaryScanning::react(PrimaryScanned evt)
 {
   LOG_PREFIX(BackfillState::PrimaryScanning::react::PrimaryScanned);
   DEBUGDPP("", pg());
+  evt.result.version = backfill_state().backfill_info.version;
   backfill_state().backfill_info = std::move(evt.result);
   if (!backfill_state().is_suspended()) {
     return transit<Enqueuing>();

--- a/src/crimson/osd/backfill_state.h
+++ b/src/crimson/osd/backfill_state.h
@@ -387,7 +387,7 @@ struct BackfillState::PeeringFacade {
   virtual const std::set<pg_shard_t>& get_backfill_targets() const = 0;
   virtual const hobject_t& get_peer_last_backfill(pg_shard_t peer) const = 0;
   virtual const PGLog& get_pg_log() const = 0;
-  virtual const eversion_t& get_last_update() const = 0;
+  virtual eversion_t get_pg_committed_to() const = 0;
   virtual const eversion_t& get_log_tail() const = 0;
 
   // the performance impact of `std::function` has not been considered yet.

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -531,10 +531,10 @@ void PGRecovery::enqueue_push(
 {
   logger().info("{}: obj={} v={} peers={}", __func__, obj, v, peers);
   auto &peering_state = pg->get_peering_state();
-  peering_state.prepare_backfill_for_missing(obj, v, peers);
   auto [recovering, added] = pg->get_recovery_backend()->add_recovering(obj);
   if (!added)
     return;
+  peering_state.prepare_backfill_for_missing(obj, v, peers);
   std::ignore = pg->get_recovery_backend()->recover_object(obj, v).\
   handle_exception_interruptible([] (auto) {
     ceph_abort_msg("got exception on backfill's push");

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -265,11 +265,11 @@ RecoveryBackend::scan_for_backfill(
 	  }, PGBackend::load_metadata_ertr::assert_all{});
 	}
       });
-    }).then_interruptible([FNAME, this, version_map, start=std::move(start), next=std::move(next)] {
+    }).then_interruptible([FNAME, version_map, start=std::move(start),
+			  next=std::move(next), this] {
       BackfillInterval bi;
       bi.begin = std::move(start);
       bi.end = std::move(next);
-      bi.version = pg.get_info().last_update;
       bi.objects = std::move(*version_map);
       DEBUGDPP("{} BackfillInterval filled, leaving, {}",
 	       "scan_for_backfill",

--- a/src/test/crimson/test_backfill.cc
+++ b/src/test/crimson/test_backfill.cc
@@ -233,7 +233,7 @@ struct BackfillFixture::PeeringFacade
   const hobject_t& get_peer_last_backfill(pg_shard_t peer) const override {
     return backfill_targets.at(peer).last_backfill;
   }
-  const eversion_t& get_last_update() const override {
+  eversion_t get_pg_committed_to() const override {
     return backfill_source.last_update;
   }
   const eversion_t& get_log_tail() const override {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/67916
Signed-off-by: Xuehan Xu <xuxuehan@qianxin.com>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
