### PR TITLE
cephfs: Add pkgconfig file for libcephfs

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2566,6 +2566,7 @@ fi
 %{_includedir}/cephfs/metrics/Types.h
 %{_libdir}/libcephfs.so
 %{_libdir}/libcephfs_proxy.so
+%{_libdir}/pkgconfig/cephfs.pc
 
 %files -n python%{python3_pkgversion}-cephfs
 %{python3_sitearch}/cephfs.cpython*.so

--- a/debian/libcephfs-dev.install
+++ b/debian/libcephfs-dev.install
@@ -4,3 +4,4 @@ usr/include/cephfs/types.h
 usr/include/cephfs/metrics/Types.h
 usr/lib/libcephfs.so
 usr/lib/libcephfs_proxy.so
+usr/lib/pkgconfig/cephfs.pc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 set(bindir ${CMAKE_INSTALL_FULL_BINDIR})
 set(sbindir ${CMAKE_INSTALL_FULL_SBINDIR})
 set(libdir ${CMAKE_INSTALL_FULL_LIBDIR})
+set(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
 set(sysconfdir ${CMAKE_INSTALL_FULL_SYSCONFDIR})
 set(libexecdir ${CMAKE_INSTALL_FULL_LIBEXECDIR})
 set(pkgdatadir ${CMAKE_INSTALL_FULL_DATADIR})
@@ -30,6 +31,12 @@ configure_file(ceph-post-file.in
 
 configure_file(ceph-crash.in
   ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph-crash @ONLY)
+
+if(WITH_LIBCEPHFS)
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/src/cephfs.pc.in
+    ${CMAKE_BINARY_DIR}/src/cephfs.pc @ONLY)
+endif(WITH_LIBCEPHFS)
 
 # the src/.git_version file may be written out by make-dist; otherwise
 # we pull the git version from .git
@@ -832,10 +839,12 @@ if(WITH_LIBCEPHFS)
   target_link_libraries(cephfs PRIVATE client ceph-common
     ${CRYPTO_LIBS} ${EXTRALIBS})
   if(ENABLE_SHARED)
+    set(libcephfs_version 2.0.0)
+    set(libcephfs_soversion 2)
     set_target_properties(cephfs PROPERTIES
       OUTPUT_NAME cephfs
-      VERSION 2.0.0
-      SOVERSION 2)
+      VERSION ${libcephfs_version}
+      SOVERSION ${libcephfs_soversion})
     if(NOT APPLE AND NOT
         (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL Clang))
       foreach(name ceph-common client osdc)
@@ -848,6 +857,9 @@ if(WITH_LIBCEPHFS)
   install(DIRECTORY
     "include/cephfs"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(FILES
+    ${CMAKE_BINARY_DIR}/src/cephfs.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
   set(ceph_syn_srcs
     ceph_syn.cc
     client/SyntheticClient.cc)

--- a/src/cephfs.pc.in
+++ b/src/cephfs.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libcephfs
+Description: Ceph distributed file system client library
+Version: @libcephfs_version@
+Cflags: -I${includedir}/cephfs -D_FILE_OFFSET_BITS=64
+Libs: -L${libdir} -lcephfs


### PR DESCRIPTION
It is a common practice to include a pkgconfig file for a library when installed on a system to contain necessary information for that library to be compiled against other programs. These files typically include entries like name, version, description, location of header files, dependent libraries, compilation flags and so on. Utilities like `pkg-config`, `pkgconf`, `autoconf` or even CMake can query those details to compile and link against such libraries.

Here we attempt to introduce a pkgconfig file for libcephfs.

ref: https://people.freedesktop.org/~dbn/pkg-config-guide.html