### PR TITLE
blk: Don't forget call io_uring_unregister_files.

### DIFF
--- a/src/blk/kernel/io_uring.cc
+++ b/src/blk/kernel/io_uring.cc
@@ -146,7 +146,7 @@ int ioring_queue_t::init(std::vector<int> &fds)
   d->epoll_fd = epoll_create1(0);
   if (d->epoll_fd < 0) {
     ret = -errno;
-    goto close_ring_fd;
+    goto unregister_files;
   }
 
   struct epoll_event ev;
@@ -161,6 +161,8 @@ int ioring_queue_t::init(std::vector<int> &fds)
 
 close_epoll_fd:
   close(d->epoll_fd);
+unregister_files:
+  io_uring_unregister_files(&d->io_uring);
 close_ring_fd:
   io_uring_queue_exit(&d->io_uring);
 
@@ -172,6 +174,7 @@ void ioring_queue_t::shutdown()
   d->fixed_fds_map.clear();
   close(d->epoll_fd);
   d->epoll_fd = -1;
+  io_uring_unregister_files(&d->io_uring);
   io_uring_queue_exit(&d->io_uring);
 }
 


### PR DESCRIPTION
When using vstart.sh to deploy ceph cluster w/ bdev_ioring=true, met the following error messages:
> /root/ceph/build/bin/ceph-osd -i 0 -c /root/ceph/build/ceph.conf --mkfs --key AQByU/JmoSTAExAApXM0Q6Et9xgfMJ3MJg7wSw== --osd-uuid e135fff2-a02c-415a-b1fe-c154a4e61c13
>2024-09-24T13:51:46.770+0800 7c71966245c0 -1 bdev(0x5c937f62f000 /root/ceph/build/dev/osd0/block) open open w/ O_EXCL
> 2024-09-24T13:51:46.772+0800 7c71966245c0 -1 bluestore(/root/ceph/build/dev/osd0/block) _read_bdev_label unable to decode label /root/ceph/build/dev/osd0/block at offset 102: void bluestore_bdev_label_t::decode(ceph::buffer::v15_2_0::list::const_iterator&) decode past end of struct encoding: Malformed input [buffer:3]
> 2024-09-24T13:51:46.772+0800 7c71966245c0 -1 bluestore(/root/ceph/build/dev/osd0/block) _read_multi_bdev_label label at 0x40000000 correct, but osd_uuid=b89e2e1d-dc77-45fb-9a0b-34eb0a35c9a4 need=e135fff2-a02c-415a-b1fe-c154a4e61c13
> 2024-09-24T13:51:46.772+0800 7c71966245c0 -1 bluestore(/root/ceph/build/dev/osd0/block) _read_multi_bdev_label label at 0x280000000 correct, but osd_uuid=b89e2e1d-dc77-45fb-9a0b-34eb0a35c9a4 need=e135fff2-a02c-415a-b1fe-c154a4e61c13
> 2024-09-24T13:51:46.772+0800 7c71966245c0 -1 bluestore(/root/ceph/build/dev/osd0/block) _read_multi_bdev_label label at 0x1900000000 correct, but osd_uuid=b89e2e1d-dc77-45fb-9a0b-34eb0a35c9a4 need=e135fff2-a02c-415a-b1fe-c154a4e61c13
> 2024-09-24T13:51:46.773+0800 7c71966245c0 -1 bluestore(/root/ceph/build/dev/osd0/block) _read_multi_bdev_label label at 0xfa00000000 correct, but osd_uuid=b89e2e1d-dc77-45fb-9a0b-34eb0a35c9a4 need=e135fff2-a02c-415a-b1fe-c154a4e61c13
> 2024-09-24T13:51:46.773+0800 7c71966245c0 -1 bluestore(/root/ceph/build/dev/osd0/block) No valid bdev label found
> 2024-09-24T13:51:47.022+0800 7c71966245c0 -1 bluestore(/root/ceph/build/dev/osd0) _read_fsid unparsable uuid
> 2024-09-24T13:51:47.022+0800 7c71966245c0 -1 bdev(0x5c937f62f000 /root/ceph/build/dev/osd0/block) open open w/ O_EXCL
> 2024-09-24T13:51:47.022+0800 7c71966245c0 -1 bdev(0x5c937f62f000 /root/ceph/build/dev/osd0/block) open open got: (16) Device or resource busy0

This because we use io_uring_register_files when use ioruing. But we forget to unreister those files.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [x] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
