### PR TITLE
json_spirit: add missing dependency on Boost::thread

### DIFF
--- a/src/json_spirit/CMakeLists.txt
+++ b/src/json_spirit/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(json_spirit STATIC
   json_spirit_reader.cpp
   json_spirit_writer.cpp)
-target_link_libraries(json_spirit common_utf8)
+target_link_libraries(json_spirit common_utf8 Boost::thread)


### PR DESCRIPTION
This library is built with `BOOST_SPIRIT_THREADSAFE` and thus it requires linking with Boost::thread.

This mistake usually had no effect because other build targets had this dependency already, but this is fragile and depends on the linker command parameter order.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
