### PR TITLE
cephadm/smb: Add NET_RAW capability to deploy ctdbd

### DIFF
--- a/src/cephadm/cephadmlib/daemons/smb.py
+++ b/src/cephadm/cephadmlib/daemons/smb.py
@@ -370,6 +370,8 @@ class CTDBDaemonContainer(SambaContainerCommon):
         # make conditional?
         # CAP_NET_ADMIN is needed for event script to add public ips to iface
         cargs.append('--cap-add=NET_ADMIN')
+        # CAP_NET_RAW allows to send gratuitous ARPs/tickle ACKs via raw sockets
+        cargs.append('--cap-add=NET_RAW')
         return cargs
 
 


### PR DESCRIPTION
CTDB heavily depends on raw sockets to send [gratuitous ARPs](https://wiki.wireshark.org/Gratuitous_ARP)(see the second point from the list of reasons to use gratuitous ARPs). As per the current design it is also inevitable while sending [tickle ACKs](https://ctdb.samba.org/manpages/ctdb.1.html) in the event of an IP failover. man [capabilities(7)](https://www.man7.org/linux/man-pages/man7/capabilities.7.html) further mandates `CAP_NET_RAW` to use raw sockets. Therefore append `NET_RAW` to the list of capabilities while deploying _ctdbd_ containers.