### PR TITLE
mgr/status: ceph fs status redesign

### DIFF
--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -29,9 +29,18 @@ class Module(MgrModule):
         else:
             return 0
 
+    def top_activity(self, operations: dict) -> dict:
+        sorted_operations = dict(sorted(operations.items(),
+                                        key=lambda item: item[1], reverse=True))
+        top_activity = dict(list(sorted_operations.items())[0:5])
+        return { str(str(k).replace("mds_server.req_", "")).replace("_latency_count", ""):
+             v for k, v in top_activity.items() }
+
+
     @CLIReadCommand("fs status")
     def handle_fs_status(self,
                          fs: Optional[str] = None,
+                         flag: str = None,
                          format: str = 'plain') -> Tuple[int, str, str]:
         """
         Show the status of a CephFS filesystem
@@ -46,184 +55,302 @@ class Module(MgrModule):
 
         fs_filter = fs
 
+        activity_flag = flag
+
         mds_versions = defaultdict(list)
 
         fsmap = self.get("fs_map")
-        for filesystem in fsmap['filesystems']:
-            if fs_filter and filesystem['mdsmap']['fs_name'] != fs_filter:
-                continue
+        if not activity_flag:
+            for filesystem in fsmap['filesystems']:
+                if fs_filter and filesystem['mdsmap']['fs_name'] != fs_filter:
+                    continue
 
-            rank_table = PrettyTable(
-                ("RANK", "STATE", "MDS", "ACTIVITY", "DNS", "INOS", "DIRS", "CAPS"),
-                border=False,
-            )
-            rank_table.left_padding_width = 0
-            rank_table.right_padding_width = 2
+                rank_table = PrettyTable(
+                    ("RANK", "STATE", "MDS", "ACTIVITY", "DNS", "INOS", "DIRS", "CAPS"),
+                    border=False,
+                )
+                rank_table.left_padding_width = 0
+                rank_table.right_padding_width = 2
 
-            mdsmap = filesystem['mdsmap']
+                mdsmap = filesystem['mdsmap']
 
-            client_count = 0
+                client_count = 0
 
-            for rank in mdsmap["in"]:
-                up = "mds_{0}".format(rank) in mdsmap["up"]
-                if up:
-                    gid = mdsmap['up']["mds_{0}".format(rank)]
-                    info = mdsmap['info']['gid_{0}'.format(gid)]
-                    dns = self.get_latest("mds", info['name'], "mds_mem.dn")
-                    inos = self.get_latest("mds", info['name'], "mds_mem.ino")
-                    dirs = self.get_latest("mds", info['name'], "mds_mem.dir")
-                    caps = self.get_latest("mds", info['name'], "mds_mem.cap")
+                for rank in mdsmap["in"]:
+                    up = "mds_{0}".format(rank) in mdsmap["up"]
+                    if up:
+                        gid = mdsmap['up']["mds_{0}".format(rank)]
+                        info = mdsmap['info']['gid_{0}'.format(gid)]
+                        dns = self.get_latest("mds", info['name'], "mds_mem.dn")
+                        inos = self.get_latest("mds", info['name'], "mds_mem.ino")
+                        dirs = self.get_latest("mds", info['name'], "mds_mem.dir")
+                        caps = self.get_latest("mds", info['name'], "mds_mem.cap")
 
-                    if rank == 0:
-                        client_count = self.get_latest("mds", info['name'],
-                                                       "mds_sessions.session_count")
-                    elif client_count == 0:
-                        # In case rank 0 was down, look at another rank's
-                        # sessionmap to get an indication of clients.
-                        client_count = self.get_latest("mds", info['name'],
-                                                       "mds_sessions.session_count")
+                        if rank == 0:
+                            client_count = self.get_latest("mds", info['name'],
+                                                        "mds_sessions.session_count")
+                        elif client_count == 0:
+                            # In case rank 0 was down, look at another rank's
+                            # sessionmap to get an indication of clients.
+                            client_count = self.get_latest("mds", info['name'],
+                                                        "mds_sessions.session_count")
 
-                    laggy = "laggy_since" in info
+                        laggy = "laggy_since" in info
 
-                    state = info['state'].split(":")[1]
-                    if laggy:
-                        state += "(laggy)"
-                    if state == "active" and not laggy:
-                        c_state = mgr_util.colorize(state, mgr_util.GREEN)
+                        state = info['state'].split(":")[1]
+                        if laggy:
+                            state += "(laggy)"
+                        if state == "active" and not laggy:
+                            c_state = mgr_util.colorize(state, mgr_util.GREEN)
+                        else:
+                            c_state = mgr_util.colorize(state, mgr_util.YELLOW)
+
+                        # Populate based on context of state, e.g. client
+                        # ops for an active daemon, replay progress, reconnect
+                        # progress
+                        activity = ""
+
+                        if state == "active":
+                            rate = self.get_rate("mds", info['name'],
+                                                "mds_server.handle_client_request")
+                            if output_format not in ('json', 'json-pretty'):
+                                activity = "Reqs: " + mgr_util.format_dimless(rate, 5) + "/s"
+
+                        metadata = self.get_metadata('mds', info['name'],
+                                                    default=defaultdict(lambda: 'unknown'))
+                        assert metadata
+                        mds_versions[metadata['ceph_version']].append(info['name'])
+
+                        if output_format in ('json', 'json-pretty'):
+                            json_output['mdsmap'].append({
+                                'rank': rank,
+                                'name': info['name'],
+                                'state': state,
+                                'rate': rate if state == "active" else "0",
+                                'dns': dns,
+                                'inos': inos,
+                                'dirs': dirs,
+                                'caps': caps
+                            })
+                        else:
+                            rank_table.add_row([
+                                mgr_util.bold(rank.__str__()), c_state, info['name'],
+                                activity,
+                                mgr_util.format_dimless(dns, 5),
+                                mgr_util.format_dimless(inos, 5),
+                                mgr_util.format_dimless(dirs, 5),
+                                mgr_util.format_dimless(caps, 5)
+                            ])
                     else:
-                        c_state = mgr_util.colorize(state, mgr_util.YELLOW)
+                        if output_format in ('json', 'json-pretty'):
+                            json_output['mdsmap'].append({
+                                'rank': rank,
+                                'state': "failed"
+                            })
+                        else:
+                            rank_table.add_row([
+                                rank, "failed", "", "", "", "", "", ""
+                            ])
 
-                    # Populate based on context of state, e.g. client
-                    # ops for an active daemon, replay progress, reconnect
-                    # progress
-                    activity = ""
+                # Find the standby replays
+                for gid_str, daemon_info in mdsmap['info'].items():
+                    if daemon_info['state'] != "up:standby-replay":
+                        continue
 
-                    if state == "active":
-                        rate = self.get_rate("mds", info['name'],
-                                             "mds_server.handle_client_request")
-                        if output_format not in ('json', 'json-pretty'):
-                            activity = "Reqs: " + mgr_util.format_dimless(rate, 5) + "/s"
+                    inos = self.get_latest("mds", daemon_info['name'], "mds_mem.ino")
+                    dns = self.get_latest("mds", daemon_info['name'], "mds_mem.dn")
+                    dirs = self.get_latest("mds", daemon_info['name'], "mds_mem.dir")
+                    caps = self.get_latest("mds", daemon_info['name'], "mds_mem.cap")
 
-                    metadata = self.get_metadata('mds', info['name'],
-                                                 default=defaultdict(lambda: 'unknown'))
+                    events = self.get_rate("mds", daemon_info['name'], "mds_log.replayed")
+                    if output_format not in ('json', 'json-pretty'):
+                        activity = "Evts: " + mgr_util.format_dimless(events, 5) + "/s"
+
+                    metadata = self.get_metadata('mds', daemon_info['name'],
+                                                default=defaultdict(lambda: 'unknown'))
                     assert metadata
-                    mds_versions[metadata['ceph_version']].append(info['name'])
+                    mds_versions[metadata['ceph_version']].append(daemon_info['name'])
 
                     if output_format in ('json', 'json-pretty'):
                         json_output['mdsmap'].append({
                             'rank': rank,
-                            'name': info['name'],
-                            'state': state,
-                            'rate': rate if state == "active" else "0",
-                            'dns': dns,
-                            'inos': inos,
-                            'dirs': dirs,
-                            'caps': caps
+                            'name': daemon_info['name'],
+                            'state': 'standby-replay',
+                            'events': events,
+                            'dns': 5,
+                            'inos': 5,
+                            'dirs': 5,
+                            'caps': 5
                         })
                     else:
                         rank_table.add_row([
-                            mgr_util.bold(rank.__str__()), c_state, info['name'],
-                            activity,
+                            "{0}-s".format(daemon_info['rank']), "standby-replay",
+                            daemon_info['name'], activity,
                             mgr_util.format_dimless(dns, 5),
                             mgr_util.format_dimless(inos, 5),
                             mgr_util.format_dimless(dirs, 5),
                             mgr_util.format_dimless(caps, 5)
                         ])
-                else:
-                    if output_format in ('json', 'json-pretty'):
-                        json_output['mdsmap'].append({
-                            'rank': rank,
-                            'state': "failed"
-                        })
-                    else:
-                        rank_table.add_row([
-                            rank, "failed", "", "", "", "", "", ""
-                        ])
 
-            # Find the standby replays
-            for gid_str, daemon_info in mdsmap['info'].items():
-                if daemon_info['state'] != "up:standby-replay":
+
+                if output_format in ('json', 'json-pretty'):
+                    json_output['clients'].append({
+                        'fs': mdsmap['fs_name'],
+                        'clients': client_count,
+                    })
+                else:
+                    output += "{0} - {1} clients\n".format(
+                        mdsmap['fs_name'], client_count)
+                    output += "=" * len(mdsmap['fs_name']) + "\n"
+                    output += rank_table.get_string() + "\n"
+
+            if not output and not json_output and fs_filter is not None:
+                return errno.EINVAL, "", "Invalid filesystem: " + fs_filter
+            
+        elif activity_flag == "-E":
+            for filesystem in fsmap['filesystems']:
+                if fs_filter and filesystem['mdsmap']['fs_name'] != fs_filter:
                     continue
 
-                inos = self.get_latest("mds", daemon_info['name'], "mds_mem.ino")
-                dns = self.get_latest("mds", daemon_info['name'], "mds_mem.dn")
-                dirs = self.get_latest("mds", daemon_info['name'], "mds_mem.dir")
-                caps = self.get_latest("mds", daemon_info['name'], "mds_mem.cap")
+                mdsmap = filesystem['mdsmap']
 
-                events = self.get_rate("mds", daemon_info['name'], "mds_log.replayed")
-                if output_format not in ('json', 'json-pretty'):
-                    activity = "Evts: " + mgr_util.format_dimless(events, 5) + "/s"
+                client_count = 0
 
-                metadata = self.get_metadata('mds', daemon_info['name'],
-                                             default=defaultdict(lambda: 'unknown'))
-                assert metadata
-                mds_versions[metadata['ceph_version']].append(daemon_info['name'])
+                for rank in mdsmap["in"]:
+                    up = "mds_{0}".format(rank) in mdsmap["up"]
+                    if up:
+                        gid = mdsmap['up']["mds_{0}".format(rank)]
+                        info = mdsmap['info']['gid_{0}'.format(gid)]
 
+                        if rank == 0:
+                            client_count = self.get_latest("mds", info['name'],
+                                                        "mds_sessions.session_count")
+                        elif client_count == 0:
+                            # In case rank 0 was down, look at another rank's
+                            # sessionmap to get an indication of clients.
+                            client_count = self.get_latest("mds", info['name'],
+                                                        "mds_sessions.session_count")
+
+                        laggy = "laggy_since" in info
+
+                        state = info['state'].split(":")[1]
+                        if laggy:
+                            state += "(laggy)"
+                        if state == "active" and not laggy:
+                            c_state = mgr_util.colorize(state, mgr_util.GREEN)
+                        else:
+                            c_state = mgr_util.colorize(state, mgr_util.YELLOW)
+
+                        operations_dict = {
+                            "mds_server.req_create_latency_count" : 0,
+                            "mds_server.req_getattr_latency_count": 0,
+                            "mds_server.req_getfilelock_latency_count": 0,
+                            "mds_server.req_getvxattr_latency_count": 0,
+                            "mds_server.req_link_latency_count": 0,
+                            "mds_server.req_lookup_latency_count": 0,
+                            "mds_server.req_lookuphash_latency_count": 0,
+                            "mds_server.req_lookupino_latency_count": 0,
+                            "mds_server.req_lookupname_latency_count": 0,
+                            "mds_server.req_lookupparent_latency_count": 0,
+                            "mds_server.req_lookupsnap_latency_count": 0,
+                            "mds_server.req_lssnap_latency_count": 0,
+                            "mds_server.req_mkdir_latency_count": 0,
+                            "mds_server.req_mknod_latency_count": 0,
+                            "mds_server.req_mksnap_latency_count": 0,
+                            "mds_server.req_open_latency_count": 0,
+                            "mds_server.req_readdir_latency_count": 0,
+                            "mds_server.req_rename_latency_count": 0,
+                            "mds_server.req_renamesnap_latency_count": 0,
+                            "mds_server.req_rmdir_latency_count": 0,
+                            "mds_server.req_rmsnap_latency_count": 0,
+                            "mds_server.req_rmxattr_latency_count": 0,
+                            "mds_server.req_setattr_latency_count": 0,
+                            "mds_server.req_setdirlayout_latency_count": 0,
+                            "mds_server.req_setfilelock_latency_count": 0,
+                            "mds_server.req_setlayout_latency_count": 0,
+                            "mds_server.req_setxattr_latency_count": 0,
+                            "mds_server.req_symlink_latency_count": 0,
+                            "mds_server.req_unlink_latency_count": 0
+                        }
+
+                        if state == "active":
+                            for ops in operations_dict.keys():
+                                operations_dict[ops] = self.get_rate("mds", info['name'], str(ops))
+
+                        activity_table = PrettyTable(border=False)
+                        top_activities = self.top_activity(operations_dict)
+                        activity_table.left_padding_width = 0
+                        activity_table.right_padding_width = 2
+
+                        if output_format in ('json', 'json-pretty'):
+                            top_activities.update({
+                                'rank': rank,
+                                'state': state,
+                                'name': info['name'],
+                                })
+                            json_output['mdsmap'].append(top_activities)
+                        else:
+                            activity_table.add_column("RANK", [mgr_util.bold(rank.__str__())])
+                            activity_table.add_column("MDS", [info["name"]])
+                            activity_table.add_column("STATE", [c_state])
+                            for item, val in top_activities.items():
+                                activity_table.add_column(item, [mgr_util.format_dimless(val, 5) + "/s"])
+                    else:
+                        if output_format in ('json', 'json-pretty'):
+                            json_output['mdsmap'].append({
+                                'rank': rank,
+                                'state': "failed"
+                            })
+                        else:
+                            activity_table.add_row([
+                                rank, "failed", "", "", "", "", "", ""
+                            ])
                 if output_format in ('json', 'json-pretty'):
-                    json_output['mdsmap'].append({
-                        'rank': rank,
-                        'name': daemon_info['name'],
-                        'state': 'standby-replay',
-                        'events': events,
-                        'dns': 5,
-                        'inos': 5,
-                        'dirs': 5,
-                        'caps': 5
+                    json_output['clients'].append({
+                        'fs': mdsmap['fs_name'],
+                        'clients': client_count,
                     })
                 else:
-                    rank_table.add_row([
-                        "{0}-s".format(daemon_info['rank']), "standby-replay",
-                        daemon_info['name'], activity,
-                        mgr_util.format_dimless(dns, 5),
-                        mgr_util.format_dimless(inos, 5),
-                        mgr_util.format_dimless(dirs, 5),
-                        mgr_util.format_dimless(caps, 5)
-                    ])
+                    output += "{0} - {1} clients\n".format(
+                        mdsmap['fs_name'], client_count)
+                    output += "=" * len(mdsmap['fs_name']) + "\n"
+                    output += "ACTIVITY TABLE (req/s)" + "\n"
+                    output += activity_table.get_string() + "\n"
+        else:
+            return errno.EINVAL, "", "Invalid argument/flag " + activity_flag
+        
+        df = self.get("df")
+        pool_stats = dict([(p['id'], p['stats']) for p in df['pools']])
+        osdmap = self.get("osd_map")
+        pools = dict([(p['pool'], p) for p in osdmap['pools']])
+        metadata_pool_id = mdsmap['metadata_pool']
+        data_pool_ids = mdsmap['data_pools']
 
-            df = self.get("df")
-            pool_stats = dict([(p['id'], p['stats']) for p in df['pools']])
-            osdmap = self.get("osd_map")
-            pools = dict([(p['pool'], p) for p in osdmap['pools']])
-            metadata_pool_id = mdsmap['metadata_pool']
-            data_pool_ids = mdsmap['data_pools']
-
-            pools_table = PrettyTable(["POOL", "TYPE", "USED", "AVAIL"],
-                                      border=False)
-            pools_table.left_padding_width = 0
-            pools_table.right_padding_width = 2
-            for pool_id in [metadata_pool_id] + data_pool_ids:
-                pool_type = "metadata" if pool_id == metadata_pool_id else "data"
-                stats = pool_stats[pool_id]
-
-                if output_format in ('json', 'json-pretty'):
-                    json_output['pools'].append({
-                        'id': pool_id,
-                        'name': pools[pool_id]['pool_name'],
-                        'type': pool_type,
-                        'used': stats['bytes_used'],
-                        'avail': stats['max_avail']
-                    })
-                else:
-                    pools_table.add_row([
-                        pools[pool_id]['pool_name'], pool_type,
-                        mgr_util.format_bytes(stats['bytes_used'], 5),
-                        mgr_util.format_bytes(stats['max_avail'], 5)
-                    ])
+        pools_table = PrettyTable(["POOL", "TYPE", "USED", "AVAIL"],
+                                border=False)
+        pools_table.left_padding_width = 0
+        pools_table.right_padding_width = 2
+        for pool_id in [metadata_pool_id] + data_pool_ids:
+            pool_type = "metadata" if pool_id == metadata_pool_id else "data"
+            stats = pool_stats[pool_id]
 
             if output_format in ('json', 'json-pretty'):
-                json_output['clients'].append({
-                    'fs': mdsmap['fs_name'],
-                    'clients': client_count,
+                json_output['pools'].append({
+                    'id': pool_id,
+                    'name': pools[pool_id]['pool_name'],
+                    'type': pool_type,
+                    'used': stats['bytes_used'],
+                    'avail': stats['max_avail']
                 })
             else:
-                output += "{0} - {1} clients\n".format(
-                    mdsmap['fs_name'], client_count)
-                output += "=" * len(mdsmap['fs_name']) + "\n"
-                output += rank_table.get_string()
-                output += "\n" + pools_table.get_string() + "\n"
+                pools_table.add_row([
+                    pools[pool_id]['pool_name'], pool_type,
+                    mgr_util.format_bytes(stats['bytes_used'], 5),
+                    mgr_util.format_bytes(stats['max_avail'], 5)
+                ])
 
-        if not output and not json_output and fs_filter is not None:
-            return errno.EINVAL, "", "Invalid filesystem: " + fs_filter
+        if output_format not in ('json', 'json-pretty'):
+            output += "\n" + pools_table.get_string() + "\n"
 
         standby_table = PrettyTable(["STANDBY MDS"], border=False)
         standby_table.left_padding_width = 0


### PR DESCRIPTION
This PR breaks down the ACTIVITY column in ceph fs status output into various types of operations.It will display the top five operations by their rates (req/s).
This can be seen by running following command:
`ceph fs status --flag=-E`

Fixes:https://tracker.ceph.com/issues/66211
Signed-off-by: Neeraj Pratap Singh <neesingh@redhat.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
