### PR TITLE
doc/install: Keep the name field of the created user consistent with …

### DIFF
--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -475,7 +475,7 @@ thread on the ceph-users mailing list
 
    .. prompt:: bash #
       
-      ceph auth get-or-create client.short-hostname-of-rgw mon 'allow rw' osd 'allow rwx'
+      ceph auth get-or-create client.$(hostname -s) mon 'allow rw' osd 'allow rwx'
 
 #. On one of the RGW nodes, do the following:
 


### PR DESCRIPTION
…the node name in the Start RADOSGW service command

If the user name does not match the name of the node that started the RADOSGW service, this will cause confusion for those who are new to ceph. Because they can't start the radosgw service normally as shown in the tutorial.

Signed-off-by: hejindong <wodeshijie3394@126.com>
