### PR TITLE
dencoding: check struct_v against DECODE_START(v, ...) at compile-time

### DIFF
--- a/src/common/versioned_variant.h
+++ b/src/common/versioned_variant.h
@@ -203,7 +203,7 @@ void decode(std::variant<Ts...>& v, bufferlist::const_iterator& p)
 
   // use struct_v as an index into the variant after converting it into a
   // compile-time index I
-  const uint8_t index = struct_v - converted_max_version;
+  const uint8_t index = struct_v.v - converted_max_version;
   boost::mp11::mp_with_index<sizeof...(Ts)>(index, [&v, &p] (auto I) {
       // default-construct the type at index I and call its decoder
       decode(v.template emplace<I>(), p);

--- a/src/include/ceph_assert.h
+++ b/src/include/ceph_assert.h
@@ -144,4 +144,10 @@ using namespace ceph;
    ? _CEPH_ASSERT_VOID_CAST (0)					\
    : ::ceph::__ceph_assertf_fail (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, __VA_ARGS__))
 
+#define consteval_assert(expr, msg)	\
+  do {					\
+    if (!(expr)) {			\
+      throw (msg);			\
+    }					\
+  } while(false)
 #endif

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -1790,6 +1790,42 @@ inline std::enable_if_t<traits::supported && !traits::featured> decode_nohead(
     "' v=" + std::to_string(code_v)+ " cannot decode v=" + std::to_string(struct_v) +
     " minimal_decoder=" + std::to_string(struct_compat));
 }
+
+// compile-time  checker for struct_v to detect mismatch of declared
+// decoder version with actually implemented blocks like "struct_v < 100".
+// it addresses the common problem of forgetting to bump the version up
+// in decoder's `DECODE_START` (or `DENC_START`) when adding a new
+// schema revision.
+template <__u8 MaxV>
+struct StructVChecker
+{
+  struct CheckingWrapper {
+    consteval CheckingWrapper(__u8 c) : c(c) {
+      consteval_assert(
+        c <= MaxV,
+	"checking against higher version than declared in DECODE_START");
+    }
+    __u8 c;
+  };
+  // we want the implicit conversion to take place but with lower
+  // rank than the CheckingWrapper-conversion during struct_v cmps.
+  template<class T=void> operator __u8() {
+    return v;
+  }
+  // need the wrapper as the operator cannot be consteval; otherwise
+  // it couldn't have accessed the non-constexpr `v`.
+  auto operator<=>(CheckingWrapper c) {
+    return v <=> c.c;
+  }
+  auto operator==(CheckingWrapper c) {
+    return v == c.c;
+  }
+  auto operator!=(CheckingWrapper c) {
+    return v != c.c;
+  }
+  __u8 v;
+};
+
 #define DENC_HELPERS							\
   /* bound_encode */							\
   static void _denc_start(size_t& p,					\
@@ -1857,39 +1893,39 @@ inline std::enable_if_t<traits::supported && !traits::featured> decode_nohead(
 // Due to -2 compatibility rule we cannot bump up compat until U____ release.
 // SQUID=19 T____=20 U____=21
 
-#define DENC_START(v, compat, p)					\
-  __u8 struct_v = v;							\
+#define DENC_START(_v, compat, p)					\
+  StructVChecker<_v> struct_v{_v};					\
   __u8 struct_compat = compat;						\
   char *_denc_pchar;							\
   uint32_t _denc_u32;							\
   static_assert(CEPH_RELEASE >= (CEPH_RELEASE_SQUID /*19*/ + 2) || compat == 1);	\
-  _denc_start(p, &struct_v, &struct_compat, &_denc_pchar, &_denc_u32);	\
+  _denc_start(p, &struct_v.v, &struct_compat, &_denc_pchar, &_denc_u32);	\
   do {
 
 // For the only type that is with compat 2: unittest.
-#define DENC_START_COMPAT_2(v, compat, p)				\
-  __u8 struct_v = v;							\
+#define DENC_START_COMPAT_2(_v, compat, p)				\
+  StructVChecker<_v> struct_v{_v};					\
   __u8 struct_compat = compat;						\
   char *_denc_pchar;							\
   uint32_t _denc_u32;							\
   static_assert(CEPH_RELEASE >= (CEPH_RELEASE_SQUID /*19*/ + 2) || compat == 2);	\
-  _denc_start(p, &struct_v, &struct_compat, &_denc_pchar, &_denc_u32);	\
+  _denc_start(p, &struct_v.v, &struct_compat, &_denc_pchar, &_denc_u32);	\
   do {
 
 // For osd_reqid_t which cannot be upgraded at all.
 // We used it to communicate with clients and now we cannot safely upgrade.
-#define DENC_START_OSD_REQID(v, compat, p)				\
-  __u8 struct_v = v;							\
+#define DENC_START_OSD_REQID(_v, compat, p)				\
+  StructVChecker<_v> struct_v{_v};					\
   __u8 struct_compat = compat;						\
   char *_denc_pchar;							\
   uint32_t _denc_u32;							\
   static_assert(compat == 2, "osd_reqid_t cannot be upgraded");		\
-  _denc_start(p, &struct_v, &struct_compat, &_denc_pchar, &_denc_u32);	\
+  _denc_start(p, &struct_v.v, &struct_compat, &_denc_pchar, &_denc_u32);	\
   do {
 
 #define DENC_FINISH(p)							\
   } while (false);							\
-  _denc_finish(p, &struct_v, &struct_compat, &_denc_pchar, &_denc_u32);
+  _denc_finish(p, &struct_v.v, &struct_compat, &_denc_pchar, &_denc_u32);
 
 
 // ----------------------------------------------------------------------

--- a/src/librbd/journal/Types.cc
+++ b/src/librbd/journal/Types.cc
@@ -422,7 +422,7 @@ void EventEntry::encode(bufferlist& bl) const {
 }
 
 void EventEntry::decode(bufferlist::const_iterator& it) {
-  DECODE_START(1, it);
+  DECODE_START(5, it);
 
   uint32_t event_type;
   decode(event_type, it);

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1771,7 +1771,7 @@ void CInode::decode_lock_ilink(bufferlist::const_iterator& p)
 {
   ceph_assert(!is_auth());
   auto _inode = allocate_inode(*get_inode());
-  DECODE_START(1, p);
+  DECODE_START(2, p);
   decode(_inode->version, p);
   utime_t tm;
   decode(tm, p);

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -664,7 +664,7 @@ void FSMap::decode(bufferlist::const_iterator& p)
   struct_version = 0;
   DECODE_START(STRUCT_VERSION, p);
   DECODE_OLDEST(7);
-  struct_version = struct_v;
+  struct_version = struct_v.v;
   decode(epoch, p);
   decode(next_filesystem_id, p);
   decode(legacy_client_fscid, p);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11187,7 +11187,7 @@ void MDCache::decode_replica_dir(CDir *&dir, bufferlist::const_iterator& p, CIno
 
 void MDCache::decode_replica_dentry(CDentry *&dn, bufferlist::const_iterator& p, CDir *dir, MDSContext::vec& finished)
 {
-  DECODE_START(1, p);
+  DECODE_START(3, p);
   string name;
   snapid_t last;
   decode(name, p);
@@ -11463,7 +11463,7 @@ void MDCache::encode_remote_dentry_link(CDentry::linkage_t *dnl, bufferlist& bl)
 
 void MDCache::decode_remote_dentry_link(CDir *dir, CDentry *dn, bufferlist::const_iterator& p)
 {
-  DECODE_START(1, p);
+  DECODE_START(2, p);
   inodeno_t ino;
   __u8 d_type;
   decode(ino, p);

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -166,7 +166,7 @@ struct InodeStat {
   void decode(ceph::buffer::list::const_iterator &p, const uint64_t features) {
     using ceph::decode;
     if (features == (uint64_t)-1) {
-      DECODE_START(7, p);
+      DECODE_START(8, p);
       decode(vino.ino, p);
       decode(vino.snapid, p);
       decode(rdev, p);

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -146,7 +146,7 @@ public:
     }
 
     void decode(ceph::buffer::list::const_iterator &bl) {
-      DECODE_START(1, bl);
+      DECODE_START(2, bl);
       decode(name, bl);
       decode(can_run, bl);
       decode(error_string, bl);

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -231,7 +231,7 @@ struct DataStats {
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator &p) {
-    DECODE_START(1, p);
+    DECODE_START(3, p);
     // we moved from having fields in kb to fields in byte
     if (struct_v > 2) {
       decode(fs_stats.byte_total, p);

--- a/src/osd/ECMsgTypes.cc
+++ b/src/osd/ECMsgTypes.cc
@@ -220,7 +220,7 @@ void ECSubRead::decode(bufferlist::const_iterator &bl)
     decode(to_read, bl);
   }
   decode(attrs_to_read, bl);
-  if (struct_v > 2 && struct_v > struct_compat) {
+  if (struct_v > 2 && struct_v.v > struct_compat) {
     decode(subchunks, bl);
   } else {
     for (auto &i : to_read) {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -942,7 +942,7 @@ void OSDMap::Incremental::decode(ceph::buffer::list::const_iterator& bl)
   }
 
   {
-    DECODE_START(10, bl); // extended, osd-only data
+    DECODE_START(12, bl); // extended, osd-only data
     decode(new_hb_back_up, bl);
     decode(new_up_thru, bl);
     decode(new_last_clean_interval, bl);
@@ -3637,7 +3637,7 @@ void OSDMap::decode(ceph::buffer::list::const_iterator& bl)
   }
 
   {
-    DECODE_START(10, bl); // extended, osd-only data
+    DECODE_START(12, bl); // extended, osd-only data
     decode(osd_addrs->hb_back_addrs, bl);
     decode(osd_info, bl);
     decode(blocklist, bl);

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1499,7 +1499,7 @@ void pool_opts_t::encode(ceph::buffer::list& bl, uint64_t features) const
 
 void pool_opts_t::decode(ceph::buffer::list::const_iterator& bl)
 {
-  DECODE_START(1, bl);
+  DECODE_START(2, bl);
   __u32 n;
   decode(n, bl);
   opts.clear();
@@ -3718,7 +3718,7 @@ void pg_notify_t::encode(ceph::buffer::list &bl) const
 
 void pg_notify_t::decode(ceph::buffer::list::const_iterator &bl)
 {
-  DECODE_START(3, bl);
+  DECODE_START(4, bl);
   decode(query_epoch, bl);
   decode(epoch_sent, bl);
   decode(info, bl);
@@ -4570,7 +4570,7 @@ void ObjectModDesc::visit(Visitor *visitor) const
   auto bp = bl.cbegin();
   try {
     while (!bp.end()) {
-      DECODE_START(max_required_version, bp);
+      DECODE_START_UNCHECKED(max_required_version, bp);
       uint8_t code;
       decode(code, bp);
       switch (code) {

--- a/src/rgw/driver/rados/rgw_obj_manifest.h
+++ b/src/rgw/driver/rados/rgw_obj_manifest.h
@@ -297,7 +297,7 @@ public:
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN_32(7, 2, 2, bl);
+    DECODE_START_LEGACY_COMPAT_LEN_32(8, 2, 2, bl);
     decode(obj_size, bl);
     decode(objs, bl);
     if (struct_v >= 3) {

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -295,7 +295,7 @@ public:
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(3, bl);
+    DECODE_START(4, bl);
     decode(prefix, bl);
     if (struct_v >= 2) {
       decode(obj_tags, bl);

--- a/src/rgw/rgw_meta_sync_status.h
+++ b/src/rgw/rgw_meta_sync_status.h
@@ -29,7 +29,7 @@ struct rgw_meta_sync_info {
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(state, bl);
     decode(num_shards, bl);
     if (struct_v >= 2) {

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -281,7 +281,7 @@ struct rgw_pubsub_dest {
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(5, bl);
+    DECODE_START(7, bl);
     std::string dummy;
     decode(dummy, bl);
     decode(dummy, bl);

--- a/src/rgw/rgw_zone_types.h
+++ b/src/rgw/rgw_zone_types.h
@@ -573,7 +573,7 @@ struct RGWZoneGroupPlacementTier {
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     decode(tier_type, bl);
     decode(storage_class, bl);
     decode(retain_head_object, bl);

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -446,3 +446,39 @@ if(WITH_SYSTEMD)
   target_link_libraries(unittest_journald_logger ceph-common)
   add_ceph_unittest(unittest_journald_logger)
 endif()
+
+# Validation of the DECODE_START's struct_v compile-time checker.
+# First, ensure buildability of the test program itself. This is
+# useful to avoid false positives coming from other-than-the-assert
+# build failures.
+add_executable(unittest_decode_start_v_checker
+  test_decode_start_v_checker.cpp)
+target_link_libraries(unittest_decode_start_v_checker global)
+set_target_properties(unittest_decode_start_v_checker
+  PROPERTIES
+  EXCLUDE_FROM_ALL TRUE
+  EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+add_test(
+  NAME unittest_decode_start_v_checker
+  COMMAND ${CMAKE_COMMAND} --build . --target unittest_decode_start_v_checker --config $<CONFIGURATION>
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+# Second, ensure that adding a single, wrongly versioned comparison
+# fails the build.
+add_executable(unittest_decode_start_v_checker_expect_failure
+  test_decode_start_v_checker.cpp)
+target_link_libraries(unittest_decode_start_v_checker_expect_failure global)
+target_compile_definitions(unittest_decode_start_v_checker_expect_failure
+  PRIVATE SHOULD_FAIL)
+set_target_properties(
+  unittest_decode_start_v_checker_expect_failure
+  PROPERTIES
+  EXCLUDE_FROM_ALL TRUE
+  EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+# Add the test bypassing the macros from AddCephTest.cmake. The idea is to
+# invoke "cmake --build ..." as the actual test and check whether it fails.
+add_test(NAME unittest_decode_start_v_checker_expect_failure
+         COMMAND ${CMAKE_COMMAND} --build . --target unittest_decode_start_v_checker_expect_failure --config $<CONFIGURATION>
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_tests_properties(unittest_decode_start_v_checker_expect_failure
+  PROPERTIES WILL_FAIL TRUE)

--- a/src/test/common/test_decode_start_v_checker.cpp
+++ b/src/test/common/test_decode_start_v_checker.cpp
@@ -1,0 +1,29 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "include/encoding.h"
+#include "include/denc.h"
+
+int main (void) {
+  ceph::buffer::list::const_iterator dummy;
+  DECODE_START(42, dummy);
+  if (struct_v >= 42)
+    /* OK */;
+#ifdef SHOULD_FAIL
+  if (struct_v >= 43)
+    /* NOK */;
+#endif
+  DECODE_FINISH(dummy);
+}


### PR DESCRIPTION
Typical problem found in recent reviews of dencoding changes is missed increment of the version number passed to `DECODE_START()` macro in a decoder.
It's easy to overlook and hard to find as the number is used for rarely happening explicit breaks of schema compatibility.

This commit brings compile-time checks for `struct_v` in decoders (and for `denc` also in encoders) to find a situation when it's compared against version higher than declared using the `DECODE_START(v, ...)` macro.

Additionally, the patch fixes the currently existing issues of this genre buried across the entire code base.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

--------------
The goldbot snippet is available [here](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:22,endLineNumber:10,positionColumn:22,positionLineNumber:10,selectionStartColumn:8,selectionStartLineNumber:10,startColumn:8,startLineNumber:10),source:'%23include+%3Ciostream%3E%0A%23include+%3Cstdexcept%3E%0A%23include+%3Ctype_traits%3E%0A%23include+%3Cstdint.h%3E%0A%0A%23define+consteval_assert(cond,+msg)+%5C%0A++if+(!!(cond))+%7B+throw+(msg)%3B+%7D%0A%0Atemplate+%3Cunsigned+MaxV%3E%0Astruct+VersionChecker%0A%7B%0A++struct+CheckingWrapper+%7B%0A++++consteval+CheckingWrapper(unsigned+c)+:+c(c)+%7B%0A++++++consteval_assert(%0A++++++++c+%3C%3D+MaxV,+%22checking+against+higher+version+than+declared+in+DECODE_START%22)%3B%0A++++%7D%0A++++unsigned+c%3B%0A++%7D%3B%0A++//+we+want+the+implicit+conversion+to+take+place+but+with+lower%0A++//+rank+than+the+CheckingWrapper-conversion+during+struct_v+cmps.%0A++template%3Cclass+T%3Dvoid%3E+operator+char()+%7B%0A++++return+v%3B%0A++%7D%0A%0A++//+need+the+wrapper+as+the+operator+cannot+be+consteval%3B+otherwise%0A++//+it+couldn!'t+have+accessed+the+non-constexpr+%60v%60.%0A++auto+operator%3C%3D%3E(CheckingWrapper+c)+const+%7B%0A++++return+v+%3C%3D%3E+c.c%3B%0A++%7D%0A++auto+operator%3D%3D(CheckingWrapper+c)+const+%7B%0A++++return+v+%3D%3D+c.c%3B%0A++%7D%0A++unsigned+v%3B%0A%7D%3B%0A%0A%23define+macro(v)+%5C%0A++VersionChecker%3Cv%3E+struct_v%7Bv%7D%0Aint+main(int+argc,+char**+argv)+%7B%0A++VersionChecker%3C42%3E+vc%3B%0A++std::cout+%3C%3C+(vc+%3C+41)+%3C%3C+std::endl%3B%0A++VersionChecker%3C41%3E+v%7B3%7D%3B%0A++if+(vc+%3C+43)+%7B%7D%0A++char+xxx%3B%0A++xxx+%3D+vc%3B%0A++char+yyy%7Bvc%7D%3B%0A++return+0%3B%0A%7D'),l:'5',n:'1',o:'C%2B%2B+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((g:!((h:compiler,i:(compiler:clang1910,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!(),options:'-std%3Dc%2B%2B20',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+x86-64+clang+19.1.0+(Editor+%231)',t:'0')),k:50,l:'4',m:50,n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(editorid:1,fontScale:14,fontUsePx:'0',j:1,wrap:'1'),l:'5',n:'0',o:'Output+of+x86-64+clang+19.1.0+(Compiler+%231)',t:'0')),header:(),l:'4',m:50,n:'0',o:'',s:0,t:'0')),k:50,l:'3',n:'0',o:'',t:'0')),l:'2',n:'0',o:'',t:'0')),version:4).

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
