### PR TITLE
quincy: doc/README.md: improve formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,19 +95,19 @@ Using the `-j` option with an argument appropriate to the hardware on which the
 to limit the job number to 3, run the command `ninja -j 3`. On average, each
 `ninja` job run in parallel needs approximately 2.5 GiB of RAM.
 
-This documentation assumes that your build directory is a subdirectory of the
-`ceph.git` checkout. If the build directory is located elsewhere, point
-`CEPH_GIT_DIR` to the correct path of the checkout. Additional CMake args can
-be specified by setting ARGS before invoking ``do_cmake.sh``.  See [cmake
-options](#cmake-options) for more details. For example:
+   This documentation assumes that your build directory is a subdirectory of
+   the `ceph.git` checkout. If the build directory is located elsewhere, point
+   `CEPH_GIT_DIR` to the correct path of the checkout. Additional CMake args 
+   can be specified by setting ARGS before invoking ``do_cmake.sh``. 
+   See [cmake options](#cmake-options) for more details. For example:
 
-    ARGS="-DCMAKE_C_COMPILER=gcc-7" ./do_cmake.sh
+       ARGS="-DCMAKE_C_COMPILER=gcc-7" ./do_cmake.sh
 
-To build only certain targets, run a command of the following form:
+   To build only certain targets, run a command of the following form:
 
 	ninja [target name]
 
-To install:
+5. Install the vstart cluster:
 
 	ninja install
  


### PR DESCRIPTION
Improve the formatting of the section "Building Ceph" in the file README.md.

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 7171f73c81d603f8ff62198fc1e5f50c20a0aa05)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
