### PR TITLE
quincy: doc/README.md: create selectable commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,15 @@ To build Ceph, follow this procedure:
    contains `do_cmake.sh` and `CONTRIBUTING.rst`.
 2. Run the `do_cmake.sh` script:
 
-    >``./do_cmake.sh``
+       ./do_cmake.sh
+
+   ``do_cmake.sh`` by default creates a "debug build" of Ceph, which can be 
+   up to five times slower than a non-debug build. Pass 
+   ``-DCMAKE_BUILD_TYPE=RelWithDebInfo`` to ``do_cmake.sh`` to create a 
+   non-debug build.
 3. Move into the `build` directory:
 
-    >``cd build``
+       cd build
 4. Use the `ninja` buildsystem to build the development environment:
 
     >``ninja``
@@ -112,11 +117,11 @@ to limit the job number to 3, run the command `ninja -j 3`. On average, each
 
    To build only certain targets, run a command of the following form:
 
-	ninja [target name]
+       ninja [target name]
 
 5. Install the vstart cluster:
 
-	ninja install
+       ninja install
  
 ### CMake Options
 


### PR DESCRIPTION
An indentation of five spaces relative to the previous line creates a command that is copyable with a single mouse click. This commit adds those copyabale commands to the procedure in the section "Building Ceph".

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 36c620b04f3a88562d75955b46cc1864de60ce70)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

