### PR TITLE
doc/rados: edit "Placement Groups Never Get Clean"

### DIFF
--- a/doc/rados/troubleshooting/troubleshooting-pg.rst
+++ b/doc/rados/troubleshooting/troubleshooting-pg.rst
@@ -5,16 +5,16 @@
 Placement Groups Never Get Clean
 ================================
 
-If, after you have created your cluster, any Placement Groups (PGs) remain in
-the ``active`` status, the ``active+remapped`` status or the
-``active+degraded`` status and never achieves an ``active+clean`` status, you
-likely have a problem with your configuration.
+Placement Groups (PGs) that remain in the ``active`` status, the
+``active+remapped`` status or the ``active+degraded`` status and never achieve
+an ``active+clean`` status might indicate a problem with the configuration of
+the Ceph cluster. 
 
-In such a situation, it may be necessary to review the settings in the `Pool,
-PG and CRUSH Config Reference`_ and make appropriate adjustments.
+In such a situation, review the settings in the `Pool, PG and CRUSH Config
+Reference`_ and make appropriate adjustments.
 
 As a general rule, run your cluster with more than one OSD and a pool size
-greater than two object replicas.
+of greater than two object replicas.
 
 .. _one-node-cluster:
 


### PR DESCRIPTION
Make grammar improvements (and correct a verb disagreement) in the section "Placement Groups Never Get Clean" in
doc/rados/troubleshooting/troubleshooting-pg.rst.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
