### PR TITLE
reef: ceph.spec.in: we need jsonnet for all distroes for make check

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -417,9 +417,9 @@ BuildRequires:	python%{python3_pkgversion}-scipy
 BuildRequires:	python%{python3_pkgversion}-werkzeug
 BuildRequires:	python%{python3_pkgversion}-pyOpenSSL
 %endif
+BuildRequires:	jsonnet
 %if 0%{?suse_version}
 BuildRequires:	golang-github-prometheus-prometheus
-BuildRequires:	jsonnet
 BuildRequires:	libxmlsec1-1
 BuildRequires:	libxmlsec1-nss1
 BuildRequires:	libxmlsec1-openssl1


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68347

---

backport of https://github.com/ceph/ceph/pull/59640
parent tracker: https://tracker.ceph.com/issues/67938

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh