### PR TITLE
squid: qa/suites/rbd/iscsi: enable all supported container hosts

### DIFF
--- a/qa/suites/rbd/iscsi/0-single-container-host.yaml
+++ b/qa/suites/rbd/iscsi/0-single-container-host.yaml
@@ -1,1 +1,0 @@
-.qa/distros/single-container-host.yaml

--- a/qa/suites/rbd/iscsi/base/install.yaml
+++ b/qa/suites/rbd/iscsi/base/install.yaml
@@ -9,6 +9,10 @@ tasks:
     - ceph orch host ls
     - ceph orch device ls
 - install:
-    extra_packages:
+    extra_system_packages:
+      deb:
+      - open-iscsi
+      - multipath-tools
+      rpm:
       - iscsi-initiator-utils
       - device-mapper-multipath

--- a/qa/suites/rbd/iscsi/supported-container-hosts$
+++ b/qa/suites/rbd/iscsi/supported-container-hosts$
@@ -1,0 +1,1 @@
+.qa/distros/supported-container-hosts/

--- a/qa/tasks/ceph_iscsi_client.py
+++ b/qa/tasks/ceph_iscsi_client.py
@@ -31,8 +31,15 @@ def task(ctx, config):
         remote.run(args=['sudo', 'systemctl', 'restart', 'iscsid'])
 
         remote.run(args=['sudo', 'modprobe', 'dm_multipath'])
-        remote.run(args=['sudo', 'mpathconf', '--enable'])
         conf = dedent('''
+        defaults {
+                user_friendly_names yes
+                find_multipaths yes
+        }
+
+        blacklist {
+        }
+
         devices {
                 device {
                         vendor                 "LIO-ORG"
@@ -50,7 +57,7 @@ def task(ctx, config):
         }
         ''')
         path = "/etc/multipath.conf"
-        remote.sudo_write_file(path, conf, append=True)
+        remote.sudo_write_file(path, conf)
         remote.run(args=['sudo', 'systemctl', 'start', 'multipathd'])
 
     yield

--- a/src/test/cli-integration/rbd/gwcli_create.t
+++ b/src/test/cli-integration/rbd/gwcli_create.t
@@ -1,43 +1,50 @@
-Podman find iSCSI container
-===========================
-  $ ISCSI_CONTAINER=$(sudo podman ps -a | grep -F 'iscsi' | grep -Fv 'tcmu' | awk '{print $1}')
+Cephadm prefers podman to docker
+================================
+  $ CENGINE=docker
+  > if command -v podman >/dev/null; then
+  >   CENGINE=podman
+  > fi
+
+Find iSCSI container
+====================
+  $ ISCSI_CONTAINER=$(sudo $CENGINE ps -a | grep -F 'iscsi' | grep -Fv 'tcmu' | awk '{print $1}')
 
 Dismiss the "could not load preferences file .gwcli/prefs.bin" warning
 ======================================================================
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls >/dev/null 2>&1
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls >/dev/null 2>&1
 
 Create a datapool/block0 disk
 =============================
-  $ sudo podman exec $ISCSI_CONTAINER gwcli disks/ create pool=datapool image=block0 size=300M wwn=36001405da17b74481464e9fa968746d3
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls disks/ | grep 'o- disks' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli disks/ create pool=datapool image=block0 size=300M wwn=36001405da17b74481464e9fa968746d3
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls disks/ | grep 'o- disks' | awk -F'[' '{print $2}'
   300M, Disks: 1]
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls disks/ | grep 'o- datapool' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls disks/ | grep 'o- datapool' | awk -F'[' '{print $2}'
   datapool (300M)]
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls disks/ | grep 'o- block0' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls disks/ | grep 'o- block0' | awk -F'[' '{print $2}'
   datapool/block0 (Unknown, 300M)]
 
 Create the target IQN
 =====================
-  $ sudo podman exec $ISCSI_CONTAINER gwcli iscsi-targets/ create target_iqn=iqn.2003-01.com.redhat.iscsi-gw:ceph-gw
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- iscsi-targets' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli iscsi-targets/ create target_iqn=iqn.2003-01.com.redhat.iscsi-gw:ceph-gw
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- iscsi-targets' | awk -F'[' '{print $2}'
   DiscoveryAuth: None, Targets: 1]
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- iqn.2003-01.com.redhat.iscsi-gw:ceph-gw' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- iqn.2003-01.com.redhat.iscsi-gw:ceph-gw' | awk -F'[' '{print $2}'
   Auth: None, Gateways: 0]
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- disks' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- disks' | awk -F'[' '{print $2}'
   Disks: 0]
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- gateways' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- gateways' | awk -F'[' '{print $2}'
   Up: 0/0, Portals: 0]
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- host-groups' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- host-groups' | awk -F'[' '{print $2}'
   Groups : 0]
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- hosts' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- hosts' | awk -F'[' '{print $2}'
   Auth: ACL_ENABLED, Hosts: 0]
 
 Create the first gateway
 ========================
   $ HOST=$(python3 -c "import socket; print(socket.getfqdn())")
   > IP=`hostname -i | awk '{print $1}'`
-  > sudo podman exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/gateways create ip_addresses=$IP gateway_name=$HOST
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- gateways' | awk -F'[' '{print $2}'
+  > sudo $CENGINE exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/gateways create ip_addresses=$IP gateway_name=$HOST
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- gateways' | awk -F'[' '{print $2}'
   Up: 1/1, Portals: 1]
 
 Create the second gateway
@@ -45,34 +52,34 @@ Create the second gateway
   $ IP=`cat /etc/ceph/iscsi-gateway.cfg |grep 'trusted_ip_list' | awk -F'[, ]' '{print $3}'`
   > if [ "$IP" != `hostname -i | awk '{print $1}'` ]; then
   >   HOST=$(python3 -c "import socket; print(socket.getfqdn('$IP'))")
-  >   sudo podman exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/gateways create ip_addresses=$IP gateway_name=$HOST
+  >   sudo $CENGINE exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/gateways create ip_addresses=$IP gateway_name=$HOST
   > fi
   $ IP=`cat /etc/ceph/iscsi-gateway.cfg |grep 'trusted_ip_list' | awk -F'[, ]' '{print $4}'`
   > if [ "$IP" != `hostname -i | awk '{print $1}'` ]; then
   >   HOST=$(python3 -c "import socket; print(socket.getfqdn('$IP'))")
-  >   sudo podman exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/gateways create ip_addresses=$IP gateway_name=$HOST
+  >   sudo $CENGINE exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/gateways create ip_addresses=$IP gateway_name=$HOST
   > fi
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- gateways' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- gateways' | awk -F'[' '{print $2}'
   Up: 2/2, Portals: 2]
 
 Attach the disk
 ===============
-  $ sudo podman exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/disks/ add disk=datapool/block0
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- disks' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/disks/ add disk=datapool/block0
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- disks' | awk -F'[' '{print $2}'
   Disks: 1]
 
 Create a host
 =============
-  $ sudo podman exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/hosts create client_iqn=iqn.1994-05.com.redhat:client
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- hosts' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/hosts create client_iqn=iqn.1994-05.com.redhat:client
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- hosts' | awk -F'[' '{print $2}'
   Auth: ACL_ENABLED, Hosts: 1]
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- iqn.1994-05.com.redhat:client' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- iqn.1994-05.com.redhat:client' | awk -F'[' '{print $2}'
   Auth: None, Disks: 0(0.00Y)]
 
 Map the LUN
 ===========
-  $ sudo podman exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/hosts/iqn.1994-05.com.redhat:client disk disk=datapool/block0
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- hosts' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/hosts/iqn.1994-05.com.redhat:client disk disk=datapool/block0
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- hosts' | awk -F'[' '{print $2}'
   Auth: ACL_ENABLED, Hosts: 1]
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- iqn.1994-05.com.redhat:client' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- iqn.1994-05.com.redhat:client' | awk -F'[' '{print $2}'
   Auth: None, Disks: 1(300M)]

--- a/src/test/cli-integration/rbd/gwcli_delete.t
+++ b/src/test/cli-integration/rbd/gwcli_delete.t
@@ -1,31 +1,38 @@
-Podman find iSCSI container
-===========================
-  $ ISCSI_CONTAINER=$(sudo podman ps -a | grep -F 'iscsi' | grep -Fv 'tcmu' | awk '{print $1}')
+Cephadm prefers podman to docker
+================================
+  $ CENGINE=docker
+  > if command -v podman >/dev/null; then
+  >   CENGINE=podman
+  > fi
+
+Find iSCSI container
+====================
+  $ ISCSI_CONTAINER=$(sudo $CENGINE ps -a | grep -F 'iscsi' | grep -Fv 'tcmu' | awk '{print $1}')
 
 Dismiss the "could not load preferences file .gwcli/prefs.bin" warning
 ======================================================================
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls >/dev/null 2>&1
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls >/dev/null 2>&1
 
 Delete the host
 ===============
-  $ sudo podman exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/hosts delete client_iqn=iqn.1994-05.com.redhat:client
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- hosts' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/hosts delete client_iqn=iqn.1994-05.com.redhat:client
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- hosts' | awk -F'[' '{print $2}'
   Auth: ACL_ENABLED, Hosts: 0]
 
 Delete the iscsi-targets disk
 =============================
-  $ sudo podman exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/disks/ delete disk=datapool/block0
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- disks' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli iscsi-targets/iqn.2003-01.com.redhat.iscsi-gw:ceph-gw/disks/ delete disk=datapool/block0
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- disks' | awk -F'[' '{print $2}'
   Disks: 0]
 
 Delete the target IQN
 =====================
-  $ sudo podman exec $ISCSI_CONTAINER gwcli iscsi-targets/ delete target_iqn=iqn.2003-01.com.redhat.iscsi-gw:ceph-gw
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- iscsi-targets' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli iscsi-targets/ delete target_iqn=iqn.2003-01.com.redhat.iscsi-gw:ceph-gw
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls iscsi-targets/ | grep 'o- iscsi-targets' | awk -F'[' '{print $2}'
   DiscoveryAuth: None, Targets: 0]
 
 Delete the disks
 ================
-  $ sudo podman exec $ISCSI_CONTAINER gwcli disks/ delete image_id=datapool/block0
-  $ sudo podman exec $ISCSI_CONTAINER gwcli ls disks/ | grep 'o- disks' | awk -F'[' '{print $2}'
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli disks/ delete image_id=datapool/block0
+  $ sudo $CENGINE exec $ISCSI_CONTAINER gwcli ls disks/ | grep 'o- disks' | awk -F'[' '{print $2}'
   0.00Y, Disks: 0]

--- a/src/test/cli-integration/rbd/iscsi_client.t
+++ b/src/test/cli-integration/rbd/iscsi_client.t
@@ -1,7 +1,7 @@
 Login to the target
 ===================
   $ IP=`cat /etc/ceph/iscsi-gateway.cfg |grep 'trusted_ip_list' | awk -F'[, ]' '{print $3}'`
-  > sudo iscsiadm -m discovery -t st -p $IP -l 2&> /dev/null
+  $ sudo iscsiadm -m discovery -t st -p $IP -l >/dev/null 2>&1
   $ sleep 10
   $ sudo ls /dev/disk/by-path/ |grep 'iscsi-iqn.2003-01.com.redhat.iscsi-gw:ceph-gw' |wc -l
   2


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68366

---

backport of https://github.com/ceph/ceph/pull/60005
parent tracker: https://tracker.ceph.com/issues/68213