### PR TITLE
squid: doc/rados: add osd_deep_scrub_interval setting operation

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1507,6 +1507,14 @@ that they are to be cleaned, and not that they have been examined and found to
 be clean). Misplaced or degraded PGs might not be flagged as ``clean`` (see
 *PG_AVAILABILITY* and *PG_DEGRADED* above).
 
+This document offers two methods of setting the value of
+``osd_deep_scrub_interval``. The first method listed here changes the value of
+``osd_deep_scrub_interval`` globally. The second method listed here changes the
+value of ``osd_deep scrub interval`` for OSDs and for the Manager daemon.
+
+First Method
+~~~~~~~~~~~~
+
 To manually initiate a deep scrub of a clean PG, run the following command:
 
 .. prompt:: bash $
@@ -1516,7 +1524,7 @@ To manually initiate a deep scrub of a clean PG, run the following command:
 Under certain conditions, the warning ``X PGs not deep-scrubbed in time``
 appears. This might be because the cluster contains many large PGs, which take
 longer to deep-scrub. To remedy this situation, you must change the value of
-``osd_deep_scrub_interval`` either globally or for the Manager daemon.
+``osd_deep_scrub_interval`` globally.
 
 #. Confirm that ``ceph health detail`` returns a ``pgs not deep-scrubbed in
    time`` warning::
@@ -1531,6 +1539,46 @@ longer to deep-scrub. To remedy this situation, you must change the value of
    .. prompt:: bash #
 
       ceph config set global osd_deep_scrub_interval 1209600
+
+The above procedure was developed by Eugen Block in September of 2024.
+
+See `Eugen Block's blog post <https://heiterbiswolkig.blogs.nde.ag/2024/09/06/pgs-not-deep-scrubbed-in-time/>`_ for much more detail.
+
+See `Redmine tracker issue #44959 <https://tracker.ceph.com/issues/44959>`_.
+
+Second Method
+~~~~~~~~~~~~~
+
+To manually initiate a deep scrub of a clean PG, run the following command:
+
+.. prompt:: bash $
+
+   ceph pg deep-scrub <pgid>
+
+Under certain conditions, the warning ``X PGs not deep-scrubbed in time``
+appears. This might be because the cluster contains many large PGs, which take
+longer to deep-scrub. To remedy this situation, you must change the value of
+``osd_deep_scrub_interval`` for OSDs and for the Manager daemon.
+
+#. Confirm that ``ceph health detail`` returns a ``pgs not deep-scrubbed in
+   time`` warning::
+
+      # ceph health detail
+      HEALTH_WARN 1161 pgs not deep-scrubbed in time
+      [WRN] PG_NOT_DEEP_SCRUBBED: 1161 pgs not deep-scrubbed in time
+      pg 86.fff not deep-scrubbed since 2024-08-21T02:35:25.733187+0000
+
+#. Change the ``osd_deep_scrub_interval`` for OSDs:   
+
+   .. prompt:: bash #
+
+      ceph config set osd osd_deep_scrub_interval 1209600
+
+#. Change the ``osd_deep_scrub_interval`` for Managers:   
+
+   .. prompt:: bash #
+
+      ceph config set mgr osd_deep_scrub_interval 1209600
 
 The above procedure was developed by Eugen Block in September of 2024.
 


### PR DESCRIPTION
Add a second method of changing the value of osd_deep_scrub_interval to remedy the condition indicated by the "PGs not deep-scrubbed in time" warning.

This procedure was developed by Eugen Block, and is at the time of this commit available on his blog at
https://heiterbiswolkig.blogs.nde.ag/2024/09/06/pgs-not-deep-scrubbed-in-time/

Co-authored-by: Eugen Block <eblock@nde.ag>
Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit f57e99e1731af3affee1c299bb9a79852e31f5ea)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
