### PR TITLE
quincy: doc/rados: add "pgs not deep scrubbed in time" info

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1513,6 +1513,32 @@ To manually initiate a deep scrub of a clean PG, run the following command:
 
    ceph pg deep-scrub <pgid>
 
+Under certain conditions, the warning ``X PGs not deep-scrubbed in time``
+appears. This might be because the cluster contains many large PGs, which take
+longer to deep-scrub. To remedy this situation, you must change the value of
+``osd_deep_scrub_interval`` either globally or for the Manager daemon.
+
+#. Confirm that ``ceph health detail`` returns a ``pgs not deep-scrubbed in
+   time`` warning::
+
+      # ceph health detail
+      HEALTH_WARN 1161 pgs not deep-scrubbed in time
+      [WRN] PG_NOT_DEEP_SCRUBBED: 1161 pgs not deep-scrubbed in time
+      pg 86.fff not deep-scrubbed since 2024-08-21T02:35:25.733187+0000
+
+#. Change ``osd_deep_scrub_interval`` globally:   
+
+   .. prompt:: bash #
+
+      ceph config set global osd_deep_scrub_interval 1209600
+
+The above procedure was developed by Eugen Block in September of 2024.
+
+See `Eugen Block's blog post <https://heiterbiswolkig.blogs.nde.ag/2024/09/06/pgs-not-deep-scrubbed-in-time/>`_ for much more detail.
+
+See `Redmine tracker issue #44959 <https://tracker.ceph.com/issues/44959>`_.
+
+
 
 PG_SLOW_SNAP_TRIMMING
 _____________________


### PR DESCRIPTION
Add a procedure to doc/rados/operations/health-warnings.rst that explains how to remedy the "X PGs not deep-scrubbed in time" health warning.

This procedure was developed by Eugen Block, and is at the time of this commit available on his blog at
https://heiterbiswolkig.blogs.nde.ag/2024/09/06/pgs-not-deep-scrubbed-in-time/

Co-authored-by: Eugen Block <eblock@nde.ag>
Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit d620a51c306d1ebcdfc974dc0b85dc46cfde8d40)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
