### PR TITLE
squid: cmake: use ExternalProjects to build isa-l and isa-l_crypto libraries

### DIFF
--- a/cmake/modules/BuildISAL.cmake
+++ b/cmake/modules/BuildISAL.cmake
@@ -1,0 +1,42 @@
+# use an ExternalProject to build isa-l using its makefile
+function(build_isal)
+  set(isal_BINARY_DIR ${CMAKE_BINARY_DIR}/src/isa-l)
+  set(isal_INSTALL_DIR ${isal_BINARY_DIR}/install)
+  set(isal_INCLUDE_DIR "${isal_INSTALL_DIR}/include")
+  set(isal_LIBRARY "${isal_INSTALL_DIR}/lib/libisal.a")
+
+  # this include directory won't exist until the install step, but the
+  # imported targets need it early for INTERFACE_INCLUDE_DIRECTORIES
+  file(MAKE_DIRECTORY "${isal_INCLUDE_DIR}")
+
+  set(configure_cmd env CC=${CMAKE_C_COMPILER} ./configure --prefix=${isal_INSTALL_DIR})
+  # build a static library with -fPIC that we can link into crypto/compressor plugins
+  list(APPEND configure_cmd --with-pic --enable-static --disable-shared)
+
+  # clear the DESTDIR environment variable from debian/rules,
+  # because it messes with the internal install paths of arrow's bundled deps
+  set(NO_DESTDIR_COMMAND ${CMAKE_COMMAND} -E env --unset=DESTDIR)
+
+  include(ExternalProject)
+  ExternalProject_Add(isal_ext
+    SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/isa-l"
+    CONFIGURE_COMMAND ./autogen.sh COMMAND ${configure_cmd}
+    BUILD_COMMAND ${NO_DESTDIR_COMMAND} make -j3
+    BUILD_IN_SOURCE 1
+    BUILD_BYPRODUCTS ${isal_LIBRARY}
+    INSTALL_COMMAND ${NO_DESTDIR_COMMAND} make install
+    UPDATE_COMMAND ""
+    LOG_CONFIGURE ON
+    LOG_BUILD ON
+    LOG_INSTALL ON
+    LOG_MERGED_STDOUTERR ON
+    LOG_OUTPUT_ON_FAILURE ON)
+
+  # add imported library target ISAL::Crypto
+  add_library(ISAL::ISAL STATIC IMPORTED GLOBAL)
+  add_dependencies(ISAL::ISAL isal_ext)
+  set_target_properties(ISAL::ISAL PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${isal_INCLUDE_DIR}
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+    IMPORTED_LOCATION ${isal_LIBRARY})
+endfunction()

--- a/cmake/modules/BuildISALCrypto.cmake
+++ b/cmake/modules/BuildISALCrypto.cmake
@@ -1,0 +1,31 @@
+# use an ExternalProject to build isa-l_crypto using its makefile
+function(build_isal_crypto)
+  set(ISAL_CRYPTO_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/crypto/isa-l/isa-l_crypto)
+  set(ISAL_CRYPTO_INCLUDE_DIR "${ISAL_CRYPTO_SOURCE_DIR}/include")
+  set(ISAL_CRYPTO_LIBRARY "${ISAL_CRYPTO_SOURCE_DIR}/bin/isa-l_crypto.a")
+
+  include(FindMake)
+  find_make("MAKE_EXECUTABLE" "make_cmd")
+
+  include(ExternalProject)
+  ExternalProject_Add(isal_crypto_ext
+    SOURCE_DIR ${ISAL_CRYPTO_SOURCE_DIR}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ${make_cmd} -f <SOURCE_DIR>/Makefile.unx
+    BUILD_IN_SOURCE 1
+    BUILD_BYPRODUCTS ${ISAL_CRYPTO_LIBRARY}
+    INSTALL_COMMAND ""
+    UPDATE_COMMAND ""
+    LOG_CONFIGURE ON
+    LOG_BUILD ON
+    LOG_MERGED_STDOUTERR ON
+    LOG_OUTPUT_ON_FAILURE ON)
+
+  # add imported library target ISAL::Crypto
+  add_library(ISAL::Crypto STATIC IMPORTED GLOBAL)
+  add_dependencies(ISAL::Crypto isal_crypto_ext)
+  set_target_properties(ISAL::Crypto PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${ISAL_CRYPTO_INCLUDE_DIR}
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+    IMPORTED_LOCATION ${ISAL_CRYPTO_LIBRARY})
+endfunction()

--- a/src/crypto/isa-l/CMakeLists.txt
+++ b/src/crypto/isa-l/CMakeLists.txt
@@ -1,36 +1,17 @@
-set(isal_dir ${CMAKE_SOURCE_DIR}/src/crypto/isa-l/isa-l_crypto)
-set(CMAKE_ASM_FLAGS "-i ${isal_dir}/aes/ -i ${isal_dir}/include/ ${CMAKE_ASM_FLAGS}")
+# build isa-l_crypto from its makefile and expose as target ISAL::Crypto
+include(BuildISALCrypto)
+build_isal_crypto()
 
 set(isal_crypto_plugin_srcs
   isal_crypto_accel.cc 
-  isal_crypto_plugin.cc
-  ${isal_dir}/aes/cbc_pre.c
-  ${isal_dir}/aes/cbc_multibinary.asm
-  ${isal_dir}/aes/keyexp_128.asm
-  ${isal_dir}/aes/keyexp_192.asm
-  ${isal_dir}/aes/keyexp_256.asm
-  ${isal_dir}/aes/keyexp_multibinary.asm
-  ${isal_dir}/aes/cbc_dec_128_x4_sse.asm
-  ${isal_dir}/aes/cbc_dec_128_x8_avx.asm
-  ${isal_dir}/aes/cbc_dec_192_x4_sse.asm
-  ${isal_dir}/aes/cbc_dec_192_x8_avx.asm
-  ${isal_dir}/aes/cbc_dec_256_x4_sse.asm
-  ${isal_dir}/aes/cbc_dec_256_x8_avx.asm
-  ${isal_dir}/aes/cbc_enc_128_x4_sb.asm
-  ${isal_dir}/aes/cbc_enc_128_x8_sb.asm
-  ${isal_dir}/aes/cbc_enc_192_x4_sb.asm
-  ${isal_dir}/aes/cbc_enc_192_x8_sb.asm
-  ${isal_dir}/aes/cbc_enc_256_x4_sb.asm
-  ${isal_dir}/aes/cbc_enc_256_x8_sb.asm)
+  isal_crypto_plugin.cc)
 
 if(HAVE_NASM_X64)
 add_dependencies(crypto_plugins ceph_crypto_isal)
 endif(HAVE_NASM_X64)
 
 add_library(ceph_crypto_isal SHARED ${isal_crypto_plugin_srcs})
-target_include_directories(ceph_crypto_isal PRIVATE ${isal_dir}/include)
-
-target_link_libraries(ceph_crypto_isal PRIVATE Boost::context)
+target_link_libraries(ceph_crypto_isal PRIVATE ISAL::Crypto Boost::context)
 
 set_target_properties(ceph_crypto_isal PROPERTIES
   VERSION 1.0.0

--- a/src/erasure-code/isa/CMakeLists.txt
+++ b/src/erasure-code/isa/CMakeLists.txt
@@ -1,97 +1,19 @@
-# ISA
-set(isal_src_dir ${CMAKE_SOURCE_DIR}/src/isa-l)
-include_directories(${isal_src_dir}/include)
+# build isa-l from its makefile and expose as target ISAL::ISAL
+include(BuildISAL)
+build_isal()
 
-if(HAVE_NASM_X64_AVX2)
-  set(CMAKE_ASM_FLAGS "-i ${isal_src_dir}/include/ ${CMAKE_ASM_FLAGS}")
-  set(isa_srcs
-    ${isal_src_dir}/erasure_code/ec_base.c
-    ${isal_src_dir}/erasure_code/gf_2vect_dot_prod_sse.asm
-    ${isal_src_dir}/erasure_code/gf_3vect_dot_prod_sse.asm
-    ${isal_src_dir}/erasure_code/gf_4vect_dot_prod_sse.asm
-    ${isal_src_dir}/erasure_code/gf_5vect_dot_prod_sse.asm
-    ${isal_src_dir}/erasure_code/gf_6vect_dot_prod_sse.asm
-    ${isal_src_dir}/erasure_code/gf_vect_dot_prod_sse.asm
-    ${isal_src_dir}/erasure_code/gf_2vect_mad_avx2.asm
-    ${isal_src_dir}/erasure_code/gf_3vect_mad_avx2.asm
-    ${isal_src_dir}/erasure_code/gf_4vect_mad_avx2.asm
-    ${isal_src_dir}/erasure_code/gf_5vect_mad_avx2.asm
-    ${isal_src_dir}/erasure_code/gf_6vect_mad_avx2.asm
-    ${isal_src_dir}/erasure_code/gf_vect_mad_avx2.asm
-    ${isal_src_dir}/erasure_code/ec_highlevel_func.c
-    ${isal_src_dir}/erasure_code/gf_2vect_mad_avx.asm
-    ${isal_src_dir}/erasure_code/gf_3vect_mad_avx.asm
-    ${isal_src_dir}/erasure_code/gf_4vect_mad_avx.asm
-    ${isal_src_dir}/erasure_code/gf_5vect_mad_avx.asm
-    ${isal_src_dir}/erasure_code/gf_6vect_mad_avx.asm
-    ${isal_src_dir}/erasure_code/gf_vect_mad_avx.asm
-    ${isal_src_dir}/erasure_code/ec_multibinary.asm
-    ${isal_src_dir}/erasure_code/gf_2vect_mad_sse.asm
-    ${isal_src_dir}/erasure_code/gf_3vect_mad_sse.asm
-    ${isal_src_dir}/erasure_code/gf_4vect_mad_sse.asm
-    ${isal_src_dir}/erasure_code/gf_5vect_mad_sse.asm
-    ${isal_src_dir}/erasure_code/gf_6vect_mad_sse.asm
-    ${isal_src_dir}/erasure_code/gf_vect_mad_sse.asm
-    ${isal_src_dir}/erasure_code/gf_2vect_dot_prod_avx2.asm
-    ${isal_src_dir}/erasure_code/gf_3vect_dot_prod_avx2.asm
-    ${isal_src_dir}/erasure_code/gf_4vect_dot_prod_avx2.asm
-    ${isal_src_dir}/erasure_code/gf_5vect_dot_prod_avx2.asm
-    ${isal_src_dir}/erasure_code/gf_6vect_dot_prod_avx2.asm
-    ${isal_src_dir}/erasure_code/gf_vect_dot_prod_avx2.asm
-    ${isal_src_dir}/erasure_code/gf_vect_mul_avx.asm
-    ${isal_src_dir}/erasure_code/gf_2vect_dot_prod_avx.asm
-    ${isal_src_dir}/erasure_code/gf_3vect_dot_prod_avx.asm
-    ${isal_src_dir}/erasure_code/gf_4vect_dot_prod_avx.asm
-    ${isal_src_dir}/erasure_code/gf_5vect_dot_prod_avx.asm
-    ${isal_src_dir}/erasure_code/gf_6vect_dot_prod_avx.asm
-    ${isal_src_dir}/erasure_code/gf_vect_dot_prod_avx.asm
-    ${isal_src_dir}/erasure_code/gf_vect_mul_sse.asm
-    ${isal_src_dir}/erasure_code/gf_2vect_dot_prod_avx512.asm
-    ${isal_src_dir}/erasure_code/gf_2vect_mad_avx512.asm
-    ${isal_src_dir}/erasure_code/gf_3vect_dot_prod_avx512.asm
-    ${isal_src_dir}/erasure_code/gf_3vect_mad_avx512.asm
-    ${isal_src_dir}/erasure_code/gf_4vect_dot_prod_avx512.asm
-    ${isal_src_dir}/erasure_code/gf_4vect_mad_avx512.asm
-    ${isal_src_dir}/erasure_code/gf_vect_dot_prod_avx512.asm
-    ${isal_src_dir}/erasure_code/gf_vect_mad_avx512.asm
-    ErasureCodeIsa.cc
-    ErasureCodeIsaTableCache.cc
-    ErasureCodePluginIsa.cc
-    xor_op.cc
-  )
-elseif(HAVE_ARMV8_SIMD)
-  set(isa_srcs
-    ${isal_src_dir}/erasure_code/ec_base.c
-    ${isal_src_dir}/erasure_code/aarch64/ec_aarch64_highlevel_func.c
-    ${isal_src_dir}/erasure_code/aarch64/ec_aarch64_dispatcher.c
-    ${isal_src_dir}/erasure_code/aarch64/gf_2vect_dot_prod_neon.S
-    ${isal_src_dir}/erasure_code/aarch64/gf_2vect_mad_neon.S
-    ${isal_src_dir}/erasure_code/aarch64/gf_3vect_dot_prod_neon.S
-    ${isal_src_dir}/erasure_code/aarch64/gf_3vect_mad_neon.S
-    ${isal_src_dir}/erasure_code/aarch64/gf_4vect_dot_prod_neon.S
-    ${isal_src_dir}/erasure_code/aarch64/gf_4vect_mad_neon.S
-    ${isal_src_dir}/erasure_code/aarch64/gf_5vect_dot_prod_neon.S
-    ${isal_src_dir}/erasure_code/aarch64/gf_5vect_mad_neon.S
-    ${isal_src_dir}/erasure_code/aarch64/gf_6vect_mad_neon.S
-    ${isal_src_dir}/erasure_code/aarch64/gf_vect_dot_prod_neon.S
-    ${isal_src_dir}/erasure_code/aarch64/gf_vect_mad_neon.S
-    ${isal_src_dir}/erasure_code/aarch64/gf_vect_mul_neon.S
-    ${isal_src_dir}/erasure_code/aarch64/ec_multibinary_arm.S
-    ErasureCodeIsa.cc
-    ErasureCodeIsaTableCache.cc
-    ErasureCodePluginIsa.cc
-    xor_op.cc
-  )
-  set_source_files_properties(
-    ${isal_src_dir}/erasure_code/aarch64/ec_multibinary_arm.S
-    PROPERTIES COMPILE_FLAGS "-D__ASSEMBLY__"
-  )
-endif()
+# ISA
+set(isa_srcs
+  ErasureCodeIsa.cc
+  ErasureCodeIsaTableCache.cc
+  ErasureCodePluginIsa.cc
+  xor_op.cc
+)
 
 add_library(ec_isa SHARED
   ${isa_srcs}
   $<TARGET_OBJECTS:erasure_code_objs>)
-target_link_libraries(ec_isa ${EXTRALIBS})
+target_link_libraries(ec_isa ISAL::ISAL ${EXTRALIBS})
 set_target_properties(ec_isa PROPERTIES
   INSTALL_RPATH "")
 install(TARGETS ec_isa DESTINATION ${erasure_plugin_dir})


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68378

---

backport of https://github.com/ceph/ceph/pull/59513
parent tracker: https://tracker.ceph.com/issues/67943

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh