### PR TITLE
msg/DispatchQueue: wake up only one dispatch thread

### DIFF
--- a/src/msg/DispatchQueue.cc
+++ b/src/msg/DispatchQueue.cc
@@ -93,7 +93,7 @@ void DispatchQueue::enqueue(const ref_t<Message>& m, int priority, uint64_t id)
   } else {
     mqueue.enqueue(id, priority, m->get_cost(), QueueItem(m));
   }
-  cond.notify_all();
+  cond.notify_one();
 }
 
 void DispatchQueue::local_delivery(const ref_t<Message>& m, int priority)


### PR DESCRIPTION
When adding one message, only one thread needs to be woken up.  Waking up all is a more expensive operation and leads to unnecessary lock contention and context switches.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
