### PR TITLE
common: add missing include, reduce header dependencies

### DIFF
--- a/src/common/DecayCounter.h
+++ b/src/common/DecayCounter.h
@@ -16,13 +16,14 @@
 #define CEPH_DECAYCOUNTER_H
 
 #include "include/buffer.h"
-#include "common/Formatter.h"
 #include "common/StackStringStream.h"
 #include "common/ceph_time.h"
 
 #include <cmath>
 #include <list>
 #include <sstream>
+
+namespace ceph { class Formatter; }
 
 /**
  *

--- a/src/common/Graylog.cc
+++ b/src/common/Graylog.cc
@@ -2,6 +2,9 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "Graylog.h"
+
+#include <iostream> // for std::cerr
+
 #include "common/Formatter.h"
 #include "common/LogEntry.h"
 #include "log/Entry.h"

--- a/src/common/Journald.cc
+++ b/src/common/Journald.cc
@@ -14,6 +14,9 @@
 #include <sys/un.h>
 #include <syslog.h>
 #include <unistd.h>
+
+#include <iostream> // for std::cerr
+
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 
@@ -22,7 +25,6 @@
 #include "log/Entry.h"
 #include "log/SubsystemMap.h"
 #include "msg/msg_fmt.h"
-
 
 namespace ceph::logging {
 

--- a/src/common/StackStringStream.h
+++ b/src/common/StackStringStream.h
@@ -18,10 +18,9 @@
 #include <boost/container/small_vector.hpp>
 
 #include <algorithm>
-#include <iostream>
 #include <memory>
 #include <ostream>
-#include <sstream>
+#include <string>
 #include <string_view>
 #include <vector>
 

--- a/src/common/Thread.h
+++ b/src/common/Thread.h
@@ -17,8 +17,8 @@
 #define CEPH_THREAD_H
 
 #include <functional>
+#include <string>
 #include <string_view>
-#include <system_error>
 #include <thread>
 #include <cstring>
 

--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -6,7 +6,7 @@
 
 #include <atomic>
 #include <chrono>
-#include <iostream>
+#include <iosfwd>
 #include <list>
 #include <map>
 

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -12,7 +12,13 @@
  *
  */
 #include <poll.h>
+#include <signal.h>
 #include <sys/un.h>
+
+#ifndef WIN32
+#include <sys/wait.h>
+#endif
+
 #include <optional>
 
 #include <stdlib.h>

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -19,6 +19,8 @@
 
 #include <sys/uio.h>
 
+#include <iostream>
+
 #include "include/ceph_assert.h"
 #include "include/types.h"
 #include "include/buffer_raw.h"

--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -16,6 +16,7 @@
 #include "auth/Auth.h"
 #include "common/ceph_argparse.h"
 #include "common/config.h"
+#include "common/strtol.h" // for strict_strtof()
 #include "common/version.h"
 #include "include/str_list.h"
 

--- a/src/common/ceph_argparse.h
+++ b/src/common/ceph_argparse.h
@@ -29,6 +29,8 @@
 #include "common/entity_name.h"
 #include "include/encoding.h"
 
+class entity_addrvec_t;
+
 /////////////////////// Types ///////////////////////
 class CephInitParameters
 {

--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -16,7 +16,7 @@
 #define COMMON_CEPH_TIME_H
 
 #include <chrono>
-#include <iostream>
+#include <iosfwd>
 #include <string>
 #include <optional>
 #include <fmt/chrono.h>

--- a/src/common/error_code.cc
+++ b/src/common/error_code.cc
@@ -13,10 +13,9 @@
  * COPYING.
  */
 
-#include <exception>
+#include "common/error_code.h"
 
 #include <boost/asio/error.hpp>
-#include "common/error_code.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"

--- a/src/common/error_code.h
+++ b/src/common/error_code.h
@@ -16,9 +16,8 @@
 #ifndef COMMON_CEPH_ERROR_CODE
 #define COMMON_CEPH_ERROR_CODE
 
-#include <netdb.h>
-
-#include <boost/system.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/system/system_error.hpp>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5,6 +5,7 @@
 #include "options.h"
 #include "common/Formatter.h"
 #include "common/options/build_options.h"
+#include "common/strtol.h" // for strict_si_cast()
 
 // Helpers for validators
 #include "include/stringify.h"

--- a/src/common/options.h
+++ b/src/common/options.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <chrono>
+#include <iostream> // for std::cerr
 #include <string>
 #include <variant>
 #include <vector>

--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -18,6 +18,7 @@
 #include "common/dout.h"
 #include "common/valgrind.h"
 #include "include/common_fwd.h"
+#include "include/utime.h"
 
 using std::ostringstream;
 using std::make_pair;

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -17,6 +17,8 @@
 #ifndef CEPH_COMMON_PERF_COUNTERS_H
 #define CEPH_COMMON_PERF_COUNTERS_H
 
+#include <functional>
+#include <set>
 #include <string>
 #include <vector>
 #include <memory>
@@ -24,10 +26,11 @@
 #include <cstdint>
 
 #include "common/perf_histogram.h"
-#include "include/utime.h"
 #include "include/common_fwd.h"
 #include "common/ceph_mutex.h"
 #include "common/ceph_time.h"
+
+class utime_t;
 
 namespace TOPNSPC::common {
   class CephContext;

--- a/src/common/perf_counters_cache.h
+++ b/src/common/perf_counters_cache.h
@@ -3,6 +3,7 @@
 #include "common/perf_counters.h"
 #include "common/ceph_context.h"
 #include "common/intrusive_lru.h"
+#include "include/utime.h"
 
 namespace ceph::perf_counters {
 

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -15,6 +15,7 @@
 #include "common/pick_address.h"
 
 #include <bitset>
+#include <ifaddrs.h> // for struct ifaddrs
 #include <netdb.h>
 #include <netinet/in.h>
 #ifdef _WIN32
@@ -40,6 +41,7 @@
 #include "common/debug.h"
 #include "common/errno.h"
 #include "common/numa.h"
+#include "common/safe_io.h"
 
 #ifndef HAVE_IN_ADDR_T
 typedef uint32_t in_addr_t;

--- a/src/include/elist.h
+++ b/src/include/elist.h
@@ -15,6 +15,10 @@
 #ifndef CEPH_ELIST_H
 #define CEPH_ELIST_H
 
+#include <cstddef> // for size_t
+
+#include "include/ceph_assert.h"
+
 /*
  * elist: embedded list.
  *

--- a/src/include/str_list.h
+++ b/src/include/str_list.h
@@ -2,7 +2,6 @@
 #define CEPH_STRLIST_H
 
 #include <list>
-#include <set>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/test/admin_socket.cc
+++ b/src/test/admin_socket.cc
@@ -27,6 +27,8 @@
 #include <sys/un.h>
 #include <signal.h>
 
+#include <iostream> // for std::cout
+
 using namespace std;
 
 class AdminSocketTest

--- a/src/test/admin_socket_output.h
+++ b/src/test/admin_socket_output.h
@@ -16,6 +16,7 @@
 #define CEPH_ADMIN_SOCKET_OUTPUT_H
 
 #include <filesystem>
+#include <iostream> // for std::cout
 #include <string>
 #include <map>
 #include <set>

--- a/src/test/bench_log.cc
+++ b/src/test/bench_log.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <iostream> // for std::cout
+
 #include "include/types.h"
 #include "common/Thread.h"
 #include "common/debug.h"

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -23,6 +23,8 @@
 #include <errno.h>
 #include <sys/uio.h>
 
+#include <iostream> // for std::cout
+
 #include "include/buffer.h"
 #include "include/buffer_raw.h"
 #include "include/compat.h"

--- a/src/test/ceph_argparse.cc
+++ b/src/test/ceph_argparse.cc
@@ -15,6 +15,7 @@
 #include "common/ceph_argparse.h"
 
 #include "gtest/gtest.h"
+#include <iostream> // for std::cout
 #include <vector>
 #include "include/stringify.h"
 

--- a/src/test/common/Throttle.cc
+++ b/src/test/common/Throttle.cc
@@ -23,6 +23,7 @@
 #include <signal.h>
 
 #include <chrono>
+#include <iostream> // for std::cout
 #include <list>
 #include <mutex>
 #include <random>

--- a/src/test/common/test_cdc.cc
+++ b/src/test/common/test_cdc.cc
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <cstring>
+#include <iostream> // for std::cout
 #include <random>
 
 #include "include/types.h"

--- a/src/test/common/test_config.cc
+++ b/src/test/common/test_config.cc
@@ -19,6 +19,9 @@
  *
  *
  */
+
+#include <iostream> // for std::cout
+
 #include "common/config_proxy.h"
 #include "common/errno.h"
 #include "gtest/gtest.h"

--- a/src/test/common/test_context.cc
+++ b/src/test/common/test_context.cc
@@ -19,6 +19,9 @@
  *
  *
  */
+
+#include <iostream> // for std::cout
+
 #include "gtest/gtest.h"
 #include "include/types.h"
 #include "include/msgr.h"

--- a/src/test/common/test_shared_cache.cc
+++ b/src/test/common/test_shared_cache.cc
@@ -22,6 +22,9 @@
 
 #include <stdio.h>
 #include <signal.h>
+
+#include <iostream> // for std::cout
+
 #include "gtest/gtest.h"
 #include "common/Thread.h"
 #include "common/shared_cache.hpp"

--- a/src/test/common/test_url_escape.cc
+++ b/src/test/common/test_url_escape.cc
@@ -3,6 +3,8 @@
 
 #include "common/url_escape.h"
 
+#include <iostream> // for std::cout
+
 #include "gtest/gtest.h"
 
 TEST(url_escape, escape) {

--- a/src/test/compressor/test_compression.cc
+++ b/src/test/compressor/test_compression.cc
@@ -17,6 +17,9 @@
 #include <errno.h>
 #include <signal.h>
 #include <stdlib.h>
+
+#include <iostream> // for std::cout
+
 #include "gtest/gtest.h"
 #include "common/ceph_context.h"
 #include "common/config.h"

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -1,6 +1,8 @@
 #include <errno.h>
 #include <time.h>
 
+#include <iostream> // for std::cout
+
 #include <boost/container/small_vector.hpp>
 
 #include "gtest/gtest.h"

--- a/src/test/daemon_config.cc
+++ b/src/test/daemon_config.cc
@@ -21,6 +21,8 @@
 #include "include/rados/librados.h"
 
 #include <errno.h>
+
+#include <iostream> // for std::cout
 #include <sstream>
 #include <string>
 #include <string.h>

--- a/src/test/encoding.cc
+++ b/src/test/encoding.cc
@@ -4,6 +4,8 @@
 #include <fmt/format.h>
 #include "gtest/gtest.h"
 
+#include <iostream> // for std::cout
+
 using namespace std;
 
 template < typename T >

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -23,6 +23,8 @@
 #include "common/Thread.h"
 #include "include/stringify.h"
 #include "osd/ReplicatedBackend.h"
+
+#include <iostream> // for std::cout
 #include <sstream>
 
 using namespace std;

--- a/src/test/osdc/object_cacher_stress.cc
+++ b/src/test/osdc/object_cacher_stress.cc
@@ -23,6 +23,7 @@
 #include "MemWriteback.h"
 
 #include <atomic>
+#include <iostream> // for std::cout
 
 using namespace std;
 

--- a/src/test/perf_counters.cc
+++ b/src/test/perf_counters.cc
@@ -15,7 +15,7 @@
 #include "include/types.h" // FIXME: ordering shouldn't be important, but right 
                            // now, this include has to come before the others.
 
-
+#include "include/utime.h"
 #include "common/perf_counters_key.h"
 #include "common/perf_counters_collection.h"
 #include "common/admin_socket_client.h"

--- a/src/test/test_addrs.cc
+++ b/src/test/test_addrs.cc
@@ -17,6 +17,7 @@
 #include "msg/msg_types.h"
 #include "gtest/gtest.h"
 
+#include <iostream> // for std::cout
 #include <sstream>
 
 using namespace std;

--- a/src/test/test_denc.cc
+++ b/src/test/test_denc.cc
@@ -15,6 +15,8 @@
  */
 
 #include <stdio.h>
+
+#include <iostream> // for std::cout
 #include <numeric>
 
 #include "global/global_init.h"

--- a/src/test/test_features.cc
+++ b/src/test/test_features.cc
@@ -2,6 +2,8 @@
 // vim: ts=8 sw=2 smarttab
 #include <stdio.h>
 
+#include <iostream> // for std::cout
+
 #include "global/global_init.h"
 #include "common/ceph_argparse.h"
 #include "common/ceph_releases.h"

--- a/src/test/test_mempool.cc
+++ b/src/test/test_mempool.cc
@@ -16,6 +16,8 @@
 
 #include <stdio.h>
 
+#include <iostream> // for std::cout
+
 #include "global/global_init.h"
 #include "common/ceph_argparse.h"
 #include "global/global_context.h"

--- a/src/test/test_perf_counters_cache.cc
+++ b/src/test/test_perf_counters_cache.cc
@@ -4,6 +4,7 @@
 #include "global/global_context.h"
 #include "global/global_init.h"
 #include "include/msgr.h" // for CEPH_ENTITY_TYPE_CLIENT
+#include "include/utime.h"
 #include "gtest/gtest.h"
 
 using namespace ceph::perf_counters;

--- a/src/test/test_rewrite_latency.cc
+++ b/src/test/test_rewrite_latency.cc
@@ -1,5 +1,6 @@
 
 #include <unistd.h>
+#include <iostream> // for std::cout
 #include <map>
 #include <errno.h>
 

--- a/src/test/test_snap_mapper.cc
+++ b/src/test/test_snap_mapper.cc
@@ -1,4 +1,5 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+#include <iostream> // for std::cout
 #include <iterator>
 #include <map>
 #include <set>

--- a/src/test/test_striper.cc
+++ b/src/test/test_striper.cc
@@ -3,6 +3,8 @@
 
 #include "osdc/Striper.h"
 
+#include <iostream> // for std::cout
+
 using namespace std;
 
 TEST(Striper, Stripe1)

--- a/src/test/test_utime.cc
+++ b/src/test/test_utime.cc
@@ -1,4 +1,7 @@
 #include "include/utime.h"
+
+#include <iostream> // for std::cout
+
 #include "gtest/gtest.h"
 #include "include/stringify.h"
 #include "common/ceph_context.h"

--- a/src/test/test_workqueue.cc
+++ b/src/test/test_workqueue.cc
@@ -1,6 +1,9 @@
 #include "gtest/gtest.h"
 
 #include "common/WorkQueue.h"
+
+#include <iostream> // for std::cout
+
 #include "common/ceph_argparse.h"
 
 using namespace std;

--- a/src/test/testcrypto.cc
+++ b/src/test/testcrypto.cc
@@ -1,6 +1,8 @@
 #include "auth/Crypto.h"
-#include "common/Clock.h"
 
+#include <iostream> // for std::cout
+
+#include "common/Clock.h"
 #include "common/config.h"
 #include "common/debug.h"
 

--- a/src/test/testkeys.cc
+++ b/src/test/testkeys.cc
@@ -1,4 +1,7 @@
 #include "auth/cephx/CephxKeyServer.h"
+
+#include <iostream> // for std::cout
+
 #include "common/ceph_argparse.h"
 #include "global/global_init.h"
 #include "common/config.h"

--- a/src/tools/radosacl.cc
+++ b/src/tools/radosacl.cc
@@ -16,6 +16,8 @@
 #include <time.h>
 #include <errno.h>
 
+#include <iostream> // for std::cerr
+
 #include "include/types.h"
 #include "include/rados/librados.hpp"
 


### PR DESCRIPTION
Ceph build times are pretty bad, even for a C++ project; part of that is because Ceph has too much header+template bloat. I have started reducing header dependencies, but found many build failures because `#include` lines were missing everywhere. This PR starts adding them, to prepare for the actual cleanup.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
