### PR TITLE
mgr/cephadm: adding spec fields for oauth2-proxy whitelist_domains

### DIFF
--- a/src/pybind/mgr/cephadm/services/oauth2_proxy.py
+++ b/src/pybind/mgr/cephadm/services/oauth2_proxy.py
@@ -67,10 +67,12 @@ class OAuth2ProxyService(CephadmService):
     def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
         svc_spec = cast(OAuth2ProxySpec, self.mgr.spec_store[daemon_spec.service_name].spec)
+        whitelist_domains = svc_spec.whitelist_domains or []
+        whitelist_domains += self.get_service_ips_and_hosts('mgmt-gateway')
         context = {
             'spec': svc_spec,
             'cookie_secret': svc_spec.cookie_secret or self.generate_random_secret(),
-            'whitelist_domains': self.get_service_ips_and_hosts('mgmt-gateway'),
+            'whitelist_domains': whitelist_domains,
             'redirect_url': svc_spec.redirect_url or self.get_redirect_url()
         }
 

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1920,6 +1920,7 @@ class OAuth2ProxySpec(ServiceSpec):
                  cookie_secret: Optional[str] = None,
                  ssl_certificate: Optional[str] = None,
                  ssl_certificate_key: Optional[str] = None,
+                 whitelist_domains: Optional[List[str]] = None,
                  unmanaged: bool = False,
                  extra_container_args: Optional[GeneralArgList] = None,
                  extra_entrypoint_args: Optional[GeneralArgList] = None,
@@ -1955,6 +1956,9 @@ class OAuth2ProxySpec(ServiceSpec):
         self.ssl_certificate = ssl_certificate
         #: The multi-line SSL certificate private key for decrypting communications.
         self.ssl_certificate_key = ssl_certificate_key
+        #: List of allowed domains for safe redirection after login or logout,
+        # preventing unauthorized redirects.
+        self.whitelist_domains = whitelist_domains
         self.unmanaged = unmanaged
 
     def get_port_start(self) -> List[int]:


### PR DESCRIPTION
this field is needed in order to configure which domains are allowed for redirection during login and/or logout

Fixes: https://tracker.ceph.com/issues/67934

Configuration example:

```
service_type: oauth2-proxy
placement:
  hosts:
    - ceph-node-2
spec:
  https_address: "0.0.0.0:4180"
  provider_display_name: "My OIDC Provider"
  client_id: "oauth2-proxy"
  client_secret: "vwCLTITb2rtem583523uXcuSNItDsz1I"
  cookie_secret: "kbAEM9opAmuHskQvt0AW8oeJRaOM2BYy5Loba0kZ0SQ="
  oidc_issuer_url: "http://192.168.100.1:8080/realms/ceph"
  whitelist_domains:
    - domain1.com
    - 192.168.100.1:8080

```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
