### PR TITLE
[WIP]mgr/cephadm: fix ctdb stray daemon

### DIFF
--- a/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
+++ b/qa/suites/orch/cephadm/smb/tasks/deploy_smb_mgr_ctdb_res_basic.yaml
@@ -32,6 +32,11 @@ tasks:
 - cephadm.wait_for_service:
     service: mds.cephfs
 
+# Enable debug-level logs -- only added temporarily to test
+- cephadm.shell:
+    host.a:
+      - ceph config set mgr mgr/cephadm/log_to_cluster_level debug
+
 - cephadm.shell:
     host.a:
       # add subvolgroup & subvolumes for test

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -498,10 +498,12 @@ class CephadmServe:
                     daemon_id = s.get('id')
                     assert daemon_id
                     name = self._service_reference_name(s.get('type'), daemon_id)
+                    self.log.debug("daemon %s on host %s" % (name, host))
                     managed.extend(stray_filter(s.get('type'), daemon_id, name))
                     # Don't mark daemons we just created/removed in the last minute as stray.
                     # It may take some time for the mgr to become aware the daemon
                     # had been created/removed.
+                    self.log.debug("final managed daemons %s", managed)  # Added temporarily
                     if name in self.mgr.recently_altered_daemons:
                         continue
                     if host not in self.mgr.inventory:
@@ -550,6 +552,7 @@ class CephadmServe:
             for dd in managed
         }
         _services = [self.mgr.cephadm_services[dt] for dt in svcs]
+        self.log.debug(f"Building stray filter for {_services}")
 
         def _filter(
             service_type: str, daemon_id: str, name: str


### PR DESCRIPTION
**Issue:** 
```2024-09-21T18:52:31.772249+0000 mon.a (mon.0) 825 : cluster [WRN] Health check failed: 2 stray daemon(s) ['stray daemon ctdb.ctdb_mutex_ceph_rados_helper:0x0000000000003a08 on host smithi031 not managed by cephadm', 'stray daemon ctdb.ctdb_mutex_ceph_rados_helper:0x00000000000066f7 on host smithi136 not managed by cephadm'] not managed by cephadm (CEPHADM_STRAY_DAEMON)```

- This warning indicates that some CTDB-type daemons were registered with the cluster but were not recognized by Cephadm. 

**Fix:**
- Since CTDB also registers under a gid, Cephadm needs to convert it to its known name during the stray daemon check. This PR adds CTDB to the existing list of daemons (last added for `nfs-rgw` [here](https://github.com/ceph/ceph/pull/40711)) for which this conversion is already handled, preventing false stray daemon warnings.

Fixes: https://tracker.ceph.com/issues/68182





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
