### PR TITLE
test/crimson/test_messenger_thrash: fix a local variable scope issue

### DIFF
--- a/src/test/crimson/test_messenger_thrash.cc
+++ b/src/test/crimson/test_messenger_thrash.cc
@@ -447,15 +447,16 @@ class SyntheticWorkload {
    }
 
    seastar::future<> wait_for_done() {
-     int i = 0;
-     return seastar::do_until(
-       [this] { return !dispatcher.get_num_pending_msgs(); },
-       [this, &i]
-     {
-       if (i++ % 50 == 0){
-         print_internal_state(true);
-       }
-       return seastar::sleep(100ms);
+     return seastar::do_with(0, [this] (int &i) {
+       return seastar::do_until(
+         [this] { return !dispatcher.get_num_pending_msgs(); },
+         [this, &i] {
+           if (i++ % 50 == 0) {
+             print_internal_state(true);
+           }
+           return seastar::sleep(100ms);
+         }
+       );
      }).then([this] {
        return seastar::do_for_each(available_servers, [] (auto server) {
 	 if (verbose) {


### PR DESCRIPTION
test_messenger_thrash UT shows,

```
==461141==ERROR: AddressSanitizer: stack-use-after-return on address 0xffffb0b37c20 at pc 0xaaaad7239508 bp 0xffffeb113c50 sp 0xffffeb113c48
READ of size 4 at 0xffffb0b37c20 thread T0
    #0 0xaaaad7239504 in (anonymous namespace)::SyntheticWorkload::wait_for_done()::'lambda0'()::operator()() const /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/test/crimson/test_messenger_thrash.cc:455:13
    https://github.com/ceph/ceph/pull/1 0xaaaad723a1c0 in seastar::internal::do_until_state<(anonymous namespace)::SyntheticWorkload::wait_for_done()::'lambda'(), (anonymous namespace)::SyntheticWorkload::wait_for_done()::'lambda0'()>::run_and_dispose() /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/seastar/include/seastar/core/loop.hh:303:26
    https://github.com/ceph/ceph/pull/2 0xaaaadacfb790 in seastar::reactor::run_tasks(seastar::reactor::task_queue&) /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/seastar/src/core/reactor.cc:2653:14
    https://github.com/ceph/ceph/pull/3 0xaaaadad04288 in seastar::reactor::run_some_tasks() /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/seastar/src/core/reactor.cc:3123:9
    https://github.com/ceph/ceph/pull/4 0xaaaadad07cd0 in seastar::reactor::do_run() /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/seastar/src/core/reactor.cc:3291:9
    https://github.com/ceph/ceph/pull/5 0xaaaadad05d60 in seastar::reactor::run() /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/seastar/src/core/reactor.cc:3181:16
    https://github.com/ceph/ceph/pull/6 0xaaaadaa860d8 in seastar::app_template::run_deprecated(int, char**, std::function<void ()>&&) /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/seastar/src/core/app-template.cc:276:31
    https://github.com/ceph/ceph/pull/7 0xaaaadaa83fb0 in seastar::app_template::run(int, char**, std::function<seastar::future<int> ()>&&) /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/seastar/src/core/app-template.cc:167:12
    https://github.com/ceph/ceph/pull/8 0xaaaad7203d88 in main /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/test/crimson/test_messenger_thrash.cc:669:14
    https://github.com/ceph/ceph/pull/9 0xffffb32773f8 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    https://github.com/ceph/ceph/pull/10 0xffffb32774c8 in __libc_start_main csu/../csu/libc-start.c:392:3
    https://github.com/ceph/ceph/pull/11 0xaaaad712546c in _start (/home/jenkins-build/build/workspace/ceph-pull-requests-arm64/build/bin/unittest-seastar-messenger-thrash+0x3b5546c) (BuildId: b0048d750e057d178816f94b3ce0459971785191)
```

Address 0xffffb0b37c20 is located in stack of thread T0 at offset 32 in frame
    #0 0xaaaad7493ed8 in ceph::buffer::v15_2_0::list::buffers_t::clear_and_dispose() /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/include/buffer.h:596


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
