### PR TITLE
mgr/nfs: earmark resolver for subvolume

### DIFF
--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -6,6 +6,7 @@ from mgr_module import MgrModule, CLICommand, Option, CLICheckNonemptyFileInput
 import object_format
 import orchestrator
 from orchestrator.module import IngressType
+from mgr_util import CephFSEarmarkResolver
 
 from .export import ExportMgr, AppliedExportResults
 from .cluster import NFSCluster
@@ -41,6 +42,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             cmount_path: Optional[str] = "/"
     ) -> Dict[str, Any]:
         """Create a CephFS export"""
+        earmark_resolver = CephFSEarmarkResolver(self)
         return self.export_mgr.create_export(
             fsal_type='cephfs',
             fs_name=fsname,
@@ -51,7 +53,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
             squash=squash,
             addr=client_addr,
             sectype=sectype,
-            cmount_path=cmount_path
+            cmount_path=cmount_path,
+            earmark_resolver=earmark_resolver
         )
 
     @CLICommand('nfs export create rgw', perm='rw')
@@ -114,8 +117,10 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     @CLICheckNonemptyFileInput(desc='Export JSON or Ganesha EXPORT specification')
     @object_format.Responder()
     def _cmd_nfs_export_apply(self, cluster_id: str, inbuf: str) -> AppliedExportResults:
+        earmark_resolver = CephFSEarmarkResolver(self)
         """Create or update an export by `-i <json_or_ganesha_export_file>`"""
-        return self.export_mgr.apply_export(cluster_id, export_config=inbuf)
+        return self.export_mgr.apply_export(cluster_id, export_config=inbuf,
+                                            earmark_resolver=earmark_resolver)
 
     @CLICommand('nfs cluster create', perm='rw')
     @object_format.EmptyResponder()


### PR DESCRIPTION
Depends on https://github.com/ceph/ceph/pull/54277. https://github.com/ceph/ceph/pull/59111, https://github.com/ceph/ceph/pull/59387

  - Inter module level scope handling for `nfs export create cephfs` :
  ```
  [ceph: root@ceph-node-00 /]# ceph nfs export create cephfs foo /ex1  fs1 /volumes/_nogroup/sv1/df544de8-9437-46ea-a1e3-9fb500b77663
Error EAGAIN: earmark has already been set by smb
```
  - Inter module level scope handling for `nfs export apply` :
  ```
  [ceph: root@ceph-node-00 /]# ceph nfs export apply foo -i ex2 
[
  {
    "msg": "Failed to apply export: earmark has already been set by smb",
    "pseudo": "/ex2",
    "state": "error"
  }
]
```

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
