### PR TITLE
CMakeLists.txt: do not compile {Objecter,Striper}.cc twice

### DIFF
--- a/src/osdc/CMakeLists.txt
+++ b/src/osdc/CMakeLists.txt
@@ -1,9 +1,8 @@
 set(osdc_files
   Filer.cc
   ObjectCacher.cc
-  Objecter.cc
-  error_code.cc
-  Striper.cc)
+  error_code.cc)
+# Objecter.cc and Striper.cc are part of libcommon
 add_library(osdc STATIC ${osdc_files})
 target_link_libraries(osdc ceph-common)
 if(WITH_EVENTTRACE)


### PR DESCRIPTION
Was part of https://github.com/ceph/ceph/pull/60175 (split upon @batrick's request)

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
