### PR TITLE
squid: mgr/volumes: add earmarking for subvol

### DIFF
--- a/doc/cephfs/fs-volumes.rst
+++ b/doc/cephfs/fs-volumes.rst
@@ -276,7 +276,7 @@ Use a command of the following form to create a subvolume:
 
 .. prompt:: bash #
 
-   ceph fs subvolume create <vol_name> <subvol_name> [--size <size_in_bytes>] [--group_name <subvol_group_name>] [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>] [--namespace-isolated]
+   ceph fs subvolume create <vol_name> <subvol_name> [--size <size_in_bytes>] [--group_name <subvol_group_name>] [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>] [--namespace-isolated] [--earmark <earmark>]
 
 
 The command succeeds even if the subvolume already exists.
@@ -289,6 +289,15 @@ The subvolume can be created in a separate RADOS namespace by specifying the
 default subvolume group with an octal file mode of ``755``, a uid of its
 subvolume group, a gid of its subvolume group, a data pool layout of its parent
 directory, and no size limit.
+You can also assign an earmark to a subvolume using the ``--earmark`` option.
+The earmark is a unique identifier that tags the subvolume for specific purposes,
+such as NFS or SMB services. By default, no earmark is set, allowing for flexible
+assignment based on administrative needs. An empty string ("") can be used to remove
+any existing earmark from a subvolume.
+
+The earmarking mechanism ensures that subvolumes are correctly tagged and managed,
+helping to avoid conflicts and ensuring that each subvolume is associated
+with the intended service or use case.
 
 Removing a subvolume
 ~~~~~~~~~~~~~~~~~~~~
@@ -418,6 +427,7 @@ The output format is JSON and contains the following fields.
 * ``pool_namespace``: RADOS namespace of the subvolume
 * ``features``: features supported by the subvolume
 * ``state``: current state of the subvolume
+* ``earmark``: earmark of the subvolume
 
 If a subvolume has been removed but its snapshots have been retained, the
 output contains only the following fields.
@@ -521,6 +531,33 @@ subvolume using the metadata key:
 
 Using the ``--force`` flag allows the command to succeed when it would
 otherwise fail (if the metadata key did not exist).
+
+Getting earmark of a subvolume
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use a command of the following form to get the earmark of a subvolume:
+
+.. prompt:: bash #
+
+   ceph fs subvolume earmark get <vol_name> <subvol_name> [--group_name <subvol_group_name>]
+
+Setting earmark of a subvolume
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use a command of the following form to set the earmark of a subvolume:
+
+.. prompt:: bash #
+
+   ceph fs subvolume earmark set <vol_name> <subvol_name> [--group_name <subvol_group_name>] <earmark>
+
+Removing earmark of a subvolume
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use a command of the following form to remove the earmark of a subvolume:
+
+.. prompt:: bash #
+
+   ceph fs subvolume earmark rm <vol_name> <subvol_name> [--group_name <subvol_group_name>]
 
 Creating a Snapshot of a Subvolume
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/pybind/mgr/volumes/fs/operations/subvolume.py
+++ b/src/pybind/mgr/volumes/fs/operations/subvolume.py
@@ -4,7 +4,7 @@ from .template import SubvolumeOpType
 
 from .versions import loaded_subvolumes
 
-def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, pool, mode, uid, gid):
+def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, pool, mode, uid, gid, earmark):
     """
     create a subvolume (create a subvolume with the max known version).
 
@@ -17,10 +17,11 @@ def create_subvol(mgr, fs, vol_spec, group, subvolname, size, isolate_nspace, po
     :param mode: the user permissions
     :param uid: the user identifier
     :param gid: the group identifier
+    :param earmark: metadata string to identify if subvolume is associated with nfs/smb
     :return: None
     """
     subvolume = loaded_subvolumes.get_subvolume_object_max(mgr, fs, vol_spec, group, subvolname)
-    subvolume.create(size, isolate_nspace, pool, mode, uid, gid)
+    subvolume.create(size, isolate_nspace, pool, mode, uid, gid, earmark)
 
 
 def create_clone(mgr, fs, vol_spec, group, subvolname, pool, source_volume, source_subvolume, snapname):

--- a/src/pybind/mgr/volumes/fs/operations/template.py
+++ b/src/pybind/mgr/volumes/fs/operations/template.py
@@ -68,6 +68,9 @@ class SubvolumeOpType(Enum):
     SNAP_METADATA_GET     = 'snap-metadata-get'
     SNAP_METADATA_LIST    = 'snap-metadata-ls'
     SNAP_METADATA_REMOVE  = 'snap-metadata-rm'
+    EARMARK_GET           = 'earmark-get'
+    EARMARK_SET           = 'earmark-set'
+    EARMARK_CLEAR          = 'earmark-clear'
 
 class SubvolumeTemplate(object):
     VERSION = None # type: int

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
@@ -85,7 +85,7 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
         """ Path to user data directory within a subvolume snapshot named 'snapname' """
         return self.snapshot_path(snapname)
 
-    def create(self, size, isolate_nspace, pool, mode, uid, gid):
+    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark):
         subvolume_type = SubvolumeTypes.TYPE_NORMAL
         try:
             initial_state = SubvolumeOpSm.get_init_state(subvolume_type)
@@ -103,7 +103,8 @@ class SubvolumeV1(SubvolumeBase, SubvolumeTemplate):
                 'gid': gid,
                 'data_pool': pool,
                 'pool_namespace': self.namespace if isolate_nspace else None,
-                'quota': size
+                'quota': size,
+                'earmark': earmark
             }
             self.set_attrs(subvol_path, attrs)
 

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v2.py
@@ -154,7 +154,7 @@ class SubvolumeV2(SubvolumeV1):
         self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_KEY_PATH, qpath)
         self.metadata_mgr.update_global_section(MetadataManager.GLOBAL_META_KEY_STATE, initial_state.value)
 
-    def create(self, size, isolate_nspace, pool, mode, uid, gid):
+    def create(self, size, isolate_nspace, pool, mode, uid, gid, earmark):
         subvolume_type = SubvolumeTypes.TYPE_NORMAL
         try:
             initial_state = SubvolumeOpSm.get_init_state(subvolume_type)
@@ -175,7 +175,8 @@ class SubvolumeV2(SubvolumeV1):
                 'gid': gid,
                 'data_pool': pool,
                 'pool_namespace': self.namespace if isolate_nspace else None,
-                'quota': size
+                'quota': size,
+                'earmark': earmark
             }
             self.set_attrs(subvol_path, attrs)
 

--- a/src/pybind/mgr/volumes/fs/volume.py
+++ b/src/pybind/mgr/volumes/fs/volume.py
@@ -4,10 +4,12 @@ import logging
 import mgr_util
 import inspect
 import functools
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
 
 import cephfs
+
+from ceph.fs.earmarking import CephFSVolumeEarmarking, EarmarkException  # type: ignore
 
 from mgr_util import CephfsClient
 
@@ -223,11 +225,13 @@ class VolumeClient(CephfsClient["Module"]):
         gid        = kwargs['gid']
         mode       = kwargs['mode']
         isolate_nspace = kwargs['namespace_isolated']
+        earmark    = kwargs['earmark'] or ''  # if not set, default to empty string --> no earmark
 
         oct_mode = octal_str_to_decimal_int(mode)
+
         try:
             create_subvol(
-                self.mgr, fs_handle, self.volspec, group, subvolname, size, isolate_nspace, pool, oct_mode, uid, gid)
+                self.mgr, fs_handle, self.volspec, group, subvolname, size, isolate_nspace, pool, oct_mode, uid, gid, earmark)
         except VolumeException as ve:
             # kick the purge threads for async removal -- note that this
             # assumes that the subvolume is moved to trashcan for cleanup on error.
@@ -245,6 +249,7 @@ class VolumeClient(CephfsClient["Module"]):
         gid        = kwargs['gid']
         mode       = kwargs['mode']
         isolate_nspace = kwargs['namespace_isolated']
+        earmark    = kwargs['earmark'] or ''  # if not set, default to empty string --> no earmark
 
         try:
             with open_volume(self, volname) as fs_handle:
@@ -258,7 +263,8 @@ class VolumeClient(CephfsClient["Module"]):
                                 'mode': octal_str_to_decimal_int(mode),
                                 'data_pool': pool,
                                 'pool_namespace': subvolume.namespace if isolate_nspace else None,
-                                'quota': size
+                                'quota': size,
+                                'earmark': earmark
                             }
                             subvolume.set_attrs(subvolume.path, attrs)
                     except VolumeException as ve:
@@ -598,6 +604,68 @@ class VolumeClient(CephfsClient["Module"]):
                 ret = 0, "no subvolume exists", ""
             else:
                 ret = self.volume_exception_to_retval(ve)
+        return ret
+
+    def get_earmark(self, **kwargs) -> Tuple[int, Optional[str], str]:
+        ret: Tuple[int, Optional[str], str] = 0, "", ""
+        volname    = kwargs['vol_name']
+        subvolname = kwargs['sub_name']
+        groupname  = kwargs['group_name']
+
+        try:
+            with open_volume(self, volname) as fs_handle:
+                with open_group(fs_handle, self.volspec, groupname) as group:
+                    with open_subvol(self.mgr, fs_handle, self.volspec, group, subvolname, SubvolumeOpType.EARMARK_GET) as subvolume:
+                        log.info("Getting earmark for subvolume %s", subvolume.path)
+                        fs_earmark = CephFSVolumeEarmarking(fs_handle, subvolume.path)
+                        earmark = fs_earmark.get_earmark()
+                        ret = 0, earmark, ""
+        except VolumeException as ve:
+            ret = self.volume_exception_to_retval(ve)
+        except EarmarkException as ee:
+            log.error(f"Earmark error occurred: {ee}")
+            ret = ee.to_tuple()
+        return ret
+
+    def set_earmark(self, **kwargs):  # type: ignore
+        ret       = 0, "", ""
+        volname   = kwargs['vol_name']
+        subvolname = kwargs['sub_name']
+        groupname = kwargs['group_name']
+        earmark   = kwargs['earmark']
+
+        try:
+            with open_volume(self, volname) as fs_handle:
+                with open_group(fs_handle, self.volspec, groupname) as group:
+                    with open_subvol(self.mgr, fs_handle, self.volspec, group, subvolname, SubvolumeOpType.EARMARK_SET) as subvolume:
+                        log.info("Setting earmark %s for subvolume %s", earmark, subvolume.path)
+                        fs_earmark = CephFSVolumeEarmarking(fs_handle, subvolume.path)
+                        fs_earmark.set_earmark(earmark)
+        except VolumeException as ve:
+            ret = self.volume_exception_to_retval(ve)
+        except EarmarkException as ee:
+            log.error(f"Earmark error occurred: {ee}")
+            ret = ee.to_tuple()  # type: ignore
+        return ret
+
+    def clear_earmark(self, **kwargs):  # type: ignore
+        ret       = 0, "", ""
+        volname   = kwargs['vol_name']
+        subvolname = kwargs['sub_name']
+        groupname = kwargs['group_name']
+
+        try:
+            with open_volume(self, volname) as fs_handle:
+                with open_group(fs_handle, self.volspec, groupname) as group:
+                    with open_subvol(self.mgr, fs_handle, self.volspec, group, subvolname, SubvolumeOpType.EARMARK_CLEAR) as subvolume:
+                        log.info("Removing earmark for subvolume %s", subvolume.path)
+                        fs_earmark = CephFSVolumeEarmarking(fs_handle, subvolume.path)
+                        fs_earmark.clear_earmark()
+        except VolumeException as ve:
+            ret = self.volume_exception_to_retval(ve)
+        except EarmarkException as ee:
+            log.error(f"Earmark error occurred: {ee}")
+            ret = ee.to_tuple()  # type: ignore
         return ret
 
     ### subvolume snapshot

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -141,7 +141,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=uid,type=CephInt,req=false '
                    'name=gid,type=CephInt,req=false '
                    'name=mode,type=CephString,req=false '
-                   'name=namespace_isolated,type=CephBool,req=false ',
+                   'name=namespace_isolated,type=CephBool,req=false '
+                   'name=earmark,type=CephString,req=false ',
             'desc': "Create a CephFS subvolume in a volume, and optionally, "
                     "with a specific size (in bytes), a specific data pool layout, "
                     "a specific mode, in a specific subvolume group and in separate "
