### PR TITLE
quincy: doc/README.md - add ordered list

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,19 @@ we recommend that you build `.deb` or `.rpm` packages, or refer to
 ``ceph.spec.in`` or ``debian/rules`` to see which configuration options are
 specified for production builds.
 
-To build Ceph, make sure that you are in the top-level `ceph` directory that
-contains `do_cmake.sh` and `CONTRIBUTING.rst` and run the following commands:
+To build Ceph, follow this procedure: 
 
-	./do_cmake.sh
-	cd build
-	ninja
+1. Make sure that you are in the top-level `ceph` directory that
+   contains `do_cmake.sh` and `CONTRIBUTING.rst`.
+2. Run the `do_cmake.sh` script:
+
+    >``./do_cmake.sh``
+3. Move into the `build` directory:
+
+    >``cd build``
+4. Use the `ninja` buildsystem to build the development environment:
+
+    >``ninja``
 
 ``do_cmake.sh`` by default creates a "debug build" of Ceph, which can be up to
 five times slower than a non-debug build.  Pass


### PR DESCRIPTION
Add ordered-list formatting to the "Building Ceph" section of README.md.

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 1f21057e4166f2ea9f51ee037eb8e234c1390cfb)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
