### PR TITLE
quincy: qa: wait for file creation before changing mode

### DIFF
--- a/qa/workunits/fs/snaps/snaptest-double-null.sh
+++ b/qa/workunits/fs/snaps/snaptest-double-null.sh
@@ -11,6 +11,7 @@ mkdir a
 cat > a/foo &
 mkdir a/.snap/one
 mkdir a/.snap/two
+wait
 chmod 777 a/foo
 sync   # this might crash the mds
 ps


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67742

---

backport of https://github.com/ceph/ceph/pull/59095
parent tracker: https://tracker.ceph.com/issues/67408

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh