### PR TITLE
os: simplify os::Transaction -- get rid of the Transaction::decode_bp()

### DIFF
--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -711,10 +711,6 @@ public:
       decode(s, data_bl_p);
       return s;
     }
-    void decode_bp(ceph::buffer::ptr& bp) {
-	using ceph::decode;
-      decode(bp, data_bl_p);
-    }
     void decode_bl(ceph::buffer::list& bl) {
 	using ceph::decode;
       decode(bl, data_bl_p);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3862,7 +3862,7 @@ private:
 	       CollectionRef& c,
 	       OnodeRef& o,
 	       const std::string& name,
-	       ceph::buffer::ptr& val);
+	       ceph::buffer::list& val);
   int _setattrs(TransContext *txc,
 		CollectionRef& c,
 		OnodeRef& o,


### PR DESCRIPTION
`os::Transaction::decode_bp()` has only one user: `_setattrs()` of `BlueStore`. It uses that for optimization purposes: keeping up contigous space instead of potentially fragmented `bufferlist` that would require rectifying memcpy later.
The problem is `_setattrs()` also needs to avoid keeping large raw buffers with only small subset being referenced. It achieves this by copying the data if `bufferptr:::is_partial()` returns `true`. However, this means the memcpy happens virtually always as it's hard to even imagine the `val`, decoded from the wire, can fulfill the requirement 0 waste.
Therefore the optimization doesn't make sense; it only imposes costs in terms of complexity breaking the symmetry between encode and decode in `os::Transation` (there is no `encode_bp()`).

This commit kills the optimization and simplifies `os::Transaction`.

---------
This commit has been dissected from a bigger branch of EC-related optimizations. It particularly helps https://github.com/ceph/ceph/commit/7858030a06212e160da5a3c635d54bfb5848556e which in turn is useful for the @bill-scales's optimization of alignment in rep & ec ops.



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
