### PR TITLE
crimson/os/seastore: remove unnecessary memory copy during ool write

### DIFF
--- a/src/crimson/os/seastore/random_block_manager.h
+++ b/src/crimson/os/seastore/random_block_manager.h
@@ -122,7 +122,7 @@ public:
     crimson::ct_error::enospc,
     crimson::ct_error::erange
     >;
-  virtual write_ertr::future<> write(paddr_t addr, bufferptr &buf) = 0;
+  virtual write_ertr::future<> write(paddr_t addr, bufferptr buf) = 0;
 
   using open_ertr = crimson::errorator<
     crimson::ct_error::input_output_error,

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
@@ -129,18 +129,16 @@ bool BlockRBManager::check_valid_range(rbm_abs_addr addr, bufferptr &bptr) {
 
 BlockRBManager::write_ertr::future<> BlockRBManager::write(
   paddr_t paddr,
-  bufferptr &bptr)
+  bufferptr bptr)
 {
   ceph_assert(device);
   rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
   if (!check_valid_range(addr, bptr)) {
     return crimson::ct_error::erange::make();
   }
-  bufferptr bp = bufferptr(ceph::buffer::create_page_aligned(bptr.length()));
-  bp.copy_in(0, bptr.length(), bptr.c_str());
   return device->write(
     addr,
-    std::move(bp));
+    bptr);
 }
 
 BlockRBManager::read_ertr::future<> BlockRBManager::read(

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.cc
@@ -132,6 +132,7 @@ BlockRBManager::write_ertr::future<> BlockRBManager::write(
   bufferptr bptr)
 {
   ceph_assert(device);
+  ceph_assert(bptr.is_page_aligned());
   rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
   if (!check_valid_range(addr, bptr)) {
     return crimson::ct_error::erange::make();
@@ -146,6 +147,7 @@ BlockRBManager::read_ertr::future<> BlockRBManager::read(
   bufferptr &bptr)
 {
   ceph_assert(device);
+  ceph_assert(bptr.is_page_aligned());
   rbm_abs_addr addr = convert_paddr_to_abs_addr(paddr);
   if (!check_valid_range(addr, bptr)) {
     return crimson::ct_error::erange::make();

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
@@ -43,7 +43,7 @@ public:
    */
 
   read_ertr::future<> read(paddr_t addr, bufferptr &buffer) final;
-  write_ertr::future<> write(paddr_t addr, bufferptr &buf) final;
+  write_ertr::future<> write(paddr_t addr, bufferptr buf) final;
   open_ertr::future<> open() final;
   close_ertr::future<> close() final;
 

--- a/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
+++ b/src/crimson/os/seastore/random_block_manager/block_rb_manager.h
@@ -127,6 +127,8 @@ public:
     return device->get_journal_size();
   }
 
+  bool check_valid_range(rbm_abs_addr paddr, bufferptr &bptr);
+
 #ifdef UNIT_TESTS_BUILT
   void prefill_fragmented_device() final;
 #endif

--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.cc
@@ -112,7 +112,7 @@ NVMeBlockDevice::mount_ret NVMeBlockDevice::mount()
 
 write_ertr::future<> NVMeBlockDevice::write(
   uint64_t offset,
-  bufferptr &&bptr,
+  bufferptr bptr,
   uint16_t stream) {
   logger().debug(
       "block: write offset {} len {}",
@@ -127,13 +127,13 @@ write_ertr::future<> NVMeBlockDevice::write(
   }
   if (is_end_to_end_data_protection()) {
     return seastar::do_with(
-      std::move(bptr),
+      bptr,
       [this, offset] (auto &bptr) {
       return nvme_write(offset, bptr.length(), bptr.c_str());
     });
   }
   return seastar::do_with(
-    std::move(bptr),
+    bptr,
     [this, offset, length, supported_stream] (auto& bptr) {
     return io_device[supported_stream].dma_write(
       offset, bptr.c_str(), length).handle_exception(

--- a/src/crimson/os/seastore/random_block_manager/nvme_block_device.h
+++ b/src/crimson/os/seastore/random_block_manager/nvme_block_device.h
@@ -221,7 +221,7 @@ public:
 
   write_ertr::future<> write(
     uint64_t offset,
-    bufferptr &&bptr,
+    bufferptr bptr,
     uint16_t stream = 0) override;
 
   using RBMDevice::read;

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.cc
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.cc
@@ -93,7 +93,7 @@ write_ertr::future<> RBMDevice::write_rbm_superblock()
   auto bp = bufferptr(ceph::buffer::create_page_aligned(super.block_size));
   assert(bl.length() < super.block_size);
   iter.copy(bl.length(), bp.c_str());
-  return write(RBM_START_ADDRESS, std::move(bp));
+  return write(RBM_START_ADDRESS, bp);
 }
 
 read_ertr::future<rbm_superblock_t> RBMDevice::read_rbm_superblock(
@@ -212,7 +212,7 @@ open_ertr::future<> EphemeralRBMDevice::open(
 
 write_ertr::future<> EphemeralRBMDevice::write(
   uint64_t offset,
-  bufferptr &&bptr,
+  bufferptr bptr,
   uint16_t stream) {
   LOG_PREFIX(EphemeralRBMDevice::write);
   ceph_assert(buf);

--- a/src/crimson/os/seastore/random_block_manager/rbm_device.h
+++ b/src/crimson/os/seastore/random_block_manager/rbm_device.h
@@ -128,7 +128,7 @@ public:
    */
   virtual write_ertr::future<> write(
     uint64_t offset,
-    bufferptr &&bptr,
+    bufferptr bptr,
     uint16_t stream = 0) = 0;
 
   virtual discard_ertr::future<> discard(
@@ -223,7 +223,7 @@ public:
 
   write_ertr::future<> write(
     uint64_t offset,
-    bufferptr &&bptr,
+    bufferptr bptr,
     uint16_t stream = 0) override;
 
   using RBMDevice::read;

--- a/src/test/crimson/seastore/test_randomblock_manager.cc
+++ b/src/test/crimson/seastore/test_randomblock_manager.cc
@@ -107,7 +107,9 @@ struct rbm_test_t :
       std::numeric_limits<char>::max()
     );
     char contents = distribution(generator);
-    return buffer::ptr(buffer::create(blocks * block_size, contents));
+    auto bp = bufferptr(ceph::buffer::create_page_aligned(blocks * block_size));
+    memset(bp.c_str(), contents, bp.length());
+    return bp;
   }
 
   void close() {


### PR DESCRIPTION
This PR eliminates unnecessary memory copy during the ool write in rbm.write()

Signed-off-by: Myoungwon Oh <myoungwon.oh@samsung.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
