### PR TITLE
squid: qa/mgr/dashboard: fix test race condition 

### DIFF
--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -220,13 +220,11 @@ class DashboardTestCase(MgrTestCase):
 
             # To avoid any issues with e.g. unlink bugs, we destroy and recreate
             # the filesystem rather than just doing a rm -rf of files
-            cls.mds_cluster.mds_stop()
-            cls.mds_cluster.mds_fail()
             cls.mds_cluster.delete_all_filesystems()
+            cls.mds_cluster.mds_restart() # to reset any run-time configs, etc.
             cls.fs = None  # is now invalid!
 
             cls.fs = cls.mds_cluster.newfs(create=True)
-            cls.fs.mds_restart()
 
             # In case some test messed with auth caps, reset them
             # pylint: disable=not-an-iterable

--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -221,7 +221,7 @@ class DashboardTestCase(MgrTestCase):
             # To avoid any issues with e.g. unlink bugs, we destroy and recreate
             # the filesystem rather than just doing a rm -rf of files
             cls.mds_cluster.delete_all_filesystems()
-            cls.mds_cluster.mds_restart() # to reset any run-time configs, etc.
+            cls.mds_cluster.mds_restart()  # to reset any run-time configs, etc.
             cls.fs = None  # is now invalid!
 
             cls.fs = cls.mds_cluster.newfs(create=True)

--- a/qa/tasks/mgr/dashboard/test_mgr_module.py
+++ b/qa/tasks/mgr/dashboard/test_mgr_module.py
@@ -39,9 +39,13 @@ class MgrModuleTestCase(DashboardTestCase):
 class MgrModuleTest(MgrModuleTestCase):
 
     def test_list_disabled_module(self):
