### PR TITLE
Optimize lock contention in the `Finisher` thread

### DIFF
--- a/src/common/Finisher.cc
+++ b/src/common/Finisher.cc
@@ -2,10 +2,37 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "Finisher.h"
+#include "common/perf_counters.h"
 
 #define dout_subsys ceph_subsys_finisher
 #undef dout_prefix
 #define dout_prefix *_dout << "finisher(" << this << ") "
+
+Finisher::Finisher(CephContext *cct_) :
+  cct(cct_), finisher_lock(ceph::make_mutex("Finisher::finisher_lock")),
+  thread_name("fn_anonymous"),
+  finisher_thread(this) {}
+
+Finisher::Finisher(CephContext *cct_, std::string name, std::string tn) :
+  cct(cct_), finisher_lock(ceph::make_mutex("Finisher::" + name)),
+  thread_name(tn),
+  finisher_thread(this) {
+  PerfCountersBuilder b(cct, std::string("finisher-") + name,
+			l_finisher_first, l_finisher_last);
+  b.add_u64(l_finisher_queue_len, "queue_len");
+  b.add_time_avg(l_finisher_complete_lat, "complete_latency");
+  logger = b.create_perf_counters();
+  cct->get_perfcounters_collection()->add(logger);
+  logger->set(l_finisher_queue_len, 0);
+  logger->set(l_finisher_complete_lat, 0);
+}
+
+Finisher::~Finisher() {
+  if (logger && cct) {
+    cct->get_perfcounters_collection()->remove(logger);
+    delete logger;
+  }
+}
 
 void Finisher::start()
 {

--- a/src/common/Finisher.cc
+++ b/src/common/Finisher.cc
@@ -4,6 +4,8 @@
 #include "Finisher.h"
 #include "common/perf_counters.h"
 
+#include <fmt/core.h>
+
 #define dout_subsys ceph_subsys_finisher
 #undef dout_prefix
 #define dout_prefix *_dout << "finisher(" << this << ") "
@@ -14,10 +16,10 @@ Finisher::Finisher(CephContext *cct_) :
   finisher_thread(this) {}
 
 Finisher::Finisher(CephContext *cct_, std::string name, std::string tn) :
-  cct(cct_), finisher_lock(ceph::make_mutex("Finisher::" + name)),
+  cct(cct_), finisher_lock(ceph::make_mutex(fmt::format("Finisher::{}", name))),
   thread_name(tn),
   finisher_thread(this) {
-  PerfCountersBuilder b(cct, std::string("finisher-") + name,
+  PerfCountersBuilder b(cct, fmt::format("finisher-{}", name),
 			l_finisher_first, l_finisher_last);
   b.add_u64(l_finisher_queue_len, "queue_len");
   b.add_time_avg(l_finisher_complete_lat, "complete_latency");

--- a/src/common/Finisher.cc
+++ b/src/common/Finisher.cc
@@ -20,7 +20,7 @@ void Finisher::stop()
   finisher_stop = true;
   // we don't have any new work to do, but we want the worker to wake up anyway
   // to process the stop condition.
-  finisher_cond.notify_all();
+  finisher_cond.notify_one();
   finisher_lock.unlock();
   finisher_thread.join(); // wait until the worker exits completely
   ldout(cct, 10) << __func__ << " finish" << dendl;

--- a/src/common/Finisher.cc
+++ b/src/common/Finisher.cc
@@ -40,7 +40,7 @@ void Finisher::wait_for_empty()
 
 bool Finisher::is_empty()
 {
-  std::unique_lock ul(finisher_lock);
+  const std::lock_guard l{finisher_lock};
   return finisher_queue.empty();
 }
 

--- a/src/common/Finisher.cc
+++ b/src/common/Finisher.cc
@@ -15,9 +15,9 @@ Finisher::Finisher(CephContext *cct_) :
   thread_name("fn_anonymous"),
   finisher_thread(this) {}
 
-Finisher::Finisher(CephContext *cct_, std::string name, std::string tn) :
+Finisher::Finisher(CephContext *cct_, std::string_view name, std::string &&tn) :
   cct(cct_), finisher_lock(ceph::make_mutex(fmt::format("Finisher::{}", name))),
-  thread_name(tn),
+  thread_name(std::move(tn)),
   finisher_thread(this) {
   PerfCountersBuilder b(cct, fmt::format("finisher-{}", name),
 			l_finisher_first, l_finisher_last);

--- a/src/common/Finisher.h
+++ b/src/common/Finisher.h
@@ -36,7 +36,7 @@ enum {
  * contexts to complete is thread-safe.
  */
 class Finisher {
-  CephContext *cct;
+  CephContext *const cct;
   ceph::mutex finisher_lock; ///< Protects access to queues and finisher_running.
   ceph::condition_variable finisher_cond; ///< Signaled when there is something to process.
   ceph::condition_variable finisher_empty_cond; ///< Signaled when the finisher has nothing more to process.
@@ -48,7 +48,7 @@ class Finisher {
   std::vector<std::pair<Context*,int>> finisher_queue;
   std::vector<std::pair<Context*,int>> in_progress_queue;
 
-  std::string thread_name;
+  const std::string thread_name;
 
   /// Performance counter for the finisher's queue length.
   /// Only active for named finishers.

--- a/src/common/Finisher.h
+++ b/src/common/Finisher.h
@@ -65,7 +65,7 @@ class Finisher {
  public:
   /// Add a context to complete, optionally specifying a parameter for the complete function.
   void queue(Context *c, int r = 0) {
-    std::unique_lock ul(finisher_lock);
+    const std::lock_guard l{finisher_lock};
     bool was_empty = finisher_queue.empty();
     finisher_queue.push_back(std::make_pair(c, r));
     if (was_empty) {
@@ -79,7 +79,7 @@ class Finisher {
   template<typename T>
   auto queue(T &ls) -> decltype(std::distance(ls.begin(), ls.end()), void()) {
     {
-      std::unique_lock ul(finisher_lock);
+      const std::lock_guard l{finisher_lock};
       if (finisher_queue.empty()) {
 	finisher_cond.notify_all();
       }

--- a/src/common/Finisher.h
+++ b/src/common/Finisher.h
@@ -83,11 +83,12 @@ class Finisher {
   auto queue(T &ls) -> decltype(std::distance(ls.begin(), ls.end()), void()) {
     {
       const std::lock_guard l{finisher_lock};
-      if (finisher_queue.empty() && !finisher_running) {
-	finisher_cond.notify_all();
-      }
+      const bool should_notify = finisher_queue.empty() && !finisher_running;
       for (Context *i : ls) {
 	finisher_queue.push_back(std::make_pair(i, 0));
+      }
+      if (should_notify) {
+	finisher_cond.notify_all();
       }
     }
     if (logger)

--- a/src/common/Finisher.h
+++ b/src/common/Finisher.h
@@ -113,6 +113,10 @@ class Finisher {
 
   bool is_empty();
 
+  std::string_view get_thread_name() const noexcept {
+    return thread_name;
+  }
+
   /// Construct an anonymous Finisher.
   /// Anonymous finishers do not log their queue length.
   explicit Finisher(CephContext *cct_);

--- a/src/common/Finisher.h
+++ b/src/common/Finisher.h
@@ -88,7 +88,7 @@ class Finisher {
 	finisher_queue.push_back(std::make_pair(i, 0));
       }
       if (should_notify) {
-	finisher_cond.notify_all();
+	finisher_cond.notify_one();
       }
     }
     if (logger)

--- a/src/common/Finisher.h
+++ b/src/common/Finisher.h
@@ -122,7 +122,7 @@ class Finisher {
   explicit Finisher(CephContext *cct_);
 
   /// Construct a named Finisher that logs its queue length.
-  Finisher(CephContext *cct_, std::string name, std::string tn);
+  Finisher(CephContext *cct_, std::string_view name, std::string &&tn);
   ~Finisher();
 };
 

--- a/src/mgr/ActivePyModule.h
+++ b/src/mgr/ActivePyModule.h
@@ -48,7 +48,6 @@ private:
 
   std::string m_command_perms;
   const MgrSession* m_session = nullptr;
-  std::string fin_thread_name;
 public:
   Finisher finisher; // per active module finisher to execute commands
 
@@ -56,8 +55,7 @@ public:
   ActivePyModule(const PyModuleRef &py_module_,
       LogChannelRef clog_)
     : PyModuleRunner(py_module_, clog_),
-      fin_thread_name(fmt::format("m-fin-{}", py_module->get_name()).substr(0,15)),
-      finisher(g_ceph_context, thread_name, fin_thread_name)
+      finisher(g_ceph_context, thread_name, fmt::format("m-fin-{}", py_module->get_name()).substr(0,15))
 
   {
   }
@@ -106,7 +104,7 @@ public:
 
   std::string_view get_fin_thread_name() const
   {
-    return fin_thread_name;
+    return finisher.get_thread_name();
   }
 
   bool is_authorized(const std::map<std::string, std::string>& arguments) const;

--- a/src/mgr/ActivePyModule.h
+++ b/src/mgr/ActivePyModule.h
@@ -27,6 +27,8 @@
 #include "PyModuleRunner.h"
 #include "PyModule.h"
 
+#include <fmt/core.h>
+
 #include <vector>
 #include <string>
 
@@ -54,7 +56,7 @@ public:
   ActivePyModule(const PyModuleRef &py_module_,
       LogChannelRef clog_)
     : PyModuleRunner(py_module_, clog_),
-      fin_thread_name(std::string("m-fin-" + py_module->get_name()).substr(0,15)),
+      fin_thread_name(fmt::format("m-fin-{}", py_module->get_name()).substr(0,15)),
       finisher(g_ceph_context, thread_name, fin_thread_name)
 
   {

--- a/src/mgr/ActivePyModule.h
+++ b/src/mgr/ActivePyModule.h
@@ -97,12 +97,12 @@ public:
     uri = str;
   }
 
-  std::string get_uri() const
+  std::string_view get_uri() const
   {
     return uri;
   }
 
-  std::string get_fin_thread_name() const
+  std::string_view get_fin_thread_name() const
   {
     return fin_thread_name;
   }

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -770,9 +770,9 @@ std::map<std::string, std::string> ActivePyModules::get_services() const
   std::map<std::string, std::string> result;
   std::lock_guard l(lock);
   for (const auto& [name, module] : modules) {
-    std::string svc_str = module->get_uri();
+    const std::string_view svc_str = module->get_uri();
     if (!svc_str.empty()) {
-      result[name] = svc_str;
+      result.emplace(name, svc_str);
     }
   }
 


### PR DESCRIPTION
Several patches which reduce lock contention and eliminate system calls in the `Finisher` thread, similar to what commit cc7ec3e18d1 did five years ago.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
