### PR TITLE
rgw/multisite: test-rgw-multisite.sh can create multiple zonegroups

### DIFF
--- a/src/test/rgw/test-rgw-common.sh
+++ b/src/test/rgw/test-rgw-common.sh
@@ -103,7 +103,7 @@ function init_first_zone {
 
 # create zonegroup, zone
   x $(rgw_admin $cid) zonegroup create --rgw-zonegroup=$zg --master --default
-  x $(rgw_admin $cid) zone create --rgw-zonegroup=$zg --rgw-zone=$zone --access-key=${access_key} --secret=${secret} --endpoints=$endpoints --default
+  x $(rgw_admin $cid) zone create --rgw-zonegroup=$zg --rgw-zone=$zone --access-key=${access_key} --secret=${secret} --endpoints=$endpoints --master --default
   x $(rgw_admin $cid) user create --uid=zone.user --display-name=ZoneUser --access-key=${access_key} --secret=${secret} --system
 
   x $(rgw_admin $cid) period update --commit
@@ -128,7 +128,7 @@ function init_zone_in_existing_zg {
   x $(rgw_admin $cid) period update --commit
 }
 
-function init_first_zone_in_slave_zg {
+function init_first_zone_in_peer_zg {
   [ $# -ne 8 ] && echo "init_first_zone_in_slave_zg() needs 8 params" && exit 1
 
   cid=$1

--- a/src/test/rgw/test-rgw-multisite.sh
+++ b/src/test/rgw/test-rgw-multisite.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
-[ $# -lt 1 ] && echo "usage: $0 <num-clusters> [rgw parameters...]" && exit 1
+[ $# -lt 1 ] && echo "usage: $0 <num-zones> <num-zonegroups>[rgw parameters...]" && exit 1
 
-num_clusters=$1
+num_zones=$1
+num_zonegroups=$2
 shift
 
-[ $num_clusters -lt 1 ] && echo "clusters num must be at least 1" && exit 1
+[ $num_zones -lt 1 ] && echo "clusters num must be at least 1" && exit 1
 
 . "`dirname $0`/test-rgw-common.sh"
 . "`dirname $0`/test-rgw-meta-sync.sh"
@@ -53,7 +54,7 @@ echo realm_status=$output
 
 endpoints=""
 i=2
-while [ $i -le $num_clusters ]; do
+while [ $i -le $num_zones ]; do
   x $(start_ceph_cluster c$i) -n $(get_mstart_parameters $i)
   j=1
   endpoints=""
@@ -74,10 +75,53 @@ while [ $i -le $num_clusters ]; do
   i=$((i+1))
 done
 
-i=2
-while [ $i -le $num_clusters ]; do
-  wait_for_meta_sync c1 c$i $realm_name
+endpoints=""
+k=2
+while [ $k -le $num_zonegroups ]; do
+  x $(start_ceph_cluster c$i) -n $(get_mstart_parameters $i)
+  j=1
+  endpoints=""
+  while [ $j -le $rgws ]; do
+    port=$((8000+i*100+j))
+    endpoints="$endpoints""$url:$port,"
+    j=$((j+1))
+  done
 
+  # create new zone, start rgw
+  init_first_zone_in_peer_zg c$i $realm_name zg${k} zg${k}-${i} 8101 $endpoints  $system_access_key $system_secret
+  j=1
+  while [ $j -le $rgws ]; do
+    port=$((8000+i*100+j))
+    x $(rgw c$i "$port" "$@")
+    j="$((j+1))"
+  done
+# bring up next clusters in zonegroup k
   i=$((i+1))
+
+  endpoints=""
+  l=2
+  while [ $l -le $num_zones ]; do
+    x $(start_ceph_cluster c$i) -n $(get_mstart_parameters $i)
+    j=1
+    endpoints=""
+    while [ $j -le $rgws ]; do
+      port=$((8000+i*100+j))
+      endpoints="$endpoints""$url:$port,"
+      j=$((j+1))
+    done
+
+    # create new zone, start rgw
+    init_zone_in_existing_zg c$i $realm_name zg${k} zg${k}-${i} 8101 $endpoints $zone_port $system_access_key $system_secret
+    j=1
+    while [ $j -le $rgws ]; do
+      port=$((8000+i*100+j))
+      x $(rgw c$i "$port" "$@")
+      j="$((j+1))"
+    done
+    l=$((l+1))
+    i=$((i+1))
+  done
+
+  k=$((k+1))
 done
 


### PR DESCRIPTION
the script can now be used to create multiple zonegroups.

`MON=1 OSD=1 MGR=0 MDS=0 src/test/rgw/test-rgw-multisite.sh <num_zones> <num_zonegroups>`
creates `num_zonegroups` with `num_zones` in each zonegroup. 

for example, `MON=1 OSD=1 MGR=0 MDS=0 src/test/rgw/test-rgw-multisite.sh 2 2`

for default configuration with just one zonegroup use:
`MON=1 OSD=1 MGR=0 MDS=0 src/test/rgw/test-rgw-multisite.sh <num_zones> 1`

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
