### PR TITLE
rgw/reshard: add async bi entry writer for target index shards

### DIFF
--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -495,8 +495,6 @@ struct rgw_cls_bucket_update_stats_op
   std::map<RGWObjCategory, rgw_bucket_category_stats> stats;
   std::map<RGWObjCategory, rgw_bucket_category_stats> dec_stats;
 
-  rgw_cls_bucket_update_stats_op() {}
-
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(2, 1, bl);
     encode(absolute, bl);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -788,12 +788,10 @@ struct rgw_cls_bi_put_entries_op {
 WRITE_CLASS_ENCODER(rgw_cls_bi_put_entries_op)
 
 struct rgw_cls_bi_list_op {
-  uint32_t max;
+  uint32_t max = 0;
   std::string name_filter; // limit result to one object and its instances
   std::string marker;
-  bool reshardlog;
-
-  rgw_cls_bi_list_op() : max(0), reshardlog(false) {}
+  bool reshardlog = false;
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -734,8 +734,6 @@ WRITE_CLASS_ENCODER(rgw_cls_bi_get_ret)
 struct rgw_cls_bi_put_op {
   rgw_cls_bi_entry entry;
 
-  rgw_cls_bi_put_op() {}
-
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entry, bl);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -729,6 +729,49 @@ inline bool operator!=(const rgw_bucket_category_stats& lhs,
   return !(lhs == rhs);
 }
 
+inline auto operator+(const rgw_bucket_category_stats& lhs,
+                      const rgw_bucket_category_stats& rhs)
+  -> rgw_bucket_category_stats
+{
+  return rgw_bucket_category_stats{
+    .total_size = lhs.total_size + rhs.total_size,
+    .total_size_rounded = lhs.total_size_rounded + rhs.total_size_rounded,
+    .num_entries = lhs.num_entries + rhs.num_entries,
+    .actual_size = lhs.actual_size + rhs.actual_size
+  };
+}
+inline auto operator+=(rgw_bucket_category_stats& lhs,
+                       const rgw_bucket_category_stats& rhs)
+  -> rgw_bucket_category_stats&
+{
+  lhs.total_size += rhs.total_size;
+  lhs.total_size_rounded += rhs.total_size_rounded;
+  lhs.num_entries += rhs.num_entries;
+  lhs.actual_size += rhs.actual_size;
+  return lhs;
+}
+inline auto operator-(const rgw_bucket_category_stats& lhs,
+                      const rgw_bucket_category_stats& rhs)
+  -> rgw_bucket_category_stats
+{
+  return rgw_bucket_category_stats{
+    .total_size = lhs.total_size - rhs.total_size,
+    .total_size_rounded = lhs.total_size_rounded - rhs.total_size_rounded,
+    .num_entries = lhs.num_entries - rhs.num_entries,
+    .actual_size = lhs.actual_size - rhs.actual_size
+  };
+}
+inline auto operator-=(rgw_bucket_category_stats& lhs,
+                       const rgw_bucket_category_stats& rhs)
+  -> rgw_bucket_category_stats&
+{
+  lhs.total_size -= rhs.total_size;
+  lhs.total_size_rounded -= rhs.total_size_rounded;
+  lhs.num_entries -= rhs.num_entries;
+  lhs.actual_size -= rhs.actual_size;
+  return lhs;
+}
+
 enum class cls_rgw_reshard_status : uint8_t {
   NOT_RESHARDING  = 0,
   IN_PROGRESS     = 1,

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -687,12 +687,10 @@ struct rgw_bi_log_entry {
 WRITE_CLASS_ENCODER(rgw_bi_log_entry)
 
 struct rgw_bucket_category_stats {
-  uint64_t total_size;
-  uint64_t total_size_rounded;
-  uint64_t num_entries;
+  uint64_t total_size = 0;
+  uint64_t total_size_rounded = 0;
+  uint64_t num_entries = 0;
   uint64_t actual_size{0}; //< account for compression, encryption
-
-  rgw_bucket_category_stats() : total_size(0), total_size_rounded(0), num_entries(0) {}
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(3, 2, bl);

--- a/src/neorados/CMakeLists.txt
+++ b/src/neorados/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(libneorados STATIC
 target_link_libraries(libneorados PRIVATE
   osdc ceph-common cls_lock_client ${FMT_LIB}
   ${BLKID_LIBRARIES} ${CRYPTO_LIBS} ${EXTRALIBS})
+target_include_directories(libneorados PUBLIC "${CMAKE_SOURCE_DIR}/src/include")
 
 # if(ENABLE_SHARED)
 #   add_library(libneorados ${CEPH_SHARED}

--- a/src/neorados/cls/rgw.h
+++ b/src/neorados/cls/rgw.h
@@ -1,0 +1,295 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <concepts>
+#include <iterator>
+#include <ranges>
+#include <string>
+
+#include <neorados/RADOS.hpp>
+#include "cls/rgw/cls_rgw_const.h"
+#include "cls/rgw/cls_rgw_ops.h"
+
+/// \namespace Neorados client interface for cls_rgw.
+namespace neorados::cls::rgw {
+
+/// \defgroup bi Bucket Index
+/// @{
+
+/// \brief Initialize a bucket index shard object.
+///
+/// Create a bucket index shard object and initialize its omap header.
+///
+/// Fails with -EEXIST if the object already exists.
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline
+auto bi_init()
+{
+  return ClsWriteOp{[] (WriteOp& op) {
+    op.create(true);
+    buffer::list in;
+    op.exec(RGW_CLASS, RGW_BUCKET_INIT_INDEX, in);
+  }};
+}
+
+/// \brief Initialize a bucket index shard object.
+///
+/// Create a bucket index shard object and initialize its omap header.
+///
+/// Fails with -EEXIST if the object already exists.
+///
+/// Fails with -EOPNOTSUPP if the osd version doesn't support the reshard log.
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline
+auto bi_init2()
+{
+  return ClsWriteOp{[] (WriteOp& op) {
+    op.create(true);
+    buffer::list in;
+    op.exec(RGW_CLASS, RGW_BUCKET_INIT_INDEX2, in);
+  }};
+}
+
+/// \brief Remove the bucket index shard object.
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline
+auto bi_clean()
+{
+  return ClsWriteOp{[] (WriteOp& op) {
+    op.remove();
+  }};
+}
+
+/// \brief Set the resharding status of a bucket index shard object.
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline
+auto bi_set_resharding(cls_rgw_reshard_status status)
+{
+  const auto call = cls_rgw_set_bucket_resharding_op{
+    .entry = {.reshard_status = status}
+  };
+  buffer::list in;
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)] (WriteOp& op) {
+    op.exec(RGW_CLASS, RGW_SET_BUCKET_RESHARDING, in);
+  }};
+}
+
+/// \brief Write an entry directly to the bucket index shard object.
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline
+auto bi_put(rgw_cls_bi_entry entry)
+{
+  const auto call = rgw_cls_bi_put_op{.entry = std::move(entry)};
+  buffer::list in;
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)] (WriteOp& op) {
+    op.exec(RGW_CLASS, RGW_BI_PUT, in);
+  }};
+}
+
+/// An input iterator whose value type is convertible to rgw_cls_bi_entry.
+template <typename T>
+concept bi_entry_iterator =
+    std::input_iterator<T> &&
+    std::convertible_to<std::iter_value_t<T>, rgw_cls_bi_entry>;
+
+/// An input range whose value type is convertible to rgw_cls_bi_entry.
+template <typename T>
+concept bi_entry_range =
+    std::ranges::input_range<T> &&
+    bi_entry_iterator<std::ranges::iterator_t<T>>;
+
+/// \brief Write entries directly to the bucket index shard object.
+///
+/// \param begin Beginning of a range of entries.
+/// \param end End of a range of entries.
+/// \param check_existing Subtract bucket stats for overwritten entries.
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline
+auto bi_put_entries(bi_entry_iterator auto begin,
+                    bi_entry_iterator auto end,
+                    bool check_existing)
+{
+  const auto call = rgw_cls_bi_put_entries_op{
+    .entries = {begin, end},
+    .check_existing = check_existing
+  };
+  bufferlist in;
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)] (WriteOp& op) {
+    op.exec(RGW_CLASS, RGW_BI_PUT_ENTRIES, in);
+  }};
+}
+
+/// \overload
+[[nodiscard]] inline
+auto bi_put_entries(bi_entry_range auto stats)
+{
+  // forward to iterator overload
+  return bi_put_entries(std::ranges::begin(stats),
+                        std::ranges::end(stats));
+}
+
+/// \brief List bucket index entries.
+///
+/// \param name_filter List entries whose key starts with the given prefix.
+/// \param marker Resume listing after the given marker position.
+/// \param max Maximum number of entries to return.
+/// \param reshardlog When true, list entries from the reshard log.
+/// \param out Output iterator to receive the entries.
+/// \param truncated Output parameter set to true if more entries follow.
+///
+/// \return The ClsReadOp to be passed to ReadOp::exec
+[[nodiscard]] inline
+auto bi_list(std::string name_filter,
+             std::string marker,
+             uint32_t max,
+             bool reshardlog,
+             std::output_iterator<rgw_cls_bi_entry> auto out,
+             bool& truncated)
+{
+  const auto call = rgw_cls_bi_list_op{
+    .max = max,
+    .name_filter = std::move(name_filter),
+    .marker = std::move(marker),
+    .reshardlog = reshardlog
+  };
+  buffer::list in;
+  encode(call, in);
+  return ClsReadOp{
+    [in = std::move(in), out = std::move(out), &truncated] (ReadOp& op) {
+      op.exec(RGW_CLASS, RGW_BI_LIST, in,
+        [out = std::move(out), &truncated] (boost::system::error_code ec,
+                                            const buffer::list& bl) {
+          if (ec || bl.length() == 0) {
+            truncated = false;
+            return;
+          }
+
+          rgw_cls_bi_list_ret ret;
+          auto iter = bl.cbegin();
+          decode(ret, iter); // may throw, let it propagate
+
+          std::move(ret.entries.begin(), ret.entries.end(), out);
+          truncated = ret.is_truncated;
+        });
+    }
+  };
+}
+
+/// \brief Remove all reshard log entries from a bucket index object.
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline
+auto bi_reshard_log_trim()
+{
+  return ClsWriteOp{[] (WriteOp& op) {
+    buffer::list in;
+    op.exec(RGW_CLASS, RGW_RESHARD_LOG_TRIM, in);
+  }};
+}
+
+/// An input iterator whose value type is convertible to
+/// std::pair<RGWObjCategory, rgw_bucket_category_stats>.
+template <typename T>
+concept category_stats_iterator =
+    std::input_iterator<T> &&
+    std::convertible_to<std::iter_value_t<T>,
+        std::pair<RGWObjCategory, rgw_bucket_category_stats>>;
+
+/// An input range whose value type is convertible to
+/// std::pair<RGWObjCategory, rgw_bucket_category_stats>.
+template <typename T>
+concept category_stats_range =
+    std::ranges::input_range<T> &&
+    category_stats_iterator<std::ranges::iterator_t<T>>;
+
+/// \brief Set stats for a bucket index object.
+///
+/// Set the bucket stats, replacing any existing categories.
+///
+/// \param begin Beginning of a range of category stats.
+/// \param end End of a range of category stats.
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline
+auto bi_set_stats(category_stats_iterator auto begin,
+                  category_stats_iterator auto end)
+{
+  const auto call = rgw_cls_bucket_update_stats_op{
+    .absolute = true,
+    .stats = {begin, end}
+  };
+  buffer::list in;
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)] (WriteOp& op) {
+    op.exec(RGW_CLASS, RGW_BUCKET_UPDATE_STATS, in);
+  }};
+}
+
+/// \overload
+[[nodiscard]] inline
+auto bi_set_stats(category_stats_range auto&& stats)
+{
+  // forward to iterator overload
+  return bi_set_stats(std::ranges::begin(stats),
+                      std::ranges::end(stats));
+}
+
+/// \brief Add stats to a bucket index object.
+///
+/// Add the bucket stats to any existing categories.
+///
+/// \param begin Beginning of a range of category stats.
+/// \param end End of a range of category stats.
+///
+/// \return The ClsWriteOp to be passed to WriteOp::exec
+[[nodiscard]] inline
+auto bi_add_stats(category_stats_iterator auto begin,
+                  category_stats_iterator auto end)
+{
+  const auto call = rgw_cls_bucket_update_stats_op{
+    .absolute = false,
+    .stats = {begin, end}
+  };
+  buffer::list in;
+  encode(call, in);
+  return ClsWriteOp{[in = std::move(in)] (WriteOp& op) {
+    op.exec(RGW_CLASS, RGW_BUCKET_UPDATE_STATS, in);
+  }};
+}
+
+/// \overload
+[[nodiscard]] inline
+auto bi_add_stats(category_stats_range auto stats)
+{
+  // forward to iterator overload
+  return bi_add_stats(std::ranges::begin(stats),
+                      std::ranges::end(stats));
+}
+
+/// @}
+
+} // namespace neorados::cls::rgw

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -286,7 +286,6 @@ target_link_libraries(rgw_common
     cls_user_client
     cls_version_client
     librados
-    libneorados
     rt
     ICU::uc
     OATH::OATH
@@ -297,6 +296,7 @@ target_link_libraries(rgw_common
     ${ARROW_FLIGHT_LIBRARIES}
     ${LMDB_LIBRARIES}
   PUBLIC
+    libneorados
     ${LUA_LIBRARIES}
     RapidJSON::RapidJSON
     Boost::context

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -198,6 +198,7 @@ set(librgw_common_srcs
   driver/rados/rgw_trim_mdlog.cc
   driver/rados/rgw_user.cc
   driver/rados/rgw_zone.cc
+  driver/rados/reshard_writer.cc
   driver/rados/role.cc
   driver/rados/roles.cc
   driver/rados/sync_fairness.cc

--- a/src/rgw/driver/rados/reshard_writer.cc
+++ b/src/rgw/driver/rados/reshard_writer.cc
@@ -1,0 +1,201 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "reshard_writer.h"
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/execution.hpp>
+#include <boost/asio/query.hpp>
+#include "neorados/cls/rgw.h"
+
+namespace rgwrados::reshard {
+
+BaseWriter::BaseWriter(const executor_type& ex, uint64_t max_aio)
+  : svc(boost::asio::use_service<service_type>(
+          boost::asio::query(ex, boost::asio::execution::context))),
+    ex(ex), max_aio(max_aio)
+{
+  // register for service_shutdown() notifications
+  svc.add(*this);
+}
+
+BaseWriter::~BaseWriter()
+{
+  svc.remove(*this);
+}
+
+auto BaseWriter::drain()
+  -> boost::asio::awaitable<void>
+{
+  if (outstanding > 0) {
+    Waiter waiter;
+    drain_waiters.push_back(waiter);
+    co_await waiter.get(); // may rethrow error from previous completion
+  } else if (error) {
+    // make sure errors get reported to the caller
+    throw boost::system::system_error(error);
+  }
+}
+
+void BaseWriter::on_complete(boost::system::error_code ec)
+{
+  --outstanding;
+
+  constexpr auto complete_all = [] (boost::intrusive::list<Waiter>& waiters,
+                                    std::exception_ptr eptr) {
+      while (!waiters.empty()) {
+        Waiter& waiter = waiters.front();
+        waiters.pop_front();
+        waiter.complete(eptr);
+      }
+    };
+  constexpr auto complete_one = [] (boost::intrusive::list<Waiter>& waiters,
+                                    std::exception_ptr eptr) {
+      if (!waiters.empty()) {
+        Waiter& waiter = waiters.front();
+        waiters.pop_front();
+        waiter.complete(eptr);
+      }
+    };
+
+  if (ec) {
+    if (!error) {
+      error = ec;
+    }
+    // fail all waiting calls to write()
+    auto eptr = std::make_exception_ptr(boost::system::system_error{ec});
+    complete_all(write_waiters, eptr);
+  } else {
+    // wake one waiting call to write()
+    complete_one(write_waiters, nullptr);
+  }
+
+  if (outstanding == 0) {
+    // wake all waiting calls to drain()
+    std::exception_ptr eptr;
+    if (error) {
+      eptr = std::make_exception_ptr(boost::system::system_error{error});
+    }
+    complete_all(drain_waiters, eptr);
+  }
+}
+
+void BaseWriter::service_shutdown()
+{
+  // release any outstanding completion handlers
+  constexpr auto shutdown = [] (auto& waiters) {
+      while (!waiters.empty()) {
+        Waiter& waiter = waiters.front();
+        waiters.pop_front();
+        waiter.shutdown();
+      }
+    };
+  shutdown(write_waiters);
+  shutdown(drain_waiters);
+}
+
+
+PutBatch::PutBatch(neorados::RADOS& rados,
+                   neorados::IOContext ioctx,
+                   neorados::Object object,
+                   size_t batch_size)
+  : rados(rados),
+    ioctx(std::move(ioctx)),
+    object(std::move(object)),
+    batch_size(batch_size)
+{
+  entries.reserve(batch_size); // preallocate the batch
+}
+
+[[nodiscard]] bool PutBatch::empty() const
+{
+  return entries.empty();
+}
+
+[[nodiscard]] bool PutBatch::add(rgw_cls_bi_entry entry,
+                                 std::optional<RGWObjCategory> category,
+                                 rgw_bucket_category_stats entry_stats)
+{
+  entries.push_back(std::move(entry));
+
+  if (category) {
+    stats[*category] += entry_stats;
+  }
+
+  return entries.size() >= batch_size;
+}
+
+void PutBatch::flush(Completion completion)
+{
+  neorados::WriteOp op;
+
+  // issue a separate bi_put() call for each entry
+  for (auto& entry : entries) {
+    op.exec(neorados::cls::rgw::bi_put(std::move(entry)));
+  }
+  entries.clear();
+
+  op.exec(neorados::cls::rgw::bi_add_stats(
+          std::make_move_iterator(stats.begin()),
+          std::make_move_iterator(stats.end())));
+  stats.clear();
+
+  rados.execute(object, ioctx, std::move(op), std::move(completion));
+}
+
+PutEntriesBatch::PutEntriesBatch(neorados::RADOS& rados,
+                                 neorados::IOContext ioctx,
+                                 neorados::Object object,
+                                 size_t batch_size,
+                                 bool check_existing)
+  : rados(rados),
+    ioctx(std::move(ioctx)),
+    object(std::move(object)),
+    batch_size(batch_size),
+    check_existing(check_existing)
+{
+  entries.reserve(batch_size); // preallocate the batch
+}
+
+[[nodiscard]] bool PutEntriesBatch::empty() const
+{
+  return entries.empty();
+}
+
+[[nodiscard]] bool PutEntriesBatch::add(rgw_cls_bi_entry entry,
+                                        std::optional<RGWObjCategory> category,
+                                        rgw_bucket_category_stats stats)
+{
+  entries.push_back(std::move(entry));
+  // bi_put_entries() handles stats on the server side
+  std::ignore = category;
+  std::ignore = stats;
+
+  return entries.size() >= batch_size;
+}
+
+void PutEntriesBatch::flush(Completion completion)
+{
+  neorados::WriteOp op;
+
+  op.exec(neorados::cls::rgw::bi_put_entries(
+          std::make_move_iterator(entries.begin()),
+          std::make_move_iterator(entries.end()),
+          check_existing));
+  entries.clear();
+
+  rados.execute(object, ioctx, std::move(op), std::move(completion));
+}
+
+} // namespace rgwrados::reshard

--- a/src/rgw/driver/rados/reshard_writer.h
+++ b/src/rgw/driver/rados/reshard_writer.h
@@ -1,0 +1,199 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/container/flat_map.hpp>
+#include <boost/intrusive/list.hpp>
+#include <boost/system.hpp>
+
+#include <neorados/RADOS.hpp>
+
+#include "cls/rgw/cls_rgw_types.h"
+#include "common/async/co_waiter.h"
+#include "common/async/service.h"
+
+namespace rgwrados::reshard {
+
+// base class for Writer that contains everything that doesn't
+// depend on the Batch template type
+class BaseWriter : public ceph::async::service_list_base_hook {
+ public:
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const noexcept { return ex; }
+
+  // wait for all outstanding flush completions
+  auto drain()
+    -> boost::asio::awaitable<void>;
+
+  void service_shutdown();
+
+ protected:
+  BaseWriter(const executor_type& ex, uint64_t max_aio);
+  ~BaseWriter();
+
+  using service_type = ceph::async::service<BaseWriter>;
+  service_type& svc;
+  executor_type ex;
+
+  const uint64_t max_aio;
+  uint64_t outstanding = 0;
+  boost::system::error_code error;
+
+  struct Waiter : boost::intrusive::list_base_hook<>,
+                  ceph::async::co_waiter<void, executor_type> {};
+  boost::intrusive::list<Waiter> write_waiters;
+  boost::intrusive::list<Waiter> drain_waiters;
+
+  friend struct Completion;
+  void on_complete(boost::system::error_code ec);
+};
+
+// handler that notifies the writer on completion of a flushed batch
+struct Completion {
+  BaseWriter& writer;
+
+  using executor_type = BaseWriter::executor_type;
+  boost::asio::executor_work_guard<executor_type> work =
+      make_work_guard(writer.get_executor());
+
+  executor_type get_executor() const { return work.get_executor(); }
+
+  void operator()(boost::system::error_code ec)
+  {
+    work.reset();
+    writer.on_complete(ec);
+  }
+};
+
+// example Batch type for Writer
+struct BatchArchetype final {
+  // return true if there are entries to flush
+  bool empty() const;
+  // append an entry to the batch and return whether a flush is necessary
+  bool add(rgw_cls_bi_entry entry,
+           std::optional<RGWObjCategory> category,
+           rgw_bucket_category_stats stats);
+  // flush the batch to storage, calling the given handler upon completion
+  void flush(Completion completion);
+};
+
+// Writes index entries in batches to a given target shard object
+template <typename Batch>
+class Writer : public BaseWriter {
+ public:
+  Writer(const executor_type& ex, uint64_t max_aio, Batch& batch)
+    : BaseWriter(ex, max_aio), batch(batch) {}
+
+  // add the given entry to its batch. if the batch is full, send an
+  // async write request to flush it in the background. write() only
+  // suspends once we reach the limit of outstanding write requests to
+  // avoid buffering additional entries. this is important to bound
+  // the overall memory usage of index entries
+  auto write(rgw_cls_bi_entry entry,
+             std::optional<RGWObjCategory> category,
+             rgw_bucket_category_stats stats)
+    -> boost::asio::awaitable<void>
+  {
+    if (error) {
+      // fail new writes once we're in the error state
+      throw boost::system::system_error(error);
+    }
+
+    while (outstanding >= max_aio) {
+      Waiter waiter;
+      write_waiters.push_back(waiter);
+      co_await waiter.get(); // may rethrow error from previous completion
+    }
+
+    const bool full = batch.add(entry, category, std::move(stats));
+    if (full) {
+      ++outstanding;
+      batch.flush(Completion{*this});
+    }
+  }
+
+  // if there's an incomplete batch, flush it
+  void flush()
+  {
+    if (!batch.empty()) {
+      ++outstanding;
+      batch.flush(Completion{*this});
+    }
+  }
+
+  // wait for all outstanding flush completions
+  using BaseWriter::drain;
+
+ private:
+  Batch& batch;
+};
+
+// a target shard batch that must be flushed with several bi_put() calls
+class PutBatch {
+ public:
+  PutBatch(neorados::RADOS& rados,
+           neorados::IOContext ioctx,
+           neorados::Object object,
+           size_t batch_size);
+
+  [[nodiscard]] bool empty() const;
+  [[nodiscard]] bool add(rgw_cls_bi_entry entry,
+                         std::optional<RGWObjCategory> category,
+                         rgw_bucket_category_stats stats);
+  void flush(Completion completion);
+
+ private:
+  neorados::RADOS& rados;
+  neorados::IOContext ioctx;
+  neorados::Object object;
+  const size_t batch_size;
+  std::vector<rgw_cls_bi_entry> entries;
+  using category_stats_map = boost::container::flat_map<
+      RGWObjCategory, rgw_bucket_category_stats>;
+  category_stats_map stats;
+};
+
+// a target shard batch that can be flushed with one bi_put_entries() call
+class PutEntriesBatch {
+ public:
+  PutEntriesBatch(neorados::RADOS& rados,
+                  neorados::IOContext ioctx,
+                  neorados::Object object,
+                  size_t batch_size,
+                  bool check_existing);
+
+  [[nodiscard]] bool empty() const;
+  [[nodiscard]] bool add(rgw_cls_bi_entry entry,
+                         std::optional<RGWObjCategory> category,
+                         rgw_bucket_category_stats stats);
+  void flush(Completion completion);
+
+ private:
+  neorados::RADOS& rados;
+  neorados::IOContext ioctx;
+  neorados::Object object;
+  const size_t batch_size;
+  const bool check_existing;
+  std::vector<rgw_cls_bi_entry> entries;
+};
+
+} // namespace rgwrados::reshard

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -5,6 +5,9 @@
 #include "cls/rgw/cls_rgw_client.h"
 #include "cls/rgw/cls_rgw_ops.h"
 
+// not tested, just make sure it compiles
+#include "neorados/cls/rgw.h"
+
 #include "gtest/gtest.h"
 #include "test/librados/test_cxx.h"
 #include "global/global_context.h"

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -114,6 +114,10 @@ add_executable(unittest_rgw_reshard_wait test_rgw_reshard_wait.cc)
 add_ceph_unittest(unittest_rgw_reshard_wait)
 target_link_libraries(unittest_rgw_reshard_wait ${rgw_libs})
 
+add_executable(unittest_rgw_reshard_writer test_rgw_reshard_writer.cc)
+add_ceph_unittest(unittest_rgw_reshard_writer)
+target_link_libraries(unittest_rgw_reshard_writer ${rgw_libs})
+
 set(test_rgw_a_src test_rgw_common.cc)
 add_library(test_rgw_a STATIC ${test_rgw_a_src})
 target_link_libraries(test_rgw_a ${rgw_libs})

--- a/src/test/rgw/test_rgw_reshard_writer.cc
+++ b/src/test/rgw/test_rgw_reshard_writer.cc
@@ -1,0 +1,693 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "reshard_writer.h"
+
+#include <functional>
+#include <optional>
+#include <vector>
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/io_context.hpp>
+#include <gtest/gtest.h>
+
+namespace rgwrados::reshard {
+
+template <typename T>
+auto capture(std::optional<T>& val)
+{
+  return [&val] (T value) { val = std::move(value); };
+}
+
+// mock Batch captures flush() completions for test cases to invoke manually
+class MockBatch {
+ public:
+  MockBatch(size_t batch_size, std::vector<Completion>& completions)
+    : batch_size(batch_size), completions(completions)
+  {}
+
+  bool empty() const
+  {
+    return count == 0;
+  }
+
+  bool add(rgw_cls_bi_entry entry,
+           std::optional<RGWObjCategory> category,
+           rgw_bucket_category_stats stats)
+  {
+    ++count;
+    return count == batch_size;
+  }
+
+  void flush(Completion completion)
+  {
+    completions.push_back(std::move(completion));
+    count = 0;
+  }
+
+ private:
+  const size_t batch_size;
+  size_t count = 0;
+  std::vector<Completion>& completions;
+};
+
+TEST(Writer, empty_flush)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  ASSERT_TRUE(batch.empty());
+  auto writer = Writer{ex, 1, batch};
+
+  writer.flush();
+  EXPECT_TRUE(completions.empty());
+}
+
+TEST(Writer, empty_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  ASSERT_TRUE(batch.empty());
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result;
+  boost::asio::co_spawn(ex, writer.drain(), capture(result));
+  EXPECT_FALSE(result);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+  EXPECT_TRUE(completions.empty());
+}
+
+TEST(Writer, write_no_flush)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{8, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result));
+  EXPECT_FALSE(result);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+  EXPECT_TRUE(completions.empty());
+}
+
+TEST(Writer, write_no_flush_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{8, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+    ctx.restart();
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+    EXPECT_TRUE(completions.empty());
+  }
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::co_spawn(ex, writer.drain(), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+    EXPECT_TRUE(completions.empty());
+  }
+}
+
+TEST(Writer, write_flush)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{8, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result));
+  EXPECT_FALSE(result);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+
+  writer.flush();
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  EXPECT_EQ(1, completions.size());
+}
+
+TEST(Writer, write_flush_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{8, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+    ctx.restart();
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+  }
+
+  writer.flush();
+  ASSERT_EQ(1, completions.size());
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::co_spawn(ex, writer.drain(), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    std::invoke(completions[0], boost::system::error_code{});
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+  }
+}
+
+TEST(Writer, write_batch)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result));
+  EXPECT_FALSE(result);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+  EXPECT_EQ(1, completions.size());
+}
+
+TEST(Writer, write_batch_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+    EXPECT_EQ(1, completions.size());
+  }
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::co_spawn(ex, writer.drain(), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    std::invoke(completions[0], boost::system::error_code{});
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+  }
+}
+
+TEST(Writer, write_batch_multi_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+    EXPECT_EQ(1, completions.size());
+  }
+  {
+    std::optional<std::exception_ptr> result1;
+    boost::asio::co_spawn(ex, writer.drain(), capture(result1));
+    EXPECT_FALSE(result1);
+
+    std::optional<std::exception_ptr> result2;
+    boost::asio::co_spawn(ex, writer.drain(), capture(result2));
+    EXPECT_FALSE(result2);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    std::invoke(completions[0], boost::system::error_code{});
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+
+    ASSERT_TRUE(result1);
+    EXPECT_FALSE(*result1);
+    ASSERT_TRUE(result2);
+    EXPECT_FALSE(*result2);
+  }
+}
+
+TEST(Writer, multi_write_batch)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  std::optional<std::exception_ptr> result3;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result3));
+  EXPECT_FALSE(result3);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  EXPECT_FALSE(result2);
+  ASSERT_EQ(1, completions.size());
+  std::invoke(completions[0], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result2);
+  EXPECT_FALSE(*result2);
+  EXPECT_FALSE(result3);
+  ASSERT_EQ(2, completions.size());
+  std::invoke(completions[1], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result3);
+  EXPECT_FALSE(*result3);
+  ASSERT_EQ(3, completions.size());
+  std::invoke(completions[2], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+}
+
+TEST(Writer, concurrent_multi_write_batch)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 2, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result2);
+  EXPECT_FALSE(*result2);
+  EXPECT_EQ(2, completions.size());
+
+  std::optional<std::exception_ptr> result3;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result3));
+  EXPECT_FALSE(result3);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  std::optional<std::exception_ptr> result4;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result4));
+  EXPECT_FALSE(result4);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  EXPECT_FALSE(result3);
+  ASSERT_EQ(2, completions.size());
+  std::invoke(completions[0], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result3);
+  EXPECT_FALSE(*result3);
+  EXPECT_FALSE(result4);
+  ASSERT_EQ(3, completions.size());
+  std::invoke(completions[1], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result4);
+  EXPECT_FALSE(*result4);
+  ASSERT_EQ(4, completions.size());
+  std::invoke(completions[2], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_EQ(4, completions.size());
+  std::invoke(completions[3], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+}
+
+TEST(Writer, write_batch_write_error)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+  std::invoke(completions[0], make_error_code(std::errc::no_such_file_or_directory));
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  ASSERT_TRUE(result2);
+  ASSERT_TRUE(*result2);
+  try {
+    std::rethrow_exception(*result2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+
+  std::optional<std::exception_ptr> result3;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result3));
+  EXPECT_FALSE(result3);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result3);
+  ASSERT_TRUE(*result3);
+  try {
+    std::rethrow_exception(*result3);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(Writer, write_batch_error_write)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+  std::invoke(completions[0], make_error_code(std::errc::no_such_file_or_directory));
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result2);
+  ASSERT_TRUE(*result2);
+  try {
+    std::rethrow_exception(*result2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(Writer, write_batch_drain_error)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::co_spawn(ex, writer.drain(), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+  std::invoke(completions[0], make_error_code(std::errc::no_such_file_or_directory));
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  ASSERT_TRUE(result2);
+  ASSERT_TRUE(*result2);
+  try {
+    std::rethrow_exception(*result2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+
+  std::optional<std::exception_ptr> result3;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result3));
+  EXPECT_FALSE(result3);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result3);
+  ASSERT_TRUE(*result3);
+  try {
+    std::rethrow_exception(*result3);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(Writer, write_batch_error_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::co_spawn(ex, writer.write({}, {}, {}), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+  std::invoke(completions[0], make_error_code(std::errc::no_such_file_or_directory));
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::co_spawn(ex, writer.drain(), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result2);
+  ASSERT_TRUE(*result2);
+  try {
+    std::rethrow_exception(*result2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+} // namespace rgwrados::reshard


### PR DESCRIPTION
(based on https://github.com/ceph/ceph/pull/59783 for neorados/cls/rgw.h)

adds `rgwrados::reshard::Writer<Batch>` as a c++20 coroutine version of rgw_reshard.cc's `class BucketReshardShard` which uses `aio_operate()` to flush batches of index entries to their target bucket index shard objects. that class can't be used with coroutines because it relies on blocking function `librados::AioCompletion::wait_for_complete()`. in contrast, this `Writer` uses `ceph::async::co_waiter<>` to suspend the coroutine while waiting

the goal of c++20 coroutines in reshard is to enable the concurrent processing of several source shards at a time, so this `Writer` class needs to support multiple producers. `write()` and `drain()` accomodate this by using `boost::intrusive::list<Waiter>` to track multiple waiters. we avoid dynamic allocation of these waiters by storing them on the calling coroutine's stack

for backward compatibility with older osds that don't support the 'reshard log' feature, reshard needs to support two different `Batch` types:
* a legacy one that calls `bi_put()` for each entry and `bi_add_stats()` to manually account for bucket stats, and
* a new one that calls `bi_put_entries()` (from https://github.com/ceph/ceph/pull/59581) to write the vector of entries and handle bucket stats on the server side

the `Batch` template also enables mocking for unit testing without a rados client

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
