### PR TITLE
qa/rgw: add debug log to help diagnose 'bucket check unlinked' failure

### DIFF
--- a/qa/workunits/rgw/test_rgw_bucket_check.py
+++ b/qa/workunits/rgw/test_rgw_bucket_check.py
@@ -173,6 +173,7 @@ def main():
     exec_cmd(f'radosgw-admin bucket check --fix --bucket {BUCKET_NAME}')
     out = exec_cmd(f'radosgw-admin bucket check unlinked --bucket {BUCKET_NAME} --fix --min-age-hours 0 --rgw-olh-pending-timeout-sec 0 --dump-keys')
     json_out = json.loads(out)
+    log.info(f'"bucket check unlinked" returned {json_out}, expecting {unlinked_keys}')
     assert len(json_out) == len(unlinked_keys)
     bucket.object_versions.all().delete()
     out = exec_cmd(f'radosgw-admin bucket stats --bucket {BUCKET_NAME}')


### PR DESCRIPTION
relates to https://tracker.ceph.com/issues/65654

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
