### PR TITLE
quincy: rbd-mirror: use correct ioctx for namespace

### DIFF
--- a/src/test/rbd_mirror/test_mock_PoolReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_PoolReplayer.cc
@@ -363,6 +363,14 @@ public:
           Return(0)));
   }
 
+  void expect_clone(librados::MockTestMemIoCtxImpl* mock_io_ctx) {
+    EXPECT_CALL(*mock_io_ctx, clone())
+      .WillRepeatedly(Invoke([mock_io_ctx]() {
+          mock_io_ctx->get();
+          return mock_io_ctx;
+        }));
+  }
+
   void expect_leader_watcher_init(MockLeaderWatcher& mock_leader_watcher,
                                   int r) {
     EXPECT_CALL(mock_leader_watcher, init())
@@ -727,6 +735,7 @@ TEST_F(TestMockPoolReplayer, Namespaces) {
   auto mock_remote_rados_client = mock_cluster.do_create_rados_client(
       g_ceph_context);
 
+  expect_clone(mock_local_io_ctx);
   expect_mirror_mode_get(mock_local_io_ctx);
 
   InSequence seq;
@@ -845,6 +854,7 @@ TEST_F(TestMockPoolReplayer, NamespacesError) {
   auto mock_remote_rados_client = mock_cluster.do_create_rados_client(
       g_ceph_context);
 
+  expect_clone(mock_local_io_ctx);
   expect_mirror_mode_get(mock_local_io_ctx);
 
   InSequence seq;

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -741,8 +741,12 @@ int PoolReplayer<I>::list_mirroring_namespaces(
   }
 
   for (auto &name : names) {
+    librados::IoCtx ns_ioctx;
+    ns_ioctx.dup(m_local_io_ctx);
+    ns_ioctx.set_namespace(name);
+
     cls::rbd::MirrorMode mirror_mode = cls::rbd::MIRROR_MODE_DISABLED;
-    int r = librbd::cls_client::mirror_mode_get(&m_local_io_ctx, &mirror_mode);
+    int r = librbd::cls_client::mirror_mode_get(&ns_ioctx, &mirror_mode);
     if (r < 0 && r != -ENOENT) {
       derr << "failed to get namespace mirror mode: " << cpp_strerror(r)
            << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67762

---

backport of https://github.com/ceph/ceph/pull/59401
parent tracker: https://tracker.ceph.com/issues/67676

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh