### PR TITLE
ceph-bluestore-tool: Fixes for multilple bdev label

### DIFF
--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -30,6 +30,7 @@ Synopsis
 | **ceph-bluestore-tool** reshard --path *osd path* --sharding *new sharding* [ --sharding-ctrl *control string* ]
 | **ceph-bluestore-tool** show-sharding --path *osd path*
 | **ceph-bluestore-tool** trim --path *osd path*
+| **ceph-bluestore-tool** zap-device --dev *dev path*
 
 
 Description
@@ -106,7 +107,8 @@ Commands
 
 :command:`show-label` --dev *device* [...]
 
-   Show device label(s).	   
+   Show device label(s).
+   The label may be printed while an OSD is running.
 
 :command:`free-dump` --path *osd path* [ --allocator block/bluefs-wal/bluefs-db/bluefs-slow ]
 
@@ -138,6 +140,10 @@ Commands
    This operation uses TRIM / discard to free unused blocks from BlueStore and BlueFS block devices,
    and allows the drive to perform more efficient internal housekeeping.
    If BlueStore runs with discard enabled, this option may not be useful.
+
+:command: `zap-device` --dev *dev path*
+
+   Zeros all device label locations. This effectively makes device appear empty.
 
 Options
 =======
@@ -200,8 +206,8 @@ Useful to provide necessary configuration options when access to monitor/ceph.co
 Device labels
 =============
 
-Every BlueStore block device has a single block label at the beginning of the
-device.  You can dump the contents of the label with::
+Every BlueStore block device has a block label at the beginning of the device.
+You can dump the contents of the label with::
 
   ceph-bluestore-tool show-label --dev *device*
 
@@ -209,6 +215,10 @@ The main device will have a lot of metadata, including information
 that used to be stored in small files in the OSD data directory.  The
 auxiliary devices (db and wal) will only have the minimum required
 fields (OSD UUID, size, device type, birth time).
+The main device contains additional label copies at offsets: 1G, 10G, 100G and 1000G.
+Corrupted labels are fixed as part of repair::
+
+  ceph-bluestore-tool repair --dev *device*
 
 OSD directory priming
 =====================

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6928,6 +6928,10 @@ int BlueStore::read_bdev_label(
 {
   unique_ptr<BlockDevice> bdev(BlockDevice::create(
     cct, path, nullptr, nullptr, nullptr, nullptr));
+  if (!bdev) {
+    return -EIO;
+  }
+  bdev->set_no_exclusive_lock();
   int r = bdev->open(path);
   if (r < 0)
     return r;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8992,27 +8992,20 @@ void BlueStore::trim_free_space(const string& type, std::ostream& outss)
   }
 }
 
-int BlueStore::zap_device(CephContext* cct, const string& dev, uint64_t gap_size)
+int BlueStore::zap_device(CephContext* cct, const string& dev)
 {
-  string path; // dummy var for dout
-  dout(5)<<  __func__ << " " << dev << dendl;
-  auto * _bdev =
-    BlockDevice::create(cct, dev, nullptr, nullptr, nullptr, nullptr);
+  string path = dev; // dummy var for dout
+  uint64_t brush_size;
+  dout(5) << __func__ << " " << dev << dendl;
+  unique_ptr<BlockDevice>
+    _bdev(BlockDevice::create(cct, dev, nullptr, nullptr, nullptr, nullptr));
   int r = _bdev->open(dev);
   if (r < 0)
     goto fail;
-  if (!gap_size) {
-    gap_size = _bdev->get_block_size();
-  }
-  if (p2align(gap_size, _bdev->get_block_size()) != gap_size) {
-    derr << __func__
-         << " zapping size has to be aligned with device block size: 0x" 
-         << std::hex << gap_size << " vs. 0x" << _bdev->get_block_size()
-         << std::dec << dendl;
-    return -EINVAL;
-  }
+  brush_size = std::max(_bdev->get_block_size(), BDEV_LABEL_BLOCK_SIZE);
+
   for (auto off : bdev_label_positions) {
-    uint64_t end = std::min(off + gap_size, _bdev->get_size());
+    uint64_t end = std::min(off + brush_size, _bdev->get_size());
     if (end > off) {
       uint64_t l = end - off;
       bufferlist bl;
@@ -9034,7 +9027,6 @@ int BlueStore::zap_device(CephContext* cct, const string& dev, uint64_t gap_size
     }
   }
 
-fail_close:
   _bdev->close();
 
 fail:

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8988,6 +8988,55 @@ void BlueStore::trim_free_space(const string& type, std::ostream& outss)
   }
 }
 
+int BlueStore::zap_device(CephContext* cct, const string& dev, uint64_t gap_size)
+{
+  string path; // dummy var for dout
+  dout(5)<<  __func__ << " " << dev << dendl;
+  auto * _bdev =
+    BlockDevice::create(cct, dev, nullptr, nullptr, nullptr, nullptr);
+  int r = _bdev->open(dev);
+  if (r < 0)
+    goto fail;
+  if (!gap_size) {
+    gap_size = _bdev->get_block_size();
+  }
+  if (p2align(gap_size, _bdev->get_block_size()) != gap_size) {
+    derr << __func__
+         << " zapping size has to be aligned with device block size: 0x" 
+         << std::hex << gap_size << " vs. 0x" << _bdev->get_block_size()
+         << std::dec << dendl;
+    return -EINVAL;
+  }
+  for (auto off : bdev_label_positions) {
+    uint64_t end = std::min(off + gap_size, _bdev->get_size());
+    if (end > off) {
+      uint64_t l = end - off;
+      bufferlist bl;
+      bl.append_zero(l);
+      dout(10) << __func__ << " writing 0x"
+               << std::hex << off << "~" << l
+               << std::dec << " to " << dev
+               <<  dendl;
+      r = _bdev->write(off, bl, false);
+      if (r < 0) {
+        derr << __func__ << " error writing 0x"
+             << std::hex << off << "~" << l
+             << std::dec << " to " << dev
+             << " : " << cpp_strerror(r) <<  dendl;
+        break;
+      }
+    } else {
+      break;
+    }
+  }
+
+fail_close:
+  _bdev->close();
+
+fail:
+  return r;
+}
+
 void BlueStore::set_cache_shards(unsigned num)
 {
   dout(10) << __func__ << " " << num << dendl;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3192,7 +3192,7 @@ public:
 
   int dump_bluefs_sizes(std::ostream& out);
   void trim_free_space(const std::string& type, std::ostream& outss);
-  static int zap_device(CephContext* cct, const std::string& dev, uint64_t gap_size);
+  static int zap_device(CephContext* cct, const std::string& dev);
 
 public:
   int statfs(struct store_statfs_t *buf,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3192,6 +3192,7 @@ public:
 
   int dump_bluefs_sizes(std::ostream& out);
   void trim_free_space(const std::string& type, std::ostream& outss);
+  static int zap_device(CephContext* cct, const std::string& dev, uint64_t gap_size);
 
 public:
   int statfs(struct store_statfs_t *buf,

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -290,7 +290,6 @@ int main(int argc, char **argv)
   string new_sharding = empty_sharding;
   string resharding_ctrl;
   int log_level = 30;
-  uint64_t zap_size = 0;
   bool fsck_deep = false;
   po::options_description po_options("Options");
   po_options.add_options()
@@ -317,7 +316,6 @@ int main(int argc, char **argv)
     ("resharding-ctrl", po::value<string>(&resharding_ctrl), "gives control over resharding procedure details")
     ("op", po::value<string>(&action_aux),
       "--command alias, ignored if the latter is present")
-    ("zap-size", po::value<uint64_t>(&zap_size), "size of a block written when zapping device")
     ;
   po::options_description po_positional("Positional options");
   po_positional.add_options()
@@ -1270,7 +1268,7 @@ int main(int argc, char **argv)
     bluestore.cold_close();
   } else if (action == "zap-device") {
     for(auto& dev : devs) {
-      int r = BlueStore::zap_device(cct.get(), dev, zap_size);
+      int r = BlueStore::zap_device(cct.get(), dev);
       if (r < 0) {
         cerr << "error from zap: " << cpp_strerror(r) << std::endl;
         exit(EXIT_FAILURE);

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -289,7 +289,6 @@ int main(int argc, char **argv)
   string empty_sharding(1, '\0');
   string new_sharding = empty_sharding;
   string resharding_ctrl;
-  string really;
   int log_level = 30;
   bool fsck_deep = false;
   po::options_description po_options("Options");
@@ -312,7 +311,7 @@ int main(int argc, char **argv)
     ("value,v", po::value<string>(&value), "label metadata value")
     ("allocator", po::value<vector<string>>(&allocs_name), "allocator to inspect: 'block'/'bluefs-wal'/'bluefs-db'")
     ("bdev-type", po::value<vector<string>>(&bdev_type), "bdev type to inspect: 'bdev-block'/'bdev-wal'/'bdev-db'")
-    ("really", po::value<string>(&really), "--yes-i-really-really-mean-it")
+    ("yes-i-really-really-mean-it", "additional confirmation for dangerous commands")
     ("sharding", po::value<string>(&new_sharding), "new sharding to apply")
     ("resharding-ctrl", po::value<string>(&resharding_ctrl), "gives control over resharding procedure details")
     ("op", po::value<string>(&action_aux),
@@ -354,7 +353,11 @@ int main(int argc, char **argv)
   po::variables_map vm;
   try {
     po::parsed_options parsed =
-      po::command_line_parser(argc, argv).options(po_all).allow_unregistered().run();
+      po::command_line_parser(argc, argv).options(po_all)
+        .allow_unregistered()
+        .style(po::command_line_style::default_style &
+               ~po::command_line_style::allow_guessing)
+        .run();
     po::store( parsed, vm);
     po::notify(vm);
     ceph_option_strings = po::collect_unrecognized(parsed.options,
@@ -582,7 +585,7 @@ int main(int argc, char **argv)
       cerr << "must specify bluestore path" << std::endl;
       exit(EXIT_FAILURE);
     }
-    if (really.empty() || strcmp(really.c_str(), "--yes-i-really-really-mean-it") != 0) {
+    if (!vm.count("yes-i-really-really-mean-it")) {
       cerr << "Trimming a non healthy bluestore is a dangerous operation which could cause data loss, "
            << "please run fsck and confirm with --yes-i-really-really-mean-it option"
            << std::endl;


### PR DESCRIPTION
This PR consists of:

ZAP:
https://github.com/ceph/ceph/pull/59632
show-label:
https://github.com/ceph/ceph/pull/59714
really-really-mean-it:
https://github.com/ceph/ceph/pull/59627
+
-zap-size param is removed
+
documentation added

Fixes:
https://tracker.ceph.com/issues/68048

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
