### PR TITLE
rgw/rados: RGWRados::delete_objs_inline() uses AioThrottle

### DIFF
--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <list>
+#include <vector>
 #include <boost/container/flat_map.hpp>
 #include "common/ceph_time.h"
 #include "common/Formatter.h"
@@ -1197,16 +1198,14 @@ struct cls_rgw_obj {
 WRITE_CLASS_ENCODER(cls_rgw_obj)
 
 struct cls_rgw_obj_chain {
-  std::list<cls_rgw_obj> objs;
-
-  cls_rgw_obj_chain() {}
+  std::vector<cls_rgw_obj> objs;
 
   void push_obj(const std::string& pool, const cls_rgw_obj_key& key, const std::string& loc) {
     cls_rgw_obj obj;
     obj.pool = pool;
     obj.key = key;
     obj.loc = loc;
-    objs.push_back(obj);
+    objs.push_back(std::move(obj));
   }
 
   void encode(ceph::buffer::list& bl) const {
@@ -1223,9 +1222,9 @@ struct cls_rgw_obj_chain {
 
   void dump(ceph::Formatter *f) const {
     f->open_array_section("objs");
-    for (std::list<cls_rgw_obj>::const_iterator p = objs.begin(); p != objs.end(); ++p) {
+    for (const auto& o : objs) {
       f->open_object_section("obj");
-      p->dump(f);
+      o.dump(f);
       f->close_section();
     }
     f->close_section();

--- a/src/rgw/driver/rados/rgw_gc.cc
+++ b/src/rgw/driver/rados/rgw_gc.cc
@@ -653,7 +653,6 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
 	info.tag << "', time=" << info.time << ", chain.objs.size()=" <<
 	info.chain.objs.size() << dendl;
 
-      std::list<cls_rgw_obj>::iterator liter;
       cls_rgw_obj_chain& chain = info.chain;
 
       utime_t now = ceph_clock_now();
@@ -668,9 +667,7 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
         }
       }
       if (! chain.objs.empty()) {
-	for (liter = chain.objs.begin(); liter != chain.objs.end(); ++liter) {
-	  cls_rgw_obj& obj = *liter;
-
+	for (const auto& obj : chain.objs) {
 	  if (obj.pool != last_pool) {
 	    delete ctx;
 	    ctx = new IoCtx;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8806,10 +8806,7 @@ next:
 	formatter->dump_string("tag", info.tag);
 	formatter->dump_stream("time") << info.time;
 	formatter->open_array_section("objs");
-        list<cls_rgw_obj>::iterator liter;
-	cls_rgw_obj_chain& chain = info.chain;
-	for (liter = chain.objs.begin(); liter != chain.objs.end(); ++liter) {
-	  cls_rgw_obj& obj = *liter;
+	for (const auto& obj : info.chain.objs) {
           encode_json("obj", obj, formatter.get());
 	}
 	formatter->close_section(); // objs

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -854,7 +854,7 @@ TEST_F(cls_rgw, gc_set)
     /* verify expected num of objects in chain */
     ASSERT_EQ(2, (int)entry.chain.objs.size());
 
-    list<cls_rgw_obj>::iterator oiter = entry.chain.objs.begin();
+    auto oiter = entry.chain.objs.begin();
     cls_rgw_obj obj1, obj2;
 
     /* create expected objects */
@@ -932,7 +932,7 @@ TEST_F(cls_rgw, gc_list)
     /* verify expected num of objects in chain */
     ASSERT_EQ(2, (int)entry.chain.objs.size());
 
-    list<cls_rgw_obj>::iterator oiter = entry.chain.objs.begin();
+    auto oiter = entry.chain.objs.begin();
     cls_rgw_obj obj1, obj2;
 
     /* create expected objects */


### PR DESCRIPTION
use concurrent deletes to speed up inline garbage collection

Fixes: https://tracker.ceph.com/issues/68134

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
