### PR TITLE
mgr/dashboard: Service form fixes for mTLS 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -1292,7 +1292,7 @@
         </div>
 
         <!-- root_ca_cert -->
-        <div *ngIf="serviceForm.controls.enable_auth.value"
+        <div *ngIf="serviceForm.controls.enable_mtls.value"
              class="form-group row">
           <label class="cd-col-form-label required"
                  for="root_ca_cert">
@@ -1312,7 +1312,7 @@
         </div>
 
         <!-- client_cert -->
-        <div *ngIf="serviceForm.controls.enable_auth.value"
+        <div *ngIf="serviceForm.controls.enable_mtls.value"
              class="form-group row">
           <label class="cd-col-form-label required"
                  for="client_cert">
@@ -1332,7 +1332,7 @@
         </div>
 
         <!-- client_key -->
-        <div *ngIf="serviceForm.controls.enable_auth.value"
+        <div *ngIf="serviceForm.controls.enable_mtls.value"
              class="form-group row">
           <label class="cd-col-form-label required"
                  for="client_key">
@@ -1352,7 +1352,7 @@
         </div>
 
         <!-- server_cert -->
-        <div *ngIf="serviceForm.controls.enable_auth.value"
+        <div *ngIf="serviceForm.controls.enable_mtls.value"
              class="form-group row">
           <label class="cd-col-form-label required"
                  for="server_cert">
@@ -1372,7 +1372,7 @@
         </div>
 
         <!-- server_key -->
-        <div *ngIf="serviceForm.controls.enable_auth.value"
+        <div *ngIf="serviceForm.controls.enable_mtls.value"
              class="form-group row">
           <label class="cd-col-form-label required"
                  for="server_key">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.spec.ts
@@ -769,7 +769,7 @@ x4Ea7kGVgx9kWh5XjWz9wjZvY49UKIT5ppIAWPMbLl3UpfckiuNhTA==
         formHelper.setValue('pool', 'rbd');
         formHelper.setValue('group', 'default');
         // mTLS disabled
-        formHelper.setValue('enable_auth', false);
+        formHelper.setValue('enable_mtls', false);
         component.onSubmit();
         expect(cephServiceService.update).toHaveBeenCalledWith({
           service_type: 'nvmeof',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.ts
@@ -694,12 +694,12 @@ export class ServiceFormComponent extends CdForm implements OnInit {
             case 'nvmeof':
               this.serviceForm.get('pool').setValue(response[0].spec.pool);
               this.serviceForm.get('group').setValue(response[0].spec.group);
-              this.serviceForm.get('enable_auth').setValue(response[0].spec.enable_auth);
-              this.serviceForm.get('root_ca_cert').setValue(response[0].spec.root_ca_cert);
-              this.serviceForm.get('client_cert').setValue(response[0].spec.client_cert);
-              this.serviceForm.get('client_key').setValue(response[0].spec.client_key);
-              this.serviceForm.get('server_cert').setValue(response[0].spec.server_cert);
-              this.serviceForm.get('server_key').setValue(response[0].spec.server_key);
+              this.serviceForm.get('enable_mtls').setValue(response[0].spec?.enable_auth);
+              this.serviceForm.get('root_ca_cert').setValue(response[0].spec?.root_ca_cert);
+              this.serviceForm.get('client_cert').setValue(response[0].spec?.client_cert);
+              this.serviceForm.get('client_key').setValue(response[0].spec?.client_key);
+              this.serviceForm.get('server_cert').setValue(response[0].spec?.server_cert);
+              this.serviceForm.get('server_key').setValue(response[0].spec?.server_key);
               break;
             case 'rgw':
               this.serviceForm


### PR DESCRIPTION
Due to conflicts with SSO PR, mTLS fields are not updated properly in code. This is happening only in main as noted: https://github.com/ceph/ceph/pull/59819#issuecomment-2356523491

The effect of this issue is mtls based fields not showing in service form

Fixes https://tracker.ceph.com/issues/68133

### Before
[Screencast from 2024-09-18 19-12-23.webm](https://github.com/user-attachments/assets/fe94c4de-9704-46b0-9864-4b7b7dafffae)


### After
[Screencast from 2024-09-18 19-09-45.webm](https://github.com/user-attachments/assets/4e3f69ed-3fd2-492a-91a8-7ca0f0619684)


## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
