### PR TITLE
doc/man: edit ceph-bluestore-tool.rst

### DIFF
--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -94,15 +94,17 @@ Commands
    
 :command:`bluefs-bdev-migrate` --dev-target *new-device* --devs-source *device1* [--devs-source *device2*]
 
-   Moves BlueFS data from source device(s) to the target one, source devices
-   (except the main one) are removed on success. Target device can be both
-   already attached or new device. In the latter case it's added to OSD
-   replacing one of the source devices. Following replacement rules apply
-   (in the order of precedence, stop on the first match):
+   Moves BlueFS data from source device(s) to the target device. Source devices
+   (except the main one) are removed on success. Expands the target storage
+   (updates the size label), making "bluefs-bdev-expand" unnecessary. The
+   target device can be either a new device or a device that is already
+   attached. If the device is a new device, it is added to the OSD replacing
+   one of the source devices. The following replacement rules apply (in the
+   order of precedence, stop on the first match):
 
-      - if source list has DB volume - target device replaces it.
-      - if source list has WAL volume - target device replace it.
-      - if source list has slow volume only - operation isn't permitted, requires explicit allocation via new-db/new-wal command.
+      - if the source list has DB volume - the target device replaces it.
+      - if the source list has WAL volume - the target device replaces it.
+      - if the source list has slow volume only - the operation isn't permitted and requires explicit allocation via a new-DB/new-WAL command.
 
 :command:`show-label` --dev *device* [...]
 


### PR DESCRIPTION
Edit the section "bluefs-bdev-migrate" in
doc/man/8/ceph-bluestore-tool.rst to add the information that this operation expands the target storage by updating its size label, making "bluefs-bdev-expand" unnecessary.

Improve the subject-verb agreement in this section, and supply some absent definite articles.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
