### PR TITLE
squid: rgw: decrement qlen/qactive perf counters on error

### DIFF
--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -437,6 +437,8 @@ done:
   } catch (rgw::io::Exception& e) {
     dout(0) << "ERROR: client_io->complete_request() returned "
             << e.what() << dendl;
+    perfcounter->inc(l_rgw_qlen, -1);
+    perfcounter->inc(l_rgw_qactive, -1);
   }
   if (should_log) {
     rgw_log_op(rest, s, op, penv.olog);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67922

---

backport of https://github.com/ceph/ceph/pull/59386
parent tracker: https://tracker.ceph.com/issues/48358

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh