### PR TITLE
squid: mgr/snap_schedule: correctly fetch mds_max_snaps_per_dir from mds

### DIFF
--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -361,7 +361,7 @@ class SnapSchedClient(CephfsClient):
             path = sched.path
             prune_candidates = set()
             time = datetime.now(timezone.utc)
-            mds_max_snaps_per_dir = self.mgr.get_ceph_option('mds_max_snaps_per_dir')
+            mds_max_snaps_per_dir = self.mgr.get_foreign_ceph_option('mds', 'mds_max_snaps_per_dir')
             with open_filesystem(self, sched.fs) as fs_handle:
                 snap_dir = self.mgr.rados.conf_get('client_snapdir')
                 with fs_handle.opendir(f'{path}/{snap_dir}') as d_handle:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67940

---

backport of https://github.com/ceph/ceph/pull/57388
parent tracker: https://tracker.ceph.com/issues/65895

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh