### PR TITLE
quincy: client: Prevent race condition when printing Inode in ll_sync_inode

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -14979,7 +14979,7 @@ int Client::ll_sync_inode(Inode *in, bool syncdataonly)
   if (!mref_reader.is_state_satisfied())
     return -CEPHFS_ENOTCONN;
 
-  ldout(cct, 3) << "ll_sync_inode " << *in << " " << dendl;
+  ldout(cct, 3) << "ll_sync_inode " << _get_vino(in) << " " << dendl;
   tout(cct) << "ll_sync_inode" << std::endl;
   tout(cct) << (uintptr_t)in << std::endl;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67739

---

backport of https://github.com/ceph/ceph/pull/59162
parent tracker: https://tracker.ceph.com/issues/67491

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh