### PR TITLE
ceph-volume: drop unnecessary call to `get_single_lv()`

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -191,8 +191,7 @@ class Zap(object):
         Device examples: vg-name/lv-name, /dev/vg-name/lv-name
         Requirements: Must be a logical volume (LV)
         """
-        lv = api.get_single_lv(filters={'lv_name': device.lv_name, 'vg_name':
-                                        device.vg_name})
+        lv: api.Volume = device.lv_api
         self.unmount_lv(lv)
 
         zap_device(device.path)


### PR DESCRIPTION
`Zap.zap_lv()` currently makes a call to `get_single_lv()`:

```
        lv = api.get_single_lv(filters={'lv_name': device.lv_name,
                                        'vg_name': device.vg_name})
```

this isn't needed and redundant as zap_lv() takes an instance of `Device()` as argument which has already a `lv_api` attribute:

class Device in device.py:

```
            else:
                vgname, lvname = self.path.split('/')
                filters = {'lv_name': lvname, 'vg_name': vgname}
            lv = lvm.get_single_lv(filters=filters)         # <---- same call

        if lv:
            self.lv_api = lv
```

This implies a duplicate call to `subprocess.Popen()` unnecessarily.

Fixes: https://tracker.ceph.com/issues/68312
