### PR TITLE
mgr/smb: stop trying to clean external store during cluster sync

### DIFF
--- a/src/pybind/mgr/smb/handler.py
+++ b/src/pybind/mgr/smb/handler.py
@@ -620,11 +620,6 @@ class ClusterConfigHandler:
             change_group.cluster.cluster_id,
             set(change_group.cache),
         )
-        external.rm_other_in_ns(
-            self.public_store,
-            change_group.cluster.cluster_id,
-            set(change_group.cache),
-        )
 
         # ensure a entity exists with access to the volumes
         for volume in vols:


### PR DESCRIPTION
It was found during testing that a sequence of commands like:
```
ceph smb cluster create slow1 user --define-user-pass=user1%badf00d --clustering=always
--placement=3
sleep 0.5
ceph smb share create slow1 share1 cephfs --subvolume=g1/sv1 --path=/
sleep 0.5
ceph smb share create slow1 share2 cephfs --subvolume=g1/sv2 --path=/
```
would create a CTDB enabled cluster that would fail to start up correctly. The issue was due to the call to `external.rm_other_in_ns` during the cluster sync operation. In the CTDB enabled mode, objects are written to the pool outside of the smb mgr module's direct control and this function, intended to keep the pool & namespace tidy, was removing files needed by CTDB-enabled mode. The failure is somewhat timing sensitive due to the ctdb enablement sidecars coming up before or after the object was deleted.

Remove this function call so that these objects stop getting deleted at inopportune times. While we could have tried making this function "smarter" and only deleting some unexpected objects, in this case I feel that keeping it simple is better. If we find this pool getting cluttered in the future we can add a smarter pool-tidying-up function later.

Fixes: https://tracker.ceph.com/issues/67946





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
