### PR TITLE
common/io_exerciser: Add version argument to callbacks in ceph_radios_io_sequence

### DIFF
--- a/src/common/io_exerciser/RadosIo.cc
+++ b/src/common/io_exerciser/RadosIo.cc
@@ -118,7 +118,8 @@ void RadosIo::applyIoOp(IoOp &op)
       op_info = std::make_shared<AsyncOpInfo>(0, op.length1);
       op_info->bl1 = db->generate_data(0, op.length1);
       op_info->wop.write_full(op_info->bl1);
-      auto create_cb = [this] (boost::system::error_code ec) {
+      auto create_cb = [this] (boost::system::error_code ec,
+                               version_t ver) {
         ceph_assert(ec == boost::system::errc::success);
         finish_io();
       };
@@ -132,7 +133,8 @@ void RadosIo::applyIoOp(IoOp &op)
       start_io();
       op_info = std::make_shared<AsyncOpInfo>();
       op_info->wop.remove();
-      auto remove_cb = [this] (boost::system::error_code ec) {
+      auto remove_cb = [this] (boost::system::error_code ec,
+                               version_t ver) {
         ceph_assert(ec == boost::system::errc::success);
         finish_io();
       };
@@ -148,7 +150,9 @@ void RadosIo::applyIoOp(IoOp &op)
       op_info->rop.read(op.offset1 * block_size,
                         op.length1 * block_size,
                         &op_info->bl1, nullptr);
-      auto read_cb = [this, op_info] (boost::system::error_code ec, bufferlist bl) {
+      auto read_cb = [this, op_info] (boost::system::error_code ec,
+                                      version_t ver,
+                                      bufferlist bl) {
         ceph_assert(ec == boost::system::errc::success);
         db->validate(op_info->bl1, op_info->offset1, op_info->length1);
         finish_io();
@@ -174,6 +178,7 @@ void RadosIo::applyIoOp(IoOp &op)
                     op.length2 * block_size,
                     &op_info->bl2, nullptr);
       auto read2_cb = [this, op_info] (boost::system::error_code ec,
+                                       version_t ver,
                                        bufferlist bl) {
         ceph_assert(ec == boost::system::errc::success);
         db->validate(op_info->bl1, op_info->offset1, op_info->length1);
@@ -202,6 +207,7 @@ void RadosIo::applyIoOp(IoOp &op)
                     op.length3 * block_size,
                     &op_info->bl3, nullptr);
       auto read3_cb = [this, op_info] (boost::system::error_code ec,
+                                       version_t ver,
                                        bufferlist bl) {
         ceph_assert(ec == boost::system::errc::success);
         db->validate(op_info->bl1, op_info->offset1, op_info->length1);
@@ -222,7 +228,8 @@ void RadosIo::applyIoOp(IoOp &op)
       op_info->bl1 = db->generate_data(op.offset1, op.length1);
 
       op_info->wop.write(op.offset1 * block_size, op_info->bl1);
-      auto write_cb = [this] (boost::system::error_code ec) {
+      auto write_cb = [this] (boost::system::error_code ec,
+                              version_t ver) {
         ceph_assert(ec == boost::system::errc::success);
         finish_io();
       };
@@ -241,7 +248,8 @@ void RadosIo::applyIoOp(IoOp &op)
       op_info->bl2 = db->generate_data(op.offset2, op.length2);
       op_info->wop.write(op.offset1 * block_size, op_info->bl1);
       op_info->wop.write(op.offset2 * block_size, op_info->bl2);
-      auto write2_cb = [this] (boost::system::error_code ec) {
+      auto write2_cb = [this] (boost::system::error_code ec,
+                               version_t ver) {
         ceph_assert(ec == boost::system::errc::success);
         finish_io();
       };
@@ -263,7 +271,8 @@ void RadosIo::applyIoOp(IoOp &op)
       op_info->wop.write(op.offset1 * block_size, op_info->bl1);
       op_info->wop.write(op.offset2 * block_size, op_info->bl2);
       op_info->wop.write(op.offset3 * block_size, op_info->bl3);
-      auto write3_cb = [this] (boost::system::error_code ec) {
+      auto write3_cb = [this] (boost::system::error_code ec,
+                               version_t ver) {
         ceph_assert(ec == boost::system::errc::success);
         finish_io();
       };


### PR DESCRIPTION
common/io_exerciser: Add version argument to callbacks in ceph_radios_io_sequence

Add new version that was missing from ceph_test_rados_io_sequence async_operate callbacks due to interface changes.
Fixes issue breaking compilation introduced in #59857, commit 54e0865cd6ed5242b6cc02a8b942c2527c77f244 (src/test/osd: create ceph_test_rados_io_sequence testing tool)

Signed-off-by: Jon Bailey <jonathan.bailey1@ibm.com>

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
