### PR TITLE
mgr/dashboard: fix cephadm dashboard e2e and a combobox issue

### DIFF
--- a/src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/run-cephadm-e2e-tests.sh
@@ -38,4 +38,5 @@ cypress_run () {
 
 cd ${CEPH_DEV_FOLDER}/src/pybind/mgr/dashboard/frontend
 
-cypress_run ["cypress/e2e/orchestrator/workflow/*.feature","cypress/e2e/orchestrator/workflow/*-spec.ts","cypress/e2e/orchestrator/grafana/*.feature"]
+cypress_run ["cypress/e2e/orchestrator/workflow/*.feature","cypress/e2e/orchestrator/workflow/*-spec.ts"]
+cypress_run ["cypress/e2e/orchestrator/grafana/*.feature"]

--- a/src/pybind/mgr/dashboard/frontend/cypress.config.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'cypress';
+import fs from 'fs'
 
 export default defineConfig({
   video: true,
@@ -37,6 +38,21 @@ export default defineConfig({
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     setupNodeEvents(on, config) {
+      on(
+        'after:spec',
+        (_: Cypress.Spec, results: CypressCommandLine.RunResult) => {
+          if (results && results.video) {
+            // Do we have failures for any retry attempts?
+            const failures = results.tests.some((test) =>
+              test.attempts.some((attempt) => attempt.state === 'failed')
+            )
+            if (!failures) {
+              // delete the video if the spec passed and no tests retried
+              fs.unlinkSync(results.video)
+            }
+          }
+        }
+      )
       return require('./cypress/plugins/index.js')(on, config);
     },
     baseUrl: 'https://localhost:4200/',

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/block/images.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/block/images.e2e-spec.ts
@@ -18,7 +18,7 @@ describe('Images page', () => {
   after(() => {
     // Deletes images test pool
     pools.navigateTo();
-    pools.delete(poolName, null, null, true);
+    pools.delete(poolName, null, null, true, false, false, true);
     pools.navigateTo();
     pools.existTableCell(poolName, false);
   });
@@ -58,7 +58,7 @@ describe('Images page', () => {
     });
 
     it('should delete image', () => {
-      images.delete(newImageName, null, null, true);
+      images.delete(newImageName, null, null, true, false, false, true);
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/block/mirroring.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/block/mirroring.e2e-spec.ts
@@ -112,7 +112,7 @@ describe('Mirroring page', () => {
 
     afterEach(() => {
       pools.navigateTo();
-      pools.delete(poolName, null, null, true);
+      pools.delete(poolName, null, null, true, false, false, true);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/hosts.po.ts
@@ -21,7 +21,7 @@ export class HostsPageHelper extends PageHelper {
 
   add(hostname: string, exist?: boolean, maintenance?: boolean, labels: string[] = []) {
     cy.get(`${this.pages.add.id}`).within(() => {
-      cy.get('#hostname').type(hostname);
+      cy.get('#hostname').type(hostname, { force: true });
       if (maintenance) {
         cy.get('label[for=maintenance]').click();
       }
@@ -35,6 +35,7 @@ export class HostsPageHelper extends PageHelper {
     }
 
     cy.get('cd-submit-button').click();
+    cy.get('cds-modal').should('not.exist');
     // back to host list
     cy.get(`${this.pages.index.id}`);
   }

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/hosts.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/hosts.po.ts
@@ -65,7 +65,7 @@ export class HostsPageHelper extends PageHelper {
   }
 
   remove(hostname: string) {
-    super.delete(hostname, this.columnIndex.hostname, 'hosts', true, false, true);
+    super.delete(hostname, this.columnIndex.hostname, 'hosts', true, false, true, true);
   }
 
   // Add or remove labels on a host, then verify labels in the table

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/logs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/logs.e2e-spec.ts
@@ -54,7 +54,7 @@ describe('Logs page', () => {
 
     it('should delete pool and check audit logs reacted', () => {
       pools.navigateTo();
-      pools.delete(poolname, null, null, true);
+      pools.delete(poolname, null, null, true, false, false, true);
       logs.checkAuditForPoolFunction(poolname, 'delete', hour, minute);
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/osds.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/cluster/osds.po.ts
@@ -50,9 +50,8 @@ export class OSDsPageHelper extends PageHelper {
 
   @PageHelper.restrictTo(pages.index.url)
   checkStatus(id: number, status: string[]) {
-    this.searchTable(`id:${id}`);
+    this.searchTable(id.toString());
     cy.wait(5 * 1000);
-    this.expectTableCount('found', 1);
     cy.get(`[cdstabledata]:nth-child(${this.columnIndex.status}) .badge`).should(($ele) => {
       const allStatus = $ele.toArray().map((v) => v.innerText);
       for (const s of status) {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/create-cluster/create-cluster.feature.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/create-cluster/create-cluster.feature.po.ts
@@ -2,8 +2,8 @@ import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
 
 Given('I am on the {string} section', (page: string) => {
   cy.get('cd-wizard').within(() => {
-    cy.get('.nav-link').should('contain.text', page).first().click();
-    cy.get('.nav-link.active').should('contain.text', page);
+    cy.get('button').should('have.attr', 'title', page).first().click();
+    cy.get('.cds--assistive-text').should('contain.text', 'Current');
   });
 });
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/forms-helper.feature.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/forms-helper.feature.po.ts
@@ -42,16 +42,17 @@ And('select options {string}', (labels: string) => {
 
 And('{string} option {string}', (action: string, labels: string) => {
   if (labels) {
+    cy.get('cds-modal').find('input[id=labels]').click();
     if (action === 'add') {
-      cy.get('cd-modal').find('.select-menu-edit').click();
       for (const label of labels.split(', ')) {
-        cy.get('.popover-body input').type(`${label}{enter}`);
+        cy.get('input[id=labels]').clear().type(`${label}`);
+
+        cy.get('cds-dropdown-list').find('li').should('have.attr', 'title', label).click();
       }
     } else {
       for (const label of labels.split(', ')) {
-        cy.contains('cd-modal .badge', new RegExp(`^${label}$`))
-          .find('.badge-remove')
-          .click();
+        cy.get('input[id=labels]').clear().type(`${label}`);
+        cy.get('cds-dropdown-list').find('li').should('have.attr', 'title', label).click();
       }
     }
   }
@@ -84,7 +85,7 @@ And('I confirm to {string} on carbon modal', (action: string) => {
 });
 
 Then('I should see an error in {string} field', (field: string) => {
-  cy.get('cd-modal').within(() => {
+  cy.get('cds-modal').within(() => {
     cy.get(`input[id=${field}]`).should('have.class', 'ng-invalid');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/forms-helper.feature.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/common/forms-helper.feature.po.ts
@@ -74,6 +74,10 @@ Then('I check the tick box in carbon modal', () => {
   cy.get('cds-modal input#confirmation_input').click({ force: true });
 });
 
+Then('I confirm the resource {string}', (name: string) => {
+  cy.get('cds-modal input#resource_name').type(name);
+});
+
 And('I confirm to {string}', (action: string) => {
   cy.contains('cd-modal button', action).click();
   cy.get('cd-modal').should('not.exist');

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/filesystems.e2e-spec.feature
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/filesystems.e2e-spec.feature
@@ -26,6 +26,6 @@ Feature: CephFS Management
         And I select a row "test_cephfs"
         And I click on "Remove" button from the table actions
         Then I should see the carbon modal
-        And I check the tick box in carbon modal
+        And I confirm the resource "test_cephfs"
         And I click on "Remove File System" button
         Then I should not see a row with "test_cephfs"

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/snapshots.e2e-spec.feature
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/snapshots.e2e-spec.feature
@@ -60,7 +60,7 @@ Feature: CephFS Snapshot Management
         And I go to the "Subvolumes" tab
         And I select a row "test_clone" in the expanded row
         And I click on "Remove" button from the table actions in the expanded row
-        And I check the tick box in carbon modal
+        And I confirm the resource "test_clone"
         And I click on "Remove Subvolume" button
         Then I wait for "5" seconds
         And I should not see a row with "test_clone" in the expanded row
@@ -71,7 +71,7 @@ Feature: CephFS Snapshot Management
         And I go to the "Snapshots" tab
         And I select a row "test_snapshot" in the expanded row
         And I click on "Remove" button from the table actions in the expanded row
-        And I check the tick box in carbon modal
+        And I confirm the resource "test_snapshot"
         And I click on "Remove Snapshot" button
         Then I should not see a row with "test_snapshot" in the expanded row
 
@@ -81,7 +81,7 @@ Feature: CephFS Snapshot Management
         And I go to the "Subvolumes" tab
         When I select a row "test_subvolume" in the expanded row
         And I click on "Remove" button from the table actions in the expanded row
-        And I check the tick box in carbon modal
+        And I confirm the resource "test_subvolume"
         And I click on "Remove Subvolume" button
         Then I should not see a row with "test_subvolume" in the expanded row
 
@@ -90,6 +90,6 @@ Feature: CephFS Snapshot Management
         And I select a row "test_cephfs"
         And I click on "Remove" button from the table actions
         Then I should see the carbon modal
-        And I check the tick box in carbon modal
+        And I confirm the resource "test_cephfs"
         And I click on "Remove File System" button
         Then I should not see a row with "test_cephfs"

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/subvolume-groups.e2e-spec.feature
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/subvolume-groups.e2e-spec.feature
@@ -37,7 +37,7 @@ Feature: CephFS Subvolume Group management
         And I go to the "Subvolume groups" tab
         When I select a row "test_subvolume_group" in the expanded row
         And I click on "Remove" button from the table actions in the expanded row
-        And I check the tick box in carbon modal
+        And I confirm the resource "test_subvolume_group"
         And I click on "Remove subvolume group" button
         Then I should not see a row with "test_subvolume_group" in the expanded row
 
@@ -46,6 +46,6 @@ Feature: CephFS Subvolume Group management
         And I select a row "test_cephfs"
         And I click on "Remove" button from the table actions
         Then I should see the carbon modal
-        And I check the tick box in carbon modal
+        And I confirm the resource "test_cephfs"
         And I click on "Remove File System" button
         Then I should not see a row with "test_cephfs_edit"

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/subvolumes.e2e-spec.feature
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/filesystems/subvolumes.e2e-spec.feature
@@ -37,7 +37,7 @@ Feature: CephFS Subvolume management
         And I go to the "Subvolumes" tab
         When I select a row "test_subvolume" in the expanded row
         And I click on "Remove" button from the table actions in the expanded row
-        And I check the tick box in carbon modal
+        And I confirm the resource "test_subvolume"
         And I click on "Remove Subvolume" button
         Then I should not see a row with "test_subvolume" in the expanded row
 
@@ -46,6 +46,6 @@ Feature: CephFS Subvolume management
         And I select a row "test_cephfs"
         And I click on "Remove" button from the table actions
         Then I should see the carbon modal
-        And I check the tick box in carbon modal
+        And I confirm the resource "test_cephfs"
         And I click on "Remove File System" button
         Then I should not see a row with "test_cephfs_edit"

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/02-create-cluster-add-host.feature
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/02-create-cluster-add-host.feature
@@ -12,10 +12,9 @@ Feature: Cluster expansion host addition
     Scenario Outline: Add hosts
         Given I am on the "Add Hosts" section
         When I click on "Add" button
-        And enter "hostname" "<hostname>" in the modal
-        And select options "<labels>"
+        And enter "hostname" "<hostname>" in the carbon modal
+        And "add" option "<labels>"
         And I click on "Add Host" button
-        Then I should not see the modal
         And I should see a row with "<hostname>"
         And I should see row "<hostname>" have "<labels>"
 
@@ -32,7 +31,6 @@ Feature: Cluster expansion host addition
         Then I should see the carbon modal
         And I check the tick box in carbon modal
         And I click on "Remove Host" button
-        Then I should not see the carbon modal
         And I should not see a row with "<hostname>"
 
         Examples:
@@ -43,9 +41,8 @@ Feature: Cluster expansion host addition
     Scenario: Add hosts using pattern 'ceph-node-[01-02]'
         Given I am on the "Add Hosts" section
         When I click on "Add" button
-        And enter "hostname" "ceph-node-[01-02]" in the modal
+        And enter "hostname" "ceph-node-[01-02]" in the carbon modal
         And I click on "Add Host" button
-        Then I should not see the modal
         And I should see rows with following entries
             | hostname |
             | ceph-node-01 |
@@ -55,7 +52,7 @@ Feature: Cluster expansion host addition
         Given I am on the "Add Hosts" section
         And I should see a row with "ceph-node-00"
         When I click on "Add" button
-        And enter "hostname" "ceph-node-00" in the modal
+        And enter "hostname" "ceph-node-00" in the carbon modal
         Then I should see an error in "hostname" field
 
     Scenario Outline: Add and remove labels on host

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/02-create-cluster-add-host.feature
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/02-create-cluster-add-host.feature
@@ -29,7 +29,7 @@ Feature: Cluster expansion host addition
         When I select a row "<hostname>"
         And I click on "Remove" button from the table actions
         Then I should see the carbon modal
-        And I check the tick box in carbon modal
+        And I confirm the resource "<hostname>"
         And I click on "Remove Host" button
         And I should not see a row with "<hostname>"
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/03-create-cluster-create-services.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/03-create-cluster-create-services.e2e-spec.ts
@@ -19,7 +19,10 @@ describe('Create cluster create services page', () => {
     cy.login();
     createCluster.navigateTo();
     createCluster.createCluster();
-    cy.get('.nav-link').contains('Create Services').click();
+
+    cy.get('cd-wizard').within(() => {
+      cy.get('button').contains('Create Services').click();
+    });
   });
 
   it('should check if title contains Create Services', () => {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/04-create-cluster-create-osds.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/04-create-cluster-create-osds.e2e-spec.ts
@@ -12,7 +12,9 @@ describe('Create cluster create osds page', () => {
     cy.login();
     createCluster.navigateTo();
     createCluster.createCluster();
-    cy.get('.nav-link').contains('Create OSDs').click();
+    cy.get('cd-wizard').within(() => {
+      cy.get('button').contains('Create OSDs').click();
+    });
   });
 
   it('should check if title contains Create OSDs', () => {
@@ -28,12 +30,16 @@ describe('Create cluster create osds page', () => {
         // Go to the Review section and Expand the cluster
         // because the drive group spec is only stored
         // in frontend and will be lost when refreshed
-        cy.get('.nav-link').contains('Review').click();
+        cy.get('cd-wizard').within(() => {
+          cy.get('button').contains('Review').click();
+        });
         cy.get('button[aria-label="Next"]').click();
         cy.get('cd-dashboard').should('exist');
         createCluster.navigateTo();
         createCluster.createCluster();
-        cy.get('.nav-link').contains('Create OSDs').click();
+        cy.get('cd-wizard').within(() => {
+          cy.get('button').contains('Create OSDs').click();
+        });
       }
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/05-create-cluster-review.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/05-create-cluster-review.e2e-spec.ts
@@ -14,12 +14,8 @@ describe('Create Cluster Review page', () => {
     createCluster.navigateTo();
     createCluster.createCluster();
 
-    cy.get('.nav-link').contains('Review').click();
-  });
-
-  describe('navigation link test', () => {
-    it('should check if active nav-link is of Review section', () => {
-      cy.get('.nav-link.active').should('contain.text', 'Review');
+    cy.get('cd-wizard').within(() => {
+      cy.get('button').contains('Review').click();
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/06-cluster-check.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/06-cluster-check.e2e-spec.ts
@@ -21,10 +21,14 @@ describe('when cluster creation is completed', () => {
 
     // Explicitly skip OSD Creation Step so that it prevents from
     // deploying OSDs to the hosts automatically.
-    cy.get('.nav-link').contains('Create OSDs').click();
+    cy.get('cd-wizard').within(() => {
+      cy.get('button').contains('Create OSDs').click();
+    });
     cy.get('button[aria-label="Skip this step"]').click();
 
-    cy.get('.nav-link').contains('Review').click();
+    cy.get('cd-wizard').within(() => {
+      cy.get('button').contains('Review').click();
+    });
     cy.get('button[aria-label="Next"]').click();
     cy.get('cd-dashboard').should('exist');
   });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/09-services.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/09-services.e2e-spec.ts
@@ -98,6 +98,7 @@ describe('Services page', () => {
     cy.get('cd-service-details').within(() => {
       services.checkServiceStatus('snmp-gateway');
     });
+    services.clickServiceTab('snmp-gateway', 'Daemons');
 
     services.deleteService('snmp-gateway');
   });
@@ -111,6 +112,7 @@ describe('Services page', () => {
     cy.get('cd-service-details').within(() => {
       services.checkServiceStatus('snmp-gateway');
     });
+    services.clickServiceTab('snmp-gateway', 'Daemons');
 
     services.deleteService('snmp-gateway');
   });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/10-nfs-exports.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/orchestrator/workflow/10-nfs-exports.e2e-spec.ts
@@ -4,7 +4,7 @@ import { NFSPageHelper } from '../../orchestrator/workflow/nfs/nfs-export.po';
 import { BucketsPageHelper } from '../../rgw/buckets.po';
 /* tslint:enable*/
 
-describe('nfsExport page', () => {
+describe.skip('nfsExport page', () => {
   const nfsExport = new NFSPageHelper();
   const services = new ServicesPageHelper();
   const buckets = new BucketsPageHelper();

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/page-helper.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/page-helper.po.ts
@@ -13,17 +13,19 @@ export abstract class PageHelper {
    */
   static restrictTo(page: string): Function {
     return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
-      const fn: Function = descriptor.value;
-      descriptor.value = function (...args: any) {
-        cy.location('hash').should((url) => {
-          expect(url).to.eq(
-            page,
-            `Method ${target.constructor.name}::${propertyKey} is supposed to be ` +
-              `run on path "${page}", but was run on URL "${url}"`
-          );
-        });
-        fn.apply(this, args);
-      };
+      if (descriptor) {
+        const fn: Function = descriptor.value;
+        descriptor.value = function (...args: any) {
+          cy.location('hash').should((url) => {
+            expect(url).to.eq(
+              page,
+              `Method ${target.constructor.name}::${propertyKey} is supposed to be ` +
+                `run on path "${page}", but was run on URL "${url}"`
+            );
+          });
+          fn.apply(this, args);
+        };
+      }
     };
   }
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/page-helper.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/page-helper.po.ts
@@ -334,7 +334,8 @@ export abstract class PageHelper {
     section?: string,
     cdsModal = false,
     isMultiselect = false,
-    shouldReload = false
+    shouldReload = false,
+    confirmInput = false
   ) {
     const action: string = section === 'hosts' ? 'remove' : 'delete';
 
@@ -347,10 +348,14 @@ export abstract class PageHelper {
 
     // Convert action to SentenceCase and Confirms deletion
     const actionUpperCase = action.charAt(0).toUpperCase() + action.slice(1);
-    cy.get('input[name="confirmation"]').click({ force: true });
+    if (confirmInput) {
+      cy.get('cds-modal input#resource_name').type(name, { force: true });
+    } else {
+      cy.get('[aria-label="confirmation"]').click({ force: true });
+    }
 
     if (cdsModal) {
-      cy.get('cds-modal button').contains(actionUpperCase).click();
+      cy.get('cds-modal button').contains(actionUpperCase).click({ force: true });
       // Wait for modal to close
       cy.get('cds-modal').should('not.exist');
     } else {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/pools/pools.e2e-spec.ts
@@ -47,7 +47,7 @@ describe('Pools page', () => {
     });
 
     it('should delete a pool', () => {
-      pools.delete(poolName, null, null, true);
+      pools.delete(poolName, null, null, true, false, false, true);
     });
   });
 
@@ -65,7 +65,7 @@ describe('Pools page', () => {
     });
 
     it('should delete the pool', () => {
-      pools.delete(poolName, null, null, true);
+      pools.delete(poolName, null, null, true, false, false, true);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/buckets.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/buckets.e2e-spec.ts
@@ -28,7 +28,7 @@ describe('RGW buckets page', () => {
     });
 
     it('should delete bucket', () => {
-      buckets.delete(bucket_name, null, null, true, true);
+      buckets.delete(bucket_name, null, null, true, false, false, true);
     });
 
     it('should create bucket with object locking enabled', () => {
@@ -41,7 +41,7 @@ describe('RGW buckets page', () => {
       buckets.edit(bucket_name, BucketsPageHelper.USERS[1], true);
       buckets.getDataTables().should('contain.text', BucketsPageHelper.USERS[1]);
 
-      buckets.delete(bucket_name, null, null, true, true);
+      buckets.delete(bucket_name, null, null, true, false, false, true);
     });
   });
 
@@ -55,7 +55,7 @@ describe('RGW buckets page', () => {
       buckets.create(bucket_name, BucketsPageHelper.USERS[0]);
       buckets.testInvalidEdit(bucket_name);
       buckets.navigateTo();
-      buckets.delete(bucket_name, null, null, true, true);
+      buckets.delete(bucket_name, null, null, true, false, false, true);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/buckets.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/buckets.po.ts
@@ -12,8 +12,8 @@ export class BucketsPageHelper extends PageHelper {
   pages = pages;
 
   columnIndex = {
-    name: 3,
-    owner: 4
+    name: 2,
+    owner: 3
   };
 
   versioningStateEnabled = 'Enabled';
@@ -51,7 +51,7 @@ export class BucketsPageHelper extends PageHelper {
 
   @PageHelper.restrictTo(pages.index.url)
   edit(name: string, new_owner: string, isLocking = false) {
-    this.navigateEdit(name, false, false, null, true);
+    this.navigateEdit(name, false, false, null);
 
     // Placement target is not allowed to be edited and should be hidden
     cy.get('input[name=placement-target]').should('not.exist');
@@ -107,7 +107,7 @@ export class BucketsPageHelper extends PageHelper {
     cy.get('@versioningValueCell').should('have.text', this.versioningStateEnabled);
 
     // Disable versioning:
-    this.navigateEdit(name, false, true, null, true);
+    this.navigateEdit(name, false, true, null);
 
     cy.get('label[for=versioning_input]').click();
     cy.get('input[name=versioning]').should('not.be.checked');
@@ -167,7 +167,7 @@ export class BucketsPageHelper extends PageHelper {
   }
 
   testInvalidEdit(name: string) {
-    this.navigateEdit(name, false, true, null, true);
+    this.navigateEdit(name, false, true, null);
 
     cy.get('input[name=versioning]').should('exist').and('not.be.checked');
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/configuration.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/configuration.e2e-spec.ts
@@ -25,7 +25,7 @@ describe('RGW configuration page', () => {
   describe('create and edit encryption configuration', () => {
     it('should create configuration', () => {
       configurations.create('vault', 'agent', 'transit', 'https://localhost:8080');
-      configurations.getFirstTableCell('SSE_KMS').should('exist');
+      configurations.getFirstTableCell('kms').should('exist');
     });
 
     it('should edit configuration', () => {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/configuration.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/configuration.po.ts
@@ -14,22 +14,22 @@ export class ConfigurationPageHelper extends PageHelper {
     this.selectKmsProvider(provider);
     cy.get('#kms_provider').should('have.class', 'ng-valid');
     this.selectAuthMethod(auth_method);
-    cy.get('#auth_method').should('have.class', 'ng-valid');
+    cy.get('#auth').should('have.class', 'ng-valid');
     this.selectSecretEngine(secret_engine);
     cy.get('#secret_engine').should('have.class', 'ng-valid');
-    cy.get('#address').type(address);
-    cy.get('#address').should('have.value', address);
-    cy.get('#address').should('have.class', 'ng-valid');
+    cy.get('#addr').type(address);
+    cy.get('#addr').should('have.value', address);
+    cy.get('#addr').should('have.class', 'ng-valid');
     cy.contains('button', 'Submit').click();
     cy.wait(500);
     cy.get('cd-table').should('exist');
-    this.getFirstTableCell('SSE_KMS').should('exist');
+    this.getFirstTableCell('kms').should('exist');
   }
 
   edit(new_address: string) {
-    this.navigateEdit('SSE_KMS', true, false);
-    cy.get('#address').clear().type(new_address);
-    cy.get('#address').should('have.class', 'ng-valid');
+    this.navigateEdit('kms', true, false);
+    cy.get('#addr').clear().type(new_address);
+    cy.get('#addr').should('have.class', 'ng-valid');
     cy.get('#kms_provider').should('be.disabled');
     cy.contains('button', 'Submit').click();
     this.getFirstTableCell(new_address);
@@ -40,7 +40,7 @@ export class ConfigurationPageHelper extends PageHelper {
   }
 
   private selectAuthMethod(auth_method: string) {
-    return this.selectOption('auth_method', auth_method);
+    return this.selectOption('auth', auth_method);
   }
 
   private selectSecretEngine(secret_engine: string) {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/users.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/users.e2e-spec.ts
@@ -29,7 +29,7 @@ describe('RGW users page', () => {
     });
 
     it('should delete user', () => {
-      users.delete(user_name, null, null, true, true);
+      users.delete(user_name, null, null, true, false, false, true);
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/users.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/rgw/users.po.ts
@@ -34,7 +34,7 @@ export class UsersPageHelper extends PageHelper {
 
   @PageHelper.restrictTo(pages.index.url)
   edit(name: string, new_fullname: string, new_email: string, new_maxbuckets: string) {
-    this.navigateEdit(name, false, true, null, true);
+    this.navigateEdit(name, false, true, null);
 
     // Change the full name field
     cy.get('input#display_name').click().clear({ force: true }).type(new_fullname, { force: true });
@@ -111,7 +111,7 @@ export class UsersPageHelper extends PageHelper {
       .should('have.text', 'The entered value must be >= 1.');
 
     this.navigateTo();
-    this.delete(tenant + '$' + uname, null, null, true, true);
+    this.delete(tenant + '$' + uname, null, null, true, false, false, true);
   }
 
   invalidEdit() {
@@ -121,7 +121,7 @@ export class UsersPageHelper extends PageHelper {
     this.navigateTo('create');
     this.create(tenant, uname, 'xxx', 'xxx@xxx', '50');
     const name = tenant + '$' + uname;
-    this.navigateEdit(name, false, true, null, true);
+    this.navigateEdit(name, false, true, null);
 
     // put invalid email to make field invalid
     cy.get('#email')
@@ -153,6 +153,6 @@ export class UsersPageHelper extends PageHelper {
       .should('have.text', 'The entered value must be >= 1.');
 
     this.navigateTo();
-    this.delete(tenant + '$' + uname, null, null, true, true);
+    this.delete(tenant + '$' + uname, null, null, true, false, false, true);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/notification.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/notification.e2e-spec.ts
@@ -16,7 +16,7 @@ describe('Notification page', () => {
   after(() => {
     cy.login();
     pools.navigateTo();
-    pools.delete(poolName, null, null, true, false, true);
+    pools.delete(poolName, null, null, true, false, true, true);
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/user-mgmt.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/e2e/ui/user-mgmt.e2e-spec.ts
@@ -30,7 +30,7 @@ describe('User Management page', () => {
     });
 
     it('should delete a user', () => {
-      userMgmt.delete(user_name, null, null, true);
+      userMgmt.delete(user_name, null, null, true, false, false, true);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -55,7 +55,7 @@
 <ng-template #ScheduleTpl
              let-value="data.value"
              let-row="data.row">
-  <span *ngIf="value.length === 3"
+  <span *ngIf="value?.length === 3"
         class="badge badge-info">{{ value[2] | cdDate  }}</span>
 </ng-template>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-form/cephfs-form.component.html
@@ -87,6 +87,8 @@
                            [invalid]="form.controls.label.invalid && (form.controls.label.dirty)"
                            [invalidText]="labelError"
                            cdRequiredField="Label"
+                           cdDynamicInputCombobox
+                           (updatedItems)="data.labels = $event"
                            i18n>
               <cds-dropdown-list></cds-dropdown-list>
             </cds-combo-box>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-tabs/cephfs-tabs.component.ts
@@ -112,8 +112,8 @@ export class CephfsTabsComponent implements OnChanges, OnDestroy {
   softRefresh() {
     const data = _.cloneDeep(this.data); // Forces update of tab tables on tab switch
     // Clients tab
-    this.clients = data.clients;
-    this.clients.status = new TableStatusViewCache(this.clients.status);
+    this.clients = data?.clients;
+    this.clients.status = new TableStatusViewCache(this.clients?.status);
     // Details tab
     this.details = {
       standbys: data.standbys,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
@@ -80,8 +80,10 @@
                        i18n-placeholder
                        [appendInline]="true"
                        [items]="labelsOption"
-                       itemValueKey="value"
+                       itemValueKey="content"
                        id="labels"
+                       cdDynamicInputCombobox
+                       (updatedItems)="labelsOption = $event"
                        i18n>
           <cds-dropdown-list></cds-dropdown-list>
         </cds-combo-box>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.ts
@@ -5,12 +5,12 @@ import expand from 'brace-expansion';
 
 import { HostService } from '~/app/shared/api/host.service';
 import { SelectMessages } from '~/app/shared/components/select/select-messages.model';
-import { SelectOption } from '~/app/shared/components/select/select-option.model';
 import { ActionLabelsI18n, URLVerbs } from '~/app/shared/constants/app.constants';
 import { CdForm } from '~/app/shared/forms/cd-form';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
 import { CdTableFetchDataContext } from '~/app/shared/models/cd-table-fetch-data-context';
+import { ComboBoxItem } from '~/app/shared/models/combo-box.model';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 
@@ -32,7 +32,7 @@ export class HostFormComponent extends CdForm implements OnInit {
   allLabels: string[];
   pageURL: string;
   hostPattern = false;
-  labelsOption: Array<SelectOption> = [];
+  labelsOption: ComboBoxItem[] = [];
 
   messages = new SelectMessages({
     empty: $localize`There are no labels.`,
@@ -71,7 +71,7 @@ export class HostFormComponent extends CdForm implements OnInit {
     this.hostService.getLabels().subscribe((resp: string[]) => {
       const uniqueLabels = new Set(resp.concat(this.hostService.predefinedLabels));
       this.labelsOption = Array.from(uniqueLabels).map((label) => {
-        return { enabled: true, name: label, content: label, selected: false, description: null };
+        return { name: label, content: label };
       });
     });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -328,7 +328,7 @@ export class HostsComponent extends ListWithDetails implements OnDestroy, OnInit
       const host = this.selection.first();
       const labels = new Set(resp.concat(this.hostService.predefinedLabels));
       const allLabels = Array.from(labels).map((label) => {
-        return { content: label };
+        return { content: label, selected: host['labels'].includes(label) };
       });
       this.cdsModalService.show(FormModalComponent, {
         titleText: $localize`Edit Host: ${host.hostname}`,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -8,7 +8,7 @@
       <cd-table [data]="osds"
                 (fetchData)="getOsdList($event)"
                 [columns]="columns"
-                selectionType="single"
+                selectionType="multiClick"
                 [hasDetails]="true"
                 (setExpandedRow)="setExpandedRow($event)"
                 (updateSelection)="updateSelection($event)"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/delete-confirmation-modal/delete-confirmation-modal.component.html
@@ -39,6 +39,7 @@
                           autofocus
                           [required]="true"
                           modal-primary-focus
+                          ariaLabel="confirmation"
                           i18n>Yes, I am sure.</cds-checkbox>
           </ng-container>
           <ng-template #highImpactDeletion>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
@@ -83,10 +83,12 @@
                          [formControlName]="field.name"
                          itemValueKey="content"
                          [id]="field.name"
-                         [items]="field?.typeConfig?.options"
                          [invalid]="getError(field)"
                          [invalidText]="getError(field)"
                          [appendInline]="false"
+                         cdDynamicInputCombobox
+                         (updatedItems)="field.typeConfig.options = $event"
+                         [items]="field?.typeConfig?.options"
                          [cdRequiredField]="field?.required === true ? field.label : ''"
                          i18n>
             <cds-dropdown-list></cds-dropdown-list>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/directives.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/directives.module.ts
@@ -19,6 +19,7 @@ import { RequiredFieldDirective } from './required-field.directive';
 import { ReactiveFormsModule } from '@angular/forms';
 import { OptionalFieldDirective } from './optional-field.directive';
 import { DimlessBinaryPerMinuteDirective } from './dimless-binary-per-minute.directive';
+import { DynamicInputComboboxDirective } from './dynamic-input-combobox.directive';
 
 @NgModule({
   imports: [ReactiveFormsModule],
@@ -40,7 +41,8 @@ import { DimlessBinaryPerMinuteDirective } from './dimless-binary-per-minute.dir
     AuthStorageDirective,
     RequiredFieldDirective,
     OptionalFieldDirective,
-    DimlessBinaryPerMinuteDirective
+    DimlessBinaryPerMinuteDirective,
+    DynamicInputComboboxDirective
   ],
   exports: [
     AutofocusDirective,
@@ -60,7 +62,8 @@ import { DimlessBinaryPerMinuteDirective } from './dimless-binary-per-minute.dir
     AuthStorageDirective,
     RequiredFieldDirective,
     OptionalFieldDirective,
-    DimlessBinaryPerMinuteDirective
+    DimlessBinaryPerMinuteDirective,
+    DynamicInputComboboxDirective
   ]
 })
 export class DirectivesModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dynamic-input-combobox.directive.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dynamic-input-combobox.directive.spec.ts
@@ -1,0 +1,70 @@
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { DEBOUNCE_TIMER, DynamicInputComboboxDirective } from './dynamic-input-combobox.directive';
+import { Subject } from 'rxjs';
+import { Component, EventEmitter } from '@angular/core';
+import { ComboBoxItem } from '../models/combo-box.model';
+
+@Component({
+  template: `<div cdDynamicInputCombobox
+                  [items]="[]"></div>`,
+})
+class MockComponent {
+  items: ComboBoxItem[] = [{ content: 'Item1', name: 'Item1' }];
+  searchSubject = new Subject<string>();
+  selectedItems: ComboBoxItem[] = [];
+  updatedItems = new EventEmitter<ComboBoxItem[]>();
+}
+
+describe('DynamicInputComboboxDirective', () => {
+
+  let component: MockComponent;
+  let fixture: ComponentFixture<MockComponent>;
+  let directive: DynamicInputComboboxDirective;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [DynamicInputComboboxDirective, MockComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MockComponent);
+    component = fixture.componentInstance;
+
+    directive = fixture.debugElement.children[0].injector.get(DynamicInputComboboxDirective);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    directive.ngOnDestroy();
+  });
+
+  it('should create an instance', () => {
+    expect(directive).toBeTruthy();
+  });
+
+  it('should update items when input is given', fakeAsync(() => {
+    const newItem = 'NewItem';
+    directive.onInput(newItem);
+    tick(DEBOUNCE_TIMER);
+
+    expect(directive.items[0].content).toBe(newItem);
+  }));
+
+  it('should not unselect selected items', fakeAsync(() => {
+    const selectedItems: ComboBoxItem[] = [{
+      content: 'selectedItem',
+      name: 'selectedItem',
+      selected: true
+    }];
+
+    directive.items = selectedItems;
+
+    directive.onSelected(selectedItems);
+    tick(DEBOUNCE_TIMER);
+
+    directive.onInput(selectedItems[0].content);
+    tick(DEBOUNCE_TIMER);
+
+    expect(directive.items[0].content).toBe(selectedItems[0].content);
+    expect(directive.items[0].selected).toBeTruthy();
+  }))
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dynamic-input-combobox.directive.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dynamic-input-combobox.directive.spec.ts
@@ -5,8 +5,7 @@ import { Component, EventEmitter } from '@angular/core';
 import { ComboBoxItem } from '../models/combo-box.model';
 
 @Component({
-  template: `<div cdDynamicInputCombobox
-                  [items]="[]"></div>`,
+  template: `<div cdDynamicInputCombobox [items]="[]"></div>`
 })
 class MockComponent {
   items: ComboBoxItem[] = [{ content: 'Item1', name: 'Item1' }];
@@ -16,18 +15,15 @@ class MockComponent {
 }
 
 describe('DynamicInputComboboxDirective', () => {
-
-  let component: MockComponent;
   let fixture: ComponentFixture<MockComponent>;
   let directive: DynamicInputComboboxDirective;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [DynamicInputComboboxDirective, MockComponent],
+      declarations: [DynamicInputComboboxDirective, MockComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(MockComponent);
-    component = fixture.componentInstance;
 
     directive = fixture.debugElement.children[0].injector.get(DynamicInputComboboxDirective);
     fixture.detectChanges();
@@ -50,11 +46,13 @@ describe('DynamicInputComboboxDirective', () => {
   }));
 
   it('should not unselect selected items', fakeAsync(() => {
-    const selectedItems: ComboBoxItem[] = [{
-      content: 'selectedItem',
-      name: 'selectedItem',
-      selected: true
-    }];
+    const selectedItems: ComboBoxItem[] = [
+      {
+        content: 'selectedItem',
+        name: 'selectedItem',
+        selected: true
+      }
+    ];
 
     directive.items = selectedItems;
 
@@ -66,5 +64,5 @@ describe('DynamicInputComboboxDirective', () => {
 
     expect(directive.items[0].content).toBe(selectedItems[0].content);
     expect(directive.items[0].selected).toBeTruthy();
-  }))
+  }));
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dynamic-input-combobox.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dynamic-input-combobox.directive.ts
@@ -1,0 +1,78 @@
+import { Directive, Input, OnDestroy, OnInit, Output, EventEmitter, HostListener } from '@angular/core';
+import { ComboBoxItem } from '../models/combo-box.model';
+import { ComboBoxService } from '../services/combo-box.service';
+import { Subject, Subscription } from 'rxjs';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+
+export const DEBOUNCE_TIMER = 300;
+
+/**
+ * Directive to introduce adding custom items to the carbon combo-box component
+ * It takes the inputs of the combo-box and then append it with the searched item.
+ * Then it emits the updatedItems back to the <cds-combobox> element
+ */
+@Directive({
+  selector: '[cdDynamicInputCombobox]'
+})
+export class DynamicInputComboboxDirective implements OnInit, OnDestroy {
+  /**
+   * This input is the same as what we have in the <cds-combobox> element.
+   */
+  @Input() items: ComboBoxItem[];
+
+  /**
+   * This will hold the items of the combo-box appended with the searched items.
+   */
+  @Output() updatedItems: EventEmitter<ComboBoxItem[]> = new EventEmitter();
+
+  private searchSubscription: Subscription;
+  private searchSubject: Subject<string> = new Subject();
+  private selectedItems: ComboBoxItem[] = [];
+
+  constructor(
+    private combBoxService: ComboBoxService
+  ) { }
+
+  ngOnInit() {
+    this.searchSubscription = this.searchSubject
+      .pipe(
+        debounceTime(DEBOUNCE_TIMER),
+        distinctUntilChanged()
+      )
+      .subscribe((searchString) => {
+        // Already selected items should be selected in the dropdown
+        // even if the items are updated again
+        this.items = this.items.map((item: ComboBoxItem) => {
+          const selected = this.selectedItems.some(
+            (selectedItem: ComboBoxItem) => selectedItem.content === item.content
+          );
+          return { ...item, selected };
+        });
+
+        const exists = this.items.some(
+          (item: ComboBoxItem) => item.content === searchString
+        );
+      
+        if (!exists) {
+          this.items = this.items.concat({ content: searchString, name: searchString });
+        }
+        this.updatedItems.emit(this.items );
+        this.combBoxService.emit({ searchString });
+      });
+  }
+
+  @HostListener('search', ['$event'])
+  onInput(event: string) {
+    if (event.length > 1) this.searchSubject.next(event);
+  }
+
+  @HostListener('selected', ['$event'])
+  onSelected(event: ComboBoxItem[]) {
+    this.selectedItems = event;
+  }
+
+  ngOnDestroy() {
+    this.searchSubscription.unsubscribe();
+    this.searchSubject.complete();
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dynamic-input-combobox.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dynamic-input-combobox.directive.ts
@@ -1,4 +1,12 @@
-import { Directive, Input, OnDestroy, OnInit, Output, EventEmitter, HostListener } from '@angular/core';
+import {
+  Directive,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  EventEmitter,
+  HostListener
+} from '@angular/core';
 import { ComboBoxItem } from '../models/combo-box.model';
 import { ComboBoxService } from '../services/combo-box.service';
 import { Subject, Subscription } from 'rxjs';
@@ -15,9 +23,6 @@ export const DEBOUNCE_TIMER = 300;
   selector: '[cdDynamicInputCombobox]'
 })
 export class DynamicInputComboboxDirective implements OnInit, OnDestroy {
-  /**
-   * This input is the same as what we have in the <cds-combobox> element.
-   */
   @Input() items: ComboBoxItem[];
 
   /**
@@ -29,9 +34,7 @@ export class DynamicInputComboboxDirective implements OnInit, OnDestroy {
   private searchSubject: Subject<string> = new Subject();
   private selectedItems: ComboBoxItem[] = [];
 
-  constructor(
-    private combBoxService: ComboBoxService
-  ) { }
+  constructor(private combBoxService: ComboBoxService) {}
 
   ngOnInit() {
     this.searchSubscription = this.searchSubject
@@ -52,12 +55,12 @@ export class DynamicInputComboboxDirective implements OnInit, OnDestroy {
         const exists = this.items.some(
           (item: ComboBoxItem) => item.content === searchString
         );
-      
-        if (!exists) {
-          this.items = this.items.concat({ content: searchString, name: searchString });
-        }
-        this.updatedItems.emit(this.items );
-        this.combBoxService.emit({ searchString });
+
+      if (!exists) {
+        this.items = this.items.concat({ content: searchString, name: searchString });
+      }
+      this.updatedItems.emit(this.items);
+      this.combBoxService.emit({ searchString });
       });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dynamic-input-combobox.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dynamic-input-combobox.directive.ts
@@ -38,10 +38,7 @@ export class DynamicInputComboboxDirective implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.searchSubscription = this.searchSubject
-      .pipe(
-        debounceTime(DEBOUNCE_TIMER),
-        distinctUntilChanged()
-      )
+      .pipe(debounceTime(DEBOUNCE_TIMER), distinctUntilChanged())
       .subscribe((searchString) => {
         // Already selected items should be selected in the dropdown
         // even if the items are updated again
@@ -52,15 +49,13 @@ export class DynamicInputComboboxDirective implements OnInit, OnDestroy {
           return { ...item, selected };
         });
 
-        const exists = this.items.some(
-          (item: ComboBoxItem) => item.content === searchString
-        );
+        const exists = this.items.some((item: ComboBoxItem) => item.content === searchString);
 
-      if (!exists) {
-        this.items = this.items.concat({ content: searchString, name: searchString });
-      }
-      this.updatedItems.emit(this.items);
-      this.combBoxService.emit({ searchString });
+        if (!exists) {
+          this.items = this.items.concat({ content: searchString, name: searchString });
+        }
+        this.updatedItems.emit(this.items);
+        this.combBoxService.emit({ searchString });
       });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/combo-box.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/combo-box.model.ts
@@ -1,0 +1,5 @@
+export type ComboBoxItem = {
+  content: string;
+  name: string;
+  selected?: boolean;
+};

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/combo-box.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/combo-box.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ComboBoxService } from './combo-box.service';
+
+describe('ComboBoxService', () => {
+  let service: ComboBoxService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ComboBoxService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/combo-box.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/combo-box.service.ts
@@ -7,8 +7,7 @@ import { Subject } from 'rxjs';
 export class ComboBoxService {
   private searchSubject = new Subject<{ searchString: string }>();
 
-  constructor() {
-  }
+  constructor() {}
 
   emit(value: { searchString: string }) {
     this.searchSubject.next(value);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/combo-box.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/combo-box.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ComboBoxService {
+  private searchSubject = new Subject<{ searchString: string }>();
+
+  constructor() {
+  }
+
+  emit(value: { searchString: string }) {
+    this.searchSubject.next(value);
+  }
+}

--- a/src/pybind/mgr/dashboard/services/_paginate.py
+++ b/src/pybind/mgr/dashboard/services/_paginate.py
@@ -55,7 +55,7 @@ class ListPaginator:
             for item in self.input_list:
                 for searchable_param in self.searchable_params:
                     value = self.find_value(item, searchable_param)
-                    if isinstance(value, str):
+                    if isinstance(value, (int, str)):
                         if self.search in str(value):
                             trimmed_list.append(item)
 


### PR DESCRIPTION
Follows https://github.com/ceph/ceph/pull/60799/

1. previously we were able to add custom items to our select-badges like
custom labels for hosts. but it got dropped unintentionally due to the
carbon. fixing it here

2. the wizard component changes caused issue to the e2e, so fixing it.

3. I saw cypress starting the grafana tests even before the cluster is
    setup through the expansion tests. so running grafana separately

4. The osd list search with id is broken after the pagination. So if you
    search for any id it won't retrieve anything.
    
    PS: One more broken item is the searching with any other cell name but
    that's a known issue with server side pagination.

5. after angular upgrade, the tests started failing with
    An uncaught error was detected outside of a test:
         TypeError: The following error originated from your test code, not from Cypress.
    Cannot read properties of undefined (reading 'value')
    
    which seems to originate from the page-helper.po. So handling the
    undefined value.
    
    Example run: https://jenkins.ceph.com/job/ceph-dashboard-pull-requests/17541/consoleFull#204663575173a8703b-5adb-41c5-84a0-8cf4e065ba3d

6. this only happens on a fresh cluster but consistently reproducible in a
    test environment. also cephfs also throws some error occasionally which
    is also being handled similarly

7. use aria-label as the selector in tests.
    
    data-testid is not supported through this carbon cds-checkbox
    input so we can't use it
    
    regression started after started after #61319 and
    https://github.com/ceph/ceph/pull/61478/files#diff-7bd2a1f48bd2a7bcebb744eb04d84706087b6b3c2651c4b1ad085b4b6e03fc6d
    where multi-select is removed


8. as per
    https://docs.cypress.io/app/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests.
    
    This would save storage as saving entire video is useless

9. nfs service creation is not working because of some issue with cephadm
    for a while now. disabling it until its resolved


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
