### PR TITLE
test/crimson: disable stall-detector on aarch64 to fix asan failures

### DIFF
--- a/src/test/crimson/seastar_runner.h
+++ b/src/test/crimson/seastar_runner.h
@@ -71,6 +71,19 @@ struct SeastarRunner {
     auto ret = app.run(argc, argv, [this] {
       on_end.reset(new seastar::readable_eventfd);
       return seastar::now().then([this] {
+// FIXME: The stall detector uses glibc backtrace function to
+// collect backtraces, this causes ASAN failures on ARM.
+// For now we just extend timeout duration to 10000h in order to
+// get the same effect as disabling the stall detector which is not provided by seastar.
+// the ticket about migrating to libunwind: https://github.com/scylladb/seastar/issues/1878
+// Will remove once the ticket fixed.
+// Ceph ticket see: https://tracker.ceph.com/issues/65635
+#ifdef __aarch64__
+	seastar::smp::invoke_on_all([] {
+	  using namespace std::chrono;
+	  seastar::engine().update_blocked_reactor_notify_ms(duration_cast<milliseconds>(10000h));
+	}).get();
+#endif
 	begin_signaled = true;
 	[[maybe_unused]] auto r = ::eventfd_write(begin_fd.get(), APP_RUNNING);
 	assert(r == 0);


### PR DESCRIPTION
Ceph crimson uses seastar on debug mode which would enable ASAN, while stall-detector uses glibc backtrace function which would cause ASAN failures on aarch64.
Reason see https://github.com/scylladb/scylladb/issues/15090#issuecomment-1763355796

Because arm ci servers in lab are "elderly", causing stall happened often, this PR is to disable stall-detector until seastar upstream migrated to libunwind, see https://github.com/scylladb/seastar/issues/1878

Seastar does not provide a function to disable stall-detector, at present, increase stall-detector time to avoid stall-detector timeout on arm platform.

fixes: https://tracker.ceph.com/issues/65635

After dozen times of triggering arm make check, all crimson/seastar related tests passed.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