-        self._ceph_cmd(['mgr', 'module', 'disable', 'iostat'])
-        self.wait_until_rest_api_accessible()
-        data = self._get('/api/mgr/module')
+        self._ceph_cmd(['mgr', 'module', 'disable', 'iostat'], wait=3)
+        data = self._get(
+            '/api/mgr/module',
+            retries=1,
+            wait_func=lambda:  # pylint: disable=unnecessary-lambda
+            self.wait_until_rest_api_accessible()
+        )
         self.assertStatus(200)
         self.assertSchema(
             data,
@@ -57,9 +61,13 @@ class MgrModuleTest(MgrModuleTestCase):
         self.assertFalse(module_info['enabled'])
 
     def test_list_enabled_module(self):
-        self._ceph_cmd(['mgr', 'module', 'enable', 'iostat'])
-        self.wait_until_rest_api_accessible()
-        data = self._get('/api/mgr/module')
+        self._ceph_cmd(['mgr', 'module', 'enable', 'iostat'], wait=3)
+        data = self._get(
+            '/api/mgr/module',
+            retries=1,
+            wait_func=lambda:  # pylint: disable=unnecessary-lambda
+            self.wait_until_rest_api_accessible()
+        )
         self.assertStatus(200)
         self.assertSchema(
             data,

--- a/qa/tasks/mgr/dashboard/test_mgr_module.py
+++ b/qa/tasks/mgr/dashboard/test_mgr_module.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import logging
 
 import requests
+from urllib3.exceptions import MaxRetryError
 
 from .helper import (DashboardTestCase, JLeaf, JList, JObj,
                      module_options_object_schema, module_options_schema,
@@ -24,10 +25,11 @@ class MgrModuleTestCase(DashboardTestCase):
         def _check_connection():
             try:
                 # Try reaching an API endpoint successfully.
+                logger.info('Trying to reach the REST API endpoint')
                 self._get('/api/mgr/module')
                 if self._resp.status_code == 200:
                     return True
-            except requests.ConnectionError:
+            except (MaxRetryError, requests.ConnectionError):
                 pass
             return False
 

--- a/qa/tasks/mgr/dashboard/test_mgr_module.py
+++ b/qa/tasks/mgr/dashboard/test_mgr_module.py
@@ -6,7 +6,8 @@ import logging
 import requests
 
 from .helper import (DashboardTestCase, JLeaf, JList, JObj,
-                     module_options_object_schema, module_options_schema)
+                     module_options_object_schema, module_options_schema,
+                     retry)
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +15,7 @@ logger = logging.getLogger(__name__)
 class MgrModuleTestCase(DashboardTestCase):
     MGRS_REQUIRED = 1
 
+    @retry(on_exception=RuntimeError, tries=2, delay=0.5, logger=logger)
     def wait_until_rest_api_accessible(self):
         """
         Wait until the REST API is accessible.

--- a/qa/tasks/mgr/dashboard/test_osd.py
+++ b/qa/tasks/mgr/dashboard/test_osd.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 import json
 
 from .helper import (DashboardTestCase, JAny, JLeaf, JList, JObj, JTuple,
-                     devices_schema)
+                     devices_schema, log, retry)
 
 
 class OsdTest(DashboardTestCase):
@@ -284,13 +284,18 @@ class OsdFlagsTest(DashboardTestCase):
                     if osd['osd'] == osd_initial['osd']:
                         self.assertGreater(len(osd['flags']), len(osd_initial['flags']))
 
-        self._ceph_cmd(['osd', 'unset-group', 'noout,noin', 'osd.0', 'osd.1', 'osd.2'])
-        flags_removed = self._get('/api/osd/flags/individual')
-        self.assertStatus(200)
-        for osd in flags_removed:
-            if osd['osd'] in [0, 1, 2]:
-                self.assertNotIn('noout', osd['flags'])
-                self.assertNotIn('noin', osd['flags'])
+        ret = self._ceph_cmd_result(['osd', 'unset-group', 'noout,noin', 'osd.0', 'osd.1', 'osd.2'])
+        self.assertEqual(ret, 0)
+
+        @retry(on_exception=AssertionError, tries=2, delay=0.5, logger=log)
+        def check_osd_flags():
+            flags_removed = self._get('/api/osd/flags/individual')
+            self.assertStatus(200)
+            for osd in flags_removed:
+                if osd['osd'] in [0, 1, 2]:
+                    self.assertNotIn('noout', osd['flags'])
+                    self.assertNotIn('noin', osd['flags'])
+        check_osd_flags()
 
     def test_add_indiv_flag(self):
         flags_update = {'noup': None, 'nodown': None, 'noin': None, 'noout': True}

--- a/qa/tasks/mgr/mgr_test_case.py
+++ b/qa/tasks/mgr/mgr_test_case.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import socket
 
 from unittest import SkipTest
 
@@ -229,15 +230,22 @@ class MgrTestCase(CephTestCase):
         """
         # Start handing out ports well above Ceph's range.
         assign_port = min_port
+        ip_addr = cls.mgr_cluster.get_mgr_map()['active_addr'].split(':')[0]
 
         for mgr_id in cls.mgr_cluster.mgr_ids:
             cls.mgr_cluster.mgr_stop(mgr_id)
             cls.mgr_cluster.mgr_fail(mgr_id)
 
+
         for mgr_id in cls.mgr_cluster.mgr_ids:
-            log.debug("Using port {0} for {1} on mgr.{2}".format(
-                assign_port, module_name, mgr_id
-            ))
+            # Find a port that isn't in use
+            while True:
+                if not cls.is_port_in_use(ip_addr, assign_port):
+                    break
+                log.debug(f"Port {assign_port} in use, trying next")
+                assign_port += 1
+
+            log.debug(f"Using port {assign_port} for {module_name} on mgr.{mgr_id}")
             cls.mgr_cluster.set_module_localized_conf(module_name, mgr_id,
                                                       config_name,
                                                       str(assign_port),
@@ -255,3 +263,8 @@ class MgrTestCase(CephTestCase):
                     mgr_map['active_name'], mgr_map['active_gid']))
             return done
         cls.wait_until_true(is_available, timeout=30)
+
+    @classmethod
+    def is_port_in_use(cls, ip_addr: str, port: int) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            return s.connect_ex((ip_addr, port)) == 0

--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -134,7 +134,7 @@ run_teuthology_tests() {
     export CEPH_OUT_CLIENT_DIR=${LOCAL_BUILD_DIR}/out/client
     find . -iname "*${COVERAGE_FILE}*" -type f -delete
 
-    python ../qa/tasks/vstart_runner.py --ignore-missing-binaries --no-verbose $OPTIONS $(echo $TEST_CASES) ||
+    python ../qa/tasks/vstart_runner.py --ignore-missing-binaries --no-verbose --debug $OPTIONS $(echo $TEST_CASES) ||
       on_tests_error
 
     deactivate


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67929, https://tracker.ceph.com/issues/67901, https://tracker.ceph.com/issues/68890

---
backport of https://github.com/ceph/ceph/pull/58995, https://github.com/ceph/ceph/pull/59530, https://github.com/ceph/ceph/pull/61744/, https://github.com/ceph/ceph/pull/60511
parent tracker: https://tracker.ceph.com/issues/66844, https://tracker.ceph.com/issues/47612, https://tracker.ceph.com/issues/62972


this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh