### PR TITLE
mgr/dashboard: improve the kcli bootstrap process

### DIFF
--- a/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/bootstrap-cluster.sh
@@ -23,11 +23,24 @@ bootstrap_extra_options='--allow-fqdn-hostname --dashboard-password-noupdate'
 # {% if expanded_cluster is not defined %}
 #   bootstrap_extra_options+=" ${bootstrap_extra_options_not_expanded}"
 # {% endif %}
+quick_install_options=''
+{% if quick_install is defined %}
+  quick_install_options="--image localhost:5000/ceph"
+{% endif %}
 
-$CEPHADM bootstrap --mon-ip $mon_ip --initial-dashboard-password {{ admin_password }} --shared_ceph_folder /mnt/{{ ceph_dev_folder }} ${bootstrap_extra_options}
+{% if nodes < 3 %}
+  bootstrap_extra_options+=" --config /root/initial-ceph.conf"
+{% endif %}
+
+{% if ceph_dev_folder is defined %}
+  bootstrap_extra_options+=" --shared_ceph_folder /mnt/{{ ceph_dev_folder }}"
+{% endif %}
+
+$CEPHADM ${quick_install_options} bootstrap --mon-ip $mon_ip --initial-dashboard-password {{ admin_password }} ${bootstrap_extra_options}
 
 fsid=$(cat /etc/ceph/ceph.conf | grep fsid | awk '{ print $3}')
 cephadm_shell="$CEPHADM shell --fsid ${fsid} -c /etc/ceph/ceph.conf -k /etc/ceph/ceph.client.admin.keyring"
+
 
 {% for number in range(1, nodes) %}
   ssh-copy-id -f -i /etc/ceph/ceph.pub  -o StrictHostKeyChecking=no root@192.168.100.10{{ number }}

--- a/src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml
+++ b/src/pybind/mgr/dashboard/ci/cephadm/ceph_cluster.yml
@@ -8,7 +8,7 @@ parameters:
  prefix: ceph
  numcpus: 1
  memory: 2048
- image: fedora36
+ image: fedora40
  notify: false
  admin_password: password
  disks:
@@ -35,8 +35,17 @@ parameters:
  sharedfolders: [{{ ceph_dev_folder }}]
  files:
   - bootstrap-cluster.sh
+  - dnf.conf.tpl
+  - load-podman-image.sh
+  - initial-ceph.conf
  cmds:
+ # updating the dnf.conf to make the dnf faster
+ - cp /root/dnf.conf.tpl /etc/dnf/dnf.conf
  - dnf -y install python3 chrony lvm2 podman
+ # setting up an insecure podman registry and then loading the ceph image to all hosts
+ {% if quick_install is defined %}
+ - /root/load-podman-image.sh
+ {% endif %}
  - sed -i "s/SELINUX=enforcing/SELINUX=permissive/" /etc/selinux/config
  - setenforce 0
  {% if number == 0 %}

--- a/src/pybind/mgr/dashboard/ci/cephadm/dnf.conf.tpl
+++ b/src/pybind/mgr/dashboard/ci/cephadm/dnf.conf.tpl
@@ -1,0 +1,10 @@
+[main]
+fastestmirror=true
+max_parallel_downloads=10
+metadata_expire=1h
+clean_requirements_on_remove=true
+assumeyes=true
+gpgcheck=1
+keepcache=0
+plugins=1
+installonly_limit=3

--- a/src/pybind/mgr/dashboard/ci/cephadm/initial-ceph.conf
+++ b/src/pybind/mgr/dashboard/ci/cephadm/initial-ceph.conf
@@ -1,0 +1,9 @@
+[global]
+osd_pool_default_min_size=1
+osd_pool_default_size=1
+
+[mon]
+mon_allow_pool_size_one=true
+mon_allow_pool_delete=true
+mon_data_avail_crit=1
+mon_data_avail_warn=1

--- a/src/pybind/mgr/dashboard/ci/cephadm/load-podman-image.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/load-podman-image.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+echo -e "[registries.insecure]\n\
+registries = ['localhost:5000']" | sudo tee /etc/containers/registries.conf
+
+podman run -d -p 5000:5000 --name my-registry registry:2
+# Load the image and capture the output
+output=$(podman load -i /root/ceph_image.tar)
+
+# Extract image name from output
+image_name=$(echo "$output" | grep -oP '(?<=^Loaded image: ).*')
+
+if [[ -n "$image_name" ]]; then
+  echo "Image loaded: $image_name"
+  podman tag "$image_name" localhost:5000/ceph
+  echo "Tagged image as localhost:5000/ceph"
+else
+  echo "Failed to load image or extract image name."
+  exit 1
+fi
+
+podman push localhost:5000/ceph
+rm -f /root/ceph_image.tar

