### PR TITLE
exporter: New metric for report ceph daemons health

### DIFF
--- a/doc/monitoring/index.rst
+++ b/doc/monitoring/index.rst
@@ -64,6 +64,30 @@ in:
 
 It is good to outline that the main tool allowing users to observe and monitor a Ceph cluster is the **Ceph dashboard**. It provides graphics where the most important cluster and service metrics are represented. Most of the examples in this document are extracted from the dashboard graphics or extrapolated from the metrics exposed by the Ceph dashboard.
 
+Ceph daemon health metrics
+==========================
+
+The Ceph exporter provides a metric called ``ceph_daemon_socket_up`` that reports the liveness status of each Ceph daemon that exposes an admin socket.
+
+The ``ceph_daemon_socket_up`` metric indicates the health status of a Ceph daemon based on its ability to respond via the admin socket, where a value of ``1`` means healthy, and ``0`` means unhealthy. Although a Ceph daemon might still be "alive" when it reports ``ceph_daemon_socket_up=0``, this situation highlights a significant issue in its functionality. As such, this metric serves as an excellent tool for detecting problems in any of the main Ceph daemons.
+
+Labels:
+- **``ceph_daemon``**: Identifier of the Ceph daemon exposing an admin socket on the host.
+- **``hostname``**: Name of the host where the Ceph daemon is running.
+
+Example:
+
+.. code-block:: bash
+
+   ceph_daemon_socket_up{ceph_daemon="mds.a",hostname="testhost"} 1
+   ceph_daemon_socket_up{ceph_daemon="osd.1",hostname="testhost"} 0
+
+To identify any Ceph daemons that were not responsive at any point in the last 12 hours, you can use the following PromQL expression:
+
+.. code-block:: bash
+
+   ceph_daemon_socket_up == 0 or min_over_time(ceph_daemon_socket_up[12h]) == 0
+
 
 Performance metrics
 ===================

--- a/src/exporter/DaemonMetricCollector.cc
+++ b/src/exporter/DaemonMetricCollector.cc
@@ -168,10 +168,17 @@ void DaemonMetricCollector::dump_asok_metrics(bool sort_metrics, int64_t counter
     if (sockClientsPing) {
       bool ok;
       sock_client.ping(&ok);
+      std::string ceph_daemon_socket_up_desc(
+      "Reports the health status of a Ceph daemon, as determined by whether it is able to respond via its admin socket (1 = healthy, 0 = unhealthy).");
+      labels_t ceph_daemon_socket_up_labels;
+      ceph_daemon_socket_up_labels["hostname"] = quote(ceph_get_hostname());
+      ceph_daemon_socket_up_labels["ceph_daemon"] = quote(daemon_name);
+      add_metric(builder, static_cast<int>(ok), "ceph_daemon_socket_up", ceph_daemon_socket_up_desc,
+             "gauge", ceph_daemon_socket_up_labels);
       if (!ok) {
         failures++;
         continue;
-      } 
+      }
     }
     std::string counter_dump_response = dump_response.size() > 0 ? dump_response :
       asok_request(sock_client, "counter dump", daemon_name);

--- a/src/exporter/DaemonMetricCollector.h
+++ b/src/exporter/DaemonMetricCollector.h
@@ -42,11 +42,11 @@ public:
   std::map<std::string, AdminSocketClient> clients;
   std::string metrics;
   std::pair<labels_t, std::string> add_fixed_name_metrics(std::string metric_name);
+  void update_sockets();
 
 private:
   std::mutex metrics_mutex;
   std::unique_ptr<MetricsBuilder> builder;
-  void update_sockets();
   void request_loop(boost::asio::steady_timer &timer);
 
   void dump_asok_metric(boost::json::object perf_info,


### PR DESCRIPTION
Ceph exporter provide metrics to report ceph daemons communication health using
 the admin socket

Fixes: 
https://bugzilla.redhat.com/show_bug.cgi?id=2146728
https://tracker.ceph.com/issues/68428


**Evidences:**

**Manual tests:**
```
--> launch of ceph exporter
jolmomar:~/.../build/bin$ ./ceph-exporter -c /home/jolmomar/Code/ceph/build/ceph.conf --sock-dir /home/jolmomar/Code/ceph/build/asok

--> Verify daemons running:
jolmomar:~/.../build/bin$ ls -lrt /home/jolmomar/Code/ceph/build/asok
total 0
srwxr-xr-x 1 jolmomar jolmomar 0 oct  7 16:17 mon.a.asok
srwxr-xr-x 1 jolmomar jolmomar 0 oct  7 16:17 mon.b.asok
srwxr-xr-x 1 jolmomar jolmomar 0 oct  7 16:17 mon.c.asok
srwxr-xr-x 1 jolmomar jolmomar 0 oct  7 16:17 mgr.x.asok
srwxr-xr-x 1 jolmomar jolmomar 0 oct  7 16:17 client.admin.24910.asok
srwxr-xr-x 1 jolmomar jolmomar 0 oct  7 16:18 osd.0.asok
srwxr-xr-x 1 jolmomar jolmomar 0 oct  7 16:18 osd.1.asok
srwxr-xr-x 1 jolmomar jolmomar 0 oct  7 16:18 osd.2.asok
srwxr-xr-x 1 jolmomar jolmomar 0 oct  7 16:18 mds.a.asok
srwxr-xr-x 1 jolmomar jolmomar 0 oct  7 16:18 mds.b.asok
srwxr-xr-x 1 jolmomar jolmomar 0 oct  7 16:18 mds.c.asok
srwxr-xr-x 1 jolmomar jolmomar 0 oct  7 16:19 client.admin.29589.asok

--> Get "daemon_socket" metrics.(mgr, exporter, or clients sockets does not produce this metric)
jolmomar:~/.../build/bin$ curl http://localhost:9926/metrics  | grep socket
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

# HELP ceph_daemon_socket_up Reports the health status of a Ceph daemon, indicating if it is able to communicate through the admin socket (1 = healthy, 0 = unhealthy).
# TYPE ceph_daemon_socket_up gauge
ceph_daemon_socket_up{ceph_daemon="mds.a",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="mds.b",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="mds.c",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="mon.a",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="mon.b",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="mon.c",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="osd.0",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="osd.1",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="osd.2",hostname="testhost"} 1
100  192k  100  192k    0     0   232M      0 --:--:-- --:--:-- --:--:--  188M


-->  Kill OSD 1. To verify metric value change:
jolmomar:~/.../build/bin$ ps -ef | grep osd
jolmomar   25865    3408  3 16:18 ?        00:00:06 /home/jolmomar/Code/ceph/build/bin/ceph-osd -i 0 -c /home/jolmomar/Code/ceph/build/ceph.conf
jolmomar   27167    3408  3 16:18 ?        00:00:06 /home/jolmomar/Code/ceph/build/bin/ceph-osd -i 1 -c /home/jolmomar/Code/ceph/build/ceph.conf
jolmomar   28463    3408  3 16:18 ?        00:00:06 /home/jolmomar/Code/ceph/build/bin/ceph-osd -i 2 -c /home/jolmomar/Code/ceph/build/ceph.conf
jolmomar   30462   29689  0 16:21 pts/6    00:00:00 grep --color=auto osd

jolmomar:~/.../build/bin$ kill -9 27167
jolmomar:~/.../build/bin$ curl http://localhost:9926/metrics  | grep socket
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
# HELP ceph_daemon_socket_up Reports the health status of a Ceph daemon, indicating if it is able to communicate through the admin socket (1 = healthy, 0 = unhealthy).
# TYPE ceph_daemon_socket_up gauge
ceph_daemon_socket_up{ceph_daemon="mds.a",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="mds.b",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="mds.c",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="mon.a",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="mon.b",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="mon.c",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="osd.0",hostname="testhost"} 1
ceph_daemon_socket_up{ceph_daemon="osd.1",hostname="testhost"} 0
ceph_daemon_socket_up{ceph_daemon="osd.2",hostname="testhost"} 1
100  167k  100  167k    0     0   210M      0 --:--:-- --:--:-- --:--:--  163M
```

**Unit test run:**
```
jolmomar:~/.../ceph/build$ ctest -V -R exporter
UpdateCTestConfiguration  from :/home/jolmomar/Code/ceph/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/home/jolmomar/Code/ceph/build/DartConfiguration.tcl
Test project /home/jolmomar/Code/ceph/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 218
    Start 218: unittest_exporter

218: Test command: /home/jolmomar/Code/ceph/build/bin/unittest_exporter
218: Working Directory: /home/jolmomar/Code/ceph/build/src/test/exporter
218: Environment variables:
218:  CEPH_ROOT=/home/jolmomar/Code/ceph
218:  CEPH_BIN=/home/jolmomar/Code/ceph/build/bin
218:  CEPH_LIB=/home/jolmomar/Code/ceph/build/lib
218:  CEPH_BUILD_DIR=/home/jolmomar/Code/ceph/build
218:  LD_LIBRARY_PATH=/home/jolmomar/Code/ceph/build/lib
218:  PATH=/home/jolmomar/Code/ceph/build/bin:/home/jolmomar/Code/ceph/src:/home/jolmomar/.local/bin:/home/jolmomar/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/var/lib/snapd/snap/bin:/home/jolmomar/.local/share/JetBrains/Toolbox/scripts:/usr/local/go/bin:/home/jolmomar/.local/share/JetBrains/Toolbox/scripts:/usr/local/go/bin:/home/jolmomar/.local/share/JetBrains/Toolbox/scripts
218:  PYTHONPATH=/home/jolmomar/Code/ceph/build/lib/cython_modules/lib.3:/home/jolmomar/Code/ceph/src/pybind
218:  CEPH_BUILD_VIRTUALENV=/home/jolmomar/Code/ceph/build
218: Test timeout computed to be: 7200
218: did not load config file, using default settings.
218: 2024-10-07T16:16:32.567+0200 7f5c59f8f080 -1 Errors while parsing config file!
218: 2024-10-07T16:16:32.567+0200 7f5c59f8f080 -1 can't open ceph.conf: (2) No such file or directory
218: 2024-10-07T16:16:32.567+0200 7f5c59f8f080 -1 Errors while parsing config file!
218: 2024-10-07T16:16:32.567+0200 7f5c59f8f080 -1 can't open ceph.conf: (2) No such file or directory
218: [==========] Running 6 tests from 1 test suite.
218: [----------] Global test environment set-up.
218: [----------] 6 tests from Exporter
218: [ RUN      ] Exporter.promethize
218: [       OK ] Exporter.promethize (0 ms)
218: [ RUN      ] Exporter.check_labels_and_metric_name
218: [       OK ] Exporter.check_labels_and_metric_name (0 ms)
218: [ RUN      ] Exporter.dump_asok_metrics
218: Actual MON Metrics: # HELP ceph_exporter_scrape_time Time spent scraping and transforming perf counters to metrics
218: # TYPE ceph_exporter_scrape_time gauge
218: ceph_exporter_scrape_time{function="dump_asok_metrics",host="testhost"} 0.184762
218: # HELP ceph_mon_num_elections Elections participated in
218: # TYPE ceph_mon_num_elections counter
218: ceph_mon_num_elections{ceph_daemon="mon.a"} 2
218: # HELP ceph_mon_num_sessions Open sessions
218: # TYPE ceph_mon_num_sessions gauge
218: ceph_mon_num_sessions{ceph_daemon="mon.a"} 1
218: # HELP ceph_mon_session_add Created sessions
218: # TYPE ceph_mon_session_add counter
218: ceph_mon_session_add{ceph_daemon="mon.a"} 1
218: # HELP ceph_mon_session_rm Removed sessions
218: # TYPE ceph_mon_session_rm counter
218: ceph_mon_session_rm{ceph_daemon="mon.a"} 577
218: # HELP ceph_mon_session_trim Trimmed sessions
218: # TYPE ceph_mon_session_trim counter
218: ceph_mon_session_trim{ceph_daemon="mon.a"} 9
218:
218: [       OK ] Exporter.dump_asok_metrics (2 ms)
218: [ RUN      ] Exporter.add_fixed_name_metrics
218: [       OK ] Exporter.add_fixed_name_metrics (0 ms)
218: [ RUN      ] Exporter.UpdateSockets
218: [       OK ] Exporter.UpdateSockets (0 ms)
218: [ RUN      ] Exporter.HealthMetrics
218: 2024-10-07T16:16:32.570+0200 7f5c4fe006c0 -1 asok(0x5556ea990e10) AdminSocket: request '[{"prefix": "counter dump"}]' not defined
218: 2024-10-07T16:16:32.570+0200 7f5c59f8f080  1 command counter dumpfailed for daemon test_daemonwith error:
218: [       OK ] Exporter.HealthMetrics (1 ms)
218: [----------] 6 tests from Exporter (3 ms total)
218:
218: [----------] Global test environment tear-down
218: [==========] 6 tests from 1 test suite ran. (3 ms total)
218: [  PASSED  ] 6 tests.
1/1 Test #218: unittest_exporter ................   Passed    0.05 sec

The following tests passed:
	unittest_exporter

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.06 sec
```

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
