### PR TITLE
rgw: initialize createparams zone_placement to avoid garbage value

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -148,7 +148,7 @@ int rgw_forward_request_to_master(const DoutPrefixProvider* dpp,
 
   // use the master zone's endpoints
   auto conn = RGWRESTConn{dpp->get_cct(), z->second.id, z->second.endpoints,
-                          creds, zg->second.id, zg->second.api_name};
+                          creds, site.get_zonegroup().id, zg->second.api_name};
   bufferlist outdata;
   constexpr size_t max_response_size = 128 * 1024; // we expect a very small response
   int ret = conn.forward(dpp, effective_owner, req, nullptr,

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -874,7 +874,7 @@ class Bucket {
       std::string zonegroup_id;
       rgw_placement_rule placement_rule;
       // zone placement is optional on buckets created for another zonegroup
-      const RGWZonePlacementInfo* zone_placement;
+      const RGWZonePlacementInfo* zone_placement = nullptr;
       RGWAccessControlPolicy policy;
       Attrs attrs;
       bool obj_lock_enabled = false;


### PR DESCRIPTION
When creating a bucket from a secondary zonegroup and forwarding the request to the master zonegroup
(i.e., when `bucket_zonegroup != &my_zonegroup`), the `createparams.zone_placement` may remain uninitialized. This can lead to garbage values and result in a segmentation fault due to invalid memory access.

By explicitly initializing `zone_placement` to `nullptr`, we can eliminate this issue in cases where zone_placement is referenced like `init_default_bucket_layout`.

Fixes: https://tracker.ceph.com/issues/68500