### PR TITLE
reef: qa: failfast mount for better performance and unblock `fs volume ls`

### DIFF
--- a/qa/cephfs/conf/mgr.yaml
+++ b/qa/cephfs/conf/mgr.yaml
@@ -2,6 +2,7 @@ overrides:
   ceph:
     conf:
       mgr:
+        client mount timeout: 30
         debug client: 20
         debug mgr: 20
         debug ms: 1

--- a/qa/suites/fs/functional/tasks/snap-schedule.yaml
+++ b/qa/suites/fs/functional/tasks/snap-schedule.yaml
@@ -15,6 +15,7 @@ overrides:
       - is full \(reached quota
       - POOL_FULL
       - POOL_BACKFILLFULL
+      - cluster \[WRN\] evicting unresponsive client
 
 tasks:
   - cephfs_test_runner:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67827

---

backport of https://github.com/ceph/ceph/pull/58547
parent tracker: https://tracker.ceph.com/issues/66009

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh