### PR TITLE
reef: osd/PeeringState: introduce osd_skip_check_past_interval_bounds

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -3221,6 +3221,12 @@ options:
   level: dev
   default: false
   with_legacy: true
+- name: osd_skip_check_past_interval_bounds
+  type: bool
+  level: dev
+  desc: See https://tracker.ceph.com/issues/64002
+  default: false
+  with_legacy: true
 - name: osd_debug_pretend_recovery_active
   type: bool
   level: dev

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -930,6 +930,10 @@ static pair<epoch_t, epoch_t> get_required_past_interval_bounds(
 
 void PeeringState::check_past_interval_bounds() const
 {
+  // See: https://tracker.ceph.com/issues/64002
+  if (cct->_conf.get_val<bool>("osd_skip_check_past_interval_bounds")) {
+    return;
+  }
   // cluster_osdmap_trim_lower_bound gives us a bound on needed
   // intervals, see doc/dev/osd_internals/past_intervals.rst
   auto oldest_epoch = pl->cluster_osdmap_trim_lower_bound();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68501

---

backport of https://github.com/ceph/ceph/pull/55147
parent tracker: https://tracker.ceph.com/issues/64002

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh