### PR TITLE
src/include/uuid.h: fix for boost 1.86.0

### DIFF
--- a/src/include/uuid.h
+++ b/src/include/uuid.h
@@ -60,7 +60,11 @@ struct uuid_d {
   }
 
   const char *bytes() const {
+#if BOOST_VERSION >= 108600
+    return (const char*)uuid.data();
+#else
     return (const char*)uuid.data;
+#endif
   }
 
   void encode(::ceph::buffer::list::contiguous_appender& p) const {


### PR DESCRIPTION
Boost 1.86.0 includes a significant rewrite of the UUID library. The Changelog[^1] notes that:

> u.data(), where u is of type uuid, now returns a pointer to the first uint8_t of the representation (same as u.begin().) For backward compatibility, data is a function object with operator(), rather than a member function, which allows most existing uses of data as a public member to remain valid, if no longer encouraged.

I don't know enough about C++ to judge how that should have worked, but it leads to a compile error here. This patch uses BOOST_VERSION to decide whether to access .data as a member or .data() as a function.

[^1]: https://www.boost.org/doc/libs/1_86_0/libs/uuid/doc/html/uuid.html#changes





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.
-->

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
