### PR TITLE
Squid: mgr/dashboard: NFS Export form fixes

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -126,14 +126,12 @@
               <option *ngIf="allsubvolgrps === null"
                       value=""
                       i18n>Loading...</option>
-              <option *ngIf="allsubvolgrps !== null && allsubvolgrps.length === 0"
-                      value=""
-                      i18n>-- No CephFS subvolume group available --</option>
-              <option *ngIf="allsubvolgrps !== null && allsubvolgrps.length > 0"
+              <option *ngIf="allsubvolgrps !== null && allsubvolgrps.length >= 0"
                       value=""
                       i18n>-- Select the CephFS subvolume group --</option>
               <option *ngFor="let subvol_grp of allsubvolgrps"
-                      [value]="subvol_grp.name">{{ subvol_grp.name }}</option>
+                      [value]="subvol_grp.name"
+                      [selected]="subvol_grp.name === nfsForm.get('subvolume_group').value">{{ subvol_grp.name }}</option>
               <option [value]="defaultSubVolGroup">{{ defaultSubVolGroup }}</option>
             </select>
           </div>
@@ -149,7 +147,9 @@
                   formControlName="subvolume"
                   name="subvolume"
                   id="subvolume"
-                  (change)="setSubVolPath()">
+                  (change)="setSubVolPath()"
+                  [invalid]="nfsForm.controls.subvolume.invalid && (nfsForm.controls.subvolume.dirty)"
+                  [invalidText]="subvolumeError">
             <option *ngIf="allsubvols === null"
                     value=""
                     i18n>Loading...</option>
@@ -160,8 +160,12 @@
                     value=""
                     i18n>-- Select the CephFS subvolume --</option>
             <option *ngFor="let subvolume of allsubvols"
-                    [value]="subvolume.name">{{ subvolume.name }}</option>
+                    [value]="subvolume.name"
+                    [selected]="subvolume.name === nfsForm.get('subvolume').value">{{ subvolume.name }}</option>
           </select>
+          <span class="invalid-feedback"
+                *ngIf="nfsForm.getValue('subvolume_group') === defaultSubVolGroup && !nfsForm.getValue('subvolume')"
+                i18n>This field is required.</span>
         </div>
       </div>
 
@@ -189,7 +193,9 @@
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('path', formDir, 'required')"
                   i18n>This field is required.</span>
