### PR TITLE
cephadm: Support Docker Live Restore

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -24,6 +24,10 @@ Requirements
 Any modern Linux distribution should be sufficient.  Dependencies
 are installed automatically by the bootstrap process below.
 
+See `Docker Live Restore <https://docs.docker.com/engine/daemon/live-restore/>`_
+for an optional feature that allows restarting Docker Engine without restarting
+all running containers.
+
 See the section :ref:`Compatibility With Podman
 Versions<cephadm-compatibility-with-podman>` for a table of Ceph versions that
 are compatible with Podman. Not every version of Podman is compatible with

--- a/src/cephadm/cephadmlib/templates/ceph.service.j2
+++ b/src/cephadm/cephadmlib/templates/ceph.service.j2
@@ -9,7 +9,7 @@ Description=Ceph %i for {{fsid}}
 After=network-online.target local-fs.target time-sync.target{% if has_docker_engine %} docker.service{% endif %}
 Wants=network-online.target local-fs.target time-sync.target
 {%- if has_docker_engine %}
-Requires=docker.service
+Wants=docker.service
 {%- endif %}
 
 PartOf=ceph-{{fsid}}.target

--- a/src/cephadm/cephadmlib/templates/init_ctr.service.j2
+++ b/src/cephadm/cephadmlib/templates/init_ctr.service.j2
@@ -5,7 +5,7 @@ After=network-online.target local-fs.target time-sync.target
 Wants=network-online.target local-fs.target time-sync.target
 {%- if has_docker_engine %}
 After=docker.service
-Requires=docker.service
+Wants=docker.service
 {%- endif %}
 Before=ceph-{{ identity.fsid }}@%i.service
 

--- a/src/cephadm/cephadmlib/templates/sidecar.service.j2
+++ b/src/cephadm/cephadmlib/templates/sidecar.service.j2
@@ -5,7 +5,7 @@ After=network-online.target local-fs.target time-sync.target
 Wants=network-online.target local-fs.target time-sync.target
 {%- if has_docker_engine %}
 After=docker.service
-Requires=docker.service
+Wants=docker.service
 {%- endif %}
 After={{ primary.service_name }}
 

--- a/src/cephadm/tests/test_unit_file.py
+++ b/src/cephadm/tests/test_unit_file.py
@@ -27,11 +27,11 @@ def _get_unit_file(ctx, fsid):
     return str(systemd_unit._get_unit_file(ctx, fsid))
 
 
-def test_docker_engine_requires_docker():
+def test_docker_engine_wants_docker():
     ctx = context.CephadmContext()
     ctx.container_engine = mock_docker()
     r = _get_unit_file(ctx, '9b9d7609-f4d5-4aba-94c8-effa764d96c9')
-    assert 'Requires=docker.service' in r
+    assert 'Wants=docker.service' in r
 
 
 def test_podman_engine_does_not_req_docker():
@@ -80,7 +80,7 @@ def test_new_docker():
         '# configuration.',
         'After=network-online.target local-fs.target time-sync.target docker.service',
         'Wants=network-online.target local-fs.target time-sync.target',
-        'Requires=docker.service',
+        'Wants=docker.service',
         'PartOf=ceph-9b9d7609-f4d5-4aba-94c8-effa764d96c9.target',
         'Before=ceph-9b9d7609-f4d5-4aba-94c8-effa764d96c9.target',
         '[Service]',


### PR DESCRIPTION
Currently with Docker Live Restore [1] enabled and while restarting Docker Engine - all Ceph container images will get restarted, while the feature allows restarting docker.service without containers downtime.

This is due to Requires=docker.service in systemd units templates, which mandates that on docker.service restart - the ceph container systemd units will be restarted as well.

Leaving After= entries, because they should allow systemd to correctly order the startup (first docker, then ceph containers).

[1]: https://docs.docker.com/engine/daemon/live-restore/

Fixes: https://tracker.ceph.com/issues/68028





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
