### PR TITLE
msg/async/ProtocolV2: pass `desc` as C string to write()

### DIFF
--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -796,7 +796,7 @@ CtPtr ProtocolV2::read(CONTINUATION_RXBPTR_TYPE<ProtocolV2> &next,
 }
 
 template <class F>
-CtPtr ProtocolV2::write(const std::string &desc,
+CtPtr ProtocolV2::write(std::string_view desc,
                         CONTINUATION_TYPE<ProtocolV2> &next,
                         F &frame) {
   ceph::bufferlist bl;
@@ -812,7 +812,7 @@ CtPtr ProtocolV2::write(const std::string &desc,
   return write(desc, next, bl);
 }
 
-CtPtr ProtocolV2::write(const std::string &desc,
+CtPtr ProtocolV2::write(std::string_view desc,
                         CONTINUATION_TYPE<ProtocolV2> &next,
                         ceph::bufferlist &buffer) {
   if (unlikely(pre_auth.enabled)) {

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -130,10 +130,10 @@ private:
   Ct<ProtocolV2> *read(CONTINUATION_RXBPTR_TYPE<ProtocolV2> &next,
                        rx_buffer_t&& buffer);
   template <class F>
-  Ct<ProtocolV2> *write(const std::string &desc,
+  Ct<ProtocolV2> *write(std::string_view desc,
                         CONTINUATION_TYPE<ProtocolV2> &next,
 			F &frame);
-  Ct<ProtocolV2> *write(const std::string &desc,
+  Ct<ProtocolV2> *write(std::string_view desc,
                         CONTINUATION_TYPE<ProtocolV2> &next,
                         ceph::bufferlist &buffer);
 


### PR DESCRIPTION
All callers really pass a C string literal, and declaring a `std::string` parameter will implicitly create two `std::string` instances: one on the caller's stack, and another one inside write() as parameter to the continuation lambda.  This causes considerable and unnecessary overhead.

This patch reduces the code size by nearly 2 kB.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
