### PR TITLE
mgr/dashboard: Nvme mTLS support and  service name changes

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -96,7 +96,7 @@
                     name="pool"
                     class="form-select"
                     formControlName="pool"
-                    (change)="onBlockPoolChange()">
+                    (change)="setNvmeServiceId()">
               <option *ngIf="rbdPools === null"
                       [ngValue]="null"
                       i18n>Loading...</option>
@@ -131,7 +131,7 @@
                      class="form-control"
                      type="text"
                      formControlName="group"
-                     (change)="onNvmeofGroupChange($event.target.value)">
+                     (change)="setNvmeServiceId()">
             </div>
             <cd-help-text i18n>
               The name of the gateway group.
@@ -1272,6 +1272,125 @@
                       i18n>
         Modifying the default settings could lead to a weaker security configuration
       </cd-alert-panel>
+
+        <!-- NVMe/TCP -->
+        <!-- mTLS -->
+        <div class="form-group row"
+             *ngIf="serviceForm.controls.service_type.value === 'nvmeof'">
+          <div class="cd-col-form-offset">
+            <div class="custom-control custom-checkbox">
+              <input class="custom-control-input"
+                     id="enable_mtls"
+                     type="checkbox"
+                     formControlName="enable_mtls">
+              <label class="custom-control-label"
+                     for="enable_mtls"
+                     i18n>Encryption</label>
+              <cd-help-text i18n>Enables mutual TLS (mTLS) between the client and the gateway server.</cd-help-text>
+            </div>
+          </div>
+        </div>
+
+        <!-- root_ca_cert -->
+        <div *ngIf="serviceForm.controls.enable_auth.value"
+             class="form-group row">
+          <label class="cd-col-form-label required"
+                 for="root_ca_cert">
+            <span i18n>Root CA certificate</span>
+          </label>
+          <div class="cd-col-form-input">
+            <textarea id="root_ca_cert"
+                      class="form-control resize-vertical text-monospace text-pre"
+                      formControlName="root_ca_cert"
+                      rows="5"></textarea>
+            <input type="file"
+                   (change)="fileUpload($event.target.files, 'root_ca_cert')">
+            <span class="invalid-feedback"
+                  *ngIf="serviceForm.showError('root_ca_cert', frm, 'required')"
+                  i18n>This field is required.</span>
+          </div>
+        </div>
+
+        <!-- client_cert -->
+        <div *ngIf="serviceForm.controls.enable_auth.value"
+             class="form-group row">
+          <label class="cd-col-form-label required"
+                 for="client_cert">
+            <span i18n>Client CA certificate</span>
+          </label>
+          <div class="cd-col-form-input">
+            <textarea id="client_cert"
+                      class="form-control resize-vertical text-monospace text-pre"
+                      formControlName="client_cert"
+                      rows="5"></textarea>
+            <input type="file"
+                   (change)="fileUpload($event.target.files, 'client_cert')">
+            <span class="invalid-feedback"
+                  *ngIf="serviceForm.showError('client_cert', frm, 'required')"
+                  i18n>This field is required.</span>
+          </div>
+        </div>
+
+        <!-- client_key -->
+        <div *ngIf="serviceForm.controls.enable_auth.value"
+             class="form-group row">
+          <label class="cd-col-form-label required"
+                 for="client_key">
+            <span i18n>Client key</span>
+          </label>
+          <div class="cd-col-form-input">
+            <textarea id="client_key"
+                      class="form-control resize-vertical text-monospace text-pre"
+                      formControlName="client_key"
+                      rows="5"></textarea>
+            <input type="file"
+                   (change)="fileUpload($event.target.files, 'client_key')">
+            <span class="invalid-feedback"
+                  *ngIf="serviceForm.showError('client_key', frm, 'required')"
+                  i18n>This field is required.</span>
+          </div>
+        </div>
+
+        <!-- server_cert -->
+        <div *ngIf="serviceForm.controls.enable_auth.value"
+             class="form-group row">
+          <label class="cd-col-form-label required"
+                 for="server_cert">
+            <span i18n>Gateway server certificate</span>
+          </label>
+          <div class="cd-col-form-input">
+            <textarea id="server_cert"
+                      class="form-control resize-vertical text-monospace text-pre"
+                      formControlName="server_cert"
+                      rows="5"></textarea>
+            <input type="file"
+                   (change)="fileUpload($event.target.files, 'server_cert')">
+            <span class="invalid-feedback"
+                  *ngIf="serviceForm.showError('server_cert', frm, 'required')"
+                  i18n>This field is required.</span>
+          </div>
+        </div>
+
+        <!-- server_key -->
+        <div *ngIf="serviceForm.controls.enable_auth.value"
+             class="form-group row">
+          <label class="cd-col-form-label required"
+                 for="server_key">
+            <span i18n>Gateway server key</span>
+          </label>
+          <div class="cd-col-form-input">
+            <textarea id="server_key"
+                      class="form-control resize-vertical text-monospace text-pre"
+                      formControlName="server_key"
+                      rows="5"></textarea>
+            <input type="file"
+                   (change)="fileUpload($event.target.files, 'server_key')">
+            <span class="invalid-feedback"
+                  *ngIf="serviceForm.showError('server_key', frm, 'required')"
+                  i18n>This field is required.</span>
+          </div>
+        </div>
+
       </div>
 
       <div class="modal-footer">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -305,7 +305,7 @@
         </div>
 
         <!-- Count -->
