### PR TITLE
rgw: cls_timeindex: avoid dup ext key (object name) indexes

### DIFF
--- a/qa/suites/rgw/verify/tasks/cls.yaml
+++ b/qa/suites/rgw/verify/tasks/cls.yaml
@@ -17,6 +17,7 @@ tasks:
         - cls/test_cls_2pc_queue.sh
         - cls/test_cls_user.sh
         - cls/test_cls_sem_set.sh
+        - cls/test_cls_timeindex.sh
         - rgw/test_rgw_gc_log.sh
         - rgw/test_rgw_obj.sh
         - rgw/test_rgw_datalog.sh

--- a/qa/suites/rgw/verify/tasks/cls.yaml
+++ b/qa/suites/rgw/verify/tasks/cls.yaml
@@ -17,6 +17,7 @@ tasks:
         - cls/test_cls_2pc_queue.sh
         - cls/test_cls_user.sh
         - cls/test_neocls_sem_set.sh
+        - cls/test_cls_timeindex.sh
         - rgw/test_rgw_gc_log.sh
         - rgw/test_rgw_obj.sh
         - rgw/test_rgw_datalog.sh

--- a/qa/workunits/cls/test_cls_timeindex.sh
+++ b/qa/workunits/cls/test_cls_timeindex.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+ceph_test_cls_timeindex
+
+exit 0

--- a/src/cls/timeindex/cls_timeindex_types.h
+++ b/src/cls/timeindex/cls_timeindex_types.h
@@ -15,7 +15,9 @@ struct cls_timeindex_entry {
   /* Mandatory timestamp. Will be part of the key. */
   utime_t key_ts;
   /* Not mandatory. The name_ext field, if not empty, will form second
-   * part of the key. */
+   * part of the key. Also, a non empt key_ext is unique:
+     when adding an entry with key_ext that already exists the old
+     entry will be removed. */
   std::string key_ext;
   /* Become value of OMAP-based mapping. */
   ceph::buffer::list value;

--- a/src/test/cls_timeindex/CMakeLists.txt
+++ b/src/test/cls_timeindex/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(ceph_test_cls_timeindex
+  test_cls_timeindex.cc
+  )
+target_link_libraries(ceph_test_cls_timeindex
+  cls_timeindex_client
+  librados
+  global
+  ${UNITTEST_LIBS}
+  ${BLKID_LIBRARIES}
+  ${CMAKE_DL_LIBS}
+  ${CRYPTO_LIBS}
+  ${EXTRALIBS}
+  radostest-cxx
+  )
+install(TARGETS
+  ceph_test_cls_timeindex
+  DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/cls_timeindex/test_cls_timeindex.cc
+++ b/src/test/cls_timeindex/test_cls_timeindex.cc
@@ -1,0 +1,126 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 sts=2 expandtab
+
+#include <iostream>
+#include <errno.h>
+
+#include "include/types.h"
+#include "msg/msg_types.h"
+#include "include/rados/librados.hpp"
+
+#include "test/librados/test_cxx.h"
+#include "gtest/gtest.h"
+
+#include "cls/timeindex/cls_timeindex_client.h"
+
+using namespace librados;
+
+static void add_entry(IoCtx &ioctx,
+                      const std::string &oid,
+                      const utime_t &key_ts,
+                      const std::string &key_ext,
+                      const bufferlist &value) {
+  ObjectWriteOperation op;
+
+  cls_timeindex_add(op, key_ts, key_ext, value);
+  ASSERT_EQ(0, ioctx.operate(oid, &op));
+}
+
+static void list_entries(IoCtx &ioctx,
+                         const std::string &oid,
+                         const utime_t &start_ts,
+                         const utime_t &end_ts,
+                         std::list<cls_timeindex_entry> *entries) {
+  std::string out_marker;
+  bool truncated = true;
+  bufferlist bl;
+  ObjectReadOperation op;
+
+  entries->clear();
+  cls_timeindex_list(op, start_ts, end_ts, "", 10000, *entries,
+                     &out_marker, &truncated);
+  ASSERT_EQ(0, ioctx.operate(oid, &op, &bl));
+  ASSERT_FALSE(truncated);
+}
+
+static void trim_entries(IoCtx &ioctx,
+                         const std::string &oid,
+                         const utime_t &start_ts,
+                         const utime_t &end_ts) {
+  ObjectWriteOperation op;
+
+  cls_timeindex_trim(op, start_ts, end_ts, "", "");
+  ASSERT_EQ(0, ioctx.operate(oid, &op));
+}
+
+static void check_entry(const cls_timeindex_entry &e,
+                        const utime_t &key_ts,
+                        const std::string &key_ext,
+                        const bufferlist &value) {
+  ASSERT_EQ(key_ts, e.key_ts);
+  ASSERT_EQ(key_ext, e.key_ext);
+  ASSERT_EQ(value, e.value);
+}
+
+class TestClsTimeindex : public ::testing::Test {
+public:
+
+  static void SetUpTestCase() {
+    _pool_name = get_temp_pool_name();
+    ASSERT_EQ("", create_one_pool_pp(_pool_name, _rados));
+  }
+
+  static void TearDownTestCase() {
+    ASSERT_EQ(0, destroy_one_pool_pp(_pool_name, _rados));
+  }
+
+  static std::string _pool_name;
+  static Rados _rados;
+};
+
+std::string TestClsTimeindex::_pool_name;
+Rados TestClsTimeindex::_rados;
+
+
+TEST_F(TestClsTimeindex, Basic) {
+  IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  const std::string oid = "foo";
+  ASSERT_EQ(0, ioctx.create(oid, false));
+
+  bufferlist bl;
+
+  // add
+  add_entry(ioctx, oid, utime_t(100, 0), "key1", bufferlist());
+  add_entry(ioctx, oid, utime_t(200, 0), "key2", bl);
+
+  // list
+  std::list<cls_timeindex_entry> entries;
+
+  list_entries(ioctx, oid, utime_t(0, 0), utime_t(1000, 0), &entries);
+  ASSERT_EQ(2U, entries.size());
+  check_entry(*(entries.begin()), utime_t(100, 0), "key1", bufferlist());
+  entries.pop_front();
+  check_entry(*(entries.begin()), utime_t(200, 0), "key2", bl);
+
+  // trim
+  trim_entries(ioctx, oid, utime_t(0, 0), utime_t(150, 0));
+
+  list_entries(ioctx, oid, utime_t(0, 0), utime_t(1000, 0), &entries);
+  ASSERT_EQ(1U, entries.size());
+  check_entry(*(entries.begin()), utime_t(200, 0), "key2", bl);
+
+  // replace
+  bl.append("bar");
+  add_entry(ioctx, oid, utime_t(300, 0), "key2", bl);
+
+  list_entries(ioctx, oid, utime_t(0, 0), utime_t(1000, 0), &entries);
+  ASSERT_EQ(1U, entries.size());
+  check_entry(*(entries.begin()), utime_t(300, 0), "key2", bl);
+
+  trim_entries(ioctx, oid, utime_t(0, 0), utime_t(1000, 0));
+
+  list_entries(ioctx, oid, utime_t(0, 0), utime_t(1000, 0), &entries);
+  ASSERT_EQ(0U, entries.size());
+}


### PR DESCRIPTION
When adding an index (an object expiration time) we want the old index with the same ext key (object name) to be removed as it is not valid anymore.

Fixes: https://tracker.ceph.com/issues/68380





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
