### PR TITLE
global: use getgrnam() instead of getgrnam_r() for setgroup

### DIFF
--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -268,10 +268,7 @@ global_init(const std::map<std::string,std::string> *defaults,
     if (g_conf()->setgroup.length() > 0) {
       gid = atoi(g_conf()->setgroup.c_str());
       if (!gid) {
-	char buf[4096];
-	struct group gr;
-	struct group *g = 0;
-	getgrnam_r(g_conf()->setgroup.c_str(), &gr, buf, sizeof(buf), &g);
+	group *g = getgrnam(g_conf()->setgroup.c_str());
 	if (!g) {
 	  cerr << "unable to look up group '" << g_conf()->setgroup << "'"
 	       << ": " << cpp_strerror(errno) << std::endl;


### PR DESCRIPTION
`getgrnam_r()` can fail with `ERANGE` if the provided buffer isn't large enough to hold the list of members

use `getgrnam()` instead which doesn't take an input buffer, but returns a pointer to the group. this function isn't thread-safe, but we shouldn't expect `global_init()` to race with itself or changes to the locale

Fixes: https://tracker.ceph.com/issues/40692

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
