### PR TITLE
reef: cls/user: reset stats only returns marker when truncated

### DIFF
--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -478,10 +478,6 @@ static int cls_user_reset_stats2(cls_method_context_t hctx,
     add_header_stats(&ret.acc_stats, e);
   }
 
-  /* try-update marker */
-  if(!keys.empty())
-    ret.marker = (--keys.cend())->first;
-
   if (! ret.truncated) {
     buffer::list bl;
     header.last_stats_update = op.time;
@@ -495,6 +491,10 @@ static int cls_user_reset_stats2(cls_method_context_t hctx,
     encode(ret, *out);
     return rc;
   }
+
+  /* try-update marker */
+  if(!keys.empty())
+    ret.marker = (--keys.cend())->first;
 
   /* return partial result */
   encode(ret, *out);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68426

---

backport of https://github.com/ceph/ceph/pull/59884
parent tracker: https://tracker.ceph.com/issues/51786

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh