### PR TITLE
reef: src/mon/ConnectionTracker.cc: Fix dump function

### DIFF
--- a/qa/suites/rados/singleton/all/mon-connection-score.yaml
+++ b/qa/suites/rados/singleton/all/mon-connection-score.yaml
@@ -1,0 +1,40 @@
+roles:
+- - mon.a
+  - mon.b
+  - mon.c
+  - osd.0
+  - osd.1
+  - osd.2
+  - mgr.x
+  - client.0
+
+openstack:
+  - volumes: # attached to each instance
+      count: 3
+      size: 10 # GB
+tasks:
+- install:
+- ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr_pool false --force
+    log-ignorelist:
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
+      - \(POOL_
+      - \(CACHE_POOL_
+      - \(OBJECT_
+      - \(SLOW_OPS\)
+      - \(REQUEST_SLOW\)
+      - \(TOO_FEW_PGS\)
+      - slow request
+      - \(POOL_APP_NOT_ENABLED\)
+      - overall HEALTH_
+      - \(MGR_DOWN\)
+      - \(MON_DOWN\)
+      - \(PG_AVAILABILITY\)
+      - \(SLOW_OPS\)
+- cephfs_test_runner:
+    modules:
+      - tasks.mon_connection_score

--- a/qa/tasks/ceph_test_case.py
+++ b/qa/tasks/ceph_test_case.py
@@ -361,13 +361,10 @@ class CephTestCase(unittest.TestCase, RunCephCmd):
         while True:
             if condition():
                 success_time_elapsed = 0
-                while success_time_elapsed < success_hold_time:
-                    if condition():
-                        success_time_elapsed += 1
-                        time.sleep(1)
-                        elapsed += 1
-                    else:
-                        break
+                while success_time_elapsed < success_hold_time and condition():
+                    success_time_elapsed += 1
+                    time.sleep(1)
+                    elapsed += 1
                 if success_time_elapsed == success_hold_time:
                     log.debug("wait_until_true_and_hold: success for {0}s".format(success_hold_time))
                     return

--- a/qa/tasks/mon_connection_score.py
+++ b/qa/tasks/mon_connection_score.py
@@ -1,0 +1,95 @@
+from tasks.ceph_test_case import CephTestCase
+import json
+import logging
+log = logging.getLogger(__name__)
+
+
+class TestStretchClusterNew(CephTestCase):
+
+    CLUSTER = "ceph"
+    MONS = {
+            "a": {
+                "rank": 0,
+                },
+            "b": {
+                "rank": 1,
+            },
+            "c": {
+                "rank": 2,
+            }
+        }
+    WRITE_PERIOD = 10
+    RECOVERY_PERIOD = WRITE_PERIOD * 6
+    SUCCESS_HOLD_TIME = 10
+
+    def setUp(self):
+        """
+        Set up the cluster for the test.
+        """
+        super(TestStretchClusterNew, self).setUp()
+
+    def tearDown(self):
+        """
+        Clean up the cluter after the test.
+        """
+        super(TestStretchClusterNew, self).tearDown()
+
+    def _check_connection_score(self):
+        """
+        Check the connection score of all the mons.
+        """
+        for mon, _ in self.MONS.items():
+            # get the connection score
+            cscore = self.ceph_cluster.mon_manager.raw_cluster_cmd(
+                'daemon', 'mon.{}'.format(mon),
+                'connection', 'scores', 'dump')
+            # parse the connection score
+            cscore = json.loads(cscore)
+            # check if the current mon rank is correct
+            if cscore["rank"] != self.MONS[mon]["rank"]:
+                log.error(
+                    "Rank mismatch {} != {}".format(
+                        cscore["rank"], self.MONS[mon]["rank"]
+                    )
+                )
+                return False
+            # check if current mon have all the peer reports and ourself
+            if len(cscore['reports']) != len(self.MONS):
+                log.error(
+                    "Reports count mismatch {}".format(cscore['reports'])
+                )
+                return False
+
+            for report in cscore["reports"]:
+                report_rank = []
+                for peer in report["peer_scores"]:
+                    # check if the peer is alive
+                    if not peer["peer_alive"]:
+                        log.error("Peer {} is not alive".format(peer))
+                        return False
+                    report_rank.append(peer["peer_rank"])
+
+                # check if current mon has all the ranks and no duplicates
+                expected_ranks = [
+                    rank
+                    for data in self.MONS.values()
+                    for rank in data.values()
+                ]
+                if report_rank.sort() != expected_ranks.sort():
+                    log.error("Rank mismatch in report {}".format(report))
+                    return False
+
+        log.info("Connection score is clean!")
+        return True
+
+    def test_connection_score(self):
+        # check if all mons are in quorum
+        self.ceph_cluster.mon_manager.wait_for_mon_quorum_size(3)
+        # check if all connection scores reflect this
+        self.wait_until_true_and_hold(
+            lambda: self._check_connection_score(),
+            # Wait for 4 minutes for the connection score to recover
+            timeout=self.RECOVERY_PERIOD * 4,
+            # Hold the clean connection score for 60 seconds
+            success_hold_time=self.SUCCESS_HOLD_TIME * 6
+        )

--- a/src/mon/ConnectionTracker.cc
+++ b/src/mon/ConnectionTracker.cc
@@ -325,13 +325,13 @@ void ConnectionReport::dump(ceph::Formatter *f) const
   f->dump_int("rank", rank);
   f->dump_int("epoch", epoch);
   f->dump_int("version", epoch_version);
-  f->open_object_section("peer_scores");
+  f->open_array_section("peer_scores");
   for (auto i : history) {
     f->open_object_section("peer");
     f->dump_int("peer_rank", i.first);
     f->dump_float("peer_score", i.second);
     f->dump_bool("peer_alive", current.find(i.first)->second);
-    f->close_section();
+    f->close_section(); // peer
   }
   f->close_section(); // peer scores
 }
@@ -354,11 +354,11 @@ void ConnectionTracker::dump(ceph::Formatter *f) const
   f->dump_int("version", version);
   f->dump_float("half_life", half_life);
   f->dump_int("persist_interval", persist_interval);
-  f->open_object_section("reports");
+  f->open_array_section("reports");
   for (const auto& i : peer_reports) {
     f->open_object_section("report");
     i.second.dump(f);
-    f->close_section();
+    f->close_section(); // report
   }
   f->close_section(); // reports
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68281

---

backport of https://github.com/ceph/ceph/pull/57146
parent tracker: https://tracker.ceph.com/issues/65695

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
