### PR TITLE
squid: cephadm: Support Docker Live Restore

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -24,6 +24,10 @@ Requirements
 Any modern Linux distribution should be sufficient.  Dependencies
 are installed automatically by the bootstrap process below.
 
+See `Docker Live Restore <https://docs.docker.com/engine/daemon/live-restore/>`_
+for an optional feature that allows restarting Docker Engine without restarting
+all running containers.
+
 See the section :ref:`Compatibility With Podman
 Versions<cephadm-compatibility-with-podman>` for a table of Ceph versions that
 are compatible with Podman. Not every version of Podman is compatible with

--- a/src/cephadm/cephadmlib/templates/ceph.service.j2
+++ b/src/cephadm/cephadmlib/templates/ceph.service.j2
@@ -9,7 +9,7 @@ Description=Ceph %i for {{fsid}}
 After=network-online.target local-fs.target time-sync.target{% if has_docker_engine %} docker.service{% endif %}
 Wants=network-online.target local-fs.target time-sync.target
 {%- if has_docker_engine %}
-Requires=docker.service
+Wants=docker.service
 {%- endif %}
 
 PartOf=ceph-{{fsid}}.target

--- a/src/cephadm/cephadmlib/templates/init_ctr.service.j2
+++ b/src/cephadm/cephadmlib/templates/init_ctr.service.j2
@@ -5,7 +5,7 @@ After=network-online.target local-fs.target time-sync.target
 Wants=network-online.target local-fs.target time-sync.target
 {%- if has_docker_engine %}
 After=docker.service
-Requires=docker.service
+Wants=docker.service
 {%- endif %}
 Before=ceph-{{ identity.fsid }}@%i.service
 

--- a/src/cephadm/cephadmlib/templates/sidecar.service.j2
+++ b/src/cephadm/cephadmlib/templates/sidecar.service.j2
@@ -5,7 +5,7 @@ After=network-online.target local-fs.target time-sync.target
 Wants=network-online.target local-fs.target time-sync.target
 {%- if has_docker_engine %}
 After=docker.service
-Requires=docker.service
+Wants=docker.service
 {%- endif %}
 After={{ primary.service_name }}
 

--- a/src/cephadm/tests/test_unit_file.py
+++ b/src/cephadm/tests/test_unit_file.py
@@ -27,11 +27,11 @@ def _get_unit_file(ctx, fsid):
     return str(systemd_unit._get_unit_file(ctx, fsid))
 
 
-def test_docker_engine_requires_docker():
+def test_docker_engine_wants_docker():
     ctx = context.CephadmContext()
     ctx.container_engine = mock_docker()
     r = _get_unit_file(ctx, '9b9d7609-f4d5-4aba-94c8-effa764d96c9')
-    assert 'Requires=docker.service' in r
+    assert 'Wants=docker.service' in r
 
 
 def test_podman_engine_does_not_req_docker():
@@ -80,7 +80,7 @@ def test_new_docker():
         '# configuration.',
         'After=network-online.target local-fs.target time-sync.target docker.service',
         'Wants=network-online.target local-fs.target time-sync.target',
-        'Requires=docker.service',
+        'Wants=docker.service',
         'PartOf=ceph-9b9d7609-f4d5-4aba-94c8-effa764d96c9.target',
         'Before=ceph-9b9d7609-f4d5-4aba-94c8-effa764d96c9.target',
         '[Service]',


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68159

---

backport of https://github.com/ceph/ceph/pull/59730
parent tracker: https://tracker.ceph.com/issues/68028

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh