### PR TITLE
mon: add nvmeof healthchecks

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1636,14 +1636,21 @@ bucket are the same.
 NVMeoF Gateway
 --------------
 
-NVMOEF_SINGLE_GATEWAY
-__________________________________
+NVMEOF_SINGLE_GATEWAY
+_____________________
 
 One of the gateway group has only one gateway. This is not ideal because it makes
 high availability (HA) impossible with a single gatway in a group. This can lead to 
 problems with failover and failback operations for the NVMeoF gateway.
 
 It's recommended to have multiple NVMeoF gateways in a group.
+
+NVMEOF_GATEWAY_DOWN
+___________________
+
+Some of the gateways are in the GW_UNAVAILABLE state. If a NVMeoF daemon has crashed, 
+the daemon log file (found at ``/var/log/ceph/``) may contain troubleshooting information.
+
 
 Miscellaneous
 -------------

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1633,6 +1633,18 @@ We encourage you to fix this by making the weights even on both dividing buckets
 This can be done by making sure the combined weight of the OSDs on each dividing
 bucket are the same.
 
+NVMeoF Gateway
+--------------
+
+NVMOEF_SINGLE_GATEWAY
+__________________________________
+
+One of the gateway group has only one gateway. This is not ideal because it makes
+high availability (HA) impossible with a single gatway in a group. This can lead to 
+problems with failover and failback operations for the NVMeoF gateway.
+
+It's recommended to have multiple NVMeoF gateways in a group.
+
 Miscellaneous
 -------------
 

--- a/qa/suites/nvmeof/basic/clusters/4-gateways-2-initiator.yaml
+++ b/qa/suites/nvmeof/basic/clusters/4-gateways-2-initiator.yaml
@@ -28,3 +28,5 @@ overrides:
       mon:
         # cephadm can take up to 5 minutes to bring up remaining mons
         mon down mkfs grace: 300
+    log-ignorelist:
+      - NVMEOF_SINGLE_GATEWAY

--- a/qa/suites/nvmeof/thrash/thrashers/nvmeof_mon_thrash.yaml
+++ b/qa/suites/nvmeof/thrash/thrashers/nvmeof_mon_thrash.yaml
@@ -8,6 +8,9 @@ overrides:
       - out of quorum
       # nvmeof daemon thrashing
       - CEPHADM_FAILED_DAEMON
+      - NVMEOF_SINGLE_GATEWAY
+      - NVMEOF_GATEWAY_DOWN
+      - are in unavailable state
       - is in error state
       - failed cephadm daemon
 

--- a/qa/suites/nvmeof/thrash/thrashers/nvmeof_thrash.yaml
+++ b/qa/suites/nvmeof/thrash/thrashers/nvmeof_thrash.yaml
@@ -3,6 +3,9 @@ overrides:
     log-ignorelist:  
       # nvmeof daemon thrashing
       - CEPHADM_FAILED_DAEMON
+      - NVMEOF_SINGLE_GATEWAY
+      - NVMEOF_GATEWAY_DOWN
+      - are in unavailable state
       - is in error state
       - failed cephadm daemon
 

--- a/src/mon/NVMeofGwMap.cc
+++ b/src/mon/NVMeofGwMap.cc
@@ -883,7 +883,8 @@ struct CMonRequestProposal : public Context {
 
 void NVMeofGwMap::get_health_checks(health_check_map_t *checks) const 
 {
-  list<string> detail;
+  list<string> singleGatewayDetail;
+  list<string> gatewayDownDetail;
   for (const auto& created_map_pair: created_gws) {
     const auto& group_key = created_map_pair.first;
     auto& group = group_key.second;
@@ -891,16 +892,33 @@ void NVMeofGwMap::get_health_checks(health_check_map_t *checks) const
     if ( gw_created_map.size() == 1) {
       ostringstream ss;
       ss << "NVMeoF Gateway Group '" << group << "' has 1 gateway." ;
-      detail.push_back(ss.str());
+      singleGatewayDetail.push_back(ss.str());
+    }
+    for (const auto& gw_created_pair: gw_created_map) {
+      const auto& gw_id = gw_created_pair.first;
+      const auto& gw_created  = gw_created_pair.second;
+      if (gw_created.availability == gw_availability_t::GW_UNAVAILABLE) {
+        ostringstream ss;
+        ss << "NVMeoF Gateway '" << gw_id << "' is unavailable." ;
+        gatewayDownDetail.push_back(ss.str());
+      }
     }
   }
-  if (!detail.empty()) {
+  if (!singleGatewayDetail.empty()) {
     ostringstream ss;
-    ss << detail.size() << " group(s) have only 1 nvmeof gateway"
+    ss << singleGatewayDetail.size() << " group(s) have only 1 nvmeof gateway"
       << "; HA is not possible with single gateway.";
     auto& d = checks->add("NVMEOF_SINGLE_GATEWAY", HEALTH_WARN,
-        ss.str(), detail.size());
-    d.detail.swap(detail);
+        ss.str(), singleGatewayDetail.size());
+    d.detail.swap(singleGatewayDetail);
+  }
+  if (!gatewayDownDetail.empty()) {
+    ostringstream ss;
+    ss << gatewayDownDetail.size() << " gateway(s) are in unavailable state"
+      << "; gateway might be down, try to redeploy.";
+    auto& d = checks->add("NVMEOF_GATEWAY_DOWN", HEALTH_WARN,
+        ss.str(), gatewayDownDetail.size());
+    d.detail.swap(gatewayDownDetail);
   }
 }
 

--- a/src/mon/NVMeofGwMap.h
+++ b/src/mon/NVMeofGwMap.h
@@ -27,6 +27,9 @@
 #include "NVMeofGwTypes.h"
 
 using ceph::coarse_mono_clock;
+
+class health_check_map_t;
+
 class Monitor;
 /*-------------------*/
 class NVMeofGwMap
@@ -140,6 +143,8 @@ public:
     decode(fsm_timers, bl);
     DECODE_FINISH(bl);
   }
+
+  void get_health_checks(health_check_map_t *checks) const;
 };
 
 #include "NVMeofGwSerialize.h"

--- a/src/mon/NVMeofGwMon.cc
+++ b/src/mon/NVMeofGwMon.cc
@@ -176,6 +176,11 @@ void NVMeofGwMon::encode_pending(MonitorDBStore::TransactionRef t)
 	   << HAVE_FEATURE(mon.get_quorum_con_features(), NVMEOFHA) << dendl;
   put_version(t, pending_map.epoch, bl);
   put_last_committed(t, pending_map.epoch);
+
+  //health
+  health_check_map_t checks;
+  pending_map.get_health_checks(&checks);
+  encode_health(checks, t);
 }
 
 void NVMeofGwMon::update_from_paxos(bool *need_bootstrap)
@@ -188,6 +193,7 @@ void NVMeofGwMon::update_from_paxos(bool *need_bootstrap)
     bufferlist bl;
     int err = get_version(version, bl);
     ceph_assert(err == 0);
+    load_health();
 
     auto p = bl.cbegin();
     map.decode(p);


### PR DESCRIPTION
Add NVMeofGwMap::get_health_checks which raises
NVMEOF_SINGLE_GATEWAY if any of the groups have
1 gateway.

In NVMeofGwMon, call `encode_health` and `load_health` 
to register healthchecks. This will add nvmeof healthchecks 
to "ceph health" output.

In src/mon/NVMeofGwMap.cc,
add warning NVMEOF_GATEWAY_DOWN when any
gateway is in GW_UNAVAILABLE state.

Fixes (partially): https://github.com/ceph/ceph-nvmeof/issues/565


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
