### PR TITLE
squid: qa: some test set `refuse_client_session`, so the cluster log is expected

### DIFF
--- a/qa/suites/fs/functional/tasks/admin.yaml
+++ b/qa/suites/fs/functional/tasks/admin.yaml
@@ -10,6 +10,7 @@ overrides:
       - \(MDS_CLIENTS_BROKEN_ROOTSQUASH\)
       - report clients with broken root_squash implementation
       - evicting unresponsive client
+      - as file system flag refuse_client_session is set
 tasks:
   - cephfs_test_runner:
       fail_on_skip: false


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67256

---

backport of https://github.com/ceph/ceph/pull/58218
parent tracker: https://tracker.ceph.com/issues/66639

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh