### PR TITLE
Doc: Update foundation.rst - Add Link To Ceph Charter

### DIFF
--- a/doc/foundation.rst
+++ b/doc/foundation.rst
@@ -15,7 +15,7 @@ The Ceph Foundation is organized as a directed fund under the Linux
 Foundation. Premier and General Member organizations contribute a
 yearly fee to become members. Associate members are educational
 institutions or government organizations and are invited to join at no
-cost.
+cost. Read and download the `Ceph Foundation Charter <https://charter.cephfoundation.org>`_.
 
 For more information, see `https://ceph.com/foundation
 <https://ceph.com/foundation>`_.


### PR DESCRIPTION
I noticed the Ceph charter was not linked from this page. This PR adds that link. Note this goes to a redirect, so if the charter is updated, we do not need to adjust this link. I will also look into adding the charter to the website.


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [X] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

