### PR TITLE
squid: doc: fix typo

### DIFF
--- a/doc/jaegertracing/index.rst
+++ b/doc/jaegertracing/index.rst
@@ -14,8 +14,8 @@ BASIC ARCHITECTURE AND TERMINOLOGY
   Protocol. The agent is meant to be placed on the same host as the
   instrumented application. (The Jaeger agent acts like a sidecar listener.)
 * JAEGER COLLECTOR: A daemon that receives spans sent by the Jaeger agent. The
-  Jaeger collector then stitches the spans together to form a trace. (A databse
-  can be enabled to persist a database for these traces).
+  Jaeger collector then stitches the spans together to form a trace. (A database
+  can be enabled to persist these traces).
 * JAEGER QUERY AND CONSOLE FRONTEND: The UI-based frontend that presents
   reports of the jaeger traces. Accessible at  http://<jaeger frontend host>:16686.
 


### PR DESCRIPTION
Fixed a typo in the jaeger traces documentation.

Signed-off-by: N Balachandran <nibalach@redhat.com>
(cherry picked from commit 5a11bc00e6c068c965bb7d961feeb47353cc893c)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

