### PR TITLE
rgw/notification: Forward Topic & Notification creation request to master when notification_v2 enabled

### DIFF
--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -234,7 +234,13 @@ bool verify_topic_permission(const DoutPrefixProvider* dpp, req_state* s,
   return verify_topic_permission(dpp, s, topic.owner, arn, policy, op);
 }
 
-// command (AWS compliant): 
+bool should_forward_request_to_master(req_state* s, rgw::sal::Driver* driver) {
+  return (!driver->is_meta_master() &&
+          rgw::all_zonegroups_support(*s->penv.site,
+                                      rgw::zone_features::notification_v2));
+}
+
+// command (AWS compliant):
 // POST
 // Action=CreateTopic&Name=<topic-name>[&OpaqueData=data][&push-endpoint=<endpoint>[&persistent][&<arg1>=<value1>]]
 class RGWPSCreateTopicOp : public RGWOp {
@@ -273,7 +279,7 @@ class RGWPSCreateTopicOp : public RGWOp {
     // Remove the args that are parsed, so the push_endpoint_args only contains
     // necessary one's which is parsed after this if. but only if master zone,
     // else we do not remove as request is forwarded to master.
-    if (driver->is_meta_master()) {
+    if (!should_forward_request_to_master(s, driver)) {
       s->info.args.remove("OpaqueData");
       s->info.args.remove("push-endpoint");
       s->info.args.remove("persistent");
@@ -396,7 +402,7 @@ class RGWPSCreateTopicOp : public RGWOp {
 
 void RGWPSCreateTopicOp::execute(optional_yield y) {
   // master request will replicate the topic creation.
-  if (!driver->is_meta_master()) {
+  if (should_forward_request_to_master(s, driver)) {
     op_ret = rgw_forward_request_to_master(
         this, *s->penv.site, s->owner.id, &bl_post_body, nullptr, s->info, y);
     if (op_ret < 0) {
@@ -858,7 +864,7 @@ class RGWPSSetTopicAttributesOp : public RGWOp {
 };
 
 void RGWPSSetTopicAttributesOp::execute(optional_yield y) {
-  if (!driver->is_meta_master()) {
+  if (should_forward_request_to_master(s, driver)) {
     op_ret = rgw_forward_request_to_master(
         this, *s->penv.site, s->owner.id, &bl_post_body, nullptr, s->info, y);
     if (op_ret < 0) {
@@ -1003,9 +1009,10 @@ class RGWPSDeleteTopicOp : public RGWOp {
 };
 
 void RGWPSDeleteTopicOp::execute(optional_yield y) {
-  if (!driver->is_meta_master()) {
+  if (should_forward_request_to_master(s, driver)) {
     op_ret = rgw_forward_request_to_master(
         this, *s->penv.site, s->owner.id, &bl_post_body, nullptr, s->info, y);
+
     if (op_ret < 0) {
       ldpp_dout(this, 1)
           << "DeleteTopic forward_request_to_master returned ret = " << op_ret
@@ -1255,7 +1262,7 @@ int RGWPSCreateNotifOp::verify_permission(optional_yield y) {
 }
 
 void RGWPSCreateNotifOp::execute(optional_yield y) {
-  if (!driver->is_meta_master()) {
+  if (should_forward_request_to_master(s, driver)) {
     op_ret = rgw_forward_request_to_master(
         this, *s->penv.site, s->owner.id, &data, nullptr, s->info, y);
     if (op_ret < 0) {
@@ -1457,7 +1464,7 @@ int RGWPSDeleteNotifOp::verify_permission(optional_yield y) {
 }
 
 void RGWPSDeleteNotifOp::execute(optional_yield y) {
-  if (!driver->is_meta_master()) {
+  if (should_forward_request_to_master(s, driver)) {
     bufferlist indata;
     op_ret = rgw_forward_request_to_master(
         this, *s->penv.site, s->owner.id, &indata, nullptr, s->info, y);


### PR DESCRIPTION
 Fixes: (https://tracker.ceph.com/issues/68227)

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
