### PR TITLE
squid: mon: fix `fs set down` to adjust max_mds only when cluster is not down

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -913,6 +913,11 @@ function test_mon_mds()
   ceph fs set $FS_NAME cluster_down true
   ceph fs set $FS_NAME cluster_down false
 
+  ceph fs set $FS_NAME max_mds 2
+  ceph fs get $FS_NAME | expect_true grep -P -q 'max_mds\t2'
+  ceph fs set $FS_NAME down false
+  ceph fs get $FS_NAME | expect_true grep -P -q 'max_mds\t2'
+
   ceph mds compat rm_incompat 4
   ceph mds compat rm_incompat 4
 

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -540,6 +540,11 @@ public:
 
       ss << fsp->get_mds_map().get_fs_name();
 
+      if (!is_down && fsp->get_mds_map().get_max_mds() > 0) {
+        ss << " is already online";
+        return 0;
+      }
+
       fsmap.modify_filesystem(
           fsp->get_fscid(),
           [is_down](auto&& fs)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67374

---

backport of https://github.com/ceph/ceph/pull/58582
parent tracker: https://tracker.ceph.com/issues/66960

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh