### PR TITLE
node-proxy: fix a regression when processing the RedFish API

### DIFF
--- a/src/ceph-node-proxy/ceph_node_proxy/baseredfishsystem.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/baseredfishsystem.py
@@ -34,7 +34,7 @@ class EndpointMgr:
                     self.log.debug(f'entrypoint found: {to_snake_case(k)} = {v["@odata.id"]}')
                     _name: str = to_snake_case(k)
                     _url: str = v['@odata.id']
-                    e = Endpoint(self, _url, self.client)
+                    e = Endpoint(_url, self.client)
                     setattr(self, _name, e)
             setattr(self, 'session', json_data['Links']['Sessions']['@odata.id'])  # TODO(guits): needs to be fixed
         except (URLError, KeyError) as e:


### PR DESCRIPTION
ce360a4a5f6 introduced a regression.

`Endpoint()` doesn't take a `EndpointMgr` object as parameter. The call `e = Endpoint(self, _url, self.client)` obviously throws the following error:

```
TypeError: __init__() takes 3 positional arguments but 4 were given
```

This commit fixes it.

Fixes: https://tracker.ceph.com/issues/68231
