### PR TITLE
radosgw-admin: create user without creds cli

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -548,6 +548,13 @@ Options
 
     Generate random secret key.
 
+.. option:: --generate-key
+
+    create user with or without credentials.
+    If this option set to false, then user cannot set --gen-access-key/--gen-secret/--secret-key/--access-key.
+    If this option set to true, then user cannot set  --secret-key/--access-key and bypass options for --gen-secret/--gen-access-key.
+    Default is true.
+
 .. option:: --key-type=<type>
 
     Key type, options are: swift, s3.

--- a/doc/radosgw/admin.rst
+++ b/doc/radosgw/admin.rst
@@ -262,6 +262,7 @@ include:
 - ``--secret-key=<key>`` manually specifies a S3 secret key or a Swift secret key.
 - ``--gen-access-key`` automatically generates a random S3 access key.
 - ``--gen-secret`` automatically generates a random S3 secret key or a random Swift secret key.
+- ``--generate-key`` create user with or without credentials. If sets to false, then user cannot set ``gen-secret/gen-access-key/access-key/secret-key``
 
 Adding S3 keys
 ~~~~~~~~~~~~~~

--- a/src/bash_completion/radosgw-admin
+++ b/src/bash_completion/radosgw-admin
@@ -19,7 +19,7 @@ _radosgw_admin()
 
         if [[ ${cur} == -* ]] ; then
             COMPREPLY=( $(compgen -W "--uid --subuser --access-key --os-user --email --auth_uid --secret --os-secret --gen-access-key --gen-secret \
-                                      --access --display-name --bucket --object --date --conf --name --id --version -s -w" -- ${cur}) )
+                                      --access --display-name --bucket --object --date --conf --name --id --version -s -w --generate-key" -- ${cur}) )
             return 0
         fi
 

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -225,6 +225,7 @@
      --secret/--secret-key=<key>       specify secret key
      --gen-access-key                  generate random access key (for S3)
      --gen-secret                      generate random secret key
+     --generate-key                    create user with or without credentials
      --key-type=<type>                 key type, options are: swift, s3
      --key-active=<bool>               activate or deactivate a key
      --temp-url-key[-2]=<key>          temp url key


### PR DESCRIPTION
 Add an option `--no-credentials` for radosgw-admin cli to create user without credentials.

Fixes: https://tracker.ceph.com/issues/67930
Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
