### PR TITLE
mgr/dashboard: fix minor issues in carbon tables

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
@@ -1,22 +1,22 @@
 <div class="row">
-  <div class="col-sm-6">
+  <div class="col-sm-8">
     <legend i18n>Ranks</legend>
     <cd-table [data]="data.ranks"
               [columns]="columns.ranks"
               [toolHeader]="false">
     </cd-table>
 
-    <legend i18n>Standbys</legend>
-    <cd-table-key-value [data]="standbys">
-    </cd-table-key-value>
-  </div>
-
-  <div class="col-sm-6">
     <legend i18n>Pools</legend>
     <cd-table [data]="data.pools"
               [columns]="columns.pools"
               [toolHeader]="false">
     </cd-table>
+  </div>
+
+  <div class="col-sm-4">
+    <legend i18n>Standbys</legend>
+    <cd-table-key-value [data]="standbys">
+    </cd-table-key-value>
   </div>
 </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-list/cephfs-subvolume-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-subvolume-list/cephfs-subvolume-list.component.html
@@ -1,12 +1,12 @@
 <div class="row">
-  <div class="col-sm-1"
+  <div class="col-sm-2"
        *ngIf="subVolumeGroups$ | async as subVolumeGroups">
     <cd-vertical-navigation title="Groups"
                             [items]="subvolumeGroupList"
                             inputIdentifier="group-filter"
                             (emitActiveItem)="selectSubVolumeGroup($event)"></cd-vertical-navigation>
   </div>
-  <div class="col-11 vertical-line">
+  <div class="col-10 vertical-line">
     <cd-table [data]="subVolumes$ | async"
               columnMode="flex"
               [columns]="columns"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -232,13 +232,13 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
     pagination_obs.observable.subscribe(
       (services: CephServiceSpec[]) => {
         this.services = services;
-        this.count = pagination_obs.count;
         this.services = this.services.filter((col: any) => {
           if (col.service_type === 'mgmt-gateway' && col.status.running) {
             this.isMgmtGateway = true;
           }
           return !this.hiddenServices.includes(col.service_name);
         });
+        this.count = this.services.length;
         this.isLoadingServices = false;
       },
       () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.html
@@ -139,26 +139,24 @@
                 <td><pre>{{ selection.bucket_policy | json}}</pre></td>
               </tr>
               <tr>
-                <div>
-                  <td i18n
-                      class="bold w-25">Lifecycle
-                    <div *ngIf="(selection.lifecycle | json) !== '{}'"
-                         class="input-group">
-                      <button type="button"
-                              class="btn btn-light"
-                              [ngClass]="{'active': lifecycleFormat === 'json'}"
-                              (click)="lifecycleFormat = 'json'">
-                            JSON
-                      </button>
-                      <button type="button"
-                              class="btn btn-light"
-                              [ngClass]="{'active': lifecycleFormat === 'xml'}"
-                              (click)="lifecycleFormat = 'xml'">
-                            XML
-                      </button>
-                    </div>
-                  </td>
-                </div>
+                <td i18n
+                    class="bold w-25">Lifecycle
+                  <div *ngIf="(selection.lifecycle | json) !== '{}'"
+                       class="input-group">
+                    <button type="button"
+                            class="btn btn-light"
+                            [ngClass]="{'active': lifecycleFormat === 'json'}"
+                            (click)="lifecycleFormat = 'json'">
+                          JSON
+                    </button>
+                    <button type="button"
+                            class="btn btn-light"
+                            [ngClass]="{'active': lifecycleFormat === 'xml'}"
+                            (click)="lifecycleFormat = 'xml'">
+                          XML
+                    </button>
+                  </div>
+                </td>
                 <td>
                   <pre *ngIf="lifecycleFormat === 'json'">{{selection.lifecycle | json}}</pre>
                   <pre *ngIf="lifecycleFormat === 'xml'">{{ (selection.lifecycle | xml) || '-'}}</pre>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.html
@@ -102,7 +102,7 @@
           <cd-alert-panel type="info"
                           i18n>
             Multi-site needs to be configured in order to see the multi-site sync status.
-            Please consult the <cd-doc section="multisite"></cd-doc> on how to configure and enable the multi-site functionality.
+            Please consult the <cd-doc section="multisite"></cd-doc>&nbsp;on how to configure and enable the multi-site functionality.
           </cd-alert-panel>
         </span>
       </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/device-list/device-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/device-list/device-list.component.html
@@ -40,11 +40,11 @@
 
 <ng-template #lifeExpectancy
              let-value="data.value">
-  <span *ngIf="!value.life_expectancy_enabled"
+  <span *ngIf="!value?.life_expectancy_enabled"
         i18n>{{ "" | notAvailable }}</span>
-  <span *ngIf="value.min && !value.max">&gt; {{value.min | i18nPlural: translationMapping}}</span>
-  <span *ngIf="value.max && !value.min">&lt; {{value.max | i18nPlural: translationMapping}}</span>
-  <span *ngIf="value.max && value.min">{{value.min}} to {{value.max | i18nPlural: translationMapping}}</span>
+  <span *ngIf="value?.min && !value?.max">&gt; {{value.min | i18nPlural: translationMapping}}</span>
+  <span *ngIf="value?.max && !value?.min">&lt; {{value.max | i18nPlural: translationMapping}}</span>
+  <span *ngIf="value?.max && value?.min">{{value.min}} to {{value.max | i18nPlural: translationMapping}}</span>
 </ng-template>
 
 <ng-template #lifeExpectancyTimestamp

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/doc/doc.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/doc/doc.component.html
@@ -1,2 +1,2 @@
 <a href="{{ docUrl }}"
-   target="_blank">{{ docText }}</a>
+   target="_blank">&nbsp;{{ docText }}</a>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -72,7 +72,8 @@
               i18n-title
               i18n-description
               class="toolbar-action"
-              placement="bottom">
+              placement="bottom"
+              *ngIf="fetchData?.observers?.length > 0">
         <svg cdsIcon="renew"
              size="16"
              [ngClass]="{ 'cds--toolbar-action__icon': true, 'reload': loadingIndicator }"></svg>
@@ -195,7 +196,8 @@
                   (selectPage)="onPageChange($event)"
                   [disabled]="limit === 0"
                   [skeleton]="loadingIndicator"
-                  [pageInputDisabled]="limit === 0">
+                  [pageInputDisabled]="limit === 0"
+                  *ngIf="footer">
   </cds-pagination>
 </cds-table-container>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -411,7 +411,7 @@ export class TableComponent implements AfterViewInit, OnInit, OnChanges, OnDestr
                 template: col?.headerTemplate,
                 // if cellClass is a function it cannot be called here as it requires table data to execute
                 // instead if cellClass is a function it will be called and applied while parsing the data
-                className: _.isString(col?.cellClass) ? col?.cellClass : col?.className,
+                className: _.isString(col?.cellClass) ? `${col?.cellClass}` : `${col?.className}`,
                 visible: !col.isHidden,
                 sortable: _.isNil(col.sortable) ? true : col.sortable
               })
@@ -553,12 +553,12 @@ export class TableComponent implements AfterViewInit, OnInit, OnChanges, OnDestr
     // this method was triggered by ngOnChanges().
     if (this.fetchData.observers.length > 0) {
       this.loadingIndicator = true;
+      const loadingSubscription = this.fetchData.subscribe(() => {
+        this.loadingIndicator = false;
+        this.cdRef.detectChanges();
+      });
+      this._subscriptions.add(loadingSubscription);
     }
-    const loadingSubscription = this.fetchData.subscribe(() => {
-      this.loadingIndicator = false;
-      this.cdRef.detectChanges();
-    });
-    this._subscriptions.add(loadingSubscription);
 
     if (_.isInteger(this.autoReload) && this.autoReload > 0) {
       this.reloadSubscriber = this.timerService

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -237,4 +237,5 @@ formly-form {
 // Overriding legend css due to change in bootstrap v5 and setting it to none;
 legend {
   float: none;
+  margin-top: 1rem;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/_carbon-defaults.scss
@@ -46,6 +46,18 @@ tr.cds--expandable-row > td:first-of-type {
   padding-inline-start: 1rem !important;
 }
 
+tr.cds--expandable-row {
+  th,
+  tr td {
+    padding-inline-start: 0;
+  }
+}
+
+tbody:has(td.cds--table-column-checkbox) > tr.cds--expandable-row[data-child-row] td,
+tr.cds--parent-row.cds--expandable-row + tr[data-child-row] td {
+  padding-inline-start: 1rem;
+}
+
 th {
   padding-block: 0 !important;
 }


### PR DESCRIPTION
- fixes table in table structure's unusual padding
- fixes the ceph fs details page where table was getting hidden
- improving the subvolume list page by changing the spacings there
- hide the refresh button where it shouldn't be shown.
- fixes the osd details view where disks and osds are not shown in it.
- fixes the service count issue in the expand cluster view.

Fixes: https://tracker.ceph.com/issues/68050


**BEFORE**
![Screenshot from 2024-09-12 18-59-19](https://github.com/user-attachments/assets/123ff9f4-1782-47d1-8fa0-a90c8cca120e)
![Screenshot from 2024-09-12 18-59-30](https://github.com/user-attachments/assets/70c77ed5-dcc4-4496-9218-8852b62fca5c)
![Screenshot from 2024-09-12 18-59-37](https://github.com/user-attachments/assets/810de36b-261d-4722-8da3-1e382a256f47)
![Screenshot from 2024-09-12 19-02-04](https://github.com/user-attachments/assets/3a37e014-434d-421f-911e-ed522684df54)



**AFTER**
![Screenshot from 2024-09-12 18-49-36](https://github.com/user-attachments/assets/49865ede-915b-4236-85af-1eeda68bad25)
![Screenshot from 2024-09-12 18-49-48](https://github.com/user-attachments/assets/956d9fcb-9caa-4c3c-b100-e4577839a1e9)
![Screenshot from 2024-09-12 18-50-03](https://github.com/user-attachments/assets/1f482380-e422-47e6-ab89-7c7a0b5e319f)
![Screenshot from 2024-09-12 18-50-53](https://github.com/user-attachments/assets/0ecaccc0-0bcd-4ceb-8633-c01b9c942d5a)
![Screenshot from 2024-09-12 18-49-25](https://github.com/user-attachments/assets/0c5e00de-5332-4a56-b6ce-89cf73d5daf7)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
