### PR TITLE
squid: mgr/cephadm: make ssh keepalive settings configurable

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -513,6 +513,19 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             'the host (in seconds)'
         ),
         Option(
+            'ssh_keepalive_interval',
+            type='int',
+            default=7,
+            desc='How often ssh connections are checked for liveness'
+        ),
+        Option(
+            'ssh_keepalive_count_max',
+            type='int',
+            default=3,
+            desc='How many times ssh connections can fail liveness checks '
+            'before the host is marked offline'
+        ),
+        Option(
             'cephadm_log_destination',
             type='str',
             default='',
@@ -613,6 +626,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.default_cephadm_command_timeout = 0
             self.cephadm_log_destination = ''
             self.oob_default_addr = ''
+            self.ssh_keepalive_interval = 0
+            self.ssh_keepalive_count_max = 0
 
         self.notify(NotifyType.mon_map, None)
         self.config_notify()

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -242,10 +242,6 @@ class SSHManager:
         if log_command:
             logger.debug(f'Running command: {rcmd}')
         try:
-            test_cmd = RemoteSudoCommand(
-                Executables.TRUE, [], use_sudo=use_sudo
-            )
-            r = await conn.run(str(test_cmd), check=True, timeout=5)  # host quick check
             r = await conn.run(str(rcmd), input=stdin)
         # handle these Exceptions otherwise you might get a weird error like
         # TypeError: __init__() missing 1 required positional argument: 'reason' (due to the asyncssh error interacting with raise_if_exception)

--- a/src/pybind/mgr/cephadm/ssh.py
+++ b/src/pybind/mgr/cephadm/ssh.py
@@ -168,7 +168,9 @@ class SSHManager:
             with self.redirect_log(host, addr):
                 try:
                     ssh_options = asyncssh.SSHClientConnectionOptions(
-                        keepalive_interval=7, keepalive_count_max=3)
+                        keepalive_interval=self.mgr.ssh_keepalive_interval,
+                        keepalive_count_max=self.mgr.ssh_keepalive_count_max
+                    )
                     conn = await asyncssh.connect(addr, username=self.mgr.ssh_user, client_keys=[self.mgr.tkey.name],
                                                   known_hosts=None, config=[self.mgr.ssh_config_fname],
                                                   preferred_auth=['publickey'], options=ssh_options)


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/59610

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
