### PR TITLE
quincy: doc/rados: add confval directives to health-checks

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1499,8 +1499,8 @@ ____________________
 One or more Placement Groups (PGs) have not been deep scrubbed recently. PGs
 are normally scrubbed every :confval:`osd_deep_scrub_interval` seconds at most.
 This health check is raised if a certain percentage (determined by
-``mon_warn_pg_not_deep_scrubbed_ratio``) of the interval has elapsed after the
-time the scrub was scheduled and no scrub has been performed.
+:confval:`mon_warn_pg_not_deep_scrubbed_ratio`) of the interval has elapsed
+after the time the scrub was scheduled and no scrub has been performed.
 
 PGs will receive a deep scrub only if they are flagged as *clean* (which means
 that they are to be cleaned, and not that they have been examined and found to
@@ -1508,9 +1508,10 @@ be clean). Misplaced or degraded PGs might not be flagged as ``clean`` (see
 *PG_AVAILABILITY* and *PG_DEGRADED* above).
 
 This document offers two methods of setting the value of
-``osd_deep_scrub_interval``. The first method listed here changes the value of
-``osd_deep_scrub_interval`` globally. The second method listed here changes the
-value of ``osd_deep scrub interval`` for OSDs and for the Manager daemon.
+:confval:`osd_deep_scrub_interval`. The first method listed here changes the
+value of :confval:`osd_deep_scrub_interval` globally. The second method listed
+here changes the value of :confval:`osd_deep scrub interval` for OSDs and for
+the Manager daemon.
 
 First Method
 ~~~~~~~~~~~~
@@ -1521,10 +1522,10 @@ To manually initiate a deep scrub of a clean PG, run the following command:
 
    ceph pg deep-scrub <pgid>
 
-Under certain conditions, the warning ``X PGs not deep-scrubbed in time``
+Under certain conditions, the warning ``PGs not deep-scrubbed in time``
 appears. This might be because the cluster contains many large PGs, which take
 longer to deep-scrub. To remedy this situation, you must change the value of
-``osd_deep_scrub_interval`` globally.
+:confval:`osd_deep_scrub_interval` globally.
 
 #. Confirm that ``ceph health detail`` returns a ``pgs not deep-scrubbed in
    time`` warning::
@@ -1555,10 +1556,10 @@ To manually initiate a deep scrub of a clean PG, run the following command:
 
    ceph pg deep-scrub <pgid>
 
-Under certain conditions, the warning ``X PGs not deep-scrubbed in time``
+Under certain conditions, the warning ``PGs not deep-scrubbed in time``
 appears. This might be because the cluster contains many large PGs, which take
 longer to deep-scrub. To remedy this situation, you must change the value of
-``osd_deep_scrub_interval`` for OSDs and for the Manager daemon.
+:confval:`osd_deep_scrub_interval` for OSDs and for the Manager daemon.
 
 #. Confirm that ``ceph health detail`` returns a ``pgs not deep-scrubbed in
    time`` warning::


### PR DESCRIPTION
Add confval directives to doc/rados/operations/health-checks.rst, as requested by Anthony D'Atri here: https://github.com/ceph/ceph/pull/59635#pullrequestreview-2286205705

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit a159821ddfcecaa75f5a92af7e22ea198d82a8db)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