@@ -270,6 +271,31 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                    'name=force,type=CephBool,req=false ',
             'desc': "Remove custom metadata (key-value) associated with the key of a CephFS subvolume in a volume, "
                     "and optionally, in a specific subvolume group",
+            'perm': 'rw'
+        },
+        {
+            'cmd': 'fs subvolume earmark get '
+                   'name=vol_name,type=CephString '
+                   'name=sub_name,type=CephString '
+                   'name=group_name,type=CephString,req=false ',
+            'desc': "Get earmark for a subvolume",
+            'perm': 'r'
+        },
+        {
+            'cmd': 'fs subvolume earmark set '
+                   'name=vol_name,type=CephString '
+                   'name=sub_name,type=CephString '
+                   'name=group_name,type=CephString,req=false '
+                   'name=earmark,type=CephString ',
+            'desc': "Set earmark for a subvolume",
+            'perm': 'rw'
+        },
+        {
+            'cmd': 'fs subvolume earmark rm '
+                   'name=vol_name,type=CephString '
+                   'name=sub_name,type=CephString '
+                   'name=group_name,type=CephString,req=false ',
+            'desc': "Remove earmark from a subvolume",
             'perm': 'rw'
         },
         {
@@ -631,6 +657,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                               group_name=cmd['group_name'],
                                               new_size=cmd['new_size'],
                                               no_shrink=cmd.get('no_shrink', False))
+
     @mgr_cmd_wrap
     def _cmd_fs_subvolumegroup_ls(self, inbuf, cmd):
         return self.vc.list_subvolume_groups(vol_name=cmd['vol_name'])
@@ -652,7 +679,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                         uid=cmd.get('uid', None),
                                         gid=cmd.get('gid', None),
                                         mode=cmd.get('mode', '755'),
-                                        namespace_isolated=cmd.get('namespace_isolated', False))
+                                        namespace_isolated=cmd.get('namespace_isolated', False),
+                                        earmark=cmd.get('earmark', None))
 
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_rm(self, inbuf, cmd):
@@ -733,7 +761,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _cmd_fs_subvolume_exist(self, inbuf, cmd):
         return self.vc.subvolume_exists(vol_name=cmd['vol_name'],
                                         group_name=cmd.get('group_name', None))
-    
+
     @mgr_cmd_wrap
     def _cmd_fs_subvolume_metadata_set(self, inbuf, cmd):
         return self.vc.set_user_metadata(vol_name=cmd['vol_name'],
@@ -762,7 +790,26 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                       key_name=cmd['key_name'],
                                       group_name=cmd.get('group_name', None),
                                       force=cmd.get('force', False))
-    
+
+    @mgr_cmd_wrap
+    def _cmd_fs_subvolume_earmark_get(self, inbuf, cmd):
+        return self.vc.get_earmark(vol_name=cmd['vol_name'],
+                                   sub_name=cmd['sub_name'],
+                                   group_name=cmd.get('group_name', None))
+
+    @mgr_cmd_wrap
+    def _cmd_fs_subvolume_earmark_set(self, inbuf, cmd):
+        return self.vc.set_earmark(vol_name=cmd['vol_name'],
+                                      sub_name=cmd['sub_name'],
+                                      group_name=cmd.get('group_name', None),
+                                      earmark=cmd['earmark'])
+
+    @mgr_cmd_wrap
+    def _cmd_fs_subvolume_earmark_rm(self, inbuf, cmd):
+        return self.vc.clear_earmark(vol_name=cmd['vol_name'],
+                                      sub_name=cmd['sub_name'],
+                                      group_name=cmd.get('group_name', None))
+
     @mgr_cmd_wrap
     def _cmd_fs_quiesce(self, inbuf, cmd):
         return self.vc.quiesce(cmd)

--- a/src/python-common/ceph/fs/__init__.py
+++ b/src/python-common/ceph/fs/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+log = logging.getLogger(__name__)

--- a/src/python-common/ceph/fs/earmarking.py
+++ b/src/python-common/ceph/fs/earmarking.py
@@ -1,0 +1,108 @@
+"""
+Module: CephFS Volume Earmarking
+
+This module provides the `CephFSVolumeEarmarking` class, which is designed to manage the earmarking
+of subvolumes within a CephFS filesystem. The earmarking mechanism allows
+administrators to tag specific subvolumes with identifiers that indicate their intended use
+such as NFS or SMB, ensuring that only one file service is assigned to a particular subvolume
+at a time. This is crucial to prevent data corruption in environments where
+mixed protocol support (NFS and SMB) is not yet available.
+
+Key Features:
+- **Set Earmark**: Assigns an earmark to a subvolume.
+- **Get Earmark**: Retrieves the existing earmark of a subvolume, if any.
+- **Remove Earmark**: Removes the earmark from a subvolume, making it available for reallocation.
+- **Validate Earmark**: Ensures that the earmark follows the correct format and only uses
+supported top-level scopes.
+"""
+
+import errno
+import enum
+import logging
+from typing import Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+XATTR_SUBVOLUME_EARMARK_NAME = 'user.ceph.subvolume.earmark'
+
+
+class EarmarkTopScope(enum.Enum):
+    NFS = "nfs"
+    SMB = "smb"
+
+
+class EarmarkException(Exception):
+    def __init__(self, error_code: int, error_message: str) -> None:
+        self.errno = error_code
+        self.error_str = error_message
+
+    def to_tuple(self) -> Tuple[int, Optional[str], str]:
+        return self.errno, "", self.error_str
+
+    def __str__(self) -> str:
+        return f"{self.errno} ({self.error_str})"
+
+
+class CephFSVolumeEarmarking:
+    def __init__(self, fs, path: str) -> None:
+        self.fs = fs
+        self.path = path
+
+    def _handle_cephfs_error(self, e: Exception, action: str) -> None:
+        if isinstance(e, ValueError):
+            raise EarmarkException(errno.EINVAL, f"Invalid earmark specified: {e}") from e
+        elif isinstance(e, OSError):
+            log.error(f"Error {action} earmark: {e}")
+            raise EarmarkException(-e.errno, e.strerror) from e
+        else:
+            log.error(f"Unexpected error {action} earmark: {e}")
+            raise EarmarkException(errno.EIO, "Unexpected error") from e
+
+    def _validate_earmark(self, earmark: str) -> bool:
+        """
+        Validates that the earmark string is either empty or composed of parts separated by scopes,
+        with the top-level scope being either 'nfs' or 'smb'.
+
+        :param earmark: The earmark string to validate.
+        :return: True if valid, False otherwise.
+        """
+        if not earmark or earmark in (scope.value for scope in EarmarkTopScope):
+            return True
+
+        parts = earmark.split('.')
+
+        if parts[0] not in (scope.value for scope in EarmarkTopScope):
+            return False
+
+        # Check if all parts are non-empty (to ensure valid dot-separated format)
+        return all(parts)
+
+    def get_earmark(self) -> Optional[str]:
+        try:
+            earmark_value = (
+                self.fs.getxattr(self.path, XATTR_SUBVOLUME_EARMARK_NAME)
+                .decode('utf-8')
+            )
+            return earmark_value
+        except Exception as e:
+            self._handle_cephfs_error(e, "getting")
+            return None
+
+    def set_earmark(self, earmark: str):
+        # Validate the earmark before attempting to set it
+        if not self._validate_earmark(earmark):
+            raise EarmarkException(
+                errno.EINVAL,
+                f"Invalid earmark specified: '{earmark}'. "
+                "A valid earmark should either be empty or start with 'nfs' or 'smb', "
+                "followed by dot-separated non-empty components."
+                )
+
+        try:
+            self.fs.setxattr(self.path, XATTR_SUBVOLUME_EARMARK_NAME, earmark.encode('utf-8'), 0)
+            log.info(f"Earmark '{earmark}' set on {self.path}.")
+        except Exception as e:
+            self._handle_cephfs_error(e, "setting")
+
+    def clear_earmark(self) -> None:
+        self.set_earmark("")

--- a/src/python-common/ceph/tests/test_earmarking.py
+++ b/src/python-common/ceph/tests/test_earmarking.py
@@ -1,0 +1,86 @@
+import pytest
+import errno
+from unittest import mock
+
+from ceph.fs.earmarking import CephFSVolumeEarmarking, EarmarkException, EarmarkTopScope
+# Mock constants
+XATTR_SUBVOLUME_EARMARK_NAME = 'user.ceph.subvolume.earmark'
+
+
+class TestCephFSVolumeEarmarking:
+
+    @pytest.fixture
+    def mock_fs(self):
+        return mock.Mock()
+
+    @pytest.fixture
+    def earmarking(self, mock_fs):
+        return CephFSVolumeEarmarking(mock_fs, "/test/path")
+
+    def test_get_earmark_success(self, earmarking, mock_fs):
+        mock_fs.getxattr.return_value = b"nfs"
+        result = earmarking.get_earmark()
+        assert result == "nfs"
+        mock_fs.getxattr.assert_called_once_with("/test/path", XATTR_SUBVOLUME_EARMARK_NAME)
+
+    def test_get_earmark_no_earmark_set(self, earmarking, mock_fs):
+        mock_fs.getxattr.return_value = b""
+        result = earmarking.get_earmark()
+
+        assert result == ""
+        mock_fs.getxattr.assert_called_once_with("/test/path", XATTR_SUBVOLUME_EARMARK_NAME)
+
+    def test_get_earmark_error(self, earmarking, mock_fs):
+        mock_fs.getxattr.side_effect = OSError(errno.EIO, "I/O error")
+
+        with pytest.raises(EarmarkException) as excinfo:
+            earmarking.get_earmark()
+
+        assert excinfo.value.errno == -errno.EIO
+        assert "I/O error" in str(excinfo.value)
+
+        # Ensure that the getxattr method was called exactly once
+        mock_fs.getxattr.assert_called_once_with("/test/path", XATTR_SUBVOLUME_EARMARK_NAME)
+
+    def test_set_earmark_success(self, earmarking, mock_fs):
+        earmarking.set_earmark(EarmarkTopScope.NFS.value)
+        mock_fs.setxattr.assert_called_once_with(
+            "/test/path", XATTR_SUBVOLUME_EARMARK_NAME, b"nfs", 0
+        )
+
+    def test_set_earmark_invalid(self, earmarking):
+        with pytest.raises(EarmarkException) as excinfo:
+            earmarking.set_earmark("invalid_scope")
+
+        assert excinfo.value.errno == errno.EINVAL
+        assert "Invalid earmark specified" in str(excinfo.value)
+
+    def test_set_earmark_error(self, earmarking, mock_fs):
+        mock_fs.setxattr.side_effect = OSError(errno.EIO, "I/O error")
+
+        with pytest.raises(EarmarkException) as excinfo:
+            earmarking.set_earmark(EarmarkTopScope.NFS.value)
+
+        assert excinfo.value.errno == -errno.EIO
+        assert "I/O error" in str(excinfo.value)
+        mock_fs.setxattr.assert_called_once_with(
+            "/test/path", XATTR_SUBVOLUME_EARMARK_NAME, b"nfs", 0
+        )
+
+    def test_clear_earmark_success(self, earmarking, mock_fs):
+        earmarking.clear_earmark()
+        mock_fs.setxattr.assert_called_once_with(
+            "/test/path", XATTR_SUBVOLUME_EARMARK_NAME, b"", 0
+        )
+
+    def test_clear_earmark_error(self, earmarking, mock_fs):
+        mock_fs.setxattr.side_effect = OSError(errno.EIO, "I/O error")
+
+        with pytest.raises(EarmarkException) as excinfo:
+            earmarking.clear_earmark()
+
+        assert excinfo.value.errno == -errno.EIO
+        assert "I/O error" in str(excinfo.value)
+        mock_fs.setxattr.assert_called_once_with(
+            "/test/path", XATTR_SUBVOLUME_EARMARK_NAME, b"", 0
+        )


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68125

---

backport of https://github.com/ceph/ceph/pull/59111
parent tracker: https://tracker.ceph.com/issues/67460

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh