### PR TITLE
cls/user: reset stats only returns marker when truncated

### DIFF
--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -482,10 +482,6 @@ static int cls_user_reset_stats2(cls_method_context_t hctx,
     add_header_stats(&ret.acc_stats, e);
   }
 
-  /* try-update marker */
-  if(!keys.empty())
-    ret.marker = (--keys.cend())->first;
-
   if (! ret.truncated) {
     buffer::list bl;
     header.last_stats_update = op.time;
@@ -499,6 +495,10 @@ static int cls_user_reset_stats2(cls_method_context_t hctx,
     encode(ret, *out);
     return rc;
   }
+
+  /* try-update marker */
+  if(!keys.empty())
+    ret.marker = (--keys.cend())->first;
 
   /* return partial result */
   encode(ret, *out);


### PR DESCRIPTION
the returned marker is a bucket name. when bucket names are long, the response can overflow the 64-byte limit on responses to write operations with librados::OPERATION_RETURNVEC. this leads to errors like:

> ERROR: could not reset user stats: (75) Value too large for defined data type

however, the client only needs this marker string to resume listing after a truncated response. if the listing is not truncated, we can omit the marker to save space

in general, users will have less than MAX_ENTRIES=1000 buckets, so won't get truncated listings

Fixes: https://tracker.ceph.com/issues/51786

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
