### PR TITLE
squid: ceph-volume: switch over to new disk sorting behavior

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -224,7 +224,6 @@ class Batch(object):
             action='store_true',
             help=('deploy multi-device OSDs if rotational and non-rotational drives '
                   'are passed in DEVICES'),
-            default=True
         )
         parser.add_argument(
             '--no-auto',
@@ -383,7 +382,6 @@ class Batch(object):
         '''
         mlogger.warning('DEPRECATION NOTICE')
         mlogger.warning('You are using the legacy automatic disk sorting behavior')
-        mlogger.warning('The Pacific release will change the default to --no-auto')
         rotating = []
         ssd = []
         for d in self.args.devices:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67924

---

backport of https://github.com/ceph/ceph/pull/59170
parent tracker: https://tracker.ceph.com/issues/67497

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh