### PR TITLE
qa/tasks/tox: unpin tox version

### DIFF
--- a/qa/tasks/tox.py
+++ b/qa/tasks/tox.py
@@ -35,7 +35,7 @@ def task(ctx, config):
         ctx.cluster.only(client).run(args=[
             'source', '{tvdir}/bin/activate'.format(tvdir=tvdir),
             run.Raw('&&'),
-            'pip', 'install', 'tox==3.15.0'
+            'pip', 'install', 'tox'
         ])
 
     # export the path Keystone and Tempest


### PR DESCRIPTION
noticed when debugging https://tracker.ceph.com/issues/67986 that our tox has been pinned to an old version. after unpinning, 4.18.1 appears to be the current version from pip

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
