### PR TITLE
squid: suites/upgrade/quincy-x: update the ignore list

### DIFF
--- a/qa/suites/upgrade/quincy-x/filestore-remove-check/1-ceph-install/quincy.yaml
+++ b/qa/suites/upgrade/quincy-x/filestore-remove-check/1-ceph-install/quincy.yaml
@@ -30,3 +30,14 @@ overrides:
     conf:
       mon:
         mon warn on osd down out interval zero: false
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
+      - OSD_DOWN
+      - mons down
+      - mon down
+      - MON_DOWN
+      - out of quorum
+      - PG_DEGRADED
+      - Reduced data availability
+      - Degraded data redundancy
+      - OSDMAP_FLAGS

--- a/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
+++ b/qa/suites/upgrade/quincy-x/parallel/0-start.yaml
@@ -31,3 +31,14 @@ overrides:
     conf:
       osd:
         osd shutdown pgref assert: true
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
+      - OSD_DOWN
+      - mons down
+      - mon down
+      - MON_DOWN
+      - out of quorum
+      - PG_DEGRADED
+      - Reduced data availability
+      - Degraded data redundancy
+      - OSDMAP_FLAGS

--- a/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/quincy-x/stress-split/1-start.yaml
@@ -1,3 +1,16 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - \(POOL_APP_NOT_ENABLED\)
+      - OSD_DOWN
+      - mons down
+      - mon down
+      - MON_DOWN
+      - out of quorum
+      - PG_DEGRADED
+      - Reduced data availability
+      - Degraded data redundancy
+      - OSDMAP_FLAGS
 tasks:
 - install:
     branch: quincy


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67138

---

backport of https://github.com/ceph/ceph/pull/58277
parent tracker: https://tracker.ceph.com/issues/65422

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh