### PR TITLE
Add Asok Command: Dump Messenger Status (Connections, TCP stats, ..)

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -80,6 +80,8 @@
   an empty string can be assigned to it. Additionally, commands
   `ceph fs subvolume earmark set`, `ceph fs subvolume earmark get` and
   `ceph fs subvolume earmark rm` have been added to set, get and remove earmark from a given subvolume.
+* RADOS: Add ``messenger dump`` command to retrieve runtime information
+  on connections, sockets, and kernel TCP stats from the messenger.
 
 * RADOS: A performance botteneck in the balancer mgr module has been fixed.
   Related Tracker: https://tracker.ceph.com/issues/68657

--- a/doc/rados/operations/monitoring.rst
+++ b/doc/rados/operations/monitoring.rst
@@ -655,3 +655,86 @@ Runtime`_.
 
 .. _Viewing a Configuration at Runtime: ../../configuration/ceph-conf#viewing-a-configuration-at-runtime
 .. _Storage Capacity: ../../configuration/mon-config-ref#storage-capacity
+
+Messenger Status
+=================
+
+Ceph daemons and librados clients support an admin socket command
+``messenger dump`` that surfaces a snapshot of runtime information
+about connections, sockets, bound addresses, and kernel TCP stats (via
+tcp(7) TCP_INFO).
+
+.. note:: The queried messenger needs to lock the connection data
+  structures for the time it takes to create the snapshot. This lock's
+  duration is in the order of tens of milliseconds. This might
+  interfere with normal operation. Use the ``dumpcontents`` argument
+  to limit data structures dumped.
+
+Examples
+---------
+
+When a command is issued without specifying a messenger to dump, the
+list of available messengers is returned:
+
+.. prompt:: bash $
+
+   ceph tell osd.0 messenger dump
+
+.. code-block:: javascript
+
+ {
+    "messengers": [
+        "client",
+        "cluster",
+        "hb_back_client",
+        "hb_back_server",
+        "hb_front_client",
+        "hb_front_server",
+        "ms_objecter",
+        "temp_mon_client"
+    ]
+  }
+
+The ``client`` and ``cluster`` messengers correspond to the configured
+client / cluster network (see :doc:`/rados/configuration/network-config-ref`). Messengers
+with ``hb_`` prefix are part of the heartbeat system.
+
+List all current connections on the client messenger:
+
+.. code-block:: bash
+
+	    ceph tell osd.0 messenger dump client \
+	       | jq -r '.messenger.connections[].async_connection |
+	                   [.conn_id, .socket_fd, .worker_id,
+			    if .status.connected then "connected" else "disconnected" end,
+			    .state,
+			    "\(.peer.type).\(.peer.entity_name.id).\(.peer.id)",
+			    .protocol.v2.con_mode, .protocol.v2.crypto.rx, .protocol.v2.compression.rx] |
+			   @tsv'
+
+.. code-block:: bash
+
+  249     102     0       connected       STATE_CONNECTION_ESTABLISHED    client.admin.6407       crc    PLAIN   UNCOMPRESSED
+  242     99      1       connected       STATE_CONNECTION_ESTABLISHED    client.rgw.8000.4473    crc     PLAIN   UNCOMPRESSED
+  248     89      1       connected       STATE_CONNECTION_ESTABLISHED    mgr..-1 secure  AES-128-GCM     UNCOMPRESSED
+  32      101     2       connected       STATE_CONNECTION_ESTABLISHED    client.rgw.8000.4483    crc     PLAIN   UNCOMPRESSED
+  3       86      2       connected       STATE_CONNECTION_ESTABLISHED    mon..-1 secure  AES-128-GCM     UNCOMPRESSED
+  244     102     0       connected       STATE_CONNECTION_ESTABLISHED    client.admin.6383       crc     PLAIN   UNCOMPRESSED
+
+
+Print active connections and their TCP round trip time and retransmission counters:
+
+.. code-block:: bash
+
+	    ceph tell osd.0 messenger dump client --tcp-info \
+	       | jq -r '.messenger.connections[].async_connection |
+	                   select(.status.connected) |
+			   select(.peer.type != "client") |
+			   [.conn_id, .socket_fd, .worker_id,
+			    "\(.peer.type).\(.peer.global_id)",
+			    .tcp_info.tcpi_rtt_us, .tcp_info.tcpi_rttvar_us, .tcp_info.tcpi_total_retrans] |
+			    @tsv'
+.. code-block:: bash
+
+	248     89      1       mgr.0   863     1677    0
+	3       86      2       mon.0   230     278     0

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -2900,6 +2900,51 @@ function test_per_pool_scrub_status()
   ceph osd pool rm noscrub_pool2 noscrub_pool2 --yes-i-really-really-mean-it
 }
 
+function do_messenger_dump_basics_test()
+{
+  local target="$1"
+  ceph tell "$target" messenger dump | expect_true jq --exit-status '.messengers | length > 0'
+  ceph tell "$target" messenger dump | jq -r '.messengers[]' | while read messenger; do
+    dump="$(ceph tell "$target" messenger dump "$messenger" all)"
+    expect_true jq --exit-status 'has("messenger")' <<< "$dump"
+    expect_true jq --exit-status 'has("name")' <<< "$dump"
+    expect_true jq --arg expected_messenger "$messenger" --exit-status '
+	 .name == $expected_messenger' <<< "$dump"
+    expect_true jq --exit-status '.messenger | type == "object"' <<< "$dump"
+    expect_true jq --exit-status '.messenger |
+        all([.connections,
+             .listen_sockets,
+	     .anon_conns,
+	     .accepting_conns,
+	     .deleted_conns][];
+            type == "array")' \
+		<<< "$dump"
+  done
+}
+
+function test_osd_messenger_dump()
+{
+  do_messenger_dump_basics_test osd.0
+}
+function test_mon_messenger_dump()
+{
+  do_messenger_dump_basics_test mon.a
+  # Testing the tcp_info feature requires at lease one messenger TCP
+  # conneciton. Test only the mon as it is very unlikely that it
+  # doesn't have an active connection. Also only test for one
+  # connection, as disconnected connections don't set tcp_info
+  expect_true ceph tell "$target" messenger dump mon --tcp-info \
+    | jq 'any(.messenger.connections[].async_connection.tcp_info; has("tcpi_state"))'
+}
+function test_mgr_messenger_dump()
+{
+  do_messenger_dump_basics_test mgr
+}
+function test_mds_messenger_dump()
+{
+  do_messenger_dump_basics_test mds.a
+}
+
 #
 # New tests should be added to the TESTS array below
 #
@@ -2944,6 +2989,7 @@ MON_TESTS+=" mon_caps"
 MON_TESTS+=" mon_cephdf_commands"
 MON_TESTS+=" mon_tell_help_command"
 MON_TESTS+=" mon_stdin_stdout"
+MON_TESTS+=" mon_messenger_dump"
 
 OSD_TESTS+=" osd_bench"
 OSD_TESTS+=" osd_negative_filestore_merge_threshold"
@@ -2952,14 +2998,17 @@ OSD_TESTS+=" admin_heap_profiler"
 OSD_TESTS+=" osd_tell_help_command"
 OSD_TESTS+=" osd_compact"
 OSD_TESTS+=" per_pool_scrub_status"
+OSD_TESTS+=" osd_messenger_dump"
 
 MDS_TESTS+=" mds_tell"
 MDS_TESTS+=" mon_mds"
 MDS_TESTS+=" mon_mds_metadata"
 MDS_TESTS+=" mds_tell_help_command"
+MDS_TESTS+=" mds_messenger_dump"
 
 MGR_TESTS+=" mgr_tell"
 MGR_TESTS+=" mgr_devices"
+MGR_TESTS+=" mgr_messenger_dump"
 
 TESTS+=$MON_TESTS
 TESTS+=$OSD_TESTS

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -104,7 +104,8 @@ set(common_srcs
   pretty_binary.cc
   utf8.c
   util.cc
-  version.cc)
+  version.cc
+  tcp_info.cc)
 
 if(WITH_SYSTEMD)
   list(APPEND common_srcs

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -47,6 +47,7 @@
 #include "crush/CrushLocation.h"
 
 class AdminSocket;
+class AdminSocketHook;
 class CryptoHandler;
 class CryptoRandom;
 class MonMap;
@@ -381,8 +382,13 @@ private:
 #ifdef CEPH_DEBUG_MUTEX
   md_config_obs_t *_lockdep_obs;
 #endif
+
+  std::unique_ptr<AdminSocketHook> _msgr_hook;
+  ceph::mutex _msgr_hook_lock = ceph::make_mutex("CephContext::msgr_hook");
 public:
   TOPNSPC::crush::CrushLocation crush_location;
+  void modify_msgr_hook(std::function<AdminSocketHook*(void)> create,
+			std::function<void(AdminSocketHook*)> add);
 private:
 
   enum {

--- a/src/common/tcp_info.cc
+++ b/src/common/tcp_info.cc
@@ -1,0 +1,121 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2024 Clyso GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "common/tcp_info.h"
+
+#include "common/Formatter.h"
+
+namespace ceph {
+
+#ifdef _WIN32
+struct tcp_info {};
+
+bool tcp_info(int fd, struct tcp_info& info) {
+  return false;
+}
+bool dump_tcp_info(int fd, Formatter* f) {
+  return false;
+}
+
+#else
+
+bool tcp_info(int fd, struct tcp_info& info) {
+  socklen_t info_len = sizeof(info);
+  return (getsockopt(fd, SOL_TCP, TCP_INFO, &info, &info_len) == 0);
+}
+
+static const char* get_tcpi_state_name(uint8_t state) {
+  switch (state) {
+    case TCP_ESTABLISHED:
+      return "established";
+    case TCP_SYN_SENT:
+      return "syn sent";
+    case TCP_SYN_RECV:
+      return "syn recv";
+    case TCP_FIN_WAIT1:
+      return "fin wait1";
+    case TCP_FIN_WAIT2:
+      return "fin wait2";
+    case TCP_TIME_WAIT:
+      return "time wait";
+    case TCP_CLOSE:
+      return "close";
+    case TCP_CLOSE_WAIT:
+      return "close wait";
+    case TCP_LAST_ACK:
+      return "last ack";
+    case TCP_LISTEN:
+      return "listen";
+    case TCP_CLOSING:
+      return "closing";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+bool dump_tcp_info(int fd, Formatter* f) {
+  struct tcp_info info;
+  if (!tcp_info(fd, info)) {
+    return false;
+  }
+
+  f->open_object_section("tcp_info");
+  f->dump_string("tcpi_state", get_tcpi_state_name(info.tcpi_state));
+  f->dump_unsigned("tcpi_retransmits", info.tcpi_retransmits);
+  f->dump_unsigned("tcpi_probes", info.tcpi_probes);
+  f->dump_unsigned("tcpi_backoff", info.tcpi_backoff);
+  f->dump_unsigned("tcpi_rto_us", info.tcpi_rto);
+  f->dump_unsigned("tcpi_ato_us", info.tcpi_ato);
+  f->dump_unsigned("tcpi_snd_mss", info.tcpi_snd_mss);
+  f->dump_unsigned("tcpi_rcv_mss", info.tcpi_rcv_mss);
+  f->dump_unsigned("tcpi_unacked", info.tcpi_unacked);
+  f->dump_unsigned("tcpi_lost", info.tcpi_lost);
+  f->dump_unsigned("tcpi_retrans", info.tcpi_retrans);
+  f->dump_unsigned("tcpi_pmtu", info.tcpi_pmtu);
+  f->dump_unsigned("tcpi_rtt_us", info.tcpi_rtt);
+  f->dump_unsigned("tcpi_rttvar_us", info.tcpi_rttvar);
+  f->dump_unsigned("tcpi_total_retrans", info.tcpi_total_retrans);
+  f->dump_unsigned("tcpi_last_data_sent_ms", info.tcpi_last_data_sent);
+  f->dump_unsigned("tcpi_last_ack_sent_ms", info.tcpi_last_ack_sent);
+  f->dump_unsigned("tcpi_last_data_recv_ms", info.tcpi_last_data_recv);
+  f->dump_unsigned("tcpi_last_ack_recv_ms", info.tcpi_last_ack_recv);
+
+  f->open_array_section("tcpi_options");
+  if (info.tcpi_options & TCPI_OPT_TIMESTAMPS) {
+    f->dump_string("option", "timestamps");
+  }
+  if (info.tcpi_options & TCPI_OPT_SACK) {
+    f->dump_string("option", "sack");
+  }
+  if (info.tcpi_options & TCPI_OPT_WSCALE) {
+    f->dump_string("option", "wscale");
+  }
+  if (info.tcpi_options & TCPI_OPT_ECN) {
+    f->dump_string("option", "ecn");
+  }
+  if (info.tcpi_options & TCPI_OPT_ECN_SEEN) {
+    f->dump_string("option", "ecn seen");
+  }
+  if (info.tcpi_options & TCPI_OPT_SYN_DATA) {
+    f->dump_string("option", "syn data");
+  }
+  f->close_section();
+
+  f->close_section();
+  return true;
+}
+
+#endif
+
+}  // namespace ceph

--- a/src/common/tcp_info.h
+++ b/src/common/tcp_info.h
@@ -1,0 +1,30 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2024 Clyso GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+
+#include "Formatter.h"
+
+namespace ceph {
+
+/// Return TCP_INFO socket stats (see tcp(7)). Return true on success.
+bool tcp_info(int fd, struct tcp_info& info);
+/// Dump TCP_INFO socket stats to formatter. Use struct tcp_info variables
+/// names as keys. Returns true on success.
+bool dump_tcp_info(int fd, Formatter* f);
+
+}  // namespace ceph

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -298,13 +298,13 @@ public:
    * Get the number of Messages which the Messenger has received
    * but not yet dispatched.
    */
-  virtual int get_dispatch_queue_len() = 0;
+  virtual int get_dispatch_queue_len() const = 0;
 
   /**
    * Get age of oldest undelivered message
    * (0 if the queue is empty)
    */
-  virtual double get_dispatch_queue_max_age(utime_t now) = 0;
+  virtual double get_dispatch_queue_max_age(utime_t now) const = 0;
 
   /**
    * @} // Accessors
@@ -522,7 +522,9 @@ public:
    * @} // Startup/Shutdown
    */
 
-  virtual void dump(Formatter* f) = 0;
+  virtual void dump(
+      Formatter* f, std::function<bool(const std::string&)> filter =
+                        [](const std::string&) { return true; }) const = 0;
 
   /**
    * @defgroup Messaging

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -28,6 +28,7 @@
 #include "Message.h"
 #include "Dispatcher.h"
 #include "Policy.h"
+#include "common/Formatter.h"
 #include "common/Throttle.h"
 #include "include/Context.h"
 #include "include/types.h"
@@ -520,6 +521,8 @@ public:
   /**
    * @} // Startup/Shutdown
    */
+
+  virtual void dump(Formatter* f) = 0;
 
   /**
    * @defgroup Messaging

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -14,9 +14,15 @@
  *
  */
 
+#include <fmt/core.h>
 #include <unistd.h>
 
+#include "common/ceph_strings.h"
+#include "common/ceph_time.h"
+#include "common/iso_8601.h"
+#include "common/tcp_info.h"
 #include "include/Context.h"
+#include "include/msgr.h"
 #include "include/random.h"
 #include "common/errno.h"
 #include "AsyncMessenger.h"
@@ -809,4 +815,62 @@ void AsyncConnection::tick(uint64_t id)
       last_tick_id = center->create_time_event(inactive_timeout_us, tick_handler);
     }
   }
+}
+
+void AsyncConnection::dump(Formatter *f) {
+  std::lock_guard<std::mutex> l(lock);
+
+  f->open_object_section("async_connection");
+  f->dump_string("state", get_state_name(state));
+  f->dump_unsigned("messenger_nonce", async_msgr->get_nonce());
+
+  f->open_object_section("status");
+  f->dump_bool("connected", is_connected());
+  f->dump_bool("loopback", is_loopback);
+  f->close_section();  // status
+
+  if (cs) {
+    f->dump_int("socket_fd", cs.fd());
+    if (!dump_tcp_info(cs.fd(), f)) {
+      f->dump_null("tcp_info");
+    }
+  } else {
+    f->dump_null("socket_fd");
+    f->dump_null("tcp_info");
+  }
+  f->dump_int("conn_id", conn_id);
+
+  f->open_object_section("peer");
+  f->dump_object("entity_name", get_peer_entity_name());
+  f->dump_string("type", ceph_entity_type_name(get_peer_type()));
+  f->dump_int("id", get_peer_id());
+  f->dump_int("global_id", get_peer_global_id());
+  f->open_object_section("addr");
+  peer_addrs->dump(f);
+  f->close_section();  // addr
+  f->close_section();  // peer
+
+  f->dump_string("last_connect_started_ago",
+                 ceph::timespan_str(ceph::coarse_mono_clock::now() -
+                                    last_connect_started));
+  f->dump_string(
+      "last_active_ago",
+      fmt::format("{}", ceph::timespan_str(ceph::coarse_mono_clock::now() -
+                                           last_active)));
+  f->dump_string("recv_start_time_ago",
+                 fmt::format("{}", ceph::timespan_str(ceph::mono_clock::now() -
+                                                      recv_start_time)));
+  f->dump_unsigned("last_tick_id", last_tick_id);
+  f->dump_object("socket_addr", socket_addr);
+  f->dump_object("target_addr", target_addr);
+  f->dump_int("port", port);
+  f->open_object_section("protocol");
+  if (protocol) {
+    protocol->dump(f);
+  } else {
+    f->dump_null("null");
+  }
+  f->close_section();  // protocol
+  f->dump_int("worker_id", worker ? worker->id : -1);
+  f->close_section();  // async_connection
 }

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -817,7 +817,7 @@ void AsyncConnection::tick(uint64_t id)
   }
 }
 
-void AsyncConnection::dump(Formatter *f) {
+void AsyncConnection::dump(Formatter *f, bool tcp_info) {
   std::lock_guard<std::mutex> l(lock);
 
   f->open_object_section("async_connection");
@@ -831,7 +831,7 @@ void AsyncConnection::dump(Formatter *f) {
 
   if (cs) {
     f->dump_int("socket_fd", cs.fd());
-    if (!dump_tcp_info(cs.fd(), f)) {
+    if (!tcp_info || !dump_tcp_info(cs.fd(), f)) {
       f->dump_null("tcp_info");
     }
   } else {

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -243,6 +243,8 @@ private:
 
   bool is_msgr2() const override;
 
+  void dump(Formatter* f);
+
   friend class Protocol;
   friend class ProtocolV1;
   friend class ProtocolV2;

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -243,7 +243,7 @@ private:
 
   bool is_msgr2() const override;
 
-  void dump(Formatter* f);
+  void dump(Formatter* f, bool tcp_info);
 
   friend class Protocol;
   friend class ProtocolV1;

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -97,11 +97,11 @@ public:
    */
   bool set_addr_unknowns(const entity_addrvec_t &addr) override;
 
-  int get_dispatch_queue_len() override {
+  int get_dispatch_queue_len() const override {
     return dispatch_queue.get_queue_len();
   }
 
-  double get_dispatch_queue_max_age(utime_t now) override {
+  double get_dispatch_queue_max_age(utime_t now) const override {
     return dispatch_queue.get_max_age(now);
   }
   /** @} Accessors */
@@ -137,7 +137,9 @@ public:
   void wait() override;
   int shutdown() override;
 
-  void dump(Formatter* f) override;
+  void dump(
+      Formatter* f, std::function<bool(const std::string&)> filter =
+      [](const std::string&) { return true; }) const override;
 
   /** @} // Startup/Shutdown */
 
@@ -225,7 +227,7 @@ private:
   std::string ms_type;
 
   /// overall lock used for AsyncMessenger data structures
-  ceph::mutex lock = ceph::make_mutex("AsyncMessenger::lock");
+  mutable ceph::mutex lock = ceph::make_mutex("AsyncMessenger::lock");
   // AsyncMessenger stuff
   /// approximately unique ID set by the Constructor for use in entity_addr_t
   uint64_t nonce;

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -81,7 +81,7 @@ class AsyncMessengerSocketHook : public AdminSocketHook {
   int call(
       std::string_view command, const cmdmap_t& cmdmap, const bufferlist&,
       Formatter* f, std::ostream& errss, ceph::buffer::list& out) override;
-  void add_messenger(const std::string& name, AsyncMessenger& msgr);
+  bool add_messenger(const std::string& name, AsyncMessenger& msgr);
   void remove_messenger(AsyncMessenger& msgr);
   std::list<std::string> messengers() const;
 };

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -62,6 +62,7 @@ class Processor {
 	   entity_addrvec_t* bound_addrs);
   void start();
   void accept();
+  friend class AsyncMessenger;
 };
 
 /*
@@ -135,6 +136,8 @@ public:
   int start() override;
   void wait() override;
   int shutdown() override;
+
+  void dump(Formatter* f) override;
 
   /** @} // Startup/Shutdown */
 

--- a/src/msg/async/Protocol.h
+++ b/src/msg/async/Protocol.h
@@ -132,6 +132,8 @@ public:
   virtual void write_event() = 0;
   virtual bool is_queued() = 0;
 
+  virtual void dump(Formatter *f) = 0;
+
   int get_con_mode() const {
     return auth_meta->con_mode;
   }

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -422,6 +422,17 @@ bool ProtocolV1::is_queued() {
   return !out_q.empty() || connection->is_queued();
 }
 
+void ProtocolV1::dump(Formatter* f) {
+  f->open_object_section("v1");
+  f->dump_string("state", get_state_name(state));
+  f->dump_unsigned("connect_seq", connect_seq);
+  f->dump_unsigned("peer_global_seq", peer_global_seq);
+  if (auth_meta) {
+    f->dump_string("con_mode", ceph_con_mode_name(auth_meta->con_mode));
+  }
+  f->close_section();  // v1
+}
+
 void ProtocolV1::run_continuation(CtPtr pcontinuation) {
   if (pcontinuation) {
     CONTINUATION_RUN(*pcontinuation);

--- a/src/msg/async/ProtocolV1.h
+++ b/src/msg/async/ProtocolV1.h
@@ -235,6 +235,8 @@ public:
   virtual void write_event() override;
   virtual bool is_queued() override;
 
+  virtual void dump(Formatter *f) override;
+
   // Client Protocol
 private:
   int global_seq;

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -766,6 +766,40 @@ bool ProtocolV2::is_queued() {
   return !out_queue.empty() || connection->is_queued();
 }
 
+void ProtocolV2::dump(Formatter *f) {
+  f->open_object_section("v2");
+  f->dump_string("state", get_state_name(state));
+  if (auth_meta) {
+    f->dump_string("con_mode", ceph_con_mode_name(auth_meta->con_mode));
+  }
+  f->dump_bool("rev1", HAVE_MSGR2_FEATURE(peer_supported_features, REVISION_1));
+  f->dump_unsigned("connect_seq", connect_seq);
+  f->dump_unsigned("peer_global_seq", peer_global_seq);
+
+  f->open_object_section("crypto");
+  f->dump_string(
+      "rx", session_stream_handlers.rx
+                ? session_stream_handlers.rx->cipher_name()
+                : "PLAIN");
+  f->dump_string(
+      "tx", session_stream_handlers.tx
+                ? session_stream_handlers.tx->cipher_name()
+                : "PLAIN");
+  f->close_section();  // crypto
+
+  f->open_object_section("compression");
+  f->dump_string(
+      "rx", session_compression_handlers.rx
+                ? session_compression_handlers.rx->compressor_name()
+                : "UNCOMPRESSED");
+  f->dump_string(
+      "tx", session_compression_handlers.tx
+                ? session_compression_handlers.tx->compressor_name()
+                : "UNCOMPRESSED");
+  f->close_section();  // compression
+  f->close_section();  // v2
+}
+
 CtPtr ProtocolV2::read(CONTINUATION_RXBPTR_TYPE<ProtocolV2> &next,
                        rx_buffer_t &&buffer) {
   const auto len = buffer->length();

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -223,6 +223,8 @@ public:
   virtual void write_event() override;
   virtual bool is_queued() override;
 
+  virtual void dump(Formatter *f) override;
+
 private:
   // Client Protocol
   CONTINUATION_DECL(ProtocolV2, start_client_banner_exchange);

--- a/src/msg/async/compression_onwire.cc
+++ b/src/msg/async/compression_onwire.cc
@@ -83,4 +83,12 @@ void TxHandler::done()
   ldout(m_cct, 25) << __func__ << " compression ratio=" << get_ratio() << dendl;
 }
 
+std::string_view RxHandler::compressor_name() const {
+  return m_compressor->get_type_name();
+}
+
+std::string_view TxHandler::compressor_name() const {
+  return m_compressor->get_type_name();
+}
+
 } // namespace ceph::compression::onwire

--- a/src/msg/async/compression_onwire.h
+++ b/src/msg/async/compression_onwire.h
@@ -41,6 +41,8 @@ namespace ceph::compression::onwire {
      * @returns true on success, false on failure
      */
     std::optional<ceph::bufferlist> decompress(const ceph::bufferlist &input);
+
+    std::string_view compressor_name() const;
   };
 
   class TxHandler final : private Handler {
@@ -81,6 +83,8 @@ namespace ceph::compression::onwire {
     uint64_t get_final_size() const {
       return m_onwire_size;
     }
+
+    std::string_view compressor_name() const;
 
   private:
     uint64_t m_min_size; 

--- a/src/msg/async/crypto_onwire.cc
+++ b/src/msg/async/crypto_onwire.cc
@@ -76,6 +76,10 @@ public:
 
   void authenticated_encrypt_update(const ceph::bufferlist& plaintext) override;
   ceph::bufferlist authenticated_encrypt_final() override;
+
+  std::string_view cipher_name() const override {
+    return "AES-128-GCM";
+  };
 };
 
 void AES128GCM_OnWireTxHandler::reset_tx_handler(const uint32_t* first,
@@ -198,6 +202,10 @@ public:
   void reset_rx_handler() override;
   void authenticated_decrypt_update(ceph::bufferlist& bl) override;
   void authenticated_decrypt_update_final(ceph::bufferlist& bl) override;
+
+  std::string_view cipher_name() const override {
+    return "AES-128-GCM";
+  };
 };
 
 void AES128GCM_OnWireRxHandler::reset_rx_handler()

--- a/src/msg/async/crypto_onwire.h
+++ b/src/msg/async/crypto_onwire.h
@@ -86,6 +86,8 @@ struct TxHandler {
   // Generates authentication signature and returns bufferlist crafted
   // basing on plaintext from preceding call to _update().
   virtual ceph::bufferlist authenticated_encrypt_final() = 0;
+
+  virtual std::string_view cipher_name() const = 0;
 };
 
 class RxHandler {
@@ -109,6 +111,8 @@ public:
   // for overall decryption sequence.
   // Throws on integrity/authenticity checks
   virtual void authenticated_decrypt_update_final(ceph::bufferlist& bl) = 0;
+
+  virtual std::string_view cipher_name() const = 0;
 };
 
 struct rxtx_t {

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -103,7 +103,7 @@ class MessengerTest : public ::testing::TestWithParam<const char*> {
 class FakeDispatcher : public Dispatcher {
  public:
   struct Session : public RefCountedObject {
-    atomic<uint64_t> count;
+    std::atomic<uint64_t> count;
     ConnectionRef con;
 
     explicit Session(ConnectionRef c): RefCountedObject(g_ceph_context), count(0), con(c) {
@@ -1744,7 +1744,7 @@ class SyntheticDispatcher : public Dispatcher {
   bool got_connect;
   map<ConnectionRef, list<uint64_t> > conn_sent;
   map<uint64_t, bufferlist> sent;
-  atomic<uint64_t> index;
+  std::atomic<uint64_t> index;
   SyntheticWorkload *workload;
 
   SyntheticDispatcher(bool s, SyntheticWorkload *wl):

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -19,6 +19,7 @@
 #include <list>
 #include <memory>
 #include <set>
+#include <gmock/gmock-matchers.h>
 #include <stdlib.h>
 #include <time.h>
 #include <unistd.h>
@@ -26,6 +27,8 @@
 #include <boost/random/binomial_distribution.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
+#include <sstream>
+#include "common/Formatter.h"
 #include <gtest/gtest.h>
 
 #define MSG_POLICY_UNIT_TESTING
@@ -40,6 +43,7 @@
 #include "msg/Message.h"
 #include "msg/Messenger.h"
 #include "msg/msg_types.h"
+#include "msg/async/AsyncMessenger.h"
 
 typedef boost::mt11213b gen_type;
 
@@ -895,6 +899,122 @@ TEST_P(MessengerTest, ReconnectRaceTest) {
 
   delete cli_interceptor;
   delete srv_interceptor;
+}
+
+TEST_P(MessengerTest, DumpBasics) {
+  // rudimentary check dump results. see integration test in
+  // qa/workunits/cephtool/test.sh for detailed tests
+  if (std::strstr(GetParam(), "async") == nullptr) {
+    GTEST_SKIP() << "skipping as only async messengers have a messenger dump hook";
+  }
+
+  FakeDispatcher cli_dispatcher(false), srv_dispatcher(true);
+  entity_addr_t bind_addr;
+  bind_addr.parse("v2:127.0.0.1");
+  server_msgr->bind(bind_addr);
+  server_msgr->add_dispatcher_head(&srv_dispatcher);
+  server_msgr->start();
+  client_msgr->add_dispatcher_head(&cli_dispatcher);
+  client_msgr->start();
+
+  auto f = Formatter::create_unique("json");
+  std::ostringstream os;
+
+  server_msgr->get_myaddrs().dump(f.get());
+  f->flush(os);
+  const auto server_addr = os.str();
+
+  ConnectionRef conn = client_msgr->connect_to(server_msgr->get_mytype(),
+					       server_msgr->get_myaddrs());
+  f->reset();
+  os.clear();
+  server_msgr->dump(f.get());
+  f->flush(os);
+  const auto server_dump = os.str();
+  f->reset();
+  os.clear();
+  client_msgr->dump(f.get());
+  f->flush(os);
+  const auto client_dump = os.str();
+
+  ASSERT_THAT(server_dump, ::testing::HasSubstr(server_addr)) << server_dump;
+  ASSERT_THAT(client_dump, ::testing::HasSubstr(server_addr)) << client_dump;
+
+  server_msgr->shutdown();
+  server_msgr->wait();
+  client_msgr->shutdown();
+  client_msgr->wait();
+}
+
+TEST(MessengerTest, AdminSocketHookLifecycle) {
+  DummyAuthClientServer dummy_auth(g_ceph_context);
+  Messenger* server_msgr = Messenger::create(
+      g_ceph_context, "async+unix", entity_name_t::OSD(0), "server", getpid());
+  Messenger* client_msgr = Messenger::create(
+      g_ceph_context, "async+unix", entity_name_t::CLIENT(-1), "client",
+      getpid());
+  server_msgr->set_default_policy(Messenger::Policy::stateless_server(0));
+  client_msgr->set_default_policy(Messenger::Policy::lossy_client(0));
+  server_msgr->set_auth_client(&dummy_auth);
+  server_msgr->set_auth_server(&dummy_auth);
+  client_msgr->set_auth_client(&dummy_auth);
+  client_msgr->set_auth_server(&dummy_auth);
+  server_msgr->set_require_authorizer(false);
+  FakeDispatcher cli_dispatcher(false), srv_dispatcher(true);
+  entity_addr_t bind_addr;
+  bind_addr.parse("v2:127.0.0.1");
+  server_msgr->bind(bind_addr);
+  server_msgr->add_dispatcher_head(&srv_dispatcher);
+  server_msgr->start();
+  client_msgr->add_dispatcher_head(&cli_dispatcher);
+  client_msgr->start();
+
+  bool create_called = false;
+  bool add_called = false;
+  g_ceph_context->modify_msgr_hook(
+      [&]() -> AdminSocketHook* {
+        create_called = true;
+        return nullptr;
+      },
+      [&](AdminSocketHook* ptr) {
+        ASSERT_FALSE(create_called);
+        add_called = true;
+        if (auto hook = dynamic_cast<AsyncMessengerSocketHook*>(ptr)) {
+          auto msgrs = hook->messengers();
+          ASSERT_EQ(2, msgrs.size());
+          ASSERT_THAT(
+              msgrs, ::testing::UnorderedElementsAre("server", "client"));
+        } else {
+          FAIL() << "invalid type";
+        }
+      });
+  ASSERT_TRUE(add_called);
+
+  client_msgr->shutdown();
+  client_msgr->wait();
+  delete client_msgr;
+
+  g_ceph_context->modify_msgr_hook(
+      [&]() -> AdminSocketHook* {
+        create_called = true;
+        return nullptr;
+      },
+      [&](AdminSocketHook* ptr) {
+        ASSERT_FALSE(create_called);
+        add_called = true;
+        if (auto hook = dynamic_cast<AsyncMessengerSocketHook*>(ptr)) {
+          auto msgrs = hook->messengers();
+          ASSERT_EQ(1, msgrs.size());
+          ASSERT_THAT(msgrs, ::testing::ElementsAre("server"));
+        } else {
+          FAIL() << "invalid type";
+        }
+      });
+
+  server_msgr->shutdown();
+  server_msgr->wait();
+
+  delete server_msgr;
 }
 
 TEST_P(MessengerTest, SimpleTest) {


### PR DESCRIPTION
## Goal

Make connection information and statistics of a running Ceph Messenger easily accessible for field debugging.
Export data as JSON to allow tools to display the information.

## Implementation

Add `dump(Formatter..)` methods to the Async Messenger and Connection to dump snapshots of the current state of connections, dispatch queue, workers, listen sockets and TCP socket statistics via TCP_INFO.

Add a utility to get TCP information and statistics from the kernel.

Add a `dump_messenger` command to MON, MGR, OSD, MDS, Objecter and librados.

## Examples

<details>
<summary>bin/ceph tell mgr.x dump_messenger</summary>

```json
{
    "messenger": {
        "mgr": {
            "nonce": 2755615045626245882,
            "my_name": {
                "type": "mgr",
                "num": 4133
            },
            "my_addrs": {
                "addrvec": [
                    {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    {
                        "type": "v1",
                        "addr": "192.168.101.23:6801",
                        "nonce": 3158717178
                    }
                ]
            },
            "listen_sockets": [
                {
                    "socket_fd": 64,
                    "worker_id": 0
                },
                {
                    "socket_fd": 65,
                    "worker_id": 0
                }
            ],
            "dispatch_queue": {
                "length": 0,
                "max_age_ago": "0s"
            },
            "connections_count": 3,
            "connections": [
                {
                    "addrvec": [
                        {
                            "type": "any",
                            "addr": "192.168.101.23:0",
                            "nonce": 1273322280
                        }
                    ],
                    "async_connection": {
                        "state": "STATE_CONNECTION_ESTABLISHED",
                        "messenger_nonce": 2755615045626245882,
                        "status": {
                            "connected": true,
                            "loopback": false
                        },
                        "socket_fd": 69,
                        "tcp_info": {
                            "tcpi_state": "established",
                            "tcpi_retransmits": 0,
                            "tcpi_probes": 0,
                            "tcpi_backoff": 0,
                            "tcpi_rto_us": 203333,
                            "tcpi_ato_us": 40000,
                            "tcpi_snd_mss": 32768,
                            "tcpi_rcv_mss": 3600,
                            "tcpi_unacked": 0,
                            "tcpi_lost": 0,
                            "tcpi_retrans": 0,
                            "tcpi_pmtu": 65535,
                            "tcpi_rtt_us": 149,
                            "tcpi_rttvar_us": 236,
                            "tcpi_total_retrans": 0,
                            "tcpi_last_data_sent_ms": 662950,
                            "tcpi_last_ack_sent_ms": 0,
                            "tcpi_last_data_recv_ms": 2860,
                            "tcpi_last_ack_recv_ms": 2860,
                            "tcpi_options": [
                                "timestamps",
                                "sack",
                                "wscale"
                            ]
                        },
                        "conn_id": 262,
                        "peer": {
                            "entity_name": "mon.",
                            "type": "mon",
                            "id": 2,
                            "global_id": 0,
                            "addr": {
                                "addrvec": [
                                    {
                                        "type": "any",
                                        "addr": "192.168.101.23:0",
                                        "nonce": 1273322280
                                    }
                                ]
                            }
                        },
                        "last_connect_started_ago": "13h",
                        "last_active_ago": "2s",
                        "recv_start_time_ago": "2s",
                        "last_tick_id": 189,
                        "socket_addr": {
                            "type": "v2",
                            "addr": "192.168.101.23:6800",
                            "nonce": 3158717178
                        },
                        "target_addr": {
                            "type": "any",
                            "addr": "192.168.101.23:0",
                            "nonce": 1273322280
                        },
                        "port": -1,
                        "protocol_type": 2,
                        "worker_id": 0
                    }
                },
                {
                    "addrvec": [
                        {
                            "type": "any",
                            "addr": "192.168.101.23:0",
                            "nonce": 526448351
                        }
                    ],
                    "async_connection": {
                        "state": "STATE_CONNECTION_ESTABLISHED",
                        "messenger_nonce": 2755615045626245882,
                        "status": {
                            "connected": true,
                            "loopback": false
                        },
                        "socket_fd": 71,
                        "tcp_info": {
                            "tcpi_state": "established",
                            "tcpi_retransmits": 0,
                            "tcpi_probes": 0,
                            "tcpi_backoff": 0,
                            "tcpi_rto_us": 203333,
                            "tcpi_ato_us": 40000,
                            "tcpi_snd_mss": 32768,
                            "tcpi_rcv_mss": 3600,
                            "tcpi_unacked": 0,
                            "tcpi_lost": 0,
                            "tcpi_retrans": 0,
                            "tcpi_pmtu": 65535,
                            "tcpi_rtt_us": 116,
                            "tcpi_rttvar_us": 187,
                            "tcpi_total_retrans": 0,
                            "tcpi_last_data_sent_ms": 662974,
                            "tcpi_last_ack_sent_ms": 0,
                            "tcpi_last_data_recv_ms": 2890,
                            "tcpi_last_ack_recv_ms": 2890,
                            "tcpi_options": [
                                "timestamps",
                                "sack",
                                "wscale"
                            ]
                        },
                        "conn_id": 261,
                        "peer": {
                            "entity_name": "mon.",
                            "type": "mon",
                            "id": 1,
                            "global_id": 0,
                            "addr": {
                                "addrvec": [
                                    {
                                        "type": "any",
                                        "addr": "192.168.101.23:0",
                                        "nonce": 526448351
                                    }
                                ]
                            }
                        },
                        "last_connect_started_ago": "13h",
                        "last_active_ago": "2s",
                        "recv_start_time_ago": "2s",
                        "last_tick_id": 156,
                        "socket_addr": {
                            "type": "v2",
                            "addr": "192.168.101.23:6800",
                            "nonce": 3158717178
                        },
                        "target_addr": {
                            "type": "any",
                            "addr": "192.168.101.23:0",
                            "nonce": 526448351
                        },
                        "port": -1,
                        "protocol_type": 2,
                        "worker_id": 2
                    }
                },
                {
                    "addrvec": [
                        {
                            "type": "any",
                            "addr": "192.168.101.23:0",
                            "nonce": 443182049
                        }
                    ],
                    "async_connection": {
                        "state": "STATE_CONNECTION_ESTABLISHED",
                        "messenger_nonce": 2755615045626245882,
                        "status": {
                            "connected": true,
                            "loopback": false
                        },
                        "socket_fd": 66,
                        "tcp_info": {
                            "tcpi_state": "established",
                            "tcpi_retransmits": 0,
                            "tcpi_probes": 0,
                            "tcpi_backoff": 0,
                            "tcpi_rto_us": 203333,
                            "tcpi_ato_us": 40000,
                            "tcpi_snd_mss": 32768,
                            "tcpi_rcv_mss": 3584,
                            "tcpi_unacked": 0,
                            "tcpi_lost": 0,
                            "tcpi_retrans": 0,
                            "tcpi_pmtu": 65535,
                            "tcpi_rtt_us": 140,
                            "tcpi_rttvar_us": 236,
                            "tcpi_total_retrans": 0,
                            "tcpi_last_data_sent_ms": 662977,
                            "tcpi_last_ack_sent_ms": 0,
                            "tcpi_last_data_recv_ms": 2890,
                            "tcpi_last_ack_recv_ms": 2890,
                            "tcpi_options": [
                                "timestamps",
                                "sack",
                                "wscale"
                            ]
                        },
                        "conn_id": 260,
                        "peer": {
                            "entity_name": "mon.",
                            "type": "mon",
                            "id": 0,
                            "global_id": 0,
                            "addr": {
                                "addrvec": [
                                    {
                                        "type": "any",
                                        "addr": "192.168.101.23:0",
                                        "nonce": 443182049
                                    }
                                ]
                            }
                        },
                        "last_connect_started_ago": "13h",
                        "last_active_ago": "2s",
                        "recv_start_time_ago": "2s",
                        "last_tick_id": 195,
                        "socket_addr": {
                            "type": "v2",
                            "addr": "192.168.101.23:6800",
                            "nonce": 3158717178
                        },
                        "target_addr": {
                            "type": "any",
                            "addr": "192.168.101.23:0",
                            "nonce": 443182049
                        },
                        "port": -1,
                        "protocol_type": 2,
                        "worker_id": 1
                    }
                }
            ],
            "anon_conns": [
                {
                    "state": "STATE_CLOSED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": false,
                        "loopback": false
                    },
                    "socket_fd": null,
                    "tcp_info": null,
                    "conn_id": 270,
                    "peer": {
                        "entity_name": "client.admin",
                        "type": "client",
                        "id": 4695,
                        "global_id": 4695,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "any",
                                    "addr": "192.168.101.23:0",
                                    "nonce": 1316060334
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "9s",
                    "recv_start_time_ago": "9s",
                    "last_tick_id": 0,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "any",
                        "addr": "192.168.101.23:0",
                        "nonce": 1316060334
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 0
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 75,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 203333,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 536,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 652,
                        "tcpi_rttvar_us": 1167,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 4,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 0,
                        "tcpi_last_ack_recv_ms": 0,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 271,
                    "peer": {
                        "entity_name": "client.admin",
                        "type": "client",
                        "id": 4747,
                        "global_id": 4747,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "any",
                                    "addr": "192.168.101.23:0",
                                    "nonce": 2171041931
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "0s",
                    "recv_start_time_ago": "0.000459719s",
                    "last_tick_id": 194,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "any",
                        "addr": "192.168.101.23:0",
                        "nonce": 2171041931
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 0
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 77,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 206666,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 536,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 5122,
                        "tcpi_rttvar_us": 10208,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 570150,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 570150,
                        "tcpi_last_ack_recv_ms": 570107,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 266,
                    "peer": {
                        "entity_name": "client.admin",
                        "type": "client",
                        "id": 4647,
                        "global_id": 4647,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "any",
                                    "addr": "192.168.101.23:0",
                                    "nonce": 2223455213
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "9m",
                    "recv_start_time_ago": "9m",
                    "last_tick_id": 198,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "any",
                        "addr": "192.168.101.23:0",
                        "nonce": 2223455213
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 1
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 74,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 203333,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 3408,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 265,
                        "tcpi_rttvar_us": 477,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 631330,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 1157,
                        "tcpi_last_ack_recv_ms": 1157,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 265,
                    "peer": {
                        "entity_name": "osd.2",
                        "type": "osd",
                        "id": 2,
                        "global_id": 4207,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "v2",
                                    "addr": "192.168.101.23:6818",
                                    "nonce": 767111767
                                },
                                {
                                    "type": "v1",
                                    "addr": "192.168.101.23:6819",
                                    "nonce": 767111767
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "1.1567s",
                    "recv_start_time_ago": "1.15617s",
                    "last_tick_id": 197,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6818",
                        "nonce": 767111767
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 1
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 70,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 203333,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 3408,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 263,
                        "tcpi_rttvar_us": 480,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 645080,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 4907,
                        "tcpi_last_ack_recv_ms": 4907,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 263,
                    "peer": {
                        "entity_name": "osd.0",
                        "type": "osd",
                        "id": 0,
                        "global_id": 4184,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "v2",
                                    "addr": "192.168.101.23:6802",
                                    "nonce": 15296027
                                },
                                {
                                    "type": "v1",
                                    "addr": "192.168.101.23:6803",
                                    "nonce": 15296027
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "4s",
                    "recv_start_time_ago": "4s",
                    "last_tick_id": 196,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6802",
                        "nonce": 15296027
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 1
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 76,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 206666,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 536,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 5702,
                        "tcpi_rttvar_us": 11359,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 662987,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 662987,
                        "tcpi_last_ack_recv_ms": 662940,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 258,
                    "peer": {
                        "entity_name": "mgr.x",
                        "type": "client",
                        "id": 4150,
                        "global_id": 4150,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "any",
                                    "addr": "192.168.101.23:0",
                                    "nonce": 1027708740
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "11m",
                    "recv_start_time_ago": "11m",
                    "last_tick_id": 193,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "any",
                        "addr": "192.168.101.23:0",
                        "nonce": 1027708740
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 1
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 73,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 203333,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 3408,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 285,
                        "tcpi_rttvar_us": 514,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 638727,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 3550,
                        "tcpi_last_ack_recv_ms": 3550,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 264,
                    "peer": {
                        "entity_name": "osd.1",
                        "type": "osd",
                        "id": 1,
                        "global_id": 4201,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "v2",
                                    "addr": "192.168.101.23:6810",
                                    "nonce": 1057561382
                                },
                                {
                                    "type": "v1",
                                    "addr": "192.168.101.23:6811",
                                    "nonce": 1057561382
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "3s",
                    "recv_start_time_ago": "3s",
                    "last_tick_id": 157,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6810",
                        "nonce": 1057561382
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 2
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 72,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 203333,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 32768,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 88,
                        "tcpi_rttvar_us": 130,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 662977,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 2890,
                        "tcpi_last_ack_recv_ms": 2890,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 259,
                    "peer": {
                        "entity_name": "mgr.x",
                        "type": "mgr",
                        "id": 4133,
                        "global_id": 4133,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "any",
                                    "addr": "192.168.101.23:0",
                                    "nonce": 1135620142
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "2s",
                    "recv_start_time_ago": "2s",
                    "last_tick_id": 188,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "any",
                        "addr": "192.168.101.23:0",
                        "nonce": 1135620142
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 0
                }
            ],
            "accepting_conns": [
                {
                    "state": "STATE_CLOSED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": false,
                        "loopback": false
                    },
                    "socket_fd": null,
                    "tcp_info": null,
                    "conn_id": 270,
                    "peer": {
                        "entity_name": "client.admin",
                        "type": "client",
                        "id": 4695,
                        "global_id": 4695,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "any",
                                    "addr": "192.168.101.23:0",
                                    "nonce": 1316060334
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "9s",
                    "recv_start_time_ago": "9s",
                    "last_tick_id": 0,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "any",
                        "addr": "192.168.101.23:0",
                        "nonce": 1316060334
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 0
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 75,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 203333,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 536,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 652,
                        "tcpi_rttvar_us": 1167,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 4,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 0,
                        "tcpi_last_ack_recv_ms": 0,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 271,
                    "peer": {
                        "entity_name": "client.admin",
                        "type": "client",
                        "id": 4747,
                        "global_id": 4747,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "any",
                                    "addr": "192.168.101.23:0",
                                    "nonce": 2171041931
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "0s",
                    "recv_start_time_ago": "0.00082067s",
                    "last_tick_id": 194,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "any",
                        "addr": "192.168.101.23:0",
                        "nonce": 2171041931
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 0
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 77,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 206666,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 536,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 5122,
                        "tcpi_rttvar_us": 10208,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 570150,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 570150,
                        "tcpi_last_ack_recv_ms": 570107,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 266,
                    "peer": {
                        "entity_name": "client.admin",
                        "type": "client",
                        "id": 4647,
                        "global_id": 4647,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "any",
                                    "addr": "192.168.101.23:0",
                                    "nonce": 2223455213
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "9m",
                    "recv_start_time_ago": "9m",
                    "last_tick_id": 198,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "any",
                        "addr": "192.168.101.23:0",
                        "nonce": 2223455213
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 1
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 74,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 203333,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 3408,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 265,
                        "tcpi_rttvar_us": 477,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 631330,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 1157,
                        "tcpi_last_ack_recv_ms": 1157,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 265,
                    "peer": {
                        "entity_name": "osd.2",
                        "type": "osd",
                        "id": 2,
                        "global_id": 4207,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "v2",
                                    "addr": "192.168.101.23:6818",
                                    "nonce": 767111767
                                },
                                {
                                    "type": "v1",
                                    "addr": "192.168.101.23:6819",
                                    "nonce": 767111767
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "1.1567s",
                    "recv_start_time_ago": "1.15652s",
                    "last_tick_id": 197,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6818",
                        "nonce": 767111767
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 1
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 70,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 203333,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 3408,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 263,
                        "tcpi_rttvar_us": 480,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 645080,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 4907,
                        "tcpi_last_ack_recv_ms": 4907,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 263,
                    "peer": {
                        "entity_name": "osd.0",
                        "type": "osd",
                        "id": 0,
                        "global_id": 4184,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "v2",
                                    "addr": "192.168.101.23:6802",
                                    "nonce": 15296027
                                },
                                {
                                    "type": "v1",
                                    "addr": "192.168.101.23:6803",
                                    "nonce": 15296027
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "4s",
                    "recv_start_time_ago": "4s",
                    "last_tick_id": 196,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6802",
                        "nonce": 15296027
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 1
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 76,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 206666,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 536,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 5702,
                        "tcpi_rttvar_us": 11359,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 662987,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 662987,
                        "tcpi_last_ack_recv_ms": 662940,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 258,
                    "peer": {
                        "entity_name": "mgr.x",
                        "type": "client",
                        "id": 4150,
                        "global_id": 4150,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "any",
                                    "addr": "192.168.101.23:0",
                                    "nonce": 1027708740
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "11m",
                    "recv_start_time_ago": "11m",
                    "last_tick_id": 193,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "any",
                        "addr": "192.168.101.23:0",
                        "nonce": 1027708740
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 1
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 73,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 203333,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 3408,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 285,
                        "tcpi_rttvar_us": 514,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 638727,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 3550,
                        "tcpi_last_ack_recv_ms": 3550,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 264,
                    "peer": {
                        "entity_name": "osd.1",
                        "type": "osd",
                        "id": 1,
                        "global_id": 4201,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "v2",
                                    "addr": "192.168.101.23:6810",
                                    "nonce": 1057561382
                                },
                                {
                                    "type": "v1",
                                    "addr": "192.168.101.23:6811",
                                    "nonce": 1057561382
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "3s",
                    "recv_start_time_ago": "3s",
                    "last_tick_id": 157,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6810",
                        "nonce": 1057561382
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 2
                },
                {
                    "state": "STATE_CONNECTION_ESTABLISHED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": false
                    },
                    "socket_fd": 72,
                    "tcp_info": {
                        "tcpi_state": "established",
                        "tcpi_retransmits": 0,
                        "tcpi_probes": 0,
                        "tcpi_backoff": 0,
                        "tcpi_rto_us": 203333,
                        "tcpi_ato_us": 40000,
                        "tcpi_snd_mss": 32768,
                        "tcpi_rcv_mss": 32768,
                        "tcpi_unacked": 0,
                        "tcpi_lost": 0,
                        "tcpi_retrans": 0,
                        "tcpi_pmtu": 65535,
                        "tcpi_rtt_us": 88,
                        "tcpi_rttvar_us": 130,
                        "tcpi_total_retrans": 0,
                        "tcpi_last_data_sent_ms": 662977,
                        "tcpi_last_ack_sent_ms": 0,
                        "tcpi_last_data_recv_ms": 2890,
                        "tcpi_last_ack_recv_ms": 2890,
                        "tcpi_options": [
                            "timestamps",
                            "sack",
                            "wscale"
                        ]
                    },
                    "conn_id": 259,
                    "peer": {
                        "entity_name": "mgr.x",
                        "type": "mgr",
                        "id": 4133,
                        "global_id": 4133,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "any",
                                    "addr": "192.168.101.23:0",
                                    "nonce": 1135620142
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "2s",
                    "recv_start_time_ago": "2s",
                    "last_tick_id": 188,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "any",
                        "addr": "192.168.101.23:0",
                        "nonce": 1135620142
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 0
                }
            ],
            "deleted_conns": [
                {
                    "state": "STATE_CLOSED",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": false,
                        "loopback": false
                    },
                    "socket_fd": null,
                    "tcp_info": null,
                    "conn_id": 270,
                    "peer": {
                        "entity_name": "client.admin",
                        "type": "client",
                        "id": 4695,
                        "global_id": 4695,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "any",
                                    "addr": "192.168.101.23:0",
                                    "nonce": 1316060334
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "9s",
                    "recv_start_time_ago": "9s",
                    "last_tick_id": 0,
                    "socket_addr": {
                        "type": "v2",
                        "addr": "192.168.101.23:6800",
                        "nonce": 3158717178
                    },
                    "target_addr": {
                        "type": "any",
                        "addr": "192.168.101.23:0",
                        "nonce": 1316060334
                    },
                    "port": -1,
                    "protocol_type": 2,
                    "worker_id": 0
                }
            ],
            "local_connection": [
                {
                    "state": "STATE_NONE",
                    "messenger_nonce": 2755615045626245882,
                    "status": {
                        "connected": true,
                        "loopback": true
                    },
                    "socket_fd": null,
                    "tcp_info": null,
                    "conn_id": 1,
                    "peer": {
                        "entity_name": "",
                        "type": "mgr",
                        "id": -1,
                        "global_id": 0,
                        "addr": {
                            "addrvec": [
                                {
                                    "type": "v2",
                                    "addr": "192.168.101.23:6800",
                                    "nonce": 3158717178
                                },
                                {
                                    "type": "v1",
                                    "addr": "192.168.101.23:6801",
                                    "nonce": 3158717178
                                }
                            ]
                        }
                    },
                    "last_connect_started_ago": "13h",
                    "last_active_ago": "5h",
                    "recv_start_time_ago": "13h",
                    "last_tick_id": 0,
                    "socket_addr": {
                        "type": "none",
                        "addr": "(unrecognized address family 0)",
                        "nonce": 0
                    },
                    "target_addr": {
                        "type": "none",
                        "addr": "(unrecognized address family 0)",
                        "nonce": 0
                    },
                    "port": -1,
                    "protocol_type": 1,
                    "worker_id": 2
                }
            ]
        }
    }
}
```
</details>

A top-like tool that makes this a bit more palatable is in another repo (with screenshot) https://github.com/irq0/cntop

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

Fixes: https://tracker.ceph.com/issues/69491