### PR TITLE
osd: optimize handling of RGW's start_after & filter during OMAP iteration 

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -763,7 +763,8 @@ public:
    */
   virtual ObjectMap::ObjectMapIterator get_omap_iterator(
     CollectionHandle &c,   ///< [in] collection
-    const ghobject_t &oid  ///< [in] object
+    const ghobject_t &oid, ///< [in] object
+    std::string start_from = std::string{}  ///< [in] key the iterator should point to at the beginning
     ) = 0;
 
   virtual int flush_journal() { return -EOPNOTSUPP; }

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -761,10 +761,18 @@ public:
    *
    * @return iterator, null on error
    */
+  struct omap_iter_seek_t {
+    std::string seek_position;
+    enum {
+      LOWER_BOUND,
+      UPPER_BOUND
+    } seek_type = LOWER_BOUND;
+    static omap_iter_seek_t min_lower_bound() { return {}; }
+  };
   virtual ObjectMap::ObjectMapIterator get_omap_iterator(
     CollectionHandle &c,   ///< [in] collection
     const ghobject_t &oid, ///< [in] object
-    std::string start_from = std::string{}  ///< [in] key the iterator should point to at the beginning
+    omap_iter_seek_t start_from = omap_iter_seek_t::min_lower_bound()  ///< [in] where the iterator should point to at the beginning
     ) = 0;
 
   virtual int flush_journal() { return -EOPNOTSUPP; }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5511,7 +5511,7 @@ void BlueStore::MempoolThread::_update_cache_settings()
 #define dout_prefix *_dout << "bluestore.OmapIteratorImpl(" << this << ") "
 
 BlueStore::OmapIteratorImpl::OmapIteratorImpl(
-  PerfCounters* _logger, CollectionRef c, OnodeRef& o, KeyValueDB::Iterator it)
+  PerfCounters* _logger, CollectionRef c, OnodeRef& o, KeyValueDB::Iterator it, string start_from)
   : logger(_logger), c(c), o(o), it(it)
 {
   logger->inc(l_bluestore_omap_iterator_count);
@@ -5519,7 +5519,9 @@ BlueStore::OmapIteratorImpl::OmapIteratorImpl(
   if (o->onode.has_omap()) {
     o->get_omap_key(string(), &head);
     o->get_omap_tail(&tail);
-    it->lower_bound(head);
+    string key;
+    o->get_omap_key(start_from, &key);
+    it->lower_bound(key);
   }
 }
 BlueStore::OmapIteratorImpl::~OmapIteratorImpl()
@@ -13699,7 +13701,8 @@ int BlueStore::omap_check_keys(
 
 ObjectMap::ObjectMapIterator BlueStore::get_omap_iterator(
   CollectionHandle &c_,              ///< [in] collection
-  const ghobject_t &oid  ///< [in] object
+  const ghobject_t &oid,  ///< [in] object
+  std::string start_from  ///< [in] key the iterator should point to at the beginning
   )
 {
   Collection *c = static_cast<Collection *>(c_.get());
@@ -13724,7 +13727,7 @@ ObjectMap::ObjectMapIterator BlueStore::get_omap_iterator(
     bounds.upper_bound = std::move(upper_bound);
   }
   KeyValueDB::Iterator it = db->get_iterator(o->get_omap_prefix(), 0, std::move(bounds));
-  return ObjectMap::ObjectMapIterator(new OmapIteratorImpl(logger,c, o, it));
+  return ObjectMap::ObjectMapIterator(new OmapIteratorImpl(logger,c, o, it, start_from));
 }
 
 // -----------------

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5511,7 +5511,7 @@ void BlueStore::MempoolThread::_update_cache_settings()
 #define dout_prefix *_dout << "bluestore.OmapIteratorImpl(" << this << ") "
 
 BlueStore::OmapIteratorImpl::OmapIteratorImpl(
-  PerfCounters* _logger, CollectionRef c, OnodeRef& o, KeyValueDB::Iterator it, string start_from)
+  PerfCounters* _logger, CollectionRef c, OnodeRef& o, KeyValueDB::Iterator it, const omap_iter_seek_t& start_from)
   : logger(_logger), c(c), o(o), it(it)
 {
   logger->inc(l_bluestore_omap_iterator_count);
@@ -5520,8 +5520,12 @@ BlueStore::OmapIteratorImpl::OmapIteratorImpl(
     o->get_omap_key(string(), &head);
     o->get_omap_tail(&tail);
     string key;
-    o->get_omap_key(start_from, &key);
-    it->lower_bound(key);
+    o->get_omap_key(start_from.seek_position, &key);
+    if (start_from.seek_type == omap_iter_seek_t::LOWER_BOUND) {
+      it->lower_bound(key);
+    } else {
+      it->upper_bound(key);
+    }
   }
 }
 BlueStore::OmapIteratorImpl::~OmapIteratorImpl()
@@ -13702,7 +13706,7 @@ int BlueStore::omap_check_keys(
 ObjectMap::ObjectMapIterator BlueStore::get_omap_iterator(
   CollectionHandle &c_,              ///< [in] collection
   const ghobject_t &oid,  ///< [in] object
-  std::string start_from  ///< [in] key the iterator should point to at the beginning
+  const omap_iter_seek_t start_from  ///< [in] where the iterator should point to at the beginning
   )
 {
   Collection *c = static_cast<Collection *>(c_.get());

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1744,7 +1744,7 @@ public:
 
     std::string _stringify() const;
   public:
-    OmapIteratorImpl(PerfCounters* l, CollectionRef c, OnodeRef& o, KeyValueDB::Iterator it, std::string start_from);
+    OmapIteratorImpl(PerfCounters* l, CollectionRef c, OnodeRef& o, KeyValueDB::Iterator it, const omap_iter_seek_t& start_from);
     virtual ~OmapIteratorImpl();
     int seek_to_first() override;
     int upper_bound(const std::string &after) override;
@@ -3420,7 +3420,7 @@ public:
   ObjectMap::ObjectMapIterator get_omap_iterator(
     CollectionHandle &c,   ///< [in] collection
     const ghobject_t &oid, ///< [in] object
-    std::string start_from = std::string{}  ///< [in] key the iterator should point to at the beginning
+    omap_iter_seek_t start_from = omap_iter_seek_t::min_lower_bound()  ///< [in] where the iterator should point to at the beginning
     ) override;
 
   void set_fsid(uuid_d u) override {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1744,7 +1744,7 @@ public:
 
     std::string _stringify() const;
   public:
-    OmapIteratorImpl(PerfCounters* l, CollectionRef c, OnodeRef& o, KeyValueDB::Iterator it);
+    OmapIteratorImpl(PerfCounters* l, CollectionRef c, OnodeRef& o, KeyValueDB::Iterator it, std::string start_from);
     virtual ~OmapIteratorImpl();
     int seek_to_first() override;
     int upper_bound(const std::string &after) override;
@@ -3419,7 +3419,8 @@ public:
 
   ObjectMap::ObjectMapIterator get_omap_iterator(
     CollectionHandle &c,   ///< [in] collection
-    const ghobject_t &oid  ///< [in] object
+    const ghobject_t &oid, ///< [in] object
+    std::string start_from = std::string{}  ///< [in] key the iterator should point to at the beginning
     ) override;
 
   void set_fsid(uuid_d u) override {

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -1849,7 +1849,7 @@ int KStore::omap_check_keys(
 ObjectMap::ObjectMapIterator KStore::get_omap_iterator(
   CollectionHandle& ch,              ///< [in] collection
   const ghobject_t &oid,   ///< [in] object
-  std::string start_from  ///< [in] key the iterator should point to at the beginning
+  omap_iter_seek_t start_from  ///< [in] where the iterator should point to at the beginning
   )
 {
 

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -1848,7 +1848,8 @@ int KStore::omap_check_keys(
 
 ObjectMap::ObjectMapIterator KStore::get_omap_iterator(
   CollectionHandle& ch,              ///< [in] collection
-  const ghobject_t &oid  ///< [in] object
+  const ghobject_t &oid,   ///< [in] object
+  std::string start_from  ///< [in] key the iterator should point to at the beginning
   )
 {
 

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -550,7 +550,8 @@ public:
   using ObjectStore::get_omap_iterator;
   ObjectMap::ObjectMapIterator get_omap_iterator(
     CollectionHandle& c,              ///< [in] collection
-    const ghobject_t &oid  ///< [in] object
+    const ghobject_t &oid,  ///< [in] object
+    std::string start_from  ///< [in] key the iterator should point to at the beginning
     ) override;
 
   void set_fsid(uuid_d u) override {

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -172,7 +172,7 @@ public:
     KeyValueDB::Iterator it;
     std::string head, tail;
   public:
-    OmapIteratorImpl(CollectionRef c, OnodeRef o, KeyValueDB::Iterator it);
+    OmapIteratorImpl(CollectionRef c, OnodeRef o, KeyValueDB::Iterator it, const omap_iter_seek_t& start_from);
     int seek_to_first() override;
     int upper_bound(const std::string &after) override;
     int lower_bound(const std::string &to) override;

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -551,7 +551,7 @@ public:
   ObjectMap::ObjectMapIterator get_omap_iterator(
     CollectionHandle& c,              ///< [in] collection
     const ghobject_t &oid,  ///< [in] object
-    std::string start_from  ///< [in] key the iterator should point to at the beginning
+    omap_iter_seek_t start_from = omap_iter_seek_t::min_lower_bound()  ///< [in] where the iterator should point to at the beginning
     ) override;
 
   void set_fsid(uuid_d u) override {

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -630,7 +630,7 @@ public:
 ObjectMap::ObjectMapIterator MemStore::get_omap_iterator(
   CollectionHandle& ch,
   const ghobject_t& oid,
-  std::string start_from)
+  omap_iter_seek_t start_from)
 {
   dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;
   Collection *c = static_cast<Collection*>(ch.get());

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -629,7 +629,8 @@ public:
 
 ObjectMap::ObjectMapIterator MemStore::get_omap_iterator(
   CollectionHandle& ch,
-  const ghobject_t& oid)
+  const ghobject_t& oid,
+  std::string start_from)
 {
   dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;
   Collection *c = static_cast<Collection*>(ch.get());

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -384,7 +384,8 @@ public:
   using ObjectStore::get_omap_iterator;
   ObjectMap::ObjectMapIterator get_omap_iterator(
     CollectionHandle& c,              ///< [in] collection
-    const ghobject_t &oid  ///< [in] object
+    const ghobject_t &oid,  ///< [in] object
+    std::string start_from  ///< [in] key the iterator should point to at the beginning
     ) override;
 
   void set_fsid(uuid_d u) override;

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -385,7 +385,7 @@ public:
   ObjectMap::ObjectMapIterator get_omap_iterator(
     CollectionHandle& c,              ///< [in] collection
     const ghobject_t &oid,  ///< [in] object
-    std::string start_from  ///< [in] key the iterator should point to at the beginning
+    omap_iter_seek_t start_from  ///< [in] where the iterator should point to at the beginning
     ) override;
 
   void set_fsid(uuid_d u) override;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7709,9 +7709,10 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	bool truncated = false;
 	if (oi.is_omap()) {
 	  ObjectMap::ObjectMapIterator iter = osd->store->get_omap_iterator(
-	    ch, ghobject_t(soid)
+	    ch, ghobject_t(soid), start_after
 	    );
 	  ceph_assert(iter);
+	  // the get_omap_iterator() seeks to lower bound
 	  iter->upper_bound(start_after);
 	  for (num = 0; iter->valid(); ++num, iter->next()) {
 	    if (num >= max_return ||
@@ -7756,7 +7757,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	bufferlist bl;
 	if (oi.is_omap()) {
 	  ObjectMap::ObjectMapIterator iter = osd->store->get_omap_iterator(
-	    ch, ghobject_t(soid)
+	    ch, ghobject_t(soid), start_after
 	    );
           if (!iter) {
             result = -ENOENT;

--- a/src/test/objectstore/ObjectStoreImitator.h
+++ b/src/test/objectstore/ObjectStoreImitator.h
@@ -343,7 +343,8 @@ public:
   }
   ObjectMap::ObjectMapIterator
   get_omap_iterator(CollectionHandle &c,  ///< [in] collection
-                    const ghobject_t &oid ///< [in] object
+                    const ghobject_t &oid,///< [in] object
+                    omap_iter_seek_t start_from ///< [in] where the iterator should point to at the beginning
                     ) override {
     return {};
   }


### PR DESCRIPTION
Currently an OSD does up to 3 key seeks while iterating over OMAP:

1. to rewind to the first OMAP entry of particular RADOS object in the whole, global key namespace;
2. then to find the pagination-related `start_after` key;
3. then to respect the `filter` parameter.
    
This is pretty inefficient as `Seek()` in RocksDB is logarithmic, so `Seek(n)` should be cheaper than `Seek(n/2)` + `Seek(n/2)`.
    
~~Also, this change further narrows the RocksDB iterator's bound.~~
    
Please note there are other inefficiencies. The underlying `Seeks()` are performed under the collection lock and the iterator is one-time only. Ultimately we could try to cache it and reuse across multiple rounds of the same listing of RGW.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

-------------

~~The impact of this change is currently unknown. I'm hunting for a cluster to verify it. Draft for now.~~

Benchmarking & profiling under the freshly extended, **unreviewed** `rados bench`: https://gist.github.com/rzarzynski/dbfedcb55bd9c9cafeb0b0c3358a32ec

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