--- a/src/pybind/mgr/dashboard/ci/cephadm/quick-bootstrap.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/quick-bootstrap.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+source bootstrap-cluster.sh > /dev/null 2>&1
+
+set +x
+
+show_help() {
+  echo "Usage: ./quick-bootstrap.sh [OPTIONS]"
+  echo ""
+  echo "Options:"
+  echo "  -u, --use-cached-image     Uses the existing podman image in local. Only use this if there is such an image present."
+  echo "  -dir, --ceph-dir             Use this to provide the local ceph directory. eg. --ceph-dir=/path/to/ceph"
+  echo "  -e, --expanded-cluster     To add all the hosts and deploy OSDs on top of it."
+  echo "  -h, --help             Display this help message."
+  echo ""
+  echo "Example:"
+  echo "  ./quick-bootstrap.sh --use-cached-image"
+}
+
+use_cached_image=false
+extra_args="-P quick_install=True"
+
+for arg in "$@"; do
+  case "$arg" in
+    -u|--use-cached-image)
+      use_cached_image=true
+      ;;
+    -dir=*|--ceph-dir=*)
+      extra_args+=" -P ceph_dev_folder=${arg#*=}"
+      ;;
+    -e|--expanded-cluster)
+      extra_args+=" -P expanded_cluster=True"
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg"
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+image_name=$(echo "$CEPHADM_IMAGE")
+ceph_cluster_yml='ceph_cluster.yml'
+node_count=$(awk '/nodes:/ {print $2}' "${ceph_cluster_yml}")
+
+if [[ ${use_cached_image} == false ]]; then
+    printf "Pulling the image: %s\n" "$image_name"
+    podman pull "${image_name}"
+fi
+
+rm -f ceph_image.tar
+
+printf "Saving the image: %s\n" "$image_name"
+podman save -o ceph_image.tar quay.ceph.io/ceph-ci/ceph:main
+
+printf "Creating the plan\n"
+kcli create plan -f ceph_cluster.yml ${extra_args} ceph
+
+attempt=0
+
+MAX_ATTEMPTS=10
+SLEEP_INTERVAL=5
+
+printf "Waiting for the host to be reachable\n"
+while [[ ${attempt} -lt ${MAX_ATTEMPTS} ]]; do
+    if ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10 root@192.168.100.100 exit; then
+        break
+    else
+        echo "Waiting for ssh connection to be available..., attempt: ${attempt}"
+        ((attempt++))
+        sleep ${SLEEP_INTERVAL}
+    fi
+done
+
+printf "Copying the image to the hosts\n"
+
+for node in $(seq 0 $((node_count - 1))); do
+    scp -o StrictHostKeyChecking=no ceph_image.tar root@192.168.100.10"${node}":/root/
+done
+
+rm -f ceph_image.tar
+kcli ssh -u root -- ceph-node-00 'journalctl -n all -ft cloud-init'

--- a/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
+++ b/src/pybind/mgr/dashboard/ci/cephadm/start-cluster.sh
@@ -59,8 +59,8 @@ fi
 npm run build ${FRONTEND_BUILD_OPTS} &
 
 cd ${CEPH_DEV_FOLDER}
-: ${VM_IMAGE:='fedora36'}
-: ${VM_IMAGE_URL:='https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2'}
+: ${VM_IMAGE:='fedora40'}
+: ${VM_IMAGE_URL:='https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2'}
 kcli download image -p ceph-dashboard -u ${VM_IMAGE_URL} ${VM_IMAGE}
 kcli delete plan -y ceph || true
 # Compile cephadm locally for the shared_ceph_folder to pick it up


### PR DESCRIPTION
I have a new script added for starting the kcli cluster called quick-bootstrap.sh

The goal is to use that script to download the ceph image on local (rather than inside vm) and then copy them over to all the vms that is being spawned by the kcli. This way all the hosts will get the ceph image which will make the deployment loads faster.

Another thing I added is to add some dnf.conf to improve parallel_downlaods and get the fastest server to install deps

eg:
```
╰─$ ./quick-bootstrap.sh -h                                                                                    255 ↵
+ set +x
Usage: ./quick-bootstrap.sh [OPTIONS]

Options:
  -u, --use-cached-image     Uses the existing podman image in local. Only use this if there is such an image present.
  -dir, --ceph-dir             Use this to provide the local ceph directory. eg. --ceph-dir=/path/to/ceph
  -e, --expanded-cluster     To add all the hosts and deploy OSDs on top of it.
  -h, --help             Display this help message.

Example:
  ./quick-bootstrap.sh --use-cached-image

```

```
./quick-bootstrap.sh -u --ceph-dir=/home/nia/projects/ceph
```



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
