### PR TITLE
mgr/dashboard: Add group selector in subsystems views

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -53,6 +53,7 @@ import { NvmeofInitiatorsFormComponent } from './nvmeof-initiators-form/nvmeof-i
 import {
   ButtonModule,
   CheckboxModule,
+  ComboBoxModule,
   DatePickerModule,
   GridModule,
   IconModule,
@@ -95,7 +96,8 @@ import Reset from '@carbon/icons/es/reset/32';
     SelectModule,
     NumberModule,
     ModalModule,
-    DatePickerModule
+    DatePickerModule,
+    ComboBoxModule
   ],
   declarations: [
     RbdListComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-list/nvmeof-listeners-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-listeners-list/nvmeof-listeners-list.component.ts
@@ -24,6 +24,8 @@ const BASE_URL = 'block/nvmeof/subsystems';
 export class NvmeofListenersListComponent implements OnInit, OnChanges {
   @Input()
   subsystemNQN: string;
+  @Input()
+  group: string;
 
   listenerColumns: any;
   tableActions: CdTableAction[];
@@ -64,10 +66,10 @@ export class NvmeofListenersListComponent implements OnInit, OnChanges {
         permission: 'create',
         icon: Icons.add,
         click: () =>
-          this.router.navigate([
-            BASE_URL,
-            { outlets: { modal: [URLVerbs.CREATE, this.subsystemNQN, 'listener'] } }
-          ]),
+          this.router.navigate(
+            [BASE_URL, { outlets: { modal: [URLVerbs.CREATE, this.subsystemNQN, 'listener'] } }],
+            { queryParams: { group: this.group } }
+          ),
         canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
       },
       {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-details/nvmeof-subsystems-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-details/nvmeof-subsystems-details.component.html
@@ -15,7 +15,8 @@
       <a ngbNavLink
          i18n>Listeners</a>
       <ng-template ngbNavContent>
-        <cd-nvmeof-listeners-list [subsystemNQN]="subsystemNQN">
+        <cd-nvmeof-listeners-list [subsystemNQN]="subsystemNQN"
+                                  [group]="group">
         </cd-nvmeof-listeners-list>
       </ng-template>
     </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-details/nvmeof-subsystems-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-details/nvmeof-subsystems-details.component.ts
@@ -9,6 +9,8 @@ import { NvmeofSubsystem } from '~/app/shared/models/nvmeof';
 export class NvmeofSubsystemsDetailsComponent implements OnChanges {
   @Input()
   selection: NvmeofSubsystem;
+  @Input()
+  group: NvmeofSubsystem;
 
   selectedItem: any;
   data: any;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems-form/nvmeof-subsystems-form.component.spec.ts
@@ -20,6 +20,7 @@ describe('NvmeofSubsystemsFormComponent', () => {
   let form: CdFormGroup;
   let formHelper: FormHelper;
   const mockTimestamp = 1720693470789;
+  const mockGroupName = 'default';
 
   beforeEach(async () => {
     spyOn(Date, 'now').and.returnValue(mockTimestamp);
@@ -42,6 +43,7 @@ describe('NvmeofSubsystemsFormComponent', () => {
     form = component.subsystemForm;
     formHelper = new FormHelper(form);
     fixture.detectChanges();
+    component.group = mockGroupName;
   });
 
   it('should create', () => {
@@ -60,7 +62,8 @@ describe('NvmeofSubsystemsFormComponent', () => {
       expect(nvmeofService.createSubsystem).toHaveBeenCalledWith({
         nqn: expectedNqn,
         max_namespaces: MAX_NAMESPACE,
-        enable_ha: true
+        enable_ha: true,
+        gw_group: mockGroupName
       });
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.html
@@ -1,4 +1,20 @@
 <cd-nvmeof-tabs></cd-nvmeof-tabs>
+
+<div class="pb-3"
+     cdsCol
+     [columnNumbers]="{md: 4}">
+  <cds-combo-box
+      type="single"
+      label="Selected Gateway Group"
+      i18n-placeholder
+      placeholder="Enter group"
+      [items]="gwGroups"
+      (selected)="onGroupSelection($event)"
+      (clear)="onGroupClear()">
+    <cds-dropdown-list></cds-dropdown-list>
+  </cds-combo-box>
+</div>
+
 <legend i18n>
   Subsystems
   <cd-help-text>
@@ -23,7 +39,8 @@
   </div>
 
   <cd-nvmeof-subsystems-details *cdTableDetail
-                                [selection]="expandedRow">
+                                [selection]="expandedRow"
+                                [group]="group">
   </cd-nvmeof-subsystems-details>
 </cd-table>
 <router-outlet name="modal"></router-outlet>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.spec.ts
@@ -11,6 +11,7 @@ import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { NvmeofSubsystemsComponent } from './nvmeof-subsystems.component';
 import { NvmeofTabsComponent } from '../nvmeof-tabs/nvmeof-tabs.component';
 import { NvmeofSubsystemsDetailsComponent } from '../nvmeof-subsystems-details/nvmeof-subsystems-details.component';
+import { ComboBoxModule, GridModule } from 'carbon-components-angular';
 
 const mockSubsystems = [
   {
@@ -26,9 +27,35 @@ const mockSubsystems = [
   }
 ];
 
+const mockGroups = [
+  [
+    {
+      service_name: 'nvmeof.rbd.default',
+      service_type: 'nvmeof',
+      unmanaged: false,
+      spec: {
+        group: 'default'
+      }
+    },
+    {
+      service_name: 'nvmeof.rbd.foo',
+      service_type: 'nvmeof',
+      unmanaged: false,
+      spec: {
+        group: 'foo'
+      }
+    }
+  ],
+  2
+];
+
 class MockNvmeOfService {
   listSubsystems() {
     return of(mockSubsystems);
+  }
+
+  listGatewayGroups() {
+    return of(mockGroups);
   }
 }
 
@@ -53,7 +80,7 @@ describe('NvmeofSubsystemsComponent', () => {
         NvmeofTabsComponent,
         NvmeofSubsystemsDetailsComponent
       ],
-      imports: [HttpClientModule, RouterTestingModule, SharedModule],
+      imports: [HttpClientModule, RouterTestingModule, SharedModule, ComboBoxModule, GridModule],
       providers: [
         { provide: NvmeofService, useClass: MockNvmeOfService },
         { provide: AuthStorageService, useClass: MockAuthStorageService },
@@ -77,4 +104,12 @@ describe('NvmeofSubsystemsComponent', () => {
     tick();
     expect(component.subsystems).toEqual(mockSubsystems);
   }));
+
+  it('should load gateway groups correctly', () => {
+    expect(component.gwGroups.length).toBe(2);
+  });
+
+  it('should set first group as default initially', () => {
+    expect(component.group).toBe(mockGroups[0][0].spec.group);
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/nvmeof-subsystems/nvmeof-subsystems.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { CdTableSelection } from '~/app/shared/models/cd-table-selection';
@@ -14,6 +14,12 @@ import { FinishedTask } from '~/app/shared/models/finished-task';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { NvmeofService } from '~/app/shared/api/nvmeof.service';
 import { ModalCdsService } from '~/app/shared/services/modal-cds.service';
+import { CephServiceSpec } from '~/app/shared/models/service.interface';
+
+type ComboBoxItem = {
+  content: string;
+  selected?: boolean;
+};
 
 const BASE_URL = 'block/nvmeof/subsystems';
 
@@ -29,6 +35,8 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
   selection = new CdTableSelection();
   tableActions: CdTableAction[];
   subsystemDetails: any[];
+  gwGroups: ComboBoxItem[] = [];
+  group: string = null;
 
   constructor(
     private nvmeofService: NvmeofService,
@@ -36,13 +44,18 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
     public actionLabels: ActionLabelsI18n,
     private router: Router,
     private modalService: ModalCdsService,
-    private taskWrapper: TaskWrapperService
+    private taskWrapper: TaskWrapperService,
+    private route: ActivatedRoute
   ) {
     super();
     this.permission = this.authStorageService.getPermissions().nvmeof;
   }
 
   ngOnInit() {
+    this.route.queryParams.subscribe((params) => {
+      if (params?.['group']) this.onGroupSelection({ content: params?.['group'] });
+    });
+    this.getGatewayGroups();
     this.subsystemsColumns = [
       {
         name: $localize`NQN`,
@@ -62,7 +75,10 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
         name: this.actionLabels.CREATE,
         permission: 'create',
         icon: Icons.add,
-        click: () => this.router.navigate([BASE_URL, { outlets: { modal: [URLVerbs.CREATE] } }]),
+        click: () =>
+          this.router.navigate([BASE_URL, { outlets: { modal: [URLVerbs.CREATE] } }], {
+            queryParams: { group: this.group }
+          }),
         canBePrimary: (selection: CdTableSelection) => !selection.hasSelection
       },
       {
@@ -92,13 +108,14 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
     ];
   }
 
+  // Subsystems
   updateSelection(selection: CdTableSelection) {
     this.selection = selection;
   }
 
   getSubsystems() {
     this.nvmeofService
-      .listSubsystems()
+      .listSubsystems(this.group)
       .subscribe((subsystems: NvmeofSubsystem[] | NvmeofSubsystem) => {
         if (Array.isArray(subsystems)) this.subsystems = subsystems;
         else this.subsystems = [subsystems];
@@ -114,8 +131,34 @@ export class NvmeofSubsystemsComponent extends ListWithDetails implements OnInit
       submitActionObservable: () =>
         this.taskWrapper.wrapTaskAroundCall({
           task: new FinishedTask('nvmeof/subsystem/delete', { nqn: subsystem.nqn }),
-          call: this.nvmeofService.deleteSubsystem(subsystem.nqn)
+          call: this.nvmeofService.deleteSubsystem(subsystem.nqn, this.group)
         })
+    });
+  }
+
+  // Gateway groups
+  onGroupSelection(selected: ComboBoxItem) {
+    selected.selected = true;
+    this.group = selected.content;
+    this.getSubsystems();
+  }
+
+  onGroupClear() {
+    this.group = null;
+    this.getSubsystems();
+  }
+
+  getGatewayGroups() {
+    this.nvmeofService.listGatewayGroups().subscribe((response: CephServiceSpec[][]) => {
+      if (response?.[0].length) {
+        this.gwGroups = response[0].map((group: CephServiceSpec) => {
+          return {
+            content: group?.spec?.group
+          };
+        });
+      }
+      // Select first group if no group is selected
+      if (!this.group && this.gwGroups.length) this.onGroupSelection(this.gwGroups[0]);
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.spec.ts
@@ -6,6 +6,8 @@ import { NvmeofService } from '../../shared/api/nvmeof.service';
 describe('NvmeofService', () => {
   let service: NvmeofService;
   let httpTesting: HttpTestingController;
+  const mockGroupName = 'default';
+  const mockNQN = 'nqn.2001-07.com.ceph:1721041732363';
 
   configureTestBed({
     providers: [NvmeofService],
@@ -25,34 +27,51 @@ describe('NvmeofService', () => {
     expect(service).toBeTruthy();
   });
 
+  it('should call listGatewayGroups', () => {
+    service.listGatewayGroups().subscribe();
+    const req = httpTesting.expectOne('api/nvmeof/gateway/group');
+    expect(req.request.method).toBe('GET');
+  });
+
   it('should call listGateways', () => {
     service.listGateways().subscribe();
     const req = httpTesting.expectOne('api/nvmeof/gateway');
     expect(req.request.method).toBe('GET');
   });
 
+  it('should call listSubsystems', () => {
+    service.listSubsystems(mockGroupName).subscribe();
+    const req = httpTesting.expectOne(`api/nvmeof/subsystem?gw_group=${mockGroupName}`);
+    expect(req.request.method).toBe('GET');
+  });
+
   it('should call getSubsystem', () => {
-    service.getSubsystem('nqn.2001-07.com.ceph:1721041732363').subscribe();
-    const req = httpTesting.expectOne('api/nvmeof/subsystem/nqn.2001-07.com.ceph:1721041732363');
+    service.getSubsystem(mockNQN, mockGroupName).subscribe();
+    const req = httpTesting.expectOne(`api/nvmeof/subsystem/${mockNQN}?gw_group=${mockGroupName}`);
     expect(req.request.method).toBe('GET');
   });
 
   it('should call createSubsystem', () => {
     const request = {
-      nqn: 'nqn.2001-07.com.ceph:1721041732363',
+      nqn: mockNQN,
       enable_ha: true,
-      initiators: '*'
+      initiators: '*',
+      gw_group: mockGroupName
     };
     service.createSubsystem(request).subscribe();
     const req = httpTesting.expectOne('api/nvmeof/subsystem');
     expect(req.request.method).toBe('POST');
   });
 
+  it('should call deleteSubsystem', () => {
+    service.deleteSubsystem(mockNQN, mockGroupName).subscribe();
+    const req = httpTesting.expectOne(`api/nvmeof/subsystem/${mockNQN}?gw_group=${mockGroupName}`);
+    expect(req.request.method).toBe('DELETE');
+  });
+
   it('should call getInitiators', () => {
-    service.getInitiators('nqn.2001-07.com.ceph:1721041732363').subscribe();
-    const req = httpTesting.expectOne(
-      'api/nvmeof/subsystem/nqn.2001-07.com.ceph:1721041732363/host'
-    );
+    service.getInitiators(mockNQN).subscribe();
+    const req = httpTesting.expectOne(`api/nvmeof/subsystem/${mockNQN}/host`);
     expect(req.request.method).toBe('GET');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/nvmeof.service.ts
@@ -36,32 +36,42 @@ const UI_API_PATH = 'ui-api/nvmeof';
 export class NvmeofService {
   constructor(private http: HttpClient) {}
 
+  // Gateway groups
+  listGatewayGroups() {
+    return this.http.get(`${API_PATH}/gateway/group`);
+  }
+
   // Gateways
   listGateways() {
     return this.http.get(`${API_PATH}/gateway`);
   }
 
   // Subsystems
-  listSubsystems() {
-    return this.http.get(`${API_PATH}/subsystem`);
+  listSubsystems(group: string) {
+    return this.http.get(`${API_PATH}/subsystem?gw_group=${group}`);
   }
 
-  getSubsystem(subsystemNQN: string) {
-    return this.http.get(`${API_PATH}/subsystem/${subsystemNQN}`);
+  getSubsystem(subsystemNQN: string, group: string) {
+    return this.http.get(`${API_PATH}/subsystem/${subsystemNQN}?gw_group=${group}`);
   }
 
-  createSubsystem(request: { nqn: string; max_namespaces?: number; enable_ha: boolean }) {
+  createSubsystem(request: {
+    nqn: string;
+    enable_ha: boolean;
+    gw_group: string;
+    max_namespaces?: number;
+  }) {
     return this.http.post(`${API_PATH}/subsystem`, request, { observe: 'response' });
   }
 
-  deleteSubsystem(subsystemNQN: string) {
-    return this.http.delete(`${API_PATH}/subsystem/${subsystemNQN}`, {
+  deleteSubsystem(subsystemNQN: string, group: string) {
+    return this.http.delete(`${API_PATH}/subsystem/${subsystemNQN}?gw_group=${group}`, {
       observe: 'response'
     });
   }
 
-  isSubsystemPresent(subsystemNqn: string): Observable<boolean> {
-    return this.getSubsystem(subsystemNqn).pipe(
+  isSubsystemPresent(subsystemNqn: string, group: string): Observable<boolean> {
+    return this.getSubsystem(subsystemNqn, group).pipe(
       mapTo(true),
       catchError((e) => {
         e?.preventDefault();


### PR DESCRIPTION
- Allows listing the subsystems per gateway group.
- Using carbon combobox component for the selector.
- Adds unit tests for switcher and updates existing.

Fixes https://tracker.ceph.com/issues/68129

Signed-off-by: Afreen Misbah <afreen23.git@gmail.com>

## Demo
[Screencast from 2024-09-18 18-27-06.webm](https://github.com/user-attachments/assets/652ce122-010e-4eca-997e-d530546d54ea)


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
