### PR TITLE
monitor: add availability score feature

### DIFF
--- a/qa/standalone/mon/availability.sh
+++ b/qa/standalone/mon/availability.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2024 IBM <contact@ibm.com>
+#
+# Author: Shraddha Agrawal <shraddhaag@ibm.com> 
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library Public License for more details.
+#
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7124" # git grep '\<7124\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+function TEST_availablity_score() {
+    local dir=$1
+
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
+    
+    ceph config set osd osd_recovery_delay_start 10000
+    ceph config get osd.* osd_recovery_delay_start
+    ceph osd pool create foo 64
+    ceph osd pool set foo size 2 --yes-i-really-mean-it 
+
+    WAIT_FOR_CLEAN_TIMEOUT=60 wait_for_clean
+    ceph osd pool stats
+
+    ceph -s 
+    ceph health | grep HEALTH_OK || return 1
+    ceph osd pool availability-status
+    AVAILABILITY_STATUS=$(ceph osd pool availability-status | grep -w "foo")
+    SCORE=$(echo "$AVAILABILITY_STATUS" | awk '{print $7}')
+    IS_AVAILABLE=$(echo "$AVAILABILITY_STATUS" | awk '{print $8}')
+    if [ $IS_AVAILABLE -ne 1 ]; then
+      echo "Failed: Pool is not available in availabilty status"
+    fi
+
+    # write some objects
+    for i in $(seq 1 10); do
+      rados --pool foo put object_id$i /etc/group;
+    done
+
+    # kill OSD 0 
+    kill_daemons $dir TERM osd.0 >&2 < /dev/null || return 1
+    sleep 10
+    ceph -s
+    ceph osd pool availability-status
+
+    #write more objects 
+    for i in $(seq 1 20); do
+      rados --pool foo put object_id$i /etc/group;
+    done
+
+    # bring osd 0 back up 
+    activate_osd $dir 0 || return 1
+    ceph -s
+    ceph osd pool availability-status
+
+    # kill osd 1
+    kill_daemons $dir TERM osd.1 >&2 < /dev/null || return 1
+    ceph -s
+    ceph osd pool availability-status
+
+    # wait for 10 seconds so availability score is refreshed
+    # check ceph heath and availability score
+    sleep 10
+    ceph -s
+    ceph osd pool availability-status
+    AVAILABILITY_STATUS=$(ceph osd pool availability-status | grep -w "foo")
+    IS_AVAILABLE=$(echo "$AVAILABILITY_STATUS" | awk '{print $8}')
+    NEW_SCORE=$(echo "$AVAILABILITY_STATUS" | awk '{print $7}')
+    if [ $IS_AVAILABLE -ne 0 ]; then
+      echo "Failed: Pool is available in availabilty status when unfound objects present"
+      return 1
+    fi
+    if (( $(echo "$NEW_SCORE >= $SCORE" | bc -l) )); then
+      echo "Failed: Availability score for the pool did not drop"
+      return 1
+    fi
+
+    echo "TEST PASSED"
+    return 0
+}
+
+main availability "$@"

--- a/src/mon/MgrStatMonitor.h
+++ b/src/mon/MgrStatMonitor.h
@@ -14,12 +14,14 @@ class MgrStatMonitor : public PaxosService {
   PGMapDigest digest;
   ServiceMap service_map;
   std::map<std::string,ProgressEvent> progress_events;
+  std::map<uint64_t, PoolAvailability> pool_availability;
 
   // pending commit
   PGMapDigest pending_digest;
   health_check_map_t pending_health_checks;
   std::map<std::string,ProgressEvent> pending_progress_events;
   ceph::buffer::list pending_service_map_bl;
+  std::map<uint64_t, PoolAvailability> pending_pool_availability;
 
 public:
   MgrStatMonitor(Monitor &mn, Paxos &p, const std::string& service_name);
@@ -48,6 +50,8 @@ public:
 
   bool preprocess_getpoolstats(MonOpRequestRef op);
   bool preprocess_statfs(MonOpRequestRef op);
+
+  void calc_pool_availability();
 
   void check_sub(Subscription *sub);
   void check_subs();
@@ -81,6 +85,10 @@ public:
 
   const PGMapDigest& get_digest() {
     return digest;
+  }
+
+  const std::map<uint64_t, PoolAvailability>& get_pool_availability() {
+    return pool_availability;
   }
 
   ceph_statfs get_statfs(OSDMap& osdmap,

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1243,6 +1243,9 @@ COMMAND("osd pool stretch unset "
 		"name=min_size,type=CephInt,range=0 ",
 		"unset the stretch mode for the pool",
 		"osd", "rw")
+COMMAND("osd pool availability-status", \
+        "obtain availability stats from all pools", \
+        "osd", "r")
 COMMAND("osd utilization",
 	"get basic pg distribution stats",
 	"osd", "r")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -111,6 +111,8 @@ using ceph::ErasureCodeProfile;
 using ceph::Formatter;
 using ceph::JSONFormatter;
 using ceph::make_message;
+using ceph::make_timespan;
+using ceph::timespan_str;
 using namespace std::literals;
 
 #define dout_subsys ceph_subsys_mon
@@ -14407,6 +14409,33 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     wait_for_commit(op, new Monitor::C_Command(mon, op, 0, rs,
 						   get_last_committed() + 1));
     return true;
+  } else if (prefix == "osd pool availability-status") {
+    TextTable tbl;
+    tbl.define_column("POOL", TextTable::LEFT, TextTable::LEFT);
+    tbl.define_column("UPTIME", TextTable::LEFT, TextTable::RIGHT);
+    tbl.define_column("DOWNTIME", TextTable::LEFT, TextTable::RIGHT);
+    tbl.define_column("NUMFAILURES", TextTable::LEFT, TextTable::RIGHT);
+    tbl.define_column("MTBF", TextTable::LEFT, TextTable::RIGHT);
+    tbl.define_column("MTTR", TextTable::LEFT, TextTable::RIGHT);
+    tbl.define_column("SCORE", TextTable::LEFT, TextTable::RIGHT);
+    tbl.define_column("AVAILABLE", TextTable::LEFT, TextTable::RIGHT);
+    std::map<uint64_t, PoolAvailability> pool_availability = mon.mgrstatmon()->get_pool_availability();
+    for (const auto& i : pool_availability) {
+      const auto& p = i.second;
+      double mtbf = p.num_failures > 0 ? (p.uptime / p.num_failures) : 0;
+      double mttr = p.num_failures > 0 ? (p.downtime / p.num_failures) : 0;
+      double score = mtbf > 0 ? mtbf / (mtbf +  mttr): 1.0;
+      tbl << p.pool_name;
+      tbl << timespan_str(make_timespan(p.uptime));
+      tbl << timespan_str(make_timespan(p.downtime));
+      tbl << p.num_failures;
+      tbl << timespan_str(make_timespan(mtbf));
+      tbl << timespan_str(make_timespan(mttr));
+      tbl << score;
+      tbl << p.is_avail;
+      tbl << TextTable::endrow;
+    }
+    rdata.append(stringify(tbl));
   } else if (prefix == "osd force-create-pg") {
     pg_t pgid;
     string pgidstr;

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -56,7 +56,7 @@ MEMPOOL_DEFINE_OBJECT_FACTORY(PGMap::Incremental, pgmap_inc, pgmap);
 void PGMapDigest::encode(bufferlist& bl, uint64_t features) const
 {
   // NOTE: see PGMap::encode_digest
-  uint8_t v = 4;
+  uint8_t v = 5;
   assert(HAVE_FEATURE(features, SERVER_NAUTILUS));
   ENCODE_START(v, 1, bl);
   encode(num_pg, bl);
@@ -77,12 +77,13 @@ void PGMapDigest::encode(bufferlist& bl, uint64_t features) const
   encode(avail_space_by_rule, bl);
   encode(purged_snaps, bl);
   encode(osd_sum_by_class, bl, features);
+  encode(pool_pg_unavailable_map, bl);
   ENCODE_FINISH(bl);
 }
 
 void PGMapDigest::decode(bufferlist::const_iterator& p)
 {
-  DECODE_START(4, p);
+  DECODE_START(5, p);
   assert(struct_v >= 4);
   decode(num_pg, p);
   decode(num_pg_active, p);
@@ -102,6 +103,9 @@ void PGMapDigest::decode(bufferlist::const_iterator& p)
   decode(avail_space_by_rule, p);
   decode(purged_snaps, p);
   decode(osd_sum_by_class, p);
+  if (struct_v >= 5) {
+    decode(pool_pg_unavailable_map, p);
+  }
   DECODE_FINISH(p);
 }
 
@@ -148,6 +152,18 @@ void PGMapDigest::dump(ceph::Formatter *f) const
     f->open_object_section("count");
     f->dump_string("state", pg_state_string(p.first));
     f->dump_unsigned("num", p.second);
+    f->close_section();
+  }
+  f->close_section();
+  f->open_array_section("pool_pg_unavailable_map");
+  for (auto& p : pool_pg_unavailable_map) {
+    f->open_object_section("pool_pg_unavailable_map");
+    f->dump_string("poolid", std::to_string(p.first));
+    f->open_array_section("pgs");
+    for (const auto& pg : p.second) {
+      f->dump_stream("pg") << pg;
+    }
+    f->close_section();
     f->close_section();
   }
   f->close_section();
@@ -1261,6 +1277,46 @@ void PGMap::apply_incremental(CephContext *cct, const Incremental& inc)
     last_pg_scan = inc.pg_scan;
 }
 
+/*
+  Returns a map of all pools in a cluster. Each value lists any PGs that 
+  are in any of the following states: 
+  - non-active 
+  - stale 
+
+  Eg: {1=[1.0],2=[],3=[]}
+  Here the cluster has 3 pools with id 1,2,3 and pool 1 has an inactive PG 1.0
+*/
+void PGMap::get_unavailable_pg_in_pool_map(const OSDMap& osdmap)
+{
+  dout(20) << __func__ << dendl;
+  pool_pg_unavailable_map.clear();
+  utime_t now(ceph_clock_now());
+  utime_t cutoff = now - utime_t(g_conf().get_val<int64_t>("mon_pg_stuck_threshold"), 0);
+  for (auto i = pg_stat.begin();
+       i != pg_stat.end();
+       ++i) {
+    const auto poolid = i->first.pool();
+    pool_pg_unavailable_map[poolid];
+    utime_t val = cutoff;
+
+    if (!(i->second.state & PG_STATE_ACTIVE)) { // This case covers unknown state since unknow state bit == 0;
+      if (i->second.last_active < val)
+	val = i->second.last_active;
+    }
+
+    if (i->second.state & PG_STATE_STALE) {
+      if (i->second.last_unstale < val)
+	val = i->second.last_unstale;
+    }
+
+    if (val < cutoff) {
+      pool_pg_unavailable_map[poolid].push_back(i->first);
+      dout(20) << "pool: " << poolid << " pg: " << i->first
+         << " is stuck unavailable" << " state: " << i->second.state << dendl;
+    }
+  }
+}
+
 void PGMap::calc_stats()
 {
   num_pg = 0;
@@ -1488,6 +1544,7 @@ void PGMap::encode_digest(const OSDMap& osdmap,
   get_rules_avail(osdmap, &avail_space_by_rule);
   calc_osd_sum_by_class(osdmap);
   calc_purged_snaps();
+  get_unavailable_pg_in_pool_map(osdmap);
   PGMapDigest::encode(bl, features);
 }
 

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1283,6 +1283,8 @@ void PGMap::apply_incremental(CephContext *cct, const Incremental& inc)
   - non-active 
   - stale 
 
+  Any PG that has unfound objects is also added to the map. 
+
   Eg: {1=[1.0],2=[],3=[]}
   Here the cluster has 3 pools with id 1,2,3 and pool 1 has an inactive PG 1.0
 */
@@ -1313,6 +1315,10 @@ void PGMap::get_unavailable_pg_in_pool_map(const OSDMap& osdmap)
       pool_pg_unavailable_map[poolid].push_back(i->first);
       dout(20) << "pool: " << poolid << " pg: " << i->first
          << " is stuck unavailable" << " state: " << i->second.state << dendl;
+    } else if (i->second.stats.sum.num_objects_unfound) {
+      pool_pg_unavailable_map[poolid].push_back(i->first);
+      dout(20) << "pool: " << poolid << " pg: " << i->first
+         << " has " << i->second.stats.sum.num_objects_unfound << " unfound objects" << dendl;
     }
   }
 }

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -27,6 +27,9 @@
 #include "common/Formatter.h"
 #include "osd/osd_types.h"
 #include "include/mempool.h"
+#include "mon/health_check.h"
+#include <sstream>
+#include "mon/mon_types.h"
 
 #include <cstdint>
 #include <iosfwd>
@@ -57,6 +60,7 @@ public:
   osd_stat_t osd_sum;
   mempool::pgmap::map<std::string,osd_stat_t> osd_sum_by_class;
   mempool::pgmap::unordered_map<uint64_t,int32_t> num_pg_by_state;
