### PR TITLE
reef: osd/scrub: reduce osd_requested_scrub_priority default value

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3656,7 +3656,7 @@ options:
 - name: osd_requested_scrub_priority
   type: uint
   level: advanced
-  default: 120
+  default: 5
   fmt_desc: The priority set for user requested scrub on the work queue.  If
     this value were to be smaller than ``osd_client_op_priority`` it
     can be boosted to the value of ``osd_client_op_priority`` when


### PR DESCRIPTION
No scrub messages should have a higher priority than client op messages. The default value should therefore be below osd_client_op_priority, which is 63.

But as a followup PR would eliminate the special queue priority for 'requested' scrub messages, the default value is set to equal osd_scrub_priority.

Backport of https://github.com/ceph/ceph/pull/59793

Original tracker: https://tracker.ceph.com/issues/68072
Backport tracker: https://tracker.ceph.com/issues/68155

Signed-off-by: Ronen Friedman [rfriedma@redhat.com](mailto:rfriedma@redhat.com)
(cherry picked from commit b98a46582e5e21de13e51017ea35dabdc19db71d)
