### PR TITLE
squid: mgr/cephadm: open ceph-exporter when firewalld is enabled

### DIFF
--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -2562,6 +2562,9 @@ class CephExporterSpec(ServiceSpec):
         self.prio_limit = prio_limit
         self.stats_period = stats_period
 
+    def get_port_start(self) -> List[int]:
+        return [self.port or 9926]
+
     def validate(self) -> None:
         super(CephExporterSpec, self).validate()
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68138

---

backport of https://github.com/ceph/ceph/pull/59694
parent tracker: https://tracker.ceph.com/issues/67975

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh