### PR TITLE
ceph.spec.in: Fix unversioned Obsoletes: rpmbuild warning

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1184,7 +1184,7 @@ Group:		System/Libraries
 Obsoletes:	libcephfs1 < %{_epoch_prefix}%{version}-%{release}
 %if 0%{?rhel} || 0%{?fedora} || 0%{?openEuler}
 Obsoletes:	ceph-libs < %{_epoch_prefix}%{version}-%{release}
-Obsoletes:	ceph-libcephfs
+Obsoletes:	ceph-libcephfs < %{_epoch_prefix}%{version}-%{release}
 %endif
 %description -n libcephfs2
 Ceph is a distributed network file system designed to provide excellent


### PR DESCRIPTION
Fix the following warning while building source rpm with `rpmbuild`:

> warning: line 1187: It's not recommended to have unversioned Obsoletes: Obsoletes: ceph-libcephfs