### PR TITLE
script: add format_contributors.sh script to format list of contributors for ceph.io

### DIFF
--- a/src/script/format_contributors.sh
+++ b/src/script/format_contributors.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# This script is to be used after running the credits.sh script (see https://tracker.ceph.com/projects/ceph/wiki/Ceph_contributors_list_maintenance_guide)
+# as a helper tool to format the contributer names suitable for a ceph.io blog post (see the bottom of https://ceph.io/en/news/blog/2023/v18-2-0-reef-released/).
+
+# To use:
+# ./format_contributors.sh <input file of names copied from credits.sh output>
+# Sample input file:
+#     1      586 Casey Bodley <cbodley@redhat.com>
+#     2      544 John Mulligan <jmulligan@redhat.com>
+#     3      395 Zac Dover <zac.dover@proton.me>
+#     4      345 Patrick Donnelly <pdonnell@redhat.com>
+#     5      276 Matan Breizman <mbreizma@redhat.com>
+#     6      218 Xuehan Xu <xuxuehan@qianxin.com>
+#     7      212 Samuel Just <sjust@redhat.com>
+#     8      198 Adam King <adking@redhat.com>
+# ...etc.
+
+# Check if the input is provided
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <input_file>"
+    exit 1
+fi
+
+input_file="$1"
+
+# Declare an array to hold names
+declare -a names
+
+# Read the input file line by line
+while IFS= read -r line; do
+    # Extract the name (everything after the first two whitespace-separated fields and before the first angle bracket)
+    name=$(echo "$line" | sed -E 's/^[[:space:]]*[0-9]+[[:space:]]+[0-9]+[[:space:]]+([^<]+)<.*/\1/')
+    # Append the name to the array if it's not empty
+    if [[ -n $name ]]; then
+        names+=("$name")
+    fi
+done < "$input_file"
+
+# Sort the names alphabetically
+sorted_names=()
+for name in "${names[@]}"; do
+    inserted=false
+    for ((i=0; i<${#sorted_names[@]}; i++)); do
+        if [[ "$name" < "${sorted_names[i]}" ]]; then
+            sorted_names=("${sorted_names[@]:0:i}" "$name" "${sorted_names[@]:i}")
+            inserted=true
+            break
+        fi
+    done
+    # If not inserted, add it to the end
+    if ! $inserted; then
+        sorted_names+=("$name")
+    fi
+done
+
+# Output the formatted and sorted names with trimmed spaces
+for name in "${sorted_names[@]}"; do
+    # Trim any extra spaces
+    trimmed_name=$(echo "$name" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    echo "$trimmed_name &squf;"
+done


### PR DESCRIPTION
This script is to be used after running the credits.sh script (see https://tracker.ceph.com/projects/ceph/wiki/Ceph_contributors_list_maintenance_guide) as a helper tool to format the contributer names suitable for a ceph.io blog post (see the bottom of https://ceph.io/en/news/blog/2023/v18-2-0-reef-released/).

To use:
`./format_contributors.sh <input file of names copied from credits.sh output>`

Sample input file:
```
     1      586 Casey Bodley <cbodley@redhat.com>
     2      544 John Mulligan <jmulligan@redhat.com>
     3      395 Zac Dover <zac.dover@proton.me>
     4      345 Patrick Donnelly <pdonnell@redhat.com>
     5      276 Matan Breizman <mbreizma@redhat.com>
     6      218 Xuehan Xu <xuxuehan@qianxin.com>
     7      212 Samuel Just <sjust@redhat.com>
     8      198 Adam King <adking@redhat.com>
```
 ...etc.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
