### PR TITLE
quincy: librbd/migration: prune snapshot extents in RawFormat::list_snaps()

### DIFF
--- a/qa/workunits/rbd/cli_migration.sh
+++ b/qa/workunits/rbd/cli_migration.sh
@@ -25,7 +25,10 @@ cleanup_tempdir() {
 create_base_image() {
     local image=$1
 
-    rbd create --size 1G ${image}
+    # size is not a multiple of object size to trigger an edge case in
+    # list-snaps
+    rbd create --size 1025M ${image}
+
     rbd bench --io-type write --io-pattern rand --io-size=4K --io-total 256M ${image}
     rbd snap create ${image}@1
     rbd bench --io-type write --io-pattern rand --io-size=4K --io-total 64M ${image}

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -35,6 +35,7 @@
 #include "librbd/io/ObjectDispatcher.h"
 #include "librbd/io/QosImageDispatch.h"
 #include "librbd/io/IoOperations.h"
+#include "librbd/io/Utils.h"
 #include "librbd/journal/StandardPolicy.h"
 #include "librbd/operation/ResizeRequest.h"
 
@@ -692,13 +693,7 @@ librados::IoCtx duplicate_io_ctx(librados::IoCtx& io_ctx) {
   uint64_t ImageCtx::prune_parent_extents(vector<pair<uint64_t,uint64_t> >& objectx,
 					  uint64_t overlap)
   {
-    // drop extents completely beyond the overlap
-    while (!objectx.empty() && objectx.back().first >= overlap)
-      objectx.pop_back();
-
-    // trim final overlapping extent
-    if (!objectx.empty() && objectx.back().first + objectx.back().second > overlap)
-      objectx.back().second = overlap - objectx.back().first;
+    io::util::prune_extents(objectx, overlap);
 
     uint64_t len = 0;
     for (vector<pair<uint64_t,uint64_t> >::iterator p = objectx.begin();

--- a/src/librbd/io/Utils.cc
+++ b/src/librbd/io/Utils.cc
@@ -153,6 +153,21 @@ int clip_request(I *image_ctx, Extents *image_extents) {
   return 0;
 }
 
+void prune_extents(Extents& extents, uint64_t size) {
+  // drop extents completely beyond size
+  while (!extents.empty() && extents.back().first >= size) {
+    extents.pop_back();
+  }
+
+  if (!extents.empty()) {
+    // trim final overlapping extent
+    auto& last_extent = extents.back();
+    if (last_extent.first + last_extent.second > size) {
+      last_extent.second = size - last_extent.first;
+    }
+  }
+}
+
 void unsparsify(CephContext* cct, ceph::bufferlist* bl,
                 const Extents& extent_map, uint64_t bl_off,
                 uint64_t out_bl_len) {

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -46,6 +46,7 @@ inline uint64_t get_extents_length(const Extents &extents) {
   return total_bytes;
 }
 
+void prune_extents(Extents& extents, uint64_t size);
 void unsparsify(CephContext* cct, ceph::bufferlist* bl,
                 const Extents& extent_map, uint64_t bl_off,
                 uint64_t out_bl_len);

--- a/src/librbd/migration/NativeFormat.cc
+++ b/src/librbd/migration/NativeFormat.cc
@@ -6,7 +6,6 @@
 #include "common/dout.h"
 #include "common/errno.h"
 #include "librbd/ImageCtx.h"
-#include "librbd/ImageState.h"
 #include "librbd/Utils.h"
 #include "librbd/asio/ContextWQ.h"
 #include "librbd/io/ImageDispatchSpec.h"

--- a/src/librbd/migration/QCOWFormat.cc
+++ b/src/librbd/migration/QCOWFormat.cc
@@ -8,7 +8,6 @@
 #include "include/intarith.h"
 #include "librbd/AsioEngine.h"
 #include "librbd/ImageCtx.h"
-#include "librbd/ImageState.h"
 #include "librbd/Utils.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ReadResult.h"

--- a/src/librbd/migration/RawFormat.cc
+++ b/src/librbd/migration/RawFormat.cc
@@ -5,7 +5,6 @@
 #include "common/dout.h"
 #include "common/errno.h"
 #include "librbd/ImageCtx.h"
-#include "librbd/ImageState.h"
 #include "librbd/Utils.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ReadResult.h"

--- a/src/librbd/migration/RawFormat.cc
+++ b/src/librbd/migration/RawFormat.cc
@@ -9,6 +9,7 @@
 #include "librbd/Utils.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ReadResult.h"
+#include "librbd/io/Utils.h"
 #include "librbd/migration/SnapshotInterface.h"
 #include "librbd/migration/SourceSpecBuilder.h"
 #include "librbd/migration/Utils.h"
@@ -209,7 +210,9 @@ void RawFormat<I>::list_snaps(io::Extents&& image_extents,
                                &previous_size, &sparse_extents);
 
     // build set of data/zeroed extents for the current snapshot
-    snapshot->list_snap(io::Extents{image_extents}, list_snaps_flags,
+    auto snapshot_extents = image_extents;
+    io::util::prune_extents(snapshot_extents, snap_info.size);
+    snapshot->list_snap(std::move(snapshot_extents), list_snaps_flags,
                         &sparse_extents, parent_trace, gather_ctx->new_sub());
   }
 

--- a/src/test/librbd/migration/test_mock_RawFormat.cc
+++ b/src/test/librbd/migration/test_mock_RawFormat.cc
@@ -466,7 +466,7 @@ TEST_F(TestMockMigrationRawFormat, ListSnapsMerge) {
   expect_snapshot_get_info(*mock_snapshot_interface_2, snap_info_2);
   io::SparseExtents sparse_extents_2;
   sparse_extents_2.insert(0, 32, {io::SPARSE_EXTENT_STATE_DATA, 32});
-  expect_snapshot_list_snap(*mock_snapshot_interface_2, {{0, 123}},
+  expect_snapshot_list_snap(*mock_snapshot_interface_2, {{0, 64}},
                             sparse_extents_2, 0);
 
   expect_snapshot_get_info(*mock_snapshot_interface_head, snap_info_head);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67896

---

backport of https://github.com/ceph/ceph/pull/59551
parent tracker: https://tracker.ceph.com/issues/67845