### PR TITLE
msg: Optimize receive buffering

### DIFF
--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -54,7 +54,7 @@ class AsyncConnection : public Connection {
   ssize_t read(unsigned len, char *buffer,
                std::function<void(char *, ssize_t)> callback);
   ssize_t read_until(unsigned needed, char *p);
-  ssize_t read_bulk(std::span<char> dest);
+  ssize_t read_bulk(std::span<const std::span<char>> dest);
 
   ssize_t write(ceph::buffer::list &bl, std::function<void(ssize_t)> callback,
                 bool more=false);

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -187,6 +187,13 @@ private:
   ceph::buffer::list outgoing_bl;
   bool open_write = false;
 
+  /**
+   * True when we know that the kernel's socket receive buffer has run
+   * empty.  Until we get a notification from the kernel, we skip all
+   * further read calls.
+   */
+  bool skip_read = false;
+
   std::mutex write_lock;
 
   std::mutex lock;

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -54,7 +54,7 @@ class AsyncConnection : public Connection {
   ssize_t read(unsigned len, char *buffer,
                std::function<void(char *, ssize_t)> callback);
   ssize_t read_until(unsigned needed, char *p);
-  ssize_t read_bulk(char *buf, unsigned len);
+  ssize_t read_bulk(std::span<char> dest);
 
   ssize_t write(ceph::buffer::list &bl, std::function<void(ssize_t)> callback,
                 bool more=false);

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -64,11 +64,7 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
   }
 
   ssize_t read(char *buf, size_t len) override {
-    #ifdef _WIN32
     ssize_t r = ::recv(_fd, buf, len, 0);
-    #else
-    ssize_t r = ::read(_fd, buf, len);
-    #endif
     if (r < 0)
       r = -ceph_sock_errno();
     return r;

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -262,8 +262,7 @@ int PosixServerSocketImpl::accept(ConnectedSocket *sock, const SocketOptions &op
   out->set_sockaddr((sockaddr*)&ss);
   handler.set_priority(sd, opt.priority, out->get_family());
 
-  std::unique_ptr<PosixConnectedSocketImpl> csi(new PosixConnectedSocketImpl(handler, *out, sd, true));
-  *sock = ConnectedSocket(std::move(csi));
+  *sock = ConnectedSocket(std::make_unique<PosixConnectedSocketImpl>(handler, *out, sd, true));
   return 0;
 }
 
@@ -311,8 +310,7 @@ int PosixWorker::listen(entity_addr_t &sa,
   }
 
   *sock = ServerSocket(
-          std::unique_ptr<PosixServerSocketImpl>(
-	    new PosixServerSocketImpl(net, listen_sd, sa, addr_slot)));
+          std::make_unique<PosixServerSocketImpl>(net, listen_sd, sa, addr_slot));
   return 0;
 }
 
@@ -331,7 +329,7 @@ int PosixWorker::connect(const entity_addr_t &addr, const SocketOptions &opts, C
 
   net.set_priority(sd, opts.priority, addr.get_family());
   *socket = ConnectedSocket(
-      std::unique_ptr<PosixConnectedSocketImpl>(new PosixConnectedSocketImpl(net, addr, sd, !opts.nonblock)));
+      std::make_unique<PosixConnectedSocketImpl>(net, addr, sd, !opts.nonblock));
   return 0;
 }
 

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -63,8 +63,8 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
     }
   }
 
-  ssize_t read(char *buf, size_t len) override {
-    ssize_t r = ::recv(_fd, buf, len, 0);
+  ssize_t read(const std::span<char> dest) override {
+    ssize_t r = ::recv(_fd, dest.data(), dest.size(), 0);
     if (r < 0)
       r = -ceph_sock_errno();
     return r;

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -33,6 +33,7 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
+#include <span>
 #include <string>
 
 class Worker;
@@ -40,7 +41,7 @@ class ConnectedSocketImpl {
  public:
   virtual ~ConnectedSocketImpl() {}
   virtual int is_connected() = 0;
-  virtual ssize_t read(char*, size_t) = 0;
+  virtual ssize_t read(std::span<char> dest) = 0;
   virtual ssize_t send(ceph::buffer::list &bl, bool more) = 0;
   virtual void shutdown() = 0;
   virtual void close() = 0;
@@ -104,8 +105,8 @@ class ConnectedSocket {
   /// Read the input stream with copy.
   ///
   /// Copy an object returning data sent from the remote endpoint.
-  ssize_t read(char* buf, size_t len) {
-    return _csi->read(buf, len);
+  ssize_t read(std::span<char> buffer) {
+    return _csi->read(buffer);
   }
   /// Gets the output stream.
   ///

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -42,6 +42,7 @@ class ConnectedSocketImpl {
   virtual ~ConnectedSocketImpl() {}
   virtual int is_connected() = 0;
   virtual ssize_t read(std::span<char> dest) = 0;
+  virtual ssize_t readv(std::span<const std::span<char>> dest);
   virtual ssize_t send(ceph::buffer::list &bl, bool more) = 0;
   virtual void shutdown() = 0;
   virtual void close() = 0;
@@ -107,6 +108,14 @@ class ConnectedSocket {
   /// Copy an object returning data sent from the remote endpoint.
   ssize_t read(std::span<char> buffer) {
     return _csi->read(buffer);
+  }
+  /// Read the input stream with copy.
+  ///
+  /// Copy an object returning data sent from the remote endpoint.
+  //
+  // This is the scatter-gather version of read().
+  ssize_t readv(std::span<const std::span<char>> dest) {
+    return _csi->readv(dest);
   }
   /// Gets the output stream.
   ///

--- a/src/msg/async/dpdk/DPDKStack.h
+++ b/src/msg/async/dpdk/DPDKStack.h
@@ -68,7 +68,9 @@ class NativeConnectedSocketImpl : public ConnectedSocketImpl {
     return _conn.is_connected();
   }
 
-  virtual ssize_t read(char *buf, size_t len) override {
+  virtual ssize_t read(std::span<char> dest) override {
+    char *const buf = dest.data();
+    const size_t len = dest.size();
     size_t left = len;
     ssize_t r = 0;
     size_t off = 0;

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -246,7 +246,7 @@ void RDMAConnectedSocketImpl::handle_connection() {
   }
 }
 
-ssize_t RDMAConnectedSocketImpl::read(char* buf, size_t len)
+ssize_t RDMAConnectedSocketImpl::read(std::span<char> dest)
 {
   eventfd_t event_val = 0;
   int r = eventfd_read(notify_fd, &event_val);
@@ -254,16 +254,16 @@ ssize_t RDMAConnectedSocketImpl::read(char* buf, size_t len)
                  << " r = " << r << dendl;
 
   if (!active) {
-    ldout(cct, 1) << __func__ << " when ib not active. len: " << len << dendl;
+    ldout(cct, 1) << __func__ << " when ib not active. len: " << dest.size() << dendl;
     return -EAGAIN;
   }
 
   if (0 == connected) {
-    ldout(cct, 1) << __func__ << " when ib not connected. len: " << len <<dendl;
+    ldout(cct, 1) << __func__ << " when ib not connected. len: " << dest.size() <<dendl;
     return -EAGAIN;
   }
   ssize_t read = 0;
-  read = read_buffers(buf,len);
+  read = read_buffers(dest.data(), dest.size());
 
   if (is_server && connected == 0) {
     ldout(cct, 20) << __func__ << " we do not need last handshake, QP: " << local_qpn << " peer QP: " << peer_qpn << dendl;

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -214,7 +214,7 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
   void get_wc(std::vector<ibv_wc> &w);
   virtual int is_connected() override { return connected; }
 
-  virtual ssize_t read(char* buf, size_t len) override;
+  virtual ssize_t read(std::span<char> dest) override;
   virtual ssize_t send(ceph::buffer::list &bl, bool more) override;
   virtual void shutdown() override;
   virtual void close() override;

--- a/src/test/msgr/test_async_networkstack.cc
+++ b/src/test/msgr/test_async_networkstack.cc
@@ -233,10 +233,10 @@ TEST_P(NetworkWorkerTest, SimpleTest) {
     if (is_my_accept) {
       center->create_file_event(srv_socket.fd(), EVENT_READABLE, &cb);
       {
-        r = srv_socket.read(buf, sizeof(buf));
+        r = srv_socket.read(buf);
         while (r == -EAGAIN) {
           ASSERT_TRUE(cb.poll(500));
-          r = srv_socket.read(buf, sizeof(buf));
+          r = srv_socket.read(buf);
           cb.reset();
         }
         ASSERT_EQ(len, r);
@@ -258,11 +258,11 @@ TEST_P(NetworkWorkerTest, SimpleTest) {
     if (is_my_accept) {
       cb.reset();
       ASSERT_TRUE(cb.poll(500));
-      r = srv_socket.read(buf, sizeof(buf));
+      r = srv_socket.read(buf);
       if (r == -EAGAIN) {
         cb.reset();
         ASSERT_TRUE(cb.poll(1000*500));
-        r = srv_socket.read(buf, sizeof(buf));
+        r = srv_socket.read(buf);
       }
       ASSERT_EQ(0, r);
       center->delete_file_event(srv_socket.fd(), EVENT_READABLE);
@@ -384,7 +384,7 @@ TEST_P(NetworkWorkerTest, AcceptAndCloseTest) {
         int i = 3;
         while (!i--) {
           ASSERT_TRUE(cb.poll(500));
-          r = cli_socket.read(buf, sizeof(buf));
+          r = cli_socket.read(buf);
           if (r == 0)
             break;
         }
@@ -541,7 +541,7 @@ TEST_P(NetworkWorkerTest, ComplexTest) {
       if (srv_socket) {
         char buf[1000];
         if (len > 0) {
-          r = srv_socket.read(buf, sizeof(buf));
+          r = srv_socket.read(buf);
           ASSERT_TRUE(r > 0 || r == -EAGAIN);
           if (r > 0) {
             read_string.append(buf, r);
@@ -729,8 +729,8 @@ class StressFactory {
         buffer.resize(m->len);
       bool must_no = false;
       while (true) {
-        r = socket.read((char*)buffer.data() + read_offset,
-                        m->len - read_offset);
+        r = socket.read({(char*)buffer.data() + read_offset,
+                         m->len - read_offset});
         ASSERT_TRUE(r == -EAGAIN || r > 0);
         if (r == -EAGAIN)
           break;
@@ -852,7 +852,7 @@ class StressFactory {
       while (true) {
         char buf[4096];
         bufferptr data;
-        r = socket.read(buf, sizeof(buf));
+        r = socket.read(buf);
         ASSERT_TRUE(r == -EAGAIN || (r >= 0 && (size_t)r <= sizeof(buf)));
         if (r == 0) {
           ASSERT_TRUE(buffers.empty());


### PR DESCRIPTION
This is one of the bigger optimization that led to a 2x increase in MDS performance. I added a wrapper for scatter-gather `recvmsg()` and use it to fill both the caller-provided buffer and the internal receive buffer with one single system call. This eliminates lots of follow-up `recv()` system calls and thus reduces system call overhead.

More similar optimizations to come.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