-        <div *ngIf="!serviceForm.controls.unmanaged.value"
+        <div *ngIf="!serviceForm.controls.unmanaged.value && serviceForm.controls.service_type.value !== 'nvmeof'"
              class="form-group row">
           <label class="cd-col-form-label"
                  for="count">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
@@ -469,7 +469,22 @@ x4Ea7kGVgx9kWh5XjWz9wjZvY49UKIT5ppIAWPMbLl3UpfckiuNhTA==
         expect(countEl).toBeNull();
       });
 
-      it('should submit nvmeof', () => {
+      it('should not show certs and keys field with mTLS disabled', () => {
+        formHelper.setValue('ssl', true);
+        fixture.detectChanges();
+        const root_ca_cert = fixture.debugElement.query(By.css('#root_ca_cert'));
+        const client_cert = fixture.debugElement.query(By.css('#client_cert'));
+        const client_key = fixture.debugElement.query(By.css('#client_key'));
+        const server_cert = fixture.debugElement.query(By.css('#server_cert'));
+        const server_key = fixture.debugElement.query(By.css('#server_key'));
+        expect(root_ca_cert).toBeNull();
+        expect(client_cert).toBeNull();
+        expect(client_key).toBeNull();
+        expect(server_cert).toBeNull();
+        expect(server_key).toBeNull();
+      });
+
+      it('should submit nvmeof without mTLS', () => {
         component.onSubmit();
         expect(cephServiceService.create).toHaveBeenCalledWith({
           service_type: 'nvmeof',
@@ -477,7 +492,32 @@ x4Ea7kGVgx9kWh5XjWz9wjZvY49UKIT5ppIAWPMbLl3UpfckiuNhTA==
           placement: {},
           unmanaged: false,
           pool: 'rbd',
-          group: 'default'
+          group: 'default',
+          enable_auth: false
+        });
+      });
+
+      it('should submit nvmeof with mTLS', () => {
+        formHelper.setValue('enable_mtls', true);
+        formHelper.setValue('root_ca_cert', 'root_ca_cert');
+        formHelper.setValue('client_cert', 'client_cert');
+        formHelper.setValue('client_key', 'client_key');
+        formHelper.setValue('server_cert', 'server_cert');
+        formHelper.setValue('server_key', 'server_key');
+        component.onSubmit();
+        expect(cephServiceService.create).toHaveBeenCalledWith({
+          service_type: 'nvmeof',
+          service_id: 'rbd.default',
+          placement: {},
+          unmanaged: false,
+          pool: 'rbd',
+          group: 'default',
+          enable_auth: true,
+          root_ca_cert: 'root_ca_cert',
+          client_cert: 'client_cert',
+          client_key: 'client_key',
+          server_cert: 'server_cert',
+          server_key: 'server_key'
         });
       });
     });
