### PR TITLE
doc/install: add prompts to install-storage-cluster

### DIFF
--- a/doc/install/install-storage-cluster.rst
+++ b/doc/install/install-storage-cluster.rst
@@ -11,9 +11,11 @@ Installing with APT
 ===================
 
 Once you have added either release or development packages to APT, you should
-update APT's database and install Ceph::
+update APT's database and install Ceph:
 
-	sudo apt-get update && sudo apt-get install ceph ceph-mds
+.. prompt:: bash $
+
+   sudo apt-get update && sudo apt-get install ceph ceph-mds
 
 
 Installing with RPM
@@ -22,63 +24,71 @@ Installing with RPM
 To install Ceph with RPMs, execute the following steps:
 
 
-#. Install ``yum-plugin-priorities``. ::
+#. Install ``yum-plugin-priorities``:
 
-	sudo yum install yum-plugin-priorities
+   .. prompt:: bash #
+
+      sudo yum install yum-plugin-priorities
 
 #. Ensure ``/etc/yum/pluginconf.d/priorities.conf`` exists.
 
-#. Ensure ``priorities.conf`` enables the plugin. :: 
+#. Ensure ``priorities.conf`` enables the plugin::
 
-	[main]
-	enabled = 1
+     [main]
+     enabled = 1
 
 #. Ensure your YUM ``ceph.repo`` entry includes ``priority=2``. See
    `Get Packages`_ for details::
 
-	[ceph]
-	name=Ceph packages for $basearch
-	baseurl=https://download.ceph.com/rpm-{ceph-release}/{distro}/$basearch
-	enabled=1
-	priority=2
-	gpgcheck=1
-	gpgkey=https://download.ceph.com/keys/release.asc
+     [ceph]
+     name=Ceph packages for $basearch
+     baseurl=https://download.ceph.com/rpm-{ceph-release}/{distro}/$basearch
+     enabled=1
+     priority=2
+     gpgcheck=1
+     gpgkey=https://download.ceph.com/keys/release.asc
+     
+     [ceph-noarch]
+     name=Ceph noarch packages
+     baseurl=https://download.ceph.com/rpm-{ceph-release}/{distro}/noarch
+     enabled=1
+     priority=2
+     gpgcheck=1
+     gpgkey=https://download.ceph.com/keys/release.asc
+     
+     [ceph-source]
+     name=Ceph source packages
+     baseurl=https://download.ceph.com/rpm-{ceph-release}/{distro}/SRPMS
+     enabled=0
+     priority=2
+     gpgcheck=1
+     gpgkey=https://download.ceph.com/keys/release.asc
 
-	[ceph-noarch]
-	name=Ceph noarch packages
-	baseurl=https://download.ceph.com/rpm-{ceph-release}/{distro}/noarch
-	enabled=1
-	priority=2
-	gpgcheck=1
-	gpgkey=https://download.ceph.com/keys/release.asc
 
-	[ceph-source]
-	name=Ceph source packages
-	baseurl=https://download.ceph.com/rpm-{ceph-release}/{distro}/SRPMS
-	enabled=0
-	priority=2
-	gpgcheck=1
-	gpgkey=https://download.ceph.com/keys/release.asc
+#. Install pre-requisite packages:
 
+   .. prompt:: bash $
 
-#. Install pre-requisite packages::  
-
-	sudo yum install snappy gdisk python-argparse gperftools-libs
+      sudo yum install snappy gdisk python-argparse gperftools-libs
 
 
 Once you have added either release or development packages, or added a
-``ceph.repo`` file to ``/etc/yum.repos.d``, you can install Ceph packages. :: 
+``ceph.repo`` file to ``/etc/yum.repos.d``, you can install Ceph packages:
 
-	sudo yum install ceph
+.. prompt:: bash $
+
+   sudo yum install ceph
 
 
 Installing a Build
 ==================
 
-If you build Ceph from source code, you may install Ceph in user space
-by executing the following:: 
+If you build Ceph from source code, you may install Ceph in user space by
+executing the following:
 
-	sudo ninja install
+.. prompt:: bash $
+
+   sudo ninja install
 
 If you install Ceph locally, ``ninja`` will place the executables in
 ``usr/local/bin``. You may add the Ceph configuration file to the


### PR DESCRIPTION
Add prompts to doc/install/install-storage-cluster.rst.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
