### PR TITLE
mgr/dashboard: zonegroup level policy created at master zone did not sync to non-master zone

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -180,21 +180,21 @@ class RgwMultisiteController(RESTController):
     @CreatePermission
     def create_sync_policy_group(self, group_id: str, status: str, bucket_name=''):
         multisite_instance = RgwMultisite()
-        return multisite_instance.create_sync_policy_group(group_id, status, bucket_name)
+        return multisite_instance.create_sync_policy_group(group_id, status, bucket_name, True)
 
     @Endpoint(method='PUT', path='/sync-policy-group')
     @EndpointDoc("Update the sync policy group")
     @UpdatePermission
     def update_sync_policy_group(self, group_id: str, status: str, bucket_name=''):
         multisite_instance = RgwMultisite()
-        return multisite_instance.update_sync_policy_group(group_id, status, bucket_name)
+        return multisite_instance.update_sync_policy_group(group_id, status, bucket_name, True)
 
     @Endpoint(method='DELETE', path='/sync-policy-group')
     @EndpointDoc("Remove the sync policy group")
     @DeletePermission
     def remove_sync_policy_group(self, group_id: str, bucket_name=''):
         multisite_instance = RgwMultisite()
-        return multisite_instance.remove_sync_policy_group(group_id, bucket_name)
+        return multisite_instance.remove_sync_policy_group(group_id, bucket_name, True)
 
     @Endpoint(method='PUT', path='/sync-flow')
     @EndpointDoc("Create or update the sync flow")
@@ -206,7 +206,7 @@ class RgwMultisiteController(RESTController):
                          bucket_name=''):
         multisite_instance = RgwMultisite()
         return multisite_instance.create_sync_flow(group_id, flow_id, flow_type, zones,
-                                                   bucket_name, source_zone, destination_zone)
+                                                   bucket_name, source_zone, destination_zone, True)
 
     @Endpoint(method='DELETE', path='/sync-flow')
     @EndpointDoc("Remove the sync flow")
@@ -216,7 +216,7 @@ class RgwMultisiteController(RESTController):
                          bucket_name=''):
         multisite_instance = RgwMultisite()
         return multisite_instance.remove_sync_flow(group_id, flow_id, flow_type, source_zone,
-                                                   destination_zone, zones, bucket_name)
+                                                   destination_zone, zones, bucket_name, True)
 
     @Endpoint(method='PUT', path='/sync-pipe')
     @EndpointDoc("Create or update the sync pipe")
@@ -229,7 +229,7 @@ class RgwMultisiteController(RESTController):
         multisite_instance = RgwMultisite()
         return multisite_instance.create_sync_pipe(group_id, pipe_id, source_zones,
                                                    destination_zones, source_bucket,
-                                                   destination_bucket, bucket_name)
+                                                   destination_bucket, bucket_name, True)
 
     @Endpoint(method='DELETE', path='/sync-pipe')
     @EndpointDoc("Remove the sync pipe")
@@ -242,7 +242,7 @@ class RgwMultisiteController(RESTController):
         multisite_instance = RgwMultisite()
         return multisite_instance.remove_sync_pipe(group_id, pipe_id, source_zones,
                                                    destination_zones, destination_bucket,
-                                                   bucket_name)
+                                                   bucket_name, True)
 
 
 @APIRouter('/rgw/daemon', Scope.RGW)

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/multisite.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/multisite.e2e-spec.ts
@@ -1,7 +1,17 @@
+import { BucketsPageHelper } from './buckets.po';
 import { MultisitePageHelper } from './multisite.po';
 
 describe('Multisite page', () => {
   const multisite = new MultisitePageHelper();
+  const buckets = new BucketsPageHelper();
+  const bucket_name = 'e2ebucket';
+
+  before(() => {
+    cy.login();
+    buckets.navigateTo('create');
+    buckets.create(bucket_name, BucketsPageHelper.USERS[0]);
+    buckets.getFirstTableCell(bucket_name).should('exist');
+  });
 
   beforeEach(() => {
     cy.login();
@@ -17,13 +27,13 @@ describe('Multisite page', () => {
   describe('create, edit & delete sync group policy', () => {
     it('should create policy', () => {
       multisite.navigateTo('create');
-      multisite.create('test', 'Enabled');
+      multisite.create('test', 'Enabled', bucket_name);
       multisite.getFirstTableCell('test').should('exist');
     });
 
     it('should edit policy status', () => {
       multisite.navigateTo();
-      multisite.edit('test', 'Forbidden');
+      multisite.edit('test', 'Forbidden', bucket_name);
     });
 
     it('should delete policy', () => {
@@ -36,7 +46,7 @@ describe('Multisite page', () => {
   describe.skip('create, edit & delete symmetrical sync Flow', () => {
     it('Preparing...(creating sync group policy)', () => {
       multisite.navigateTo('create');
-      multisite.create('test', 'Enabled');
+      multisite.create('test', 'Enabled', bucket_name);
       multisite.getFirstTableCell('test').should('exist');
     });
     describe('symmetrical Flow creation started', () => {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/multisite.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/multisite.po.ts
@@ -22,21 +22,22 @@ export class MultisitePageHelper extends PageHelper {
   }
 
   @PageHelper.restrictTo(pages.create.url)
-  create(group_id: string, status: string) {
+  create(group_id: string, status: string, bucket_name: string) {
     // Enter in group_id
     cy.get('#group_id').type(group_id);
     // Show Status
     this.selectOption('status', status);
     cy.get('#status').should('have.class', 'ng-valid');
-
+    // Enter the bucket_name
+    cy.get('#bucket_name').type(bucket_name);
     // Click the create button and wait for policy to be made
     cy.contains('button', 'Create Sync Policy Group').wait(WAIT_TIMER).click();
     this.getFirstTableCell(group_id).should('exist');
   }
 
   @PageHelper.restrictTo(pages.index.url)
-  edit(group_id: string, status: string) {
-    cy.visit(`${pages.edit.url}/${group_id})`);
+  edit(group_id: string, status: string, bucket_name: string) {
+    cy.visit(`${pages.edit.url}/${group_id}/${bucket_name})`);
 
     // Change the status field
     this.selectOption('status', status);

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -2032,7 +2032,8 @@ class RgwMultisite:
         except SubprocessError as error:
             raise DashboardException(error, http_status_code=500, component='rgw')
 
-    def create_sync_policy_group(self, group_id: str, status: str, bucket_name: str = ''):
+    def create_sync_policy_group(self, group_id: str, status: str, bucket_name: str = '',
+                                 update_period=False):
         rgw_sync_policy_cmd = ['sync', 'group', 'create', '--group-id', group_id,
                                '--status', SyncStatus[status].value]
         if bucket_name:
@@ -2044,8 +2045,11 @@ class RgwMultisite:
                                          http_status_code=500, component='rgw')
         except SubprocessError as error:
             raise DashboardException(error, http_status_code=500, component='rgw')
+        if not bucket_name and update_period:
+            self.update_period()
 
-    def update_sync_policy_group(self, group_id: str, status: str, bucket_name: str = ''):
+    def update_sync_policy_group(self, group_id: str, status: str, bucket_name: str = '',
+                                 update_period=False):
         rgw_sync_policy_cmd = ['sync', 'group', 'modify', '--group-id', group_id,
                                '--status', SyncStatus[status].value]
         if bucket_name:
@@ -2057,8 +2061,10 @@ class RgwMultisite:
                                          http_status_code=500, component='rgw')
         except SubprocessError as error:
             raise DashboardException(error, http_status_code=500, component='rgw')
+        if not bucket_name and update_period:
+            self.update_period()
 
-    def remove_sync_policy_group(self, group_id: str, bucket_name=''):
+    def remove_sync_policy_group(self, group_id: str, bucket_name='', update_period=False):
         rgw_sync_policy_cmd = ['sync', 'group', 'remove', '--group-id', group_id]
         if bucket_name:
             rgw_sync_policy_cmd += ['--bucket', bucket_name]
@@ -2069,11 +2075,14 @@ class RgwMultisite:
                                          http_status_code=500, component='rgw')
         except SubprocessError as error:
             raise DashboardException(error, http_status_code=500, component='rgw')
+        if not bucket_name and update_period:
+            self.update_period()
 
     def create_sync_flow(self, group_id: str, flow_id: str, flow_type: str,
                          zones: Optional[Dict[str, List]] = None, bucket_name: str = '',
                          source_zone: Optional[str] = None,
-                         destination_zone: Optional[str] = None):
+                         destination_zone: Optional[str] = None,
+                         update_period=False):
         rgw_sync_policy_cmd = ['sync', 'group', 'flow', 'create', '--group-id', group_id,
                                '--flow-id', flow_id, '--flow-type', SyncFlowTypes[flow_type].value]
 
@@ -2114,10 +2123,13 @@ class RgwMultisite:
                 if len(zones['removed']) > 0:
                     self.remove_sync_flow(group_id, flow_id, flow_type, source_zone,
                                           destination_zone, zones['removed'], bucket_name)
+        if not bucket_name and update_period:
+            self.update_period()
 
     def remove_sync_flow(self, group_id: str, flow_id: str, flow_type: str,
                          source_zone='', destination_zone='',
-                         zones: Optional[List[str]] = None, bucket_name: str = ''):
+                         zones: Optional[List[str]] = None, bucket_name: str = '',
+                         update_period=False):
         rgw_sync_policy_cmd = ['sync', 'group', 'flow', 'remove', '--group-id', group_id,
                                '--flow-id', flow_id, '--flow-type', SyncFlowTypes[flow_type].value]
 
@@ -2138,13 +2150,16 @@ class RgwMultisite:
                                          http_status_code=500, component='rgw')
         except SubprocessError as error:
             raise DashboardException(error, http_status_code=500, component='rgw')
+        if not bucket_name and update_period:
+            self.update_period()
 
     def create_sync_pipe(self, group_id: str, pipe_id: str,
                          source_zones: Dict[str, Any],
                          destination_zones: Dict[str, Any],
                          source_bucket: str = '',
                          destination_bucket: str = '',
-                         bucket_name: str = ''):
+                         bucket_name: str = '',
+                         update_period=False):
 
         if source_zones['added'] or destination_zones['added']:
             rgw_sync_policy_cmd = ['sync', 'group', 'pipe', 'create',
@@ -2173,6 +2188,8 @@ class RgwMultisite:
                                              http_status_code=500, component='rgw')
             except SubprocessError as error:
                 raise DashboardException(error, http_status_code=500, component='rgw')
+            if not bucket_name and update_period:
+                self.update_period()
 
         if source_zones['removed'] or destination_zones['removed']:
             self.remove_sync_pipe(group_id, pipe_id, source_zones['removed'],
@@ -2182,7 +2199,8 @@ class RgwMultisite:
     def remove_sync_pipe(self, group_id: str, pipe_id: str,
                          source_zones: Optional[List[str]] = None,
                          destination_zones: Optional[List[str]] = None,
-                         destination_bucket: str = '', bucket_name: str = ''):
+                         destination_bucket: str = '', bucket_name: str = '',
+                         update_period=False):
         rgw_sync_policy_cmd = ['sync', 'group', 'pipe', 'remove',
                                '--group-id', group_id, '--pipe-id', pipe_id]
 
@@ -2206,6 +2224,8 @@ class RgwMultisite:
                                          http_status_code=500, component='rgw')
         except SubprocessError as error:
             raise DashboardException(error, http_status_code=500, component='rgw')
+        if not bucket_name and update_period:
+            self.update_period()
 
     def create_dashboard_admin_sync_group(self, zonegroup_name: str = ''):
 


### PR DESCRIPTION
added period update for zonegroup level changes so as to sync them
    
Fixes: https://tracker.ceph.com/issues/68049

Signed-off-by: Naman Munet <nmunet@redhat.com>

https://github.com/user-attachments/assets/1dd9a28d-fda0-4c12-96c7-a974d778dd86

Video Description: After creating sync policy in first cluster (with zone1-zg-1realm1 set as default), it is propogating changes to the second cluster (with zone3-zg1-realm1 as default), it means the policy is synced across zones.


**NOTE**:  This PR is being worked upon commits from another [PR](https://github.com/ceph/ceph/pull/59061), please review only the latest commit which belongs to the current PR.
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
