### PR TITLE
cls/rgw: fix rgw list-object-versions key-marker behavior to match s3

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -648,8 +648,7 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
       }
 
       // filter out noncurrent versions, delete markers, and initial marker
-      if (!op.list_versions &&
-	  (!entry.is_visible() || op.start_obj.name == key.name)) {
+      if ((!entry.is_visible() || op.start_obj.name == key.name)) {
         CLS_LOG(20, "%s: entry %s[%s] is not visible",
 		__func__, key.name.c_str(), key.instance.c_str());
         continue;

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -647,9 +647,17 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
         continue;
       }
 
-      // filter out noncurrent versions, delete markers, and initial marker
-      if ((!entry.is_visible() || op.start_obj.name == key.name)) {
+      //When it is not a list versions request, filter out noncurrent versions, delete markers, and initial marker
+      if (!op.list_versions &&
+	  (!entry.is_visible() || op.start_obj.name == key.name)) {
         CLS_LOG(20, "%s: entry %s[%s] is not visible",
+		__func__, key.name.c_str(), key.instance.c_str());
+        continue;
+      }
+
+      //When it is a list versions request with just key marker, filter out objects key marker
+      if (op.list_versions && op.start_obj.instance.empty() && op.start_obj.name == key.name) {
+        CLS_LOG(20, "%s: skipping the initial marker %s[%s]",
 		__func__, key.name.c_str(), key.instance.c_str());
         continue;
       }


### PR DESCRIPTION
The key-marker parameter in the list-object-versions operation is inclusive in RGW, while it's exclusive in S3. This commit updates RGW's behavior to make the key-marker parameter exclusive, ensuring consistent behavior between RGW and S3.

Fixes: https://tracker.ceph.com/issues/68055





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
