### PR TITLE
quincy: mds: misc fixes for MDSAuthCaps code

### DIFF
--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -176,14 +176,29 @@ bool MDSCapMatch::match(std::string_view target_path,
 
 bool MDSCapMatch::match_path(std::string_view target_path) const
 {
-  if (path.length()) {
-    if (target_path.find(path) != 0)
+  string _path = path;
+  // drop any tailing /
+  while (_path.length() && _path[_path.length() - 1] == '/') {
+    _path = path.substr(0, _path.length() - 1);
+  }
+
+  if (_path.length()) {
+    if (target_path.find(_path) != 0)
       return false;
-    // if path doesn't already have a trailing /, make sure the target
-    // does so that path=/foo doesn't match target_path=/food
-    if (target_path.length() > path.length() &&
-	path[path.length()-1] != '/' &&
-	target_path[path.length()] != '/')
+    /* In case target_path.find(_path) == 0 && target_path.length() == _path.length():
+     *  path=/foo  _path=/foo target_path=/foo     --> match
+     *  path=/foo/ _path=/foo target_path=/foo     --> match
+     *
+     * In case target_path.find(_path) == 0 && target_path.length() > _path.length():
+     *  path=/foo/ _path=/foo target_path=/foo/    --> match
+     *  path=/foo  _path=/foo target_path=/foo/    --> match
+     *  path=/foo/ _path=/foo target_path=/foo/d   --> match
+     *  path=/foo  _path=/foo target_path=/food    --> mismatch
+     *
+     * All the other cases                         --> mismatch
+     */
+    if (target_path.length() > _path.length() &&
+	target_path[_path.length()] != '/')
       return false;
   }
 

--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -154,7 +154,7 @@ bool MDSCapMatch::match(std::string_view target_path,
       bool gid_matched = false;
       if (std::find(gids.begin(), gids.end(), caller_gid) != gids.end())
 	gid_matched = true;
-      if (caller_gid_list) {
+      else if (caller_gid_list) {
 	for (auto i = caller_gid_list->begin(); i != caller_gid_list->end(); ++i) {
 	  if (std::find(gids.begin(), gids.end(), *i) != gids.end()) {
 	    gid_matched = true;

--- a/src/test/libcephfs/access.cc
+++ b/src/test/libcephfs/access.cc
@@ -111,7 +111,9 @@ TEST(AccessTest, Foo) {
 
 TEST(AccessTest, Path) {
   string good = get_unique_dir();
+  string good_slash = get_unique_dir("good_slash") + "/";
   string bad = get_unique_dir();
+>>>>>>> 516b0999f5b (test/libcephfs: add test case for slash tailing path for access)
   string user = "libcephfs_path_test." + stringify(rand());
   struct ceph_mount_info *admin;
   ASSERT_EQ(0, ceph_create(&admin, NULL));
@@ -119,10 +121,14 @@ TEST(AccessTest, Path) {
   ASSERT_EQ(0, ceph_conf_parse_env(admin, NULL));
   ASSERT_EQ(0, ceph_mount(admin, "/"));
   ASSERT_EQ(0, ceph_mkdir(admin, good.c_str(), 0755));
+  ASSERT_EQ(0, ceph_mkdir(admin, good_slash.c_str(), 0755));
   ASSERT_EQ(0, ceph_mkdir(admin, string(good + "/p").c_str(), 0755));
+  ASSERT_EQ(0, ceph_mkdir(admin, string(good_slash + "/p").c_str(), 0755));
   ASSERT_EQ(0, ceph_mkdir(admin, bad.c_str(), 0755));
   ASSERT_EQ(0, ceph_mkdir(admin, string(bad + "/p").c_str(), 0755));
   int fd = ceph_open(admin, string(good + "/q").c_str(), O_CREAT|O_WRONLY, 0755);
+  ceph_close(admin, fd);
+  fd = ceph_open(admin, string(good_slash + "/q").c_str(), O_CREAT|O_WRONLY, 0755);
   ceph_close(admin, fd);
   fd = ceph_open(admin, string(bad + "/q").c_str(), O_CREAT|O_WRONLY, 0755);
   ceph_close(admin, fd);
@@ -134,7 +140,7 @@ TEST(AccessTest, Path) {
   ASSERT_EQ(0, do_mon_command(
       "{\"prefix\": \"auth get-or-create\", \"entity\": \"client." + user + "\", "
       "\"caps\": [\"mon\", \"allow r\", \"osd\", \"allow rwx\", "
-      "\"mds\", \"allow r, allow rw path=" + good + "\""
+      "\"mds\", \"allow r, allow rw path=" + good + ", allow rw path=" + good_slash + "\""
       "], \"format\": \"json\"}", &key));
 
   struct ceph_mount_info *cmount;
@@ -154,6 +160,16 @@ TEST(AccessTest, Path) {
   ceph_close(cmount, fd);
   ASSERT_GE(ceph_unlink(cmount, string(good + "/y").c_str()), 0);
   ASSERT_GE(ceph_rmdir(cmount, string(good + "/x").c_str()), 0);
+
+  ASSERT_GE(ceph_mkdir(cmount, string(good_slash + "/x").c_str(), 0755), 0);
+  ASSERT_GE(ceph_rmdir(cmount, string(good_slash + "/p").c_str()), 0);
+  ASSERT_GE(ceph_unlink(cmount, string(good_slash + "/q").c_str()), 0);
+  fd = ceph_open(cmount, string(good_slash + "/y").c_str(), O_CREAT|O_WRONLY, 0755);
+  ASSERT_GE(fd, 0);
+  ceph_write(cmount, fd, "bar", 3, 0);
+  ceph_close(cmount, fd);
+  ASSERT_GE(ceph_unlink(cmount, string(good_slash + "/y").c_str()), 0);
+  ASSERT_GE(ceph_rmdir(cmount, string(good_slash + "/x").c_str()), 0);
 
   fd = ceph_open(cmount, string(bad + "/z").c_str(), O_RDONLY, 0644);
   ASSERT_GE(fd, 0);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68454

---

backport of https://github.com/ceph/ceph/pull/54381
parent tracker: https://tracker.ceph.com/issues/68453

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh