### PR TITLE
include: interval_set: Relax requirements and enhance performance of interval sets

### DIFF
--- a/src/common/interval_map.h
+++ b/src/common/interval_map.h
@@ -277,7 +277,7 @@ public:
   const_iterator get_lower_range(
       K off,
       K len) const {
-    return const_iterator(get_range_fst(off, len));
+    return const_iterator(get_range_fst(off));
   }
   K get_start_off() const
   {
@@ -292,7 +292,7 @@ public:
     return i->first + i->second.first;
   }
   bool contains(K off, K len) const {
-    auto it = get_range_fst(off, len);
+    auto it = get_range_fst(off);
     if (it == m.end()) return false;
 
     K _off = it->first;

--- a/src/common/interval_map.h
+++ b/src/common/interval_map.h
@@ -61,6 +61,16 @@ class interval_map {
     auto lst = m.lower_bound(off + len);
     return std::make_pair(fst, lst);
   }
+  cmapiter get_range_fst(K off) const {
+    // fst is first iterator with end after off (may be end)
+    auto fst = m.upper_bound(off);
+    if (fst != m.begin())
+      --fst;
+    if (fst != m.end() && off >= (fst->first + fst->second.first))
+      ++fst;
+
+    return fst;
+  }
   void try_merge(mapiter niter) {
     if (niter != m.begin()) {
       auto prev = niter;
@@ -257,6 +267,32 @@ public:
     K len) const {
     auto rng = get_range(off, len);
     return std::make_pair(const_iterator(rng.first), const_iterator(rng.second));
+  }
+
+  const_iterator get_lower_range(
+      K off,
+      K len) const {
+    return const_iterator(get_range_fst(off, len));
+  }
+  K get_start_off() const
+  {
+    auto i = m.begin();
+    ceph_assert(i != m.end());
+    return i->first;
+  }
+  K get_end_off() const
+  {
+    auto i = m.rbegin();
+    ceph_assert(i != m.rend());
+    return i->first + i->second.first;
+  }
+  bool contains(K off, K len) const {
+    auto it = get_range_fst(off, len);
+    if (it == m.end()) return false;
+
+    K _off = it->first;
+    K _len = it->second.first;
+    return _off <= off && _off + _len >= off + len;
   }
   unsigned ext_count() const {
     return m.size();

--- a/src/common/interval_map.h
+++ b/src/common/interval_map.h
@@ -51,11 +51,7 @@ class interval_map {
   }
   std::pair<cmapiter, cmapiter> get_range(K off, K len) const {
     // fst is first iterator with end after off (may be end)
-    auto fst = m.upper_bound(off);
-    if (fst != m.begin())
-      --fst;
-    if (fst != m.end() && off >= (fst->first + fst->second.first))
-      ++fst;
+    auto fst = get_range_fst(off);
 
     // lst is first iterator with start after off + len (may be end)
     auto lst = m.lower_bound(off + len);
@@ -258,7 +254,7 @@ public:
     constexpr bool contains(K _off, K _len) const {
       K off = get_off();
       K len = get_len();
-      return off <= _off && off + len >= _off + _len;
+      return off <= _off && _off + _len <= off + len;
     }
   };
   const_iterator begin() const {

--- a/src/common/interval_map.h
+++ b/src/common/interval_map.h
@@ -255,6 +255,11 @@ public:
     const_iterator &operator*() {
       return *this;
     }
+    constexpr bool contains(K _off, K _len) const {
+      K off = get_off();
+      K len = get_len();
+      return off <= _off && off + len >= _off + _len;
+    }
   };
   const_iterator begin() const {
     return const_iterator(m.begin());

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -440,6 +440,11 @@ class interval_set {
     if (p->first+p->second < start+len) return false;
     return true;
   }
+  bool contains(interval_set const &other) const {
+    interval_set tmp;
+    tmp.intersection_of(*this, other);
+    return tmp == other;
+  }
   bool intersects(T start, T len) const {
     interval_set a;
     a.insert(start, len);

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -827,6 +827,20 @@ class interval_set {
     return std::move(m);
   }
 
+  /*
+  * Round down interval starts and round up interval ends alignment the specified @alignment
+  */
+  void align(T alignment) {
+    interval_set tmp;
+    for (const auto& [start, len] : m) {
+      T aligned_start = (start / alignment) * alignment;
+      T aligned_len = ((start + len + alignment - 1) / alignment) * alignment - aligned_start;
+
+      tmp.insert(aligned_start, aligned_len);
+    }
+    swap(tmp);
+  }
+
 private:
   // data
   uint64_t _size = 0;

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -493,13 +493,13 @@ class interval_set {
     insert(val, 1);
   }
 
-  /** This insert method adds an interval into the interval map, with some
-   * caveats and restrictions. Inserts must be new interval or append to
-   * an existing interval. Adding an unsupported interval will result in an
-   * assert firing.
+  /** This insert function adds an interval into the interval map, for cases
+   * where intervals are required to never overlap. Inserts must be a new
+   * interval or append to an existing interval. Adding an interval which
+   * intersects with an existing interval will result in an assert firing.
    *
-   * NOTE: Unless you need the asserts/policing provided by this function,
-   *       you are likely better off with union_insert().
+   * NOTE: Unless you need the policing provided by this function, you are
+   *       probably better off with union_insert().
    *
    * @param start - the offset at the start of the interval
    * @param len - the length of the interval being added.
@@ -573,13 +573,10 @@ class interval_set {
     //cout << "insert " << start << "~" << len << endl;
     T new_len = len;
     auto p = find_adj_m(start);
-    auto o = std::pair(start, len);
     T end = start + len;
 
     if(len == 0) {
-      if (p != m.end() && start >= p->first && start < p->first + p->second) {
-        o = *p;
-      }
+      //No-op
     } else if (p == m.end()) {
       m[start] = len;                  // new interval
     } else {
@@ -599,8 +596,6 @@ class interval_set {
           new_len = new_len - std::min(a, b);
           p->second += n->second - std::min(a, b);
         }
-
-        o = *p;
       } else {
         T old_len = 0;
         T new_end = end;
@@ -609,8 +604,8 @@ class interval_set {
           new_end = std::max(pend, end);
           old_len = old_len + p->second;
         }
-        m[start] = o.second = new_end - start;
-        new_len = o.second - old_len;
+        m[start] = new_end - start;
+        new_len = new_end - start - old_len;
       }
     }
 

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -498,7 +498,7 @@ class interval_set {
     T new_len = len;
     auto p = find_adj_m(start);
     auto o = std::pair(start, len);
-    T end = start+len;
+    T end = start + len;
 
     if(len == 0) {
       if (p != m.end() && start >= p->first && start < p->first + p->second) {
@@ -828,7 +828,7 @@ class interval_set {
   }
 
   /*
-  * Round down interval starts and round up interval ends alignment the specified @alignment
+  * Round down interval starts and round up interval ends to specified alignment.
   */
   void align(T alignment) {
     interval_set tmp;

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -495,58 +495,55 @@ class interval_set {
 
   void insert(T start, T len, T *pstart=0, T *plen=0) {
     //cout << "insert " << start << "~" << len << endl;
-    ceph_assert(len > 0);
-    _size += len;
+    T new_len = len;
     auto p = find_adj_m(start);
-    if (p == m.end()) {
+    auto o = std::pair(start, len);
+    T end = start+len;
+
+    if(len == 0) {
+      if (p != m.end() && start >= p->first && start < p->first + p->second) {
+        o = *p;
+      }
+    } else if (p == m.end()) {
       m[start] = len;                  // new interval
-      if (pstart)
-	*pstart = start;
-      if (plen)
-	*plen = len;
     } else {
       if (p->first < start) {
-        
-        if (p->first + p->second != start) {
-          //cout << "p is " << p->first << "~" << p->second << ", start is " << start << ", len is " << len << endl;
-          ceph_abort();
-        }
-        
-        p->second += len;               // append to end
-        
+        T pend = p->first + p->second;
+        new_len = new_len - (std::min(pend, end) - start); // Remove the overlap
+        p->second = std::max(pend, end) - p->first; // Adjust existing
+
+        // Some usages of interval_set do not implement the + operator.
         auto n = p;
         ++n;
-	if (pstart)
-	  *pstart = p->first;
-        if (n != m.end() && 
-            start+len == n->first) {   // combine with next, too!
-          p->second += n->second;
-	  if (plen)
-	    *plen = p->second;
-          m.erase(n);
-        } else {
-	  if (plen)
-	    *plen = p->second;
-	}
-      } else {
-        if (start+len == p->first) {
-	  if (pstart)
-	    *pstart = start;
-	  if (plen)
-	    *plen = len + p->second;
-	  T psecond = p->second;
-          m.erase(p);
-          m[start] = len + psecond;  // append to front
-        } else {
-          ceph_assert(p->first > start+len);
-	  if (pstart)
-	    *pstart = start;
-	  if (plen)
-	    *plen = len;
-          m[start] = len;              // new interval
+        for (; n != m.end() && end >= n->first; n = m.erase(n)) {
+          // The follow is split out to avoid template issues.
+          // This adds the part of n which is not overlapping with the insert.
+          T a = n->second;
+          T b = end - n->first;
+          new_len = new_len - std::min(a, b);
+          p->second += n->second - std::min(a, b);
         }
+
+        o = *p;
+      } else {
+        T old_len = 0;
+        T new_end = end;
+        for (;p != m.end() && end >= p->first; p = m.erase(p)) {
+          T pend = p->first + p->second;
+          new_end = std::max(pend, end);
+          old_len = old_len + p->second;
+        }
+        m[start] = o.second = new_end - start;
+        new_len = o.second - old_len;
       }
     }
+
+    _size += new_len;
+
+    if (pstart)
+      *pstart = o.first;
+    if (plen)
+      *plen = o.second;
   }
 
   void swap(interval_set& other) {
@@ -677,31 +674,17 @@ class interval_set {
     ceph_assert(&a != this);
     ceph_assert(&b != this);
     clear();
-    
-    //cout << "union_of" << endl;
 
-    // a
-    m = a.m;
-    _size = a._size;
-
-    // - (a*b)
-    interval_set ab;
-    ab.intersection_of(a, b);
-    subtract(ab);
-
-    // + b
+    insert(a);
     insert(b);
-    return;
   }
+
   void union_of(const interval_set &b) {
-    interval_set a;
-    swap(a);    
-    union_of(a, b);
+    insert(b);
   }
   void union_insert(T off, T len) {
-    interval_set a;
-    a.insert(off, len);
-    union_of(a);
+    // insert supports overlapping entries. This function is redundant.
+    insert(off, len);
   }
 
   bool subset_of(const interval_set &big) const {

--- a/src/test/common/test_interval_map.cc
+++ b/src/test/common/test_interval_map.cc
@@ -335,3 +335,40 @@ TYPED_TEST(IntervalMapTest, merge) {
   m.insert(10, 4, gen(4));
   m.insert(11, 1, gen(1));
 }
+
+TYPED_TEST(IntervalMapTest, contains) {
+  USING_WITH_MERGE;
+  imap m;
+  m.insert(10, 4, gen(4));
+
+  ASSERT_TRUE(m.begin().contains(10,4));
+  ASSERT_TRUE(m.begin().contains(11,3));
+  ASSERT_TRUE(m.begin().contains(10,3));
+  ASSERT_TRUE(m.begin().contains(11,2));
+  ASSERT_FALSE(m.begin().contains(8,2));
+  ASSERT_FALSE(m.begin().contains(14,2));
+  ASSERT_FALSE(m.begin().contains(8,3));
+  ASSERT_FALSE(m.begin().contains(13,2));
+}
+
+TYPED_TEST(IntervalMapTest, get_start_end_off)
+{
+  USING_NO_MERGE;
+  imap m;
+
+  m.insert(0, 5, gen(5));
+  ASSERT_EQ(0, m.get_start_off());
+  ASSERT_EQ(5, m.get_end_off());
+
+  m.insert(5, 5, gen(5));
+  ASSERT_EQ(0, m.get_start_off());
+  ASSERT_EQ(10, m.get_end_off());
+
+  m.erase(0,5);
+  ASSERT_EQ(5, m.get_start_off());
+  ASSERT_EQ(10, m.get_end_off());
+
+  m.insert(20,5, gen(5));
+  ASSERT_EQ(5, m.get_start_off());
+  ASSERT_EQ(25, m.get_end_off());
+}

--- a/src/test/common/test_interval_set.cc
+++ b/src/test/common/test_interval_set.cc
@@ -599,72 +599,613 @@ TYPED_TEST(IntervalSetTest, span_of) {
   ASSERT_EQ( iset1.size(), 0);
 }
 
+TYPED_TEST(IntervalSetTest, compare_union) {
+  typedef typename TestFixture::ISet ISet;
+  ISet iset1, iset2;
+  ASSERT_TRUE(iset1 == iset1);
+  ASSERT_TRUE(iset1 == iset2);
+
+  iset1.insert(1);
+  ASSERT_FALSE(iset1 == iset2);
+
+  iset2.insert(1);
+  ASSERT_TRUE(iset1 == iset2);
+
+  iset1.union_insert(2, 3);
+  iset2.union_insert(2, 4);
+  ASSERT_FALSE(iset1 == iset2);
+
+  iset2.erase(2, 4);
+  iset2.erase(1);
+  iset2.union_insert(2, 3);
+  iset2.insert(1);
+  ASSERT_TRUE(iset1 == iset2);
+
+  iset1.union_insert(100, 10);
+  iset2.union_insert(100, 5);
+  ASSERT_FALSE(iset1 == iset2);
+  iset2.union_insert(105, 5);
+  ASSERT_TRUE(iset1 == iset2);
+
+  iset1.union_insert(200, 10);
+  iset2.union_insert(205, 5);
+  ASSERT_FALSE(iset1 == iset2);
+  iset2.union_insert(200, 1);
+  iset2.union_insert(202, 3);
+  ASSERT_FALSE(iset1 == iset2);
+  iset2.union_insert(201, 1);
+  ASSERT_TRUE(iset1 == iset2);
+
+  iset1.clear();
+  ASSERT_FALSE(iset1 == iset2);
+  iset2.clear();
+  ASSERT_TRUE(iset1 == iset2);
+}
+
+TYPED_TEST(IntervalSetTest, contains_union) {
+  typedef typename TestFixture::ISet ISet;
+  ISet iset1;
+  ASSERT_FALSE(iset1.contains( 1 ));
+  ASSERT_FALSE(iset1.contains( 0, 1 ));
+
+  iset1.insert(1);
+  ASSERT_TRUE(iset1.contains( 1 ));
+  ASSERT_FALSE(iset1.contains( 0 ));
+  ASSERT_FALSE(iset1.contains( 2 ));
+  ASSERT_FALSE(iset1.contains( 0, 1 ));
+  ASSERT_FALSE(iset1.contains( 0, 2 ));
+  ASSERT_TRUE(iset1.contains( 1, 1 ));
+  ASSERT_FALSE(iset1.contains( 1, 2 ));
+
+  iset1.union_insert(2, 3);
+  ASSERT_TRUE(iset1.contains( 1 ));
+  ASSERT_FALSE(iset1.contains( 0 ));
+  ASSERT_TRUE(iset1.contains( 2 ));
+  ASSERT_FALSE(iset1.contains( 0, 1 ));
+  ASSERT_FALSE(iset1.contains( 0, 2 ));
+  ASSERT_TRUE(iset1.contains( 1, 1 ));
+  ASSERT_TRUE(iset1.contains( 1, 2 ));
+  ASSERT_TRUE(iset1.contains( 1, 3 ));
+  ASSERT_TRUE(iset1.contains( 1, 4 ));
+  ASSERT_FALSE(iset1.contains( 1, 5 ));
+  ASSERT_TRUE(iset1.contains( 2, 1 ));
+  ASSERT_TRUE(iset1.contains( 2, 2 ));
+  ASSERT_TRUE(iset1.contains( 2, 3 ));
+  ASSERT_FALSE(iset1.contains( 2, 4 ));
+  ASSERT_TRUE(iset1.contains( 3, 2 ));
+  ASSERT_TRUE(iset1.contains( 4, 1 ));
+  ASSERT_FALSE(iset1.contains( 4, 2 ));
+
+  iset1.union_insert(10, 10);
+  ASSERT_TRUE(iset1.contains( 1, 4 ));
+  ASSERT_FALSE(iset1.contains( 1, 5 ));
+  ASSERT_TRUE(iset1.contains( 2, 2 ));
+  ASSERT_FALSE(iset1.contains( 2, 4 ));
+
+  ASSERT_FALSE(iset1.contains( 1, 10 ));
+  ASSERT_FALSE(iset1.contains( 9, 1 ));
+  ASSERT_FALSE(iset1.contains( 9 ));
+  ASSERT_FALSE(iset1.contains( 9, 11 ));
+  ASSERT_TRUE(iset1.contains( 10, 1 ));
+  ASSERT_TRUE(iset1.contains( 11, 9 ));
+  ASSERT_TRUE(iset1.contains( 11, 2 ));
+  ASSERT_TRUE(iset1.contains( 18, 2 ));
+  ASSERT_TRUE(iset1.contains( 18, 2 ));
+  ASSERT_TRUE(iset1.contains( 10 ));
+  ASSERT_TRUE(iset1.contains( 19 ));
+  ASSERT_FALSE(iset1.contains( 20 ));
+  ASSERT_FALSE(iset1.contains( 21 ));
+
+  ASSERT_FALSE(iset1.contains( 11, 11 ));
+  ASSERT_FALSE(iset1.contains( 18, 9 ));
+
+  iset1.clear();
+  ASSERT_FALSE(iset1.contains( 1 ));
+  ASSERT_FALSE(iset1.contains( 0 ));
+  ASSERT_FALSE(iset1.contains( 2 ));
+  ASSERT_FALSE(iset1.contains( 0, 1 ));
+  ASSERT_FALSE(iset1.contains( 0, 2 ));
+  ASSERT_FALSE(iset1.contains( 1, 1 ));
+  ASSERT_FALSE(iset1.contains( 10, 2 ));
+}
+
+TYPED_TEST(IntervalSetTest, intersects_union) {
+  typedef typename TestFixture::ISet ISet;
+  ISet iset1;
+  ASSERT_FALSE(iset1.intersects( 1, 1 ));
+  ASSERT_FALSE(iset1.intersects( 0, 1 ));
+  ASSERT_FALSE(iset1.intersects( 0, 10 ));
+
+  iset1.insert(1);
+  ASSERT_TRUE(iset1.intersects( 1, 1 ));
+  ASSERT_FALSE(iset1.intersects( 0, 1 ));
+  ASSERT_FALSE(iset1.intersects( 2, 1 ));
+  ASSERT_TRUE(iset1.intersects( 0, 2 ));
+  ASSERT_TRUE(iset1.intersects( 0, 20 ));
+  ASSERT_TRUE(iset1.intersects( 1, 2 ));
+  ASSERT_TRUE(iset1.intersects( 1, 20 ));
+
+  iset1.union_insert(2, 3);
+  ASSERT_FALSE(iset1.intersects( 0, 1 ));
+  ASSERT_TRUE(iset1.intersects( 0, 2 ));
+  ASSERT_TRUE(iset1.intersects( 0, 200 ));
+  ASSERT_TRUE(iset1.intersects( 1, 1 ));
+  ASSERT_TRUE(iset1.intersects( 1, 4 ));
+  ASSERT_TRUE(iset1.intersects( 1, 5 ));
+  ASSERT_TRUE(iset1.intersects( 2, 1 ));
+  ASSERT_TRUE(iset1.intersects( 2, 2 ));
+  ASSERT_TRUE(iset1.intersects( 2, 3 ));
+  ASSERT_TRUE(iset1.intersects( 2, 4 ));
+  ASSERT_TRUE(iset1.intersects( 3, 2 ));
+  ASSERT_TRUE(iset1.intersects( 4, 1 ));
+  ASSERT_TRUE(iset1.intersects( 4, 2 ));
+  ASSERT_FALSE(iset1.intersects( 5, 2 ));
+
+  iset1.union_insert(10, 10);
+  ASSERT_TRUE(iset1.intersects( 1, 4 ));
+  ASSERT_TRUE(iset1.intersects( 1, 5 ));
+  ASSERT_TRUE(iset1.intersects( 1, 10 ));
+  ASSERT_TRUE(iset1.intersects( 2, 2 ));
+  ASSERT_TRUE(iset1.intersects( 2, 4 ));
+  ASSERT_FALSE(iset1.intersects( 5, 1 ));
+  ASSERT_FALSE(iset1.intersects( 5, 2 ));
+  ASSERT_FALSE(iset1.intersects( 5, 5 ));
+  ASSERT_TRUE(iset1.intersects( 5, 12 ));
+  ASSERT_TRUE(iset1.intersects( 5, 20 ));
+
+  ASSERT_FALSE(iset1.intersects( 9, 1 ));
+  ASSERT_TRUE(iset1.intersects( 9, 2 ));
+
+  ASSERT_TRUE(iset1.intersects( 9, 11 ));
+  ASSERT_TRUE(iset1.intersects( 10, 1 ));
+  ASSERT_TRUE(iset1.intersects( 11, 9 ));
+  ASSERT_TRUE(iset1.intersects( 11, 2 ));
+  ASSERT_TRUE(iset1.intersects( 11, 11 ));
+  ASSERT_TRUE(iset1.intersects( 18, 2 ));
+  ASSERT_TRUE(iset1.intersects( 18, 9 ));
+  ASSERT_FALSE(iset1.intersects( 20, 1 ));
+  ASSERT_FALSE(iset1.intersects( 21, 12 ));
+
+  iset1.clear();
+  ASSERT_FALSE(iset1.intersects( 0, 1 ));
+  ASSERT_FALSE(iset1.intersects( 0, 2 ));
+  ASSERT_FALSE(iset1.intersects( 1, 1 ));
+  ASSERT_FALSE(iset1.intersects( 5, 2 ));
+  ASSERT_FALSE(iset1.intersects( 10, 2 ));
+}
+
+TYPED_TEST(IntervalSetTest, insert_erase_union) {
+  typedef typename TestFixture::ISet ISet;
+  ISet iset1, iset2;
+
+  iset1.union_insert(3, 5);
+  ASSERT_EQ(1, iset1.num_intervals());
+  ASSERT_EQ(5, iset1.size());
+
+  //adding standalone interval
+  iset1.union_insert(15, 10);
+  ASSERT_EQ(2, iset1.num_intervals());
+  ASSERT_EQ(15, iset1.size());
+
+  //adding leftmost standalone interval
+  iset1.union_insert(1, 1);
+  ASSERT_EQ(3, iset1.num_intervals());
+  ASSERT_EQ(16, iset1.size());
+
+  //adding leftmost adjucent interval
+  iset1.union_insert(0, 1);
+  ASSERT_EQ(3, iset1.num_intervals());
+  ASSERT_EQ(17, iset1.size());
+
+  //adding interim interval that merges leftmost and subseqent intervals
+  iset1.union_insert(2, 1);
+  ASSERT_EQ(2, iset1.num_intervals());
+  ASSERT_EQ(18, iset1.size());
+
+  //adding rigtmost standalone interval 
+  iset1.union_insert(30, 5);
+  ASSERT_EQ(3, iset1.num_intervals());
+  ASSERT_EQ(23, iset1.size());
+
+  //adding rigtmost adjusent interval 
+  iset1.union_insert(35, 10);
+  ASSERT_EQ(3, iset1.num_intervals());
+  ASSERT_EQ(33, iset1.size());
+
+  //adding interim interval that merges with the interval preceeding the rightmost
+  iset1.union_insert(25, 1);
+  ASSERT_EQ(3, iset1.num_intervals());
+  ASSERT_EQ(34, iset1.size());
+
+  //adding interim interval that merges with the rightmost and preceeding intervals
+  iset1.union_insert(26, 4);
+  ASSERT_EQ(2, iset1.num_intervals());
+  ASSERT_EQ(38, iset1.size());
+
+  //and finally build single interval filling the gap at  8-15 using different interval set
+  iset2.union_insert( 8, 1 );
+  iset2.union_insert( 14, 1 );
+  iset2.union_insert( 9, 4 );
+  iset1.union_of( iset2 );
+  iset1.union_insert(13, 1);
+  ASSERT_EQ(1, iset1.num_intervals());
+  ASSERT_EQ(45, iset1.size());
+
+  //now reverses the process using subtract & erase
+  iset1.subtract( iset2 );
+  iset1.erase(13, 1);
+  ASSERT_EQ( 2, iset1.num_intervals() );
+  ASSERT_EQ(38, iset1.size());
+  ASSERT_TRUE( iset1.contains( 7, 1 ));
+  ASSERT_FALSE( iset1.contains( 8, 7 ));
+  ASSERT_TRUE( iset1.contains( 15, 1 ));
+  ASSERT_TRUE( iset1.contains( 26, 4 ));
+
+  iset1.erase(26, 4);
+  ASSERT_EQ(3, iset1.num_intervals());
+  ASSERT_EQ(34, iset1.size());
+  ASSERT_TRUE( iset1.contains( 7, 1 ));
+  ASSERT_FALSE( iset1.intersects( 8, 7 ));
+  ASSERT_TRUE( iset1.contains( 15, 1 ));
+  ASSERT_TRUE( iset1.contains( 25, 1 ));
+  ASSERT_FALSE( iset1.contains( 26, 4 ));
+  ASSERT_TRUE( iset1.contains( 30, 1 ));
+
+  iset1.erase(25, 1);
+  ASSERT_EQ(3, iset1.num_intervals());
+  ASSERT_EQ(33, iset1.size());
+  ASSERT_TRUE( iset1.contains( 24, 1 ));
+  ASSERT_FALSE( iset1.contains( 25, 1 ));
+  ASSERT_FALSE( iset1.intersects( 26, 4 ));
+  ASSERT_TRUE( iset1.contains( 30, 1 ));
+  ASSERT_TRUE( iset1.contains( 35, 10 ));
+
+  iset1.erase(35, 10);
+  ASSERT_EQ(3, iset1.num_intervals());
+  ASSERT_EQ(23, iset1.size());
+  ASSERT_TRUE( iset1.contains( 30, 5 ));
+  ASSERT_TRUE( iset1.contains( 34, 1 ));
+  ASSERT_FALSE( iset1.contains( 35, 10 ));
+  ASSERT_FALSE(iset1.contains( 45, 1 ));
+
+  iset1.erase(30, 5);
+  ASSERT_EQ(2, iset1.num_intervals());
+  ASSERT_EQ(18, iset1.size());
+  ASSERT_TRUE( iset1.contains( 2, 1 ));
+  ASSERT_TRUE( iset1.contains( 24, 1 ));
+  ASSERT_FALSE( iset1.contains( 25, 1 ));
+  ASSERT_FALSE( iset1.contains( 29, 1 ));
+  ASSERT_FALSE( iset1.contains( 30, 5 ));
+  ASSERT_FALSE( iset1.contains( 35, 1 ));
+
+  iset1.erase(2, 1);
+  ASSERT_EQ(3, iset1.num_intervals());
+  ASSERT_EQ( iset1.size(), 17 );
+  ASSERT_TRUE( iset1.contains( 0, 1 ));
+  ASSERT_TRUE( iset1.contains( 1, 1 ));
+  ASSERT_FALSE( iset1.contains( 2, 1 ));
+  ASSERT_TRUE( iset1.contains( 3, 1 ));
+  ASSERT_TRUE( iset1.contains( 15, 1 ));
+  ASSERT_FALSE( iset1.contains( 25, 1 ));
+
+  iset1.erase( 0, 1);
+  ASSERT_EQ(3, iset1.num_intervals());
+  ASSERT_EQ(16, iset1.size());
+  ASSERT_FALSE( iset1.contains( 0, 1 ));
+  ASSERT_TRUE( iset1.contains( 1, 1 ));
+  ASSERT_FALSE( iset1.contains( 2, 1 ));
+  ASSERT_TRUE( iset1.contains( 3, 1 ));
+  ASSERT_TRUE( iset1.contains( 15, 1 ));
+
+  iset1.erase(1, 1);
+  ASSERT_EQ(2, iset1.num_intervals());
+  ASSERT_EQ(15, iset1.size());
+  ASSERT_FALSE( iset1.contains( 1, 1 ));
+  ASSERT_TRUE( iset1.contains( 15, 10 ));
+  ASSERT_TRUE( iset1.contains( 3, 5 ));
+
+  iset1.erase(15, 10);
+  ASSERT_EQ(1, iset1.num_intervals());
+  ASSERT_EQ(5, iset1.size());
+  ASSERT_FALSE( iset1.contains( 1, 1 ));
+  ASSERT_FALSE( iset1.contains( 15, 10 ));
+  ASSERT_FALSE( iset1.contains( 25, 1 ));
+  ASSERT_TRUE( iset1.contains( 3, 5 ));
+
+  iset1.erase( 3, 1);
+  ASSERT_EQ(1, iset1.num_intervals());
+  ASSERT_EQ(4, iset1.size());
+  ASSERT_FALSE( iset1.contains( 1, 1 ));
+  ASSERT_FALSE( iset1.contains( 15, 10 ));
+  ASSERT_FALSE( iset1.contains( 25, 1 ));
+  ASSERT_TRUE( iset1.contains( 4, 4 ));
+  ASSERT_FALSE( iset1.contains( 3, 5 ));
+
+  iset1.erase( 4, 4);
+  ASSERT_EQ(0, iset1.num_intervals());
+  ASSERT_EQ(0, iset1.size());
+  ASSERT_FALSE( iset1.contains( 1, 1 ));
+  ASSERT_FALSE( iset1.contains( 15, 10 ));
+  ASSERT_FALSE( iset1.contains( 25, 1 ));
+  ASSERT_FALSE( iset1.contains( 3, 4 ));
+  ASSERT_FALSE( iset1.contains( 3, 5 ));
+  ASSERT_FALSE( iset1.contains( 4, 4 ));
+
+
+}
+
+TYPED_TEST(IntervalSetTest, intersect_of_union) {
+  typedef typename TestFixture::ISet ISet;
+  ISet iset1, iset2, iset3;
+
+  iset1.intersection_of( iset2, iset3 );
+  ASSERT_TRUE( iset1.num_intervals() == 0);
+  ASSERT_TRUE( iset1.size() == 0);
+
+  iset2.union_insert( 0, 1 );
+  iset2.union_insert( 5, 10 );
+  iset2.union_insert( 30, 10 );
+
+  iset3.union_insert( 0, 2 );
+  iset3.union_insert( 15, 1 );
+  iset3.union_insert( 20, 5 );
+  iset3.union_insert( 29, 3 );
+  iset3.union_insert( 35, 3 );
+  iset3.union_insert( 39, 3 );
+
+  iset1.intersection_of( iset2, iset3 );
+  ASSERT_TRUE( iset1.num_intervals() == 4);
+  ASSERT_TRUE( iset1.size() == 7);
+
+  ASSERT_TRUE( iset1.contains( 0, 1 ));
+  ASSERT_FALSE( iset1.contains( 0, 2 ));
+
+  ASSERT_FALSE( iset1.contains( 5, 11 ));
+  ASSERT_FALSE( iset1.contains( 4, 1 ));
+  ASSERT_FALSE( iset1.contains( 16, 1 ));
+  
+  ASSERT_FALSE( iset1.contains( 20, 5 ));
+
+  ASSERT_FALSE( iset1.contains( 29, 1 ));
+  ASSERT_FALSE( iset1.contains( 30, 10 ));
+
+  ASSERT_TRUE( iset1.contains( 30, 2 ));
+  ASSERT_TRUE( iset1.contains( 35, 3 ));
+  ASSERT_FALSE( iset1.contains( 35, 4 ));
+
+  ASSERT_TRUE( iset1.contains( 39, 1 ));
+  ASSERT_FALSE( iset1.contains( 38, 2 ));
+  ASSERT_FALSE( iset1.contains( 39, 2 ));
+
+  iset3=iset1;
+  iset1.intersection_of(iset2);
+  ASSERT_TRUE( iset1 == iset3);
+
+  iset2.clear();
+  iset2.union_insert(0,1);
+  iset1.intersection_of(iset2);
+  ASSERT_TRUE( iset1.num_intervals() == 1);
+  ASSERT_TRUE( iset1.size() == 1);
+
+  iset1 = iset3;
+  iset2.clear();
+  iset1.intersection_of(iset2);
+  ASSERT_TRUE( iset1.num_intervals() == 0);
+  ASSERT_TRUE( iset1.size() == 0);
+
+}
+
+TYPED_TEST(IntervalSetTest, union_of_union) {
+  typedef typename TestFixture::ISet ISet;
+  ISet iset1, iset2, iset3;
+
+  iset1.union_of( iset2, iset3 );
+  ASSERT_TRUE( iset1.num_intervals() == 0);
+  ASSERT_TRUE( iset1.size() == 0);
+
+  iset2.union_insert( 0, 1 );
+  iset2.union_insert( 5, 10 );
+  iset2.union_insert( 30, 10 );
+
+  iset3.union_insert( 0, 2 );
+  iset3.union_insert( 15, 1 );
+  iset3.union_insert( 20, 5 );
+  iset3.union_insert( 29, 3 );
+  iset3.union_insert( 39, 3 );
+
+  iset1.union_of( iset2, iset3 );
+  ASSERT_TRUE( iset1.num_intervals() == 4);
+  ASSERT_EQ( iset1.size(), 31);
+  ASSERT_TRUE( iset1.contains( 0, 2 ));
+  ASSERT_FALSE( iset1.contains( 0, 3 ));
+
+  ASSERT_TRUE( iset1.contains( 5, 11 ));
+  ASSERT_FALSE( iset1.contains( 4, 1 ));
+  ASSERT_FALSE( iset1.contains( 16, 1 ));
+  
+  ASSERT_TRUE( iset1.contains( 20, 5 ));
+
+  ASSERT_TRUE( iset1.contains( 30, 10 ));
+  ASSERT_TRUE( iset1.contains( 29, 13 ));
+  ASSERT_FALSE( iset1.contains( 29, 14 ));
+  ASSERT_FALSE( iset1.contains( 42, 1 ));
+
+  iset2.clear();
+  iset1.union_of(iset2);
+  ASSERT_TRUE( iset1.num_intervals() == 4);
+  ASSERT_EQ( iset1.size(), 31);
+
+  iset3.clear();
+  iset3.union_insert( 29, 3 );
+  iset3.union_insert( 39, 2 );
+  iset1.union_of(iset3);
+
+  ASSERT_TRUE( iset1.num_intervals() == 4);
+  ASSERT_EQ( iset1.size(), 31); //actually we added nothing
+  ASSERT_TRUE( iset1.contains( 29, 13 ));
+  ASSERT_FALSE( iset1.contains( 29, 14 ));
+  ASSERT_FALSE( iset1.contains( 42, 1 ));
+
+}
+
+TYPED_TEST(IntervalSetTest, subset_of_union) {
+  typedef typename TestFixture::ISet ISet;
+  ISet iset1, iset2;
+
+  ASSERT_TRUE(iset1.subset_of(iset2));
+
+  iset1.union_insert(5,10);
+  ASSERT_FALSE(iset1.subset_of(iset2));
+
+  iset2.union_insert(6,8);
+  ASSERT_FALSE(iset1.subset_of(iset2));
+
+  iset2.union_insert(5,1);
+  ASSERT_FALSE(iset1.subset_of(iset2));
+
+  iset2.union_insert(14,10);
+  ASSERT_TRUE(iset1.subset_of(iset2));
+
+  iset1.union_insert( 20, 4);
+  ASSERT_TRUE(iset1.subset_of(iset2));
+
+  iset1.union_insert( 24, 1);
+  ASSERT_FALSE(iset1.subset_of(iset2));
+
+  iset2.union_insert( 24, 1);
+  ASSERT_TRUE(iset1.subset_of(iset2));
+
+  iset1.union_insert( 30, 5);
+  ASSERT_FALSE(iset1.subset_of(iset2));
+
+  iset2.union_insert( 30, 5);
+  ASSERT_TRUE(iset1.subset_of(iset2));
+
+  iset2.erase( 30, 1);
+  ASSERT_FALSE(iset1.subset_of(iset2));
+
+  iset1.erase( 30, 1);
+  ASSERT_TRUE(iset1.subset_of(iset2));
+
+  iset2.erase( 34, 1);
+  ASSERT_FALSE(iset1.subset_of(iset2));
+
+  iset1.erase( 34, 1);
+  ASSERT_TRUE(iset1.subset_of(iset2));
+
+  iset1.union_insert( 40, 5);
+  ASSERT_FALSE(iset1.subset_of(iset2));
+
+  iset2.union_insert( 39, 7);
+  ASSERT_TRUE(iset1.subset_of(iset2));
+
+  iset1.union_insert( 50, 5);
+  iset2.union_insert( 55, 2);
+  ASSERT_FALSE(iset1.subset_of(iset2));
+}
+
+TYPED_TEST(IntervalSetTest, span_of_union) {
+  typedef typename TestFixture::ISet ISet;
+  ISet iset1, iset2;
+
+  iset2.union_insert(5,5);
+  iset2.union_insert(20,5);
+
+  iset1.span_of( iset2, 8, 5 );
+  ASSERT_EQ( iset1.num_intervals(), 2);
+  ASSERT_EQ( iset1.size(), 5);
+  ASSERT_TRUE( iset1.contains( 8, 2 ));
+  ASSERT_TRUE( iset1.contains( 20, 3 ));
+  
+  iset1.span_of( iset2, 3, 5 );
+  ASSERT_EQ( iset1.num_intervals(), 1);
+  ASSERT_EQ( iset1.size(), 5);
+  ASSERT_TRUE( iset1.contains( 5, 5 ));
+
+  iset1.span_of( iset2, 10, 7 );
+  ASSERT_EQ( iset1.num_intervals(), 1);
+  ASSERT_EQ( iset1.size(), 5);
+  ASSERT_TRUE( iset1.contains( 20, 5 ));
+  ASSERT_FALSE( iset1.contains( 20, 6 ));
+
+  iset1.span_of( iset2, 5, 10);
+  ASSERT_EQ( iset1.num_intervals(), 2);
+  ASSERT_EQ( iset1.size(), 10);
+  ASSERT_TRUE( iset1.contains( 5, 5 ));
+  ASSERT_TRUE( iset1.contains( 20, 5 ));
+
+  iset1.span_of( iset2, 100, 5 );
+  ASSERT_EQ( iset1.num_intervals(), 0);
+  ASSERT_EQ( iset1.size(), 0);
+}
+
+
 TYPED_TEST(IntervalSetTest, align) {
   typedef typename TestFixture::ISet ISet;
   {
     ISet iset1, iset2;
 
-    iset1.insert(1, 2);
+    iset1.union_insert(1, 2);
     iset1.align(8);
-    iset2.insert(0,8);
+    iset2.union_insert(0,8);
     ASSERT_TRUE(iset1 == iset2);
   }
 
   {
     ISet iset1, iset2;
 
-    iset1.insert(1, 2);
-    iset1.insert(4, 2);
+    iset1.union_insert(1, 2);
+    iset1.union_insert(4, 2);
 
     iset1.align(8);
-    iset2.insert(0,8);
+    iset2.union_insert(0,8);
     ASSERT_TRUE(iset1 == iset2);
   }
 
   {
     ISet iset1, iset2;
 
-    iset1.insert(7, 2);
-    iset1.insert(15, 2);
+    iset1.union_insert(7, 2);
+    iset1.union_insert(15, 2);
 
     iset1.align(8);
-    iset2.insert(0,24);
+    iset2.union_insert(0,24);
     ASSERT_TRUE(iset1 == iset2);
   }
 
   {
     ISet iset1, iset2;
 
-    iset1.insert(8, 2);
-    iset1.insert(12, 2);
+    iset1.union_insert(8, 2);
+    iset1.union_insert(12, 2);
 
     iset1.align(8);
-    iset2.insert(8,8);
+    iset2.union_insert(8,8);
     ASSERT_TRUE(iset1 == iset2);
   }
 
   {
     ISet iset1, iset2;
 
-    iset1.insert(8, 2);
-    iset1.insert(12, 2);
+    iset1.union_insert(8, 2);
+    iset1.union_insert(12, 2);
 
     iset1.align(8);
-    iset2.insert(8,8);
+    iset2.union_insert(8,8);
     ASSERT_TRUE(iset1 == iset2);
   }
 
   {
     ISet iset1, iset2;
 
-    iset1.insert(0, 1);
-    iset1.insert(23, 1);
-    iset1.insert(40, 1);
+    iset1.union_insert(0, 1);
+    iset1.union_insert(23, 1);
+    iset1.union_insert(40, 1);
 
     iset1.align(8);
-    iset2.insert(0, 8);
-    iset2.insert(16, 8);
-    iset2.insert(40, 8);
+    iset2.union_insert(0, 8);
+    iset2.union_insert(16, 8);
+    iset2.union_insert(40, 8);
 
     ASSERT_TRUE(iset1 == iset2);
   }
@@ -672,11 +1213,11 @@ TYPED_TEST(IntervalSetTest, align) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(4, 2);
-    iset1.insert(12, 2);
+    iset1.union_insert(4, 2);
+    iset1.union_insert(12, 2);
 
     iset1.align(8);
-    iset2.insert(0,16);
+    iset2.union_insert(0,16);
     ASSERT_TRUE(iset1 == iset2);
   }
 
@@ -685,16 +1226,16 @@ TYPED_TEST(IntervalSetTest, align) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(4, 1);
-    iset1.insert(8, 10);
+    iset1.union_insert(4, 1);
+    iset1.union_insert(8, 10);
 
     iset1.align(10);
-    iset2.insert(0,20);
+    iset2.union_insert(0,20);
     ASSERT_TRUE(iset1 == iset2);
   }
 }
 
-TYPED_TEST(IntervalSetTest, insert) {
+TYPED_TEST(IntervalSetTest, union_insert) {
   // Tests targetted at refactor allowing over-lapping inserts.
   typedef typename TestFixture::ISet ISet;
 
@@ -702,9 +1243,9 @@ TYPED_TEST(IntervalSetTest, insert) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(1, 4);
-    iset1.insert(1, 4);
-    iset2.insert(1, 4);
+    iset1.union_insert(1, 4);
+    iset1.union_insert(1, 4);
+    iset2.union_insert(1, 4);
 
     ASSERT_TRUE(iset1 == iset2);
   }
@@ -713,9 +1254,9 @@ TYPED_TEST(IntervalSetTest, insert) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
-    iset1.insert(1, 2);
-    iset2.insert(1, 6);
+    iset1.union_insert(3, 4);
+    iset1.union_insert(1, 2);
+    iset2.union_insert(1, 6);
 
     ASSERT_TRUE(iset1 == iset2);
   }
@@ -724,9 +1265,9 @@ TYPED_TEST(IntervalSetTest, insert) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
-    iset1.insert(2, 2);
-    iset2.insert(2, 5);
+    iset1.union_insert(3, 4);
+    iset1.union_insert(2, 2);
+    iset2.union_insert(2, 5);
 
     ASSERT_TRUE(iset1 == iset2);
   }
@@ -735,9 +1276,9 @@ TYPED_TEST(IntervalSetTest, insert) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
-    iset1.insert(2, 3);
-    iset2.insert(2, 5);
+    iset1.union_insert(3, 4);
+    iset1.union_insert(2, 3);
+    iset2.union_insert(2, 5);
 
     ASSERT_TRUE(iset1 == iset2);
   }
@@ -746,9 +1287,9 @@ TYPED_TEST(IntervalSetTest, insert) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
-    iset1.insert(7, 2);
-    iset2.insert(3, 6);
+    iset1.union_insert(3, 4);
+    iset1.union_insert(7, 2);
+    iset2.union_insert(3, 6);
 
     ASSERT_TRUE(iset1 == iset2);
   }
@@ -757,9 +1298,9 @@ TYPED_TEST(IntervalSetTest, insert) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
-    iset1.insert(6, 2);
-    iset2.insert(3, 5);
+    iset1.union_insert(3, 4);
+    iset1.union_insert(6, 2);
+    iset2.union_insert(3, 5);
 
     ASSERT_TRUE(iset1 == iset2);
   }
@@ -768,231 +1309,231 @@ TYPED_TEST(IntervalSetTest, insert) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
-    iset1.insert(5, 3);
-    iset2.insert(3, 5);
+    iset1.union_insert(3, 4);
+    iset1.union_insert(5, 3);
+    iset2.union_insert(3, 5);
 
     ASSERT_TRUE(iset1 == iset2);
   }
 
-  // insert entirely contains existing.
+  // union_insert entirely contains existing.
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
-    iset1.insert(2, 6);
-    iset2.insert(2, 6);
+    iset1.union_insert(3, 4);
+    iset1.union_insert(2, 6);
+    iset2.union_insert(2, 6);
 
     ASSERT_TRUE(iset1 == iset2);
   }
 
-  // insert entirely contained within existing
+  // union_insert entirely contained within existing
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
-    iset1.insert(4, 2);
-    iset2.insert(3, 4);
+    iset1.union_insert(3, 4);
+    iset1.union_insert(4, 2);
+    iset2.union_insert(3, 4);
 
     ASSERT_TRUE(iset1 == iset2);
   }
 
-  // insert joins exactly
+  // union_insert joins exactly
   {
     ISet iset1, iset2;
 
-    iset1.insert(2, 4);
-    iset1.insert(10, 4);
-    iset1.insert(6, 4);
-    iset2.insert(2, 12);
+    iset1.union_insert(2, 4);
+    iset1.union_insert(10, 4);
+    iset1.union_insert(6, 4);
+    iset2.union_insert(2, 12);
 
     ASSERT_TRUE(iset1 == iset2);
   }
 
-  // insert join - overlaps before
+  // union_insert join - overlaps before
   {
     ISet iset1, iset2;
 
-    iset1.insert(2, 4);
-    iset1.insert(10, 4);
-    iset1.insert(5, 5);
-    iset2.insert(2, 12);
+    iset1.union_insert(2, 4);
+    iset1.union_insert(10, 4);
+    iset1.union_insert(5, 5);
+    iset2.union_insert(2, 12);
 
     ASSERT_TRUE(iset1 == iset2);
   }
 
-  // insert join - overlaps after
+  // union_insert join - overlaps after
   {
     ISet iset1, iset2;
 
-    iset1.insert(2, 4);
-    iset1.insert(10, 4);
-    iset1.insert(6, 5);
-    iset2.insert(2, 12);
+    iset1.union_insert(2, 4);
+    iset1.union_insert(10, 4);
+    iset1.union_insert(6, 5);
+    iset2.union_insert(2, 12);
 
     ASSERT_TRUE(iset1 == iset2);
   }
 
-  // insert join - overlaps before and after
+  // union_insert join - overlaps before and after
   {
     ISet iset1, iset2;
 
-    iset1.insert(2, 4);
-    iset1.insert(10, 4);
-    iset1.insert(5, 7);
-    iset2.insert(2, 12);
+    iset1.union_insert(2, 4);
+    iset1.union_insert(10, 4);
+    iset1.union_insert(5, 7);
+    iset2.union_insert(2, 12);
 
     ASSERT_TRUE(iset1 == iset2);
   }
 
-  // insert join multiple - start/start.
+  // union_insert join multiple - start/start.
   {
     ISet iset1, iset2;
 
-    iset1.insert(2, 4);
-    iset1.insert(8, 4);
-    iset1.insert(16, 4);
-    iset1.insert(24, 4);
-    iset1.insert(2, 22);
+    iset1.union_insert(2, 4);
+    iset1.union_insert(8, 4);
+    iset1.union_insert(16, 4);
+    iset1.union_insert(24, 4);
+    iset1.union_insert(2, 22);
 
-    iset2.insert(2, 26);
+    iset2.union_insert(2, 26);
 
     ASSERT_TRUE(iset1 == iset2);
   }
 
-  // insert join multiple - start/middle.
+  // union_insert join multiple - start/middle.
   {
     ISet iset1, iset2;
 
-    iset1.insert(2, 4);
-    iset1.insert(8, 4);
-    iset1.insert(16, 4);
-    iset1.insert(24, 4);
-    iset1.insert(2, 23);
+    iset1.union_insert(2, 4);
+    iset1.union_insert(8, 4);
+    iset1.union_insert(16, 4);
+    iset1.union_insert(24, 4);
+    iset1.union_insert(2, 23);
 
-    iset2.insert(2, 26);
+    iset2.union_insert(2, 26);
 
     ASSERT_TRUE(iset1 == iset2);
   }
-  // insert join multiple - start/end.
+  // union_insert join multiple - start/end.
   {
     ISet iset1, iset2;
 
-    iset1.insert(2, 4);
-    iset1.insert(8, 4);
-    iset1.insert(16, 4);
-    iset1.insert(24, 4);
-    iset1.insert(2, 26);
+    iset1.union_insert(2, 4);
+    iset1.union_insert(8, 4);
+    iset1.union_insert(16, 4);
+    iset1.union_insert(24, 4);
+    iset1.union_insert(2, 26);
 
-    iset2.insert(2, 26);
-
-    ASSERT_TRUE(iset1 == iset2);
-  }
-
-  // insert join multiple - middle/start.
-  {
-    ISet iset1, iset2;
-
-    iset1.insert(2, 4);
-    iset1.insert(8, 4);
-    iset1.insert(16, 4);
-    iset1.insert(24, 4);
-    iset1.insert(3, 21);
-
-    iset2.insert(2, 26);
+    iset2.union_insert(2, 26);
 
     ASSERT_TRUE(iset1 == iset2);
   }
 
-  // insert join multiple - middle/middle.
+  // union_insert join multiple - middle/start.
   {
     ISet iset1, iset2;
 
-    iset1.insert(2, 4);
-    iset1.insert(8, 4);
-    iset1.insert(16, 4);
-    iset1.insert(24, 4);
-    iset1.insert(3, 22);
+    iset1.union_insert(2, 4);
+    iset1.union_insert(8, 4);
+    iset1.union_insert(16, 4);
+    iset1.union_insert(24, 4);
+    iset1.union_insert(3, 21);
 
-    iset2.insert(2, 26);
-
-    ASSERT_TRUE(iset1 == iset2);
-  }
-  // insert join multiple - middle/end.
-  {
-    ISet iset1, iset2;
-
-    iset1.insert(2, 4);
-    iset1.insert(8, 4);
-    iset1.insert(16, 4);
-    iset1.insert(24, 4);
-    iset1.insert(3, 25);
-
-    iset2.insert(2, 26);
+    iset2.union_insert(2, 26);
 
     ASSERT_TRUE(iset1 == iset2);
   }
 
-  // insert join multiple - end/start.
+  // union_insert join multiple - middle/middle.
   {
     ISet iset1, iset2;
 
-    iset1.insert(2, 4);
-    iset1.insert(8, 4);
-    iset1.insert(16, 4);
-    iset1.insert(24, 4);
-    iset1.insert(6, 18);
+    iset1.union_insert(2, 4);
+    iset1.union_insert(8, 4);
+    iset1.union_insert(16, 4);
+    iset1.union_insert(24, 4);
+    iset1.union_insert(3, 22);
 
-    iset2.insert(2, 26);
+    iset2.union_insert(2, 26);
+
+    ASSERT_TRUE(iset1 == iset2);
+  }
+  // union_insert join multiple - middle/end.
+  {
+    ISet iset1, iset2;
+
+    iset1.union_insert(2, 4);
+    iset1.union_insert(8, 4);
+    iset1.union_insert(16, 4);
+    iset1.union_insert(24, 4);
+    iset1.union_insert(3, 25);
+
+    iset2.union_insert(2, 26);
 
     ASSERT_TRUE(iset1 == iset2);
   }
 
-  // insert join multiple - start/middle.
+  // union_insert join multiple - end/start.
   {
     ISet iset1, iset2;
 
-    iset1.insert(2, 4);
-    iset1.insert(8, 4);
-    iset1.insert(16, 4);
-    iset1.insert(24, 4);
-    iset1.insert(6, 19);
+    iset1.union_insert(2, 4);
+    iset1.union_insert(8, 4);
+    iset1.union_insert(16, 4);
+    iset1.union_insert(24, 4);
+    iset1.union_insert(6, 18);
 
-    iset2.insert(2, 26);
-
-    ASSERT_TRUE(iset1 == iset2);
-  }
-  // insert join multiple - start/end.
-  {
-    ISet iset1, iset2;
-
-    iset1.insert(2, 4);
-    iset1.insert(8, 4);
-    iset1.insert(16, 4);
-    iset1.insert(24, 4);
-    iset1.insert(6, 22);
-
-    iset2.insert(2, 26);
+    iset2.union_insert(2, 26);
 
     ASSERT_TRUE(iset1 == iset2);
   }
 
-  // insert entirely contained within existing
+  // union_insert join multiple - start/middle.
   {
     ISet iset1, iset2;
 
-    iset1.insert(0x3000,  0xd000);
-    iset1.insert(0x11000, 0xf000);
-    iset1.insert(0x20000, 0x9000);
-    iset1.insert(0x9000,  0x1000);
-    iset1.insert(0xa000,  0x1000);
-    iset1.insert(0xb000,  0x1000);
-    iset1.insert(0x18000, 0x1000);
-    iset1.insert(0x19000, 0x1000);
-    iset1.insert(0xc000,  0x4000);
-    iset1.insert(0x10000, 0x8000);
-    iset1.insert(0x10000, 0x1000);
-    iset2.insert(0x2c000, 0x10000);
+    iset1.union_insert(2, 4);
+    iset1.union_insert(8, 4);
+    iset1.union_insert(16, 4);
+    iset1.union_insert(24, 4);
+    iset1.union_insert(6, 19);
+
+    iset2.union_insert(2, 26);
+
+    ASSERT_TRUE(iset1 == iset2);
+  }
+  // union_insert join multiple - start/end.
+  {
+    ISet iset1, iset2;
+
+    iset1.union_insert(2, 4);
+    iset1.union_insert(8, 4);
+    iset1.union_insert(16, 4);
+    iset1.union_insert(24, 4);
+    iset1.union_insert(6, 22);
+
+    iset2.union_insert(2, 26);
+
+    ASSERT_TRUE(iset1 == iset2);
+  }
+
+  // union_insert entirely contained within existing
+  {
+    ISet iset1, iset2;
+
+    iset1.union_insert(0x3000,  0xd000);
+    iset1.union_insert(0x11000, 0xf000);
+    iset1.union_insert(0x20000, 0x9000);
+    iset1.union_insert(0x9000,  0x1000);
+    iset1.union_insert(0xa000,  0x1000);
+    iset1.union_insert(0xb000,  0x1000);
+    iset1.union_insert(0x18000, 0x1000);
+    iset1.union_insert(0x19000, 0x1000);
+    iset1.union_insert(0xc000,  0x4000);
+    iset1.union_insert(0x10000, 0x8000);
+    iset1.union_insert(0x10000, 0x1000);
+    iset2.union_insert(0x2c000, 0x10000);
 
     iset2.intersection_of(iset1);
 
@@ -1006,9 +1547,9 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(4, 4);
+    iset1.union_insert(4, 4);
     iset1.erase(1, 2);
-    iset2.insert(4, 4);
+    iset2.union_insert(4, 4);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1017,9 +1558,9 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
+    iset1.union_insert(3, 4);
     iset1.erase(1, 2);
-    iset2.insert(3, 4);
+    iset2.union_insert(3, 4);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1028,9 +1569,9 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
+    iset1.union_insert(3, 4);
     iset1.erase(1, 3);
-    iset2.insert(4, 3);
+    iset2.union_insert(4, 3);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1039,9 +1580,9 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
+    iset1.union_insert(3, 4);
     iset1.erase(1, 4);
-    iset2.insert(5, 2);
+    iset2.union_insert(5, 2);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1050,7 +1591,7 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
+    iset1.union_insert(3, 4);
     iset1.erase(1, 6);
 
     ASSERT_EQ(iset1, iset2);
@@ -1060,7 +1601,7 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
+    iset1.union_insert(3, 4);
     iset1.erase(1, 7);
 
     ASSERT_EQ(iset1, iset2);
@@ -1070,10 +1611,10 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
+    iset1.union_insert(3, 4);
     iset1.erase(4, 2);
-    iset2.insert(3, 1);
-    iset2.insert(6, 1);
+    iset2.union_insert(3, 1);
+    iset2.union_insert(6, 1);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1082,9 +1623,9 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
+    iset1.union_insert(3, 4);
     iset1.erase(4, 3);
-    iset2.insert(3, 1);
+    iset2.union_insert(3, 1);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1093,9 +1634,9 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
+    iset1.union_insert(3, 4);
     iset1.erase(4, 4);
-    iset2.insert(3, 1);
+    iset2.union_insert(3, 1);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1104,9 +1645,9 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
+    iset1.union_insert(3, 4);
     iset1.erase(7, 1);
-    iset2.insert(3, 4);
+    iset2.union_insert(3, 4);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1115,9 +1656,9 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
+    iset1.union_insert(3, 4);
     iset1.erase(8, 1);
-    iset2.insert(3, 4);
+    iset2.union_insert(3, 4);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1126,11 +1667,11 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
-    iset1.insert(10, 4);
+    iset1.union_insert(3, 4);
+    iset1.union_insert(10, 4);
     iset1.erase(8, 1);
-    iset2.insert(3, 4);
-    iset2.insert(10, 4);
+    iset2.union_insert(3, 4);
+    iset2.union_insert(10, 4);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1139,8 +1680,8 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
-    iset1.insert(10, 4);
+    iset1.union_insert(3, 4);
+    iset1.union_insert(10, 4);
     iset1.erase(3, 11);
 
     ASSERT_EQ(iset1, iset2);
@@ -1150,10 +1691,10 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 1);
-    iset1.insert(5, 1);
-    iset1.insert(7, 1);
-    iset1.insert(9, 1);
+    iset1.union_insert(3, 1);
+    iset1.union_insert(5, 1);
+    iset1.union_insert(7, 1);
+    iset1.union_insert(9, 1);
     iset1.erase(2, 9);
 
     ASSERT_EQ(iset1, iset2);
@@ -1163,14 +1704,14 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(1, 1);
-    iset1.insert(3, 1);
-    iset1.insert(5, 1);
-    iset1.insert(7, 1);
-    iset1.insert(9, 1);
+    iset1.union_insert(1, 1);
+    iset1.union_insert(3, 1);
+    iset1.union_insert(5, 1);
+    iset1.union_insert(7, 1);
+    iset1.union_insert(9, 1);
     iset1.erase(2, 6);
-    iset2.insert(1, 1);
-    iset2.insert(9, 1);
+    iset2.union_insert(1, 1);
+    iset2.union_insert(9, 1);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1179,15 +1720,15 @@ TYPED_TEST(IntervalSetTest, erase) {
   {
     ISet iset1, iset2;
 
-    iset1.insert(1, 1);
-    iset1.insert(3, 4);
-    iset1.insert(8, 1);
-    iset1.insert(10, 1);
-    iset1.insert(12, 4);
+    iset1.union_insert(1, 1);
+    iset1.union_insert(3, 4);
+    iset1.union_insert(8, 1);
+    iset1.union_insert(10, 1);
+    iset1.union_insert(12, 4);
     iset1.erase(4, 11);
-    iset2.insert(1, 1);
-    iset2.insert(3, 1);
-    iset2.insert(15, 1);
+    iset2.union_insert(1, 1);
+    iset2.union_insert(3, 1);
+    iset2.union_insert(15, 1);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1200,7 +1741,7 @@ TYPED_TEST(IntervalSetTest, erase_after)
   {
     ISet iset1, iset2;
 
-    iset1.insert(4, 4);
+    iset1.union_insert(4, 4);
     iset1.erase_after(1);
 
     ASSERT_EQ(iset1, iset2);
@@ -1210,7 +1751,7 @@ TYPED_TEST(IntervalSetTest, erase_after)
   {
     ISet iset1, iset2;
 
-    iset1.insert(4, 4);
+    iset1.union_insert(4, 4);
     iset1.erase_after(4);
 
     ASSERT_EQ(iset1, iset2);
@@ -1220,9 +1761,9 @@ TYPED_TEST(IntervalSetTest, erase_after)
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
+    iset1.union_insert(3, 4);
     iset1.erase_after(4);
-    iset2.insert(3, 1);
+    iset2.union_insert(3, 1);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1231,9 +1772,9 @@ TYPED_TEST(IntervalSetTest, erase_after)
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
+    iset1.union_insert(3, 4);
     iset1.erase_after(7);
-    iset2.insert(3, 4);
+    iset2.union_insert(3, 4);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1242,10 +1783,10 @@ TYPED_TEST(IntervalSetTest, erase_after)
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
-    iset1.insert(10, 4);
+    iset1.union_insert(3, 4);
+    iset1.union_insert(10, 4);
     iset1.erase_after(8);
-    iset2.insert(3, 4);
+    iset2.union_insert(3, 4);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1254,8 +1795,8 @@ TYPED_TEST(IntervalSetTest, erase_after)
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 4);
-    iset1.insert(10, 4);
+    iset1.union_insert(3, 4);
+    iset1.union_insert(10, 4);
     iset1.erase_after(3);
 
     ASSERT_EQ(iset1, iset2);
@@ -1265,10 +1806,10 @@ TYPED_TEST(IntervalSetTest, erase_after)
   {
     ISet iset1, iset2;
 
-    iset1.insert(3, 1);
-    iset1.insert(5, 1);
-    iset1.insert(7, 1);
-    iset1.insert(9, 1);
+    iset1.union_insert(3, 1);
+    iset1.union_insert(5, 1);
+    iset1.union_insert(7, 1);
+    iset1.union_insert(9, 1);
     iset1.erase_after(2);
 
     ASSERT_EQ(iset1, iset2);
@@ -1278,13 +1819,13 @@ TYPED_TEST(IntervalSetTest, erase_after)
   {
     ISet iset1, iset2;
 
-    iset1.insert(1, 1);
-    iset1.insert(3, 1);
-    iset1.insert(5, 1);
-    iset1.insert(7, 1);
-    iset1.insert(9, 1);
+    iset1.union_insert(1, 1);
+    iset1.union_insert(3, 1);
+    iset1.union_insert(5, 1);
+    iset1.union_insert(7, 1);
+    iset1.union_insert(9, 1);
     iset1.erase_after(2);
-    iset2.insert(1, 1);
+    iset2.union_insert(1, 1);
 
     ASSERT_EQ(iset1, iset2);
   }
@@ -1306,10 +1847,10 @@ TYPED_TEST(IntervalSetTest, subtract) {
   // erase many with border
   {
     ISet iset1, iset2, iset3;
-    iset1.insert(1, 1);
+    iset1.union_insert(1, 1);
     iset1.subtract(iset2);
 
-    iset3.insert(1, 1);
+    iset3.union_insert(1, 1);
     ASSERT_EQ(iset1, iset3);
   }
 
@@ -1317,7 +1858,7 @@ TYPED_TEST(IntervalSetTest, subtract) {
   // erase many with border
   {
     ISet iset1, iset2, iset3;
-    iset2.insert(1, 1);
+    iset2.union_insert(1, 1);
     iset1.subtract(iset2);
 
     ASSERT_EQ(iset1, iset3);
@@ -1327,18 +1868,18 @@ TYPED_TEST(IntervalSetTest, subtract) {
   {
     ISet iset1, iset2, iset3;
 
-    iset1.insert(1, 1);
-    iset1.insert(3, 1);
-    iset1.insert(5, 1);
-    iset1.insert(7, 1);
-    iset1.insert(9, 1);
+    iset1.union_insert(1, 1);
+    iset1.union_insert(3, 1);
+    iset1.union_insert(5, 1);
+    iset1.union_insert(7, 1);
+    iset1.union_insert(9, 1);
 
-    iset2.insert(1, 4);
-    iset2.insert(7, 3);
+    iset2.union_insert(1, 4);
+    iset2.union_insert(7, 3);
 
     iset1.subtract(iset2);
 
-    iset3.insert(5, 1);
+    iset3.union_insert(5, 1);
     ASSERT_EQ(iset1, iset3);
   }
 
@@ -1346,17 +1887,17 @@ TYPED_TEST(IntervalSetTest, subtract) {
   {
     ISet iset1, iset2, iset3;
 
-    iset1.insert(0, 5);
-    iset1.insert(10, 5);
-    iset1.insert(20, 5);
-    iset1.insert(30, 5);
-    iset1.insert(40, 4);
+    iset1.union_insert(0, 5);
+    iset1.union_insert(10, 5);
+    iset1.union_insert(20, 5);
+    iset1.union_insert(30, 5);
+    iset1.union_insert(40, 4);
 
-    iset2.insert(20, 25);
+    iset2.union_insert(20, 25);
     iset1.subtract(iset2);
 
-    iset3.insert(0, 5);
-    iset3.insert(10, 5);
+    iset3.union_insert(0, 5);
+    iset3.union_insert(10, 5);
 
     ASSERT_EQ(iset1, iset3);
   }


### PR DESCRIPTION
These commits enhance the insert/erase function of interval sets.  The main intent is to enhance flexibility to callers, but in many cases, performance is likely also improved.  Where performance is not improved, there should be no performance reduction. 

There is also a new "align" method which allows for all intervals within a set to be aligned to an arbitrary alignment. This will be consumed by the new optimised erasure code. 



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
