### PR TITLE
reef: mgr/dashboard: Wrong(half) uid is observed in dashboard

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.html
@@ -36,7 +36,7 @@
         <tr>
           <td i18n
               class="bold w-25">User ID</td>
-          <td class="w-75">{{ user.user_id }}</td>
+          <td class="w-75">{{ user.uid }}</td>
         </tr>
         <tr>
           <td i18n


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68143

---

backport of https://github.com/ceph/ceph/pull/59554
parent tracker: https://tracker.ceph.com/issues/67850

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh