### PR TITLE
crimson: don't retain InternalClientRequest on interval change even if primary does not change

### DIFF
--- a/src/crimson/osd/osd_operations/client_request_common.cc
+++ b/src/crimson/osd/osd_operations/client_request_common.cc
@@ -71,30 +71,4 @@ CommonClientRequest::do_recover_missing(
   }
 }
 
-bool CommonClientRequest::should_abort_request(
-  const Operation& op,
-  std::exception_ptr eptr)
-{
-  if (*eptr.__cxa_exception_type() ==
-      typeid(::crimson::common::actingset_changed)) {
-    try {
-      std::rethrow_exception(eptr);
-    } catch(::crimson::common::actingset_changed& e) {
-      if (e.is_primary()) {
-        logger().debug("{} {} operation restart, acting set changed", __func__, op);
-        return false;
-      } else {
-        logger().debug("{} {} operation abort, up primary changed", __func__, op);
-        return true;
-      }
-    }
-  } else {
-    assert(*eptr.__cxa_exception_type() ==
-      typeid(crimson::common::system_shutdown_exception));
-    crimson::get_logger(ceph_subsys_osd).debug(
-        "{} {} operation skipped, system shutdown", __func__, op);
-    return true;
-  }
-}
-
 } // namespace crimson::osd

--- a/src/crimson/osd/osd_operations/client_request_common.h
+++ b/src/crimson/osd/osd_operations/client_request_common.h
@@ -16,9 +16,6 @@ struct CommonClientRequest {
     Ref<PG> pg,
     const hobject_t& soid,
     const osd_reqid_t& reqid);
-
-  static bool should_abort_request(
-    const crimson::Operation& op, std::exception_ptr eptr);
 };
 
 } // namespace crimson::osd


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/68068


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