-
+            <span class="invalid-feedback"
+                  *ngIf="nfsForm.get('path').hasError('isIsolatedSlash') && nfsForm.get('path').touched"
+                  i18n>Export on CephFS volume "<code>/</code>" not allowed.</span>
             <span class="invalid-feedback"
                   *ngIf="nfsForm.showError('path', formDir, 'pattern')"
                   i18n>Path need to start with a '/' and can be followed by a word</span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -92,7 +92,7 @@ describe('NfsFormComponent', () => {
       clients: [],
       cluster_id: 'mynfs',
       fsal: { fs_name: '', name: 'CEPH' },
-      path: '/',
+      path: '',
       protocolNfsv4: true,
       protocolNfsv3: true,
       pseudo: '',
@@ -100,7 +100,7 @@ describe('NfsFormComponent', () => {
       security_label: false,
       squash: 'no_root_squash',
       subvolume: '',
-      subvolume_group: '',
+      subvolume_group: '_nogroup',
       transportTCP: true,
       transportUDP: true
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -31,6 +31,7 @@ import { NfsFormClientComponent } from '../nfs-form-client/nfs-form-client.compo
 import { getFsalFromRoute, getPathfromFsal } from '../utils';
 import { CephfsSubvolumeService } from '~/app/shared/api/cephfs-subvolume.service';
 import { CephfsSubvolumeGroupService } from '~/app/shared/api/cephfs-subvolume-group.service';
+import { DEFAULT_SUBVOLUME_GROUP } from '~/app/shared/constants/cephfs.constant';
 
 @Component({
   selector: 'cd-nfs-form',
@@ -71,7 +72,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
   selectedFsName: string = '';
   selectedSubvolGroup: string = '';
   selectedSubvol: string = '';
-  defaultSubVolGroup = '_nogroup';
+  defaultSubVolGroup = DEFAULT_SUBVOLUME_GROUP;
 
   pathDataSource = (text$: Observable<string>) => {
     return text$.pipe(
@@ -160,9 +161,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
   }
 
   volumeChangeHandler() {
-    this.pathChangeHandler();
-    const fs_name = this.nfsForm.getValue('fsal').fs_name;
-    this.getSubVolGrp(fs_name);
+    this.isDefaultSubvolumeGroup();
   }
 
   async getSubVol() {
@@ -176,6 +175,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
     ).subscribe((data: any) => {
       this.allsubvols = data;
     });
+    this.setUpVolumeValidation();
   }
 
   getSubVolGrp(fs_name: string) {
@@ -185,16 +185,15 @@ export class NfsFormComponent extends CdForm implements OnInit {
   }
 
   setSubVolGrpPath(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      const subvolGroup = this.nfsForm.getValue('subvolume_group');
-      const fs_name = this.nfsForm.getValue('fsal').fs_name;
+    const fsName = this.nfsForm.getValue('fsal').fs_name;
+    const subvolGroup = this.nfsForm.getValue('subvolume_group');
 
-      if (subvolGroup === this.defaultSubVolGroup) {
+    return new Promise<void>((resolve, reject) => {
+      if (subvolGroup == this.defaultSubVolGroup) {
         this.updatePath('/volumes/' + this.defaultSubVolGroup);
-        resolve();
-      } else {
+      } else if (subvolGroup != '') {
         this.subvolgrpService
-          .info(fs_name, subvolGroup)
+          .info(fsName, subvolGroup)
           .pipe(map((data) => data['path']))
           .subscribe(
             (path) => {
@@ -203,8 +202,21 @@ export class NfsFormComponent extends CdForm implements OnInit {
             },
             (error) => reject(error)
           );
+      } else {
+        this.updatePath('');
+        this.setUpVolumeValidation();
       }
+      resolve();
     });
+  }
+
+  // Checking if subVolGroup is "_nogroup" and updating path to default as "/volumes/_nogroup else blank."
+  isDefaultSubvolumeGroup() {
+    const fsName = this.nfsForm.getValue('fsal').fs_name;
+    this.getSubVolGrp(fsName);
+    this.getSubVol();
+    this.updatePath('/volumes/' + this.defaultSubVolGroup);
+    this.setUpVolumeValidation();
   }
 
   setSubVolPath(): Promise<void> {
@@ -226,9 +238,21 @@ export class NfsFormComponent extends CdForm implements OnInit {
     });
   }
 
+  setUpVolumeValidation() {
+    const subvolumeGroup = this.nfsForm.get('subvolume_group').value;
+    const subVolumeControl = this.nfsForm.get('subvolume');
+
+    // SubVolume is required if SubVolume Group is "_nogroup".
+    if (subvolumeGroup == this.defaultSubVolGroup) {
+      subVolumeControl?.setValidators([Validators.required]);
+    } else {
+      subVolumeControl?.clearValidators();
+    }
+    subVolumeControl?.updateValueAndValidity();
+  }
+
   updatePath(path: string) {
     this.nfsForm.patchValue({ path: path });
-    this.pathChangeHandler();
   }
 
   createForm() {
@@ -248,10 +272,13 @@ export class NfsFormComponent extends CdForm implements OnInit {
           ]
         })
       }),
-      subvolume_group: new UntypedFormControl(''),
+      subvolume_group: new UntypedFormControl(this.defaultSubVolGroup),
       subvolume: new UntypedFormControl(''),
-      path: new UntypedFormControl('/', {
-        validators: [Validators.required]
+      path: new UntypedFormControl('', {
+        validators: [
+          Validators.required,
+          CdValidators.custom('isIsolatedSlash', this.isolatedSlashCondition) // Path can never be single "/".
+        ]
       }),
       protocolNfsv3: new UntypedFormControl(true, {
         validators: [
@@ -416,6 +443,10 @@ export class NfsFormComponent extends CdForm implements OnInit {
     this.defaultAccessType[name] = accessType;
   }
 
+  isolatedSlashCondition(value: string): boolean {
+    return value === '/';
+  }
+
   setPathValidation() {
     const path = this.nfsForm.get('path');
     if (this.storageBackend === SUPPORTED_FSAL.RGW) {
@@ -462,14 +493,6 @@ export class NfsFormComponent extends CdForm implements OnInit {
     );
   }
 
-  pathChangeHandler() {
-    if (!this.isEdit) {
-      this.nfsForm.patchValue({
-        pseudo: this.generatePseudo()
-      });
-    }
-  }
-
   private getBucketTypeahead(path: string): Observable<any> {
     if (_.isString(path) && path !== '/' && path !== '') {
       return this.rgwBucketService.list().pipe(
@@ -483,20 +506,6 @@ export class NfsFormComponent extends CdForm implements OnInit {
     } else {
       return of([]);
     }
-  }
-
-  private generatePseudo() {
-    let newPseudo = this.nfsForm.getValue('pseudo');
-    if (this.nfsForm.get('pseudo') && !this.nfsForm.get('pseudo').dirty) {
-      newPseudo = undefined;
-      if (this.storageBackend === 'CEPH') {
-        newPseudo = '/cephfs';
-        if (_.isString(this.nfsForm.getValue('path'))) {
-          newPseudo += this.nfsForm.getValue('path');
-        }
-      }
-    }
-    return newPseudo;
   }
 
   submitAction() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/cephfs.constant.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/cephfs.constant.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_SUBVOLUME_GROUP = '_nogroup';


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68163

backport of: https://github.com/ceph/ceph/pull/59074

parent tracker: https://tracker.ceph.com/issues/67400

https://github.com/user-attachments/assets/d5cea3a6-08f6-4290-9fe8-259e889566a9

Conflicts snapshots->
![ceph](https://github.com/user-attachments/assets/c21efba2-6a5f-478e-8e50-7cb17ac155bf)
![NFS](https://github.com/user-attachments/assets/34cf0c33-fa2d-4d9c-a19d-225c6a19a1d0)
![NFS-fsname](https://github.com/user-attachments/assets/4a116a36-4eec-433b-a6c7-e41c4abeb5e6)
![NFS-path](https://github.com/user-attachments/assets/a311a53c-6ada-44d1-a6d1-4db50c837d5f)
![Nfs-spec](https://github.com/user-attachments/assets/b9a2267a-df93-4091-871f-e75d64321d95)
![NFS-subvolgrp](https://github.com/user-attachments/assets/47a3fbdb-0870-4a61-9442-cbb6acd73a03)
![NFS-subvol-path](https://github.com/user-attachments/assets/97e9331c-7628-4067-a4e9-7c0ee372d43e)
![RemovePsuedoPath](https://github.com/user-attachments/assets/b7c0503f-6006-4abd-89f5-0e6c57070529)


For adding error message fro CephFS path replaced ng-template with span.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
