### PR TITLE
mgr/PyModule: do not lock in get_name(), get_error_string()

### DIFF
--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -163,7 +163,7 @@ public:
   const std::string &get_name() const {
     return module_name;
   }
-  const std::string &get_error_string() const {
+  std::string get_error_string() const {
     std::lock_guard l(lock) ; return error_string;
   }
   bool get_can_run() const {

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -161,7 +161,7 @@ public:
   }
 
   const std::string &get_name() const {
-    std::lock_guard l(lock) ; return module_name;
+    return module_name;
   }
   const std::string &get_error_string() const {
     std::lock_guard l(lock) ; return error_string;


### PR DESCRIPTION
The way these methods used the lock is completely wrong: in the protected code block, they do not access anything that needs to be protected.  All they effectively do is return the `this` pointer with an offset to the `module_name` or `error_string` field; but they do not actually access these fields.  The actual access is done by the caller, after the mutex has been unlocked already.

But anyway, these fields do not need any protection.  Both fields are `const` and thus cannot be modified by other threads.  So instead of fixing the return value (removing the `&`), let's just remove the lock.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
