### PR TITLE
osd/scrub: remove the requested_scrub flags set

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1318,7 +1318,7 @@ Scrub::schedule_result_t PG::start_scrubbing(
        get_pgbackend()->auto_repair_supported());
 
   return m_scrubber->start_scrub_session(
-      candidate.level, osd_restrictions, pg_cond, m_planned_scrub);
+      candidate.level, osd_restrictions, pg_cond);
 }
 
 double PG::next_deepscrub_interval() const
@@ -1351,8 +1351,7 @@ void PG::on_scrub_schedule_input_change(Scrub::delay_ready_t delay_ready)
 void PG::scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type)
 {
   ceph_assert(m_scrubber);
-  std::ignore =
-      m_scrubber->scrub_requested(scrub_level, scrub_type, m_planned_scrub);
+  std::ignore = m_scrubber->scrub_requested(scrub_level, scrub_type);
 }
 
 void PG::clear_ready_to_merge() {
@@ -1907,11 +1906,10 @@ ostream& operator<<(ostream& out, const PG& pg)
 {
   out << pg.recovery_state;
 
-  // listing all scrub-related flags - both current and "planned next scrub"
+  // listing all scrub-related flags
   if (pg.is_scrubbing()) {
     out << *pg.m_scrubber;
   }
-  out << pg.m_planned_scrub;
 
   if (pg.recovery_ops_active)
     out << " rops=" << pg.recovery_ops_active;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1279,12 +1279,6 @@ void PG::requeue_map_waiters()
   }
 }
 
-bool PG::get_must_scrub() const
-{
-  dout(20) << __func__ << " must_scrub? " << (m_planned_scrub.must_scrub ? "true" : "false") << dendl;
-  return m_planned_scrub.must_scrub;
-}
-
 unsigned int PG::scrub_requeue_priority(Scrub::scrub_prio_t with_priority) const
 {
   return m_scrubber->scrub_requeue_priority(with_priority);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -179,13 +179,6 @@ public:
   /// and be removed only in the PrimaryLogPG destructor.
   std::unique_ptr<ScrubPgIF> m_scrubber;
 
-  /// flags detailing scheduling/operation characteristics of the next scrub 
-  requested_scrub_t m_planned_scrub;
-
-  const requested_scrub_t& get_planned_scrub() const {
-    return m_planned_scrub;
-  }
-
   /// scrubbing state for both Primary & replicas
   bool is_scrub_active() const { return m_scrubber->is_scrub_active(); }
 
@@ -1386,11 +1379,6 @@ public:
  const pg_info_t& get_pg_info(ScrubberPasskey) const final { return info; }
 
  OSDService* get_pg_osd(ScrubberPasskey) const { return osd; }
-
- requested_scrub_t& get_planned_scrub(ScrubberPasskey)
- {
-   return m_planned_scrub;
- }
 
  void force_object_missing(ScrubberPasskey,
                            const std::set<pg_shard_t>& peer,

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -685,8 +685,6 @@ public:
   void shutdown();
   virtual void on_shutdown() = 0;
 
-  bool get_must_scrub() const;
-
   Scrub::schedule_result_t start_scrubbing(
     const Scrub::SchedEntry& candidate,
     Scrub::OSDRestrictions osd_restrictions);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1055,7 +1055,7 @@ void PrimaryLogPG::do_command(
     f->close_section();
 
     if (is_primary() && is_active() && m_scrubber) {
-      m_scrubber->dump_scrubber(f.get(), m_planned_scrub);
+      m_scrubber->dump_scrubber(f.get());
     }
 
     f->open_object_section("agent_state");
@@ -1185,7 +1185,7 @@ void PrimaryLogPG::do_command(
     if (is_primary()) {
       scrub_level_t deep = (prefix == "deep-scrub") ? scrub_level_t::deep
 						    : scrub_level_t::shallow;
-      m_scrubber->on_operator_forced_scrub(f.get(), deep, m_planned_scrub);
+      m_scrubber->on_operator_forced_scrub(f.get(), deep);
     } else {
       ss << "Not primary";
       ret = -EPERM;
@@ -13226,7 +13226,7 @@ void PrimaryLogPG::_clear_recovery_state()
 #ifdef DEBUG_RECOVERY_OIDS
   recovering_oids.clear();
 #endif
-  dout(15) << __func__ << " flags: " << m_planned_scrub << dendl;
+  dout(15) << __func__ << dendl;
 
   last_backfill_started = hobject_t();
   set<hobject_t>::iterator i = backfills_in_flight.begin();

--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -232,7 +232,9 @@ Scrub::schedule_result_t OsdScrub::initiate_a_scrub(
     const Scrub::SchedEntry& candidate,
     Scrub::OSDRestrictions restrictions)
 {
-  dout(20) << fmt::format("trying pg[{}]", candidate.pgid) << dendl;
+  dout(20) << fmt::format(
+		  "trying pg[{}] (target:{})", candidate.pgid, candidate)
+	   << dendl;
 
   // we have a candidate to scrub. We need some PG information to
   // know if scrubbing is allowed

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -67,8 +67,6 @@ ostream& operator<<(ostream& out, const requested_scrub_t& sf)
     out << " planned AUTO_REPAIR";
   if (sf.must_deep_scrub)
     out << " MUST_DEEP_SCRUB";
-  if (sf.must_scrub)
-    out << " MUST_SCRUB";
   if (sf.need_auto)
     out << " NEED_AUTO";
   if (sf.req_scrub)
@@ -646,7 +644,6 @@ scrub_level_t PgScrubber::scrub_requested(
   }
 
   // modifying the planned-scrub flags - to be removed shortly
-  req_flags.must_scrub = true;
   req_flags.must_deep_scrub = deep_requested;
   req_flags.must_repair = repair_requested;
   // User might intervene, so clear this
@@ -2183,8 +2180,6 @@ void PgScrubber::on_mid_scrub_abort(Scrub::delay_cause_t issue)
   // e.g. - the 'aborted_schedule' data should be passed thru the scrubber.
   // In this current patchwork, for example, we are only guessing at
   // the original value of 'must_deep_scrub'.
-  m_planned_scrub.must_scrub = m_planned_scrub.must_deep_scrub ||
-			       m_planned_scrub.must_scrub;
   m_planned_scrub.must_repair = m_planned_scrub.must_repair || m_is_repair;
   m_planned_scrub.need_auto = m_planned_scrub.need_auto || m_flags.auto_repair;
 

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -154,11 +154,9 @@ bool PgScrubber::verify_against_abort(epoch_t epoch_to_verify)
 
 bool PgScrubber::should_abort() const
 {
-  // note that set_op_parameters() guarantees that we would never have
-  // must_scrub set (i.e. possibly have started a scrub even though noscrub
-  // was set), without having 'required' also set.
-  if (m_flags.required) {
-    return false;  // not stopping 'required' scrubs for configuration changes
+  if (!ScrubJob::observes_noscrub_flags(m_active_target->urgency())) {
+    // not aborting some types of high-priority scrubs
+    return false;
   }
 
   // note: deep scrubs are allowed even if 'no-scrub' is set (but not

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -61,8 +61,6 @@ ostream& operator<<(ostream& out, const scrub_flags_t& sf)
 
 ostream& operator<<(ostream& out, const requested_scrub_t& sf)
 {
-  if (sf.must_repair)
-    out << " MUST_REPAIR";
   if (sf.auto_repair)
     out << " planned AUTO_REPAIR";
   if (sf.need_auto)
@@ -642,7 +640,6 @@ scrub_level_t PgScrubber::scrub_requested(
   }
 
   // modifying the planned-scrub flags - to be removed shortly
-  req_flags.must_repair = repair_requested;
   // User might intervene, so clear this
   req_flags.need_auto = false;
   req_flags.req_scrub = true;
@@ -2428,7 +2425,9 @@ void PgScrubber::dump_scrubber(
     f->dump_bool("must_scrub", earliest.is_high_priority());
     f->dump_bool(
 	"must_deep_scrub", m_scrub_job->deep_target.is_high_priority());
-    f->dump_bool("must_repair", request_flags.must_repair);
+    // the following data item is deprecated. Will be replaced by a set
+    // of reported attributes that match the updated scrub-job state.
+    f->dump_bool("must_repair", earliest.urgency() == urgency_t::must_repair);
     f->dump_bool("need_auto", request_flags.need_auto);
 
     f->dump_stream("scrub_reg_stamp")

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -670,8 +670,9 @@ void PgScrubber::recovery_completed()
     m_osds->get_scrub_services().dequeue_target(m_pg_id, scrub_level_t::deep);
     auto& trgt = m_scrub_job->get_target(scrub_level_t::deep);
     trgt.up_urgency_to(urgency_t::after_repair);
-    trgt.sched_info.schedule.scheduled_at = {0, 0};
-    trgt.sched_info.schedule.not_before = ceph_clock_now();
+    const auto clock_now = ceph_clock_now();
+    trgt.sched_info.schedule.scheduled_at = clock_now;
+    trgt.sched_info.schedule.not_before = clock_now;
     m_osds->get_scrub_services().enqueue_target(trgt);
   }
 }
@@ -695,8 +696,9 @@ void PgScrubber::request_rescrubbing(requested_scrub_t& request_flags)
   request_flags.need_auto = true;
   auto& trgt = m_scrub_job->get_target(scrub_level_t::deep);
   trgt.up_urgency_to(urgency_t::repairing);
-  trgt.sched_info.schedule.scheduled_at = {0, 0};
-  trgt.sched_info.schedule.not_before = ceph_clock_now();
+  const auto clock_now = ceph_clock_now();
+  trgt.sched_info.schedule.scheduled_at = clock_now;
+  trgt.sched_info.schedule.not_before = clock_now;
 }
 
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -843,29 +843,11 @@ class PgScrubber : public ScrubPgIF,
   Scrub::sched_conf_t populate_config_params() const;
 
   /**
-   * use the 'planned scrub' flags to determine the urgency attribute
-   * of the 'deep target' part of the ScrubJob object.
-   *
-   * Returns 'true' if a high-priority 'urgency' level was set by this
-   * call (note: not if it was already set).
-   *
-   * Note: in the previous implementation, if the shallow scrub had
-   * high priority, and it was time for the periodic deep scrub, a
-   * high priority deep scrub was initiated. This behavior is not
-   * replicated here.
-   */
-  bool flags_to_deep_priority(
-      const Scrub::sched_conf_t& app_conf,
-      utime_t scrub_clock_now);
-
-  /**
    * recompute the two ScrubJob targets, taking into account not
-   * only the up-to-date 'last' stamps, but also the 'planned scrub'
-   * flags.
+   * only the up-to-date 'last' stamps, but also the 'urgency'
+   * attributes of both targets.
    */
-  void update_targets(
-      const requested_scrub_t& planned,
-      utime_t scrub_clock_now);
+  void update_targets(utime_t scrub_clock_now);
 
   /*
    * Select a range of objects to scrub.

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -143,9 +143,8 @@ struct scrub_flags_t {
   unsigned int priority{0};
 
   /**
-   * set by queue_scrub() if either planned_scrub.auto_repair or
-   * need_auto were set.
-   * Tested at scrub end.
+   * set by set_op_parameters() for deep scrubs, if the hardware
+   * supports auto repairing and osd_scrub_auto_repair is enabled.
    */
   bool auto_repair{false};
 
@@ -365,14 +364,8 @@ class PgScrubber : public ScrubPgIF,
 
   /**
    * finalize the parameters of the initiated scrubbing session:
-   *
-   * The "current scrub" flags (m_flags) are set from the 'planned_scrub'
-   * flag-set; PG_STATE_SCRUBBING, and possibly PG_STATE_DEEP_SCRUB &
-   * PG_STATE_REPAIR are set.
    */
-  void set_op_parameters(
-      Scrub::ScrubPGPreconds pg_cond,
-      const requested_scrub_t& request) final;
+  void set_op_parameters(Scrub::ScrubPGPreconds pg_cond) final;
 
   void cleanup_store(ObjectStore::Transaction* t) final;
 
@@ -841,7 +834,7 @@ class PgScrubber : public ScrubPgIF,
   /**
    * initiate a deep-scrub after the current scrub ended with errors.
    */
-  void request_rescrubbing(requested_scrub_t& req_flags);
+  void request_rescrubbing();
 
   /**
    * combine cluster & pool configuration options into a single struct

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -209,8 +209,7 @@ class PgScrubber : public ScrubPgIF,
   Scrub::schedule_result_t start_scrub_session(
       scrub_level_t s_or_d,
       Scrub::OSDRestrictions osd_restrictions,
-      Scrub::ScrubPGPreconds pg_cond,
-      const requested_scrub_t& requested_flags) final;
+      Scrub::ScrubPGPreconds pg_cond) final;
 
   void initiate_regular_scrub(epoch_t epoch_queued) final;
 
@@ -281,8 +280,7 @@ class PgScrubber : public ScrubPgIF,
 
   scrub_level_t scrub_requested(
       scrub_level_t scrub_level,
-      scrub_type_t scrub_type,
-      requested_scrub_t& req_flags) final;
+      scrub_type_t scrub_type) final;
 
   /**
    * let the scrubber know that a recovery operation has completed.
@@ -311,11 +309,9 @@ class PgScrubber : public ScrubPgIF,
 
   void on_operator_forced_scrub(
     ceph::Formatter* f,
-    scrub_level_t scrub_level,
-    requested_scrub_t& request_flags) final;
+    scrub_level_t scrub_level) final;
 
-  void dump_scrubber(ceph::Formatter* f,
-		     const requested_scrub_t& request_flags) const final;
+  void dump_scrubber(ceph::Formatter* f) const final;
 
   // used if we are a replica
 
@@ -746,10 +742,6 @@ class PgScrubber : public ScrubPgIF,
 				   //output?
 
   scrub_flags_t m_flags;
-
-  /// a reference to the details of the next scrub (as requested and managed by
-  /// the PG)
-  requested_scrub_t& m_planned_scrub;
 
   bool m_active{false};
 

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -156,13 +156,6 @@ struct scrub_flags_t {
 
   /// checked at the end of the scrub, to possibly initiate a deep-scrub
   bool deep_scrub_on_error{false};
-
-  /**
-   * scrub must not be aborted.
-   * Set for explicitly requested scrubs, and for scrubs originated by the
-   * pairing process with the 'repair' flag set (in the RequestScrub event).
-   */
-  bool required{false};
 };
 
 ostream& operator<<(ostream& out, const scrub_flags_t& sf);
@@ -187,9 +180,6 @@ struct formatter<scrub_flags_t> {
     if (sf.deep_scrub_on_error) {
       txt += sep ? ",deep-scrub-on-error" : "deep-scrub-on-error";
       sep = true;
-    }
-    if (sf.required) {
-      txt += sep ? ",required" : "required";
     }
     return fmt::format_to(ctx.out(), "{}", txt);
   }

--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -876,14 +876,6 @@ class PgScrubber : public ScrubPgIF,
       utime_t scrub_clock_now);
 
   /**
-   * use the 'planned scrub' flags to determine the urgency attribute
-   * of the 'shallow target' part of the ScrubJob object.
-   */
-  void flags_to_shallow_priority(
-      const Scrub::sched_conf_t& app_conf,
-      utime_t scrub_clock_now);
-
-  /**
    * recompute the two ScrubJob targets, taking into account not
    * only the up-to-date 'last' stamps, but also the 'planned scrub'
    * flags.

--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -435,3 +435,9 @@ bool ScrubJob::has_high_queue_priority(urgency_t urgency)
 {
   return urgency >= urgency_t::operator_requested;
 }
+
+bool ScrubJob::is_repair_implied(urgency_t urgency)
+{
+  return urgency == urgency_t::after_repair ||
+	 urgency == urgency_t::repairing || urgency == urgency_t::must_repair;
+}

--- a/src/osd/scrubber/scrub_job.cc
+++ b/src/osd/scrubber/scrub_job.cc
@@ -120,13 +120,7 @@ void ScrubJob::adjust_shallow_schedule(
 
   auto& sh_times = shallow_target.sched_info.schedule;	// shorthand
 
-  if (!ScrubJob::requires_randomization(shallow_target.urgency())) {
-    // the target time is already set. Make sure to reset the n.b. and
-    // the (irrelevant) deadline
-    sh_times.not_before = sh_times.scheduled_at;
-    sh_times.deadline = sh_times.scheduled_at;
-
-  } else {
+  if (ScrubJob::requires_randomization(shallow_target.urgency())) {
     utime_t adj_not_before = last_scrub;
     utime_t adj_target = last_scrub;
     sh_times.deadline = adj_target;
@@ -152,6 +146,13 @@ void ScrubJob::adjust_shallow_schedule(
     }
     sh_times.scheduled_at = adj_target;
     sh_times.not_before = adj_not_before;
+
+  } else {
+
+    // the target time is already set. Make sure to reset the n.b. and
+    // the (irrelevant) deadline
+    sh_times.not_before = sh_times.scheduled_at;
+    sh_times.deadline = sh_times.scheduled_at;
   }
 
   dout(10) << fmt::format(
@@ -428,4 +429,9 @@ bool ScrubJob::observes_random_backoff(urgency_t urgency)
 bool ScrubJob::observes_recovery(urgency_t urgency)
 {
   return urgency < urgency_t::operator_requested;
+}
+
+bool ScrubJob::has_high_queue_priority(urgency_t urgency)
+{
+  return urgency >= urgency_t::operator_requested;
 }

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -366,6 +366,8 @@ class ScrubJob {
   static bool observes_random_backoff(urgency_t urgency);
 
   static bool observes_recovery(urgency_t urgency);
+
+  static bool has_high_queue_priority(urgency_t urgency);
 };
 }  // namespace Scrub
 

--- a/src/osd/scrubber/scrub_job.h
+++ b/src/osd/scrubber/scrub_job.h
@@ -334,18 +334,19 @@ class ScrubJob {
  *
  * The following table summarizes the limitations in effect per urgency level:
  *
- *  +------------+------------+--------------+----------+-------------+
- *  | limitation | must-scrub | after-repair | operator | must-repair |
- *  +------------+------------+--------------+----------+-------------+
- *  | reservation|    yes!    |      no      |     no   |      no     |
- *  | dow/time   |    yes     |     yes      |     no   |      no     |
- *  | ext-sleep  |    no?     |      no      |     no   |      no     |
- *  | load       |    yes     |      no      |     no   |      no     |
- *  | noscrub    |    yes     |      no?     |     no   |      no     |
- *  | max-scrubs |    yes     |      yes?    |     no   |      no     |
- *  | backoff    |    yes     |      no      |     no   |      no     |
- *  | recovery   |    yes     |      no      |     no   |      no     |
- *  +------------+------------+--------------+----------+-------------+
+ *  +------------+---------+--------------+---------+----------+-------------+
+ *  | limitation |  must-  | after-repair |repairing| operator | must-repair |
+ *  |            |  scrub  |(aft recovery)|(errors) | request  |             |
+ *  +------------+---------+--------------+---------+----------+-------------+
+ *  | reservation|    yes! |      no      |    no?  +     no   |      no     |
+ *  | dow/time   |    yes  |     yes      |    no   +     no   |      no     |
+ *  | ext-sleep  |    no   |      no      |    no   +     no   |      no     |
+ *  | load       |    yes  |      no      |    no   +     no   |      no     |
+ *  | noscrub    |    yes  |      no?     |    Yes  +     no   |      no     |
+ *  | max-scrubs |    yes  |      yes     |    Yes  +     no   |      no     |
+ *  | backoff    |    yes  |      no      |    no   +     no   |      no     |
+ *  | recovery   |    yes  |      yes     |    Yes  +     no   |      no     |
+ *  +------------+---------+--------------+---------+----------+-------------+
  */
 
   // a set of helper functions for determining, for each urgency level, what
@@ -367,7 +368,11 @@ class ScrubJob {
 
   static bool observes_recovery(urgency_t urgency);
 
+  // translating the 'urgency' into scrub behavior traits
+
   static bool has_high_queue_priority(urgency_t urgency);
+
+  static bool is_repair_implied(urgency_t urgency);
 };
 }  // namespace Scrub
 

--- a/src/osd/scrubber/scrub_queue_entry.h
+++ b/src/osd/scrubber/scrub_queue_entry.h
@@ -37,18 +37,20 @@ namespace Scrub {
  *   This type of scrub is always deep.
  *   (note: this urgency level is not implemented in this commit)
  *
+ * 'repairing' - the target is currently being deep-scrubbed with the repair
+ *   flag set. Triggered by a previous shallow scrub that ended with errors.
+ *
  * 'operator_requested' - the target was manually requested for scrubbing by
  *   an administrator.
  *
  * 'must_repair' - the target is required to be deep-scrubbed with the
- *   repair flag set, as:
- *      - the scrub was initiated by a message specifying 'do_repair'; or
- *   or - a deep scrub is required after the previous scrub ended with errors.
+ *   repair flag set, initiated by a message specifying 'do_repair'.
  */
 enum class urgency_t {
   periodic_regular,
   must_scrub,
   after_repair,
+  repairing,
   operator_requested,
   must_repair,
 };
@@ -200,6 +202,7 @@ struct formatter<Scrub::urgency_t> : formatter<std::string_view> {
       case periodic_regular:    desc = "periodic-regular"; break;
       case must_scrub:          desc = "must-scrub"; break;
       case after_repair:        desc = "after-repair"; break;
+      case repairing:           desc = "repairing"; break;
       case operator_requested:  desc = "operator-requested"; break;
       case must_repair:         desc = "must-repair"; break;
       // better to not have a default case, so that the compiler will warn

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -317,14 +317,6 @@ struct requested_scrub_t {
    * scrubbing starts, will cause auto_repair to be set.
    */
   bool need_auto{false};
-
-  /*
-   * the value of auto_repair is determined in sched_scrub() (once per scrub.
-   * previous value is not remembered). Set if
-   * - allowed by configuration and backend, and
-   * - for periodic scrubs: time_for_deep was just set RRR
-   */
-  bool auto_repair{false};
 };
 
 std::ostream& operator<<(std::ostream& out, const requested_scrub_t& sf);
@@ -337,8 +329,7 @@ struct fmt::formatter<requested_scrub_t> {
   auto format(const requested_scrub_t& rs, FormatContext& ctx) const
   {
     return fmt::format_to(ctx.out(),
-                          "(plnd:{}{}{})",
-                          rs.auto_repair ? " auto_repair" : "",
+                          "(plnd:{}{})",
                           rs.need_auto ? " need_auto" : "",
                           rs.req_scrub ? " req_scrub" : "");
   }
@@ -457,9 +448,7 @@ struct ScrubPgIF {
       Scrub::ScrubPGPreconds pg_cond,
       const requested_scrub_t& requested_flags) = 0;
 
-  virtual void set_op_parameters(
-      Scrub::ScrubPGPreconds pg_cond,
-      const requested_scrub_t&) = 0;
+  virtual void set_op_parameters(Scrub::ScrubPGPreconds pg_cond) = 0;
 
   /// stop any active scrubbing (on interval end) and unregister from
   /// the OSD scrub queue

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -307,16 +307,6 @@ struct requested_scrub_t {
    * Will be copied into the 'required' scrub flag upon scrub start.
    */
   bool req_scrub{false};
-
-  /**
-   * Set from:
-   *  - scrub_requested() with need_auto param set, which only happens in
-   *  - scrub_finish() - if can_autorepair is set, and we have errors
-   *
-   * If set, will prevent the OSD from casually postponing our scrub. When
-   * scrubbing starts, will cause auto_repair to be set.
-   */
-  bool need_auto{false};
 };
 
 std::ostream& operator<<(std::ostream& out, const requested_scrub_t& sf);
@@ -329,8 +319,7 @@ struct fmt::formatter<requested_scrub_t> {
   auto format(const requested_scrub_t& rs, FormatContext& ctx) const
   {
     return fmt::format_to(ctx.out(),
-                          "(plnd:{}{})",
-                          rs.need_auto ? " need_auto" : "",
+                          "(plnd:{})",
                           rs.req_scrub ? " req_scrub" : "");
   }
 };

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -318,12 +318,6 @@ struct requested_scrub_t {
    */
   bool need_auto{false};
 
-  /**
-   * - 'must_repair' is checked by the OSD when scheduling the scrubs.
-   * - also checked & cleared at pg::queue_scrub()
-   */
-  bool must_repair{false};
-
   /*
    * the value of auto_repair is determined in sched_scrub() (once per scrub.
    * previous value is not remembered). Set if
@@ -343,8 +337,7 @@ struct fmt::formatter<requested_scrub_t> {
   auto format(const requested_scrub_t& rs, FormatContext& ctx) const
   {
     return fmt::format_to(ctx.out(),
-                          "(plnd:{}{}{}{})",
-                          rs.must_repair ? " must_repair" : "",
+                          "(plnd:{}{}{})",
                           rs.auto_repair ? " auto_repair" : "",
                           rs.need_auto ? " need_auto" : "",
                           rs.req_scrub ? " req_scrub" : "");

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -314,21 +314,11 @@ struct requested_scrub_t {
    *  - scrub_finish() - if can_autorepair is set, and we have errors
    *
    * If set, will prevent the OSD from casually postponing our scrub. When
-   * scrubbing starts, will cause must_deep_scrub and auto_repair to
-   * be set.
+   * scrubbing starts, will cause auto_repair to be set.
    */
   bool need_auto{false};
 
   /**
-   * Set for scrub-after-recovery just before we initiate the recovery deep
-   * scrub, or if scrub_requested() was called with either need_auto ot repair.
-   * Affects PG_STATE_DEEP_SCRUB.
-   */
-  bool must_deep_scrub{false};
-
-  /**
-   * If set, we should see must_deep_scrub, too
-   *
    * - 'must_repair' is checked by the OSD when scheduling the scrubs.
    * - also checked & cleared at pg::queue_scrub()
    */
@@ -353,10 +343,9 @@ struct fmt::formatter<requested_scrub_t> {
   auto format(const requested_scrub_t& rs, FormatContext& ctx) const
   {
     return fmt::format_to(ctx.out(),
-                          "(plnd:{}{}{}{}{})",
+                          "(plnd:{}{}{}{})",
                           rs.must_repair ? " must_repair" : "",
                           rs.auto_repair ? " auto_repair" : "",
-                          rs.must_deep_scrub ? " must_deep_scrub" : "",
                           rs.need_auto ? " need_auto" : "",
                           rs.req_scrub ? " req_scrub" : "");
   }

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -299,17 +299,6 @@ struct PgScrubBeListener {
  * for the next scrub, and one frozen at initiation (i.e. in pg::queue_scrub())
  */
 struct requested_scrub_t {
-
-  // flags to indicate explicitly requested scrubs (by admin):
-  // bool must_scrub, must_deep_scrub, must_repair, need_auto;
-
-  /**
-   * 'must_scrub' is set by an admin command (or by need_auto).
-   *  Affects the priority of the scrubbing, and the sleep periods
-   *  during the scrub.
-   */
-  bool must_scrub{false};
-
   /**
    * scrub must not be aborted.
    * Set for explicitly requested scrubs, and for scrubs originated by the
@@ -325,7 +314,7 @@ struct requested_scrub_t {
    *  - scrub_finish() - if can_autorepair is set, and we have errors
    *
    * If set, will prevent the OSD from casually postponing our scrub. When
-   * scrubbing starts, will cause must_scrub, must_deep_scrub and auto_repair to
+   * scrubbing starts, will cause must_deep_scrub and auto_repair to
    * be set.
    */
   bool need_auto{false};
@@ -338,7 +327,7 @@ struct requested_scrub_t {
   bool must_deep_scrub{false};
 
   /**
-   * If set, we should see must_deep_scrub & must_scrub, too
+   * If set, we should see must_deep_scrub, too
    *
    * - 'must_repair' is checked by the OSD when scheduling the scrubs.
    * - also checked & cleared at pg::queue_scrub()
@@ -364,11 +353,10 @@ struct fmt::formatter<requested_scrub_t> {
   auto format(const requested_scrub_t& rs, FormatContext& ctx) const
   {
     return fmt::format_to(ctx.out(),
-                          "(plnd:{}{}{}{}{}{})",
+                          "(plnd:{}{}{}{}{})",
                           rs.must_repair ? " must_repair" : "",
                           rs.auto_repair ? " auto_repair" : "",
                           rs.must_deep_scrub ? " must_deep_scrub" : "",
-                          rs.must_scrub ? " must_scrub" : "",
                           rs.need_auto ? " need_auto" : "",
                           rs.req_scrub ? " req_scrub" : "");
   }


### PR DESCRIPTION
The previous steps in the refactoring of the scheduler have
created simple constructs to hold the desired characteristics
of the next shallow and deep scrubs of each PG.

For example: whenever a shallow scrubs ends with errors that
require a recovery process, a deep scrub should be scheduled
to follow it. Previously - that was done by setting some
requested_scrub flags. Now - the urgency of the deep scrub
is set to 'repairing', and the scheduler will take care of
the rest.

The requested_scrub flags are no longer needed, and can be
removed.

Also in this PR:
Completing the refactoring of the on_mid_scrub_abort() method,
which was only partially done in the previous PRs.

