### PR TITLE
squid: qa/task: update alertmanager endpoints version

### DIFF
--- a/qa/suites/orch/cephadm/workunits/task/test_monitoring_stack_basic.yaml
+++ b/qa/suites/orch/cephadm/workunits/task/test_monitoring_stack_basic.yaml
@@ -61,6 +61,6 @@ tasks:
         curl -s http://${PROM_IP}:9095/api/v1/alerts
         curl -s http://${PROM_IP}:9095/api/v1/alerts | jq -e '.data | .alerts | .[] | select(.labels | .alertname == "CephMonDown") | .state == "firing"'
         # check alertmanager endpoints are responsive and mon down alert is active
-        curl -s http://${ALERTM_IP}:9093/api/v1/status
-        curl -s http://${ALERTM_IP}:9093/api/v1/alerts
-        curl -s http://${ALERTM_IP}:9093/api/v1/alerts | jq -e '.data | .[] | select(.labels | .alertname == "CephMonDown") | .status | .state == "active"'
+        curl -s http://${ALERTM_IP}:9093/api/v2/status
+        curl -s http://${ALERTM_IP}:9093/api/v2/alerts
+        curl -s http://${ALERTM_IP}:9093/api/v2/alerts | jq -e '.[] | select(.labels | .alertname == "CephMonDown") | .status | .state == "active"'


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68114

---

backport of https://github.com/ceph/ceph/pull/59373
parent tracker: https://tracker.ceph.com/issues/67183

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh