### PR TITLE
reef: OSD: PG stat is not synchronized between osds after deep-scrub

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3008,7 +3008,9 @@ void PeeringState::proc_primary_info(
   ceph_assert(!is_primary());
 
   update_history(oinfo.history);
-  if (!info.stats.stats_invalid && info.stats.stats.sum.num_scrub_errors) {
+  bool has_scrub_error = (!info.stats.stats_invalid && info.stats.stats.sum.num_scrub_errors);
+  info.stats = oinfo.stats;
+  if (has_scrub_error) {
     info.stats.stats.sum.num_scrub_errors = 0;
     info.stats.stats.sum.num_shallow_scrub_errors = 0;
     info.stats.stats.sum.num_deep_scrub_errors = 0;


### PR DESCRIPTION
pg stat are not synced between osds after deep-scrub. So if primary osd is killed, next primary osd has wrong stats. Reason behind it is PeeringState::proc_primary_info does not process or update any pg stats of secondary osds after deep-scrub.

backport tracker: https://tracker.ceph.com/issues/68440

--------
backport of [57582](https://github.com/ceph/ceph/pull/57582)
parent tracker: https://tracker.ceph.com/issues/66059
