### PR TITLE
squid: mgr/dashboard: update period after migrating to multi-site 

### DIFF
--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -1218,6 +1218,7 @@ class RgwMultisite:
                                              http_status_code=500, component='rgw')
             except SubprocessError as error:
                 raise DashboardException(error, http_status_code=500, component='rgw')
+        self.update_period()
 
     def create_realm(self, realm_name: str, default: bool):
         rgw_realm_create_cmd = ['realm', 'create']


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68209

---

backport of https://github.com/ceph/ceph/pull/59890
parent tracker: https://tracker.ceph.com/issues/68161

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh