### PR TITLE
include/ceph_assert: disable with NDEBUG

### DIFF
--- a/src/include/ceph_assert.h
+++ b/src/include/ceph_assert.h
@@ -92,7 +92,9 @@ using namespace ceph;
 #define ceph_abort_msgf(...)                                             \
   ::ceph::__ceph_abortf( __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, __VA_ARGS__)
 
-#ifdef __SANITIZE_ADDRESS__
+#ifdef NDEBUG
+#define ceph_assert(expr) do {} while (false)
+#elif defined(__SANITIZE_ADDRESS__)
 #define ceph_assert(expr)                           \
   do {                                              \
     ((expr))                                        \
@@ -109,7 +111,6 @@ using namespace ceph;
 #endif
 
 // this variant will *never* get compiled out to NDEBUG in the future.
-// (ceph_assert currently doesn't either, but in the future it might.)
 #ifdef __SANITIZE_ADDRESS__
 #define ceph_assert_always(expr)                    \
   do {                                              \
@@ -126,6 +127,10 @@ using namespace ceph;
     : ::ceph::__ceph_assert_fail(assert_data_ctx)); } while(false)
 #endif
 
+#ifdef NDEBUG
+#define assertf(expr, ...) do {} while (false)
+#define ceph_assertf(expr, ...) do {} while (false)
+#else
 // Named by analogy with printf.  Along with an expression, takes a format
 // string and parameters which are printed if the assertion fails.
 #define assertf(expr, ...)                  \
@@ -136,9 +141,9 @@ using namespace ceph;
   ((expr)								\
    ? _CEPH_ASSERT_VOID_CAST (0)					\
    : ::ceph::__ceph_assertf_fail (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION, __VA_ARGS__))
+#endif
 
 // this variant will *never* get compiled out to NDEBUG in the future.
-// (ceph_assertf currently doesn't either, but in the future it might.)
 #define ceph_assertf_always(expr, ...)                  \
   ((expr)								\
    ? _CEPH_ASSERT_VOID_CAST (0)					\


### PR DESCRIPTION
This makes ceph_assert() behave like the standard C assert() macro: in release builds (with `-DNDEBUG`), assertions should be compiled out, leaving no overhead.

This reduces the code size of `ceph-mds` (static build including `libceph-common`) by 550 kB.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
