### PR TITLE
Revert "Merge PR #58936 into main"

### DIFF
--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -133,8 +133,6 @@ public:
   void kick_submitter();
   void shutdown();
 
-  void finish_head_waiters();
-
   void submit_entry(LogEvent *e, MDSLogContextBase* c = 0) {
     std::lock_guard l(submit_mutex);
     _submit_entry(e, c);
@@ -148,14 +146,8 @@ public:
     return unflushed == 0;
   }
 
-  void trim_expired_segments(MDSContext* ctx=nullptr) {
-    std::unique_lock locker(submit_mutex);
-    _trim_expired_segments(locker, ctx);
-  }
-  int trim_all() {
-    return trim_to(0);
-  }
-  int trim_to(SegmentBoundary::seq_t);
+  void trim_expired_segments();
+  int trim_all();
 
   void create(MDSContext *onfinish);  // fresh, empty log! 
   void open(MDSContext *onopen);      // append() or replay() to follow!
@@ -293,7 +285,7 @@ private:
   void try_expire(LogSegment *ls, int op_prio);
   void _maybe_expired(LogSegment *ls, int op_prio);
   void _expired(LogSegment *ls);
-  void _trim_expired_segments(auto& locker, MDSContext* ctx=nullptr);
+  void _trim_expired_segments();
   void write_head(MDSContext *onfinish);
 
   void trim();
@@ -322,7 +314,5 @@ private:
   // guarded by mds_lock
   std::condition_variable_any cond;
   std::atomic<bool> upkeep_log_trim_shutdown{false};
-
-  std::map<uint64_t, std::vector<Context*>> waiting_for_expire; // protected by mds_lock
 };
 #endif

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -137,11 +137,9 @@ void MDSIOContextWrapper::finish(int r)
 void C_IO_Wrapper::complete(int r)
 {
   if (async) {
-    dout(20) << "C_IO_Wrapper::complete " << r << " async" << dendl;
     async = false;
     get_mds()->finisher->queue(this, r);
   } else {
-    dout(20) << "C_IO_Wrapper::complete " << r << " sync" << dendl;
     MDSIOContext::complete(r);
   }
 }

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -283,14 +283,6 @@ void OpenFileTable::_commit_finish(int r, uint64_t log_seq, MDSContext *fin)
   committed_log_seq = log_seq;
   num_pending_commit--;
 
-  {
-    auto last = waiting_for_commit.upper_bound(log_seq);
-    for (auto it = waiting_for_commit.begin(); it != last; it++) {
-      finish_contexts(g_ceph_context, it->second);
-    }
-    waiting_for_commit.erase(waiting_for_commit.begin(), last);
-  }
-
   if (fin)
     fin->complete(r);
 }

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -50,9 +50,6 @@ public:
     ceph_assert(!load_done);
     waiting_for_load.push_back(c);
   }
-  void wait_for_commit(uint64_t seq, Context* c) {
-    waiting_for_commit[seq].push_back(c);
-  }
 
   bool prefetch_inodes();
   bool is_prefetched() const { return prefetch_state == DONE; }
@@ -152,8 +149,6 @@ protected:
   std::set<inodeno_t> destroyed_inos_set;
 
   std::unique_ptr<PerfCounters> logger;
-
-  std::map<uint64_t, std::vector<Context*>> waiting_for_commit;
 };
 
 #endif

--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -225,10 +225,9 @@ void PurgeQueue::open(Context *completion)
       // Journaler only guarantees entries before head write_pos have been
       // fully flushed. Before appending new entries, we need to find and
       // drop any partial written entry.
