### PR TITLE
qa/rgw/multifs: add tasks/+ to concatenate tasks into same job

### DIFF
--- a/qa/suites/rgw/multifs/0-install.yaml
+++ b/qa/suites/rgw/multifs/0-install.yaml
@@ -1,0 +1,5 @@
+tasks:
+- install:
+- ceph:
+- rgw: [client.0]
+- tox: [client.0]

--- a/qa/suites/rgw/multifs/tasks/rgw_bucket_quota.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_bucket_quota.yaml
@@ -1,7 +1,4 @@
 tasks:
-- install:
-- ceph:
-- rgw: [client.0]
 - workunit:
     clients:
       client.0:

--- a/qa/suites/rgw/multifs/tasks/rgw_bucket_quota.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_bucket_quota.yaml
@@ -6,8 +6,3 @@ tasks:
     clients:
       client.0:
         - rgw/s3_bucket_quota.pl
-overrides:
-  ceph:
-    conf:
-      client:
-        rgw relaxed s3 bucket names: true

--- a/qa/suites/rgw/multifs/tasks/rgw_multipart_upload.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_multipart_upload.yaml
@@ -1,7 +1,4 @@
 tasks:
-- install:
-- ceph:
-- rgw: [client.0]
 - workunit:
     clients:
       client.0:

--- a/qa/suites/rgw/multifs/tasks/rgw_multipart_upload.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_multipart_upload.yaml
@@ -6,8 +6,3 @@ tasks:
     clients:
       client.0:
         - rgw/s3_multipart_upload.pl
-overrides:
-  ceph:
-    conf:
-      client:
-        rgw relaxed s3 bucket names: true

--- a/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
@@ -1,8 +1,4 @@
 tasks:
-- install:
-- ceph:
-- rgw: [client.0]
-- tox: [client.0]
 - ragweed:
     client.0:
       default-branch: ceph-master

--- a/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
@@ -1,8 +1,4 @@
 tasks:
-- install:
-- ceph:
-- rgw: [client.0]
-- tox: [client.0]
 - s3tests:
     client.0:
       rgw_server: client.0

--- a/qa/suites/rgw/multifs/tasks/rgw_user_quota.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_user_quota.yaml
@@ -1,7 +1,4 @@
 tasks:
-- install:
-- ceph:
-- rgw: [client.0]
 - workunit:
     clients:
       client.0:

--- a/qa/suites/rgw/multifs/tasks/rgw_user_quota.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_user_quota.yaml
@@ -6,8 +6,3 @@ tasks:
     clients:
       client.0:
         - rgw/s3_user_quota.pl
-overrides:
-  ceph:
-    conf:
-      client:
-        rgw relaxed s3 bucket names: true

--- a/qa/workunits/rgw/s3_utilities.pm
+++ b/qa/workunits/rgw/s3_utilities.pm
@@ -21,7 +21,7 @@ sub get_timestamp {
    if ($min < 10) { $min = "0$min"; }
    if ($sec < 10) { $sec = "0$sec"; }
    $year=$year+1900;
-   return $year . '_' . $mon . '_' . $mday . '_' . $hour . '_' . $min . '_' . $sec;
+   return $year . '-' . $mon . '-' . $mday . '-' . $hour . '-' . $min . '-' . $sec;
 }
 
 # Function to check if radosgw is already running
@@ -195,11 +195,12 @@ sub run_s3
                 host                  => $hostname,
                 secure                => 0,
                 retry                 => 1,
+                dns_bucket_names      => 0,
             }
       );
     }
 
-our $bucketname = 'buck_'.get_timestamp();
+our $bucketname = 'buck-'.get_timestamp();
 # create a new bucket (the test bucket)
 our $bucket = $s3->add_bucket( { bucket => $bucketname } )
       or die $s3->err. "bucket $bucketname create failed\n". $s3->errstr;


### PR DESCRIPTION
uses the same strategy from rgw/verify in https://github.com/ceph/ceph/pull/22249 to reduce the number of jobs in rgw/multifs

rgw/multifs/tasks/ contains yaml files for 5 different test cases. instead treating each test case as a separate dimension of the teuthology job matrix, combine them together in a single job

now the only dimensions come from `rgw/multifs/rgw_pool_type/{ec-profile.yaml ec.yaml replicated.yaml}`. this reduces the number of jobs in the rgw/multifs subsuite from 15 to 3

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