@@ -720,6 +760,25 @@ x4Ea7kGVgx9kWh5XjWz9wjZvY49UKIT5ppIAWPMbLl3UpfckiuNhTA==
         fixture.detectChanges();
         const groupId = fixture.debugElement.query(By.css('#group')).nativeElement;
         expect(groupId.disabled).toBeTruthy();
+      });
+
+      it('should update nvmeof service to disable mTLS', () => {
+        spyOn(cephServiceService, 'update').and.stub();
+        component.serviceType = 'nvmeof';
+        formHelper.setValue('service_type', 'nvmeof');
+        formHelper.setValue('pool', 'rbd');
+        formHelper.setValue('group', 'default');
+        // mTLS disabled
+        formHelper.setValue('enable_auth', false);
+        component.onSubmit();
+        expect(cephServiceService.update).toHaveBeenCalledWith({
+          service_type: 'nvmeof',
+          placement: {},
+          unmanaged: false,
+          pool: 'rbd',
+          group: 'default',
+          enable_auth: false
+        });
       });
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.spec.ts
@@ -123,6 +123,7 @@ describe('PoolDetailsComponent', () => {
         expectedChange(
           {
             poolDetails: {
+              application_metadata: ['rbd'],
               pg_num: 256,
               pg_num_target: 256,
               pg_placement_num: 256,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/service.interface.ts
@@ -32,6 +32,11 @@ export interface CephServiceAdditionalSpec {
   virtual_interface_networks: string[];
   pool: string;
   group: string;
+  root_ca_cert: string;
+  client_cert: string;
+  client_key: string;
+  server_cert: string;
+  server_key: string;
   rgw_frontend_ssl_certificate: string;
   ssl: boolean;
   ssl_cert: string;

--- a/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
@@ -423,9 +423,10 @@ export class Mocks {
     return { name, type, type_id, id, children, device_class };
   }
 
-  static getPool = (name: string, id: number): Pool => {
+  static getPool = (name: string, id: number, application_metadata: string[] = ['rbd']): Pool => {
     return _.merge(new Pool(name), {
       pool: id,
+      application_metadata,
       type: 'replicated',
       pg_num: 256,
       pg_placement_num: 256,


### PR DESCRIPTION
[mgr/dashboard: Adding group and pool name to service name](https://github.com/ceph/ceph/commit/551b6b2924933f5a43acc1aea98978e41193cfab) 

- Pre-populating the service name field with the format `nvmeof.<pool_name>.<group_name>`.
- This can be changed by user but by default this value will be there.
- This will help user to quickly fill form and proceed hence improving usability.
- cephadm also uses this format as of now this convention so it will make UI aligned with CLI experience

- updates unit tests to improve coverage

- hides`count` values as that is not needed for 'nvmeof' only hosts and labels required.

Fixes https://tracker.ceph.com/issues/68065

[mgr/dashboard: Add mTLS support](https://github.com/ceph/ceph/commit/4db35e8a4f8884d93874cd06da826ba0746974dd) 

- enables mTLS support from dashboard
- adds unit tests related to mTLS support
- can enable mTLS
- can disable mTLS
- inlcuded refactoring from prev commit

## Nvmeof service without mTLS
[nvme-without-mtls.webm](https://github.com/user-attachments/assets/f30ea81d-b5eb-46e2-8577-c878ce11721c)


## Nvmeof service with mTLS
[nvme-with-mtls.webm](https://github.com/user-attachments/assets/64e96ec8-a57a-4e0e-b900-63abc3fe233a)


## For testing this PR:
* `ceph osd pool create nvmeof_pool01`
* `rbd pool init nvmeof_pool01`

* From dashboard create a nvmeof service via service form
* service ID /group/pool values prepoluated
* enable encryption 
* fill in dummy cert values
* select hosts
* `count` should not be visible
* create service

* edit service created above
* uncheck encryption and proceed.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