+  mempool::pgmap::map<uint64_t,std::vector<pg_t>> pool_pg_unavailable_map;
   struct pg_count {
     int32_t acting = 0;
     int32_t up_not_acting = 0;
@@ -440,6 +444,7 @@ public:
 
   void apply_incremental(CephContext *cct, const Incremental& inc);
   void calc_stats();
+  void get_unavailable_pg_in_pool_map(const OSDMap& osdmap);
   void stat_pg_add(const pg_t &pgid, const pg_stat_t &s,
 		   bool sameosds=false);
   bool stat_pg_sub(const pg_t &pgid, const pg_stat_t &s,

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -28,6 +28,7 @@
 #include "common/bit_str.h"
 #include "common/ceph_releases.h"
 #include "msg/msg_types.h" // for entity_addrvec_t
+#include "common/Clock.h"
 
 // use as paxos_service index
 enum {
@@ -735,5 +736,73 @@ struct ProgressEvent {
   }
 };
 WRITE_CLASS_ENCODER(ProgressEvent)
+
+struct PoolAvailability {
+  std::string pool_name  = "";
+  utime_t started_at = ceph_clock_now();
+  uint64_t uptime = 0;
+  utime_t last_uptime = ceph_clock_now();
+  uint64_t downtime = 0;
+  utime_t last_downtime = ceph_clock_now();
+  uint64_t num_failures = 0;
+  bool is_avail = true;
+
+  PoolAvailability() {}
+
+  void dump(ceph::Formatter *f) const {
+    ceph_assert(f != NULL);
+    f->dump_stream("pool_name") << pool_name;
+    f->dump_stream("started_at") << started_at;
+    f->dump_int("uptime", uptime);
+    f->dump_stream("last_uptime") << last_uptime;
+    f->dump_int("downtime", downtime);
+    f->dump_stream("last_downtime") << last_downtime;
+    f->dump_int("num_failures", num_failures);
+    f->dump_bool("is_avail", is_avail);
+  }
+
+  void encode(ceph::buffer::list &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(pool_name, bl);
+    encode(started_at, bl);
+    encode(uptime, bl);
+    encode(last_uptime, bl);
+    encode(downtime, bl);
+    encode(last_downtime, bl);
+    encode(num_failures, bl);
+    encode(is_avail, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::buffer::list::const_iterator &p) {
+    DECODE_START(1, p);
+    decode(pool_name, p);
+    decode(started_at, p);
+    decode(uptime, p);
+    decode(last_uptime, p);
+    decode(downtime, p);
+    decode(last_downtime, p);
+    decode(num_failures, p);
+    decode(is_avail, p);
+    DECODE_FINISH(p);
+  }
+
+  static void generate_test_instances(std::list<PoolAvailability*>& o) {
+    o.push_back(new PoolAvailability);
+    o.back()->started_at = utime_t(123, 456);      
+    o.back()->last_uptime = utime_t(123, 456);      
+    o.back()->last_downtime = utime_t(123, 456);   
+    o.push_back(new PoolAvailability);
+    o.back()->pool_name = "foo";    
+    o.back()->started_at = utime_t(123, 456);    
+    o.back()->uptime = 100;    
+    o.back()->last_uptime = utime_t(123, 456);    
+    o.back()->downtime = 15;    
+    o.back()->last_downtime = utime_t(123, 456);    
+    o.back()->num_failures = 2;    
+    o.back()->is_avail = true;    
+  }  
+};
+WRITE_CLASS_ENCODER(PoolAvailability)
 
 #endif

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4240,7 +4240,8 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
       info.stats.last_active = now;
     if (info.stats.state & (PG_STATE_ACTIVE|PG_STATE_PEERED))
       info.stats.last_peered = now;
-    info.stats.last_unstale = now;
+    if ((info.stats.state & PG_STATE_STALE) == 0)
+      info.stats.last_unstale = now;
     if ((info.stats.state & PG_STATE_DEGRADED) == 0)
       info.stats.last_undegraded = now;
     if ((info.stats.state & PG_STATE_UNDERSIZED) == 0)

--- a/src/tools/ceph-dencoder/osd_types.h
+++ b/src/tools/ceph-dencoder/osd_types.h
@@ -170,6 +170,7 @@ TYPE(mon_feature_t)
 TYPE_FEATUREFUL(DataStats)
 TYPE_FEATUREFUL(ProgressEvent)
 TYPE(FeatureMap)
+TYPE(PoolAvailability)
 
 #include "mon/CreatingPGs.h"
 TYPE_FEATUREFUL(creating_pgs_t)


### PR DESCRIPTION

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

Builds on top of: https://github.com/ceph/ceph/pull/54249
Tracker: https://tracker.ceph.com/issues/67777 
Trello: https://trello.com/c/MNmj6CgJ/764-mon-mgr-track-availability-over-time 

## Description 
This PR introduces the command `ceph osd pool availability-status`. It outputs the availability score for each pool. The score is calculated every 5 seconds (this is currently not configurable but will be made so in followup PRs). 

A sample output of the command looks like this: 
```
$ ceph osd pool availability-status
2024-10-07T05:23:14.840+0000 7fd35b178640 -1 WARNING: all dangerous and experimental features are enabled.
2024-10-07T05:23:14.856+0000 7fd35b178640 -1 WARNING: all dangerous and experimental features are enabled.
POOL           UPTIME  DOWNTIME  NUMFAILURES  MTBF  MTTR  SCORE     AVAILABLE
rbd                2m       14s            1    2m   14s  0.908497          1
.mgr              52s        0s            0    0s    0s         1          1
cephfs.a.meta     48s        0s            0    0s    0s         1          1
cephfs.a.data     45s        0s            0    0s    0s         1          1
```

A pool is considered unavailable if any PG in the pool is not in active state or if there are unfound objects. Otherwise the pool is considered available. 

Integration tests to check availability score are added in `qa/standalone/misc`. 

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
