### PR TITLE
reef: doc: Adds release date.

### DIFF
--- a/doc/releases/reef.rst
+++ b/doc/releases/reef.rst
@@ -21,6 +21,11 @@ may encounter crashes during `pthread_create`. For workarounds, refer to the rel
 upgrading your OS to avoid this unsupported combination.
 Related tracker: https://tracker.ceph.com/issues/66989
 
+Release Date
+------------
+
+July 24, 2024
+
 Notable Changes
 ---------------
 
@@ -445,6 +450,11 @@ v18.2.2 Reef
 
 This is a hotfix release that resolves several flaws including Prometheus crashes and an encoder fix.
 
+Release Date
+------------
+
+March 11, 2024
+
 Notable Changes
 ---------------
 
@@ -462,6 +472,11 @@ v18.2.1 Reef
 
 This is the first backport release in the Reef series, and the first with Debian packages,
 for Debian Bookworm. We recommend that all users update to this release.
+
+Release Date
+------------
+
+December 18, 2023
 
 Notable Changes
 ---------------
@@ -962,6 +977,11 @@ This is the first stable release of Ceph Reef.
    soon as this bug is resolved in Debian stable.
 
    *last updated 2023 Aug 04*
+
+Release Date
+------------
+
+August 7, 2023
 
 Major Changes from Quincy
 --------------------------


### PR DESCRIPTION
The only place that I've been able to find release dates are on https://ceph.io/en/news/blog/category/release/. Including the release date in the release notes would be a welcome reduction in clicking and searching to find this information. 

This PR adds a subsection to reef.rst that contains the release dates as shown on the blog posts. If there's a different way to include the release date in the release notes, that's fine with me. My main ask to consolidate that information into the release notes.

Thanks!

Signed-off-on-by: Joel Davidow <jdavidow@nso.edu>







## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
