### PR TITLE
squid: mds: move fscrypt inode_t metadata to mds_co mempool

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -700,6 +700,12 @@ struct error_code;
       void copy_shallow(unsigned len, ptr &dest);
       void copy(unsigned len, list &dest);
       void copy(unsigned len, std::string &dest);
+      template<typename A>
+      void copy(unsigned len, std::vector<uint8_t,A>& u8v) {
+        u8v.resize(len);
+        copy(len, (char*)u8v.data());
+      }
+
       void copy_all(list &dest);
 
       // get a pointer to the currenet iterator position, return the
@@ -1139,6 +1145,10 @@ struct error_code;
     }
     void append(std::string_view s) {
       append(s.data(), s.length());
+    }
+    template<typename A>
+    void append(const std::vector<uint8_t,A>& u8v) {
+      append((const char *)u8v.data(), u8v.size());
     }
 #endif // __cplusplus >= 201703L
     void append(const ptr& bp);

--- a/src/include/cephfs/types.h
+++ b/src/include/cephfs/types.h
@@ -408,9 +408,9 @@ struct inode_t {
   bool is_file()    const { return (mode & S_IFMT) == S_IFREG; }
 
   bool is_truncating() const { return (truncate_pending > 0); }
-  void truncate(uint64_t old_size, uint64_t new_size, const bufferlist &fbl) {
+  void truncate(uint64_t old_size, uint64_t new_size, ::ceph::buffer::list::const_iterator fblp) {
     truncate(old_size, new_size);
-    fscrypt_last_block = fbl;
+    fblp.copy(fblp.get_remaining(), fscrypt_last_block);
   }
   void truncate(uint64_t old_size, uint64_t new_size) {
     ceph_assert(new_size <= old_size);
@@ -608,8 +608,7 @@ struct inode_t {
 
   std::vector<uint8_t,Allocator<uint8_t>> fscrypt_auth;
   std::vector<uint8_t,Allocator<uint8_t>> fscrypt_file;
-
-  bufferlist fscrypt_last_block;
+  std::vector<uint8_t,Allocator<uint8_t>> fscrypt_last_block;
 
 private:
   bool older_is_consistent(const inode_t &other) const;

--- a/src/include/cephfs/types.h
+++ b/src/include/cephfs/types.h
@@ -607,7 +607,7 @@ struct inode_t {
   std::basic_string<char,std::char_traits<char>,Allocator<char>> stray_prior_path; //stores path before unlink
 
   std::vector<uint8_t,Allocator<uint8_t>> fscrypt_auth;
-  std::vector<uint8_t> fscrypt_file;
+  std::vector<uint8_t,Allocator<uint8_t>> fscrypt_file;
 
   bufferlist fscrypt_last_block;
 

--- a/src/include/cephfs/types.h
+++ b/src/include/cephfs/types.h
@@ -606,7 +606,7 @@ struct inode_t {
 
   std::basic_string<char,std::char_traits<char>,Allocator<char>> stray_prior_path; //stores path before unlink
 
-  std::vector<uint8_t> fscrypt_auth;
+  std::vector<uint8_t,Allocator<uint8_t>> fscrypt_auth;
   std::vector<uint8_t> fscrypt_file;
 
   bufferlist fscrypt_last_block;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4223,7 +4223,7 @@ void CInode::encode_cap_message(const ref_t<MClientCaps> &m, Capability *cap)
   m->size = i->size;
   m->truncate_seq = i->truncate_seq;
   m->truncate_size = i->truncate_size;
-  m->fscrypt_file = i->fscrypt_file;
+  m->fscrypt_file.assign(i->fscrypt_file.begin(), i->fscrypt_file.end());
   m->fscrypt_auth.assign(i->fscrypt_auth.begin(), i->fscrypt_auth.end());
   m->mtime = i->mtime;
   m->atime = i->atime;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4224,7 +4224,7 @@ void CInode::encode_cap_message(const ref_t<MClientCaps> &m, Capability *cap)
   m->truncate_seq = i->truncate_seq;
   m->truncate_size = i->truncate_size;
   m->fscrypt_file = i->fscrypt_file;
-  m->fscrypt_auth = i->fscrypt_auth;
+  m->fscrypt_auth.assign(i->fscrypt_auth.begin(), i->fscrypt_auth.end());
   m->mtime = i->mtime;
   m->atime = i->atime;
   m->ctime = i->ctime;

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -3977,7 +3977,7 @@ void Locker::_update_cap_fields(CInode *in, int dirty, const cref_t<MClientCaps>
       pi->time_warp_seq = m->get_time_warp_seq();
     }
     if (m->fscrypt_file.size())
-      pi->fscrypt_file = m->fscrypt_file;
+      pi->fscrypt_file.assign(m->fscrypt_file.begin(), m->fscrypt_file.end());
   }
   // auth
   if (dirty & CEPH_CAP_AUTH_EXCL) {

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -4006,7 +4006,7 @@ void Locker::_update_cap_fields(CInode *in, int dirty, const cref_t<MClientCaps>
       pi->btime = m->get_btime();
     }
     if (m->fscrypt_auth.size())
-      pi->fscrypt_auth = m->fscrypt_auth;
+      pi->fscrypt_auth.assign(m->fscrypt_auth.begin(), m->fscrypt_auth.end());
   }
 }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6518,7 +6518,7 @@ void MDCache::_truncate_inode(CInode *in, LogSegment *ls)
   const auto& pi = in->get_inode();
   dout(10) << "_truncate_inode "
            << pi->truncate_from << " -> " << pi->truncate_size
-           << " fscrypt last block length is " << pi->fscrypt_last_block.length()
+           << " fscrypt last block length is " << pi->fscrypt_last_block.size()
            << " on " << *in << dendl;
 
   ceph_assert(pi->is_truncating());
@@ -6526,7 +6526,7 @@ void MDCache::_truncate_inode(CInode *in, LogSegment *ls)
   ceph_assert(pi->truncate_from < (1ULL << 63));
   ceph_assert(pi->truncate_size < pi->truncate_from ||
               (pi->truncate_size == pi->truncate_from &&
-	       pi->fscrypt_last_block.length()));
+	       pi->fscrypt_last_block.size()));
 
 
   SnapRealm *realm = in->find_snaprealm();
@@ -6541,18 +6541,20 @@ void MDCache::_truncate_inode(CInode *in, LogSegment *ls)
     ceph_assert(in->last == CEPH_NOSNAP);
   }
   dout(10) << "_truncate_inode  snapc " << snapc << " on " << *in
-           << " fscrypt_last_block length is " << pi->fscrypt_last_block.length()
+           << " fscrypt_last_block length is " << pi->fscrypt_last_block.size()
            << dendl;
   auto layout = pi->layout;
   struct ceph_fscrypt_last_block_header header;
   memset(&header, 0, sizeof(header));
   bufferlist data;
-  if (pi->fscrypt_last_block.length()) {
-    auto bl = pi->fscrypt_last_block.cbegin();
-    DECODE_START(1, bl);
-    decode(header.change_attr, bl);
-    decode(header.file_offset, bl);
-    decode(header.block_size, bl);
+  if (pi->fscrypt_last_block.size()) {
+    auto _bl = bufferlist();
+    _bl.append(pi->fscrypt_last_block);
+    auto blp = _bl.cbegin();
+    DECODE_START(1, blp);
+    decode(header.change_attr, blp);
+    decode(header.file_offset, blp);
+    decode(header.block_size, blp);
 
     /*
      * The block_size will be in unit of KB, so if the last block is not
@@ -6560,9 +6562,9 @@ void MDCache::_truncate_inode(CInode *in, LogSegment *ls)
      * header.block_size.
      */
     if (struct_len > header.block_size) {
-      bl.copy(header.block_size, data);
+      blp.copy(header.block_size, data);
     }
-    DECODE_FINISH(bl);
+    DECODE_FINISH(blp);
   }
 
   if (data.length()) {
@@ -6583,7 +6585,7 @@ void MDCache::_truncate_inode(CInode *in, LogSegment *ls)
      * this case we will always request a larger length to make sure the
      * OSD won't miss truncating the last object.
      */
-    if (pi->fscrypt_last_block.length()) {
+    if (pi->fscrypt_last_block.size()) {
       dout(10) << "_truncate_inode truncate on inode " << *in << " hits a hole!" << dendl;
       length += header.block_size;
     }
@@ -6621,7 +6623,7 @@ void MDCache::truncate_inode_write_finish(CInode *in, LogSegment *ls,
   ceph_assert(pi->truncate_from < (1ULL << 63));
   ceph_assert(pi->truncate_size < pi->truncate_from ||
               (pi->truncate_size == pi->truncate_from &&
-	       pi->fscrypt_last_block.length()));
+	       pi->fscrypt_last_block.size()));
 
 
   SnapRealm *realm = in->find_snaprealm();
@@ -6636,7 +6638,7 @@ void MDCache::truncate_inode_write_finish(CInode *in, LogSegment *ls,
     ceph_assert(in->last == CEPH_NOSNAP);
   }
   dout(10) << "_truncate_inode_write  snapc " << snapc << " on " << *in
-           << " fscrypt_last_block length is " << pi->fscrypt_last_block.length()
+           << " fscrypt_last_block length is " << pi->fscrypt_last_block.size()
            << dendl;
   auto layout = pi->layout;
   /*
@@ -6668,7 +6670,7 @@ void MDCache::truncate_inode_finish(CInode *in, LogSegment *ls)
   pi.inode->version = in->pre_dirty();
   pi.inode->truncate_from = 0;
   pi.inode->truncate_pending--;
-  pi.inode->fscrypt_last_block = bufferlist();
+  pi.inode->fscrypt_last_block.clear();
 
   EUpdate *le = new EUpdate(mds->mdlog, "truncate finish");
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3571,7 +3571,7 @@ CInode* Server::prepare_new_inode(const MDRequestRef& mdr, CDir *dir, inodeno_t 
   const cref_t<MClientRequest> &req = mdr->client_request;
 
   dout(10) << "copying fscrypt_auth len " << req->fscrypt_auth.size() << dendl;
-  _inode->fscrypt_auth = req->fscrypt_auth;
+  _inode->fscrypt_auth.assign(req->fscrypt_auth.begin(), req->fscrypt_auth.end());
   _inode->fscrypt_file = req->fscrypt_file;
 
   if (req->get_data().length()) {
@@ -5472,7 +5472,7 @@ void Server::handle_client_setattr(const MDRequestRef& mdr)
   }
 
   if (mask & CEPH_SETATTR_FSCRYPT_AUTH)
-    pi.inode->fscrypt_auth = req->fscrypt_auth;
+    pi.inode->fscrypt_auth.assign(req->fscrypt_auth.begin(), req->fscrypt_auth.end());
   if (mask & CEPH_SETATTR_FSCRYPT_FILE)
     pi.inode->fscrypt_file = req->fscrypt_file;
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5455,7 +5455,7 @@ void Server::handle_client_setattr(const MDRequestRef& mdr)
     pi.inode->time_warp_seq++;   // maybe not a timewarp, but still a serialization point.
   if (mask & CEPH_SETATTR_SIZE) {
     if (truncating_smaller) {
-      pi.inode->truncate(old_size, req->head.args.setattr.size, req->get_data());
+      pi.inode->truncate(old_size, req->head.args.setattr.size, req->get_data().cbegin());
       le->metablob.add_truncate_start(cur->ino());
     } else {
       pi.inode->size = req->head.args.setattr.size;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3572,7 +3572,7 @@ CInode* Server::prepare_new_inode(const MDRequestRef& mdr, CDir *dir, inodeno_t 
 
   dout(10) << "copying fscrypt_auth len " << req->fscrypt_auth.size() << dendl;
   _inode->fscrypt_auth.assign(req->fscrypt_auth.begin(), req->fscrypt_auth.end());
-  _inode->fscrypt_file = req->fscrypt_file;
+  _inode->fscrypt_file.assign(req->fscrypt_file.begin(), req->fscrypt_file.end());
 
   if (req->get_data().length()) {
     auto p = req->get_data().cbegin();
@@ -5474,7 +5474,7 @@ void Server::handle_client_setattr(const MDRequestRef& mdr)
   if (mask & CEPH_SETATTR_FSCRYPT_AUTH)
     pi.inode->fscrypt_auth.assign(req->fscrypt_auth.begin(), req->fscrypt_auth.end());
   if (mask & CEPH_SETATTR_FSCRYPT_FILE)
-    pi.inode->fscrypt_file = req->fscrypt_file;
+    pi.inode->fscrypt_file.assign(req->fscrypt_file.begin(), req->fscrypt_file.end());
 
   pi.inode->version = cur->pre_dirty();
   pi.inode->ctime = mdr->get_op_stamp();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67920

---

backport of https://github.com/ceph/ceph/pull/59414
parent tracker: https://tracker.ceph.com/issues/67687

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh