### PR TITLE
mgr/vol: handling the failed non-atomic operation

### DIFF
--- a/qa/suites/fs/full/tasks/mgr-osd-full.yaml
+++ b/qa/suites/fs/full/tasks/mgr-osd-full.yaml
@@ -34,3 +34,8 @@ tasks:
     clients:
       client.0:
         - fs/full/subvolume_ls.sh
+- workunit:
+    cleanup: true
+    clients:
+      client.0:
+        - fs/full/subvol_rm_retained_snap_when_cluster_is_full.sh

--- a/qa/workunits/fs/full/subvol_rm_retained_snap_when_cluster_is_full.sh
+++ b/qa/workunits/fs/full/subvol_rm_retained_snap_when_cluster_is_full.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -ex
+
+# Test that command 'ceph fs subvolume rm --retained-snapshots' fails when the
+# OSD is full.
+#
+# A subvolume is created on a cluser with OSD size 2GB and a 1GB file is written on
+# the subvolume. The OSD size is then set to below 500MB so that OSD is treated as
+# full. Now the subvolume is removed but snapshots are retained. 
+
+expect_failure() {
+	if "$@"; then return 1; else return 0; fi
+}
+
+ceph fs subvolume create cephfs sub_0
+subvol_path=$(ceph fs subvolume getpath cephfs sub_0 2>/dev/null)
+
+echo "Printing system disk usages for host as well Ceph before writing on subvolume"
+df -h
+ceph osd df
+
+sudo dd if=/dev/urandom of=$CEPH_MNT$subvol_path/1GB_file-1 status=progress bs=1M count=1000
+
+ceph osd set-full-ratio 0.2
+ceph osd set-nearfull-ratio 0.16
+ceph osd set-backfillfull-ratio 0.18
+
+timeout=30
+while [ $timeout -gt 0 ]
+do
+  health=$(ceph health detail)
+  [[ $health = *"OSD_FULL"* ]] && echo "OSD is full" && break
+  echo "Wating for osd to be full: $timeout"
+  sleep 1
+  let "timeout-=1"
+done
+
+echo "Printing disk usage for host as well as Ceph after OSD ratios have been set"
+df -h
+ceph osd df
+
+#Take snapshot
+ceph fs subvolume snapshot create cephfs sub_0 snap_0
+
+#Delete subvolume with retain snapshot fails
+expect_failure ceph fs subvolume rm cephfs sub_0 --retain-snapshots
+
+#Validate subvolume is not deleted
+ceph fs subvolume info cephfs sub_0
+
+# Validate config file is not truncated and GLOBAL section exists
+sudo grep "GLOBAL" $CEPH_MNT/volumes/_nogroup/sub_0/.meta
+
+# Hard cleanup
+sudo rmdir $CEPH_MNT/volumes/_nogroup/sub_0/.snap/snap_0
+sudo rm -rf $CEPH_MNT/volumes/_nogroup/sub_0
+
+#Reset the ratios to original values for the sake of rest of tests
+ceph osd set-full-ratio 0.95
+ceph osd set-nearfull-ratio 0.95
+ceph osd set-backfillfull-ratio 0.95
+
+echo "Printing disk usage for host as well as Ceph since test has been finished"
+df -h
+ceph osd df
+
+echo OK

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
@@ -341,14 +341,14 @@ class SubvolumeV2(SubvolumeV1):
         except cephfs.Error as e:
             raise VolumeException(-e.args[0], e.args[1])
 
-    def trash_incarnation_dir(self):
+    def trash_incarnation_dir(self, subvol_path):
         """rename subvolume (uuid component) to trash"""
         self.create_trashcan()
         try:
-            bname = os.path.basename(self.path)
+            bname = os.path.basename(subvol_path)
             tpath = os.path.join(self.trash_dir, bname)
-            log.debug("trash: {0} -> {1}".format(self.path, tpath))
-            self.fs.rename(self.path, tpath)
+            log.debug(f"trash: {subvol_path} -> {tpath}")
+            self.fs.rename(subvol_path, tpath)
             self._link_dir(tpath, bname)
         except cephfs.Error as e:
             raise VolumeException(-e.args[0], e.args[1])
@@ -378,13 +378,20 @@ class SubvolumeV2(SubvolumeV1):
                 self.auth_mdata_mgr.delete_subvolume_metadata_file(self.group.groupname, self.subvolname)
                 return
         if self.state != SubvolumeStates.STATE_RETAINED:
-            self.trash_incarnation_dir()
-            self.metadata_mgr.remove_section(MetadataManager.USER_METADATA_SECTION)
-            self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_KEY_PATH, "")
-            self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_KEY_STATE, SubvolumeStates.STATE_RETAINED.value)
-            self.metadata_mgr.flush()
-            # Delete the volume meta file, if it's not already deleted
-            self.auth_mdata_mgr.delete_subvolume_metadata_file(self.group.groupname, self.subvolname)
+            try:
+                # save subvol path for later use(renaming subvolume to trash) before deleting path section from .meta
+                subvol_path = self.path
+                self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_KEY_PATH, "")
+                self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_KEY_STATE, SubvolumeStates.STATE_RETAINED.value)
+                self.metadata_mgr.remove_section(MetadataManager.USER_METADATA_SECTION)
+                self.metadata_mgr.flush()
+                self.trash_incarnation_dir(subvol_path)
+                # Delete the volume meta file, if it's not already deleted
+                self.auth_mdata_mgr.delete_subvolume_metadata_file(self.group.groupname, self.subvolname)
+            except MetadataMgrException as e:
+                log.error(f"failed to write config: {e}")
+                raise VolumeException(e.args[0], e.args[1])
+
 
     def info(self):
         if self.state != SubvolumeStates.STATE_RETAINED:


### PR DESCRIPTION
The order of operation done for subvolume removal is reversed. The metadata is updated first followed by a rename operation on the uuid directory. If the metadata update operation fails, then the remove operations is failed thereby, keeping the subvolume metadata consistent with the uuid path.

Fixes: https://tracker.ceph.com/issues/67330
Signed-off-by: Neeraj Pratap Singh <neesingh@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
