### PR TITLE
rgw: Add a "disable replication" flag to bucket notification configuration

### DIFF
--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -1255,16 +1255,16 @@ int RGWPSCreateNotifOp::verify_permission(optional_yield y) {
 }
 
 void RGWPSCreateNotifOp::execute(optional_yield y) {
-  if (!driver->is_meta_master()) {
-    op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->owner.id, &data, nullptr, s->info, y);
-    if (op_ret < 0) {
-      ldpp_dout(this, 4) << "CreateBucketNotification "
-                            "forward_request_to_master returned ret = "
-                         << op_ret << dendl;
-      return;
-    }
-  }
+//  if (!driver->is_meta_master() && ) {
+//    op_ret = rgw_forward_request_to_master(
+//        this, *s->penv.site, s->owner.id, &data, nullptr, s->info, y);
+//    if (op_ret < 0) {
+////      ldpp_dout(this, 4) << "CreateBucketNotification "
+//                            "forward_request_to_master returned ret = "
+ //                        << op_ret << dendl;
+ //     return;
+//    }
+//  }
 
   if (rgw::all_zonegroups_support(*s->penv.site, rgw::zone_features::notification_v2)) {
     return execute_v2(y);

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -396,16 +396,16 @@ class RGWPSCreateTopicOp : public RGWOp {
 
 void RGWPSCreateTopicOp::execute(optional_yield y) {
   // master request will replicate the topic creation.
-  if (!driver->is_meta_master()) {
-    op_ret = rgw_forward_request_to_master(
-        this, *s->penv.site, s->owner.id, &bl_post_body, nullptr, s->info, y);
-    if (op_ret < 0) {
-      ldpp_dout(this, 4)
-          << "CreateTopic forward_request_to_master returned ret = " << op_ret
-          << dendl;
-      return;
-    }
-  }
+//  if (!driver->is_meta_master()) {
+//    op_ret = rgw_forward_request_to_master(
+//        this, *s->penv.site, s->owner.id, &bl_post_body, nullptr, s->info, y);
+//    if (op_ret < 0) {
+//      ldpp_dout(this, 4)
+//          << "CreateTopic forward_request_to_master returned ret = " << op_ret
+//          << dendl;
+//      return;
+//    }
+// }
 
   // don't add a persistent queue if we already have one
   const bool already_persistent = topic && topic_needs_queue(topic->dest);

--- a/src/rgw/rgw_zone_features.h
+++ b/src/rgw/rgw_zone_features.h
@@ -16,12 +16,14 @@ namespace rgw::zone_features {
 inline constexpr std::string_view resharding = "resharding";
 inline constexpr std::string_view compress_encrypted = "compress-encrypted";
 inline constexpr std::string_view notification_v2 = "notification_v2";
+inline constexpr std::string_view disable_notification_v2_replication = "disable_notification_v2_replication";
 
 // static list of features supported by this release
 inline constexpr std::initializer_list<std::string_view> supported = {
     resharding,
     compress_encrypted,
     notification_v2,
+    disable_notification_v2_replication
 };
 
 inline constexpr bool supports(std::string_view feature) {


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

For Enhancement #68104
https://tracker.ceph.com/issues/68104

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
