### PR TITLE
pybind/mgr/dashboard: add omit_usage query param to dashboard api list rbds endpoint

### DIFF
--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -217,6 +217,12 @@ paths:
         name: sort
         schema:
           type: string
+      - default: false
+        description: When true, usage information is not returned
+        in: query
+        name: omit_usage
+        schema:
+          type: boolean
       responses:
         '200':
           content:

--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -458,8 +458,8 @@ class RbdService(object):
         return namespaces
 
     @classmethod
-    def _rbd_image_stat(cls, ioctx, pool_name, namespace, image_name):
-        return cls._rbd_image(ioctx, pool_name, namespace, image_name)
+    def _rbd_image_stat(cls, ioctx, pool_name, namespace, image_name, omit_usage=False):
+        return cls._rbd_image(ioctx, pool_name, namespace, image_name, omit_usage)
 
     @classmethod
     def _rbd_image_stat_removing(cls, ioctx, pool_name, namespace, image_id):
@@ -490,7 +490,7 @@ class RbdService(object):
 
     @classmethod
     def rbd_pool_list(cls, pool_names: List[str], namespace: Optional[str] = None, offset: int = 0,
-                      limit: int = 5, search: str = '', sort: str = ''):
+                      limit: int = 5, search: str = '', sort: str = '', omit_usage=False):
         image_refs = cls._rbd_pool_image_refs(pool_names, namespace)
         params = ['name', 'pool_name', 'namespace']
         paginator = ListPaginator(offset, limit, sort, search, image_refs,
@@ -506,7 +506,8 @@ class RbdService(object):
 
                 try:
                     stat = cls._rbd_image_stat(
-                        ioctx, image_ref['pool_name'], image_ref['namespace'], image_ref['name'])
+                        ioctx, image_ref['pool_name'], image_ref['namespace'], image_ref['name'],
+                        omit_usage)
                 except rbd.ImageNotFound:
                     try:
                         stat = cls._rbd_image_stat_removing(


### PR DESCRIPTION
Allows RBD listing to be retrieved without getting associated usage info. This can be useful for large RBDs where the process of gathering such usage info is sometimes very slow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
