### PR TITLE
erasure-code: Increase SIMD_ALIGN from 32 to 64

### DIFF
--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -39,7 +39,7 @@ using std::vector;
 using ceph::bufferlist;
 
 namespace ceph {
-const unsigned ErasureCode::SIMD_ALIGN = 32;
+const unsigned ErasureCode::SIMD_ALIGN = 64;
 
 int ErasureCode::init(
   ErasureCodeProfile &profile,

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1620,7 +1620,7 @@ TEST(BufferList, contents_equal) {
 }
 
 TEST(BufferList, is_aligned) {
-  const int SIMD_ALIGN = 32;
+  const int SIMD_ALIGN = 64;
   {
     bufferlist bl;
     EXPECT_TRUE(bl.is_aligned(SIMD_ALIGN));
@@ -1648,7 +1648,7 @@ TEST(BufferList, is_aligned) {
 }
 
 TEST(BufferList, is_n_align_sized) {
-  const int SIMD_ALIGN = 32;
+  const int SIMD_ALIGN = 64;
   {
     bufferlist bl;
     EXPECT_TRUE(bl.is_n_align_sized(SIMD_ALIGN));
@@ -1792,7 +1792,7 @@ TEST(BufferList, page_aligned_appender) {
 }
 
 TEST(BufferList, rebuild_aligned_size_and_memory) {
-  const unsigned SIMD_ALIGN = 32;
+  const unsigned SIMD_ALIGN = 64;
   const unsigned BUFFER_SIZE = 67;
 
   bufferlist bl;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/61573

We want the buffers used for erasure coding to be 64-byte aligned. This should ensure that they fit a single 64 byte cache line for AVX512 instructions. If the buffers are misaligned then we can see a reduction in performance as the CPU has to do extra loads from memory.

The testing in the tracker does show a performance gain using 64-byte alignment. I wasn't able to see any improvement in my own testing, but this could be down to the CPU I used (Xeon Gold 6336Y).

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
