### PR TITLE
squid: osd/scrub: decrease default deep scrub chunk size

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -349,8 +349,10 @@ options:
   type: int
   level: advanced
   desc: Maximum number of objects to deep-scrub in a single chunk
-  fmt_desc: The maximum number of object store chunks to scrub during single operation.
-  default: 25
+  fmt_desc: The maximum number of objects to deep-scrub during single internal
+    scrub operation. Large values would improve scrubbing performance but
+    may adversely affect client operations latency.
+  default: 15
   see_also:
   - osd_scrub_chunk_min
   with_legacy: true


### PR DESCRIPTION
The previous default of 25 objects per chunk proved to take too long (many hundreds of milliseconds) on a busy cluster. As the scrubber locks all objects in the chunk for the duration, a large chunk size can cause a significant impact on the client ops' latencies.

Backport of [PR#59636](https://github.com/ceph/ceph/pull/59636)

Original tracker: https://tracker.ceph.com/issues/68057
Backport tracker: https://tracker.ceph.com/issues/68069

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
(cherry picked from commit 8c2ed94e9cbc7b1ed84b034a65b126e16b18a596)