-      auto&& last_committed = journaler.get_last_committed();
-      if (last_committed.write_pos < journaler.get_write_pos()) {
+      if (journaler.last_committed.write_pos < journaler.get_write_pos()) {
 	dout(4) << "recovering write_pos" << dendl;
-	journaler.set_read_pos(last_committed.write_pos);
+	journaler.set_read_pos(journaler.last_committed.write_pos);
 	_recover();
 	return;
       }
@@ -282,8 +281,7 @@ void PurgeQueue::_recover()
     if (journaler.get_read_pos() == journaler.get_write_pos()) {
       dout(4) << "write_pos recovered" << dendl;
       // restore original read_pos
-      auto&& last_committed = journaler.get_last_committed();
-      journaler.set_read_pos(last_committed.expire_pos);
+      journaler.set_read_pos(journaler.last_committed.expire_pos);
       journaler.set_writeable();
       recovered = true;
       finish_contexts(g_ceph_context, waiting_for_recovery);

--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -158,7 +158,7 @@ public:
 void Journaler::recover(Context *onread) 
 {
   lock_guard l(lock);
-  if (state == STATE_STOPPING) {
+  if (is_stopping()) {
     onread->complete(-EAGAIN);
     return;
   }
@@ -218,7 +218,7 @@ void Journaler::_reread_head(Context *onfinish)
 void Journaler::_finish_reread_head(int r, bufferlist& bl, Context *finish)
 {
   lock_guard l(lock);
-  if (state == STATE_STOPPING) {
+  if (is_stopping()) {
     finish->complete(-EAGAIN);
     return;
   }
@@ -250,7 +250,7 @@ void Journaler::_finish_reread_head(int r, bufferlist& bl, Context *finish)
 void Journaler::_finish_read_head(int r, bufferlist& bl)
 {
   lock_guard l(lock);
-  if (state == STATE_STOPPING)
+  if (is_stopping())
     return;
 
   ceph_assert(state == STATE_READHEAD);
@@ -342,7 +342,7 @@ void Journaler::_finish_reprobe(int r, uint64_t new_end,
 				C_OnFinisher *onfinish)
 {
   lock_guard l(lock);
-  if (state == STATE_STOPPING) {
+  if (is_stopping()) {
     onfinish->complete(-EAGAIN);
     return;
   }
@@ -359,7 +359,7 @@ void Journaler::_finish_reprobe(int r, uint64_t new_end,
 void Journaler::_finish_probe_end(int r, uint64_t end)
 {
   lock_guard l(lock);
-  if (state == STATE_STOPPING)
+  if (is_stopping())
     return;
 
   ceph_assert(state == STATE_PROBING);
@@ -413,7 +413,7 @@ void Journaler::_finish_reread_head_and_probe(int r, C_OnFinisher *onfinish)
 {
   // Expect to be called back from finish_reread_head, which already takes lock
   // lock is locked
-  if (state == STATE_STOPPING) {
+  if (is_stopping()) {
     onfinish->complete(-EAGAIN);
     return;
   }
@@ -605,7 +605,7 @@ uint64_t Journaler::append_entry(bufferlist& bl)
   write_pos += wrote;
 
   // flush previous object?
-  uint64_t su = layout.get_period();
+  uint64_t su = get_layout_period();
   ceph_assert(su > 0);
   uint64_t write_off = write_pos % su;
   uint64_t write_obj = write_pos / su;
@@ -630,7 +630,7 @@ uint64_t Journaler::append_entry(bufferlist& bl)
 
 void Journaler::_do_flush(unsigned amount)
 {
-  if (state == STATE_STOPPING)
+  if (is_stopping())
     return;
   if (write_pos == flush_pos)
     return;
@@ -645,7 +645,7 @@ void Journaler::_do_flush(unsigned amount)
 
   // zero at least two full periods ahead.  this ensures
   // that the next object will not exist.
-  uint64_t period = layout.get_period();
+  uint64_t period = get_layout_period();
   if (flush_pos + len + 2*period > prezero_pos) {
     _issue_prezero();
 
@@ -718,7 +718,7 @@ void Journaler::_do_flush(unsigned amount)
 void Journaler::wait_for_flush(Context *onsafe)
 {
   lock_guard l(lock);
-  if (state == STATE_STOPPING) {
+  if (is_stopping()) {
     if (onsafe)
       onsafe->complete(-EAGAIN);
     return;
@@ -752,7 +752,7 @@ void Journaler::_wait_for_flush(Context *onsafe)
 void Journaler::flush(Context *onsafe)
 {
   lock_guard l(lock);
-  if (state == STATE_STOPPING) {
+  if (is_stopping()) {
     if (onsafe)
       onsafe->complete(-EAGAIN);
     return;
@@ -812,7 +812,7 @@ void Journaler::_issue_prezero()
    * issue zero requests based on write_pos, even though the invariant
    * is that we zero ahead of flush_pos.
    */
-  uint64_t period = layout.get_period();
+  uint64_t period = get_layout_period();
   uint64_t to = write_pos + period * num_periods  + period - 1;
   to -= to % period;
 
@@ -1062,7 +1062,7 @@ void Journaler::_issue_read(uint64_t len)
   // here because it will wait for all object reads to complete before
   // giving us back any data.  this way we can process whatever bits
   // come in that are contiguous.
-  uint64_t period = layout.get_period();
+  uint64_t period = get_layout_period();
   while (len > 0) {
     uint64_t e = requested_pos + period;
     e -= e % period;
@@ -1079,7 +1079,7 @@ void Journaler::_issue_read(uint64_t len)
 
 void Journaler::_prefetch()
 {
-  if (state == STATE_STOPPING)
+  if (is_stopping())
     return;
 
   ldout(cct, 10) << "_prefetch" << dendl;
@@ -1096,7 +1096,7 @@ void Journaler::_prefetch()
   uint64_t raw_target = read_pos + pf;
 
   // read full log segments, so increase if necessary
-  uint64_t period = layout.get_period();
+  uint64_t period = get_layout_period();
   uint64_t remainder = raw_target % period;
   uint64_t adjustment = remainder ? period - remainder : 0;
   uint64_t target = raw_target + adjustment;
@@ -1215,8 +1215,8 @@ void Journaler::erase(Context *completion)
   lock_guard l(lock);
 
   // Async delete the journal data
-  uint64_t first = trimmed_pos / layout.get_period();
-  uint64_t num = (write_pos - trimmed_pos) / layout.get_period() + 2;
+  uint64_t first = trimmed_pos / get_layout_period();
+  uint64_t num = (write_pos - trimmed_pos) / get_layout_period() + 2;
   filer.purge_range(ino, &layout, SnapContext(), first, num,
 		    ceph::real_clock::now(), 0,
 		    wrap_finisher(new C_EraseFinish(
@@ -1231,7 +1231,7 @@ void Journaler::erase(Context *completion)
 void Journaler::_finish_erase(int data_result, C_OnFinisher *completion)
 {
   lock_guard l(lock);
-  if (state == STATE_STOPPING) {
+  if (is_stopping()) {
     completion->complete(-EAGAIN);
     return;
   }
@@ -1309,7 +1309,7 @@ void Journaler::wait_for_readable(Context *onreadable)
 
 void Journaler::_wait_for_readable(Context *onreadable)
 {
-  if (state == STATE_STOPPING) {
+  if (is_stopping()) {
     finisher->queue(onreadable, -EAGAIN);
     return;
   }
@@ -1354,11 +1354,11 @@ void Journaler::trim()
 
 void Journaler::_trim()
 {
-  if (state == STATE_STOPPING)
+  if (is_stopping())
     return;
 
   ceph_assert(!readonly);
-  uint64_t period = layout.get_period();
+  uint64_t period = get_layout_period();
   uint64_t trim_to = last_committed.expire_pos;
   trim_to -= trim_to % period;
   ldout(cct, 10) << "trim last_commited head was " << last_committed
@@ -1633,8 +1633,8 @@ void Journaler::check_isreadable()
 {
   std::unique_lock l(lock);
   while (!_is_readable() &&
-      read_pos < write_pos &&
-      !error) {
+      get_read_pos() < get_write_pos() &&
+      !get_error()) {
     C_SaferCond readable_waiter;
     _wait_for_readable(&readable_waiter);
     l.unlock();

--- a/src/osdc/Journaler.h
+++ b/src/osdc/Journaler.h
@@ -186,16 +186,6 @@ public:
       f->close_section(); // journal_header
     }
 
-    void print(std::ostream& os) const {
-      os << std::hex
-         << "Journaler::Header"
-            "(t=" << trimmed_pos
-         << " e=" << expire_pos
-         << " w=" << write_pos
-         << ")"
-         << std::dec;
-    }
-
     static void generate_test_instances(std::list<Header*> &ls)
     {
       ls.push_back(new Header());
@@ -217,14 +207,15 @@ public:
     return stream_format;
   }
 
+  Header last_committed;
+
 private:
   // me
-  Header last_committed;
   CephContext *cct;
-  mutable ceph::mutex lock;
+  std::mutex lock;
   const std::string name;
-  typedef std::lock_guard<ceph::mutex> lock_guard;
-  typedef std::unique_lock<ceph::mutex> unique_lock;
+  typedef std::lock_guard<std::mutex> lock_guard;
+  typedef std::unique_lock<std::mutex> unique_lock;
   Finisher *finisher;
   Header last_written;
   inodeno_t ino;
@@ -407,7 +398,7 @@ public:
   Journaler(const std::string &name_, inodeno_t ino_, int64_t pool,
       const char *mag, Objecter *obj, PerfCounters *l, int lkey, Finisher *f) :
     last_committed(mag),
-    cct(obj->cct), lock(ceph::make_mutex("Journaler::" + name_)), name(name_), finisher(f), last_written(mag),
+    cct(obj->cct), name(name_), finisher(f), last_written(mag),
     ino(ino_), pg_pool(pool), readonly(true),
     stream_format(-1), journal_stream(-1),
     magic(mag),
@@ -527,79 +518,24 @@ public:
 
   // Synchronous getters
   // ===================
-
-  Header get_last_committed() const {
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
-    return last_committed;
-  }
-  Header get_last_written() const {
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
-    return last_written;
-  }
-
+  // TODO: need some locks on reads for true safety
   uint64_t get_layout_period() const {
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
     return layout.get_period();
   }
-  file_layout_t get_layout() const {
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
-    return layout;
-  }
-  bool is_active() const {
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
-    return state == STATE_ACTIVE;
-  }
-  bool is_stopping() const {
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
-    return state == STATE_STOPPING;
-  }
-  int get_error() const {
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
-    return error;
-  }
-  bool is_readonly() const {
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
-    return readonly;
-  }
+  file_layout_t& get_layout() { return layout; }
+  bool is_active() { return state == STATE_ACTIVE; }
+  bool is_stopping() { return state == STATE_STOPPING; }
+  int get_error() { return error; }
+  bool is_readonly() { return readonly; }
   bool is_readable();
   bool _is_readable();
   bool try_read_entry(bufferlist& bl);
-  uint64_t get_write_pos() const {
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
-    return write_pos;
-  }
-  uint64_t get_write_safe_pos() const {
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
-    return safe_pos;
-  }
-  uint64_t get_read_pos() const {
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
-    return read_pos;
-  }
-  uint64_t get_expire_pos() const {
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
-    return expire_pos;
-  }
-  uint64_t get_trimmed_pos() const {
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
-    return trimmed_pos;
-  }
+  uint64_t get_write_pos() const { return write_pos; }
+  uint64_t get_write_safe_pos() const { return safe_pos; }
+  uint64_t get_read_pos() const { return read_pos; }
+  uint64_t get_expire_pos() const { return expire_pos; }
+  uint64_t get_trimmed_pos() const { return trimmed_pos; }
   size_t get_journal_envelope_size() const { 
-    ceph_assert(!ceph_mutex_is_locked_by_me(lock));
-    lock_guard l(lock);
     return journal_stream.get_envelope_size(); 
   }
   void check_isreadable();

--- a/src/tools/cephfs/Dumper.cc
+++ b/src/tools/cephfs/Dumper.cc
@@ -112,7 +112,6 @@ int Dumper::dump(const char *dump_file)
     fsid.print(fsid_str);
     char buf[HEADER_LEN];
     memset(buf, 0, sizeof(buf));
-    auto&& last_committed = journaler.get_last_committed();
     snprintf(buf, HEADER_LEN, "Ceph mds%d journal dump\n start offset %llu (0x%llx)\n\
        length %llu (0x%llx)\n    write_pos %llu (0x%llx)\n    format %llu\n\
        trimmed_pos %llu (0x%llx)\n    stripe_unit %lu (0x%lx)\n    stripe_count %lu (0x%lx)\n\
@@ -120,12 +119,12 @@ int Dumper::dump(const char *dump_file)
 	    role.rank, 
 	    (unsigned long long)start, (unsigned long long)start,
 	    (unsigned long long)len, (unsigned long long)len,
-	    (unsigned long long)last_committed.write_pos, (unsigned long long)last_committed.write_pos,
-	    (unsigned long long)last_committed.stream_format,
-	    (unsigned long long)last_committed.trimmed_pos, (unsigned long long)last_committed.trimmed_pos,
-            (unsigned long)last_committed.layout.stripe_unit, (unsigned long)last_committed.layout.stripe_unit,
-            (unsigned long)last_committed.layout.stripe_count, (unsigned long)last_committed.layout.stripe_count,
-            (unsigned long)last_committed.layout.object_size, (unsigned long)last_committed.layout.object_size,
+	    (unsigned long long)journaler.last_committed.write_pos, (unsigned long long)journaler.last_committed.write_pos,
+	    (unsigned long long)journaler.last_committed.stream_format,
+	    (unsigned long long)journaler.last_committed.trimmed_pos, (unsigned long long)journaler.last_committed.trimmed_pos,
+            (unsigned long)journaler.last_committed.layout.stripe_unit, (unsigned long)journaler.last_committed.layout.stripe_unit,
+            (unsigned long)journaler.last_committed.layout.stripe_count, (unsigned long)journaler.last_committed.layout.stripe_count,
+            (unsigned long)journaler.last_committed.layout.object_size, (unsigned long)journaler.last_committed.layout.object_size,
 	    fsid_str,
 	    4);
     r = safe_write(fd, buf, sizeof(buf));
@@ -157,8 +156,8 @@ int Dumper::dump(const char *dump_file)
 
       C_SaferCond cond;
       lock.lock();
-      auto&& layout = journaler.get_layout();
-      filer.read(ino, &layout, CEPH_NOSNAP, pos, read_size, &bl, 0, &cond);
+      filer.read(ino, &journaler.get_layout(), CEPH_NOSNAP,
+                 pos, read_size, &bl, 0, &cond);
       lock.unlock();
       r = cond.wait();
       if (r < 0) {
@@ -265,10 +264,9 @@ int Dumper::undump(const char *dump_file, bool force)
   }
 
   if (recovered == 0) {
-    auto&& last_committed = journaler.get_last_committed();
-    stripe_unit = last_committed.layout.stripe_unit;
-    stripe_count = last_committed.layout.stripe_count;
-    object_size = last_committed.layout.object_size;
+    stripe_unit = journaler.last_committed.layout.stripe_unit;
+    stripe_count = journaler.last_committed.layout.stripe_count;
+    object_size = journaler.last_committed.layout.object_size;
   } else {
     // try to get layout from dump file header, if failed set layout to default
     if (strstr(buf, "stripe_unit")) {


### PR DESCRIPTION
We need to revert #58936. It was forcefully merged and broke MDS, which now crashes whenever we attempt to mount ceph filesystems.

```
2024-09-25T22:52:15.995+0000 7f5443bc7640 -1 /home/ubuntu/ceph/src/osdc/Journaler.h: In function 'bool Journaler::is_readonly() const' thread 7f5443bc7640 time 2024-09-25T22:52:15.993313+0000
/home/ubuntu/ceph/src/osdc/Journaler.h: 568: FAILED ceph_assert(!true)

 ceph version 351d92 (c351d92b0d9db66780dbf0781c81428652c3eec7) squid (dev)
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x15d) [0x7f5449e62b72]
 2: /home/ubuntu/ceph/build/lib/libceph-common.so.2(+0x2bada1) [0x7f5449e62da1]
 3: (MDLog::create(MDSContext*)+0x266) [0x55d6fdcf0346]
 4: (MDSRank::boot_create()+0x1bb) [0x55d6fd8ff1bb]
 5: (MDSRankDispatcher::handle_mds_map(boost::intrusive_ptr<MMDSMap const> const&, MDSMap const&)+0x280b) [0x55d6fd905bfb]
 6: (MDSDaemon::handle_mds_map(boost::intrusive_ptr<MMDSMap const> const&)+0xe8b) [0x55d6fd8cf25b]
 7: (MDSDaemon::handle_core_message(boost::intrusive_ptr<Message const> const&)+0x371) [0x55d6fd8d2fb1]
 8: (MDSDaemon::ms_dispatch2(boost::intrusive_ptr<Message> const&)+0xfb) [0x55d6fd8d373b]
 9: (DispatchQueue::entry()+0x629) [0x7f544a1844f9]
 10: (DispatchQueue::DispatchThread::entry()+0x11) [0x7f544a278e61]
 11: (Thread::entry_wrapper()+0x54) [0x7f5449f88b94]
 12: /lib/x86_64-linux-gnu/libc.so.6(+0x94ac3) [0x7f54496a1ac3]
 13: /lib/x86_64-linux-gnu/libc.so.6(+0x126850) [0x7f5449733850]

2024-09-25T22:52:15.999+0000 7f5443bc7640 -1 *** Caught signal (Aborted) **
 in thread 7f5443bc7640 thread_name:ms_dispatch
```

Fixes: https://tracker.ceph.com/issues/68282



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
