### PR TITLE
msg/async: round timeouts up (fix busy loops)

### DIFF
--- a/src/msg/async/EventEpoll.cc
+++ b/src/msg/async/EventEpoll.cc
@@ -17,6 +17,7 @@
 #include "common/errno.h"
 #include <fcntl.h>
 #include "EventEpoll.h"
+#include "Timeout.h"
 
 #define dout_subsys ceph_subsys_ms
 
@@ -120,8 +121,7 @@ int EpollDriver::event_wait(std::vector<FiredFileEvent> &fired_events, struct ti
 {
   int retval, numevents = 0;
 
-  retval = epoll_wait(epfd, events, nevent,
-                      tvp ? (tvp->tv_sec*1000 + tvp->tv_usec/1000) : -1);
+  retval = epoll_wait(epfd, events, nevent, timeout_to_milliseconds(tvp));
   if (retval > 0) {
     numevents = retval;
     fired_events.resize(numevents);

--- a/src/msg/async/EventPoll.cc
+++ b/src/msg/async/EventPoll.cc
@@ -15,6 +15,7 @@
 
 #include "common/errno.h"
 #include "EventPoll.h"
+#include "Timeout.h"
 
 #include <unistd.h>
 #define dout_subsys ceph_subsys_ms
@@ -161,11 +162,9 @@ int PollDriver::event_wait(std::vector<FiredFileEvent> &fired_events,
 			  struct timeval *tvp) {
   int retval, numevents = 0;
 #ifdef _WIN32
-  retval = WSAPoll(pfds, max_pfds,
-		      tvp ? (tvp->tv_sec*1000 + tvp->tv_usec/1000) : -1);
+  retval = WSAPoll(pfds, max_pfds, timeout_to_milliseconds(tvp));
 #else
-  retval = poll(pfds, max_pfds,
-		      tvp ? (tvp->tv_sec*1000 + tvp->tv_usec/1000) : -1);
+  retval = poll(pfds, max_pfds, timeout_to_milliseconds(tvp));
 #endif
   if (retval > 0) {
     for (int j = 0; j < max_pfds; j++) {

--- a/src/msg/async/Timeout.h
+++ b/src/msg/async/Timeout.h
@@ -17,6 +17,8 @@
 #ifndef CEPH_MSG_TIMEOUT_H
 #define CEPH_MSG_TIMEOUT_H
 
+#include "include/intarith.h" // for div_round_up()
+
 #include <time.h> // for struct timeval
 
 /**
@@ -28,7 +30,8 @@
 constexpr int
 timeout_to_milliseconds(const struct timeval &tv) noexcept
 {
-  return tv.tv_sec * 1000 + tv.tv_usec / 1000;
+  /* round up to the next millisecond so we don't wake up too early */
+  return tv.tv_sec * 1000 + div_round_up(tv.tv_usec, 1000);
 }
 
 /**

--- a/src/msg/async/Timeout.h
+++ b/src/msg/async/Timeout.h
@@ -1,0 +1,44 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2024 IONOS SE
+ *
+ * Author: Max Kellermann <max.kellermann@ionos.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_MSG_TIMEOUT_H
+#define CEPH_MSG_TIMEOUT_H
+
+#include <time.h> // for struct timeval
+
+/**
+ * Convert the given `struct timeval` to milliseconds.
+ *
+ * This is supposed to be used as timeout parameter to system calls
+ * such as poll() and epoll_wait().
+ */
+constexpr int
+timeout_to_milliseconds(const struct timeval &tv) noexcept
+{
+  return tv.tv_sec * 1000 + tv.tv_usec / 1000;
+}
+
+/**
+ * This overload makes the timeout optional; on nullptr, it returns
+ * -1.
+ */
+constexpr int
+timeout_to_milliseconds(const struct timeval *tv) noexcept
+{
+  return tv != nullptr ? timeout_to_milliseconds(*tv) : -1;
+}
+
+#endif


### PR DESCRIPTION
Currently, we always round down, which has a bad side effect: when a timer comes closer, we have lots of early wakeups, and eventually we'll run into a busy loop (timeout=0) when the timeout is less than one millisecond; the process will remain this busy loop for one millisecond, wasting lots of CPU time.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
