### PR TITLE
librbd: introduce rbd_group_snap_namespace_type_t enum

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -249,6 +249,10 @@ typedef enum {
   RBD_GROUP_SNAP_STATE_COMPLETE
 } rbd_group_snap_state_t;
 
+typedef enum {
+  RBD_GROUP_SNAP_NAMESPACE_TYPE_USER = 0
+} rbd_group_snap_namespace_type_t;
+
 typedef struct {
   char *image_name;
   int64_t pool_id;
@@ -265,7 +269,7 @@ typedef struct {
   char *name;
   char *image_snap_name;
   rbd_group_snap_state_t state;
-  //rbd_group_snap_namespace_type_t namespace_type;
+  rbd_group_snap_namespace_type_t namespace_type;
   size_t image_snaps_count;
   rbd_group_image_snap_info_t *image_snaps;
 } rbd_group_snap_info2_t;

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -160,6 +160,7 @@ namespace librbd {
   } group_info_t;
 
   typedef rbd_group_snap_state_t group_snap_state_t;
+  typedef rbd_group_snap_namespace_type_t group_snap_namespace_type_t;
 
   typedef struct {
     std::string image_name;
@@ -177,7 +178,7 @@ namespace librbd {
     std::string name;
     std::string image_snap_name;
     group_snap_state_t state;
-    //group_snap_namespace_type_t namespace_type;
+    group_snap_namespace_type_t namespace_type;
     std::vector<group_image_snap_info_t> image_snaps;
   } group_snap_info2_t;
 

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -483,6 +483,7 @@ int GroupSnapshot_to_group_snap_info2(
   group_snap->id = cls_group_snap.id;
   group_snap->name = cls_group_snap.name;
   group_snap->state = static_cast<group_snap_state_t>(cls_group_snap.state);
+  group_snap->namespace_type = RBD_GROUP_SNAP_NAMESPACE_TYPE_USER;
   if (!image_snaps.empty()) {
     group_snap->image_snap_name = calc_ind_image_snap_name(
         group_ioctx.get_id(), group_id, cls_group_snap.id);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -275,6 +275,7 @@ void group_snap_info2_cpp_to_c(const librbd::group_snap_info2_t &cpp_info,
   c_info->name = strdup(cpp_info.name.c_str());
   c_info->image_snap_name = strdup(cpp_info.image_snap_name.c_str());
   c_info->state = cpp_info.state;
+  c_info->namespace_type = cpp_info.namespace_type;
   c_info->image_snaps_count = cpp_info.image_snaps.size();
   c_info->image_snaps = static_cast<rbd_group_image_snap_info_t*>(calloc(
     cpp_info.image_snaps.size(), sizeof(rbd_group_image_snap_info_t)));

--- a/src/pybind/rbd/c_rbd.pxd
+++ b/src/pybind/rbd/c_rbd.pxd
@@ -224,6 +224,9 @@ cdef extern from "rbd/librbd.h" nogil:
         _RBD_GROUP_SNAP_STATE_INCOMPLETE "RBD_GROUP_SNAP_STATE_INCOMPLETE"
         _RBD_GROUP_SNAP_STATE_COMPLETE "RBD_GROUP_SNAP_STATE_COMPLETE"
 
+    ctypedef enum rbd_group_snap_namespace_type_t:
+        _RBD_GROUP_SNAP_NAMESPACE_TYPE_USER "RBD_GROUP_SNAP_NAMESPACE_TYPE_USER"
+
     ctypedef struct rbd_group_image_snap_info_t:
         char *image_name
         int64_t pool_id
@@ -234,6 +237,7 @@ cdef extern from "rbd/librbd.h" nogil:
         char *name
         char *image_snap_name
         rbd_group_snap_state_t state
+        rbd_group_snap_namespace_type_t namespace_type
         size_t image_snaps_count
         rbd_group_image_snap_info_t *image_snaps
 

--- a/src/pybind/rbd/mock_rbd.pxi
+++ b/src/pybind/rbd/mock_rbd.pxi
@@ -228,6 +228,9 @@ cdef nogil:
         _RBD_GROUP_SNAP_STATE_INCOMPLETE "RBD_GROUP_SNAP_STATE_INCOMPLETE"
         _RBD_GROUP_SNAP_STATE_COMPLETE "RBD_GROUP_SNAP_STATE_COMPLETE"
 
+    ctypedef enum rbd_group_snap_namespace_type_t:
+        _RBD_GROUP_SNAP_NAMESPACE_TYPE_USER "RBD_GROUP_SNAP_NAMESPACE_TYPE_USER"
+
     ctypedef struct rbd_group_image_snap_info_t:
         char *image_name
         int64_t pool_id
@@ -238,6 +241,7 @@ cdef nogil:
         char *name
         char *image_snap_name
         rbd_group_snap_state_t state
+        rbd_group_snap_namespace_type_t namespace_type
         size_t image_snaps_count
         rbd_group_image_snap_info_t *image_snaps
 

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -134,6 +134,8 @@ RBD_GROUP_IMAGE_STATE_INCOMPLETE = _RBD_GROUP_IMAGE_STATE_INCOMPLETE
 RBD_GROUP_SNAP_STATE_INCOMPLETE = _RBD_GROUP_SNAP_STATE_INCOMPLETE
 RBD_GROUP_SNAP_STATE_COMPLETE = _RBD_GROUP_SNAP_STATE_COMPLETE
 
+RBD_GROUP_SNAP_NAMESPACE_TYPE_USER = _RBD_GROUP_SNAP_NAMESPACE_TYPE_USER
+
 RBD_IMAGE_MIGRATION_STATE_UNKNOWN = _RBD_IMAGE_MIGRATION_STATE_UNKNOWN
 RBD_IMAGE_MIGRATION_STATE_ERROR = _RBD_IMAGE_MIGRATION_STATE_ERROR
 RBD_IMAGE_MIGRATION_STATE_PREPARING = _RBD_IMAGE_MIGRATION_STATE_PREPARING
@@ -2843,6 +2845,8 @@ cdef class Group(object):
 
             * ``state`` (int) - state of the group snapshot
 
+            * ``namespace_type`` (int) - group snapshot namespace type
+
             * ``image_snap_name`` (str) - name of the image snapshots
 
             * ``image_snaps`` (list) - image snapshots that constitute the group snapshot.
@@ -2881,6 +2885,7 @@ cdef class Group(object):
             'id': decode_cstr(group_snap.id),
             'name': decode_cstr(group_snap.name),
             'state': group_snap.state,
+            'namespace_type': group_snap.namespace_type,
             'image_snap_name': decode_cstr(group_snap.image_snap_name),
             'image_snaps': image_snaps
         }
@@ -6055,6 +6060,8 @@ cdef class GroupSnapIterator(object):
 
     * ``state`` (int) - state of the group snapshot
 
+    * ``namespace_type`` (int) - group snapshot namespace type
+
     * ``image_snap_name`` (str) - name of the image snapshots
 
     * ``image_snaps`` (list) - image snapshots that constitute the group snapshot.
@@ -6105,6 +6112,7 @@ cdef class GroupSnapIterator(object):
                 'id': decode_cstr(group_snap.id),
                 'name': decode_cstr(group_snap.name),
                 'state': group_snap.state,
+                'namespace_type': group_snap.namespace_type,
                 'image_snap_name': decode_cstr(group_snap.image_snap_name),
                 'image_snaps': image_snaps,
             }

--- a/src/test/librbd/test_Groups.cc
+++ b/src/test/librbd/test_Groups.cc
@@ -522,6 +522,7 @@ TEST_F(TestGroup, snap_get_info)
                                        &gp_snap_info));
   ASSERT_STREQ(gp_snap_name, gp_snap_info.name);
   ASSERT_EQ(RBD_GROUP_SNAP_STATE_COMPLETE, gp_snap_info.state);
+  ASSERT_EQ(RBD_GROUP_SNAP_NAMESPACE_TYPE_USER, gp_snap_info.namespace_type);
   ASSERT_STREQ("", gp_snap_info.image_snap_name);
   ASSERT_EQ(0U, gp_snap_info.image_snaps_count);
 
@@ -536,6 +537,7 @@ TEST_F(TestGroup, snap_get_info)
                                        &gp_snap_info));
   ASSERT_STREQ(gp_snap_name, gp_snap_info.name);
   ASSERT_EQ(RBD_GROUP_SNAP_STATE_COMPLETE, gp_snap_info.state);
+  ASSERT_EQ(RBD_GROUP_SNAP_NAMESPACE_TYPE_USER, gp_snap_info.namespace_type);
   ASSERT_EQ(1U, gp_snap_info.image_snaps_count);
   ASSERT_EQ(m_image_name, gp_snap_info.image_snaps[0].image_name);
   ASSERT_EQ(rados_ioctx_get_id(ioctx), gp_snap_info.image_snaps[0].pool_id);
@@ -574,6 +576,7 @@ TEST_F(TestGroup, snap_get_infoPP)
                                          &gp_snap_info));
   ASSERT_EQ(gp_snap_name, gp_snap_info.name);
   ASSERT_EQ(RBD_GROUP_SNAP_STATE_COMPLETE, gp_snap_info.state);
+  ASSERT_EQ(RBD_GROUP_SNAP_NAMESPACE_TYPE_USER, gp_snap_info.namespace_type);
   ASSERT_EQ("", gp_snap_info.image_snap_name);
   ASSERT_EQ(0U, gp_snap_info.image_snaps.size());
 
@@ -587,6 +590,7 @@ TEST_F(TestGroup, snap_get_infoPP)
                                          &gp_snap_info));
   ASSERT_EQ(gp_snap_name, gp_snap_info.name);
   ASSERT_EQ(RBD_GROUP_SNAP_STATE_COMPLETE, gp_snap_info.state);
+  ASSERT_EQ(RBD_GROUP_SNAP_NAMESPACE_TYPE_USER, gp_snap_info.namespace_type);
   ASSERT_EQ(1U, gp_snap_info.image_snaps.size());
   ASSERT_EQ(m_image_name, gp_snap_info.image_snaps[0].image_name);
   ASSERT_EQ(m_ioctx.get_id(), gp_snap_info.image_snaps[0].pool_id);
@@ -652,6 +656,7 @@ TEST_F(TestGroup, snap_list2)
 
   for (int i = 0; i < 4; i++) {
     ASSERT_EQ(RBD_GROUP_SNAP_STATE_COMPLETE, gp_snaps[i].state);
+    ASSERT_EQ(RBD_GROUP_SNAP_NAMESPACE_TYPE_USER, gp_snaps[i].namespace_type);
     if (!strcmp(gp_snaps[i].name, gp_snap_names[0])) {
       ASSERT_EQ(0U, gp_snaps[i].image_snaps_count);
     } else if (!strcmp(gp_snaps[i].name, gp_snap_names[1])) {
@@ -739,6 +744,7 @@ TEST_F(TestGroup, snap_list2PP)
 
   for (const auto& gp_snap : gp_snaps) {
     ASSERT_EQ(RBD_GROUP_SNAP_STATE_COMPLETE, gp_snap.state);
+    ASSERT_EQ(RBD_GROUP_SNAP_NAMESPACE_TYPE_USER, gp_snap.namespace_type);
     if (gp_snap.name == gp_snap_names[0]) {
       ASSERT_EQ(0U, gp_snap.image_snaps.size());
     } else if (gp_snap.name == gp_snap_names[1]) {

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -49,7 +49,8 @@ from rbd import (RBD, Group, Image, ImageNotFound, InvalidArgument, ImageExists,
                  RBD_SNAP_CREATE_IGNORE_QUIESCE_ERROR,
                  RBD_WRITE_ZEROES_FLAG_THICK_PROVISION,
                  RBD_ENCRYPTION_FORMAT_LUKS1, RBD_ENCRYPTION_FORMAT_LUKS2,
-                 RBD_ENCRYPTION_FORMAT_LUKS, RBD_GROUP_SNAP_STATE_COMPLETE)
+                 RBD_ENCRYPTION_FORMAT_LUKS, RBD_GROUP_SNAP_STATE_COMPLETE,
+                 RBD_GROUP_SNAP_NAMESPACE_TYPE_USER)
 
 rados = None
 ioctx = None
@@ -2836,7 +2837,8 @@ def test_list_groups_after_removed():
 
 class TestGroups(object):
     img_snap_keys = ['image_name', 'pool_id', 'snap_id']
-    gp_snap_keys = ['id', 'image_snap_name', 'image_snaps', 'name', 'state']
+    gp_snap_keys = ['id', 'image_snap_name', 'image_snaps', 'name',
+                    'namespace_type', 'state']
 
     def setup_method(self, method):
         global snap_name
@@ -2925,6 +2927,7 @@ class TestGroups(object):
         assert sorted(snap_info_dict.keys()) == self.gp_snap_keys
         assert snap_info_dict['name'] == snap_name
         assert snap_info_dict['state'] == RBD_GROUP_SNAP_STATE_COMPLETE
+        assert snap_info_dict['namespace_type'] == RBD_GROUP_SNAP_NAMESPACE_TYPE_USER
         for image_snap in snap_info_dict['image_snaps']:
             assert sorted(image_snap.keys()) == self.img_snap_keys
             assert image_snap['pool_id'] == pool_id
@@ -2946,6 +2949,7 @@ class TestGroups(object):
         assert sorted(snap_info_dict.keys()) == self.gp_snap_keys
         assert snap_info_dict['name'] == snap_name
         assert snap_info_dict['state'] == RBD_GROUP_SNAP_STATE_COMPLETE
+        assert snap_info_dict['namespace_type'] == RBD_GROUP_SNAP_NAMESPACE_TYPE_USER
         assert snap_info_dict['image_snap_name'] == ""
         assert snap_info_dict['image_snaps'] == []
 


### PR DESCRIPTION
Commit e5ccce14c4b0 ("rbd: add group snap info command") added a commented out field in rbd_group_snap_info2_t struct but didn't define the corresponding enum, expecting it to be brought in with the patchset that introduces mirror group snapshots.  That work is still in progress, but there is already interest in the new command and APIs that use rbd_group_snap_info2_t struct and even a backport request.

Finalize the struct definition to avoid a breaking change for those users in the future.  RBD_GROUP_SNAP_NAMESPACE_TYPE_USER can be treated as dummy in terms of meaning until RBD_GROUP_SNAP_NAMESPACE_TYPE_MIRROR is added.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
