### PR TITLE
squid: mgr/cephadm: add --no-exception-when-missing flag to cert-store cert/key get

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -3145,10 +3145,13 @@ Then run the following:
         self,
         entity: str,
         service_name: Optional[str] = None,
-        hostname: Optional[str] = None
+        hostname: Optional[str] = None,
+        no_exception_when_missing: bool = False
     ) -> str:
         cert = self.cert_key_store.get_cert(entity, service_name or '', hostname or '')
         if not cert:
+            if no_exception_when_missing:
+                return ''
             raise OrchSecretNotFound(entity=entity, service_name=service_name, hostname=hostname)
         return cert
 
@@ -3157,10 +3160,13 @@ Then run the following:
         self,
         entity: str,
         service_name: Optional[str] = None,
-        hostname: Optional[str] = None
+        hostname: Optional[str] = None,
+        no_exception_when_missing: bool = False
     ) -> str:
         key = self.cert_key_store.get_key(entity, service_name or '', hostname or '')
         if not key:
+            if no_exception_when_missing:
+                return ''
             raise OrchSecretNotFound(entity=entity, service_name=service_name, hostname=hostname)
         return key
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -567,7 +567,8 @@ class Orchestrator(object):
         self,
         entity: str,
         service_name: Optional[str] = None,
-        hostname: Optional[str] = None
+        hostname: Optional[str] = None,
+        no_exception_when_missing: bool = False
     ) -> OrchResult[str]:
         raise NotImplementedError()
 
@@ -575,7 +576,8 @@ class Orchestrator(object):
         self,
         entity: str,
         service_name: Optional[str] = None,
-        hostname: Optional[str] = None
+        hostname: Optional[str] = None,
+        no_exception_when_missing: bool = False
     ) -> OrchResult[str]:
         raise NotImplementedError()
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1173,9 +1173,15 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         entity: str,
         _end_positional_: int = 0,
         service_name: Optional[str] = None,
-        hostname: Optional[str] = None
+        hostname: Optional[str] = None,
+        no_exception_when_missing: bool = False
     ) -> HandleCommandResult:
-        completion = self.cert_store_get_cert(entity, service_name, hostname)
+        completion = self.cert_store_get_cert(
+            entity,
+            service_name,
+            hostname,
+            no_exception_when_missing
+        )
         cert = raise_if_exception(completion)
         return HandleCommandResult(stdout=cert)
 
@@ -1185,9 +1191,15 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         entity: str,
         _end_positional_: int = 0,
         service_name: Optional[str] = None,
-        hostname: Optional[str] = None
+        hostname: Optional[str] = None,
+        no_exception_when_missing: bool = False
     ) -> HandleCommandResult:
-        completion = self.cert_store_get_key(entity, service_name, hostname)
+        completion = self.cert_store_get_key(
+            entity,
+            service_name,
+            hostname,
+            no_exception_when_missing
+        )
         key = raise_if_exception(completion)
         return HandleCommandResult(stdout=key)
 


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/59860 

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
