### PR TITLE
[ceph-volume] fix importlib.metadata compat

### DIFF
--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -11,8 +11,16 @@ try:
     from importlib.metadata import entry_points
 
     def get_entry_points(group: str):  # type: ignore
-        return entry_points().get(group, [])  # type: ignore
+        eps = entry_points()
+        if hasattr(eps, 'select'):
+            # New importlib.metadata uses .select()
+            return eps.select(group=group)
+        else:
+            # Fallback to older EntryPoints that returns dicts
+            return eps.get(group, [])  # type: ignore
+
 except ImportError:
+    # Fallback to `pkg_resources` for older versions
     from pkg_resources import iter_entry_points as entry_points  # type: ignore
 
     def get_entry_points(group: str):  # type: ignore


### PR DESCRIPTION
The importlib.metadata library removed older shims in releases >5.0.0 where EntryPoints objects use .select() instead of dict-like access.

Fixes: https://tracker.ceph.com/issues/68032
