### PR TITLE
squid: qa/standalone/scrub: increase status updates frequency

### DIFF
--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -57,7 +57,7 @@ function TEST_scrub_test() {
     TESTDATA="testdata.$$"
 
     run_mon $dir a --osd_pool_default_size=3 || return 1
-    run_mgr $dir x || return 1
+    run_mgr $dir x --mgr_stats_period=1 || return 1
     local ceph_osd_args="--osd-scrub-interval-randomize-ratio=0 --osd-deep-scrub-randomize-ratio=0 "
     ceph_osd_args+="--osd_scrub_backoff_ratio=0 --osd_stats_update_period_not_scrubbing=3 "
     ceph_osd_args+="--osd_stats_update_period_scrubbing=2"
@@ -160,7 +160,7 @@ function TEST_interval_changes() {
 
     # This min scrub interval results in 30 seconds backoff time
     run_mon $dir a --osd_pool_default_size=$OSDS || return 1
-    run_mgr $dir x || return 1
+    run_mgr $dir x --mgr_stats_period=1 || return 1
     for osd in $(seq 0 $(expr $OSDS - 1))
     do
       run_osd $dir $osd --osd_scrub_min_interval=$min_interval --osd_scrub_max_interval=$max_interval --osd_scrub_interval_randomize_ratio=0 || return 1
@@ -224,7 +224,7 @@ function TEST_scrub_extended_sleep() {
     DAY_END=$(expr $DAY + 3)
 
     run_mon $dir a --osd_pool_default_size=3 || return 1
-    run_mgr $dir x || return 1
+    run_mgr $dir x --mgr_stats_period=1 || return 1
 
     local ceph_osd_args="--osd-scrub-interval-randomize-ratio=0 --osd-deep-scrub-randomize-ratio=0 "
     ceph_osd_args+="--osd_scrub_backoff_ratio=0 --osd_stats_update_period_not_scrubbing=3 "
@@ -312,7 +312,7 @@ function _scrub_abort() {
     fi
 
     run_mon $dir a --osd_pool_default_size=3 || return 1
-    run_mgr $dir x || return 1
+    run_mgr $dir x --mgr_stats_period=1 || return 1
     for osd in $(seq 0 $(expr $OSDS - 1))
     do
         # Set scheduler to "wpq" until there's a reliable way to query scrub
@@ -424,7 +424,7 @@ function TEST_scrub_permit_time() {
     TESTDATA="testdata.$$"
 
     run_mon $dir a --osd_pool_default_size=3 || return 1
-    run_mgr $dir x || return 1
+    run_mgr $dir x --mgr_stats_period=1 || return 1
     local scrub_begin_hour=$(date -d '2 hour ago' +"%H" | sed 's/^0//')
     local scrub_end_hour=$(date -d '1 hour ago' +"%H" | sed 's/^0//')
     for osd in $(seq 0 $(expr $OSDS - 1))
@@ -531,7 +531,7 @@ function TEST_dump_scrub_schedule() {
     TESTDATA="testdata.$$"
 
     run_mon $dir a --osd_pool_default_size=$OSDS || return 1
-    run_mgr $dir x || return 1
+    run_mgr $dir x --mgr_stats_period=1 || return 1
 
     # Set scheduler to "wpq" until there's a reliable way to query scrub states
     # with "--osd-scrub-sleep" set to 0. The "mclock_scheduler" overrides the
@@ -637,7 +637,8 @@ function TEST_dump_scrub_schedule() {
     # missed it.
     declare -A cond_active_dmp=( ['dmp_state_has_scrubbing']="true" ['query_active']="false" )
     sched_data=()
-    wait_any_cond $pgid 10 $saved_last_stamp cond_active_dmp "WaitingActive " sched_data || return 1
+    wait_any_cond $pgid 10 $saved_last_stamp cond_active_dmp "WaitingActive " sched_data
+    sleep 4
     perf_counters $dir $OSDS
 }
 
@@ -652,7 +653,7 @@ function TEST_pg_dump_objects_scrubbed() {
 
     setup $dir || return 1
     run_mon $dir a --osd_pool_default_size=$OSDS || return 1
-    run_mgr $dir x || return 1
+    run_mgr $dir x --mgr_stats_period=1 || return 1
     for osd in $(seq 0 $(expr $OSDS - 1))
     do
       run_osd $dir $osd || return 1


### PR DESCRIPTION
To prevent test timeouts.
Also - remove a failing assertion on a specific 'pg query' output, as it is not central to the test.

Original tracker: https://tracker.ceph.com/issues/64346
Backport tracker: https://tracker.ceph.com/issues/68218

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
(cherry picked from commit 6850bce554330d09f476d4e2aa8ac6d5e3f8bf12)
