### PR TITLE
reef: mgr/dashboard: fix doc links in rgw-multisite

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-zone-form/rgw-multisite-zone-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-zone-form/rgw-multisite-zone-form.component.html
@@ -63,7 +63,7 @@
               </cd-helper>
             </span>
             <cd-helper *ngIf="action === 'edit' && !isDefaultZone">
-              <span i18n>Please consult the <a href="{{ docUrl }}">documentation</a> to follow the failover mechanism</span>
+              <span i18n>Please consult the&nbsp;<cd-doc section="rgw-multisite"></cd-doc>&nbsp;to follow the failover mechanism</span>
             </cd-helper><br>
           </div>
           <div class="custom-control custom-checkbox">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-zonegroup-form/rgw-multisite-zonegroup-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-zonegroup-form/rgw-multisite-zonegroup-form.component.html
@@ -58,7 +58,7 @@
             <cd-helper i18n>Zone group doesn't belong to the default realm.</cd-helper>
           </span>
           <cd-helper *ngIf="action === 'edit' && !info.data.is_default">
-            <span i18n>Please consult the <a href="{{ docUrl }}">documentation</a> to follow the failover mechanism</span>
+            <span i18n>Please consult the&nbsp;<cd-doc section="rgw-multisite"></cd-doc>&nbsp;to follow the failover mechanism</span>
           </cd-helper>
           <cd-helper *ngIf="action === 'edit' && info.data.is_default">
             <span i18n>You cannot unset the default flag.</span>
@@ -76,7 +76,7 @@
             <cd-helper i18n>Multiple master zone groups can't be configured. If you want to create a new zone group and make it the master zone group, you must delete the default zone group.</cd-helper>
           </span>
           <cd-helper *ngIf="action === 'edit' && !info.data.is_master">
-            <span i18n>Please consult the <a href="{{ docUrl }}">documentation</a> to follow the failover mechanism</span>
+            <span i18n>Please consult the&nbsp;<cd-doc section="rgw-multisite"></cd-doc>&nbsp;to follow the failover mechanism</span>
           </cd-helper>
           <cd-helper *ngIf="action === 'edit' && info.data.is_master">
             <span i18n>You cannot unset the master flag.</span>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68314

---

backport of https://github.com/ceph/ceph/pull/60029
parent tracker: https://tracker.ceph.com/issues/68295

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh