### PR TITLE
mgr/dashboard: ignore exceptions raised when no cert/key found

### DIFF
--- a/src/pybind/mgr/dashboard/services/nvmeof_conf.py
+++ b/src/pybind/mgr/dashboard/services/nvmeof_conf.py
@@ -129,8 +129,10 @@ class NvmeofGatewaysConfig(object):
             orch = OrchClient.instance()
             if orch.available():
                 if key:
-                    return orch.cert_store.get_key(entity, service_name)
-                return orch.cert_store.get_cert(entity, service_name)
+                    return orch.cert_store.get_key(entity, service_name,
+                                                   ignore_missing_exception=True)
+                return orch.cert_store.get_cert(entity, service_name,
+                                                ignore_missing_exception=True)
             return None
         except OrchestratorError:
             # just return None if any orchestrator error is raised

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -209,13 +209,17 @@ class CertStoreManager(ResourceManager):
 
     @wait_api_result
     def get_cert(self, entity: str, service_name: Optional[str] = None,
-                 hostname: Optional[str] = None) -> str:
-        return self.api.cert_store_get_cert(entity, service_name, hostname)
+                 hostname: Optional[str] = None,
+                 ignore_missing_exception: bool = False) -> str:
+        return self.api.cert_store_get_cert(entity, service_name, hostname,
+                                            no_exception_when_missing=ignore_missing_exception)
 
     @wait_api_result
     def get_key(self, entity: str, service_name: Optional[str] = None,
-                hostname: Optional[str] = None) -> str:
-        return self.api.cert_store_get_key(entity, service_name, hostname)
+                hostname: Optional[str] = None,
+                ignore_missing_exception: bool = False) -> str:
+        return self.api.cert_store_get_key(entity, service_name, hostname,
+                                           no_exception_when_missing=ignore_missing_exception)
 
 
 class OrchClient(object):


### PR DESCRIPTION
for nvmeof client, when there are no cert found, it raises an exception which gets logged more often because the dashboard polls the client frequently.

```
Sep 18 13:40:54 ceph-node-00 ceph-mgr[2716]: log_channel(cephadm) log [ERR] : No secret found for entity nvmeof_root_ca_cert with service name nvmeof.rbd.default
                                             Traceback (most recent call last):
                                               File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 140, in wrapper
                                                 return OrchResult(f(*args, **kwargs))
                                               File "/usr/share/ceph/mgr/cephadm/module.py", line 3271, in cert_store_get_cert
                                                 raise OrchSecretNotFound(entity=entity, service_name=service_name, hostname=hostname)
                                             cephadm.inventory.OrchSecretNotFound: No secret found for entity nvmeof_root_ca_cert with service name nvmeof.rbd.default
Sep 18 13:40:54 ceph-node-00 ceph-mgr[2716]: [dashboard INFO orchestrator] is orchestrator available: True,
Sep 18 13:40:54 ceph-node-00 ceph-mgr[2716]: [cephadm ERROR orchestrator._interface] No secret found for entity nvmeof_server_cert with service name nvmeof.rbd.default
                                             Traceback (most recent call last):
                                               File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 140, in wrapper
                                                 return OrchResult(f(*args, **kwargs))
                                               File "/usr/share/ceph/mgr/cephadm/module.py", line 3271, in cert_store_get_cert
                                                 raise OrchSecretNotFound(entity=entity, service_name=service_name, hostname=hostname)
                                             cephadm.inventory.OrchSecretNotFound: No secret found for entity nvmeof_server_cert with service name nvmeof.rbd.default
Sep 18 13:40:54 ceph-node-00 ceph-0377c7c2-75c1-11ef-bb0e-5254000e47d2-mgr-ceph-node-00-cvrrld[2712]: 2024-09-18T13:40:54.529+0000 7fbbd9272640 -1 log_channel(cephadm) log [ERR] : No secret found for entity nvmeof_server_cert with service name nvmeof.rbd.default
Sep 18 13:40:54 ceph-node-00 ceph-0377c7c2-75c1-11ef-bb0e-5254000e47d2-mgr-ceph-node-00-cvrrld[2712]: Traceback (most recent call last):
Sep 18 13:40:54 ceph-node-00 ceph-0377c7c2-75c1-11ef-bb0e-5254000e47d2-mgr-ceph-node-00-cvrrld[2712]:   File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 140, in wrapper
Sep 18 13:40:54 ceph-node-00 ceph-0377c7c2-75c1-11ef-bb0e-5254000e47d2-mgr-ceph-node-00-cvrrld[2712]:     return OrchResult(f(*args, **kwargs))
Sep 18 13:40:54 ceph-node-00 ceph-0377c7c2-75c1-11ef-bb0e-5254000e47d2-mgr-ceph-node-00-cvrrld[2712]:   File "/usr/share/ceph/mgr/cephadm/module.py", line 3271, in cert_store_get_cert
Sep 18 13:40:54 ceph-node-00 ceph-0377c7c2-75c1-11ef-bb0e-5254000e47d2-mgr-ceph-node-00-cvrrld[2712]:     raise OrchSecretNotFound(entity=entity, service_name=service_name, hostname=hostname)
Sep 18 13:40:54 ceph-node-00 ceph-0377c7c2-75c1-11ef-bb0e-5254000e47d2-mgr-ceph-node-00-cvrrld[2712]: cephadm.inventory.OrchSecretNotFound: No secret found for entity nvmeof_server_cert with service name nvmeof.rbd.default
Sep 18 13:40:54 ceph-node-00 ceph-mgr[2716]: log_channel(cephadm) log [ERR] : No secret found for entity nvmeof_server_cert with service name nvmeof.rbd.default
                                             Traceback (most recent call last):
                                               File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 140, in wrapper
                                                 return OrchResult(f(*args, **kwargs))
                                               File "/usr/share/ceph/mgr/cephadm/module.py", line 3271, in cert_store_get_cert
                                                 raise OrchSecretNotFound(entity=entity, service_name=service_name, hostname=hostname)
                                             cephadm.inventory.OrchSecretNotFound: No secret found for entity nvmeof_server_cert with service name nvmeof.rbd.default
Sep 18 13:40:54 ceph-node-00 ceph-mgr[2716]: [dashboard INFO nvmeof_client] Insecurely connecting to: 192.168.100.101:5500
```

Fixes: https://tracker.ceph.com/issues/68141





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
