### PR TITLE
squid: node-proxy: fix a regression when processing the RedFish API

### DIFF
--- a/src/ceph-node-proxy/ceph_node_proxy/baseredfishsystem.py
+++ b/src/ceph-node-proxy/ceph_node_proxy/baseredfishsystem.py
@@ -34,7 +34,7 @@ class EndpointMgr:
                     self.log.debug(f'entrypoint found: {to_snake_case(k)} = {v["@odata.id"]}')
                     _name: str = to_snake_case(k)
                     _url: str = v['@odata.id']
-                    e = Endpoint(self, _url, self.client)
+                    e = Endpoint(_url, self.client)
                     setattr(self, _name, e)
             setattr(self, 'session', json_data['Links']['Sessions']['@odata.id'])  # TODO(guits): needs to be fixed
         except (URLError, KeyError) as e:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68277

---

backport of https://github.com/ceph/ceph/pull/59981
parent tracker: https://tracker.ceph.com/issues/68231

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh