### PR TITLE
reef: qa: ignore warnings variations

### DIFF
--- a/qa/cephfs/overrides/ignorelist_health.yaml
+++ b/qa/cephfs/overrides/ignorelist_health.yaml
@@ -2,9 +2,11 @@ overrides:
   ceph:
     log-ignorelist:
       - FS_DEGRADED
+      - filesystem is degraded
       - FS_INLINE_DATA_DEPRECATED
       - FS_WITH_FAILED_MDS
       - MDS_ALL_DOWN
+      - filesystem is offline
       - MDS_DAMAGE
       - MDS_DEGRADED
       - MDS_FAILED


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67837

---

backport of https://github.com/ceph/ceph/pull/59309
parent tracker: https://tracker.ceph.com/issues/67601

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh