### PR TITLE
squid: test: test_rados_tools compare output without trimming newline

### DIFF
--- a/qa/workunits/rados/test_rados_tool.sh
+++ b/qa/workunits/rados/test_rados_tool.sh
@@ -329,10 +329,10 @@ test_xattr() {
     expect_false $RADOS_TOOL -p $POOL setxattr $OBJ 2>/dev/null
     expect_false $RADOS_TOOL -p $POOL setxattr $OBJ foo fooval extraarg 2>/dev/null
     $RADOS_TOOL -p $POOL setxattr $OBJ foo fooval
-    $RADOS_TOOL -p $POOL getxattr $OBJ foo > $V2
+    $RADOS_TOOL -p $POOL getxattr $OBJ foo > $V2 | tr -d '\n' > $V2
     cmp $V1 $V2
     cat $V1 | $RADOS_TOOL -p $POOL setxattr $OBJ bar
-    $RADOS_TOOL -p $POOL getxattr $OBJ bar > $V2
+    $RADOS_TOOL -p $POOL getxattr $OBJ bar > $V2 | tr -d '\n' > $V2
     cmp $V1 $V2
     $RADOS_TOOL -p $POOL listxattr $OBJ > $V1
     grep -q foo $V1


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67914

---

backport of https://github.com/ceph/ceph/pull/59165
parent tracker: https://tracker.ceph.com/issues/67419

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh