### PR TITLE
[stretch-cluster] mon_osd_min_in_ratio > 0.55 before making the pool stretched

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -737,8 +737,18 @@ Managing pools that are flagged with ``--bulk``
 ===============================================
 See :ref:`managing_bulk_flagged_pools`.
 
+.. _setting_values_for_a_stretch_pool:
+
 Setting values for a stretch pool
 =================================
+
+.. important:: Setting values for a stretch pool requires ``mon_osd_min_in_ratio <= 0.55``
+   to ensure that PGs get remapped to a new set of OSDs when the cluster
+   sustains multiple failures in different buckets. For example, a 3 site stretched cluster
+   is expected to sustain 33% of OSDs failing in the entire cluster, but the default value of
+   ``mon_osd_min_in_ratio`` is 0.75 which means it can only sustain 25% of OSD failures.
+   Please see: `<http://https://tracker.ceph.com/issues/68338>`_ for more information.`
+
 To set values for a stretch pool, run a command of the following form:
 
 .. prompt:: bash $
@@ -809,8 +819,6 @@ Here are the break downs of the arguments:
    
       :Type: Flag
       :Required: No.
-
-.. _setting_values_for_a_stretch_pool:
 
 Unsetting values for a stretch pool
 ===================================

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -9195,6 +9195,13 @@ int OSDMonitor::prepare_command_pool_stretch_set(const cmdmap_t& cmdmap,
     return -EINVAL;
   }
 
+  if (g_conf()->mon_osd_min_in_ratio > 0.55) {
+    ss << "mon_osd_min_in_ratio must be less than or equal to 0.55; current value is "
+       << g_conf()->mon_osd_min_in_ratio << "; Please adjust using the command"
+       << " 'ceph config set mon mon_osd_min_in_ratio <value>'";
+    return -EINVAL;
+  }
+
   p.peering_crush_bucket_count = static_cast<uint32_t>(bucket_count);
   p.peering_crush_bucket_target = static_cast<uint32_t>(bucket_target);
   p.peering_crush_bucket_barrier = static_cast<uint32_t>(bucket_barrier);


### PR DESCRIPTION
Todo:
- [ ]  Changes to the test that uses `ceph osd pool stretch set`

Problem:

PGs enter inactive state when few hosts from across DCs go down and do not get remapped to other OSDs. This causes PGs to enter peered state, and IOs stop. Observed that this is due to the OSDs on the down hosts not being marked out of the cluster. Because "mon_osd_min_in_ratio" param, which only allows 25% of the OSDs on the cluster to be marked out.

Solution:

Ensure that the user set `mon_osd_min_in_ratio` to be less than 0.55
before executing `ceph osd pool stretch set` by throwing an exception.

Also, documenting this in the documentation. 

Fixes: https://tracker.ceph.com/issues/68338

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
