### PR TITLE
orch: refactor boolean handling in drive group spec

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1344,6 +1344,7 @@ Usage:
             return HandleCommandResult(-errno.EINVAL, stderr=usage)
         try:
             host_name, raw = svc_arg.split(":")
+            list_drive_group_spec_bool_arg: List[str] = []
             drive_group_spec = {
                 'data_devices': []
             }  # type: Dict
@@ -1359,6 +1360,8 @@ Usage:
                                             'journal_devices']:
                         drive_group_spec[drv_grp_spec_arg] = []
                         drive_group_spec[drv_grp_spec_arg].append(value)
+                        if value.lower() in ['true', 'false']:
+                            list_drive_group_spec_bool_arg.append(drv_grp_spec_arg)
                     else:
                         drive_group_spec[drv_grp_spec_arg] = value
                 elif drv_grp_spec_arg is not None:
@@ -1371,15 +1374,9 @@ Usage:
                 drive_group_spec[dev_type] = DeviceSelection(
                     paths=drive_group_spec[dev_type]) if drive_group_spec.get(dev_type) else None
 
-            valid_true_vals = {'true', '1'}
-            valid_false_vals = {'false', '0'}
-            for drive_group_spec_bool_arg in ['encrypted', 'unmanaged', 'preview_only']:
-                drive_group_spec_value: Optional[str] = drive_group_spec.get(drive_group_spec_bool_arg)
-                if isinstance(drive_group_spec_value, str):
-                    value_lower = drive_group_spec_value.lower()
-                    if value_lower not in valid_true_vals and value_lower not in valid_false_vals:
-                        raise OrchestratorValidationError(usage)
-                    drive_group_spec[drive_group_spec_bool_arg] = value_lower in valid_true_vals
+            for drive_group_spec_bool_arg in list_drive_group_spec_bool_arg:
+                drive_group_spec_value: str = drive_group_spec[drive_group_spec_bool_arg]
+                drive_group_spec[drive_group_spec_bool_arg] = drive_group_spec_value.lower() == "true"
 
             drive_group = DriveGroupSpec(
                 placement=PlacementSpec(host_pattern=host_name),


### PR DESCRIPTION
The intent of 42721c03ee6f was to address an issue where boolean parameters weren't handled correctly.

I noticed that a parameter (`tpm2`) was missed, which made me realize that maintaining a list of these boolean parameters is necessary.

To simplify things, we should only accept `"true"` or `"false"` (in any case), allowing us to avoid the need to maintain a list of boolean parameters.

This change introduces a `list_drive_group_spec_bool_arg` to store boolean arguments related to drive group specifications, simplifying the validation process for boolean values by directly checking if the values are 'true' or 'false'.

Fixes: https://tracker.ceph.com/issues/68045