### PR TITLE
mds: enforce usage of host error in cephfs, use errorcode32_t in MClientReply message

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -623,3 +623,9 @@ It is also adding 2 new mon commands, to notify monitor about the gateway creati
   - nvme-gw create
   - nvme-gw delete
 Relevant tracker: https://tracker.ceph.com/issues/64777
+
+* MDS now uses host errors, as defined in errno.cc, for current platform.
+errorcode32_t is converting, internally, the error code from host to ceph, when encoding, and vice versa,
+when decoding, resulting having LINUX codes on the wire, and HOST code on the receiver.
+All CEPHFS_E* defines have been removed across Ceph (including the python binding).
+Relevant tracker: https://tracker.ceph.com/issues/64611

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -250,7 +250,7 @@ int Client::get_fd_inode(int fd, InodeRef *in) {
   } else {
     Fh *f = get_filehandle(fd);
     if (!f) {
-      r = -CEPHFS_EBADF;
+      r = -EBADF;
     } else {
       *in = f->inode;
     }
@@ -1941,7 +1941,7 @@ int Client::verify_reply_trace(int r, MetaSession *session,
 	if (got_created_ino &&
 	    created_ino.val != target->ino.val) {
 	  ldout(cct, 5) << "create got ino " << created_ino << " but then failed on lookup; EINTR?" << dendl;
-	  r = -CEPHFS_EINTR;
+	  r = -EINTR;
 	}
 	if (ptarget)
 	  ptarget->swap(target);
@@ -2013,7 +2013,7 @@ int Client::make_request(MetaRequest *request,
       break;
 
     if (blocklisted) {
-      request->abort(-CEPHFS_EBLOCKLISTED);
+      request->abort(-EBLOCKLISTED);
       break;
     }
 
@@ -2045,7 +2045,7 @@ int Client::make_request(MetaRequest *request,
     if (!have_open_session(mds)) {
       session = _get_or_open_mds_session(mds);
       if (session->state == MetaSession::STATE_REJECTED) {
-	request->abort(-CEPHFS_EPERM);
+	request->abort(-EPERM);
 	break;
       }
       // wait
@@ -2062,7 +2062,7 @@ int Client::make_request(MetaRequest *request,
     }
 
     if (feature_needed != ULONG_MAX && !session->mds_features.test(feature_needed)) {
-      request->abort(-CEPHFS_EOPNOTSUPP);
+      request->abort(-EOPNOTSUPP);
       break;
     }
 
@@ -2521,7 +2521,7 @@ void Client::handle_client_session(const MConstRef<MClientSession>& m)
 	error_str = "unknown error";
       lderr(cct) << "mds." << from << " rejected us (" << error_str << ")" << dendl;
 
-      _closed_mds_session(session.get(), -CEPHFS_EPERM, true);
+      _closed_mds_session(session.get(), -EPERM, true);
     }
     break;
 
@@ -2626,7 +2626,7 @@ ref_t<MClientRequest> Client::build_client_request(MetaRequest *request, mds_ran
     old_max_retry = 1 << (old_max_retry * CHAR_BIT);
     if ((old_version && request->retry_attempt >= old_max_retry) ||
         (uint32_t)request->retry_attempt >= UINT32_MAX) {
-      request->abort(-CEPHFS_EMULTIHOP);
+      request->abort(-EMULTIHOP);
       request->caller_cond->notify_all();
       ldout(cct, 1) << __func__ << " request tid " << request->tid
                     << " retry seq overflow" << ", abort it" << dendl;
@@ -2705,7 +2705,7 @@ void Client::handle_client_request_forward(const MConstRef<MClientRequestForward
    */
   auto num_fwd = fwd->get_num_fwd();
   if (num_fwd <= request->num_fwd || (uint32_t)num_fwd >= UINT32_MAX) {
-    request->abort(-CEPHFS_EMULTIHOP);
+    request->abort(-EMULTIHOP);
     request->caller_cond->notify_all();
     ldout(cct, 0) << __func__ << " request tid " << tid << " new num_fwd "
       << num_fwd << " old num_fwd " << request->num_fwd << ", fwd seq overflow"
@@ -2841,12 +2841,12 @@ void Client::_handle_full_flag(int64_t pool)
 {
   ldout(cct, 1) << __func__ << ": FULL: cancelling outstanding operations "
     << "on " << pool << dendl;
-  // Cancel all outstanding ops in this pool with -CEPHFS_ENOSPC: it is necessary
+  // Cancel all outstanding ops in this pool with -ENOSPC: it is necessary
   // to do this rather than blocking, because otherwise when we fill up we
   // potentially lock caps forever on files with dirty pages, and we need
   // to be able to release those caps to the MDS so that it can delete files
   // and free up space.
-  epoch_t cancelled_epoch = objecter->op_cancel_writes(-CEPHFS_ENOSPC, pool);
+  epoch_t cancelled_epoch = objecter->op_cancel_writes(-ENOSPC, pool);
 
   // For all inodes with layouts in this pool and a pending flush write op
   // (i.e. one of the ones we will cancel), we've got to purge_set their data
@@ -2855,7 +2855,7 @@ void Client::_handle_full_flag(int64_t pool)
   // Fortunately since we're cancelling everything in a given pool, we don't
   // need to know which ops belong to which ObjectSet, we can just blow all
   // the un-flushed cached data away and mark any dirty inodes' async_err
-  // field with -CEPHFS_ENOSPC as long as we're sure all the ops we cancelled were
+  // field with -ENOSPC as long as we're sure all the ops we cancelled were
   // affecting this pool, and all the objectsets we're purging were also
   // in this pool.
   for (unordered_map<vinodeno_t,Inode*>::iterator i = inode_map.begin();
@@ -2867,7 +2867,7 @@ void Client::_handle_full_flag(int64_t pool)
       ldout(cct, 4) << __func__ << ": FULL: inode 0x" << std::hex << i->first << std::dec
         << " has dirty objects, purging and setting ENOSPC" << dendl;
       objectcacher->purge_set(&inode->oset);
-      inode->set_async_err(-CEPHFS_ENOSPC);
+      inode->set_async_err(-ENOSPC);
     }
   }
 
@@ -2893,12 +2893,12 @@ void Client::handle_osd_map(const MConstRef<MOSDMap>& m)
     lderr(cct) << "I was blocklisted at osd epoch " << epoch << dendl;
     blocklisted = true;
 
-    _abort_mds_sessions(-CEPHFS_EBLOCKLISTED);
+    _abort_mds_sessions(-EBLOCKLISTED);
 
     // Since we know all our OSD ops will fail, cancel them all preemtively,
     // so that on an unhealthy cluster we can umount promptly even if e.g.
     // some PGs were inaccessible.
-    objecter->op_cancel_writes(-CEPHFS_EBLOCKLISTED);
+    objecter->op_cancel_writes(-EBLOCKLISTED);
 
   } 
 
@@ -3069,7 +3069,7 @@ void Client::cancel_commands(const MDSMap& newmap)
        * has its own lock.
        */
       op.con->mark_down();
-      return -CEPHFS_ETIMEDOUT;
+      return -ETIMEDOUT;
     }
     return 0;
   });
@@ -3337,14 +3337,14 @@ void Client::kick_requests_closed(MetaSession *session)
 	if (is_dir_operation(req)) {
 	  Inode *dir = req->inode();
 	  ceph_assert(dir);
-	  dir->set_async_err(-CEPHFS_EIO);
+	  dir->set_async_err(-EIO);
 	  lderr(cct) << "kick_requests_closed drop req of inode(dir) : "
 		     <<  dir->ino  << " " << req->get_tid() << dendl;
 	  req->unsafe_dir_item.remove_myself();
 	}
 	if (req->target) {
 	  InodeRef &in = req->target;
-	  in->set_async_err(-CEPHFS_EIO);
+	  in->set_async_err(-EIO);
 	  lderr(cct) << "kick_requests_closed drop req of inode : "
 		     <<  in->ino  << " " << req->get_tid() << dendl;
 	  req->unsafe_target_item.remove_myself();
@@ -3675,14 +3675,14 @@ int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
       ldout(cct, 10) << "get_caps " << *in << " need " << ccap_string(need)
 		     << " file_wanted " << ccap_string(file_wanted) << ", EBADF "
 		     << dendl;
-      return -CEPHFS_EBADF;
+      return -EBADF;
     }
 
     if ((fh->mode & CEPH_FILE_MODE_WR) && fh->gen != fd_gen)
-      return -CEPHFS_EBADF;
+      return -EBADF;
 
     if ((in->flags & I_ERROR_FILELOCK) && fh->has_any_filelocks())
-      return -CEPHFS_EIO;
+      return -EIO;
 
     int implemented;
     int have = in->caps_issued(&implemented);
@@ -3747,7 +3747,7 @@ int Client::get_caps(Fh *fh, int need, int want, int *phave, loff_t endoff)
 	((in->auth_cap && in->auth_cap->session->readonly) ||
 	 // userland clients are only allowed to read if fscrypt enabled
 	 in->is_fscrypt_enabled()))
-      return -CEPHFS_EROFS;
+      return -EROFS;
 
     if (in->flags & I_CAP_DROPPED) {
       int mds_wanted = in->caps_mds_wanted();
@@ -4403,7 +4403,7 @@ bool Client::_flush(Inode *in, Context *onfinish)
     ldout(cct, 8) << __func__ << ": FULL, purging for ENOSPC" << dendl;
     objectcacher->purge_set(&in->oset);
     if (onfinish) {
-      onfinish->complete(-CEPHFS_ENOSPC);
+      onfinish->complete(-ENOSPC);
     }
     return true;
   }
@@ -4652,7 +4652,7 @@ void Client::remove_session_caps(MetaSession *s, int err)
     }
     caps &= CEPH_CAP_FILE_CACHE | CEPH_CAP_FILE_BUFFER;
     if (caps && !in->caps_issued_mask(caps, true)) {
-      if (err == -CEPHFS_EBLOCKLISTED) {
+      if (err == -EBLOCKLISTED) {
 	if (in->oset.dirty_or_tx) {
 	  lderr(cct) << __func__ << " still has dirty data on " << *in << dendl;
 	  in->set_async_err(err);
@@ -5992,7 +5992,7 @@ int Client::mds_check_access(std::string& path, const UserPerm& perms, int mask)
                    << !!(mask & MAY_READ) << "/" << !!(mask & MAY_WRITE) << dendl;
   }
 
-  return -CEPHFS_EACCES;
+  return -EACCES;
 }
 
 int Client::inode_permission(Inode *in, const UserPerm& perms, unsigned want)
@@ -6002,19 +6002,19 @@ int Client::inode_permission(Inode *in, const UserPerm& perms, unsigned want)
     // For files, Read/write DACs are always overridable but executable DACs are
     // overridable when there is at least one exec bit set
     if(!S_ISDIR(in->mode) && (want & CLIENT_MAY_EXEC) && !(in->mode & S_IXUGO))
-      return -CEPHFS_EACCES;
+      return -EACCES;
     return 0;
   }
   
   if (perms.uid() != in->uid && (in->mode & S_IRWXG)) {
     int ret = _posix_acl_permission(in, perms, want);
-    if (ret != -CEPHFS_EAGAIN)
+    if (ret != -EAGAIN)
       return ret;
   }
 
   // check permissions before doing anything else
   if (!in->check_mode(perms, want))
-    return -CEPHFS_EACCES;
+    return -EACCES;
   return 0;
 }
 
@@ -6028,7 +6028,7 @@ int Client::xattr_permission(Inode *in, const char *name, unsigned want,
   r = 0;
   if (strncmp(name, "system.", 7) == 0) {
     if ((want & CLIENT_MAY_WRITE) && (perms.uid() != 0 && perms.uid() != in->uid))
-      r = -CEPHFS_EPERM;
+      r = -EPERM;
   } else {
     r = inode_permission(in, perms, want);
   }
@@ -6057,7 +6057,7 @@ int Client::may_setattr(Inode *in, struct ceph_statx *stx, int mask,
       goto out;
   }
 
-  r = -CEPHFS_EPERM;
+  r = -EPERM;
   if (mask & CEPH_SETATTR_UID) {
     if (perms.uid() != 0 && (perms.uid() != in->uid || stx->stx_uid != in->uid))
       goto out;
@@ -6132,11 +6132,11 @@ int Client::may_open(Inode *in, int flags, const UserPerm& perms)
       if (flags & O_PATH)
         break;
 #endif
-      r = -CEPHFS_ELOOP;
+      r = -ELOOP;
       goto out;
     case S_IFDIR:
       if (want & CLIENT_MAY_WRITE) {
-	r = -CEPHFS_EISDIR;
+	r = -EISDIR;
 	goto out;
       }
       break;
@@ -6196,7 +6196,7 @@ int Client::may_delete(Inode *dir, const char *name, const UserPerm& perms)
     if (r < 0)
       goto out;
     if (dir->uid != perms.uid() && otherin->uid != perms.uid())
-      r = -CEPHFS_EPERM;
+      r = -EPERM;
   }
 out:
   ldout(cct, 3) << __func__ << " " << dir << " = " << r <<  dendl;
@@ -6208,7 +6208,7 @@ int Client::may_delete(const char *relpath, const UserPerm& perms) {
 
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   filepath path(relpath);
   string name = path.last_dentry();
@@ -6240,7 +6240,7 @@ int Client::may_hardlink(Inode *in, const UserPerm& perms)
     goto out;
   }
 
-  r = -CEPHFS_EPERM;
+  r = -EPERM;
   if (!S_ISREG(in->mode))
     goto out;
 
@@ -6298,7 +6298,7 @@ int Client::resolve_mds(
     if (mdsmap.is_down(role.rank)) {
       lderr(cct) << __func__ << ": targets rank: " << role.rank
                  << " is down" << dendl;
-      return -CEPHFS_EAGAIN;
+      return -EAGAIN;
     }
     auto& info = mdsmap.get_info(role.rank);
     ldout(cct, 10) << __func__ << ": resolved " << mds_spec << " to role '"
@@ -6322,7 +6322,7 @@ int Client::resolve_mds(
       lderr(cct) << __func__ << ": gid " << mds_gid << " not in MDS map"
                  << dendl;
       lderr(cct) << "FSMap: " << *fsmap << dendl;
-      return -CEPHFS_ENOENT;
+      return -ENOENT;
     }
   } else if (mds_spec == "*") {
     // It is a wildcard: use all MDSs
@@ -6332,7 +6332,7 @@ int Client::resolve_mds(
     if (mds_info.empty()) {
       lderr(cct) << __func__ << ": no MDS daemons found" << dendl;
       lderr(cct) << "FSMap: " << *fsmap << dendl;
-      return -CEPHFS_ENOENT;
+      return -ENOENT;
     }
 
     for (const auto& [gid, info] : mds_info) {
@@ -6346,7 +6346,7 @@ int Client::resolve_mds(
     if (mds_gid == mds_gid_t{0}) {
       lderr(cct) << __func__ << ": no MDS daemons found by name `" << mds_spec << "'" << dendl;
       lderr(cct) << "FSMap: " << *fsmap << dendl;
-      return -CEPHFS_ENOENT;
+      return -ENOENT;
     } else {
       auto& info = fsmap->get_info_gid(mds_gid);
       ldout(cct, 10) << __func__ << ": resolved name '" << mds_spec
@@ -6443,7 +6443,7 @@ int Client::mds_command(
 {
   RWRef_t iref_reader(initialize_state, CLIENT_INITIALIZED);
   if (!iref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::unique_lock cl(client_lock);
 
@@ -6476,7 +6476,7 @@ int Client::mds_command(
   }
   if (non_laggy.size() == 0) {
     *outs = "All targeted MDS daemons are laggy";
-    return -CEPHFS_ENOENT;
+    return -ENOENT;
   }
 
   if (metadata.empty()) {
@@ -6611,7 +6611,7 @@ int Client::subscribe_mdsmap(const std::string &fs_name)
       return r;
     fscid = fsmap_user->get_fs_cid(resolved_fs_name);
     if (fscid == FS_CLUSTER_ID_NONE) {
-      return -CEPHFS_ENOENT;
+      return -ENOENT;
     }
 
     std::ostringstream oss;
@@ -6673,7 +6673,7 @@ int Client::mount(const std::string &mount_root, const UserPerm& perms,
   if(mdsmap->test_flag(CEPH_MDSMAP_REFUSE_CLIENT_SESSION)) {
     lderr(cct) << "connections cannot be made while" 
                   " the flag refuse_client_session is set" << dendl;
-    return -CEPHFS_EACCES;
+    return -EACCES;
   }
 
   populate_metadata(mount_root.empty() ? "/" : mount_root);
@@ -6688,7 +6688,7 @@ int Client::mount(const std::string &mount_root, const UserPerm& perms,
     req->head.args.getattr.mask = CEPH_STAT_CAP_INODE_ALL;
     int res = make_request(req, perms);
     if (res < 0) {
-      if (res == -CEPHFS_EACCES && root) {
+      if (res == -EACCES && root) {
 	ldout(cct, 1) << __func__ << " EACCES on parent of mount point; quotas may not work" << dendl;
 	break;
       }
@@ -6761,7 +6761,7 @@ void Client::_close_sessions()
       while (!mds_ranks_closing.empty()) {
         auto session = mds_sessions.at(*mds_ranks_closing.begin());
         // this prunes entry from mds_sessions and mds_ranks_closing
-        _closed_mds_session(session.get(), -CEPHFS_ETIMEDOUT);
+        _closed_mds_session(session.get(), -ETIMEDOUT);
       }
     }
 
@@ -6866,9 +6866,9 @@ void Client::_unmount(bool abort)
   if (abort) {
     mount_aborted = true;
     // Abort all mds sessions
-    _abort_mds_sessions(-CEPHFS_ENOTCONN);
+    _abort_mds_sessions(-ENOTCONN);
 
-    objecter->op_cancel_writes(-CEPHFS_ENOTCONN);
+    objecter->op_cancel_writes(-ENOTCONN);
   } else {
     // flush the mdlog for pending requests, if any
     flush_mdlog_sync();
@@ -7074,7 +7074,7 @@ void Client::tick()
     MetaRequest *req = mds_requests.begin()->second;
 
     if (req->created + mount_timeout < now) {
-      req->abort(-CEPHFS_ETIMEDOUT);
+      req->abort(-ETIMEDOUT);
       if (req->caller_cond) {
         req->kick = true;
         req->caller_cond->notify_all();
@@ -7378,12 +7378,12 @@ int Client::_lookup(Inode *dir, const string& dname, int mask, InodeRef *target,
   }
 
   if (!dir->is_dir()) {
-    r = -CEPHFS_ENOTDIR;
+    r = -ENOTDIR;
     goto done;
   }
 
   if (dname.length() > NAME_MAX) {
-    r = -CEPHFS_ENAMETOOLONG;
+    r = -ENAMETOOLONG;
     goto done;
   }
 
@@ -7420,7 +7420,7 @@ relookup:
 	if (!dn->inode && (dir->flags & I_COMPLETE)) {
 	  ldout(cct, 10) << __func__ << " concluded ENOENT locally for "
 			 << *dir << " dn '" << dname << "'" << dendl;
-	  return -CEPHFS_ENOENT;
+	  return -ENOENT;
 	}
       }
     } else {
@@ -7444,7 +7444,7 @@ relookup:
     if (dir->caps_issued_mask(CEPH_CAP_FILE_SHARED, true) &&
 	(dir->flags & I_COMPLETE)) {
       ldout(cct, 10) << __func__ << " concluded ENOENT locally for " << *dir << " dn '" << dname << "'" << dendl;
-      return -CEPHFS_ENOENT;
+      return -ENOENT;
     }
   }
 
@@ -7467,7 +7467,7 @@ relookup:
     if (alternate_name)
       *alternate_name = dn->alternate_name;
   } else {
-    r = -CEPHFS_ENOENT;
+    r = -ENOENT;
   }
   touch_dn(dn);
   goto done;
@@ -7496,7 +7496,7 @@ int Client::walk(std::string_view path, walk_dentry_result* wdr, const UserPerm&
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 10) << __func__ << ": " << path << dendl;
 
@@ -7560,7 +7560,7 @@ int Client::path_walk(const filepath& origpath, walk_dentry_result* result, cons
       symlinks++;
       ldout(cct, 20) << " symlink count " << symlinks << ", value is '" << next->symlink << "'" << dendl;
       if (symlinks > MAXSYMLINKS) {
-	return -CEPHFS_ELOOP;
+	return -ELOOP;
       }
 
       if (i < path.depth() - 1) {
@@ -7595,7 +7595,7 @@ int Client::path_walk(const filepath& origpath, walk_dentry_result* result, cons
     i++;
   }
   if (!cur)
-    return -CEPHFS_ENOENT;
+    return -ENOENT;
   if (result) {
     result->in = std::move(cur);
     result->alternate_name = std::move(alternate_name);
@@ -7610,7 +7610,7 @@ int Client::link(const char *relexisting, const char *relpath, const UserPerm& p
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << "link" << std::endl;
   tout(cct) << relexisting << std::endl;
@@ -7625,7 +7625,7 @@ int Client::link(const char *relexisting, const char *relpath, const UserPerm& p
   if (r < 0)
     return r;
   if (std::string(relpath) == "/") {
-    r = -CEPHFS_EEXIST;
+    r = -EEXIST;
     return r;
   }
   filepath path(relpath);
@@ -7637,7 +7637,7 @@ int Client::link(const char *relexisting, const char *relpath, const UserPerm& p
     return r;
   if (cct->_conf->client_permissions) {
     if (S_ISDIR(in->mode)) {
-      r = -CEPHFS_EPERM;
+      r = -EPERM;
       return r;
     }
     r = may_hardlink(in.get(), perm);
@@ -7660,7 +7660,7 @@ int Client::unlinkat(int dirfd, const char *relpath, int flags, const UserPerm& 
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   tout(cct) << __func__ << std::endl;
@@ -7669,7 +7669,7 @@ int Client::unlinkat(int dirfd, const char *relpath, int flags, const UserPerm& 
   tout(cct) << flags << std::endl;
 
   if (std::string(relpath) == "/") {
-    return flags & AT_REMOVEDIR ? -CEPHFS_EBUSY : -CEPHFS_EISDIR;
+    return flags & AT_REMOVEDIR ? -EBUSY : -EISDIR;
   }
 
   filepath path(relpath);
@@ -7707,14 +7707,14 @@ int Client::rename(const char *relfrom, const char *relto, const UserPerm& perm,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << relfrom << std::endl;
   tout(cct) << relto << std::endl;
 
   if (std::string(relfrom) == "/" || std::string(relto) == "/")
-    return -CEPHFS_EBUSY;
+    return -EBUSY;
 
   filepath from(relfrom);
   filepath to(relto);
@@ -7738,7 +7738,7 @@ int Client::rename(const char *relfrom, const char *relto, const UserPerm& perm,
     if (r < 0)
       return r;
     r = may_delete(todir.get(), toname.c_str(), perm);
-    if (r < 0 && r != -CEPHFS_ENOENT)
+    if (r < 0 && r != -ENOENT)
       return r;
   }
   r = _rename(fromdir.get(), fromname.c_str(), todir.get(), toname.c_str(), perm, std::move(alternate_name));
@@ -7758,7 +7758,7 @@ int Client::mkdirat(int dirfd, const char *relpath, mode_t mode, const UserPerm&
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << dirfd << std::endl;
@@ -7767,7 +7767,7 @@ int Client::mkdirat(int dirfd, const char *relpath, mode_t mode, const UserPerm&
   ldout(cct, 10) << __func__ << ": " << relpath << dendl;
 
   if (std::string(relpath) == "/") {
-    return -CEPHFS_EEXIST;
+    return -EEXIST;
   }
 
   filepath path(relpath);
@@ -7800,7 +7800,7 @@ int Client::mkdirs(const char *relpath, mode_t mode, const UserPerm& perms)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 10) << "Client::mkdirs " << relpath << dendl;
   tout(cct) << __func__ << std::endl;
@@ -7827,7 +7827,7 @@ int Client::mkdirs(const char *relpath, mode_t mode, const UserPerm& perms)
       break;
     cur.swap(next);
   }
-  if (r!=-CEPHFS_ENOENT) return r;
+  if (r!=-ENOENT) return r;
   ldout(cct, 20) << __func__ << " got through " << i << " directories on path " << relpath << dendl;
   //make new directory at each level
   for (; i<path.depth(); ++i) {
@@ -7840,7 +7840,7 @@ int Client::mkdirs(const char *relpath, mode_t mode, const UserPerm& perms)
     r = _mkdir(cur.get(), path[i].c_str(), mode, perms, &next);
     
     //check proper creation/existence
-    if(-CEPHFS_EEXIST == r && i < path.depth() - 1) {
+    if(-EEXIST == r && i < path.depth() - 1) {
       r = _lookup(cur.get(), path[i].c_str(), CEPH_CAP_AUTH_SHARED, &next, perms);
     }	
     if (r < 0) 
@@ -7862,7 +7862,7 @@ int Client::mknod(const char *relpath, mode_t mode, const UserPerm& perms, dev_t
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << relpath << std::endl;
@@ -7870,7 +7870,7 @@ int Client::mknod(const char *relpath, mode_t mode, const UserPerm& perms, dev_t
   tout(cct) << rdev << std::endl;
 
   if (std::string(relpath) == "/")
-    return -CEPHFS_EEXIST;
+    return -EEXIST;
 
   filepath path(relpath);
   string name = path.last_dentry();
@@ -7901,7 +7901,7 @@ int Client::symlinkat(const char *target, int dirfd, const char *relpath, const 
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   tout(cct) << __func__ << std::endl;
@@ -7910,7 +7910,7 @@ int Client::symlinkat(const char *target, int dirfd, const char *relpath, const 
   tout(cct) << relpath << std::endl;
 
   if (std::string(relpath) == "/") {
-    return -CEPHFS_EEXIST;
+    return -EEXIST;
   }
 
   filepath path(relpath);
@@ -7946,7 +7946,7 @@ int Client::readlink(const char *relpath, char *buf, loff_t size, const UserPerm
 int Client::readlinkat(int dirfd, const char *relpath, char *buf, loff_t size, const UserPerm& perms) {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   tout(cct) << __func__ << std::endl;
@@ -7962,7 +7962,7 @@ int Client::readlinkat(int dirfd, const char *relpath, char *buf, loff_t size, c
 
   if (!strcmp(relpath, "")) {
     if (!dirinode.get()->is_symlink())
-      return -CEPHFS_ENOENT;
+      return -ENOENT;
     return _readlink(dirinode.get(), buf, size);
   }
 
@@ -7979,7 +7979,7 @@ int Client::readlinkat(int dirfd, const char *relpath, char *buf, loff_t size, c
 int Client::_readlink(Inode *in, char *buf, size_t size)
 {
   if (!in->is_symlink())
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
 
   // copy into buf (at most size bytes)
   int r = in->symlink.length();
@@ -8021,7 +8021,7 @@ int Client::_getvxattr(
   mds_rank_t rank)
 {
   if (!xattr_name || strlen(xattr_name) <= 0 || strlen(xattr_name) > 255) {
-    return -CEPHFS_ENODATA;
+    return -ENODATA;
   }
 
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_GETVXATTR);
@@ -8037,8 +8037,8 @@ int Client::_getvxattr(
   ldout(cct, 10) << __func__ << " result=" << res << dendl;
 
   if (res < 0) {
-    if (res == -CEPHFS_EOPNOTSUPP) {
-      return -CEPHFS_ENODATA;
+    if (res == -EOPNOTSUPP) {
+      return -ENODATA;
     }
     return res;
   }
@@ -8056,7 +8056,7 @@ int Client::_getvxattr(
 
   if (size > 0) {
     if (len > size) {
-      res = -CEPHFS_ERANGE; // insufficient output buffer space
+      res = -ERANGE; // insufficient output buffer space
     } else {
       memcpy(value, buf.c_str(), len);
     }
@@ -8102,22 +8102,22 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
     ccap_string(issued) <<  " aux size " << auxsize << " perms " << perms << dendl;
 
   if (in->snapid != CEPH_NOSNAP) {
-    return -CEPHFS_EROFS;
+    return -EROFS;
   }
   if ((mask & CEPH_SETATTR_SIZE) &&
       (uint64_t)stx->stx_size > in->size &&
       is_quota_bytes_exceeded(in, (uint64_t)stx->stx_size - in->size,
 			      perms)) {
-    return -CEPHFS_EDQUOT;
+    return -EDQUOT;
   }
 
   // Can't set fscrypt_auth and file at the same time!
   if ((mask & (CEPH_SETATTR_FSCRYPT_AUTH|CEPH_SETATTR_FSCRYPT_FILE)) ==
       (CEPH_SETATTR_FSCRYPT_AUTH|CEPH_SETATTR_FSCRYPT_FILE))
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
 
   if (!aux && (mask & (CEPH_SETATTR_FSCRYPT_AUTH|CEPH_SETATTR_FSCRYPT_FILE)))
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
 
   memset(&args, 0, sizeof(args));
 
@@ -8256,7 +8256,7 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
     if ((uint64_t)stx->stx_size >= mdsmap->get_max_filesize()) {
       //too big!
       ldout(cct,10) << "unable to set size to " << stx->stx_size << ". Too large!" << dendl;
-      return -CEPHFS_EFBIG;
+      return -EFBIG;
     }
 
     ldout(cct,10) << "changing size to " << stx->stx_size << dendl;
@@ -8451,7 +8451,7 @@ int Client::setattr(const char *relpath, struct stat *attr, int mask,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << relpath << std::endl;
@@ -8472,7 +8472,7 @@ int Client::setattrx(const char *relpath, struct ceph_statx *stx, int mask,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << relpath << std::endl;
@@ -8492,7 +8492,7 @@ int Client::fsetattr(int fd, struct stat *attr, int mask, const UserPerm& perms)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << fd << std::endl;
@@ -8501,10 +8501,10 @@ int Client::fsetattr(int fd, struct stat *attr, int mask, const UserPerm& perms)
   std::scoped_lock lock(client_lock);
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #if defined(__linux__) && defined(O_PATH)
   if (f->flags & O_PATH)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #endif
   return _setattr(f->inode, attr, mask, perms);
 }
@@ -8513,7 +8513,7 @@ int Client::fsetattrx(int fd, struct ceph_statx *stx, int mask, const UserPerm& 
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << fd << std::endl;
@@ -8522,10 +8522,10 @@ int Client::fsetattrx(int fd, struct ceph_statx *stx, int mask, const UserPerm& 
   std::scoped_lock lock(client_lock);
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #if defined(__linux__) && defined(O_PATH)
   if (f->flags & O_PATH)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #endif
   return _setattrx(f->inode, stx, mask, perms);
 }
@@ -8535,7 +8535,7 @@ int Client::stat(const char *relpath, struct stat *stbuf, const UserPerm& perms,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 3) << __func__ << " enter (relpath " << relpath << " mask " << mask << ")" << dendl;
   tout(cct) << "stat" << std::endl;
@@ -8592,7 +8592,7 @@ int Client::lstat(const char *relpath, struct stat *stbuf,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 3) << __func__ << " enter (relpath " << relpath << " mask " << mask << ")" << dendl;
   tout(cct) << __func__ << std::endl;
@@ -8797,7 +8797,7 @@ int Client::fchmod(int fd, mode_t mode, const UserPerm& perms)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << fd << std::endl;
@@ -8806,10 +8806,10 @@ int Client::fchmod(int fd, mode_t mode, const UserPerm& perms)
   std::scoped_lock lock(client_lock);
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #if defined(__linux__) && defined(O_PATH)
   if (f->flags & O_PATH)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #endif
   struct stat attr;
   attr.st_mode = mode;
@@ -8820,7 +8820,7 @@ int Client::chmodat(int dirfd, const char *relpath, mode_t mode, int flags,
                     const UserPerm& perms) {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   tout(cct) << __func__ << std::endl;
@@ -8863,7 +8863,7 @@ int Client::fchown(int fd, uid_t new_uid, gid_t new_gid, const UserPerm& perms)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << fd << std::endl;
@@ -8873,10 +8873,10 @@ int Client::fchown(int fd, uid_t new_uid, gid_t new_gid, const UserPerm& perms)
   std::scoped_lock lock(client_lock);
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #if defined(__linux__) && defined(O_PATH)
   if (f->flags & O_PATH)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #endif
   struct stat attr;
   attr.st_uid = new_uid;
@@ -8897,7 +8897,7 @@ int Client::chownat(int dirfd, const char *relpath, uid_t new_uid, gid_t new_gid
                     int flags, const UserPerm& perms) {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   tout(cct) << __func__ << std::endl;
@@ -8923,7 +8923,7 @@ int Client::chownat(int dirfd, const char *relpath, uid_t new_uid, gid_t new_gid
       goto out;
     }
 #endif
-    return -CEPHFS_ENOENT;
+    return -ENOENT;
   } else {
     filepath path(relpath);
     r = path_walk(path, &in, perms, !(flags & AT_SYMLINK_NOFOLLOW), 0, dirinode);
@@ -8983,7 +8983,7 @@ int Client::utimes(const char *relpath, struct timeval times[2],
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << relpath << std::endl;
@@ -9011,7 +9011,7 @@ int Client::lutimes(const char *relpath, struct timeval times[2],
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << relpath << std::endl;
@@ -9049,7 +9049,7 @@ int Client::futimens(int fd, struct timespec times[2], const UserPerm& perms)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << fd << std::endl;
@@ -9061,10 +9061,10 @@ int Client::futimens(int fd, struct timespec times[2], const UserPerm& perms)
   std::scoped_lock lock(client_lock);
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #if defined(__linux__) && defined(O_PATH)
   if (f->flags & O_PATH)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #endif
   struct ceph_statx attr;
   utime_t(times[0]).to_timespec(&attr.stx_atime);
@@ -9077,7 +9077,7 @@ int Client::utimensat(int dirfd, const char *relpath, struct timespec times[2], 
                       const UserPerm& perms) {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   tout(cct) << __func__ << std::endl;
@@ -9101,7 +9101,7 @@ int Client::utimensat(int dirfd, const char *relpath, struct timespec times[2], 
 
 #if defined(__linux__) && defined(O_PATH)
   if (flags & O_PATH) {
-    return -CEPHFS_EBADF;
+    return -EBADF;
   }
 #endif
 
@@ -9120,7 +9120,7 @@ int Client::flock(int fd, int operation, uint64_t owner)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << fd << std::endl;
@@ -9130,7 +9130,7 @@ int Client::flock(int fd, int operation, uint64_t owner)
   std::scoped_lock lock(client_lock);
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 
   return _flock(f, operation, owner);
 }
@@ -9139,7 +9139,7 @@ int Client::opendir(const char *relpath, dir_result_t **dirpp, const UserPerm& p
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << relpath << std::endl;
@@ -9158,7 +9158,7 @@ int Client::opendir(const char *relpath, dir_result_t **dirpp, const UserPerm& p
   }
   r = _opendir(in.get(), dirpp, perms);
   /* if ENOTDIR, dirpp will be an uninitialized point and it's very dangerous to access its value */
-  if (r != -CEPHFS_ENOTDIR)
+  if (r != -ENOTDIR)
       tout(cct) << (uintptr_t)*dirpp << std::endl;
   return r;
 }
@@ -9166,7 +9166,7 @@ int Client::opendir(const char *relpath, dir_result_t **dirpp, const UserPerm& p
 int Client::fdopendir(int dirfd, dir_result_t **dirpp, const UserPerm &perms) {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   tout(cct) << __func__ << std::endl;
@@ -9189,7 +9189,7 @@ int Client::fdopendir(int dirfd, dir_result_t **dirpp, const UserPerm &perms) {
   // dirfd to the new dir_result_t so that it can be closed later.
   r = _opendir(dirinode.get(), dirpp, perms, dirfd);
   /* if ENOTDIR, dirpp will be an uninitialized point and it's very dangerous to access its value */
-  if (r != -CEPHFS_ENOTDIR) {
+  if (r != -ENOTDIR) {
       tout(cct) << (uintptr_t)*dirpp << std::endl;
   }
   return r;
@@ -9198,7 +9198,7 @@ int Client::fdopendir(int dirfd, dir_result_t **dirpp, const UserPerm &perms) {
 int Client::_opendir(Inode *in, dir_result_t **dirpp, const UserPerm& perms, int fd)
 {
   if (!in->is_dir())
-    return -CEPHFS_ENOTDIR;
+    return -ENOTDIR;
   *dirpp = new dir_result_t(in, perms, fd);
   opened_dirs.insert(*dirpp);
   ldout(cct, 8) << __func__ << "(" << in->ino << ") = " << 0 << " (" << *dirpp << ")" << dendl;
@@ -9394,7 +9394,7 @@ int Client::_readdir_get_frag(int op, dir_result_t* dirp,
   bufferlist dirbl;
   int res = make_request(req, dirp->perms, NULL, NULL, -1, &dirbl);
   
-  if (res == -CEPHFS_EAGAIN) {
+  if (res == -EAGAIN) {
     ldout(cct, 10) << __func__ << " got EAGAIN, retrying" << dendl;
     _readdir_rechoose_frag(dirp);
     return _readdir_get_frag(op, dirp, fill_req_cb);
@@ -9441,7 +9441,7 @@ int Client::_readdir_cache_cb(dir_result_t *dirp, add_dirent_cb_t cb, void *p,
   while (true) {
     int mask = caps;
     if (!dirp->inode->is_complete_and_ordered())
-      return -CEPHFS_EAGAIN;
+      return -EAGAIN;
     if (pd == dir->readdir_cache.end())
       break;
     Dentry *dn = *pd;
@@ -9467,13 +9467,13 @@ int Client::_readdir_cache_cb(dir_result_t *dirp, add_dirent_cb_t cb, void *p,
     /* fix https://tracker.ceph.com/issues/56288 */
     if (dirp->inode->dir == NULL) {
       ldout(cct, 0) << " dir is closed, so we should return" << dendl;
-      return -CEPHFS_EAGAIN;
+      return -EAGAIN;
     }
     
     // the content of readdir_cache may change after _getattr(), so pd may be invalid iterator    
     pd = dir->readdir_cache.begin() + idx;
     if (pd >= dir->readdir_cache.end() || *pd != dn)
-      return -CEPHFS_EAGAIN;
+      return -EAGAIN;
 
     struct ceph_statx stx;
     struct dirent de;
@@ -9575,7 +9575,7 @@ int Client::_readdir_r_cb(int op,
 
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::unique_lock cl(client_lock);
 
@@ -9670,7 +9670,7 @@ int Client::_readdir_r_cb(int op,
       dirp->inode->is_complete_and_ordered() &&
       dirp->inode->caps_issued_mask(CEPH_CAP_FILE_SHARED, true)) {
     int err = _readdir_cache_cb(dirp, cb, p, caps, getref);
-    if (err != -CEPHFS_EAGAIN)
+    if (err != -EAGAIN)
       return err;
   }
 
@@ -9978,7 +9978,7 @@ int Client::_getdents(dir_result_t *dir, char *buf, int buflen, bool fullent)
       if (gr.pos) { // but we got some entries already!
         return gr.pos;
       } // or we need a larger buffer
-      return -CEPHFS_ERANGE;
+      return -ERANGE;
     } else { // actual error, return it
       return r;
     }
@@ -10063,16 +10063,16 @@ int Client::create_and_open(int dirfd, const char *relpath, int flags,
 
   r = path_walk(path, &in, perms, followsym, mask, dirinode);
   if (r == 0 && (flags & O_CREAT) && (flags & O_EXCL))
-    return -CEPHFS_EEXIST;
+    return -EEXIST;
 
 #if defined(__linux__) && defined(O_PATH)
   if (r == 0 && in->is_symlink() && (flags & O_NOFOLLOW) && !(flags & O_PATH))
 #else
     if (r == 0 && in->is_symlink() && (flags & O_NOFOLLOW))
 #endif
-    return -CEPHFS_ELOOP;
+    return -ELOOP;
 
-  if (r == -CEPHFS_ENOENT && (flags & O_CREAT)) {
+  if (r == -ENOENT && (flags & O_CREAT)) {
     filepath dirpath = path;
     string dname = dirpath.last_dentry();
     dirpath.pop_dentry();
@@ -10130,7 +10130,7 @@ int Client::openat(int dirfd, const char *relpath, int flags, const UserPerm& pe
                    const char *data_pool, std::string alternate_name) {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   ldout(cct, 3) << "openat enter(" << relpath << ")" << dendl;
@@ -10155,7 +10155,7 @@ int Client::lookup_hash(inodeno_t ino, inodeno_t dirino, const char *name,
 
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_LOOKUPHASH);
@@ -10189,10 +10189,10 @@ int Client::_lookup_vino(vinodeno_t vino, const UserPerm& perms, Inode **inode)
 
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   if (is_reserved_vino(vino))
-    return -CEPHFS_ESTALE;
+    return -ESTALE;
 
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_LOOKUPINO);
   filepath path(vino.ino);
@@ -10264,7 +10264,7 @@ int Client::_lookup_name(Inode *ino, Inode *parent, const UserPerm& perms)
 
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_LOOKUPNAME);
   req->set_filepath2(filepath(parent->ino));
@@ -10362,7 +10362,7 @@ int Client::_open(Inode *in, int flags, mode_t mode, Fh **fhp,
 {
   if (in->snapid != CEPH_NOSNAP &&
       (flags & (O_WRONLY | O_RDWR | O_CREAT | O_TRUNC | O_APPEND))) {
-    return -CEPHFS_EROFS;
+    return -EROFS;
   }
 
   // use normalized flags to generate cmode
@@ -10510,7 +10510,7 @@ int Client::_close(int fd)
 
   Fh *fh = get_filehandle(fd);
   if (!fh)
-    return -CEPHFS_EBADF;
+    return -EBADF;
   if (fh->mode == CEPH_FILE_MODE_PIN) {
     ldout(cct, 20) << " unpinning ll_put() call for " << *(fh->inode.get()) << dendl;
     _ll_put(fh->inode.get(), 1);
@@ -10525,7 +10525,7 @@ int Client::_close(int fd)
 int Client::close(int fd) {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
   return _close(fd);
@@ -10538,7 +10538,7 @@ loff_t Client::lseek(int fd, loff_t offset, int whence)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << "lseek" << std::endl;
   tout(cct) << fd << std::endl;
@@ -10548,10 +10548,10 @@ loff_t Client::lseek(int fd, loff_t offset, int whence)
   std::scoped_lock lock(client_lock);
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #if defined(__linux__) && defined(O_PATH)
   if (f->flags & O_PATH)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #endif
   return _lseek(f, offset, whence);
 }
@@ -10602,7 +10602,7 @@ loff_t Client::_lseek(Fh *f, loff_t offset, int whence)
 #ifdef SEEK_DATA
   case SEEK_DATA:
     if (offset < 0 || static_cast<uint64_t>(offset) >= in->size)
-      return -CEPHFS_ENXIO;
+      return -ENXIO;
     pos = offset;
     break;
 #endif
@@ -10610,18 +10610,18 @@ loff_t Client::_lseek(Fh *f, loff_t offset, int whence)
 #ifdef SEEK_HOLE
   case SEEK_HOLE:
     if (offset < 0 || static_cast<uint64_t>(offset) >= in->size)
-      return -CEPHFS_ENXIO;
+      return -ENXIO;
     pos = in->size;
     break;
 #endif
 
   default:
     ldout(cct, 1) << __func__ << ": invalid whence value " << whence << dendl;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   if (pos < 0) {
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   } else {
     f->pos = pos;
   }
@@ -10718,7 +10718,7 @@ int Client::read(int fd, char *buf, loff_t size, loff_t offset)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << "read" << std::endl;
   tout(cct) << fd << std::endl;
@@ -10728,10 +10728,10 @@ int Client::read(int fd, char *buf, loff_t size, loff_t offset)
   std::unique_lock lock(client_lock);
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #if defined(__linux__) && defined(O_PATH)
   if (f->flags & O_PATH)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #endif
   bufferlist bl;
   /* We can't return bytes written larger than INT_MAX, clamp size to that */
@@ -10803,7 +10803,7 @@ void Client::C_Read_Sync_NonBlocking::finish(int r)
 {
   clnt->client_lock.lock();
 
-  if (r == -CEPHFS_ENOENT) {
+  if (r == -ENOENT) {
     // if we get ENOENT from OSD, assume 0 bytes returned
     goto success;
   } else if (r < 0) {
@@ -10883,7 +10883,7 @@ int64_t Client::_read(Fh *f, int64_t offset, uint64_t size, bufferlist *bl,
   CRF_iofinish *crf_iofinish = nullptr;
 
   if ((f->mode & CEPH_FILE_MODE_RD) == 0)
-    return -CEPHFS_EBADF;
+    return -EBADF;
   //bool lazy = f->mode == CEPH_FILE_MODE_LAZY;
 
   if (offset < 0) {
@@ -11241,7 +11241,7 @@ int Client::_read_sync(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
     int r = onfinish.wait();
 
     // if we get ENOENT from OSD, assume 0 bytes returned
-    if (r == -CEPHFS_ENOENT)
+    if (r == -ENOENT)
       r = 0;
     if (r < 0)
       return r;
@@ -11301,7 +11301,7 @@ int Client::write(int fd, const char *buf, loff_t size, loff_t offset)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << "write" << std::endl;
   tout(cct) << fd << std::endl;
@@ -11311,10 +11311,10 @@ int Client::write(int fd, const char *buf, loff_t size, loff_t offset)
   std::scoped_lock lock(client_lock);
   Fh *fh = get_filehandle(fd);
   if (!fh)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #if defined(__linux__) && defined(O_PATH)
   if (fh->flags & O_PATH)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #endif
   /* We can't return bytes written larger than INT_MAX, clamp size to that */
   size = std::min(size, (loff_t)INT_MAX);
@@ -11338,10 +11338,10 @@ int64_t Client::_preadv_pwritev_locked(Fh *fh, const struct iovec *iov,
 
 #if defined(__linux__) && defined(O_PATH)
     if (fh->flags & O_PATH)
-        return -CEPHFS_EBADF;
+        return -EBADF;
 #endif
     if(iovcnt < 0) {
-      return -CEPHFS_EINVAL;
+      return -EINVAL;
     }
     loff_t totallen = 0;
     for (int i = 0; i < iovcnt; i++) {
@@ -11383,7 +11383,7 @@ int Client::_preadv_pwritev(int fd, const struct iovec *iov, int iovcnt,
 {
     RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
     if (!mref_reader.is_state_satisfied())
-      return -CEPHFS_ENOTCONN;
+      return -ENOTCONN;
 
     tout(cct) << fd << std::endl;
     tout(cct) << offset << std::endl;
@@ -11391,7 +11391,7 @@ int Client::_preadv_pwritev(int fd, const struct iovec *iov, int iovcnt,
     std::scoped_lock cl(client_lock);
     Fh *fh = get_filehandle(fd);
     if (!fh)
-      return -CEPHFS_EBADF;
+      return -EBADF;
     return _preadv_pwritev_locked(fh, iov, iovcnt, offset, write, true,
                                   onfinish, blp);
 }
@@ -11528,7 +11528,7 @@ bool Client::C_Write_Finisher::try_complete()
     if (fsync_r < 0) {
       ldout(clnt->cct, 19) << " complete with fsync_r " << fsync_r << dendl;
       onfinish->complete(fsync_r);
-    } else if (onuninlinefinished_r < 0 && onuninlinefinished_r != -CEPHFS_ECANCELED) {
+    } else if (onuninlinefinished_r < 0 && onuninlinefinished_r != -ECANCELED) {
       ldout(clnt->cct, 19) << " complete with onuninlinefinished_r " << onuninlinefinished_r << dendl;
       onfinish->complete(onuninlinefinished_r);
     } else {
@@ -11555,24 +11555,24 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
   C_SaferCond *cond_iofinish = NULL;
 
   if (size < 1) { // zero bytes write is not supported by osd
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   if ( (uint64_t)(offset+size) > mdsmap->get_max_filesize() && //exceeds config
        (uint64_t)(offset+size) > in->size ) { //exceeds filesize 
-      return -CEPHFS_EFBIG;              
+      return -EFBIG;              
 	}
   //ldout(cct, 7) << "write fh " << fh << " size " << size << " offset " << offset << dendl;
 
   if (objecter->osdmap_pool_full(in->layout.pool_id)) {
-    return -CEPHFS_ENOSPC;
+    return -ENOSPC;
   }
 
   ceph_assert(in->snapid == CEPH_NOSNAP);
 
   // was Fh opened as writeable?
   if ((f->mode & CEPH_FILE_MODE_WR) == 0)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 
   // use/adjust fd pos?
   if (offset < 0) {
@@ -11597,7 +11597,7 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
   uint64_t endoff = offset + size;
   if (endoff > in->size && is_quota_bytes_exceeded(in, endoff - in->size,
 						   f->actor_perms)) {
-    return -CEPHFS_EDQUOT;
+    return -EDQUOT;
   }
 
   //bool lazy = f->mode == CEPH_FILE_MODE_LAZY;
@@ -11731,7 +11731,7 @@ int64_t Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
         int uninline_ret = onuninline->wait();
         client_lock.lock();
 
-        if (uninline_ret >= 0 || uninline_ret == -CEPHFS_ECANCELED) {
+        if (uninline_ret >= 0 || uninline_ret == -ECANCELED) {
           in->inline_data.clear();
           in->inline_version = CEPH_INLINE_NONE;
           in->mark_caps_dirty(CEPH_CAP_FILE_WR);
@@ -11825,7 +11825,7 @@ done:
     int uninline_ret = onuninline->wait();
     client_lock.lock();
 
-    if (uninline_ret >= 0 || uninline_ret == -CEPHFS_ECANCELED) {
+    if (uninline_ret >= 0 || uninline_ret == -ECANCELED) {
       in->inline_data.clear();
       in->inline_version = CEPH_INLINE_NONE;
       in->mark_caps_dirty(CEPH_CAP_FILE_WR);
@@ -11863,7 +11863,7 @@ int Client::ftruncate(int fd, loff_t length, const UserPerm& perms)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   tout(cct) << fd << std::endl;
@@ -11872,13 +11872,13 @@ int Client::ftruncate(int fd, loff_t length, const UserPerm& perms)
   std::scoped_lock lock(client_lock);
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #if defined(__linux__) && defined(O_PATH)
   if (f->flags & O_PATH)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #endif
   if ((f->mode & CEPH_FILE_MODE_WR) == 0)
-    return -CEPHFS_EBADF;
+    return -EBADF;
   struct stat attr;
   attr.st_size = length;
   return _setattr(f->inode, &attr, CEPH_SETATTR_SIZE, perms);
@@ -11888,7 +11888,7 @@ int Client::fsync(int fd, bool syncdataonly)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << "fsync" << std::endl;
   tout(cct) << fd << std::endl;
@@ -11897,10 +11897,10 @@ int Client::fsync(int fd, bool syncdataonly)
   std::scoped_lock lock(client_lock);
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #if defined(__linux__) && defined(O_PATH)
   if (f->flags & O_PATH)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #endif
   int r = _fsync(f, syncdataonly);
   if (r == 0) {
@@ -12198,7 +12198,7 @@ int Client::fstat(int fd, struct stat *stbuf, const UserPerm& perms, int mask)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << "fstat mask " << hex << mask << dec << std::endl;
   tout(cct) << fd << std::endl;
@@ -12206,7 +12206,7 @@ int Client::fstat(int fd, struct stat *stbuf, const UserPerm& perms, int mask)
   std::scoped_lock lock(client_lock);
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
   int r = _getattr(f->inode, mask, perms);
   if (r < 0)
     return r;
@@ -12220,7 +12220,7 @@ int Client::fstatx(int fd, struct ceph_statx *stx, const UserPerm& perms,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << "fstatx flags " << hex << flags << " want " << want << dec << std::endl;
   tout(cct) << fd << std::endl;
@@ -12228,7 +12228,7 @@ int Client::fstatx(int fd, struct ceph_statx *stx, const UserPerm& perms,
   std::scoped_lock lock(client_lock);
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 
   unsigned mask = statx_to_mask(flags, want);
 
@@ -12251,7 +12251,7 @@ int Client::statxat(int dirfd, const char *relpath,
                     unsigned int want, unsigned int flags) {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   tout(cct) << __func__ << " flags " << hex << flags << " want " << want << dec << std::endl;
@@ -12275,7 +12275,7 @@ int Client::statxat(int dirfd, const char *relpath,
       goto out;
     }
 #endif
-    return -CEPHFS_ENOENT;
+    return -ENOENT;
   } else {
     filepath path(relpath);
     r = path_walk(path, &in, perms, !(flags & AT_SYMLINK_NOFOLLOW), mask, dirinode);
@@ -12304,7 +12304,7 @@ int Client::chdir(const char *relpath, std::string &new_cwd,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << "chdir" << std::endl;
   tout(cct) << relpath << std::endl;
@@ -12318,7 +12318,7 @@ int Client::chdir(const char *relpath, std::string &new_cwd,
     return r;
 
   if (!(in.get()->is_dir()))
-    return -CEPHFS_ENOTDIR;
+    return -ENOTDIR;
 
   if (cwd != in)
     cwd.swap(in);
@@ -12384,7 +12384,7 @@ int Client::statfs(const char *path, struct statvfs *stbuf,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << std::endl;
   unsigned long int total_files_on_fs;
@@ -12495,7 +12495,7 @@ int Client::_do_filelock(Inode *in, Fh *fh, int lock_type, int op, int sleep,
 		 << " " << fl->l_start << "~" << fl->l_len << dendl;
 
   if (in->flags & I_ERROR_FILELOCK)
-    return -CEPHFS_EIO;
+    return -EIO;
 
   int lock_cmd;
   if (F_RDLCK == fl->l_type)
@@ -12505,7 +12505,7 @@ int Client::_do_filelock(Inode *in, Fh *fh, int lock_type, int op, int sleep,
   else if (F_UNLCK == fl->l_type)
     lock_cmd = CEPH_LOCK_UNLOCK;
   else
-    return -CEPHFS_EIO;
+    return -EIO;
 
   if (op != CEPH_MDS_OP_SETFILELOCK || lock_cmd == CEPH_LOCK_UNLOCK)
     sleep = 0;
@@ -12578,7 +12578,7 @@ int Client::_do_filelock(Inode *in, Fh *fh, int lock_type, int op, int sleep,
 	lock_state = in->flock_locks.get();
       } else {
 	ceph_abort();
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
       }
       _update_lock_state(fl, owner, lock_state);
 
@@ -12604,7 +12604,7 @@ int Client::_interrupt_filelock(MetaRequest *req)
 {
   // Set abort code, but do not kick. The abort code prevents the request
   // from being re-sent.
-  req->abort(-CEPHFS_EINTR);
+  req->abort(-EINTR);
   if (req->mds < 0)
     return 0; // haven't sent the request
 
@@ -12617,7 +12617,7 @@ int Client::_interrupt_filelock(MetaRequest *req)
     lock_type = CEPH_LOCK_FCNTL_INTR;
   else {
     ceph_abort();
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   MetaRequest *intr_req = new MetaRequest(CEPH_MDS_OP_SETFILELOCK);
@@ -12787,7 +12787,7 @@ int Client::_flock(Fh *fh, int cmd, uint64_t owner)
       type = F_UNLCK;
       break;
     default:
-      return -CEPHFS_EINVAL;
+      return -EINVAL;
   }
 
   struct flock fl;
@@ -12803,7 +12803,7 @@ int Client::_flock(Fh *fh, int cmd, uint64_t owner)
 int Client::get_snap_info(const char *path, const UserPerm &perms, SnapInfo *snap_info) {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   std::scoped_lock lock(client_lock);
@@ -12814,7 +12814,7 @@ int Client::get_snap_info(const char *path, const UserPerm &perms, SnapInfo *sna
   }
 
   if (in->snapid == CEPH_NOSNAP) {
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   snap_info->id = in->snapid;
@@ -12877,7 +12877,7 @@ void Client::ll_register_callbacks(struct ceph_client_callback_args *args)
 int Client::ll_register_callbacks2(struct ceph_client_callback_args *args)
 {
   if (is_mounting() || is_mounted() || is_unmounting())
-    return -CEPHFS_EBUSY;
+    return -EBUSY;
 
   _ll_register_callbacks(args);
   return 0;
@@ -12889,7 +12889,7 @@ std::pair<int, bool> Client::test_dentry_handling(bool can_invalidate)
 
   RWRef_t iref_reader(initialize_state, CLIENT_INITIALIZED);
   if (!iref_reader.is_state_satisfied())
-    return std::make_pair(-CEPHFS_ENOTCONN, false);
+    return std::make_pair(-ENOTCONN, false);
 
   can_invalidate_dentries = can_invalidate;
 
@@ -12958,7 +12958,7 @@ int Client::sync_fs()
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock l(client_lock);
 
@@ -13000,7 +13000,7 @@ int Client::lazyio(int fd, int enable)
   std::scoped_lock l(client_lock);
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 
   return _lazyio(f, enable);
 }
@@ -13022,7 +13022,7 @@ int Client::lazyio_propagate(int fd, loff_t offset, size_t count)
   
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 
   // for now
   _fsync(f, true);
@@ -13038,7 +13038,7 @@ int Client::lazyio_synchronize(int fd, loff_t offset, size_t count)
   
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
   Inode *in = f->inode.get();
   
   _fsync(f, true);
@@ -13059,7 +13059,7 @@ int Client::mksnap(const char *relpath, const char *name, const UserPerm& perm,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock l(client_lock);
 
@@ -13081,7 +13081,7 @@ int Client::rmsnap(const char *relpath, const char *name, const UserPerm& perms,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock l(client_lock);
 
@@ -13106,13 +13106,13 @@ int Client::get_caps_issued(int fd)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 
   return f->inode->caps_issued();
 }
@@ -13121,7 +13121,7 @@ int Client::get_caps_issued(const char *path, const UserPerm& perms)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -13188,7 +13188,7 @@ int Client::ll_lookup(Inode *parent, const char *name, struct stat *attr,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vparent = _get_vino(parent);
   ldout(cct, 3) << __func__ << " " << vparent << " " << name << dendl;
@@ -13235,10 +13235,10 @@ int Client::ll_lookup_vino(
   ceph_assert(inode != NULL);
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   if (is_reserved_vino(vino))
-    return -CEPHFS_ESTALE;
+    return -ESTALE;
 
   std::scoped_lock lock(client_lock);
   ldout(cct, 3) << __func__ << " " << vino << dendl;
@@ -13288,7 +13288,7 @@ int Client::ll_lookupx(Inode *parent, const char *name, Inode **out,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vparent = _get_vino(parent);
   ldout(cct, 3) << __func__ << " " << vparent << " " << name << dendl;
@@ -13330,7 +13330,7 @@ int Client::ll_walk(const char* name, Inode **out, struct ceph_statx *stx,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   filepath fp(name, 0);
   InodeRef in;
@@ -13525,7 +13525,7 @@ int Client::ll_getattr(Inode *in, struct stat *attr, const UserPerm& perms)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -13542,7 +13542,7 @@ int Client::ll_getattrx(Inode *in, struct ceph_statx *stx, unsigned int want,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -13592,7 +13592,7 @@ int Client::ll_setattrx(Inode *in, struct ceph_statx *stx, int mask,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -13615,7 +13615,7 @@ int Client::ll_setattr(Inode *in, struct stat *attr, int mask,
 
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -13639,7 +13639,7 @@ int Client::getxattr(const char *path, const char *name, void *value, size_t siz
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -13655,7 +13655,7 @@ int Client::lgetxattr(const char *path, const char *name, void *value, size_t si
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -13671,13 +13671,13 @@ int Client::fgetxattr(int fd, const char *name, void *value, size_t size,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
   return _getxattr(f->inode, name, value, size, perms);
 }
 
@@ -13686,7 +13686,7 @@ int Client::listxattr(const char *path, char *list, size_t size,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -13702,7 +13702,7 @@ int Client::llistxattr(const char *path, char *list, size_t size,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -13717,13 +13717,13 @@ int Client::flistxattr(int fd, char *list, size_t size, const UserPerm& perms)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
   return Client::_listxattr(f->inode.get(), list, size, perms);
 }
 
@@ -13732,7 +13732,7 @@ int Client::removexattr(const char *path, const char *name,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -13748,7 +13748,7 @@ int Client::lremovexattr(const char *path, const char *name,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -13763,13 +13763,13 @@ int Client::fremovexattr(int fd, const char *name, const UserPerm& perms)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
   return _removexattr(f->inode, name, perms);
 }
 
@@ -13778,7 +13778,7 @@ int Client::setxattr(const char *path, const char *name, const void *value,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   _setxattr_maybe_wait_for_osdmap(name, value, size);
 
@@ -13796,7 +13796,7 @@ int Client::lsetxattr(const char *path, const char *name, const void *value,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   _setxattr_maybe_wait_for_osdmap(name, value, size);
 
@@ -13814,7 +13814,7 @@ int Client::fsetxattr(int fd, const char *name, const void *value, size_t size,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   _setxattr_maybe_wait_for_osdmap(name, value, size);
 
@@ -13822,7 +13822,7 @@ int Client::fsetxattr(int fd, const char *name, const void *value, size_t size,
 
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
   return _setxattr(f->inode, name, value, size, flags, perms);
 }
 
@@ -13834,7 +13834,7 @@ int Client::_getxattr(Inode *in, const char *name, void *value, size_t size,
 
   vxattr = _match_vxattr(in, name);
   if (vxattr) {
-    r = -CEPHFS_ENODATA;
+    r = -ENODATA;
 
     // Do a force getattr to get the latest quota before returning
     // a value to userspace.
@@ -13856,12 +13856,12 @@ int Client::_getxattr(Inode *in, const char *name, void *value, size_t size,
     if (!(vxattr->exists_cb && !(this->*(vxattr->exists_cb))(in))) {
       r = (this->*(vxattr->getxattr_cb))(in, buf, sizeof(buf));
     } else {
-      r = -CEPHFS_ENODATA;
+      r = -ENODATA;
     }
 
     if (size != 0) {
       if (r > (int)size) {
-	r = -CEPHFS_ERANGE;
+	r = -ERANGE;
       } else if (r > 0) {
 	memcpy(value, buf, r);
       }
@@ -13877,14 +13877,14 @@ int Client::_getxattr(Inode *in, const char *name, void *value, size_t size,
   }
 
   if (acl_type == NO_ACL && !strncmp(name, "system.", 7)) {
-    r = -CEPHFS_EOPNOTSUPP;
+    r = -EOPNOTSUPP;
     goto out;
   }
 
   r = _getattr(in, CEPH_STAT_CAP_XATTR, perms, in->xattr_version == 0);
   if (r == 0) {
     string n(name);
-    r = -CEPHFS_ENODATA;
+    r = -ENODATA;
     auto it = in->xattrs.find(n);
     if (it != in->xattrs.end()) {
       r = it->second.length();
@@ -13892,7 +13892,7 @@ int Client::_getxattr(Inode *in, const char *name, void *value, size_t size,
 	if (size >= (unsigned)r)
 	  memcpy(value, it->second.c_str(), r);
 	else
-	  r = -CEPHFS_ERANGE;
+	  r = -ERANGE;
       }
     }
   }
@@ -13917,7 +13917,7 @@ int Client::ll_getxattr(Inode *in, const char *name, void *value,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vino = _get_vino(in);
 
@@ -13957,7 +13957,7 @@ int Client::_listxattr(Inode *in, char *name, size_t size,
       continue;
 
     if (this_len > size) {
-      r = -CEPHFS_ERANGE;
+      r = -ERANGE;
       goto out;
     }
 
@@ -13975,7 +13975,7 @@ int Client::ll_listxattr(Inode *in, char *names, size_t size,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vino = _get_vino(in);
 
@@ -14025,13 +14025,13 @@ int Client::_setxattr(Inode *in, const char *name, const void *value,
 		      size_t size, int flags, const UserPerm& perms)
 {
   if (in->snapid != CEPH_NOSNAP) {
-    return -CEPHFS_EROFS;
+    return -EROFS;
   }
 
   if (size == 0) {
     value = "";
   } else if (value == NULL) {
-      return -CEPHFS_EINVAL;
+      return -EINVAL;
   }
 
   bool posix_acl_xattr = false;
@@ -14043,7 +14043,7 @@ int Client::_setxattr(Inode *in, const char *name, const void *value,
       strncmp(name, "trusted.", 8) &&
       strncmp(name, "ceph.", 5) &&
       !posix_acl_xattr)
-    return -CEPHFS_EOPNOTSUPP;
+    return -EOPNOTSUPP;
 
   bool check_realm = false;
 
@@ -14070,23 +14070,23 @@ int Client::_setxattr(Inode *in, const char *name, const void *value,
     } else if (!strcmp(name, ACL_EA_DEFAULT)) {
       if (value) {
 	if (!S_ISDIR(in->mode))
-	  return -CEPHFS_EACCES;
+	  return -EACCES;
 	int ret = posix_acl_check(value, size);
 	if (ret < 0)
-	  return -CEPHFS_EINVAL;
+	  return -EINVAL;
 	if (ret == 0) {
 	  value = NULL;
 	  size = 0;
 	}
       }
     } else {
-      return -CEPHFS_EOPNOTSUPP;
+      return -EOPNOTSUPP;
     }
   } else {
     const VXattr *vxattr = _match_vxattr(in, name);
     if (vxattr) {
       if (vxattr->readonly)
-	return -CEPHFS_EOPNOTSUPP;
+	return -EOPNOTSUPP;
       if (vxattr->setxattr_cb)
 	return (this->*(vxattr->setxattr_cb))(in, value, size, perms);
       if (vxattr->name.compare(0, 10, "ceph.quota") == 0 && value)
@@ -14099,12 +14099,12 @@ int Client::_setxattr(Inode *in, const char *name, const void *value,
     // check if snaprealm was created for quota inode
     if (in->quota.is_enabled() &&
 	!(in->snaprealm && in->snaprealm->ino == in->ino))
-      ret = -CEPHFS_EOPNOTSUPP;
+      ret = -EOPNOTSUPP;
   }
 
   if ((!strcmp(name, ACL_EA_ACCESS) ||
       !strcmp(name, ACL_EA_DEFAULT)) &&
-      ret == -CEPHFS_ENODATA)
+      ret == -ENODATA)
     ret = 0;
 
   return ret;
@@ -14130,10 +14130,10 @@ int Client::_setxattr_check_data_pool(string& name, string& value, const OSDMap 
     keys_and_values<string::iterator> p;    // create instance of parser
     std::map<string, string> m;             // map to receive results
     if (!qi::parse(begin, end, p, m)) {     // returns true if successful
-      return -CEPHFS_EINVAL;
+      return -EINVAL;
     }
     if (begin != end)
-      return -CEPHFS_EINVAL;
+      return -EINVAL;
     for (map<string,string>::iterator q = m.begin(); q != m.end(); ++q) {
       if (q->first == "pool") {
 	tmp = q->second;
@@ -14149,11 +14149,11 @@ int Client::_setxattr_check_data_pool(string& name, string& value, const OSDMap 
     try {
       pool = boost::lexical_cast<unsigned>(tmp);
       if (!osdmap->have_pg_pool(pool))
-	return -CEPHFS_ENOENT;
+	return -ENOENT;
     } catch (boost::bad_lexical_cast const&) {
       pool = osdmap->lookup_pg_pool_name(tmp);
       if (pool < 0) {
-	return -CEPHFS_ENOENT;
+	return -ENOENT;
       }
     }
   }
@@ -14175,7 +14175,7 @@ void Client::_setxattr_maybe_wait_for_osdmap(const char *name, const void *value
       return _setxattr_check_data_pool(rest, v, &o);
     });
 
-    if (r == -CEPHFS_ENOENT) {
+    if (r == -ENOENT) {
       bs::error_code ec;
       ldout(cct, 20) << __func__ << ": waiting for latest osdmap" << dendl;
       objecter->wait_for_latest_osdmap(ca::use_blocked[ec]);
@@ -14189,7 +14189,7 @@ int Client::ll_setxattr(Inode *in, const char *name, const void *value,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   _setxattr_maybe_wait_for_osdmap(name, value, size);
 
@@ -14212,7 +14212,7 @@ int Client::ll_setxattr(Inode *in, const char *name, const void *value,
 int Client::_removexattr(Inode *in, const char *name, const UserPerm& perms)
 {
   if (in->snapid != CEPH_NOSNAP) {
-    return -CEPHFS_EROFS;
+    return -EROFS;
   }
 
   // same xattrs supported by kernel client
@@ -14222,11 +14222,11 @@ int Client::_removexattr(Inode *in, const char *name, const UserPerm& perms)
       strncmp(name, "ceph.", 5) &&
       strcmp(name, ACL_EA_ACCESS) &&
       strcmp(name, ACL_EA_DEFAULT))
-    return -CEPHFS_EOPNOTSUPP;
+    return -EOPNOTSUPP;
 
   const VXattr *vxattr = _match_vxattr(in, name);
   if (vxattr && vxattr->readonly)
-    return -CEPHFS_EOPNOTSUPP;
+    return -EOPNOTSUPP;
 
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_RMXATTR);
   filepath path;
@@ -14239,7 +14239,7 @@ int Client::_removexattr(Inode *in, const char *name, const UserPerm& perms)
 
   if ((!strcmp(name, ACL_EA_ACCESS) ||
       !strcmp(name, ACL_EA_DEFAULT)) &&
-      res == -CEPHFS_ENODATA)
+      res == -ENODATA)
     res = 0;
 
   trim_cache();
@@ -14261,7 +14261,7 @@ int Client::ll_removexattr(Inode *in, const char *name, const UserPerm& perms)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vino = _get_vino(in);
 
@@ -14448,7 +14448,7 @@ size_t Client::_vxattrcb_dir_rctime(Inode *in, char *val, size_t size)
 }
 bool Client::_vxattrcb_dir_pin_exists(Inode *in)
 {
-  return in->dir_pin != -CEPHFS_ENODATA;
+  return in->dir_pin != -ENODATA;
 }
 size_t Client::_vxattrcb_dir_pin(Inode *in, char *val, size_t size)
 {
@@ -14696,7 +14696,7 @@ int Client::ll_readlink(Inode *in, char *buf, size_t buflen, const UserPerm& per
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vino = _get_vino(in);
 
@@ -14722,13 +14722,13 @@ int Client::_mknod(Inode *dir, const char *name, mode_t mode, dev_t rdev,
 		<< ", gid " << perms.gid() << ")" << dendl;
 
   if (strlen(name) > NAME_MAX)
-    return -CEPHFS_ENAMETOOLONG;
+    return -ENAMETOOLONG;
 
   if (dir->snapid != CEPH_NOSNAP) {
-    return -CEPHFS_EROFS;
+    return -EROFS;
   }
   if (is_quota_files_exceeded(dir, perms)) {
-    return -CEPHFS_EDQUOT;
+    return -EDQUOT;
   }
 
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_MKNOD);
@@ -14771,7 +14771,7 @@ int Client::ll_mknod(Inode *parent, const char *name, mode_t mode,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vparent = _get_vino(parent);
 
@@ -14809,7 +14809,7 @@ int Client::ll_mknodx(Inode *parent, const char *name, mode_t mode,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   unsigned caps = statx_to_mask(flags, want);
 
@@ -14852,12 +14852,12 @@ int Client::_create(Inode *dir, const char *name, int flags, mode_t mode,
     mode << dec << ")" << dendl;
 
   if (strlen(name) > NAME_MAX)
-    return -CEPHFS_ENAMETOOLONG;
+    return -ENAMETOOLONG;
   if (dir->snapid != CEPH_NOSNAP) {
-    return -CEPHFS_EROFS;
+    return -EROFS;
   }
   if (is_quota_files_exceeded(dir, perms)) {
-    return -CEPHFS_EDQUOT;
+    return -EDQUOT;
   }
 
   // use normalized flags to generate cmode
@@ -14872,9 +14872,9 @@ int Client::_create(Inode *dir, const char *name, int flags, mode_t mode,
     pool_id = objecter->with_osdmap(
       std::mem_fn(&OSDMap::lookup_pg_pool_name), data_pool);
     if (pool_id < 0)
-      return -CEPHFS_EINVAL;
+      return -EINVAL;
     if (pool_id > 0xffffffffll)
-      return -CEPHFS_ERANGE;  // bummer!
+      return -ERANGE;  // bummer!
   }
 
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_CREATE);
@@ -14945,13 +14945,13 @@ int Client::_mkdir(Inode *dir, const char *name, mode_t mode, const UserPerm& pe
 		<< ", gid " << perm.gid() << ")" << dendl;
 
   if (strlen(name) > NAME_MAX)
-    return -CEPHFS_ENAMETOOLONG;
+    return -ENAMETOOLONG;
 
   if (dir->snapid != CEPH_NOSNAP && dir->snapid != CEPH_SNAPDIR) {
-    return -CEPHFS_EROFS;
+    return -EROFS;
   }
   if (is_quota_files_exceeded(dir, perm)) {
-    return -CEPHFS_EDQUOT;
+    return -EDQUOT;
   }
 
   bool is_snap_op = dir->snapid == CEPH_SNAPDIR;
@@ -15009,7 +15009,7 @@ int Client::ll_mkdir(Inode *parent, const char *name, mode_t mode,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vparent = _get_vino(parent);
 
@@ -15046,7 +15046,7 @@ int Client::ll_mkdirx(Inode *parent, const char *name, mode_t mode, Inode **out,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vparent = _get_vino(parent);
 
@@ -15088,13 +15088,13 @@ int Client::_symlink(Inode *dir, const char *name, const char *target,
 		<< dendl;
 
   if (strlen(name) > NAME_MAX)
-    return -CEPHFS_ENAMETOOLONG;
+    return -ENAMETOOLONG;
 
   if (dir->snapid != CEPH_NOSNAP) {
-    return -CEPHFS_EROFS;
+    return -EROFS;
   }
   if (is_quota_files_exceeded(dir, perms)) {
-    return -CEPHFS_EDQUOT;
+    return -EDQUOT;
   }
 
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_SYMLINK);
@@ -15127,7 +15127,7 @@ int Client::ll_symlink(Inode *parent, const char *name, const char *value,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vparent = _get_vino(parent);
 
@@ -15165,7 +15165,7 @@ int Client::ll_symlinkx(Inode *parent, const char *name, const char *value,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vparent = _get_vino(parent);
 
@@ -15204,7 +15204,7 @@ int Client::_unlink(Inode *dir, const char *name, const UserPerm& perm)
 		<< ")" << dendl;
 
   if (dir->snapid != CEPH_NOSNAP) {
-    return -CEPHFS_EROFS;
+    return -EROFS;
   }
 
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_UNLINK);
@@ -15245,7 +15245,7 @@ int Client::ll_unlink(Inode *in, const char *name, const UserPerm& perm)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vino = _get_vino(in);
 
@@ -15270,7 +15270,7 @@ int Client::_rmdir(Inode *dir, const char *name, const UserPerm& perms)
 		<< perms.uid() << " gid " << perms.gid() << ")" << dendl;
 
   if (dir->snapid != CEPH_NOSNAP && dir->snapid != CEPH_SNAPDIR) {
-    return -CEPHFS_EROFS;
+    return -EROFS;
   }
 
   int op = dir->snapid == CEPH_SNAPDIR ? CEPH_MDS_OP_RMSNAP : CEPH_MDS_OP_RMDIR;
@@ -15316,7 +15316,7 @@ int Client::ll_rmdir(Inode *in, const char *name, const UserPerm& perms)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vino = _get_vino(in);
 
@@ -15344,14 +15344,14 @@ int Client::_rename(Inode *fromdir, const char *fromname, Inode *todir, const ch
 		<< dendl;
 
   if (fromdir->snapid != todir->snapid)
-    return -CEPHFS_EXDEV;
+    return -EXDEV;
 
   int op = CEPH_MDS_OP_RENAME;
   if (fromdir->snapid != CEPH_NOSNAP) {
     if (fromdir == todir && fromdir->snapid == CEPH_SNAPDIR)
       op = CEPH_MDS_OP_RENAMESNAP;
     else
-      return -CEPHFS_EROFS;
+      return -EROFS;
   }
 
   // don't allow cross-quota renames
@@ -15361,7 +15361,7 @@ int Client::_rename(Inode *fromdir, const char *fromname, Inode *todir, const ch
     Inode *todir_root =
       todir->quota.is_enabled() ? todir : get_quota_root(todir, perm);
     if (fromdir_root != todir_root) {
-      return -CEPHFS_EXDEV;
+      return -EXDEV;
     }
   }
 
@@ -15412,7 +15412,7 @@ int Client::_rename(Inode *fromdir, const char *fromname, Inode *todir, const ch
       }
       req->other_inode_drop = CEPH_CAP_LINK_SHARED | CEPH_CAP_LINK_EXCL;
       break;
-    case -CEPHFS_ENOENT:
+    case -ENOENT:
       break;
     default:
       goto fail;
@@ -15453,7 +15453,7 @@ int Client::ll_rename(Inode *parent, const char *name, Inode *newparent,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vparent = _get_vino(parent);
   vinodeno_t vnewparent = _get_vino(newparent);
@@ -15473,7 +15473,7 @@ int Client::ll_rename(Inode *parent, const char *name, Inode *newparent,
     if (r < 0)
       return r;
     r = may_delete(newparent, newname, perm);
-    if (r < 0 && r != -CEPHFS_ENOENT)
+    if (r < 0 && r != -ENOENT)
       return r;
   }
 
@@ -15486,13 +15486,13 @@ int Client::_link(Inode *in, Inode *dir, const char *newname, const UserPerm& pe
 		<< " uid " << perm.uid() << " gid " << perm.gid() << ")" << dendl;
 
   if (strlen(newname) > NAME_MAX)
-    return -CEPHFS_ENAMETOOLONG;
+    return -ENAMETOOLONG;
 
   if (in->snapid != CEPH_NOSNAP || dir->snapid != CEPH_NOSNAP) {
-    return -CEPHFS_EROFS;
+    return -EROFS;
   }
   if (is_quota_files_exceeded(dir, perm)) {
-    return -CEPHFS_EDQUOT;
+    return -EDQUOT;
   }
 
   in->break_all_delegs();
@@ -15524,7 +15524,7 @@ int Client::ll_link(Inode *in, Inode *newparent, const char *newname,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vino = _get_vino(in);
   vinodeno_t vnewparent = _get_vino(newparent);
@@ -15542,7 +15542,7 @@ int Client::ll_link(Inode *in, Inode *newparent, const char *newname,
 
   if (!fuse_default_permissions) {
     if (S_ISDIR(in->mode))
-      return -CEPHFS_EPERM;
+      return -EPERM;
 
     int r = may_hardlink(in, perm);
     if (r < 0)
@@ -15660,7 +15660,7 @@ int Client::ll_opendir(Inode *in, int flags, dir_result_t** dirpp,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vino = _get_vino(in);
 
@@ -15688,7 +15688,7 @@ int Client::ll_releasedir(dir_result_t *dirp)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 3) << "ll_releasedir " << dirp << dendl;
   tout(cct) << "ll_releasedir" << std::endl;
@@ -15704,7 +15704,7 @@ int Client::ll_fsyncdir(dir_result_t *dirp)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 3) << "ll_fsyncdir " << dirp << dendl;
   tout(cct) << "ll_fsyncdir" << std::endl;
@@ -15720,7 +15720,7 @@ int Client::ll_open(Inode *in, int flags, Fh **fhp, const UserPerm& perms)
 
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vino = _get_vino(in);
 
@@ -15772,9 +15772,9 @@ int Client::_ll_create(Inode *parent, const char *name, mode_t mode,
   int r = _lookup(parent, name, caps, in, perms);
 
   if (r == 0 && (flags & O_CREAT) && (flags & O_EXCL))
-    return -CEPHFS_EEXIST;
+    return -EEXIST;
 
-  if (r == -CEPHFS_ENOENT && (flags & O_CREAT)) {
+  if (r == -ENOENT && (flags & O_CREAT)) {
     if (!fuse_default_permissions) {
       r = may_create(parent, perms);
       if (r < 0)
@@ -15843,7 +15843,7 @@ int Client::ll_create(Inode *parent, const char *name, mode_t mode,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
   InodeRef in;
@@ -15874,7 +15874,7 @@ int Client::ll_createx(Inode *parent, const char *name, mode_t mode,
   unsigned caps = statx_to_mask(lflags, want);
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
   InodeRef in;
@@ -15901,7 +15901,7 @@ loff_t Client::ll_lseek(Fh *fh, loff_t offset, int whence)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << "ll_lseek" << std::endl;
   tout(cct) << offset << std::endl;
@@ -15915,7 +15915,7 @@ int Client::ll_read(Fh *fh, loff_t off, loff_t len, bufferlist *bl)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   /* We can't return bytes written larger than INT_MAX, clamp len to that */
@@ -15924,7 +15924,7 @@ int Client::ll_read(Fh *fh, loff_t off, loff_t len, bufferlist *bl)
   std::scoped_lock lock(client_lock);
   if (fh == NULL || !_ll_fh_exists(fh)) {
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
-    return -CEPHFS_EBADF;
+    return -EBADF;
   }
 
   ldout(cct, 3) << "ll_read " << fh << " " << fh->inode->ino << " " << " " << off << "~" << len << dendl;
@@ -15947,7 +15947,7 @@ int Client::ll_read_block(Inode *in, uint64_t blockid,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vinodeno_t vino = _get_vino(in);
   object_t oid = file_object_t(vino.ino, blockid);
@@ -15986,10 +15986,10 @@ int Client::ll_write_block(Inode *in, uint64_t blockid,
 
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   if (length == 0) {
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
   if (true || sync) {
     /* if write is stable, the epilogue is waiting on
@@ -16043,7 +16043,7 @@ int Client::ll_commit_blocks(Inode *in,
 		  << offset << " to " << length << dendl;
 
     if (length == 0) {
-      return -CEPHFS_EINVAL;
+      return -EINVAL;
     }
 
     std::scoped_lock lock(client_lock);
@@ -16060,7 +16060,7 @@ int Client::ll_write(Fh *fh, loff_t off, loff_t len, const char *data)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   /* We can't return bytes written larger than INT_MAX, clamp len to that */
@@ -16069,7 +16069,7 @@ int Client::ll_write(Fh *fh, loff_t off, loff_t len, const char *data)
   std::scoped_lock lock(client_lock);
   if (fh == NULL || !_ll_fh_exists(fh)) {
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
-    return -CEPHFS_EBADF;
+    return -EBADF;
   }
 
   ldout(cct, 3) << "ll_write " << fh << " " << fh->inode->ino << " " << off <<
@@ -16089,13 +16089,13 @@ int64_t Client::ll_writev(struct Fh *fh, const struct iovec *iov, int iovcnt, in
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   std::scoped_lock cl(client_lock);
   if (fh == NULL || !_ll_fh_exists(fh)) {
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
-    return -CEPHFS_EBADF;
+    return -EBADF;
   }
   return _preadv_pwritev_locked(fh, iov, iovcnt, off, true, false);
 }
@@ -16104,13 +16104,13 @@ int64_t Client::ll_readv(struct Fh *fh, const struct iovec *iov, int iovcnt, int
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   std::scoped_lock cl(client_lock);
   if (fh == NULL || !_ll_fh_exists(fh)) {
     ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
-    return -CEPHFS_EBADF;
+    return -EBADF;
   }
   return _preadv_pwritev_locked(fh, iov, iovcnt, off, false, false);
 }
@@ -16124,7 +16124,7 @@ int64_t Client::ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov,
 
     RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
     if (!mref_reader.is_state_satisfied()) {
-      retval = -CEPHFS_ENOTCONN;
+      retval = -ENOTCONN;
       if (onfinish != nullptr) {
         onfinish->complete(retval);
         /* async call should always return zero to caller and allow the
@@ -16139,7 +16139,7 @@ int64_t Client::ll_preadv_pwritev(struct Fh *fh, const struct iovec *iov,
 
     if(fh == NULL || !_ll_fh_exists(fh)) {
       ldout(cct, 3) << "(fh)" << fh << " is invalid" << dendl;
-      retval = -CEPHFS_EBADF;
+      retval = -EBADF;
     }
 
     if (retval != 0) {
@@ -16187,7 +16187,7 @@ int Client::ll_flush(Fh *fh)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 3) << "ll_flush " << fh << " " << fh->inode->ino << " " << dendl;
   tout(cct) << "ll_flush" << std::endl;
@@ -16201,7 +16201,7 @@ int Client::ll_fsync(Fh *fh, bool syncdataonly)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 3) << "ll_fsync " << fh << " " << fh->inode->ino << " " << dendl;
   tout(cct) << "ll_fsync" << std::endl;
@@ -16220,7 +16220,7 @@ int Client::ll_sync_inode(Inode *in, bool syncdataonly)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 3) << "ll_sync_inode " << _get_vino(in) << " " << dendl;
   tout(cct) << "ll_sync_inode" << std::endl;
@@ -16275,32 +16275,32 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
   ceph_assert(ceph_mutex_is_locked_by_me(client_lock));
 
   if (offset < 0 || length <= 0)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
 
   if (mode == 0 || (mode & ~(FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE)))
-    return -CEPHFS_EOPNOTSUPP;
+    return -EOPNOTSUPP;
 
   if ((mode & FALLOC_FL_PUNCH_HOLE) && !(mode & FALLOC_FL_KEEP_SIZE))
-    return -CEPHFS_EOPNOTSUPP;
+    return -EOPNOTSUPP;
 
   Inode *in = fh->inode.get();
 
   if (objecter->osdmap_pool_full(in->layout.pool_id) &&
       !(mode & FALLOC_FL_PUNCH_HOLE)) {
-    return -CEPHFS_ENOSPC;
+    return -ENOSPC;
   }
 
   if (in->snapid != CEPH_NOSNAP)
-    return -CEPHFS_EROFS;
+    return -EROFS;
 
   if ((fh->mode & CEPH_FILE_MODE_WR) == 0)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 
   uint64_t size = offset + length;
   if (!(mode & (FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE)) &&
       size > in->size &&
       is_quota_bytes_exceeded(in, size - in->size, fh->actor_perms)) {
-    return -CEPHFS_EDQUOT;
+    return -EDQUOT;
   }
 
   int have;
@@ -16385,7 +16385,7 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
     int ret = onuninline->wait();
     client_lock.lock();
 
-    if (ret >= 0 || ret == -CEPHFS_ECANCELED) {
+    if (ret >= 0 || ret == -ECANCELED) {
       in->inline_data.clear();
       in->inline_version = CEPH_INLINE_NONE;
       in->mark_caps_dirty(CEPH_CAP_FILE_WR);
@@ -16402,7 +16402,7 @@ int Client::ll_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 3) << __func__ << " " << fh << " " << fh->inode->ino << " " << dendl;
   tout(cct) << __func__ << " " << mode << " " << offset << " " << length << std::endl;
@@ -16416,17 +16416,17 @@ int Client::fallocate(int fd, int mode, loff_t offset, loff_t length)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   tout(cct) << __func__ << " " << fd << mode << " " << offset << " " << length << std::endl;
 
   std::scoped_lock lock(client_lock);
   Fh *fh = get_filehandle(fd);
   if (!fh)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #if defined(__linux__) && defined(O_PATH)
   if (fh->flags & O_PATH)
-    return -CEPHFS_EBADF;
+    return -EBADF;
 #endif
   return _fallocate(fh, mode, offset, length);
 }
@@ -16435,7 +16435,7 @@ int Client::ll_release(Fh *fh)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 3) << __func__ << " (fh)" << fh << " " << fh->inode->ino << " " <<
     dendl;
@@ -16452,7 +16452,7 @@ int Client::ll_getlk(Fh *fh, struct flock *fl, uint64_t owner)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 3) << "ll_getlk (fh)" << fh << " " << fh->inode->ino << dendl;
   tout(cct) << "ll_getk (fh)" << (uintptr_t)fh << std::endl;
@@ -16465,7 +16465,7 @@ int Client::ll_setlk(Fh *fh, struct flock *fl, uint64_t owner, int sleep)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 3) << __func__ << "  (fh) " << fh << " " << fh->inode->ino << dendl;
   tout(cct) << __func__ << " (fh)" << (uintptr_t)fh << std::endl;
@@ -16478,7 +16478,7 @@ int Client::ll_flock(Fh *fh, int cmd, uint64_t owner)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   ldout(cct, 3) << __func__ << "  (fh) " << fh << " " << fh->inode->ino << dendl;
   tout(cct) << __func__ << " (fh)" << (uintptr_t)fh << std::endl;
@@ -16496,7 +16496,7 @@ int Client::set_deleg_timeout(uint32_t timeout)
    * delegation before the session autoclose timeout kicks in.
    */
   if (timeout >= mdsmap->get_session_autoclose())
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
 
   deleg_timeout = timeout;
   return 0;
@@ -16504,11 +16504,11 @@ int Client::set_deleg_timeout(uint32_t timeout)
 
 int Client::ll_delegation(Fh *fh, unsigned cmd, ceph_deleg_cb_t cb, void *priv)
 {
-  int ret = -CEPHFS_EINVAL;
+  int ret = -EINVAL;
 
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -16523,7 +16523,7 @@ int Client::ll_delegation(Fh *fh, unsigned cmd, ceph_deleg_cb_t cb, void *priv)
     try {
       ret = inode->set_deleg(fh, cmd, cb, priv);
     } catch (std::bad_alloc&) {
-      ret = -CEPHFS_ENOMEM;
+      ret = -ENOMEM;
     }
     break;
   }
@@ -16564,7 +16564,7 @@ int Client::describe_layout(const char *relpath, file_layout_t *lp,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -16584,13 +16584,13 @@ int Client::fdescribe_layout(int fd, file_layout_t *lp)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
   Inode *in = f->inode.get();
 
   *lp = in->layout;
@@ -16603,7 +16603,7 @@ int64_t Client::get_default_pool_id()
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -16617,7 +16617,7 @@ int64_t Client::get_pool_id(const char *pool_name)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -16642,12 +16642,12 @@ int Client::get_pool_replication(int64_t pool)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
   return objecter->with_osdmap([pool](const OSDMap& o) {
-      return o.have_pg_pool(pool) ? o.get_pg_pool(pool)->get_size() : -CEPHFS_ENOENT;
+      return o.have_pg_pool(pool) ? o.get_pg_pool(pool)->get_size() : -ENOENT;
     });
 }
 
@@ -16655,13 +16655,13 @@ int Client::get_file_extent_osds(int fd, loff_t off, loff_t *len, vector<int>& o
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
   Inode *in = f->inode.get();
 
   vector<ObjectExtent> extents;
@@ -16674,7 +16674,7 @@ int Client::get_file_extent_osds(int fd, loff_t off, loff_t *len, vector<int>& o
     });
 
   if (osds.empty())
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
 
   /*
    * Return the remainder of the extent (stripe unit)
@@ -16702,12 +16702,12 @@ int Client::get_osd_crush_location(int id, vector<pair<string, string> >& path)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
   if (id < 0)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   return objecter->with_osdmap([&](const OSDMap& o) {
       return o.crush->get_full_location_ordered(id, path);
     });
@@ -16718,13 +16718,13 @@ int Client::get_file_stripe_address(int fd, loff_t offset,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
   Inode *in = f->inode.get();
 
   // which object?
@@ -16739,7 +16739,7 @@ int Client::get_file_stripe_address(int fd, loff_t offset,
       vector<int> osds;
       o.pg_to_acting_osds(pg, osds);
       if (osds.empty())
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
       for (unsigned i = 0; i < osds.size(); i++) {
 	entity_addr_t addr = o.get_addrs(osds[i]).front();
 	address.push_back(addr);
@@ -16752,13 +16752,13 @@ int Client::get_osd_addr(int osd, entity_addr_t& addr)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
   return objecter->with_osdmap([&](const OSDMap& o) {
       if (!o.exists(osd))
-	return -CEPHFS_ENOENT;
+	return -ENOENT;
 
       addr = o.get_addrs(osd).front();
       return 0;
@@ -16770,13 +16770,13 @@ int Client::enumerate_layout(int fd, vector<ObjectExtent>& result,
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
   Fh *f = get_filehandle(fd);
   if (!f)
-    return -CEPHFS_EBADF;
+    return -EBADF;
   Inode *in = f->inode.get();
 
   // map to a list of extents
@@ -16787,12 +16787,12 @@ int Client::enumerate_layout(int fd, vector<ObjectExtent>& result,
 }
 
 
-/* find an osd with the same ip.  -CEPHFS_ENXIO if none. */
+/* find an osd with the same ip.  -ENXIO if none. */
 int Client::get_local_osd()
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   std::scoped_lock lock(client_lock);
 
@@ -17094,17 +17094,17 @@ int Client::check_pool_perm(Inode *in, int need)
 
     bool errored = false;
 
-    if (rd_ret == 0 || rd_ret == -CEPHFS_ENOENT)
+    if (rd_ret == 0 || rd_ret == -ENOENT)
       have |= POOL_READ;
-    else if (rd_ret != -CEPHFS_EPERM) {
+    else if (rd_ret != -EPERM) {
       ldout(cct, 10) << __func__ << " on pool " << pool_id << " ns " << pool_ns
 		     << " rd_err = " << rd_ret << " wr_err = " << wr_ret << dendl;
       errored = true;
     }
 
-    if (wr_ret == 0 || wr_ret == -CEPHFS_EEXIST)
+    if (wr_ret == 0 || wr_ret == -EEXIST)
       have |= POOL_WRITE;
-    else if (wr_ret != -CEPHFS_EPERM) {
+    else if (wr_ret != -EPERM) {
       ldout(cct, 10) << __func__ << " on pool " << pool_id << " ns " << pool_ns
 		     << " rd_err = " << rd_ret << " wr_err = " << wr_ret << dendl;
       errored = true;
@@ -17116,7 +17116,7 @@ int Client::check_pool_perm(Inode *in, int need)
       // userspace filesystem user.
       pool_perms.erase(perm_key);
       signal_cond_list(waiting_for_pool_perm);
-      return -CEPHFS_EIO;
+      return -EIO;
     }
 
     pool_perms[perm_key] = have | POOL_CHECKED;
@@ -17126,12 +17126,12 @@ int Client::check_pool_perm(Inode *in, int need)
   if ((need & CEPH_CAP_FILE_RD) && !(have & POOL_READ)) {
     ldout(cct, 10) << __func__ << " on pool " << pool_id << " ns " << pool_ns
 		   << " need " << ccap_string(need) << ", but no read perm" << dendl;
-    return -CEPHFS_EPERM;
+    return -EPERM;
   }
   if ((need & CEPH_CAP_FILE_WR) && !(have & POOL_WRITE)) {
     ldout(cct, 10) << __func__ << " on pool " << pool_id << " ns " << pool_ns
 		   << " need " << ccap_string(need) << ", but no write perm" << dendl;
-    return -CEPHFS_EPERM;
+    return -EPERM;
   }
 
   return 0;
@@ -17147,7 +17147,7 @@ int Client::_posix_acl_permission(Inode *in, const UserPerm& perms, unsigned wan
       return posix_acl_permits(access_acl, in->uid, in->gid, perms, want);
     }
   }
-  return -CEPHFS_EAGAIN;
+  return -EAGAIN;
 }
 
 int Client::_posix_acl_chmod(Inode *in, mode_t mode, const UserPerm& perms)
@@ -17271,16 +17271,16 @@ int Client::start_reclaim(const std::string& uuid, unsigned flags,
 {
   RWRef_t iref_reader(initialize_state, CLIENT_INITIALIZED);
   if (!iref_reader.is_state_satisfied())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   if (uuid.empty())
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
 
   std::unique_lock l(client_lock);
   {
     auto it = metadata.find("uuid");
     if (it != metadata.end() && it->second == uuid)
-      return -CEPHFS_EINVAL;
+      return -EINVAL;
   }
 
   int r = subscribe_mdsmap(fs_name);
@@ -17307,10 +17307,10 @@ int Client::start_reclaim(const std::string& uuid, unsigned flags,
     if (!have_open_session(mds)) {
       session = _get_or_open_mds_session(mds);
       if (session->state == MetaSession::STATE_REJECTED)
-	return -CEPHFS_EPERM;
+	return -EPERM;
       if (session->state != MetaSession::STATE_OPENING) {
 	// umounting?
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
       }
       ldout(cct, 10) << "waiting for session to mds." << mds << " to open" << dendl;
       wait_on_context_list(session->waiting_for_open);
@@ -17319,7 +17319,7 @@ int Client::start_reclaim(const std::string& uuid, unsigned flags,
 
     session = mds_sessions.at(mds);
     if (!session->mds_features.test(CEPHFS_FEATURE_RECLAIM_CLIENT))
-      return -CEPHFS_EOPNOTSUPP;
+      return -EOPNOTSUPP;
 
     if (session->reclaim_state == MetaSession::RECLAIM_NULL ||
 	session->reclaim_state == MetaSession::RECLAIMING) {
@@ -17328,7 +17328,7 @@ int Client::start_reclaim(const std::string& uuid, unsigned flags,
       session->con->send_message2(std::move(m));
       wait_on_list(waiting_for_reclaim);
     } else if (session->reclaim_state == MetaSession::RECLAIM_FAIL) {
-      return reclaim_errno ? : -CEPHFS_ENOTRECOVERABLE;
+      return reclaim_errno ? : -ENOTRECOVERABLE;
     } else {
       mds++;
     }
@@ -17337,8 +17337,8 @@ int Client::start_reclaim(const std::string& uuid, unsigned flags,
   // didn't find target session in any mds
   if (reclaim_target_addrs.empty()) {
     if (flags & CEPH_RECLAIM_RESET)
-      return -CEPHFS_ENOENT;
-    return -CEPHFS_ENOTRECOVERABLE;
+      return -ENOENT;
+    return -ENOTRECOVERABLE;
   }
 
   if (flags & CEPH_RECLAIM_RESET)
@@ -17360,7 +17360,7 @@ int Client::start_reclaim(const std::string& uuid, unsigned flags,
 	return osd_map.is_blocklisted(reclaim_target_addrs);
       });
   if (blocklisted)
-    return -CEPHFS_ENOTRECOVERABLE;
+    return -ENOTRECOVERABLE;
 
   metadata["reclaiming_uuid"] = uuid;
   return 0;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -380,7 +380,7 @@ public:
 
   /**
    * Returns the length of the buffer that got filled in, or -errno.
-   * If it returns -CEPHFS_ERANGE you just need to increase the size of the
+   * If it returns -ERANGE you just need to increase the size of the
    * buffer and try again.
    */
   int _getdents(dir_result_t *dirp, char *buf, int buflen, bool ful);  // get a bunch of dentries at once
@@ -1890,7 +1890,7 @@ private:
   ino_t last_used_faked_ino;
   ino_t last_used_faked_root;
 
-  int local_osd = -CEPHFS_ENXIO;
+  int local_osd = -ENXIO;
   epoch_t local_osd_epoch = 0;
 
   // mds requests

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -704,13 +704,13 @@ int Inode::set_deleg(Fh *fh, unsigned type, ceph_deleg_cb_t cb, void *priv)
    * allow it, with an unusual error to make it clear.
    */
   if (!client->get_deleg_timeout())
-    return -CEPHFS_ETIME;
+    return -ETIME;
 
   // Just say no if we have any recalled delegs still outstanding
   if (has_recalled_deleg()) {
     lsubdout(client->cct, client, 10) << __func__ <<
 	  ": has_recalled_deleg" << dendl;
-    return -CEPHFS_EAGAIN;
+    return -EAGAIN;
   }
 
   // check vs. currently open files on this inode
@@ -719,17 +719,17 @@ int Inode::set_deleg(Fh *fh, unsigned type, ceph_deleg_cb_t cb, void *priv)
     if (open_count_for_write()) {
       lsubdout(client->cct, client, 10) << __func__ <<
 	    ": open for write" << dendl;
-      return -CEPHFS_EAGAIN;
+      return -EAGAIN;
     }
     break;
   case CEPH_DELEGATION_WR:
     if (open_count() > 1) {
       lsubdout(client->cct, client, 10) << __func__ << ": open" << dendl;
-      return -CEPHFS_EAGAIN;
+      return -EAGAIN;
     }
     break;
   default:
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   /*
@@ -750,7 +750,7 @@ int Inode::set_deleg(Fh *fh, unsigned type, ceph_deleg_cb_t cb, void *priv)
   if (!caps_issued_mask(need)) {
     lsubdout(client->cct, client, 10) << __func__ << ": cap mismatch, have="
       << ccap_string(caps_issued()) << " need=" << ccap_string(need) << dendl;
-    return -CEPHFS_EAGAIN;
+    return -EAGAIN;
   }
 
   for (list<Delegation>::iterator d = delegations.begin();

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -85,43 +85,43 @@ struct ceph_fuse_fake_inode_stag {
 using namespace std;
 
 static const ceph::unordered_map<int,int> cephfs_errno_to_system_errno = {
-  {CEPHFS_EBLOCKLISTED,    ESHUTDOWN},
-  {CEPHFS_EPERM,           EPERM},
-  {CEPHFS_ESTALE,          ESTALE},
-  {CEPHFS_ENOSPC,          ENOSPC},
-  {CEPHFS_ETIMEDOUT,       ETIMEDOUT},
-  {CEPHFS_EIO,             EIO},
-  {CEPHFS_ENOTCONN,        ENOTCONN},
-  {CEPHFS_EEXIST,          EEXIST},
-  {CEPHFS_EINTR,           EINTR},
-  {CEPHFS_EINVAL,          EINVAL},
-  {CEPHFS_EBADF,           EBADF},
-  {CEPHFS_EROFS,           EROFS},
-  {CEPHFS_EAGAIN,          EAGAIN},
-  {CEPHFS_EACCES,          EACCES},
-  {CEPHFS_ELOOP,           ELOOP},
-  {CEPHFS_EISDIR,          EISDIR},
-  {CEPHFS_ENOENT,          ENOENT},
-  {CEPHFS_ENOTDIR,         ENOTDIR},
-  {CEPHFS_ENAMETOOLONG,    ENAMETOOLONG},
-  {CEPHFS_EBUSY,           EBUSY},
-  {CEPHFS_EDQUOT,          EDQUOT},
-  {CEPHFS_EFBIG,           EFBIG},
-  {CEPHFS_ERANGE,          ERANGE},
-  {CEPHFS_ENXIO,           ENXIO},
-  {CEPHFS_ECANCELED,       ECANCELED},
-  {CEPHFS_ENODATA,         ENODATA},
-  {CEPHFS_EOPNOTSUPP,      EOPNOTSUPP},
-  {CEPHFS_EXDEV,           EXDEV},
-  {CEPHFS_ENOMEM,          ENOMEM},
-  {CEPHFS_ENOTRECOVERABLE, ENOTRECOVERABLE},
-  {CEPHFS_ENOSYS,          ENOSYS},
-  {CEPHFS_ENOTEMPTY,       ENOTEMPTY},
-  {CEPHFS_EDEADLK,         EDEADLK},
-  {CEPHFS_EDOM,            EDOM},
-  {CEPHFS_EMLINK,          EMLINK},
-  {CEPHFS_ETIME,           ETIME},
-  {CEPHFS_EOLDSNAPC,       EIO} // forcing to EIO for now
+  {EBLOCKLISTED,    ESHUTDOWN},
+  {EPERM,           EPERM},
+  {ESTALE,          ESTALE},
+  {ENOSPC,          ENOSPC},
+  {ETIMEDOUT,       ETIMEDOUT},
+  {EIO,             EIO},
+  {ENOTCONN,        ENOTCONN},
+  {EEXIST,          EEXIST},
+  {EINTR,           EINTR},
+  {EINVAL,          EINVAL},
+  {EBADF,           EBADF},
+  {EROFS,           EROFS},
+  {EAGAIN,          EAGAIN},
+  {EACCES,          EACCES},
+  {ELOOP,           ELOOP},
+  {EISDIR,          EISDIR},
+  {ENOENT,          ENOENT},
+  {ENOTDIR,         ENOTDIR},
+  {ENAMETOOLONG,    ENAMETOOLONG},
+  {EBUSY,           EBUSY},
+  {EDQUOT,          EDQUOT},
+  {EFBIG,           EFBIG},
+  {ERANGE,          ERANGE},
+  {ENXIO,           ENXIO},
+  {ECANCELED,       ECANCELED},
+  {ENODATA,         ENODATA},
+  {EOPNOTSUPP,      EOPNOTSUPP},
+  {EXDEV,           EXDEV},
+  {ENOMEM,          ENOMEM},
+  {ENOTRECOVERABLE, ENOTRECOVERABLE},
+  {ENOSYS,          ENOSYS},
+  {ENOTEMPTY,       ENOTEMPTY},
+  {EDEADLK,         EDEADLK},
+  {EDOM,            EDOM},
+  {EMLINK,          EMLINK},
+  {ETIME,           ETIME},
+  {EOLDSNAPC,       EIO} // forcing to EIO for now
 };
 
 /* Requirements:
@@ -283,7 +283,7 @@ static int getgroups(fuse_req_t req, gid_t **sgids)
 
   gid_t *gids = new (std::nothrow) gid_t[c];
   if (!gids) {
-    return -get_sys_errno(CEPHFS_ENOMEM);
+    return -get_sys_errno(ENOMEM);
   }
   c = fuse_req_getgroups(req, c, gids);
   if (c < 0) {
@@ -293,7 +293,7 @@ static int getgroups(fuse_req_t req, gid_t **sgids)
   }
   return c;
 #endif
-  return -get_sys_errno(CEPHFS_ENOSYS);
+  return -get_sys_errno(ENOSYS);
 }
 
 static void get_fuse_groups(UserPerm& perms, fuse_req_t req)
@@ -379,7 +379,7 @@ static void fuse_ll_getattr(fuse_req_t req, fuse_ino_t ino,
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *in = cfuse->iget(ino);
   if (!in) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -406,7 +406,7 @@ static void fuse_ll_setattr(fuse_req_t req, fuse_ino_t ino, struct stat *attr,
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *in = cfuse->iget(ino);
   if (!in) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -448,7 +448,7 @@ static void fuse_ll_setxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *in = cfuse->iget(ino);
   if (!in) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -468,7 +468,7 @@ static void fuse_ll_listxattr(fuse_req_t req, fuse_ino_t ino, size_t size)
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *in = cfuse->iget(ino);
   if (!in) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -498,7 +498,7 @@ static void fuse_ll_getxattr(fuse_req_t req, fuse_ino_t ino, const char *name,
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *in = cfuse->iget(ino);
   if (!in) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -523,7 +523,7 @@ static void fuse_ll_removexattr(fuse_req_t req, fuse_ino_t ino,
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *in = cfuse->iget(ino);
   if (!in) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -544,7 +544,7 @@ static void fuse_ll_opendir(fuse_req_t req, fuse_ino_t ino,
   void *dirp;
   Inode *in = cfuse->iget(ino);
   if (!in) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -570,7 +570,7 @@ static void fuse_ll_readlink(fuse_req_t req, fuse_ino_t ino)
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *in = cfuse->iget(ino);
   if (!in) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -595,7 +595,7 @@ static void fuse_ll_mknod(fuse_req_t req, fuse_ino_t parent, const char *name,
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *i2, *i1 = cfuse->iget(parent);
   if (!i1) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -659,7 +659,7 @@ static void fuse_ll_mkdir(fuse_req_t req, fuse_ino_t parent, const char *name,
 
   i1 = cfuse->iget(parent);
   if (!i1) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -684,7 +684,7 @@ static void fuse_ll_unlink(fuse_req_t req, fuse_ino_t parent, const char *name)
   UserPerm perm(ctx->uid, ctx->gid);
   Inode *in = cfuse->iget(parent);
   if (!in) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -703,7 +703,7 @@ static void fuse_ll_rmdir(fuse_req_t req, fuse_ino_t parent, const char *name)
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *in = cfuse->iget(parent);
   if (!in) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -724,7 +724,7 @@ static void fuse_ll_symlink(fuse_req_t req, const char *existing,
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *i2, *i1 = cfuse->iget(parent);
   if (!i1) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -757,7 +757,7 @@ static void fuse_ll_rename(fuse_req_t req, fuse_ino_t parent, const char *name,
   // cephfs does not support renameat2 flavors; follow same logic as done in
   // kclient's ceph_rename()
   if (flags) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 #endif
@@ -768,7 +768,7 @@ static void fuse_ll_rename(fuse_req_t req, fuse_ino_t parent, const char *name,
   Inode *in = cfuse->iget(parent);
   Inode *nin = cfuse->iget(newparent);
   if (!in || !nin) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -790,7 +790,7 @@ static void fuse_ll_link(fuse_req_t req, fuse_ino_t ino, fuse_ino_t newparent,
   Inode *in = cfuse->iget(ino);
   Inode *nin = cfuse->iget(newparent);
   if (!in || !nin) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -836,7 +836,7 @@ static void fuse_ll_open(fuse_req_t req, fuse_ino_t ino,
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *in = cfuse->iget(ino);
   if (!in) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -1033,7 +1033,7 @@ static void fuse_ll_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
   rc.req = req;
   rc.snap = cfuse->fino_snap(ino);
   if (rc.snap == CEPH_MAXSNAP) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
   rc.buf = new char[size];
@@ -1041,7 +1041,7 @@ static void fuse_ll_readdir(fuse_req_t req, fuse_ino_t ino, size_t size,
   rc.pos = 0;
 
   int r = cfuse->client->readdir_r_cb(dirp, fuse_ll_add_dirent, &rc);
-  if (r == 0 || r == -CEPHFS_ENOSPC)  /* ignore ENOSPC from our callback */
+  if (r == 0 || r == -ENOSPC)  /* ignore ENOSPC from our callback */
     fuse_reply_buf(req, rc.buf, rc.pos);
   else
     fuse_reply_err(req, get_sys_errno(-r));
@@ -1073,7 +1073,7 @@ static void fuse_ll_access(fuse_req_t req, fuse_ino_t ino, int mask)
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *in = cfuse->iget(ino);
   if (!in) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -1094,7 +1094,7 @@ static void fuse_ll_create(fuse_req_t req, fuse_ino_t parent, const char *name,
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *i1 = cfuse->iget(parent), *i2;
   if (!i1) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 
@@ -1134,7 +1134,7 @@ static void fuse_ll_statfs(fuse_req_t req, fuse_ino_t ino)
   UserPerm perms(ctx->uid, ctx->gid);
   Inode *in = cfuse->iget(ino);
   if (!in) {
-    fuse_reply_err(req, get_sys_errno(CEPHFS_EINVAL));
+    fuse_reply_err(req, get_sys_errno(EINVAL));
     return;
   }
 

--- a/src/client/posix_acl.cc
+++ b/src/client/posix_acl.cc
@@ -76,7 +76,7 @@ int posix_acl_check(const void *xattr, size_t size)
 int posix_acl_equiv_mode(const void *xattr, size_t size, mode_t *mode_p)
 {
   if (posix_acl_check(xattr, size) < 0)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
 
   int not_equiv = 0;
   mode_t mode = 0;
@@ -105,7 +105,7 @@ int posix_acl_equiv_mode(const void *xattr, size_t size, mode_t *mode_p)
 	not_equiv = 1;
 	break;
       default:
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
     }
     ++entry;
   }
@@ -117,7 +117,7 @@ int posix_acl_equiv_mode(const void *xattr, size_t size, mode_t *mode_p)
 int posix_acl_inherit_mode(bufferptr& acl, mode_t *mode_p)
 {
   if (posix_acl_check(acl.c_str(), acl.length()) <= 0)
-    return -CEPHFS_EIO;
+    return -EIO;
 
   acl_ea_entry *group_entry = NULL, *mask_entry = NULL;
   mode_t mode = *mode_p;
@@ -152,7 +152,7 @@ int posix_acl_inherit_mode(bufferptr& acl, mode_t *mode_p)
 	not_equiv = 1;
 	break;
       default:
-	return -CEPHFS_EIO;
+	return -EIO;
 
     }
     ++entry;
@@ -165,7 +165,7 @@ int posix_acl_inherit_mode(bufferptr& acl, mode_t *mode_p)
     mask_entry->e_perm = perm;
   } else {
     if (!group_entry)
-      return -CEPHFS_EIO;
+      return -EIO;
     __u16 perm = group_entry->e_perm;
     perm &= (mode >> 3) | ~S_IRWXO;
     mode &= (perm << 3) | ~S_IRWXG;
@@ -179,7 +179,7 @@ int posix_acl_inherit_mode(bufferptr& acl, mode_t *mode_p)
 int posix_acl_access_chmod(bufferptr& acl, mode_t mode)
 {
   if (posix_acl_check(acl.c_str(), acl.length()) <= 0)
-    return -CEPHFS_EIO;
+    return -EIO;
 
   acl_ea_entry *group_entry = NULL, *mask_entry = NULL;
 
@@ -211,7 +211,7 @@ int posix_acl_access_chmod(bufferptr& acl, mode_t mode)
     mask_entry->e_perm = (mode & S_IRWXG) >> 3;
   } else {
     if (!group_entry)
-      return -CEPHFS_EIO;
+      return -EIO;
     group_entry->e_perm = (mode & S_IRWXG) >> 3;
   }
   return 0;
@@ -221,7 +221,7 @@ int posix_acl_permits(const bufferptr& acl, uid_t i_uid, gid_t i_gid,
 			 const UserPerm& perms, unsigned want)
 {
   if (posix_acl_check(acl.c_str(), acl.length()) < 0)
-    return -CEPHFS_EIO;
+    return -EIO;
 
   const acl_ea_header *header = reinterpret_cast<const acl_ea_header*>(acl.c_str());
   const acl_ea_entry *entry = header->a_entries;
@@ -258,16 +258,16 @@ int posix_acl_permits(const bufferptr& acl, uid_t i_uid, gid_t i_gid,
 	break;
       case ACL_OTHER:
 	if (group_found)
-	  return -CEPHFS_EACCES;
+	  return -EACCES;
 	else
 	  goto check_perm;
 	break;
       default:
-	return -CEPHFS_EIO;
+	return -EIO;
     }
     ++entry;
   }
-  return -CEPHFS_EIO;
+  return -EIO;
 
 check_mask:
   next_entry = entry + 1;
@@ -277,12 +277,12 @@ check_mask:
       __u16 mask = next_entry->e_perm;
       if ((perm & mask & want) == want)
 	return 0;
-      return -CEPHFS_EACCES;
+      return -EACCES;
     }
     ++next_entry;
   }
 check_perm:
   if ((perm & want) == want)
     return 0;
-  return -CEPHFS_EACCES;
+  return -EACCES;
 }

--- a/src/common/win32/errno.cc
+++ b/src/common/win32/errno.cc
@@ -47,6 +47,11 @@ __u32 ceph_to_hostos_errno_unsigned(__u32 r)
     case 9: return EBADF;
     case 10: return ECHILD;
     // same as EWOULDBLOCK
+    // need to be careful of treating EWOULDBLOCK same way as EAGAIN
+    // in errno.h (in Windows) the EWOULDBLOCK is set to 140, while EAGAIN is 11
+    // In the cephfs client tests we changed assertions that expected EWOULDBLOCK to EAGAIN,
+    // since MDS returns EAGAIN for all cases. EWOULBLOCK originally was used with socket context,
+    // so semantically it makes sense to use EAGAIN for operations that indicate some possible waiting/retry
     case 11: return EAGAIN;
     case 12: return ENOMEM;
     case 13: return EACCES;
@@ -597,57 +602,4 @@ std::string win32_lasterror_str()
 {
   DWORD err = ::GetLastError();
   return win32_strerror(err);
-}
-
-static const ceph::unordered_map<int,NTSTATUS> cephfs_errno_to_ntstatus = {
-  {CEPHFS_EBLOCKLISTED,    STATUS_SYSTEM_SHUTDOWN},
-  {CEPHFS_EPERM,           STATUS_ACCESS_DENIED},
-  {CEPHFS_ESTALE,          STATUS_INVALID_HANDLE},
-  {CEPHFS_ENOSPC,          STATUS_DISK_FULL},
-  {CEPHFS_ETIMEDOUT,       STATUS_TIMEOUT},
-  {CEPHFS_EIO,             STATUS_DATA_ERROR},
-  {CEPHFS_ENOTCONN,        STATUS_CONNECTION_DISCONNECTED},
-  {CEPHFS_EEXIST,          STATUS_OBJECT_NAME_COLLISION},
-  {CEPHFS_EINTR,           STATUS_RETRY},
-  {CEPHFS_EINVAL,          STATUS_INVALID_PARAMETER},
-  {CEPHFS_EBADF,           STATUS_INVALID_HANDLE},
-  {CEPHFS_EROFS,           STATUS_MEDIA_WRITE_PROTECTED},
-  {CEPHFS_EAGAIN,          STATUS_RETRY},
-  {CEPHFS_EACCES,          STATUS_ACCESS_DENIED},
-  {CEPHFS_ELOOP,           STATUS_TOO_MANY_LINKS},
-  {CEPHFS_EISDIR,          STATUS_FILE_IS_A_DIRECTORY},
-  {CEPHFS_ENOENT,          STATUS_OBJECT_NAME_NOT_FOUND},
-  {CEPHFS_ENOTDIR,         STATUS_NOT_A_DIRECTORY},
-  {CEPHFS_ENAMETOOLONG,    STATUS_NAME_TOO_LONG},
-  {CEPHFS_EBUSY,           STATUS_DEVICE_BUSY},
-  {CEPHFS_EDQUOT,          STATUS_QUOTA_EXCEEDED},
-  {CEPHFS_EFBIG,           STATUS_FILE_TOO_LARGE},
-  {CEPHFS_ERANGE,          STATUS_INVALID_PARAMETER},
-  {CEPHFS_ENXIO,           STATUS_NOT_FOUND},
-  {CEPHFS_ECANCELED,       STATUS_REQUEST_CANCELED},
-  {CEPHFS_ENODATA,         STATUS_NOT_FOUND},
-  {CEPHFS_EOPNOTSUPP,      STATUS_NOT_SUPPORTED},
-  {CEPHFS_EXDEV,           STATUS_NOT_SAME_DEVICE},
-  {CEPHFS_ENOMEM,          STATUS_NO_MEMORY},
-  {CEPHFS_ENOTRECOVERABLE, STATUS_INTERNAL_ERROR},
-  {CEPHFS_ENOSYS,          STATUS_NOT_IMPLEMENTED},
-  {CEPHFS_ENOTEMPTY,       STATUS_DIRECTORY_NOT_EMPTY},
-  {CEPHFS_EDEADLK,         STATUS_POSSIBLE_DEADLOCK},
-  {CEPHFS_EDOM,            STATUS_INVALID_PARAMETER},
-  {CEPHFS_EMLINK,          STATUS_TOO_MANY_LINKS},
-  {CEPHFS_ETIME,           STATUS_TIMEOUT},
-  {CEPHFS_EOLDSNAPC,       STATUS_DATA_ERROR}
-};
-
-__u32 cephfs_errno_to_ntstatus_map(int cephfs_errno)
-{
-  cephfs_errno = abs(cephfs_errno);
-
-  if (cephfs_errno == 0)
-    return 0;
-
-  auto it = cephfs_errno_to_ntstatus.find(cephfs_errno);
-  if (it != cephfs_errno_to_ntstatus.end())
-    return it->second;
-  return STATUS_INTERNAL_ERROR;
 }

--- a/src/dokan/ceph_dokan.cc
+++ b/src/dokan/ceph_dokan.cc
@@ -111,7 +111,7 @@ static NTSTATUS do_open_file(
   if (fd < 0) {
     dout(2) << __func__ << " " << path
             << ": ceph_open failed. Error: " << fd << dendl;
-    return cephfs_errno_to_ntstatus_map(fd);
+    return errno_to_ntstatus(fd);
   }
 
   fdc->fd = fd;
@@ -133,7 +133,7 @@ static NTSTATUS WinCephCreateDirectory(
   if (ret < 0) {
     dout(2) << __func__ << " " << path
             << ": ceph_mkdir failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntstatus_map(ret);
+    return errno_to_ntstatus(ret);
   }
   return 0;
 }
@@ -358,7 +358,7 @@ static NTSTATUS WinCephReadFile(
     if (fd_new < 0) {
       dout(2) << __func__ << " " << path
               << ": ceph_open failed. Error: " << fd_new << dendl;
-      return cephfs_errno_to_ntstatus_map(fd_new);
+      return errno_to_ntstatus(fd_new);
     }
 
     int ret = ceph_read(cmount, fd_new, (char*) Buffer, BufferLength, Offset);
@@ -368,7 +368,7 @@ static NTSTATUS WinCephReadFile(
               << ". Offset: " << Offset
               << "Buffer length: " << BufferLength << dendl;
       ceph_close(cmount, fd_new);
-      return cephfs_errno_to_ntstatus_map(ret);
+      return errno_to_ntstatus(ret);
     }
     *ReadLength = ret;
     ceph_close(cmount, fd_new);
@@ -380,7 +380,7 @@ static NTSTATUS WinCephReadFile(
               << ": ceph_read failed. Error: " << ret
               << ". Offset: " << Offset
               << "Buffer length: " << BufferLength << dendl;
-      return cephfs_errno_to_ntstatus_map(ret);
+      return errno_to_ntstatus(ret);
     }
     *ReadLength = ret;
     return 0;
@@ -409,7 +409,7 @@ static NTSTATUS WinCephWriteFile(
       if (ret) {
         dout(2) << __func__ << " " << path
                 << ": ceph_statx failed. Error: " << ret << dendl;
-        return cephfs_errno_to_ntstatus_map(ret);
+        return errno_to_ntstatus(ret);
       }
 
       Offset = stbuf.stx_size;
@@ -445,7 +445,7 @@ static NTSTATUS WinCephWriteFile(
     if (fd_new < 0) {
       dout(2) << __func__ << " " << path
               << ": ceph_open failed. Error: " << fd_new << dendl;
-      return cephfs_errno_to_ntstatus_map(fd_new);
+      return errno_to_ntstatus(fd_new);
     }
 
     int ret = ceph_write(cmount, fd_new, (char*) Buffer,
@@ -456,7 +456,7 @@ static NTSTATUS WinCephWriteFile(
               << ". Offset: " << Offset
               << "Buffer length: " << NumberOfBytesToWrite << dendl;
       ceph_close(cmount, fd_new);
-      return cephfs_errno_to_ntstatus_map(ret);
+      return errno_to_ntstatus(ret);
     }
     *NumberOfBytesWritten = ret;
     ceph_close(cmount, fd_new);
@@ -469,7 +469,7 @@ static NTSTATUS WinCephWriteFile(
               << ": ceph_write failed. Error: " << ret
               << ". Offset: " << Offset
               << "Buffer length: " << NumberOfBytesToWrite << dendl;
-      return cephfs_errno_to_ntstatus_map(ret);
+      return errno_to_ntstatus(ret);
     }
     *NumberOfBytesWritten = ret;
     return 0;
@@ -490,7 +490,7 @@ static NTSTATUS WinCephFlushFileBuffers(
   if (ret) {
     dout(2) << __func__ << " " << get_path(FileName)
             << ": ceph_sync failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntstatus_map(ret);
+    return errno_to_ntstatus(ret);
   }
   return 0;
 }
@@ -513,14 +513,14 @@ static NTSTATUS WinCephGetFileInformation(
     if (ret) {
       dout(2) << __func__ << " " << path
               << ": ceph_statx failed. Error: " << ret << dendl;
-      return cephfs_errno_to_ntstatus_map(ret);
+      return errno_to_ntstatus(ret);
     }
   } else {
     int ret = ceph_fstatx(cmount, fdc->fd, &stbuf, requested_attrs, 0);
     if (ret) {
       dout(2) << __func__ << " " << path
               << ": ceph_fstatx failed. Error: " << ret << dendl;
-      return cephfs_errno_to_ntstatus_map(ret);
+      return errno_to_ntstatus(ret);
     }
   }
 
@@ -557,7 +557,7 @@ static NTSTATUS WinCephFindFiles(
   if (ret != 0) {
     dout(2) << __func__ << " " << path
             << ": ceph_mkdir failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntstatus_map(ret);
+    return errno_to_ntstatus(ret);
   }
 
   // TODO: retrieve the original case (e.g. using xattr) if configured
@@ -582,7 +582,7 @@ static NTSTATUS WinCephFindFiles(
     if (ret < 0) {
       dout(2) << __func__ << " " << path
               << ": ceph_readdirplus_r failed. Error: " << ret << dendl;
-      return cephfs_errno_to_ntstatus_map(ret);
+      return errno_to_ntstatus(ret);
     }
 
     to_wstring(result.d_name).copy(findData.cFileName, MAX_PATH);
@@ -645,7 +645,7 @@ static NTSTATUS WinCephDeleteDirectory(
   if (ret != 0) {
     dout(2) << __func__ << " " << path
             << ": ceph_opendir failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntstatus_map(ret);
+    return errno_to_ntstatus(ret);
   }
 
   WIN32_FIND_DATAW findData;
@@ -682,7 +682,7 @@ static NTSTATUS WinCephMoveFile(
             << ": ceph_rename failed. Error: " << ret << dendl;
   }
 
-  return cephfs_errno_to_ntstatus_map(ret);
+  return errno_to_ntstatus(ret);
 }
 
 static NTSTATUS WinCephSetEndOfFile(
@@ -701,7 +701,7 @@ static NTSTATUS WinCephSetEndOfFile(
     dout(2) << __func__ << " " << get_path(FileName)
             << ": ceph_ftruncate failed. Error: " << ret
             << " Offset: " << ByteOffset << dendl;
-    return cephfs_errno_to_ntstatus_map(ret);
+    return errno_to_ntstatus(ret);
   }
 
   return 0;
@@ -724,7 +724,7 @@ static NTSTATUS WinCephSetAllocationSize(
   if (ret) {
     dout(2) << __func__ << " " << get_path(FileName)
             << ": ceph_fstatx failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntstatus_map(ret);
+    return errno_to_ntstatus(ret);
   }
 
   if ((unsigned long long) AllocSize < stbuf.stx_size) {
@@ -732,7 +732,7 @@ static NTSTATUS WinCephSetAllocationSize(
     if (ret) {
       dout(2) << __func__ << " " << get_path(FileName)
               << ": ceph_ftruncate failed. Error: " << ret << dendl;
-      return cephfs_errno_to_ntstatus_map(ret);
+      return errno_to_ntstatus(ret);
     }
     return 0;
   }
@@ -784,7 +784,7 @@ static NTSTATUS WinCephSetFileTime(
   if (ret) {
     dout(2) << __func__ << " " << path
             << ": ceph_setattrx failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntstatus_map(ret);
+    return errno_to_ntstatus(ret);
   }
   return 0;
 }
@@ -843,7 +843,7 @@ static NTSTATUS WinCephGetDiskFreeSpace(
   int ret = ceph_statfs(cmount, "/", &vfsbuf);
   if (ret) {
     derr << "ceph_statfs failed. Error: " << ret << dendl;
-    return cephfs_errno_to_ntstatus_map(ret);;
+    return errno_to_ntstatus(ret);;
   }
 
   *FreeBytesAvailable   = vfsbuf.f_bsize * vfsbuf.f_bfree;
@@ -907,7 +907,7 @@ NTSTATUS get_volume_serial(PDWORD serial) {
                           fsid_str, sizeof(fsid_str));
   if (ret < 0) {
     dout(2) << "Coudln't retrieve the cluster fsid. Error: " << ret << dendl;
-    return cephfs_errno_to_ntstatus_map(ret);
+    return errno_to_ntstatus(ret);
   }
 
   uuid_d fsid;
@@ -964,7 +964,7 @@ int do_map() {
   r = ceph_mount(cmount, g_cfg->root_path.c_str());
   if (r) {
     derr << "ceph_mount failed. Error: " << r << dendl;
-    return cephfs_errno_to_ntstatus_map(r);
+    return errno_to_ntstatus(r);
   }
 
   if (g_cfg->win_vol_name.empty()) {

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -809,8 +809,10 @@ copy_to_legacy_head(struct ceph_mds_request_head_legacy *legacy,
 
 /* client reply */
 struct ceph_mds_reply_head {
+	using code_t = __le32;
 	__le32 op;
-	__le32 result;
+	// the result field is interpreted by MClientReply message as errorcode32_t
+	code_t result;
 	__le32 mdsmap_epoch;
 	__u8 safe;                     /* true if committed to disk */
 	__u8 is_dentry, is_target;     /* true if dentry, target inode records

--- a/src/include/fs_types.h
+++ b/src/include/fs_types.h
@@ -13,50 +13,6 @@
 
 class JSONObj;
 
-#define CEPHFS_EBLOCKLISTED    108
-#define CEPHFS_EPERM           1
-#define CEPHFS_ESTALE          116
-#define CEPHFS_ENOSPC          28
-#define CEPHFS_ETIMEDOUT       110
-#define CEPHFS_EIO             5
-#define CEPHFS_ENOTCONN        107
-#define CEPHFS_EEXIST          17
-#define CEPHFS_EINTR           4
-#define CEPHFS_EINVAL          22
-#define CEPHFS_EBADF           9
-#define CEPHFS_EROFS           30
-#define CEPHFS_EAGAIN          11
-#define CEPHFS_EACCES          13
-#define CEPHFS_ELOOP           40
-#define CEPHFS_EISDIR          21
-#define CEPHFS_ENOENT          2
-#define CEPHFS_ENOTDIR         20
-#define CEPHFS_ENAMETOOLONG    36
-#define CEPHFS_EBUSY           16
-#define CEPHFS_EDQUOT          122
-#define CEPHFS_EFBIG           27
-#define CEPHFS_ERANGE          34
-#define CEPHFS_ENXIO           6
-#define CEPHFS_ECANCELED       125
-#define CEPHFS_ENODATA         61
-#define CEPHFS_EOPNOTSUPP      95
-#define CEPHFS_EXDEV           18
-#define CEPHFS_ENOMEM          12
-#define CEPHFS_ENOTRECOVERABLE 131
-#define CEPHFS_ENOSYS          38
-#define CEPHFS_EWOULDBLOCK     CEPHFS_EAGAIN
-#define CEPHFS_ENOTEMPTY       39
-#define CEPHFS_EDEADLK         35
-#define CEPHFS_EDEADLOCK       CEPHFS_EDEADLK
-#define CEPHFS_EDOM            33
-#define CEPHFS_EMLINK          31
-#define CEPHFS_ETIME           62
-#define CEPHFS_EOLDSNAPC       85
-#define CEPHFS_EFAULT          14
-#define CEPHFS_EISCONN         106
-#define CEPHFS_EMULTIHOP       72
-#define CEPHFS_EINPROGRESS     115
-
 // taken from linux kernel: include/uapi/linux/fcntl.h
 #define CEPHFS_AT_FDCWD        -100    /* Special value used to indicate
                                           openat should use the current

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -561,30 +561,40 @@ __s32  hostos_to_ceph_errno(__s32 e);
 #endif
 
 struct errorcode32_t {
-  int32_t code;
+  using code_t = __s32;
+  code_t code;
 
   errorcode32_t() : code(0) {}
   // cppcheck-suppress noExplicitConstructor
-  explicit errorcode32_t(int32_t i) : code(i) {}
+  explicit errorcode32_t(code_t i) : code(i) {}
 
-  operator int() const  { return code; }
-  int* operator&()      { return &code; }
-  errorcode32_t& operator=(int32_t i) {
+  operator code_t() const  { return code; }
+  code_t* operator&()      { return &code; }
+  errorcode32_t& operator=(code_t i) {
     code = i;
     return *this;
   }
   bool operator==(const errorcode32_t&) const = default;
   auto operator<=>(const errorcode32_t&) const = default;
 
+  inline code_t get_host_to_wire() const {
+    return hostos_to_ceph_errno(code);
+  }
+
+  inline void set_wire_to_host(code_t host_code) {
+    code = ceph_to_hostos_errno(host_code);
+  }
+
   void encode(ceph::buffer::list &bl) const {
     using ceph::encode;
-    __s32 newcode = hostos_to_ceph_errno(code);
-    encode(newcode, bl);
+    auto new_code = get_host_to_wire();
+    encode(new_code, bl);
   }
   void decode(ceph::buffer::list::const_iterator &bl) {
     using ceph::decode;
-    decode(code, bl);
-    code = ceph_to_hostos_errno(code);
+    code_t newcode;
+    decode(newcode, bl);
+    set_wire_to_host(newcode);
   }
   void dump(ceph::Formatter *f) const {
     f->dump_int("code", code);

--- a/src/include/win32/win32_errno.h
+++ b/src/include/win32/win32_errno.h
@@ -137,7 +137,6 @@ extern "C" {
 
 __s32 wsae_to_errno(__s32 r);
 __u32 errno_to_ntstatus(__s32 r);
-__u32 cephfs_errno_to_ntstatus_map(int cephfs_errno);
 
 #ifdef __cplusplus
 }

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -164,7 +164,7 @@ public:
   int select_filesystem(const std::string &fs_name_)
   {
     if (mounted) {
-      return -CEPHFS_EISCONN;
+      return -EISCONN;
     }
 
     fs_name = fs_name_;
@@ -181,7 +181,7 @@ public:
     int ret;
     
     if (mounted)
-      return -CEPHFS_EISCONN;
+      return -EISCONN;
 
     if (!inited) {
       ret = init();
@@ -203,7 +203,7 @@ public:
   int unmount()
   {
     if (!mounted)
-      return -CEPHFS_ENOTCONN;
+      return -ENOTCONN;
     shutdown();
     return 0;
   }
@@ -443,7 +443,7 @@ extern "C" int ceph_abort_conn(struct ceph_mount_info *cmount)
 extern "C" int ceph_release(struct ceph_mount_info *cmount)
 {
   if (cmount->is_mounted())
-    return -CEPHFS_EISCONN;
+    return -EISCONN;
   delete cmount;
   cmount = nullptr;
   return 0;
@@ -466,7 +466,7 @@ extern "C" uint64_t ceph_get_instance_id(struct ceph_mount_info *cmount)
 extern "C" int ceph_getaddrs(struct ceph_mount_info *cmount, char** addrs)
 {
   if (!cmount->is_initialized())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   auto s = cmount->getaddrs();
   *addrs = strdup(s.c_str());
   return 0;
@@ -503,14 +503,14 @@ extern "C" int ceph_conf_get(struct ceph_mount_info *cmount, const char *option,
 			     char *buf, size_t len)
 {
   if (!buf) {
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
   return cmount->conf_get(option, buf, len);
 }
 
 extern "C" int ceph_set_mount_timeout(struct ceph_mount_info *cmount, uint32_t timeout) {
   if (cmount->is_mounted()) {
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   auto timeout_str = stringify(timeout);
@@ -531,7 +531,7 @@ extern "C" int ceph_mds_command(struct ceph_mount_info *cmount,
   std::string outs;
 
   if (!cmount->is_initialized()) {
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   }
 
   // Construct inputs
@@ -572,7 +572,7 @@ extern "C" int ceph_select_filesystem(struct ceph_mount_info *cmount,
                                       const char *fs_name)
 {
   if (fs_name == nullptr) {
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   return cmount->select_filesystem(fs_name);
@@ -599,7 +599,7 @@ extern "C" struct UserPerm *ceph_mount_perms(struct ceph_mount_info *cmount)
 extern "C" int64_t ceph_get_fs_cid(struct ceph_mount_info *cmount)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->get_fs_cid();
 }
 
@@ -607,7 +607,7 @@ extern "C" int ceph_mount_perms_set(struct ceph_mount_info *cmount,
 				    struct UserPerm *perms)
 {
   if (cmount->is_mounted())
-    return -CEPHFS_EISCONN;
+    return -EISCONN;
   cmount->default_perms = *perms;
   return 0;
 }
@@ -616,14 +616,14 @@ extern "C" int ceph_statfs(struct ceph_mount_info *cmount, const char *path,
 			   struct statvfs *stbuf)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->statfs(path, stbuf, cmount->default_perms);
 }
 
 extern "C" int ceph_get_local_osd(struct ceph_mount_info *cmount)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->get_local_osd();
 }
 
@@ -635,7 +635,7 @@ extern "C" const char* ceph_getcwd(struct ceph_mount_info *cmount)
 extern "C" int ceph_chdir (struct ceph_mount_info *cmount, const char *s)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->chdir(s, cmount->default_perms);
 }
 
@@ -643,7 +643,7 @@ extern "C" int ceph_opendir(struct ceph_mount_info *cmount,
 			    const char *name, struct ceph_dir_result **dirpp)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->opendir(name, (dir_result_t **)dirpp, cmount->default_perms);
 }
 
@@ -651,14 +651,14 @@ extern "C" int ceph_fdopendir(struct ceph_mount_info *cmount, int dirfd,
                               struct ceph_dir_result **dirpp)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->fdopendir(dirfd, (dir_result_t **)dirpp, cmount->default_perms);
 }
 
 extern "C" int ceph_closedir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->closedir(reinterpret_cast<dir_result_t*>(dirp));
 }
 
@@ -666,7 +666,7 @@ extern "C" struct dirent * ceph_readdir(struct ceph_mount_info *cmount, struct c
 {
   if (!cmount->is_mounted()) {
     /* Client::readdir also sets errno to signal errors. */
-    errno = CEPHFS_ENOTCONN;
+    errno = ENOTCONN;
     return nullptr;
   }
   return cmount->get_client()->readdir(reinterpret_cast<dir_result_t*>(dirp));
@@ -675,7 +675,7 @@ extern "C" struct dirent * ceph_readdir(struct ceph_mount_info *cmount, struct c
 extern "C" int ceph_readdir_r(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, struct dirent *de)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->readdir_r(reinterpret_cast<dir_result_t*>(dirp), de);
 }
 
@@ -684,9 +684,9 @@ extern "C" int ceph_readdirplus_r(struct ceph_mount_info *cmount, struct ceph_di
 				  unsigned flags, struct Inode **out)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   if (flags & ~CEPH_REQ_FLAG_MASK)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   return cmount->get_client()->readdirplus_r(reinterpret_cast<dir_result_t*>(dirp), de, stx, want, flags, out);
 }
 
@@ -812,7 +812,7 @@ extern "C" int ceph_getdents(struct ceph_mount_info *cmount, struct ceph_dir_res
 			     char *buf, int buflen)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->getdents(reinterpret_cast<dir_result_t*>(dirp), buf, buflen);
 }
 
@@ -820,7 +820,7 @@ extern "C" int ceph_getdnames(struct ceph_mount_info *cmount, struct ceph_dir_re
 			      char *buf, int buflen)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->getdnames(reinterpret_cast<dir_result_t*>(dirp), buf, buflen);
 }
 
@@ -834,7 +834,7 @@ extern "C" void ceph_rewinddir(struct ceph_mount_info *cmount, struct ceph_dir_r
 extern "C" int64_t ceph_telldir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->telldir(reinterpret_cast<dir_result_t*>(dirp));
 }
 
@@ -848,7 +848,7 @@ extern "C" void ceph_seekdir(struct ceph_mount_info *cmount, struct ceph_dir_res
 extern "C" int ceph_may_delete(struct ceph_mount_info *cmount, const char *path)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->may_delete(path, cmount->default_perms);
 }
 
@@ -856,21 +856,21 @@ extern "C" int ceph_link (struct ceph_mount_info *cmount, const char *existing,
 			  const char *newname)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->link(existing, newname, cmount->default_perms);
 }
 
 extern "C" int ceph_unlink(struct ceph_mount_info *cmount, const char *path)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->unlink(path, cmount->default_perms);
 }
 
 extern "C" int ceph_unlinkat(struct ceph_mount_info *cmount, int dirfd, const char *relpath, int flags)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->unlinkat(dirfd, relpath, flags, cmount->default_perms);
 }
 
@@ -878,7 +878,7 @@ extern "C" int ceph_rename(struct ceph_mount_info *cmount, const char *from,
 			   const char *to)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->rename(from, to, cmount->default_perms);
 }
 
@@ -886,7 +886,7 @@ extern "C" int ceph_rename(struct ceph_mount_info *cmount, const char *from,
 extern "C" int ceph_mkdir(struct ceph_mount_info *cmount, const char *path, mode_t mode)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->mkdir(path, mode, cmount->default_perms);
 }
 
@@ -894,7 +894,7 @@ extern "C" int ceph_mkdirat(struct ceph_mount_info *cmount, int dirfd, const cha
                             mode_t mode)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->mkdirat(dirfd, relpath, mode, cmount->default_perms);
 }
 
@@ -902,7 +902,7 @@ extern "C" int ceph_mksnap(struct ceph_mount_info *cmount, const char *path, con
                            mode_t mode, struct snap_metadata *snap_metadata, size_t nr_snap_metadata)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   size_t i = 0;
   std::map<std::string, std::string> metadata;
   while (i < nr_snap_metadata) {
@@ -915,21 +915,21 @@ extern "C" int ceph_mksnap(struct ceph_mount_info *cmount, const char *path, con
 extern "C" int ceph_rmsnap(struct ceph_mount_info *cmount, const char *path, const char *name)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->rmsnap(path, name, cmount->default_perms, true);
 }
 
 extern "C" int ceph_mkdirs(struct ceph_mount_info *cmount, const char *path, mode_t mode)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->mkdirs(path, mode, cmount->default_perms);
 }
 
 extern "C" int ceph_rmdir(struct ceph_mount_info *cmount, const char *path)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->rmdir(path, cmount->default_perms);
 }
 
@@ -938,7 +938,7 @@ extern "C" int ceph_readlink(struct ceph_mount_info *cmount, const char *path,
 			     char *buf, int64_t size)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->readlink(path, buf, size, cmount->default_perms);
 }
 
@@ -946,7 +946,7 @@ extern "C" int ceph_readlinkat(struct ceph_mount_info *cmount, int dirfd,
                                const char *relpath, char *buf, int64_t size)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->readlinkat(dirfd, relpath, buf, size, cmount->default_perms);
 }
 
@@ -954,7 +954,7 @@ extern "C" int ceph_symlink(struct ceph_mount_info *cmount, const char *existing
 			    const char *newname)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->symlink(existing, newname, cmount->default_perms);
 }
 
@@ -962,7 +962,7 @@ extern "C" int ceph_symlinkat(struct ceph_mount_info *cmount, const char *existi
                             const char *newname)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->symlinkat(existing, dirfd, newname, cmount->default_perms);
 }
 
@@ -970,9 +970,9 @@ extern "C" int ceph_fstatx(struct ceph_mount_info *cmount, int fd, struct ceph_s
                             unsigned int want, unsigned int flags)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   if (flags & ~CEPH_REQ_FLAG_MASK)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   return cmount->get_client()->fstatx(fd, stx, cmount->default_perms,
                                       want, flags);
 }
@@ -981,13 +981,13 @@ extern "C" int ceph_statxat(struct ceph_mount_info *cmount, int dirfd, const cha
                             struct ceph_statx *stx, unsigned int want, unsigned int flags)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 #ifdef CEPH_AT_EMPTY_PATH
   if (flags & ~CEPH_AT_EMPTY_PATH)
 #else
   if (flags & ~CEPH_REQ_FLAG_MASK)
 #endif
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   return cmount->get_client()->statxat(dirfd, relpath, stx, cmount->default_perms,
                                        want, flags);
 }
@@ -996,9 +996,9 @@ extern "C" int ceph_statx(struct ceph_mount_info *cmount, const char *path,
 			  struct ceph_statx *stx, unsigned int want, unsigned int flags)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   if (flags & ~CEPH_REQ_FLAG_MASK)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   return cmount->get_client()->statx(path, stx, cmount->default_perms,
 				     want, flags);
 }
@@ -1007,7 +1007,7 @@ extern "C" int ceph_fsetattrx(struct ceph_mount_info *cmount, int fd,
 			      struct ceph_statx *stx, int mask)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->fsetattrx(fd, stx, mask, cmount->default_perms);
 }
 
@@ -1015,9 +1015,9 @@ extern "C" int ceph_setattrx(struct ceph_mount_info *cmount, const char *relpath
 			    struct ceph_statx *stx, int mask, int flags)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   if (flags & ~CEPH_REQ_FLAG_MASK)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   return cmount->get_client()->setattrx(relpath, stx, mask,
 					cmount->default_perms, flags);
 }
@@ -1026,7 +1026,7 @@ extern "C" int ceph_setattrx(struct ceph_mount_info *cmount, const char *relpath
 extern "C" int ceph_getxattr(struct ceph_mount_info *cmount, const char *path, const char *name, void *value, size_t size)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   return cmount->get_client()->getxattr(path, name, value, size, cmount->default_perms);
 }
@@ -1034,14 +1034,14 @@ extern "C" int ceph_getxattr(struct ceph_mount_info *cmount, const char *path, c
 extern "C" int ceph_lgetxattr(struct ceph_mount_info *cmount, const char *path, const char *name, void *value, size_t size)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->lgetxattr(path, name, value, size, cmount->default_perms);
 }
 
 extern "C" int ceph_fgetxattr(struct ceph_mount_info *cmount, int fd, const char *name, void *value, size_t size)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->fgetxattr(fd, name, value, size, cmount->default_perms);
 }
 
@@ -1049,63 +1049,63 @@ extern "C" int ceph_fgetxattr(struct ceph_mount_info *cmount, int fd, const char
 extern "C" int ceph_listxattr(struct ceph_mount_info *cmount, const char *path, char *list, size_t size)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->listxattr(path, list, size, cmount->default_perms);
 }
 
 extern "C" int ceph_llistxattr(struct ceph_mount_info *cmount, const char *path, char *list, size_t size)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->llistxattr(path, list, size, cmount->default_perms);
 }
 
 extern "C" int ceph_flistxattr(struct ceph_mount_info *cmount, int fd, char *list, size_t size)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->flistxattr(fd, list, size, cmount->default_perms);
 }
 
 extern "C" int ceph_removexattr(struct ceph_mount_info *cmount, const char *path, const char *name)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->removexattr(path, name, cmount->default_perms);
 }
 
 extern "C" int ceph_lremovexattr(struct ceph_mount_info *cmount, const char *path, const char *name)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->lremovexattr(path, name, cmount->default_perms);
 }
 
 extern "C" int ceph_fremovexattr(struct ceph_mount_info *cmount, int fd, const char *name)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->fremovexattr(fd, name, cmount->default_perms);
 }
 
 extern "C" int ceph_setxattr(struct ceph_mount_info *cmount, const char *path, const char *name, const void *value, size_t size, int flags)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->setxattr(path, name, value, size, flags, cmount->default_perms);
 }
 
 extern "C" int ceph_lsetxattr(struct ceph_mount_info *cmount, const char *path, const char *name, const void *value, size_t size, int flags)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->lsetxattr(path, name, value, size, flags, cmount->default_perms);
 }
 
 extern "C" int ceph_fsetxattr(struct ceph_mount_info *cmount, int fd, const char *name, const void *value, size_t size, int flags)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->fsetxattr(fd, name, value, size, flags, cmount->default_perms);
 }
 /* end xattr support */
@@ -1113,47 +1113,47 @@ extern "C" int ceph_fsetxattr(struct ceph_mount_info *cmount, int fd, const char
 extern "C" int ceph_stat(struct ceph_mount_info *cmount, const char *path, struct stat *stbuf)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->stat(path, stbuf, cmount->default_perms);
 }
 
 extern "C" int ceph_fstat(struct ceph_mount_info *cmount, int fd, struct stat *stbuf)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->fstat(fd, stbuf, cmount->default_perms);
 }
 
 extern int ceph_lstat(struct ceph_mount_info *cmount, const char *path, struct stat *stbuf)
 {
    if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->lstat(path, stbuf, cmount->default_perms);
 }
 
 extern "C" int ceph_chmod(struct ceph_mount_info *cmount, const char *path, mode_t mode)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->chmod(path, mode, cmount->default_perms);
 }
 extern "C" int ceph_lchmod(struct ceph_mount_info *cmount, const char *path, mode_t mode)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->lchmod(path, mode, cmount->default_perms);
 }
 extern "C" int ceph_fchmod(struct ceph_mount_info *cmount, int fd, mode_t mode)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->fchmod(fd, mode, cmount->default_perms);
 }
 
 extern "C" int ceph_chmodat(struct ceph_mount_info *cmount, int dirfd, const char *relpath,
                             mode_t mode, int flags) {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->chmodat(dirfd, relpath, mode, flags, cmount->default_perms);
 }
 
@@ -1161,28 +1161,28 @@ extern "C" int ceph_chown(struct ceph_mount_info *cmount, const char *path,
 			  int uid, int gid)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->chown(path, uid, gid, cmount->default_perms);
 }
 extern "C" int ceph_fchown(struct ceph_mount_info *cmount, int fd,
 			   int uid, int gid)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->fchown(fd, uid, gid, cmount->default_perms);
 }
 extern "C" int ceph_lchown(struct ceph_mount_info *cmount, const char *path,
 			   int uid, int gid)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->lchown(path, uid, gid, cmount->default_perms);
 }
 
 extern "C" int ceph_chownat(struct ceph_mount_info *cmount, int dirfd, const char *relpath,
                             uid_t uid, gid_t gid, int flags) {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->chownat(dirfd, relpath, uid, gid, flags, cmount->default_perms);
 }
 
@@ -1190,7 +1190,7 @@ extern "C" int ceph_utime(struct ceph_mount_info *cmount, const char *path,
 			  struct utimbuf *buf)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->utime(path, buf, cmount->default_perms);
 }
 
@@ -1198,7 +1198,7 @@ extern "C" int ceph_futime(struct ceph_mount_info *cmount, int fd,
                            struct utimbuf *buf)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->futime(fd, buf, cmount->default_perms);
 }
 
@@ -1206,7 +1206,7 @@ extern "C" int ceph_utimes(struct ceph_mount_info *cmount, const char *path,
                            struct timeval times[2])
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->utimes(path, times, cmount->default_perms);
 }
 
@@ -1214,7 +1214,7 @@ extern "C" int ceph_lutimes(struct ceph_mount_info *cmount, const char *path,
                             struct timeval times[2])
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->lutimes(path, times, cmount->default_perms);
 }
 
@@ -1222,7 +1222,7 @@ extern "C" int ceph_futimes(struct ceph_mount_info *cmount, int fd,
                             struct timeval times[2])
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->futimes(fd, times, cmount->default_perms);
 }
 
@@ -1230,14 +1230,14 @@ extern "C" int ceph_futimens(struct ceph_mount_info *cmount, int fd,
                             struct timespec times[2])
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->futimens(fd, times, cmount->default_perms);
 }
 
 extern "C" int ceph_utimensat(struct ceph_mount_info *cmount, int dirfd, const char *relpath,
                               struct timespec times[2], int flags) {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->utimensat(dirfd, relpath, times, flags, cmount->default_perms);
 }
 
@@ -1245,7 +1245,7 @@ extern "C" int ceph_flock(struct ceph_mount_info *cmount, int fd, int operation,
 			  uint64_t owner)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->flock(fd, operation, owner);
 }
 
@@ -1253,7 +1253,7 @@ extern "C" int ceph_truncate(struct ceph_mount_info *cmount, const char *path,
 			     int64_t size)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->truncate(path, size, cmount->default_perms);
 }
 
@@ -1262,7 +1262,7 @@ extern "C" int ceph_mknod(struct ceph_mount_info *cmount, const char *path,
 			  mode_t mode, dev_t rdev)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->mknod(path, mode, cmount->default_perms, rdev);
 }
 
@@ -1270,7 +1270,7 @@ extern "C" int ceph_open(struct ceph_mount_info *cmount, const char *path,
 			 int flags, mode_t mode)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->open(path, flags, cmount->default_perms, mode);
 }
 
@@ -1278,7 +1278,7 @@ extern "C" int ceph_openat(struct ceph_mount_info *cmount, int dirfd, const char
                            int flags, mode_t mode)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->openat(dirfd, relpath, flags, cmount->default_perms, mode);
 }
 
@@ -1286,7 +1286,7 @@ extern "C" int ceph_open_layout(struct ceph_mount_info *cmount, const char *path
     mode_t mode, int stripe_unit, int stripe_count, int object_size, const char *data_pool)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->open(path, flags, cmount->default_perms, mode,
 				    stripe_unit, stripe_count,
 				    object_size, data_pool);
@@ -1295,7 +1295,7 @@ extern "C" int ceph_open_layout(struct ceph_mount_info *cmount, const char *path
 extern "C" int ceph_close(struct ceph_mount_info *cmount, int fd)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->close(fd);
 }
 
@@ -1303,7 +1303,7 @@ extern "C" int64_t ceph_lseek(struct ceph_mount_info *cmount, int fd,
 			     int64_t offset, int whence)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->lseek(fd, offset, whence);
 }
 
@@ -1311,7 +1311,7 @@ extern "C" int ceph_read(struct ceph_mount_info *cmount, int fd, char *buf,
 			 int64_t size, int64_t offset)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->read(fd, buf, size, offset);
 }
 
@@ -1319,7 +1319,7 @@ extern "C" int ceph_preadv(struct ceph_mount_info *cmount, int fd,
               const struct iovec *iov, int iovcnt, int64_t offset)
 {
   if (!cmount->is_mounted())
-      return -CEPHFS_ENOTCONN;
+      return -ENOTCONN;
   return cmount->get_client()->preadv(fd, iov, iovcnt, offset);
 }
 
@@ -1327,7 +1327,7 @@ extern "C" int ceph_write(struct ceph_mount_info *cmount, int fd, const char *bu
 			  int64_t size, int64_t offset)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->write(fd, buf, size, offset);
 }
 
@@ -1335,21 +1335,21 @@ extern "C" int ceph_pwritev(struct ceph_mount_info *cmount, int fd,
               const struct iovec *iov, int iovcnt, int64_t offset)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->pwritev(fd, iov, iovcnt, offset);
 }
 
 extern "C" int ceph_ftruncate(struct ceph_mount_info *cmount, int fd, int64_t size)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->ftruncate(fd, size, cmount->default_perms);
 }
 
 extern "C" int ceph_fsync(struct ceph_mount_info *cmount, int fd, int syncdataonly)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->fsync(fd, syncdataonly);
 }
 
@@ -1357,7 +1357,7 @@ extern "C" int ceph_fallocate(struct ceph_mount_info *cmount, int fd, int mode,
 	                      int64_t offset, int64_t length)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->fallocate(fd, mode, offset, length);
 }
 
@@ -1371,7 +1371,7 @@ extern "C" int ceph_lazyio_propagate(class ceph_mount_info *cmount,
                            int fd, int64_t offset, size_t count)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return (cmount->get_client()->lazyio_propagate(fd, offset, count));
 }
 
@@ -1379,7 +1379,7 @@ extern "C" int ceph_lazyio_synchronize(class ceph_mount_info *cmount,
                            int fd, int64_t offset, size_t count)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return (cmount->get_client()->lazyio_synchronize(fd, offset, count));
 }
 
@@ -1387,7 +1387,7 @@ extern "C" int ceph_lazyio_synchronize(class ceph_mount_info *cmount,
 extern "C" int ceph_sync_fs(struct ceph_mount_info *cmount)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->sync_fs();
 }
 
@@ -1397,7 +1397,7 @@ extern "C" int ceph_get_file_stripe_unit(struct ceph_mount_info *cmount, int fh)
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->fdescribe_layout(fh, &l);
   if (r < 0)
     return r;
@@ -1410,7 +1410,7 @@ extern "C" int ceph_get_path_stripe_unit(struct ceph_mount_info *cmount, const c
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->describe_layout(path, &l, cmount->default_perms);
   if (r < 0)
     return r;
@@ -1423,7 +1423,7 @@ extern "C" int ceph_get_file_stripe_count(struct ceph_mount_info *cmount, int fh
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->fdescribe_layout(fh, &l);
   if (r < 0)
     return r;
@@ -1436,7 +1436,7 @@ extern "C" int ceph_get_path_stripe_count(struct ceph_mount_info *cmount, const 
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->describe_layout(path, &l, cmount->default_perms);
   if (r < 0)
     return r;
@@ -1449,7 +1449,7 @@ extern "C" int ceph_get_file_object_size(struct ceph_mount_info *cmount, int fh)
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->fdescribe_layout(fh, &l);
   if (r < 0)
     return r;
@@ -1462,7 +1462,7 @@ extern "C" int ceph_get_path_object_size(struct ceph_mount_info *cmount, const c
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->describe_layout(path, &l, cmount->default_perms);
   if (r < 0)
     return r;
@@ -1475,7 +1475,7 @@ extern "C" int ceph_get_file_pool(struct ceph_mount_info *cmount, int fh)
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->fdescribe_layout(fh, &l);
   if (r < 0)
     return r;
@@ -1488,7 +1488,7 @@ extern "C" int ceph_get_path_pool(struct ceph_mount_info *cmount, const char *pa
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->describe_layout(path, &l, cmount->default_perms);
   if (r < 0)
     return r;
@@ -1501,7 +1501,7 @@ extern "C" int ceph_get_file_pool_name(struct ceph_mount_info *cmount, int fh, c
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->fdescribe_layout(fh, &l);
   if (r < 0)
     return r;
@@ -1509,7 +1509,7 @@ extern "C" int ceph_get_file_pool_name(struct ceph_mount_info *cmount, int fh, c
   if (len == 0)
     return name.length();
   if (name.length() > len)
-    return -CEPHFS_ERANGE;
+    return -ERANGE;
   strncpy(buf, name.c_str(), len);
   return name.length();
 }
@@ -1517,12 +1517,12 @@ extern "C" int ceph_get_file_pool_name(struct ceph_mount_info *cmount, int fh, c
 extern "C" int ceph_get_pool_name(struct ceph_mount_info *cmount, int pool, char *buf, size_t len)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   string name = cmount->get_client()->get_pool_name(pool);
   if (len == 0)
     return name.length();
   if (name.length() > len)
-    return -CEPHFS_ERANGE;
+    return -ERANGE;
   strncpy(buf, name.c_str(), len);
   return name.length();
 }
@@ -1533,7 +1533,7 @@ extern "C" int ceph_get_path_pool_name(struct ceph_mount_info *cmount, const cha
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->describe_layout(path, &l, cmount->default_perms);
   if (r < 0)
     return r;
@@ -1541,7 +1541,7 @@ extern "C" int ceph_get_path_pool_name(struct ceph_mount_info *cmount, const cha
   if (len == 0)
     return name.length();
   if (name.length() > len)
-    return -CEPHFS_ERANGE;
+    return -ERANGE;
   strncpy(buf, name.c_str(), len);
   return name.length();
 }
@@ -1549,14 +1549,14 @@ extern "C" int ceph_get_path_pool_name(struct ceph_mount_info *cmount, const cha
 extern "C" int ceph_get_default_data_pool_name(struct ceph_mount_info *cmount, char *buf, size_t len)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   int64_t pool_id = cmount->get_client()->get_default_pool_id();
  
   string name = cmount->get_client()->get_pool_name(pool_id);
   if (len == 0)
     return name.length();
   if (name.length() > len)
-    return -CEPHFS_ERANGE;
+    return -ERANGE;
   strncpy(buf, name.c_str(), len);
   return name.length(); 
 }
@@ -1567,7 +1567,7 @@ extern "C" int ceph_get_file_layout(struct ceph_mount_info *cmount, int fh, int 
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->fdescribe_layout(fh, &l);
   if (r < 0)
     return r;
@@ -1588,7 +1588,7 @@ extern "C" int ceph_get_path_layout(struct ceph_mount_info *cmount, const char *
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->describe_layout(path, &l, cmount->default_perms);
   if (r < 0)
     return r;
@@ -1609,7 +1609,7 @@ extern "C" int ceph_get_file_replication(struct ceph_mount_info *cmount, int fh)
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->fdescribe_layout(fh, &l);
   if (r < 0)
     return r;
@@ -1623,7 +1623,7 @@ extern "C" int ceph_get_path_replication(struct ceph_mount_info *cmount, const c
   int r;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   r = cmount->get_client()->describe_layout(path, &l, cmount->default_perms);
   if (r < 0)
     return r;
@@ -1635,43 +1635,43 @@ extern "C" int ceph_set_default_file_stripe_unit(struct ceph_mount_info *cmount,
 						 int stripe)
 {
   // this option no longer exists
-  return -CEPHFS_EOPNOTSUPP;
+  return -EOPNOTSUPP;
 }
 
 extern "C" int ceph_set_default_file_stripe_count(struct ceph_mount_info *cmount,
 						  int count)
 {
   // this option no longer exists
-  return -CEPHFS_EOPNOTSUPP;
+  return -EOPNOTSUPP;
 }
 
 extern "C" int ceph_set_default_object_size(struct ceph_mount_info *cmount, int size)
 {
   // this option no longer exists
-  return -CEPHFS_EOPNOTSUPP;
+  return -EOPNOTSUPP;
 }
 
 extern "C" int ceph_set_default_file_replication(struct ceph_mount_info *cmount,
 						 int replication)
 {
   // this option no longer exists
-  return -CEPHFS_EOPNOTSUPP;
+  return -EOPNOTSUPP;
 }
 
 extern "C" int ceph_set_default_preferred_pg(struct ceph_mount_info *cmount, int osd)
 {
   // this option no longer exists
-  return -CEPHFS_EOPNOTSUPP;
+  return -EOPNOTSUPP;
 }
 
 extern "C" int ceph_get_file_extent_osds(struct ceph_mount_info *cmount, int fh,
     int64_t offset, int64_t *length, int *osds, int nosds)
 {
   if (nosds < 0)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   vector<int> vosds;
   int ret = cmount->get_client()->get_file_extent_osds(fh, offset, length, vosds);
@@ -1682,7 +1682,7 @@ extern "C" int ceph_get_file_extent_osds(struct ceph_mount_info *cmount, int fh,
     return vosds.size();
 
   if ((int)vosds.size() > nosds)
-    return -CEPHFS_ERANGE;
+    return -ERANGE;
 
   for (int i = 0; i < (int)vosds.size(); i++)
     osds[i] = vosds[i];
@@ -1694,10 +1694,10 @@ extern "C" int ceph_get_osd_crush_location(struct ceph_mount_info *cmount,
     int osd, char *path, size_t len)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   if (!path && len)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
 
   vector<pair<string, string> > loc;
   int ret = cmount->get_client()->get_osd_crush_location(osd, loc);
@@ -1725,7 +1725,7 @@ extern "C" int ceph_get_osd_crush_location(struct ceph_mount_info *cmount,
     return needed;
 
   if (needed > len)
-    return -CEPHFS_ERANGE;
+    return -ERANGE;
 
   return needed;
 }
@@ -1734,10 +1734,10 @@ extern "C" int ceph_get_osd_addr(struct ceph_mount_info *cmount, int osd,
     struct sockaddr_storage *addr)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   if (!addr)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
 
   entity_addr_t address;
   int ret = cmount->get_client()->get_osd_addr(osd, address);
@@ -1757,10 +1757,10 @@ extern "C" int ceph_get_file_stripe_address(struct ceph_mount_info *cmount, int 
   int r;
 
   if (naddr < 0)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
 
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   r = cmount->get_client()->get_file_stripe_address(fh, offset, address);
   if (r < 0)
@@ -1771,7 +1771,7 @@ extern "C" int ceph_get_file_stripe_address(struct ceph_mount_info *cmount, int 
 
   /* naddr == 0: drop through and return actual size */
   if (naddr && (address.size() > (unsigned)naddr))
-    return -CEPHFS_ERANGE;
+    return -ERANGE;
 
   return address.size();
 }
@@ -1779,7 +1779,7 @@ extern "C" int ceph_get_file_stripe_address(struct ceph_mount_info *cmount, int 
 extern "C" int ceph_localize_reads(struct ceph_mount_info *cmount, int val)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   if (!val)
     cmount->get_client()->clear_filer_flags(CEPH_OSD_FLAG_LOCALIZE_READS);
   else
@@ -1795,36 +1795,36 @@ extern "C" CephContext *ceph_get_mount_context(struct ceph_mount_info *cmount)
 extern "C" int ceph_debug_get_fd_caps(struct ceph_mount_info *cmount, int fd)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->get_caps_issued(fd);
 }
 
 extern "C" int ceph_debug_get_file_caps(struct ceph_mount_info *cmount, const char *path)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->get_caps_issued(path, cmount->default_perms);
 }
 
 extern "C" int ceph_get_stripe_unit_granularity(struct ceph_mount_info *cmount)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return CEPH_MIN_STRIPE_UNIT;
 }
 
 extern "C" int ceph_get_pool_id(struct ceph_mount_info *cmount, const char *pool_name)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
 
   if (!pool_name || !pool_name[0])
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
 
   /* negative range reserved for errors */
   int64_t pool_id = cmount->get_client()->get_pool_id(pool_name);
   if (pool_id > 0x7fffffff)
-    return -CEPHFS_ERANGE;
+    return -ERANGE;
 
   /* get_pool_id error codes fit in int */
   return (int)pool_id;
@@ -1834,7 +1834,7 @@ extern "C" int ceph_get_pool_replication(struct ceph_mount_info *cmount,
 					 int pool_id)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->get_pool_replication(pool_id);
 }
 /* Low-level exports */
@@ -1845,7 +1845,7 @@ extern "C" int ceph_ll_lookup_root(struct ceph_mount_info *cmount,
   *parent = cmount->get_client()->get_root();
   if (*parent)
     return 0;
-  return -CEPHFS_EFAULT;
+  return -EFAULT;
 }
 
 extern "C" struct Inode *ceph_ll_get_inode(class ceph_mount_info *cmount,
@@ -1881,7 +1881,7 @@ extern "C" int ceph_ll_lookup(struct ceph_mount_info *cmount,
 			      unsigned flags, const UserPerm *perms)
 {
   if (flags & ~CEPH_REQ_FLAG_MASK)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   return (cmount->get_client())->ll_lookupx(parent, name, out, stx, want,
 					    flags, *perms);
 }
@@ -1902,7 +1902,7 @@ extern "C" int ceph_ll_walk(struct ceph_mount_info *cmount, const char* name, In
 		 const UserPerm *perms)
 {
   if (flags & ~CEPH_REQ_FLAG_MASK)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   return(cmount->get_client()->ll_walk(name, i, stx, want, flags, *perms));
 }
 
@@ -1912,7 +1912,7 @@ extern "C" int ceph_ll_getattr(class ceph_mount_info *cmount,
 			       const UserPerm *perms)
 {
   if (flags & ~CEPH_REQ_FLAG_MASK)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   return (cmount->get_client()->ll_getattrx(in, stx, want, flags, *perms));
 }
 
@@ -2062,7 +2062,7 @@ extern "C" int ceph_ll_create(class ceph_mount_info *cmount,
 			      unsigned lflags, const UserPerm *perms)
 {
   if (lflags & ~CEPH_REQ_FLAG_MASK)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   return (cmount->get_client())->ll_createx(parent, name, mode, oflags, outp,
 					    fhp, stx, want, lflags, *perms);
 }
@@ -2074,7 +2074,7 @@ extern "C" int ceph_ll_mknod(class ceph_mount_info *cmount, Inode *parent,
 			     const UserPerm *perms)
 {
   if (flags & ~CEPH_REQ_FLAG_MASK)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   return (cmount->get_client())->ll_mknodx(parent, name, mode, rdev,
 					   out, stx, want, flags, *perms);
 }
@@ -2085,7 +2085,7 @@ extern "C" int ceph_ll_mkdir(class ceph_mount_info *cmount, Inode *parent,
 			     unsigned flags, const UserPerm *perms)
 {
   if (flags & ~CEPH_REQ_FLAG_MASK)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   return cmount->get_client()->ll_mkdirx(parent, name, mode, out, stx, want,
 					 flags, *perms);
 }
@@ -2147,7 +2147,7 @@ extern "C" int ceph_ll_symlink(class ceph_mount_info *cmount,
 			       unsigned flags, const UserPerm *perms)
 {
   if (flags & ~CEPH_REQ_FLAG_MASK)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   return (cmount->get_client()->ll_symlinkx(in, name, value, out, stx, want,
 					    flags, *perms));
 }
@@ -2285,7 +2285,7 @@ extern "C" uint32_t ceph_get_cap_return_timeout(class ceph_mount_info *cmount)
 extern "C" int ceph_set_deleg_timeout(class ceph_mount_info *cmount, uint32_t timeout)
 {
   if (!cmount->is_mounted())
-    return -CEPHFS_ENOTCONN;
+    return -ENOTCONN;
   return cmount->get_client()->set_deleg_timeout(timeout);
 }
 
@@ -2346,7 +2346,7 @@ extern "C" int ceph_get_snap_info(struct ceph_mount_info *cmount,
   if (nr_metadata) {
     snap_info->snap_metadata = (struct snap_metadata *)calloc(nr_metadata, sizeof(struct snap_metadata));
     if (!snap_info->snap_metadata) {
-      return -CEPHFS_ENOMEM;
+      return -ENOMEM;
     }
 
     // fill with key, value pairs
@@ -2372,7 +2372,7 @@ extern "C" int ceph_get_snap_info(struct ceph_mount_info *cmount,
 
   if (nr_metadata && i != nr_metadata) {
     ceph_free_snap_info_buffer(snap_info);
-    return -CEPHFS_ENOMEM;
+    return -ENOMEM;
   }
 
   return 0;

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1716,7 +1716,7 @@ public:
     ret1(0), ret2(0), ret3(0) { }
   void finish(int r) override {
     // check the correctness of backtrace
-    if (r >= 0 && ret3 != -CEPHFS_ECANCELED)
+    if (r >= 0 && ret3 != -ECANCELED)
       dir->inode->verify_diri_backtrace(btbl, ret3);
     if (r >= 0) r = ret1;
     if (r >= 0) r = ret2;
@@ -1760,7 +1760,7 @@ void CDir::_omap_fetch(std::set<string> *keys, MDSContext *c)
     rd.getxattr("parent", &fin->btbl, &fin->ret3);
     rd.set_last_op_flags(CEPH_OSD_OP_FLAG_FAILOK);
   } else {
-    fin->ret3 = -CEPHFS_ECANCELED;
+    fin->ret3 = -ECANCELED;
   }
 
   mdcache->mds->objecter->read(oid, oloc, rd, CEPH_NOSNAP, NULL, 0,
@@ -2007,7 +2007,7 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
   dout(10) << "_fetched header " << hdrbl.length() << " bytes "
 	   << omap.size() << " keys for " << *this << dendl;
 
-  ceph_assert(r == 0 || r == -CEPHFS_ENOENT || r == -CEPHFS_ENODATA);
+  ceph_assert(r == 0 || r == -ENOENT || r == -ENODATA);
   ceph_assert(is_auth());
   ceph_assert(!is_frozen());
 
@@ -2158,7 +2158,7 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
                                << err.what() << "(" << get_path() << ")";
 
       // Remember that this dentry is damaged.  Subsequent operations
-      // that try to act directly on it will get their CEPHFS_EIOs, but this
+      // that try to act directly on it will get their EIOs, but this
       // dirfrag as a whole will continue to look okay (minus the
       // mysteriously-missing dentry)
       go_bad_dentry(key.snapid, key.name);
@@ -2282,7 +2282,7 @@ void CDir::go_bad(bool complete)
 
   state_clear(STATE_FETCHING);
   auth_unpin(this);
-  finish_waiting(WAIT_COMPLETE, -CEPHFS_EIO);
+  finish_waiting(WAIT_COMPLETE, -EIO);
 }
 
 // -----------------------
@@ -2742,7 +2742,7 @@ void CDir::_committed(int r, version_t v)
 {
   if (r < 0) {
     // the directory could be partly purged during MDS failover
-    if (r == -CEPHFS_ENOENT && committed_version == 0 &&
+    if (r == -ENOENT && committed_version == 0 &&
 	!inode->is_base() && get_parent_dir()->inode->is_stray()) {
       r = 0;
       if (inode->snaprealm)

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1260,7 +1260,7 @@ struct C_IO_Inode_Fetched : public CInodeIOContext {
   Context *fin;
   C_IO_Inode_Fetched(CInode *i, Context *f) : CInodeIOContext(i), fin(f) {}
   void finish(int r) override {
-    // Ignore 'r', because we fetch from two places, so r is usually CEPHFS_ENOENT
+    // Ignore 'r', because we fetch from two places, so r is usually ENOENT
     in->_fetched(bl, bl2, fin);
   }
   void print(ostream& out) const override {
@@ -1300,7 +1300,7 @@ void CInode::_fetched(bufferlist& bl, bufferlist& bl2, Context *fin)
     p = bl.cbegin();
   } else {
     derr << "No data while reading inode " << ino() << dendl;
-    fin->complete(-CEPHFS_ENOENT);
+    fin->complete(-ENOENT);
     return;
   }
 
@@ -1314,7 +1314,7 @@ void CInode::_fetched(bufferlist& bl, bufferlist& bl2, Context *fin)
     if (magic != CEPH_FS_ONDISK_MAGIC) {
       dout(0) << "on disk magic '" << magic << "' != my magic '" << CEPH_FS_ONDISK_MAGIC
               << "'" << dendl;
-      fin->complete(-CEPHFS_EINVAL);
+      fin->complete(-EINVAL);
     } else {
       decode_store(p);
       dout(10) << "_fetched " << *this << dendl;
@@ -1322,7 +1322,7 @@ void CInode::_fetched(bufferlist& bl, bufferlist& bl2, Context *fin)
     }
   } catch (buffer::error &err) {
     derr << "Corrupt inode " << ino() << ": " << err.what() << dendl;
-    fin->complete(-CEPHFS_EINVAL);
+    fin->complete(-EINVAL);
     return;
   }
 }
@@ -1455,18 +1455,18 @@ void CInode::store_backtrace(CInodeCommitOperations &op, int op_prio,
 
 void CInode::_stored_backtrace(int r, version_t v, Context *fin)
 {
-  if (r == -CEPHFS_ENOENT) {
+  if (r == -ENOENT) {
     const int64_t pool = get_backtrace_pool();
     bool exists = mdcache->mds->objecter->with_osdmap(
         [pool](const OSDMap &osd_map) {
           return osd_map.have_pg_pool(pool);
         });
 
-    // This CEPHFS_ENOENT is because the pool doesn't exist (the user deleted it
+    // This ENOENT is because the pool doesn't exist (the user deleted it
     // out from under us), so the backtrace can never be written, so pretend
     // to succeed so that the user can proceed to e.g. delete the file.
     if (!exists) {
-      dout(4) << __func__ << " got CEPHFS_ENOENT: a data pool was deleted "
+      dout(4) << __func__ << " got ENOENT: a data pool was deleted "
                  "beneath us!" << dendl;
       r = 0;
     }
@@ -1538,7 +1538,7 @@ void CInode::verify_diri_backtrace(bufferlist &bl, int err)
     if (backtrace.ancestors.empty() ||
 	backtrace.ancestors[0].dname != pdn->get_name() ||
 	backtrace.ancestors[0].dirino != pdn->get_dir()->ino())
-      err = -CEPHFS_EINVAL;
+      err = -EINVAL;
   }
 
   if (err) {
@@ -3974,7 +3974,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
       sizeof(struct ceph_timespec) + 8; // btime + change_attr
 
     if (bytes > max_bytes)
-      return -CEPHFS_ENOSPC;
+      return -ENOSPC;
   }
 
 

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -737,7 +737,7 @@ int FSMap::parse_filesystem(std::string_view ns_str, Filesystem const** result) 
         return 0;
       }
     }
-    return -CEPHFS_ENOENT;
+    return -ENOENT;
   } else {
     *result = &get_filesystem(fscid);
     return 0;
@@ -1162,7 +1162,7 @@ int FSMap::parse_role(
     if (r >= 0) {
       ss << "Invalid file system";
     }
-    return -CEPHFS_ENOENT;
+    return -ENOENT;
   }
 
   return r;
@@ -1179,14 +1179,14 @@ int FSMap::parse_role(
   if (colon_pos == std::string::npos) {
     if (legacy_client_fscid == FS_CLUSTER_ID_NONE) {
       ss << "No filesystem selected";
-      return -CEPHFS_ENOENT;
+      return -ENOENT;
     }
     fs = &get_filesystem(legacy_client_fscid);
     rank_pos = 0;
   } else {
     if (parse_filesystem(role_str.substr(0, colon_pos), &fs) < 0) {
       ss << "Invalid filesystem";
-      return -CEPHFS_ENOENT;
+      return -ENOENT;
     }
     rank_pos = colon_pos+1;
   }
@@ -1197,14 +1197,14 @@ int FSMap::parse_role(
   long rank_i = strict_strtol(rank_str.c_str(), 10, &err);
   if (rank_i < 0 || !err.empty()) {
     ss << "Invalid rank '" << rank_str << "'";
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   } else {
     rank = rank_i;
   }
 
   if (fs->mds_map.in.count(rank) == 0) {
     ss << "Rank '" << rank << "' not found";
-    return -CEPHFS_ENOENT;
+    return -ENOENT;
   }
 
   *role = {fs->fscid, rank};

--- a/src/mds/JournalPointer.cc
+++ b/src/mds/JournalPointer.cc
@@ -61,7 +61,7 @@ int JournalPointer::load(Objecter *objecter)
     try {
       decode(q);
     } catch (const buffer::error &e) {
-      return -CEPHFS_EINVAL;
+      return -EINVAL;
     }
   } else {
     dout(1) << "Journal pointer '" << object_id << "' read failed: " << cpp_strerror(r) << dendl;

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -440,8 +440,8 @@ int MDBalancer::localize_balancer()
   /* success: store the balancer in memory and set the version. */
   if (!r) {
     if (ret_t == std::cv_status::timeout) {
-      mds->objecter->op_cancel(tid, -CEPHFS_ECANCELED);
-      return -CEPHFS_ETIMEDOUT;
+      mds->objecter->op_cancel(tid, -ECANCELED);
+      return -ETIMEDOUT;
     }
     bal_code.assign(lua_src.to_str());
     bal_version.assign(oid.name);
@@ -966,7 +966,7 @@ int MDBalancer::mantle_prep_rebalance()
 
   /* mantle doesn't know about cluster size, so check target len here */
   if ((int) state.targets.size() != cluster_size)
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   else if (ret)
     return ret;
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6488,7 +6488,7 @@ struct C_IO_MDC_TruncateWriteFinish : public MDCacheIOContext {
     MDCacheIOContext(c, false), in(i), ls(l), block_size(bs) {
   }
   void finish(int r) override {
-    ceph_assert(r == 0 || r == -CEPHFS_ENOENT);
+    ceph_assert(r == 0 || r == -ENOENT);
     mdcache->truncate_inode_write_finish(in, ls, block_size);
   }
   void print(ostream& out) const override {
@@ -6503,7 +6503,7 @@ struct C_IO_MDC_TruncateFinish : public MDCacheIOContext {
     MDCacheIOContext(c, false), in(i), ls(l) {
   }
   void finish(int r) override {
-    ceph_assert(r == 0 || r == -CEPHFS_ENOENT);
+    ceph_assert(r == 0 || r == -ENOENT);
     mdcache->truncate_inode_finish(in, ls);
   }
   void print(ostream& out) const override {
@@ -8350,10 +8350,10 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
       MDRequestRef null_ref;
       return path_traverse(null_ref, cf, path, MDS_TRAVERSE_DISCOVER, nullptr);
     }
-    return -CEPHFS_ESTALE;
+    return -ESTALE;
   }
   if (cur->state_test(CInode::STATE_PURGING))
-    return -CEPHFS_ESTALE;
+    return -ESTALE;
 
   if (flags & MDS_TRAVERSE_CHECK_LOCKCACHE)
     mds->locker->find_and_attach_lock_cache(mdr, cur);
@@ -8389,14 +8389,14 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
     
     if (!cur->is_dir()) {
       dout(7) << "traverse: " << *cur << " not a dir " << dendl;
-      return -CEPHFS_ENOTDIR;
+      return -ENOTDIR;
     }
 
     // walk into snapdir?
     if (path[depth].length() == 0) {
       dout(10) << "traverse: snapdir" << dendl;
       if (!mdr || depth > 0) // snapdir must be the first component
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
       snapid = CEPH_SNAPDIR;
       mdr->snapid = snapid;
       depth++;
@@ -8405,14 +8405,14 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
     // walk thru snapdir?
     if (snapid == CEPH_SNAPDIR) {
       if (!mdr)
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
       SnapRealm *realm = cur->find_snaprealm();
       snapid = realm->resolve_snapname(path[depth], cur->ino());
       dout(10) << "traverse: snap " << path[depth] << " -> " << snapid << dendl;
       if (!snapid) {
 	if (pdnvec)
 	  pdnvec->clear();   // do not confuse likes of rdlock_path_pin_ref();
-	return -CEPHFS_ENOENT;
+	return -ENOENT;
       }
       if (depth == path.depth() - 1)
 	target_inode = cur;
@@ -8441,7 +8441,7 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
         if (forimport && cur->is_quiesced()) {
           /* block discover for import */
           dout(5) << __func__ << ": blocking discover due to quiesced parent: " << *cur << dendl;
-          return -CEPHFS_EAGAIN;
+          return -EAGAIN;
         } else {
 	  dout(10) << "traverse: need dirfrag " << fg << ", doing discover from " << *cur << dendl;
 	  discover_path(cur, snapid, path.postfixpath(depth), cf.build(),
@@ -8456,7 +8456,7 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
     if (mds->damage_table.is_dirfrag_damaged(curdir)) {
       dout(4) << "traverse: stopped lookup at dirfrag "
               << *curdir << "/" << path[depth] << " snap=" << snapid << dendl;
-      return -CEPHFS_EIO;
+      return -EIO;
     }
 
     if (pdir) {
@@ -8491,14 +8491,14 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
     if (mds->damage_table.is_dentry_damaged(curdir, path[depth], snapid)) {
       dout(4) << "traverse: stopped lookup at damaged dentry "
               << *curdir << "/" << path[depth] << " snap=" << snapid << dendl;
-      return -CEPHFS_EIO;
+      return -EIO;
     }
 
     // dentry
     CDentry *dn = curdir->lookup(path[depth], snapid);
     if (dn) {
       if (dn->state_test(CDentry::STATE_PURGING))
-	return -CEPHFS_ENOENT;
+	return -ENOENT;
 
       CDentry::linkage_t *dnl = dn->get_projected_linkage();
       // If an auth check was deferred before and the target inode is found
@@ -8547,7 +8547,7 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
       if (pdnvec)
 	pdnvec->push_back(dn);
 
-      // can we conclude CEPHFS_ENOENT?
+      // can we conclude ENOENT?
       if (dnl->is_null()) {
 	dout(10) << "traverse: null+readable dentry at " << *dn << dendl;
 	if (depth == path.depth() - 1) {
@@ -8557,7 +8557,7 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
 	  if (pdnvec)
 	    pdnvec->clear();   // do not confuse likes of rdlock_path_pin_ref();
 	}
-	return -CEPHFS_ENOENT;
+	return -ENOENT;
       }
 
       // do we have inode?
@@ -8575,7 +8575,7 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
           if (mds->damage_table.is_remote_damaged(dnl->get_remote_ino())) {
             dout(4) << "traverse: remote dentry points to damaged ino "
                     << *dn << dendl;
-            return -CEPHFS_EIO;
+            return -EIO;
           }
           open_remote_dentry(dn, true, cf.build(),
 			     (path_locked && depth == path.depth() - 1));
@@ -8665,7 +8665,7 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
 	    pdnvec->clear();   // do not confuse likes of rdlock_path_pin_ref();
 	  }
 	}
-        return -CEPHFS_ENOENT;
+        return -ENOENT;
       } else {
 
         // Check DamageTable for missing fragments before trying to fetch
@@ -8673,7 +8673,7 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
         if (mds->damage_table.is_dirfrag_damaged(curdir)) {
           dout(4) << "traverse: damaged dirfrag " << *curdir
                   << ", blocking fetch" << dendl;
-          return -CEPHFS_EIO;
+          return -EIO;
         }
 
 	// directory isn't complete; reload
@@ -8699,7 +8699,7 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
         if (forimport && cur->is_quiesced()) {
           /* block discover for import */
           dout(5) << __func__ << ": blocking discover due to quiesced parent: " << *cur << dendl;
-          return -CEPHFS_EAGAIN;
+          return -EAGAIN;
         } else {
 	  dout(7) << "traverse: discover from " << path[depth] << " from " << *curdir << dendl;
 	  discover_path(curdir, snapid, path.postfixpath(depth), cf.build(),
@@ -8728,7 +8728,7 @@ int MDCache::path_traverse(const MDRequestRef& mdr, MDSContextFactory& cf,
   if (path.depth() == 0) {
     dout(7) << "no tail dentry, base " << *cur << dendl;
     if (want_dentry && !want_inode) {
-      return -CEPHFS_ENOENT;
+      return -ENOENT;
     }
     target_inode = cur;
   }
@@ -8962,7 +8962,7 @@ struct C_MDC_OpenInoTraverseDir : public MDCacheContext {
     MDCacheContext(c), ino(i), msg(m), parent(p) {}
   void finish(int r) override {
     if (r < 0 && !parent)
-      r = -CEPHFS_EAGAIN;
+      r = -EAGAIN;
     if (msg) {
       mdcache->handle_open_ino(msg, r);
       return;
@@ -9001,7 +9001,7 @@ void MDCache::_open_ino_backtrace_fetched(inodeno_t ino, bufferlist& bl, int err
     } catch (const buffer::error &decode_exc) {
       derr << "corrupt backtrace on ino x0" << std::hex << ino
            << std::dec << ": " << decode_exc.what() << dendl;
-      open_ino_finish(ino, info, -CEPHFS_EIO);
+      open_ino_finish(ino, info, -EIO);
       return;
     }
     if (backtrace.pool != info.pool && backtrace.pool != -1) {
@@ -9014,7 +9014,7 @@ void MDCache::_open_ino_backtrace_fetched(inodeno_t ino, bufferlist& bl, int err
 		      new C_OnFinisher(fin, mds->finisher));
       return;
     }
-  } else if (err == -CEPHFS_ENOENT) {
+  } else if (err == -ENOENT) {
     int64_t meta_pool = mds->get_metadata_pool();
     if (info.pool != meta_pool) {
       dout(10) << " no object in pool " << info.pool
@@ -9032,11 +9032,11 @@ void MDCache::_open_ino_backtrace_fetched(inodeno_t ino, bufferlist& bl, int err
   if (err == 0) {
     if (backtrace.ancestors.empty()) {
       dout(10) << " got empty backtrace " << dendl;
-      err = -CEPHFS_ESTALE;
+      err = -ESTALE;
     } else if (!info.ancestors.empty()) {
       if (info.ancestors[0] == backtrace.ancestors[0]) {
 	dout(10) << " got same parents " << info.ancestors[0] << " 2 times" << dendl;
-	err = -CEPHFS_EINVAL;
+	err = -EINVAL;
       } else {
 	info.last_err = 0;
       }
@@ -9160,7 +9160,7 @@ int MDCache::open_ino_traverse_dir(inodeno_t ino, const cref_t<MMDSOpenIno> &m,
     if (!diri->is_dir()) {
       dout(10) << " " << *diri << " is not dir" << dendl;
       if (i == 0)
-	err = -CEPHFS_ENOTDIR;
+	err = -ENOTDIR;
       break;
     }
 
@@ -9201,7 +9201,7 @@ int MDCache::open_ino_traverse_dir(inodeno_t ino, const cref_t<MMDSOpenIno> &m,
 
 	dout(10) << " no ino " << next_ino << " in " << *dir << dendl;
 	if (i == 0)
-	  err = -CEPHFS_ENOENT;
+	  err = -ENOENT;
       } else if (discover) {
 	if (!dnl) {
 	  filepath path(name, 0);
@@ -9216,7 +9216,7 @@ int MDCache::open_ino_traverse_dir(inodeno_t ino, const cref_t<MMDSOpenIno> &m,
 	}
 	dout(10) << " no ino " << next_ino << " in " << *dir << dendl;
 	if (i == 0)
-	  err = -CEPHFS_ENOENT;
+	  err = -ENOENT;
       }
     }
     if (hint && i == 0)
@@ -9238,7 +9238,7 @@ void MDCache::open_ino_finish(inodeno_t ino, open_ino_info_t& info, int ret)
 
 void MDCache::do_open_ino(inodeno_t ino, open_ino_info_t& info, int err)
 {
-  if (err < 0 && err != -CEPHFS_EAGAIN) {
+  if (err < 0 && err != -EAGAIN) {
     info.checked.clear();
     info.checking = MDS_RANK_NONE;
     info.check_peers = true;
@@ -9247,7 +9247,7 @@ void MDCache::do_open_ino(inodeno_t ino, open_ino_info_t& info, int err)
       info.discover = false;
       info.ancestors.clear();
     }
-    if (err != -CEPHFS_ENOENT && err != -CEPHFS_ENOTDIR)
+    if (err != -ENOENT && err != -ENOTDIR)
       info.last_err = err;
   }
 
@@ -9521,7 +9521,7 @@ void MDCache::find_ino_peers(inodeno_t ino, MDSContext *c,
   dout(5) << "find_ino_peers " << ino << " hint " << hint << dendl;
   CInode *in = get_inode(ino);
   if (in && in->state_test(CInode::STATE_PURGING)) {
-    c->complete(-CEPHFS_ESTALE);
+    c->complete(-ESTALE);
     return;
   }
   ceph_assert(!in);
@@ -9565,7 +9565,7 @@ void MDCache::_do_find_ino_peer(find_ino_peer_info_t& fip)
       dout(10) << "_do_find_ino_peer waiting for more peers to be active" << dendl;
     } else {
       dout(10) << "_do_find_ino_peer failed on " << fip.ino << dendl;
-      fip.fin->complete(-CEPHFS_ESTALE);
+      fip.fin->complete(-ESTALE);
       find_ino_peer.erase(fip.tid);
     }
   } else {
@@ -9847,7 +9847,7 @@ void MDCache::request_forward(const MDRequestRef& mdr, mds_rank_t who, int port)
     if (mds->logger) mds->logger->inc(l_mds_forward);
   } else if (mdr->internal_op >= 0) {
     dout(10) << "request_forward on internal op; cancelling" << dendl;
-    mdr->internal_op_finish->complete(-CEPHFS_EXDEV);
+    mdr->internal_op_finish->complete(-EXDEV);
   } else {
     dout(7) << "request_forward drop " << *mdr << " req " << *mdr->client_request
             << " was from mds" << dendl;
@@ -10049,7 +10049,7 @@ void MDCache::request_kill(const MDRequestRef& mdr)
   } else {
     dout(10) << "request_kill " << *mdr << dendl;
     if (mdr->internal_op_finish) {
-      mdr->internal_op_finish->complete(-CEPHFS_ECANCELED);
+      mdr->internal_op_finish->complete(-ECANCELED);
       mdr->internal_op_finish = nullptr;
     }
     request_cleanup(mdr);
@@ -10896,7 +10896,7 @@ void MDCache::handle_discover_reply(const cref_t<MDiscoverReply> &m)
   }
 
   // waiters
-  finish_contexts(g_ceph_context, error, -CEPHFS_ENOENT);  // finish errors directly
+  finish_contexts(g_ceph_context, error, -ENOENT);  // finish errors directly
   mds->queue_waiters(finished);
 }
 
@@ -12053,7 +12053,7 @@ public:
 			    const MDRequestRef& r) :
     MDCacheIOContext(m), basedirfrag(f), bits(b), mdr(r) {}
   void finish(int r) override {
-    ceph_assert(r == 0 || r == -CEPHFS_ENOENT);
+    ceph_assert(r == 0 || r == -ENOENT);
     mdcache->_fragment_old_purged(basedirfrag, bits, mdr);
   }
   void print(ostream& out) const override {
@@ -12953,7 +12953,7 @@ int MDCache::dump_cache(std::string_view fn, Formatter *f, double timeout)
       f->close_section();
     } else {
       derr << "cache usage exceeds dump threshold" << dendl;
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
     }
     return r;
   }
@@ -13166,7 +13166,7 @@ void MDCache::enqueue_scrub_work(const MDRequestRef& mdr)
 
   // Cannot scrub same dentry twice at same time
   if (in->scrub_is_in_progress()) {
-    mds->server->respond_to_request(mdr, -CEPHFS_EBUSY);
+    mds->server->respond_to_request(mdr, -EBUSY);
     return;
   } else {
     in->scrub_info();
@@ -13404,7 +13404,7 @@ void MDCache::repair_dirfrag_stats_work(const MDRequestRef& mdr)
   dout(10) << __func__ << " " << *dir << dendl;
 
   if (!dir->is_auth()) {
-    mds->server->respond_to_request(mdr, -CEPHFS_ESTALE);
+    mds->server->respond_to_request(mdr, -ESTALE);
     return;
   }
 
@@ -13511,11 +13511,11 @@ void MDCache::repair_inode_stats_work(const MDRequestRef& mdr)
   dout(10) << __func__ << " " << *diri << dendl;
 
   if (!diri->is_auth()) {
-    mds->server->respond_to_request(mdr, -CEPHFS_ESTALE);
+    mds->server->respond_to_request(mdr, -ESTALE);
     return;
   }
   if (!diri->is_dir()) {
-    mds->server->respond_to_request(mdr, -CEPHFS_ENOTDIR);
+    mds->server->respond_to_request(mdr, -ENOTDIR);
     return;
   }
 
@@ -13542,7 +13542,7 @@ void MDCache::repair_inode_stats_work(const MDRequestRef& mdr)
         dir = diri->get_or_open_dirfrag(this, leaf);
       }
       if (mds->damage_table.is_dirfrag_damaged(dir)) {
-        mds->server->respond_to_request(mdr, -CEPHFS_EIO);
+        mds->server->respond_to_request(mdr, -EIO);
         return;
       }
       if (dir->get_version() == 0) {
@@ -13614,11 +13614,11 @@ void MDCache::rdlock_dirfrags_stats_work(const MDRequestRef& mdr)
   CInode *diri = static_cast<CInode*>(mdr->internal_op_private);
   dout(10) << __func__ << " " << *diri << dendl;
   if (!diri->is_auth()) {
-    mds->server->respond_to_request(mdr, -CEPHFS_ESTALE);
+    mds->server->respond_to_request(mdr, -ESTALE);
     return;
   }
   if (!diri->is_dir()) {
-    mds->server->respond_to_request(mdr, -CEPHFS_ENOTDIR);
+    mds->server->respond_to_request(mdr, -ENOTDIR);
     return;
   }
 
@@ -13638,7 +13638,7 @@ void MDCache::flush_dentry(std::string_view path, Context *fin)
 {
   if (is_readonly()) {
     dout(10) << __func__ << ": read-only FS" << dendl;
-    fin->complete(-CEPHFS_EROFS);
+    fin->complete(-EROFS);
     return;
   }
   dout(10) << "flush_dentry " << path << dendl;
@@ -13902,8 +13902,8 @@ void MDCache::dispatch_quiesce_inode(const MDRequestRef& mdr)
     auto qimdr = get_quiesce_inode_op(in);
     if (qimdr != mdr) {
       dout(5) << __func__ << ": already quiesced by " << *qimdr << dendl;
-      qs.add_failed(mdr, -CEPHFS_EINPROGRESS);
-      mds->server->respond_to_request(mdr, -CEPHFS_EINPROGRESS);
+      qs.add_failed(mdr, -EINPROGRESS);
+      mds->server->respond_to_request(mdr, -EINPROGRESS);
       return;
     }
   }
@@ -13989,8 +13989,8 @@ void MDCache::dispatch_quiesce_inode(const MDRequestRef& mdr)
     for (auto& dir : in->get_dirfrags()) {
       if (!dir->is_auth() && !splitauth) {
         dout(5) << "auth is split and splitauth is false: " << *dir << dendl;
-        qs.add_failed(mdr, -CEPHFS_EPERM);
-        mds->server->respond_to_request(mdr, -CEPHFS_EPERM);
+        qs.add_failed(mdr, -EPERM);
+        mds->server->respond_to_request(mdr, -EPERM);
         return;
       }
     }
@@ -14098,7 +14098,7 @@ void MDCache::dispatch_quiesce_path(const MDRequestRef& mdr)
 {
   if (!mds->is_active()) {
     dout(20) << __func__ << " is not active!" << dendl;
-    mds->server->respond_to_request(mdr, -CEPHFS_EAGAIN);
+    mds->server->respond_to_request(mdr, -EAGAIN);
     return;
   }
 
@@ -14233,7 +14233,7 @@ void MDCache::dispatch_lock_path(const MDRequestRef& mdr)
   for (const auto &lock : lps.config.locks) {
     auto colonps = lock.find(':');
     if (colonps == std::string::npos) {
-      mds->server->respond_to_request(mdr, -CEPHFS_EINVAL);
+      mds->server->respond_to_request(mdr, -EINVAL);
       return;
     }
     auto lock_type = lock.substr(0, colonps);
@@ -14262,12 +14262,12 @@ void MDCache::dispatch_lock_path(const MDRequestRef& mdr)
     } else if (lock_type == "flock") {
       l = &in->flocklock;
     } else {
-      mds->server->respond_to_request(mdr, -CEPHFS_EINVAL);
+      mds->server->respond_to_request(mdr, -EINVAL);
       return;
     }
 
     if (lock_kind.size() != 1) {
-      mds->server->respond_to_request(mdr, -CEPHFS_EINVAL);
+      mds->server->respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -14282,14 +14282,14 @@ void MDCache::dispatch_lock_path(const MDRequestRef& mdr)
         lov.add_xlock(l);
         break;
       default:
-        mds->server->respond_to_request(mdr, -CEPHFS_EINVAL);
+        mds->server->respond_to_request(mdr, -EINVAL);
         return;
     }
   }
 
   if (!mds->locker->acquire_locks(mdr, lov, lps.config.ap_freeze ? in : nullptr, lps.config.ap_dont_block, true)) {
     if (lps.config.ap_dont_block && mdr->aborted) {
-      mds->server->respond_to_request(mdr, -CEPHFS_EWOULDBLOCK);
+      mds->server->respond_to_request(mdr, -EAGAIN);
     }
     return;
   }
@@ -14321,7 +14321,7 @@ MDRequestRef MDCache::lock_path(LockPathConfig config, std::function<void(MDRequ
   if (config.lifetime) {
     mds->timer.add_event_after(*config.lifetime, new LambdaContext([this, mdr]() {
       if (!mdr->result && !mdr->aborted && !mdr->killed && !mdr->dead) {
-        mdr->result = -CEPHFS_ECANCELED;
+        mdr->result = -ECANCELED;
         request_kill(mdr);
       }
     }));

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -598,7 +598,7 @@ private:
       MDSInternalContext(c->mds), cache(c), finisher(_finisher) {}
     ~C_MDS_QuiescePath() {
       if (finisher) {
-        finisher->complete(-CEPHFS_ECANCELED);
+        finisher->complete(-ECANCELED);
         finisher = nullptr;
       }
     }

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -123,7 +123,7 @@ class C_MDL_WriteError : public MDSIOContextBase {
     MDSRank *mds = get_mds();
     // assume journal is reliable, so don't choose action based on
     // g_conf()->mds_action_on_write_error.
-    if (r == -CEPHFS_EBLOCKLISTED) {
+    if (r == -EBLOCKLISTED) {
       derr << "we have been blocklisted (fenced), respawning..." << dendl;
       mds->respawn();
     } else {
@@ -876,7 +876,7 @@ int MDLog::trim_to(SegmentBoundary::seq_t seq)
     if (pending_events.count(ls->seq)) {
       dout(5) << __func__ << ": " << *ls << " has pending events" << dendl;
       locker.unlock();
-      return -CEPHFS_EAGAIN;
+      return -EAGAIN;
     }
 
     if (expiring_segments.count(ls)) {
@@ -1089,7 +1089,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
   // front = default ino and back = null
   JournalPointer jp(mds->get_nodeid(), mds->get_metadata_pool());
   const int read_result = jp.load(mds->objecter);
-  if (read_result == -CEPHFS_ENOENT) {
+  if (read_result == -ENOENT) {
     inodeno_t const default_log_ino = MDS_INO_LOG_OFFSET + mds->get_nodeid();
     jp.front = default_log_ino;
     int write_result = jp.save(mds->objecter);
@@ -1101,7 +1101,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
       mds->damaged();
       ceph_abort();  // damaged should never return
     }
-  } else if (read_result == -CEPHFS_EBLOCKLISTED) {
+  } else if (read_result == -EBLOCKLISTED) {
     derr << "Blocklisted during JournalPointer read!  Respawning..." << dendl;
     mds->respawn();
     ceph_abort(); // Should be unreachable because respawn calls execv
@@ -1123,7 +1123,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
       if (mds->is_daemon_stopping()) {
         return;
       }
-      completion->complete(-CEPHFS_EAGAIN);
+      completion->complete(-EAGAIN);
       return;
     }
     dout(1) << "Erasing journal " << jp.back << dendl;
@@ -1136,7 +1136,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
     C_SaferCond recover_wait;
     back.recover(&recover_wait);
     int recovery_result = recover_wait.wait();
-    if (recovery_result == -CEPHFS_EBLOCKLISTED) {
+    if (recovery_result == -EBLOCKLISTED) {
       derr << "Blocklisted during journal recovery!  Respawning..." << dendl;
       mds->respawn();
       ceph_abort(); // Should be unreachable because respawn calls execv
@@ -1155,7 +1155,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
 
     // If we are successful, or find no data, we can update the JournalPointer to
     // reflect that the back journal is gone.
-    if (erase_result != 0 && erase_result != -CEPHFS_ENOENT) {
+    if (erase_result != 0 && erase_result != -ENOENT) {
       derr << "Failed to erase journal " << jp.back << ": " << cpp_strerror(erase_result) << dendl;
     } else {
       dout(1) << "Successfully erased journal, updating journal pointer" << dendl;
@@ -1183,7 +1183,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
   front_journal->recover(&recover_wait);
   dout(4) << "Waiting for journal " << jp.front << " to recover..." << dendl;
   int recovery_result = recover_wait.wait();
-  if (recovery_result == -CEPHFS_EBLOCKLISTED) {
+  if (recovery_result == -EBLOCKLISTED) {
     derr << "Blocklisted during journal recovery!  Respawning..." << dendl;
     mds->respawn();
     ceph_abort(); // Should be unreachable because respawn calls execv
@@ -1206,7 +1206,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
         delete front_journal;
         return;
       }
-      completion->complete(-CEPHFS_EINVAL);
+      completion->complete(-EINVAL);
     }
   } else if (mds->is_standby_replay() || front_journal->get_stream_format() >= g_conf()->mds_journal_format) {
     /* The journal is of configured format, or we are in standbyreplay and will
@@ -1430,21 +1430,21 @@ void MDLog::_replay_thread()
     if (journaler->get_error()) {
       r = journaler->get_error();
       dout(0) << "_replay journaler got error " << r << ", aborting" << dendl;
-      if (r == -CEPHFS_ENOENT) {
+      if (r == -ENOENT) {
         if (mds->is_standby_replay()) {
           // journal has been trimmed by somebody else
-          r = -CEPHFS_EAGAIN;
+          r = -EAGAIN;
         } else {
           mds->clog->error() << "missing journal object";
           mds->damaged_unlocked();
           ceph_abort();  // Should be unreachable because damaged() calls respawn()
         }
-      } else if (r == -CEPHFS_EINVAL) {
+      } else if (r == -EINVAL) {
         if (journaler->get_read_pos() < journaler->get_expire_pos()) {
           // this should only happen if you're following somebody else
           if(journaler->is_readonly()) {
-            dout(0) << "expire_pos is higher than read_pos, returning CEPHFS_EAGAIN" << dendl;
-            r = -CEPHFS_EAGAIN;
+            dout(0) << "expire_pos is higher than read_pos, returning EAGAIN" << dendl;
+            r = -EAGAIN;
           } else {
             mds->clog->error() << "invalid journaler offsets";
             mds->damaged_unlocked();
@@ -1460,8 +1460,8 @@ void MDLog::_replay_thread()
           journaler->reread_head(&reread_fin);
           int err = reread_fin.wait();
           if (err) {
-            if (err == -CEPHFS_ENOENT && mds->is_standby_replay()) {
-              r = -CEPHFS_EAGAIN;
+            if (err == -ENOENT && mds->is_standby_replay()) {
+              r = -EAGAIN;
               dout(1) << "Journal header went away while in standby replay, journal rewritten?"
                       << dendl;
               break;
@@ -1477,8 +1477,8 @@ void MDLog::_replay_thread()
           }
 	  standby_trim_segments();
           if (journaler->get_read_pos() < journaler->get_expire_pos()) {
-            dout(0) << "expire_pos is higher than read_pos, returning CEPHFS_EAGAIN" << dendl;
-            r = -CEPHFS_EAGAIN;
+            dout(0) << "expire_pos is higher than read_pos, returning EAGAIN" << dendl;
+            r = -EAGAIN;
           }
         }
       }

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -111,7 +111,7 @@ void MDSIOContextBase::complete(int r) {
   // It's possible that the osd op requests will be stuck and then times out
   // after "rados_osd_op_timeout", the mds won't know what we should it, just
   // respawn it.
-  if (r == -CEPHFS_EBLOCKLISTED || r == -CEPHFS_ETIMEDOUT) {
+  if (r == -EBLOCKLISTED || r == -ETIMEDOUT) {
     derr << "MDSIOContextBase: failed with " << r << ", restarting..." << dendl;
     mds->respawn();
   } else {

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -142,7 +142,7 @@ void MDSDaemon::asok_command(
   dout(1) << "asok_command: " << command << " " << cmdmap
 	  << " (starting...)" << dendl;
 
-  int r = -CEPHFS_ENOSYS;
+  int r = -ENOSYS;
   bufferlist outbl;
   CachedStackStringStream css;
   auto& ss = *css;
@@ -182,7 +182,7 @@ void MDSDaemon::asok_command(
   } else if (command == "heap") {
     if (!ceph_using_tcmalloc()) {
       ss << "not using tcmalloc";
-      r = -CEPHFS_EOPNOTSUPP;
+      r = -EOPNOTSUPP;
     } else {
       string heapcmd;
       cmd_getval(cmdmap, "heapcmd", heapcmd);
@@ -214,7 +214,7 @@ void MDSDaemon::asok_command(
 	return;
       } catch (const TOPNSPC::common::bad_cmd_get& e) {
 	ss << e.what();
-	r = -CEPHFS_EINVAL;
+	r = -EINVAL;
       }
     }
   }
@@ -559,7 +559,7 @@ int MDSDaemon::init()
   // to run on Windows.
   derr << "The Ceph MDS does not support running on Windows at the moment."
        << dendl;
-  return -CEPHFS_ENOSYS;
+  return -ENOSYS;
 #endif // _WIN32
 
   dout(10) << "Dumping misc struct sizes:" << dendl;
@@ -632,7 +632,7 @@ int MDSDaemon::init()
 	 << " Maybe I have a clock skew against the monitors?" << dendl;
     std::lock_guard locker{mds_lock};
     suicide();
-    return -CEPHFS_ETIMEDOUT;
+    return -ETIMEDOUT;
   }
 
   mds_lock.lock();
@@ -726,12 +726,12 @@ void MDSDaemon::handle_command(const cref_t<MCommand> &m)
       << *m->get_connection()->peer_addrs << dendl;
 
     ss << "permission denied";
-    r = -CEPHFS_EACCES;
+    r = -EACCES;
   } else if (m->cmd.empty()) {
-    r = -CEPHFS_EINVAL;
+    r = -EINVAL;
     ss << "no command given";
   } else if (!TOPNSPC::common::cmdmap_from_json(m->cmd, &cmdmap, ss)) {
-    r = -CEPHFS_EINVAL;
+    r = -EINVAL;
   } else {
     cct->get_admin_socket()->queue_tell_command(m);
     return;

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -397,7 +397,7 @@ public:
   int remove_data_pool(int64_t poolid) {
     std::vector<int64_t>::iterator p = std::find(data_pools.begin(), data_pools.end(), poolid);
     if (p == data_pools.end())
-      return -CEPHFS_ENOENT;
+      return -ENOENT;
     data_pools.erase(p);
     return 0;
   }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -77,7 +77,7 @@ public:
 
     if (mdcache->is_readonly()) {
       dout(5) << __func__ << ": read-only FS" << dendl;
-      complete(-CEPHFS_EROFS);
+      complete(-EROFS);
       return;
     }
 
@@ -239,7 +239,7 @@ public:
   }
 
 private:
-  // context which completes itself (with -CEPHFS_ETIMEDOUT) after a specified
+  // context which completes itself (with -ETIMEDOUT) after a specified
   // timeout or when explicitly completed, whichever comes first. Note
   // that the context does not detroy itself after completion -- it
   // needs to be explicitly freed.
@@ -261,7 +261,7 @@ private:
 
       timer_task = new LambdaContext([this](int) {
           timer_task = nullptr;
-          complete(-CEPHFS_ETIMEDOUT);
+          complete(-ETIMEDOUT);
         });
       mds->timer.add_event_after(timeout, timer_task);
     }
@@ -328,7 +328,7 @@ private:
       } else if (recall_timeout > 0 && duration > recall_timeout) {
         gather.set_finisher(new C_MDSInternalNoop);
         gather.activate();
-        return handle_recall_client_state(-CEPHFS_ETIMEDOUT);
+        return handle_recall_client_state(-ETIMEDOUT);
       } else {
         uint64_t remaining = (recall_timeout == 0 ? 0 : recall_timeout-duration);
         C_ContextTimeout *ctx = new C_ContextTimeout(
@@ -938,7 +938,7 @@ void MDSRank::damaged_unlocked()
 
 void MDSRank::handle_write_error(int err)
 {
-  if (err == -CEPHFS_EBLOCKLISTED) {
+  if (err == -EBLOCKLISTED) {
     derr << "we have been blocklisted (fenced), respawning..." << dendl;
     respawn();
     return;
@@ -1585,17 +1585,17 @@ void MDSRank::boot_start(BootStep step, int r)
 {
   // Handle errors from previous step
   if (r < 0) {
-    if (is_standby_replay() && (r == -CEPHFS_EAGAIN)) {
-      dout(0) << "boot_start encountered an error CEPHFS_EAGAIN"
+    if (is_standby_replay() && (r == -EAGAIN)) {
+      dout(0) << "boot_start encountered an error EAGAIN"
               << ", respawning since we fell behind journal" << dendl;
       respawn();
-    } else if (r == -CEPHFS_EINVAL || r == -CEPHFS_ENOENT) {
+    } else if (r == -EINVAL || r == -ENOENT) {
       // Invalid or absent data, indicates damaged on-disk structures
       clog->error() << "Error loading MDS rank " << whoami << ": "
         << cpp_strerror(r);
       damaged();
       ceph_assert(r == 0);  // Unreachable, damaged() calls respawn()
-    } else if (r == -CEPHFS_EROFS) {
+    } else if (r == -EROFS) {
       dout(0) << "boot error forcing transition to read-only; MDS will try to continue" << dendl;
     } else {
       // Completely unexpected error, give up and die
@@ -2684,7 +2684,7 @@ void MDSRankDispatcher::handle_asok_command(
     std::string id;
     if(!cmd_getval(cmdmap, "id", id)) {
       *css << "malformed id";
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
       goto out;
     }
     metareqid_t mrid;
@@ -2692,7 +2692,7 @@ void MDSRankDispatcher::handle_asok_command(
       mrid = metareqid_t(id);
     } catch (const std::exception& e) {
       *css << "malformed id: " << e.what();
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
       goto out;
     }
 
@@ -2714,7 +2714,7 @@ void MDSRankDispatcher::handle_asok_command(
     std::lock_guard l(mds_lock);
     if (!mdcache->have_request(mrid)) {
       *css << "request does not exist";
-      r = -CEPHFS_ENOENT;
+      r = -ENOENT;
       goto out;
     }
     auto mdr = mdcache->request_get(mrid);
@@ -2727,7 +2727,7 @@ void MDSRankDispatcher::handle_asok_command(
     std::string id;
     if(!cmd_getval(cmdmap, "id", id)) {
       *css << "malformed id";
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
       goto out;
     }
     metareqid_t mrid;
@@ -2735,13 +2735,13 @@ void MDSRankDispatcher::handle_asok_command(
       mrid = metareqid_t(id);
     } catch (const std::exception& e) {
       *css << "malformed id: " << e.what();
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
       goto out;
     }
     std::lock_guard l(mds_lock);
     if (!mdcache->have_request(mrid)) {
       *css << "request does not exist";
-      r = -CEPHFS_ENOENT;
+      r = -ENOENT;
       goto out;
     }
     auto mdr = mdcache->request_get(mrid);
@@ -2778,7 +2778,7 @@ void MDSRankDispatcher::handle_asok_command(
 
     if (!got_val) {
       *css << "no target epoch given";
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
       goto out;
     }
     {
@@ -2811,7 +2811,7 @@ void MDSRankDispatcher::handle_asok_command(
     SessionFilter filter;
     r = filter.parse(filter_args, css.get());
     if (r != 0) {
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
       goto out;
     }
     evict_clients(filter, on_finish);
@@ -2820,7 +2820,7 @@ void MDSRankDispatcher::handle_asok_command(
     std::string client_id;
     if (!cmd_getval(cmdmap, "client_id", client_id)) {
       *css << "Invalid client_id specified";
-      r = -CEPHFS_ENOENT;
+      r = -ENOENT;
       goto out;
     }
     std::lock_guard l(mds_lock);
@@ -2828,7 +2828,7 @@ void MDSRankDispatcher::handle_asok_command(
         g_conf()->mds_session_blocklist_on_evict, *css);
     if (!evicted) {
       dout(15) << css->strv() << dendl;
-      r = -CEPHFS_ENOENT;
+      r = -ENOENT;
     }
   } else if (command == "session config" ||
 	     command == "client config") {
@@ -2846,12 +2846,12 @@ void MDSRankDispatcher::handle_asok_command(
 	     command == "scrub_start") {
     if (!is_active()) {
       *css << "MDS is not active";
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
       goto out;
     }
     else if (whoami != 0) {
       *css << "Not rank 0";
-      r = -CEPHFS_EXDEV;
+      r = -EXDEV;
       goto out;
     }
 
@@ -2877,12 +2877,12 @@ void MDSRankDispatcher::handle_asok_command(
   } else if (command == "scrub abort") {
     if (!is_active()) {
       *css << "MDS is not active";
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
       goto out;
     }
     else if (whoami != 0) {
       *css << "Not rank 0";
-      r = -CEPHFS_EXDEV;
+      r = -EXDEV;
       goto out;
     }
 
@@ -2897,12 +2897,12 @@ void MDSRankDispatcher::handle_asok_command(
   } else if (command == "scrub pause") {
     if (!is_active()) {
       *css << "MDS is not active";
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
       goto out;
     }
     else if (whoami != 0) {
       *css << "Not rank 0";
-      r = -CEPHFS_EXDEV;
+      r = -EXDEV;
       goto out;
     }
 
@@ -2917,12 +2917,12 @@ void MDSRankDispatcher::handle_asok_command(
   } else if (command == "scrub resume") {
     if (!is_active()) {
       *css << "MDS is not active";
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
       goto out;
     }
     else if (whoami != 0) {
       *css << "Not rank 0";
-      r = -CEPHFS_EXDEV;
+      r = -EXDEV;
       goto out;
     }
     command_scrub_resume(f);
@@ -2931,7 +2931,7 @@ void MDSRankDispatcher::handle_asok_command(
   } else if (command == "scrub purge_status") {
     if (whoami != 0) {
       *css << "Not rank 0";
-      r = -CEPHFS_EXDEV;
+      r = -EXDEV;
       goto out;
     }
     string tag;
@@ -2940,7 +2940,7 @@ void MDSRankDispatcher::handle_asok_command(
   } else if (command == "tag path") {
     if (whoami != 0) {
       *css << "Not rank 0";
-      r = -CEPHFS_EXDEV;
+      r = -EXDEV;
       goto out;
     }
     string path;
@@ -2968,13 +2968,13 @@ void MDSRankDispatcher::handle_asok_command(
     string path;
     if(!cmd_getval(cmdmap, "path", path)) {
       *css << "malformed path";
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
       goto out;
     }
     int64_t rank;
     if(!cmd_getval(cmdmap, "rank", rank)) {
       *css << "malformed rank";
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
       goto out;
     }
     command_export_dir(f, path, (mds_rank_t)rank);
@@ -3035,7 +3035,7 @@ void MDSRankDispatcher::handle_asok_command(
       if (mdsmap->get_tableserver() == whoami) {
 	snapserver->dump(f);
       } else {
-	r = -CEPHFS_EXDEV;
+	r = -EXDEV;
 	*css << "Not snapserver";
       }
     } else {
@@ -3063,7 +3063,7 @@ void MDSRankDispatcher::handle_asok_command(
     std::lock_guard l(mds_lock);
     damage_entry_id_t id = 0;
     if (!cmd_getval(cmdmap, "damage_id", (int64_t&)id)) {
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
       goto out;
     }
     damage_table.erase(id);
@@ -3071,7 +3071,7 @@ void MDSRankDispatcher::handle_asok_command(
     command_quiesce_db(cmdmap, on_finish);
     return;
   } else {
-    r = -CEPHFS_ENOSYS;
+    r = -ENOSYS;
   }
 out:
   on_finish(r, css->str(), outbl);
@@ -3088,7 +3088,7 @@ void MDSRankDispatcher::evict_clients(
 {
   bufferlist outbl;
   if (is_any_replay()) {
-    on_finish(-CEPHFS_EAGAIN, "MDS is replaying log", outbl);
+    on_finish(-EAGAIN, "MDS is replaying log", outbl);
     return;
   }
 
@@ -3252,18 +3252,18 @@ int MDSRank::_command_export_dir(
 
   if (target == whoami || !mdsmap->is_up(target) || !mdsmap->is_in(target)) {
     derr << "bad MDS target " << target << dendl;
-    return -CEPHFS_ENOENT;
+    return -ENOENT;
   }
 
   CInode *in = mdcache->cache_traverse(fp);
   if (!in) {
     derr << "bad path '" << path << "'" << dendl;
-    return -CEPHFS_ENOENT;
+    return -ENOENT;
   }
   CDir *dir = in->get_dirfrag(frag_t());
   if (!dir || !(dir->is_auth())) {
     derr << "bad export_dir path dirfrag frag_t() or dir not auth" << dendl;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   mdcache->migrator->export_dir(dir, target);
@@ -3848,7 +3848,7 @@ int MDSRank::config_client(int64_t session_id, bool remove,
   Session *session = sessionmap.get_session(entity_name_t(CEPH_ENTITY_TYPE_CLIENT, session_id));
   if (!session) {
     ss << "session " << session_id << " not in sessionmap!";
-    return -CEPHFS_ENOENT;
+    return -ENOENT;
   }
 
   if (option == "timeout") {
@@ -3856,7 +3856,7 @@ int MDSRank::config_client(int64_t session_id, bool remove,
       auto it = session->info.client_metadata.find("timeout");
       if (it == session->info.client_metadata.end()) {
 	ss << "Nonexistent config: " << option;
-	return -CEPHFS_ENODATA;
+	return -ENODATA;
       }
       session->info.client_metadata.erase(it);
     } else {
@@ -3864,14 +3864,14 @@ int MDSRank::config_client(int64_t session_id, bool remove,
       strtoul(value.c_str(), &end, 0);
       if (*end) {
 	ss << "Invalid config for timeout: " << value;
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
       }
       session->info.client_metadata[option] = value;
     }
     //sessionmap._mark_dirty(session, true);
   } else {
     ss << "Invalid config option: " << option;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   return 0;

--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -169,7 +169,7 @@ void MDSTable::load_2(int r, bufferlist& bl, Context *onfinish)
 {
   ceph_assert(is_opening());
   state = STATE_ACTIVE;
-  if (r == -CEPHFS_EBLOCKLISTED) {
+  if (r == -EBLOCKLISTED) {
     mds->respawn();
     return;
   }

--- a/src/mds/Mantle.cc
+++ b/src/mds/Mantle.cc
@@ -58,7 +58,7 @@ int Mantle::balance(std::string_view script,
   if (luaL_loadstring(L, script.data())) {
     mantle_dout(0) << "WARNING: mantle could not load balancer: "
             << lua_tostring(L, -1) << mantle_dendl;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   /* tell the balancer which mds is making the decision */
@@ -89,20 +89,20 @@ int Mantle::balance(std::string_view script,
   if (lua_pcall(L, 0, 1, 0) != LUA_OK) {
     mantle_dout(0) << "WARNING: mantle could not execute script: "
             << lua_tostring(L, -1) << mantle_dendl;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   /* parse response by iterating over Lua stack */
   if (lua_istable(L, -1) == 0) {
     mantle_dout(0) << "WARNING: mantle script returned a malformed response" << mantle_dendl;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   /* fill in return value */
   for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
     if (!lua_isinteger(L, -2) || !lua_isnumber(L, -1)) {
       mantle_dout(0) << "WARNING: mantle script returned a malformed response" << mantle_dendl;
-      return -CEPHFS_EINVAL;
+      return -EINVAL;
     }
     mds_rank_t rank(lua_tointeger(L, -2));
     my_targets[rank] = lua_tonumber(L, -1);

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -2352,7 +2352,7 @@ void Migrator::handle_export_discover(const cref_t<MExportDirDiscover> &m, bool 
     int r = mdcache->path_traverse(null_ref, cf, fpath, flags, &trace);
     if (r > 0) return;
     if (r < 0) {
-      if (r == -CEPHFS_EAGAIN) {
+      if (r == -EAGAIN) {
         dout(5) << "blocking import during quiesce" << dendl;
         import_reverse_discovering(df);
         mds->send_message_mds(make_message<MExportDirDiscoverAck>(df, m->get_tid(), false), from);

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -758,7 +758,7 @@ void OpenFileTable::_load_finish(int op_r, int header_r, int values_r,
 				 std::map<std::string, bufferlist> &values)
 {
   using ceph::decode;
-  int err = -CEPHFS_EINVAL;
+  int err = -EINVAL;
 
   auto decode_func = [this](unsigned idx, inodeno_t ino, bufferlist &bl) {
     auto p = bl.cbegin();

--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -225,7 +225,7 @@ void PurgeQueue::open(Context *completion)
     waiting_for_recovery.push_back(completion);
 
   journaler.recover(new LambdaContext([this](int r){
-    if (r == -CEPHFS_ENOENT) {
+    if (r == -ENOENT) {
       dout(1) << "Purge Queue not found, assuming this is an upgrade and "
                  "creating it." << dendl;
       create(NULL);
@@ -261,7 +261,7 @@ void PurgeQueue::wait_for_recovery(Context* c)
     c->complete(0);
   } else if (readonly) {
     dout(10) << "cannot wait for recovery: PurgeQueue is readonly" << dendl;
-    c->complete(-CEPHFS_EROFS);
+    c->complete(-EROFS);
   } else {
     waiting_for_recovery.push_back(c);
   }
@@ -340,7 +340,7 @@ void PurgeQueue::push(const PurgeItem &pi, Context *completion)
 
   if (readonly) {
     dout(10) << "cannot push inode: PurgeQueue is readonly" << dendl;
-    completion->complete(-CEPHFS_EROFS);
+    completion->complete(-EROFS);
     return;
   }
 
@@ -477,7 +477,7 @@ bool PurgeQueue::_consume()
           std::lock_guard l(lock);
           if (r == 0) {
             _consume();
-          } else if (r != -CEPHFS_EAGAIN) {
+          } else if (r != -EAGAIN) {
             _go_readonly(r);
           }
         }));
@@ -500,7 +500,7 @@ bool PurgeQueue::_consume()
     } catch (const buffer::error &err) {
       derr << "Decode error at read_pos=0x" << std::hex
            << journaler.get_read_pos() << dendl;
-      _go_readonly(CEPHFS_EIO);
+      _go_readonly(EIO);
     }
     dout(20) << " executing item (" << item.ino << ")" << dendl;
     _execute_item(item, journaler.get_read_pos());
@@ -581,7 +581,7 @@ void PurgeQueue::_commit_ops(int r, const std::vector<PurgeItemCommitOp>& ops_ve
 	              new LambdaContext([this, expire_to](int r) {
     std::lock_guard l(lock);
 
-    if (r == -CEPHFS_EBLOCKLISTED) {
+    if (r == -EBLOCKLISTED) {
       finisher.queue(on_error, r);
       on_error = nullptr;
       return;

--- a/src/mds/RecoveryQueue.cc
+++ b/src/mds/RecoveryQueue.cc
@@ -190,7 +190,7 @@ void RecoveryQueue::_recovered(CInode *in, int r, uint64_t size, utime_t mtime)
 
   if (r != 0) {
     dout(0) << "recovery error! " << r << dendl;
-    if (r == -CEPHFS_EBLOCKLISTED) {
+    if (r == -EBLOCKLISTED) {
       mds->respawn();
       return;
     } else {

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -66,7 +66,7 @@ int ScrubStack::_enqueue(MDSCacheObject *obj, ScrubHeaderRef& header, bool top)
   if (CInode *in = dynamic_cast<CInode*>(obj)) {
     if (in->scrub_is_in_progress()) {
       dout(10) << __func__ << " with {" << *in << "}" << ", already in scrubbing" << dendl;
-      return -CEPHFS_EBUSY;
+      return -EBUSY;
     }
     if(in->state_test(CInode::STATE_PURGING)) {
       dout(10) << *obj << " is purging, skip pushing into scrub stack" << dendl;
@@ -80,7 +80,7 @@ int ScrubStack::_enqueue(MDSCacheObject *obj, ScrubHeaderRef& header, bool top)
   } else if (CDir *dir = dynamic_cast<CDir*>(obj)) {
     if (dir->scrub_is_in_progress()) {
       dout(10) << __func__ << " with {" << *dir << "}" << ", already in scrubbing" << dendl;
-      return -CEPHFS_EBUSY;
+      return -EBUSY;
     }
     if(dir->get_inode()->state_test(CInode::STATE_PURGING)) {
       dout(10) << *obj << " is purging, skip pushing into scrub stack" << dendl;
@@ -161,14 +161,14 @@ int ScrubStack::enqueue(CInode *in, ScrubHeaderRef& header, bool top)
 {
   // abort in progress
   if (clear_stack)
-    return -CEPHFS_EAGAIN;
+    return -EAGAIN;
 
   header->set_origin(in->ino());
   auto ret = scrubbing_map.emplace(header->get_tag(), header);
   if (!ret.second) {
     dout(10) << __func__ << " with {" << *in << "}"
 	     << ", conflicting tag " << header->get_tag() << dendl;
-    return -CEPHFS_EEXIST;
+    return -EEXIST;
   }
   if (header->get_scrub_mdsdir()) {
     filepath fp;
@@ -895,7 +895,7 @@ void ScrubStack::scrub_pause(Context *on_finish) {
   // abort is in progress
   if (clear_stack) {
     if (on_finish)
-      on_finish->complete(-CEPHFS_EINVAL);
+      on_finish->complete(-EINVAL);
     return;
   }
 
@@ -922,10 +922,10 @@ bool ScrubStack::scrub_resume() {
   int r = 0;
 
   if (clear_stack) {
-    r = -CEPHFS_EINVAL;
+    r = -EINVAL;
   } else if (state == STATE_PAUSING) {
     set_state(STATE_RUNNING);
-    complete_control_contexts(-CEPHFS_ECANCELED);
+    complete_control_contexts(-ECANCELED);
   } else if (state == STATE_PAUSED) {
     set_state(STATE_RUNNING);
     kick_off_scrubs();

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -58,7 +58,7 @@ public:
    * caller should provide a context which is completed after all
    * in-progress scrub operations are completed and pending inodes
    * are removed from the scrub stack (with the context callbacks for
-   * inodes completed with -CEPHFS_ECANCELED).
+   * inodes completed with -ECANCELED).
    * @param on_finish Context callback to invoke after abort
    */
   void scrub_abort(Context *on_finish);
@@ -76,8 +76,8 @@ public:
   /**
    * Resume a paused scrub. Unlike abort or pause, this is instantaneous.
    * Pending pause operations are cancelled (context callbacks are
-   * invoked with -CEPHFS_ECANCELED).
-   * @returns 0 (success) if resumed, -CEPHFS_EINVAL if an abort is in-progress.
+   * invoked with -ECANCELED).
+   * @returns 0 (success) if resumed, -EINVAL if an abort is in-progress.
    */
   bool scrub_resume();
 
@@ -270,7 +270,7 @@ private:
 
   /**
    * Abort pending scrubs for inodes waiting in the inode stack.
-   * Completion context is complete with -CEPHFS_ECANCELED.
+   * Completion context is complete with -ECANCELED.
    */
   void abort_pending_scrubs();
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -446,7 +446,7 @@ void Server::reclaim_session(Session *session, const cref_t<MClientReclaim> &m)
   auto reply = make_message<MClientReclaimReply>(0);
   if (m->get_uuid().empty()) {
     dout(10) << __func__ << " invalid message (no uuid)" << dendl;
-    reply->set_result(-CEPHFS_EINVAL);
+    reply->set_result(-EINVAL);
     mds->send_message_client(reply, session);
     return;
   }
@@ -454,7 +454,7 @@ void Server::reclaim_session(Session *session, const cref_t<MClientReclaim> &m)
   unsigned flags = m->get_flags();
   if (flags != CEPH_RECLAIM_RESET) { // currently only support reset
     dout(10) << __func__ << " unsupported flags" << dendl;
-    reply->set_result(-CEPHFS_EINVAL);
+    reply->set_result(-EINVAL);
     mds->send_message_client(reply, session);
     return;
   }
@@ -464,7 +464,7 @@ void Server::reclaim_session(Session *session, const cref_t<MClientReclaim> &m)
     if (session->info.auth_name != target->info.auth_name) {
       dout(10) << __func__ << " session auth_name " << session->info.auth_name
 	       << " != target auth_name " << target->info.auth_name << dendl;
-      reply->set_result(-CEPHFS_EPERM);
+      reply->set_result(-EPERM);
       mds->send_message_client(reply, session);
     }
 
@@ -548,7 +548,7 @@ void Server::handle_client_reclaim(const cref_t<MClientReclaim> &m)
       dout(0) << __func__ << " client specified FLAG_FINISH with other flags."
                              " Other flags:" << flags << dendl;
       auto reply = make_message<MClientReclaimReply>(0);
-      reply->set_result(-CEPHFS_EINVAL);
+      reply->set_result(-EINVAL);
       mds->send_message_client(reply, session);
       return;
     }
@@ -2726,7 +2726,7 @@ void Server::dispatch_client_request(const MDRequestRef& mdr)
 
   if (req->may_write() && mdcache->is_readonly()) {
     dout(10) << " read-only FS" << dendl;
-    respond_to_request(mdr, -CEPHFS_EROFS);
+    respond_to_request(mdr, -EROFS);
     return;
   }
   if (mdr->has_more() && mdr->more()->peer_error) {
@@ -2757,8 +2757,8 @@ void Server::dispatch_client_request(const MDRequestRef& mdr)
       if (check_access(mdr, cur, MAY_FULL)) {
         dout(20) << __func__ << ": full, has FULL caps, permitting op " << ceph_mds_op_name(req->get_op()) << dendl;
       } else {
-        dout(20) << __func__ << ": full, responding CEPHFS_ENOSPC to op " << ceph_mds_op_name(req->get_op()) << dendl;
-        respond_to_request(mdr, -CEPHFS_ENOSPC);
+        dout(20) << __func__ << ": full, responding ENOSPC to op " << ceph_mds_op_name(req->get_op()) << dendl;
+        respond_to_request(mdr, -ENOSPC);
         return;
       }
     } else {
@@ -2882,7 +2882,7 @@ void Server::dispatch_client_request(const MDRequestRef& mdr)
 
   default:
     dout(1) << " unknown client op " << req->get_op() << dendl;
-    respond_to_request(mdr, -CEPHFS_EOPNOTSUPP);
+    respond_to_request(mdr, -EOPNOTSUPP);
   }
 }
 
@@ -3395,9 +3395,9 @@ void Server::handle_peer_auth_pin_ack(const MDRequestRef& mdr, const cref_t<MMDS
   ceph_assert(ret);
 
   if (ack->is_error_rofs()) {
-    mdr->more()->peer_error = -CEPHFS_EROFS;
+    mdr->more()->peer_error = -EROFS;
   } else if (ack->is_error_wouldblock()) {
-    mdr->more()->peer_error = -CEPHFS_EWOULDBLOCK;
+    mdr->more()->peer_error = -EAGAIN;
   }
 
   // go again?
@@ -3446,8 +3446,8 @@ bool Server::check_fragment_space(const MDRequestRef& mdr, CDir *dir)
   const auto size = dir->get_frag_size();
   const auto max = bal_fragment_size_max;
   if (size >= max) {
-    dout(10) << "fragment " << *dir << " size exceeds " << max << " (CEPHFS_ENOSPC)" << dendl;
-    respond_to_request(mdr, -CEPHFS_ENOSPC);
+    dout(10) << "fragment " << *dir << " size exceeds " << max << " (ENOSPC)" << dendl;
+    respond_to_request(mdr, -ENOSPC);
     return false;
   } else {
     dout(20) << "fragment " << *dir << " size " << size << " < "  << max << dendl;
@@ -3466,7 +3466,7 @@ bool Server::check_dir_max_entries(const MDRequestRef& mdr, CDir *in)
                    in->inode->get_projected_inode()->dirstat.nsubdirs;
   if (dir_max_entries && size >= dir_max_entries) {
     dout(10) << "entries per dir " << *in << " size exceeds " << dir_max_entries << " (ENOSPC)" << dendl;
-    respond_to_request(mdr, -CEPHFS_ENOSPC);
+    respond_to_request(mdr, -ENOSPC);
     return false;
   }
   return true;
@@ -3707,8 +3707,8 @@ void Server::_try_open_ino(const MDRequestRef& mdr, int r, inodeno_t ino)
   }
 
   // give up
-  if (r == -CEPHFS_ENOENT || r == -CEPHFS_ENODATA)
-    r = -CEPHFS_ESTALE;
+  if (r == -ENOENT || r == -ENODATA)
+    r = -ESTALE;
   respond_to_request(mdr, r);
 }
 
@@ -3720,7 +3720,7 @@ public:
   C_MDS_TryFindInode(Server *s, const MDRequestRef& r, MDCache *m, inodeno_t i) :
     ServerContext(s), mdr(r), mdcache(m), ino(i) {}
   void finish(int r) override {
-    if (r == -CEPHFS_ESTALE) { // :( find_ino_peers failed
+    if (r == -ESTALE) { // :( find_ino_peers failed
       /*
        * There has one case that when the MDS crashes and the
        * openfiletable journal couldn't be flushed and then
@@ -3776,13 +3776,13 @@ CInode* Server::rdlock_path_pin_ref(const MDRequestRef& mdr,
   if (r > 0)
     return nullptr; // delayed
   if (r < 0) {  // error
-    if (r == -CEPHFS_ENOENT && !mdr->dn[0].empty()) {
+    if (r == -ENOENT && !mdr->dn[0].empty()) {
       if (mdr->client_request &&
 	  mdr->client_request->get_dentry_wanted())
         mdr->tracedn = mdr->dn[0].back();
       respond_to_request(mdr, r);
-    } else if (r == -CEPHFS_ESTALE) {
-      dout(10) << "FAIL on CEPHFS_ESTALE but attempting recovery" << dendl;
+    } else if (r == -ESTALE) {
+      dout(10) << "FAIL on ESTALE but attempting recovery" << dendl;
       inodeno_t ino = refpath.get_ino();
       mdcache->find_ino_peers(ino, new C_MDS_TryFindInode(this, mdr, mdcache, ino));
     } else {
@@ -3840,21 +3840,21 @@ CDentry* Server::rdlock_path_xlock_dentry(const MDRequestRef& mdr,
   // figure parent dir vs dname
   if (refpath.depth() == 0) {
     dout(7) << "invalid path (zero length)" << dendl;
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return nullptr;
   }
 
   if (refpath.is_last_snap()) {
-    respond_to_request(mdr, -CEPHFS_EROFS);
+    respond_to_request(mdr, -EROFS);
     return nullptr;
   }
 
   if (refpath.is_last_dot_or_dotdot()) {
     dout(7) << "invalid path (last dot or dot_dot)" << dendl;
     if (create)
-      respond_to_request(mdr, -CEPHFS_EEXIST);
+      respond_to_request(mdr, -EEXIST);
     else
-      respond_to_request(mdr, -CEPHFS_ENOTEMPTY);
+      respond_to_request(mdr, -ENOTEMPTY);
     return nullptr;
   }
 
@@ -3875,8 +3875,8 @@ CDentry* Server::rdlock_path_xlock_dentry(const MDRequestRef& mdr,
   if (r > 0)
     return nullptr; // delayed
   if (r < 0) {
-    if (r == -CEPHFS_ESTALE) {
-      dout(10) << "FAIL on CEPHFS_ESTALE but attempting recovery" << dendl;
+    if (r == -ESTALE) {
+      dout(10) << "FAIL on ESTALE but attempting recovery" << dendl;
       inodeno_t ino = refpath.get_ino();
       mdcache->find_ino_peers(ino, new C_MDS_TryFindInode(this, mdr, mdcache, ino));
       return nullptr;
@@ -3893,20 +3893,20 @@ CDentry* Server::rdlock_path_xlock_dentry(const MDRequestRef& mdr,
     if (diri->is_system() && !diri->is_root() &&
 	(!diri->is_lost_and_found() ||
 	 mdr->client_request->get_op() != CEPH_MDS_OP_UNLINK)) {
-      respond_to_request(mdr, -CEPHFS_EROFS);
+      respond_to_request(mdr, -EROFS);
       return nullptr;
     }
   }
 
   if (!diri->is_base() && diri->get_projected_parent_dir()->inode->is_stray()) {
-    respond_to_request(mdr, -CEPHFS_ENOENT);
+    respond_to_request(mdr, -ENOENT);
     return nullptr;
   }
 
   CDentry::linkage_t *dnl = dn->get_projected_linkage();
   if (dnl->is_null()) {
     if (!create && okexist) {
-      respond_to_request(mdr, -CEPHFS_ENOENT);
+      respond_to_request(mdr, -ENOENT);
       return nullptr;
     }
 
@@ -3914,7 +3914,7 @@ CDentry* Server::rdlock_path_xlock_dentry(const MDRequestRef& mdr,
     dn->first = std::max(dn->first, next_snap);
   } else {
     if (!okexist) {
-      respond_to_request(mdr, -CEPHFS_EEXIST);
+      respond_to_request(mdr, -EEXIST);
       return nullptr;
     }
     mdr->in[0] = dnl->get_inode();
@@ -3949,12 +3949,12 @@ Server::rdlock_two_paths_xlock_destdn(const MDRequestRef& mdr, bool xlock_srcdn)
     return std::make_pair(mdr->dn[0].back(), mdr->dn[1].back());
 
   if (refpath.depth() != 1 || refpath2.depth() != 1) {
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return std::pair<CDentry*, CDentry*>(nullptr, nullptr);
   }
 
   if (refpath.is_last_snap() || refpath2.is_last_snap()) {
-    respond_to_request(mdr, -CEPHFS_EROFS);
+    respond_to_request(mdr, -EROFS);
     return std::make_pair(nullptr, nullptr);
   }
 
@@ -3963,8 +3963,8 @@ Server::rdlock_two_paths_xlock_destdn(const MDRequestRef& mdr, bool xlock_srcdn)
   int flags = MDS_TRAVERSE_RDLOCK_SNAP |  MDS_TRAVERSE_WANT_DENTRY | MDS_TRAVERSE_WANT_AUTH;
   int r = mdcache->path_traverse(mdr, cf, refpath, flags, &mdr->dn[0]);
   if (r != 0) {
-    if (r == -CEPHFS_ESTALE) {
-      dout(10) << "CEPHFS_ESTALE on path, attempting recovery" << dendl;
+    if (r == -ESTALE) {
+      dout(10) << "ESTALE on path, attempting recovery" << dendl;
       inodeno_t ino = refpath.get_ino();
       mdcache->find_ino_peers(ino, new C_MDS_TryFindInode(this, mdr, mdcache, ino));
     } else if (r < 0) {
@@ -3976,8 +3976,8 @@ Server::rdlock_two_paths_xlock_destdn(const MDRequestRef& mdr, bool xlock_srcdn)
   flags = MDS_TRAVERSE_RDLOCK_SNAP2 | MDS_TRAVERSE_WANT_DENTRY | MDS_TRAVERSE_DISCOVER;
   r = mdcache->path_traverse(mdr, cf, refpath2, flags, &mdr->dn[1]);
   if (r != 0) {
-    if (r == -CEPHFS_ESTALE) {
-      dout(10) << "CEPHFS_ESTALE on path2, attempting recovery" << dendl;
+    if (r == -ESTALE) {
+      dout(10) << "ESTALE on path2, attempting recovery" << dendl;
       inodeno_t ino = refpath2.get_ino();
       mdcache->find_ino_peers(ino, new C_MDS_TryFindInode(this, mdr, mdcache, ino));
     } else if (r < 0) {
@@ -3994,14 +3994,14 @@ Server::rdlock_two_paths_xlock_destdn(const MDRequestRef& mdr, bool xlock_srcdn)
   if (!mdr->reqid.name.is_mds()) {
     if ((srcdir->get_inode()->is_system() && !srcdir->get_inode()->is_root()) ||
 	(destdir->get_inode()->is_system() && !destdir->get_inode()->is_root())) {
-      respond_to_request(mdr, -CEPHFS_EROFS);
+      respond_to_request(mdr, -EROFS);
       return std::make_pair(nullptr, nullptr);
     }
   }
 
   if (!destdir->get_inode()->is_base() &&
       destdir->get_inode()->get_projected_parent_dir()->inode->is_stray()) {
-    respond_to_request(mdr, -CEPHFS_ENOENT);
+    respond_to_request(mdr, -ENOENT);
     return std::make_pair(nullptr, nullptr);
   }
 
@@ -4069,7 +4069,7 @@ Server::rdlock_two_paths_xlock_destdn(const MDRequestRef& mdr, bool xlock_srcdn)
     return std::make_pair(nullptr, nullptr);
 
   if (srcdn->get_projected_linkage()->is_null()) {
-    respond_to_request(mdr, -CEPHFS_ENOENT);
+    respond_to_request(mdr, -ENOENT);
     return std::make_pair(nullptr, nullptr);
   }
 
@@ -4140,7 +4140,7 @@ void Server::handle_client_getattr(const MDRequestRef& mdr, bool is_lookup)
   if (req->get_filepath().depth() == 0 && is_lookup) {
     // refpath can't be empty for lookup but it can for
     // getattr (we do getattr with empty refpath for mount of '/')
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
@@ -4311,13 +4311,13 @@ void Server::handle_client_lookup_ino(const MDRequestRef& mdr,
    * [1] https://tracker.ceph.com/issues/49922
    */
   if (MDS_IS_PRIVATE_INO(_ino)) {
-    respond_to_request(mdr, -CEPHFS_ESTALE);
+    respond_to_request(mdr, -ESTALE);
     return;
   }
 
   CInode *in = mdcache->get_inode(ino);
   if (in && in->state_test(CInode::STATE_PURGING)) {
-    respond_to_request(mdr, -CEPHFS_ESTALE);
+    respond_to_request(mdr, -ESTALE);
     return;
   }
   if (!in) {
@@ -4368,11 +4368,11 @@ void Server::handle_client_lookup_ino(const MDRequestRef& mdr,
 
   if (want_parent) {
     if (in->is_base()) {
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
     if (!diri || diri->is_stray()) {
-      respond_to_request(mdr, -CEPHFS_ESTALE);
+      respond_to_request(mdr, -ESTALE);
       return;
     }
     dout(10) << "reply to lookup_parent " << *in << dendl;
@@ -4382,7 +4382,7 @@ void Server::handle_client_lookup_ino(const MDRequestRef& mdr,
     if (want_dentry) {
       inodeno_t dirino = req->get_filepath2().get_ino();
       if (!diri || (dirino != inodeno_t() && diri->ino() != dirino)) {
-	respond_to_request(mdr, -CEPHFS_ENOENT);
+	respond_to_request(mdr, -ENOENT);
 	return;
       }
       dout(10) << "reply to lookup_name " << *in << dendl;
@@ -4415,7 +4415,7 @@ void Server::_lookup_snap_ino(const MDRequestRef& mdr)
       if (in->state_test(CInode::STATE_PURGING) ||
 	  !in->has_snap_data(vino.snapid)) {
 	if (in->is_dir() || !parent_ino) {
-	  respond_to_request(mdr, -CEPHFS_ESTALE);
+	  respond_to_request(mdr, -ESTALE);
 	  return;
 	}
 	in = NULL;
@@ -4440,7 +4440,7 @@ void Server::_lookup_snap_ino(const MDRequestRef& mdr)
     }
 
     if (!diri->is_dir()) {
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -4465,7 +4465,7 @@ void Server::_lookup_snap_ino(const MDRequestRef& mdr)
       return;
     }
 
-    respond_to_request(mdr, -CEPHFS_ESTALE);
+    respond_to_request(mdr, -ESTALE);
   } else {
     mdcache->open_ino(vino.ino, mds->get_metadata_pool(), new C_MDS_LookupIno2(this, mdr), false);
   }
@@ -4487,8 +4487,8 @@ void Server::_lookup_ino_2(const MDRequestRef& mdr, int r)
   }
 
   // give up
-  if (r == -CEPHFS_ENOENT || r == -CEPHFS_ENODATA)
-    r = -CEPHFS_ESTALE;
+  if (r == -ENOENT || r == -ENODATA)
+    r = -ESTALE;
   respond_to_request(mdr, r);
 }
 
@@ -4501,7 +4501,7 @@ void Server::handle_client_open(const MDRequestRef& mdr)
   int flags = req->head.args.open.flags;
   int cmode = ceph_flags_to_mode(flags);
   if (cmode < 0) {
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
   
@@ -4510,7 +4510,7 @@ void Server::handle_client_open(const MDRequestRef& mdr)
 
   if ((cmode & CEPH_FILE_MODE_WR) && mdcache->is_readonly()) {
     dout(7) << "read-only FS" << dendl;
-    respond_to_request(mdr, -CEPHFS_EROFS);
+    respond_to_request(mdr, -EROFS);
     return;
   }
   
@@ -4542,26 +4542,26 @@ void Server::handle_client_open(const MDRequestRef& mdr)
   // regular file?
   /*if (!cur->inode.is_file() && !cur->inode.is_dir()) {
     dout(7) << "not a file or dir " << *cur << dendl;
-    respond_to_request(mdr, -CEPHFS_ENXIO);                 // FIXME what error do we want?
+    respond_to_request(mdr, -ENXIO);                 // FIXME what error do we want?
     return;
     }*/
   if ((flags & CEPH_O_DIRECTORY) && !cur->is_dir() && !cur->is_symlink()) {
     dout(7) << "specified O_DIRECTORY on non-directory " << *cur << dendl;
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
   if ((flags & CEPH_O_TRUNC) && !cur->is_file()) {
     dout(7) << "specified O_TRUNC on !(file|symlink) " << *cur << dendl;
-    // we should return -CEPHFS_EISDIR for directory, return -CEPHFS_EINVAL for other non-regular
-    respond_to_request(mdr, cur->is_dir() ? -CEPHFS_EISDIR : -CEPHFS_EINVAL);
+    // we should return -EISDIR for directory, return -EINVAL for other non-regular
+    respond_to_request(mdr, cur->is_dir() ? -EISDIR : -EINVAL);
     return;
   }
 
   if (cur->get_inode()->inline_data.version != CEPH_INLINE_NONE &&
       !mdr->session->get_connection()->has_feature(CEPH_FEATURE_MDS_INLINE_DATA)) {
     dout(7) << "old client cannot open inline data file " << *cur << dendl;
-    respond_to_request(mdr, -CEPHFS_EPERM);
+    respond_to_request(mdr, -EPERM);
     return;
   }
   
@@ -4569,7 +4569,7 @@ void Server::handle_client_open(const MDRequestRef& mdr)
   if (mdr->snapid != CEPH_NOSNAP &&
       ((cmode & CEPH_FILE_MODE_WR) || req->may_write())) {
     dout(7) << "snap " << mdr->snapid << " is read-only " << *cur << dendl;
-    respond_to_request(mdr, -CEPHFS_EROFS);
+    respond_to_request(mdr, -EROFS);
     return;
   }
 
@@ -4739,7 +4739,7 @@ void Server::handle_client_openc(const MDRequestRef& mdr)
 
   int cmode = ceph_flags_to_mode(req->head.args.open.flags);
   if (cmode < 0) {
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
@@ -4761,7 +4761,7 @@ void Server::handle_client_openc(const MDRequestRef& mdr)
 
   if (req->get_alternate_name().size() > alternate_name_max) {
     dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
-    respond_to_request(mdr, -CEPHFS_ENAMETOOLONG);
+    respond_to_request(mdr, -ENAMETOOLONG);
     return;
   }
   dn->set_alternate_name(req->get_alternate_name());
@@ -4804,7 +4804,7 @@ void Server::handle_client_openc(const MDRequestRef& mdr)
   }
 
   if (!is_valid_layout(&layout)) {
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
@@ -4935,8 +4935,8 @@ void Server::handle_client_readdir(const MDRequestRef& mdr)
   // it's a directory, right?
   if (!diri->is_dir()) {
     // not a dir
-    dout(10) << "reply to " << *req << " readdir -CEPHFS_ENOTDIR" << dendl;
-    respond_to_request(mdr, -CEPHFS_ENOTDIR);
+    dout(10) << "reply to " << *req << " readdir -ENOTDIR" << dendl;
+    respond_to_request(mdr, -ENOTDIR);
     return;
   }
 
@@ -5262,7 +5262,7 @@ void Server::handle_client_file_setlock(const MDRequestRef& mdr)
   default:
     dout(10) << "got unknown lock type " << set_lock.type
 	     << ", dropping request!" << dendl;
-    respond_to_request(mdr, -CEPHFS_EOPNOTSUPP);
+    respond_to_request(mdr, -EOPNOTSUPP);
     return;
   }
 
@@ -5288,14 +5288,14 @@ void Server::handle_client_file_setlock(const MDRequestRef& mdr)
     if (mdr->more()->flock_was_waiting &&
 	!lock_state->is_waiting(set_lock)) {
       dout(10) << " was waiting for lock but not anymore, must have been canceled " << set_lock << dendl;
-      respond_to_request(mdr, -CEPHFS_EINTR);
+      respond_to_request(mdr, -EINTR);
     } else if (!lock_state->add_lock(set_lock, will_wait, mdr->more()->flock_was_waiting, &deadlock)) {
       dout(10) << " it failed on this attempt" << dendl;
       // couldn't set lock right now
       if (deadlock) {
-	respond_to_request(mdr, -CEPHFS_EDEADLK);
+	respond_to_request(mdr, -EDEADLK);
       } else if (!will_wait) {
-	respond_to_request(mdr, -CEPHFS_EWOULDBLOCK);
+	respond_to_request(mdr, -EAGAIN);
       } else {
 	dout(10) << " added to waiting list" << dendl;
 	ceph_assert(lock_state->is_waiting(set_lock));
@@ -5353,7 +5353,7 @@ void Server::handle_client_file_readlock(const MDRequestRef& mdr)
 
   default:
     dout(10) << "got unknown lock type " << checking_lock.type << dendl;
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
   lock_state->look_for_lock(checking_lock);
@@ -5373,11 +5373,11 @@ void Server::handle_client_setattr(const MDRequestRef& mdr)
   if (!cur) return;
 
   if (mdr->snapid != CEPH_NOSNAP) {
-    respond_to_request(mdr, -CEPHFS_EROFS);
+    respond_to_request(mdr, -EROFS);
     return;
   }
   if (cur->ino() < MDS_INO_SYSTEM_BASE && !cur->is_base()) {
-    respond_to_request(mdr, -CEPHFS_EPERM);
+    respond_to_request(mdr, -EPERM);
     return;
   }
 
@@ -5387,13 +5387,13 @@ void Server::handle_client_setattr(const MDRequestRef& mdr)
   if (req->get_header().version < 6) {
     // No changes to fscrypted inodes by downrevved clients
     if (!cur->get_inode()->fscrypt_auth.empty()) {
-      respond_to_request(mdr, -CEPHFS_EPERM);
+      respond_to_request(mdr, -EPERM);
       return;
     }
 
     // Only allow fscrypt field changes by capable clients
     if (mask & (CEPH_SETATTR_FSCRYPT_FILE|CEPH_SETATTR_FSCRYPT_AUTH)) {
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
   }
@@ -5423,10 +5423,10 @@ void Server::handle_client_setattr(const MDRequestRef& mdr)
 
   uint64_t old_size = std::max<uint64_t>(pip->size, req->head.args.setattr.old_size);
 
-  // CEPHFS_ENOSPC on growing file while full, but allow shrinks
+  // ENOSPC on growing file while full, but allow shrinks
   if (is_full && req->head.args.setattr.size > old_size) {
-    dout(20) << __func__ << ": full, responding CEPHFS_ENOSPC to setattr with larger size" << dendl;
-    respond_to_request(mdr, -CEPHFS_ENOSPC);
+    dout(20) << __func__ << ": full, responding ENOSPC to setattr with larger size" << dendl;
+    respond_to_request(mdr, -ENOSPC);
     return;
   }
 
@@ -5435,7 +5435,7 @@ void Server::handle_client_setattr(const MDRequestRef& mdr)
     if (req->get_data().length() >
         sizeof(struct ceph_fscrypt_last_block_header) + fscrypt_last_block_max_size) {
       dout(10) << __func__ << ": the last block size is too large" << dendl;
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -5471,7 +5471,7 @@ void Server::handle_client_setattr(const MDRequestRef& mdr)
         // flush the journal to make sure the clients will get the lasted
         // change_attr as possible for the next retry
         mds->mdlog->flush();
-        respond_to_request(mdr, -CEPHFS_EAGAIN);
+        respond_to_request(mdr, -EAGAIN);
         return;
       }
     }
@@ -5631,16 +5631,16 @@ void Server::handle_client_setlayout(const MDRequestRef& mdr)
   if (!cur) return;
 
   if (mdr->snapid != CEPH_NOSNAP) {
-    respond_to_request(mdr, -CEPHFS_EROFS);
+    respond_to_request(mdr, -EROFS);
     return;
   }
   if (!cur->is_file()) {
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
   if (cur->get_projected_inode()->size ||
       cur->get_projected_inode()->truncate_seq > 1) {
-    respond_to_request(mdr, -CEPHFS_ENOTEMPTY);
+    respond_to_request(mdr, -ENOTEMPTY);
     return;
   }
 
@@ -5673,7 +5673,7 @@ void Server::handle_client_setlayout(const MDRequestRef& mdr)
   }
 
   if (!is_valid_layout(&layout)) {
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
@@ -5737,7 +5737,7 @@ CInode* Server::try_get_auth_inode(const MDRequestRef& mdr, inodeno_t ino)
 {
   CInode *in = mdcache->get_inode(ino);
   if (!in || in->state_test(CInode::STATE_PURGING)) {
-    respond_to_request(mdr, -CEPHFS_ESTALE);
+    respond_to_request(mdr, -ESTALE);
     return nullptr;
   }
   if (!in->is_auth()) {
@@ -5758,7 +5758,7 @@ void Server::handle_client_setdirlayout(const MDRequestRef& mdr)
     return;
 
   if (!cur->is_dir()) {
-    respond_to_request(mdr, -CEPHFS_ENOTDIR);
+    respond_to_request(mdr, -ENOTDIR);
     return;
   }
 
@@ -5800,7 +5800,7 @@ void Server::handle_client_setdirlayout(const MDRequestRef& mdr)
   }
   
   if (!is_valid_layout(&layout)) {
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
@@ -5831,18 +5831,18 @@ int Server::parse_layout_vxattr_json(
       int64_t _pool_id = osdmap.lookup_pg_pool_name(pool_name);
       if (_pool_id < 0) {
 	dout(10) << __func__ << ": unknown pool name:" << pool_name << dendl;
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
       }
       return _pool_id;
     } else if (pool_id >= 0) {
       const auto pools = osdmap.get_pools();
       if (pools.find(pool_id) == pools.end()) {
 	dout(10) << __func__ << ": unknown pool id:" << pool_id << dendl;
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
       }
       return pool_id;
     } else {
-      return -CEPHFS_EINVAL;
+      return -EINVAL;
     }
   };
 
@@ -5880,20 +5880,20 @@ int Server::parse_layout_vxattr_json(
 	} catch (JSONDecoder::err&) {
 	  dout(10) << __func__ << ": json is missing a mandatory field named "
 		   << field << dendl;
-	  return -CEPHFS_EINVAL;
+	  return -EINVAL;
 	}
       } else {
 	dout(10) << __func__ << ": bad json" << dendl;
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
       }
     } else {
       dout(10) << __func__ << ": unknown layout vxattr " << name << dendl;
-      return -CEPHFS_ENODATA; // no such attribute
+      return -ENODATA; // no such attribute
     }
   } catch (boost::bad_lexical_cast const&) {
     dout(10) << __func__ << ": bad vxattr value:" << value
 	     << ", unable to parse for xattr:" << name << dendl;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
   return 0;
 }
@@ -5909,12 +5909,12 @@ int Server::parse_layout_vxattr_string(
       keys_and_values<string::iterator> p;    // create instance of parser
       std::map<string, string> m;             // map to receive results
       if (!qi::parse(begin, end, p, m)) {     // returns true if successful
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
       }
       string left(begin, end);
       dout(10) << __func__ << ": parsed " << m << " left '" << left << "'" << dendl;
       if (begin != end)
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
       for (map<string,string>::iterator q = m.begin(); q != m.end(); ++q) {
         // Skip validation on each attr, we do it once at the end (avoid
         // rejecting intermediate states if the overall result is ok)
@@ -5936,7 +5936,7 @@ int Server::parse_layout_vxattr_string(
 	int64_t pool = osdmap.lookup_pg_pool_name(value);
 	if (pool < 0) {
 	  dout(10) << __func__ << ": unknown pool " << value << dendl;
-	  return -CEPHFS_ENOENT;
+	  return -ENOENT;
 	}
 	layout->pool_id = pool;
       }
@@ -5946,18 +5946,18 @@ int Server::parse_layout_vxattr_string(
       layout->pool_id = osdmap.lookup_pg_pool_name(value);
       if (layout->pool_id < 0) {
 	dout(10) << __func__ << ": unknown pool " << value << dendl;
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
       }
     } else if (name == "layout.pool_namespace") {
       layout->pool_ns = value;
     } else {
       dout(10) << __func__ << ": unknown layout vxattr " << name << dendl;
-      return -CEPHFS_ENODATA; // no such attribute
+      return -ENODATA; // no such attribute
     }
   } catch (boost::bad_lexical_cast const&) {
     dout(10) << __func__ << ": bad vxattr value, unable to parse int for "
 	     << name << dendl;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
   return 0;
 }
@@ -5978,7 +5978,7 @@ int Server::parse_layout_vxattr(string name, string value, const OSDMap& osdmap,
   }
   
   if (!is_valid_layout(layout)) {
-     return -CEPHFS_EINVAL;
+     return -EINVAL;
   }
   
   return 0;
@@ -5998,12 +5998,12 @@ int Server::parse_quota_vxattr(string name, string value, quota_info_t *quota)
       keys_and_values<string::iterator> p;    // create instance of parser
       std::map<string, string> m;             // map to receive results
       if (!qi::parse(begin, end, p, m)) {     // returns true if successful
-        return -CEPHFS_EINVAL;
+        return -EINVAL;
       }
       string left(begin, end);
       dout(10) << " parsed " << m << " left '" << left << "'" << dendl;
       if (begin != end)
-        return -CEPHFS_EINVAL;
+        return -EINVAL;
       for (map<string,string>::iterator q = m.begin(); q != m.end(); ++q) {
         int r = parse_quota_vxattr(string("quota.") + q->first, q->second, quota);
         if (r < 0)
@@ -6015,26 +6015,26 @@ int Server::parse_quota_vxattr(string name, string value, quota_info_t *quota)
       if(!cast_err.empty()) {
         dout(10) << __func__ << ":  failed to parse quota.max_bytes: "
         << cast_err << dendl;
-        return -CEPHFS_EINVAL;
+        return -EINVAL;
       }
       quota->max_bytes = q;
     } else if (name == "quota.max_files") {
       int64_t q = boost::lexical_cast<int64_t>(value);
       if (q < 0)
-        return -CEPHFS_EINVAL;
+        return -EINVAL;
       quota->max_files = q;
     } else {
       dout(10) << " unknown quota vxattr " << name << dendl;
-      return -CEPHFS_EINVAL;
+      return -EINVAL;
     }
   } catch (boost::bad_lexical_cast const&) {
     dout(10) << "bad vxattr value, unable to parse int for " << name << dendl;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   if (!quota->is_valid()) {
     dout(10) << "bad quota" << dendl;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
   return 0;
 }
@@ -6073,9 +6073,9 @@ int Server::check_layout_vxattr(const MDRequestRef& mdr,
       epoch = osdmap.get_epoch();
     });
 
-  if (r == -CEPHFS_ENOENT) {
+  if (r == -ENOENT) {
     if (is_rmxattr) {
-      r = -CEPHFS_EINVAL;
+      r = -EINVAL;
 
       respond_to_request(mdr, r);
       return r;
@@ -6108,8 +6108,8 @@ int Server::check_layout_vxattr(const MDRequestRef& mdr,
 
   if (r < 0) {
 
-    if (r == -CEPHFS_ENOENT)
-      r = -CEPHFS_EINVAL;
+    if (r == -ENOENT)
+      r = -EINVAL;
 
     respond_to_request(mdr, r);
     return r;
@@ -6142,7 +6142,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
   bool adjust_realm = false;
   if (name.compare(0, 15, "ceph.dir.layout") == 0) {
     if (!cur->is_dir()) {
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -6157,7 +6157,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
 
     /* encrypted directories can't have their layout changed */
     if (!cur->get_inode()->fscrypt_auth.empty()) {
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -6200,7 +6200,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
     mdr->no_early_reply = true;
   } else if (name.compare(0, 16, "ceph.file.layout") == 0) {
     if (!cur->is_file()) {
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
     if (!cur->get_projected_inode()->has_layout()) {
@@ -6209,7 +6209,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
     }
     if (cur->get_projected_inode()->size ||
         cur->get_projected_inode()->truncate_seq > 1) {
-      respond_to_request(mdr, -CEPHFS_ENOTEMPTY);
+      respond_to_request(mdr, -ENOTEMPTY);
       return;
     }
     file_layout_t layout = cur->get_projected_inode()->layout;
@@ -6223,7 +6223,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
 
     /* encrypted files can't have their layout changed */
     if (!cur->get_inode()->fscrypt_auth.empty()) {
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -6234,7 +6234,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
     pip = pi.inode.get();
   } else if (name.compare(0, 10, "ceph.quota") == 0) { 
     if (!cur->is_dir()) {
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -6282,7 +6282,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
       val = boost::lexical_cast<bool>(value);
     } catch (boost::bad_lexical_cast const&) {
       dout(10) << "bad vxattr value, unable to parse bool for " << name << dendl;
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -6325,7 +6325,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
     pip = pi.inode.get();
   } else if (name == "ceph.dir.subvolume"sv) {
     if (!cur->is_dir()) {
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -6342,7 +6342,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
       val = boost::lexical_cast<bool>(value);
     } catch (boost::bad_lexical_cast const&) {
       dout(10) << "bad vxattr value, unable to parse bool for " << name << dendl;
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -6379,7 +6379,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
 		 << "policylock; subvol_ino: " << subvol_ino << ", "
 		 << "cur->ino: " << cur->ino()
 		 << dendl;
-	respond_to_request(mdr, -CEPHFS_EINVAL);
+	respond_to_request(mdr, -EINVAL);
 	return;
       }
     }
@@ -6406,7 +6406,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
     adjust_realm = true;
   } else if (name == "ceph.dir.pin"sv) {
     if (!cur->is_dir() || cur->is_root()) {
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -6422,12 +6422,12 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
       rank = boost::lexical_cast<mds_rank_t>(value);
       if (rank < 0) rank = MDS_RANK_NONE;
       else if (rank >= MAX_MDS) {
-        respond_to_request(mdr, -CEPHFS_EDOM);
+        respond_to_request(mdr, -EDOM);
         return;
       }
     } catch (boost::bad_lexical_cast const&) {
       dout(10) << "bad vxattr value, unable to parse int for " << name << dendl;
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -6439,7 +6439,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
     pip = pi.inode.get();
   } else if (name == "ceph.dir.pin.random"sv) {
     if (!cur->is_dir() || cur->is_root()) {
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -6455,15 +6455,15 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
       val = boost::lexical_cast<double>(value);
     } catch (boost::bad_lexical_cast const&) {
       dout(10) << "bad vxattr value, unable to parse float for " << name << dendl;
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
     if (val < 0.0 || 1.0 < val) {
-      respond_to_request(mdr, -CEPHFS_EDOM);
+      respond_to_request(mdr, -EDOM);
       return;
     } else if (mdcache->export_ephemeral_random_max < val) {
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -6475,7 +6475,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
     pip = pi.inode.get();
   } else if (name == "ceph.dir.pin.distributed"sv) {
     if (!cur->is_dir() || cur->is_root()) {
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -6491,7 +6491,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
       val = boost::lexical_cast<bool>(value);
     } catch (boost::bad_lexical_cast const&) {
       dout(10) << "bad vxattr value, unable to parse bool for " << name << dendl;
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
 
@@ -6503,7 +6503,7 @@ void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
     pip = pi.inode.get();
   } else {
     dout(10) << " unknown vxattr " << name << dendl;
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
@@ -6568,18 +6568,18 @@ int Server::xattr_validate(CInode *cur, const InodeStoreBase::xattr_map_const_pt
   if (op == CEPH_MDS_OP_SETXATTR) {
     if (xattrs) {
       if ((flags & CEPH_XATTR_CREATE) && xattrs->count(mempool::mds_co::string(xattr_name))) {
-        dout(10) << "setxattr '" << xattr_name << "' XATTR_CREATE and CEPHFS_EEXIST on " << *cur << dendl;
-        return -CEPHFS_EEXIST;
+        dout(10) << "setxattr '" << xattr_name << "' XATTR_CREATE and EEXIST on " << *cur << dendl;
+        return -EEXIST;
       }
     }
     if ((flags & CEPH_XATTR_REPLACE) && !(xattrs && xattrs->count(mempool::mds_co::string(xattr_name)))) {
-      dout(10) << "setxattr '" << xattr_name << "' XATTR_REPLACE and CEPHFS_ENODATA on " << *cur << dendl;
-      return -CEPHFS_ENODATA;
+      dout(10) << "setxattr '" << xattr_name << "' XATTR_REPLACE and ENODATA on " << *cur << dendl;
+      return -ENODATA;
     }
 
     if ((flags & CEPH_XATTR_REMOVE2) && !(xattrs && xattrs->count(mempool::mds_co::string(xattr_name)))) {
-      dout(10) << "setxattr '" << xattr_name << "' XATTR_REMOVE2 and CEPHFS_ENODATA on " << *cur << dendl;
-      return -CEPHFS_ENODATA;
+      dout(10) << "setxattr '" << xattr_name << "' XATTR_REMOVE2 and ENODATA on " << *cur << dendl;
+      return -ENODATA;
     }
 
     return 0;
@@ -6587,15 +6587,15 @@ int Server::xattr_validate(CInode *cur, const InodeStoreBase::xattr_map_const_pt
 
   if (op == CEPH_MDS_OP_RMXATTR) {
     if (!xattrs || xattrs->count(mempool::mds_co::string(xattr_name)) == 0) {
-      dout(10) << "removexattr '" << xattr_name << "' and CEPHFS_ENODATA on " << *cur << dendl;
-      return -CEPHFS_ENODATA;
+      dout(10) << "removexattr '" << xattr_name << "' and ENODATA on " << *cur << dendl;
+      return -ENODATA;
     }
 
     return 0;
   }
 
   derr << ": unhandled validation for: " << xattr_name << dendl;
-  return -CEPHFS_EINVAL;
+  return -EINVAL;
 }
 
 void Server::xattr_set(InodeStoreBase::xattr_map_ptr xattrs, const std::string &xattr_name,
@@ -6649,7 +6649,7 @@ int Server::parse_mirror_info_xattr(const std::string &name, const std::string &
   std::regex_search(value, match, regex);
   if (match.size() != 3) {
     derr << "mirror info parse error" << dendl;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   cluster_id = match[1];
@@ -6661,14 +6661,14 @@ int Server::parse_mirror_info_xattr(const std::string &name, const std::string &
 int Server::mirror_info_xattr_validate(CInode *cur, const InodeStoreBase::xattr_map_const_ptr xattrs,
                                        XattrOp *xattr_op) {
   if (!cur->is_root()) {
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   int v1 = xattr_validate(cur, xattrs, Server::MirrorXattrInfo::CLUSTER_ID, xattr_op->op, xattr_op->flags);
   int v2 = xattr_validate(cur, xattrs, Server::MirrorXattrInfo::FS_ID, xattr_op->op, xattr_op->flags);
   if (v1 != v2) {
     derr << "inconsistent mirror info state (" << v1 << "," << v2 << ")" << dendl;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   if (v1 < 0) {
@@ -6727,7 +6727,7 @@ void Server::handle_client_setxattr(const MDRequestRef& mdr)
   }
 
   if (!is_allowed_ceph_xattr(name)) {
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
@@ -6736,7 +6736,7 @@ void Server::handle_client_setxattr(const MDRequestRef& mdr)
     return;
 
   if (mdr->snapid != CEPH_NOSNAP) {
-    respond_to_request(mdr, -CEPHFS_EROFS);
+    respond_to_request(mdr, -EROFS);
     return;
   }
 
@@ -6769,7 +6769,7 @@ void Server::handle_client_setxattr(const MDRequestRef& mdr)
   if (((cur_xattrs_size + inc) > mds->mdsmap->get_max_xattr_size())) {
     dout(10) << "xattr kv pairs size too big. cur_xattrs_size "
 	     << cur_xattrs_size << ", inc " << inc << dendl;
-    respond_to_request(mdr, -CEPHFS_ENOSPC);
+    respond_to_request(mdr, -ENOSPC);
     return;
   }
 
@@ -6824,7 +6824,7 @@ void Server::handle_client_removexattr(const MDRequestRef& mdr)
   }
 
   if (!is_allowed_ceph_xattr(name)) {
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
@@ -6833,7 +6833,7 @@ void Server::handle_client_removexattr(const MDRequestRef& mdr)
     return;
 
   if (mdr->snapid != CEPH_NOSNAP) {
-    respond_to_request(mdr, -CEPHFS_EROFS);
+    respond_to_request(mdr, -EROFS);
     return;
   }
 
@@ -6883,7 +6883,7 @@ void Server::handle_client_getvxattr(const MDRequestRef& mdr)
 
   // is a ceph virtual xattr?
   if (!is_ceph_vxattr(xattr_name)) {
-    respond_to_request(mdr, -CEPHFS_ENODATA);
+    respond_to_request(mdr, -ENODATA);
     return;
   }
 
@@ -6894,12 +6894,12 @@ void Server::handle_client_getvxattr(const MDRequestRef& mdr)
 
   if (is_ceph_dir_vxattr(xattr_name)) {
     if (!cur->is_dir()) {
-      respond_to_request(mdr, -CEPHFS_ENODATA);
+      respond_to_request(mdr, -ENODATA);
       return;
     }
   } else if (is_ceph_file_vxattr(xattr_name)) {
     if (cur->is_dir()) {
-      respond_to_request(mdr, -CEPHFS_ENODATA);
+      respond_to_request(mdr, -ENODATA);
       return;
     }
   }
@@ -7000,7 +7000,7 @@ void Server::handle_client_getvxattr(const MDRequestRef& mdr)
       const auto lxi = get_inherited_layout(cur);
       *css << (uint64_t)lxi.layout.pool_id;
     } else {
-      r = -CEPHFS_ENODATA; // no such attribute
+      r = -ENODATA; // no such attribute
     }
   } else if (xattr_name == "ceph.quiesce.block"sv) {
     *css << cur->get_projected_inode()->get_quiesce_block();
@@ -7014,12 +7014,12 @@ void Server::handle_client_getvxattr(const MDRequestRef& mdr)
     } else {
       // otherwise respond as invalid request
       // since we only handle ceph vxattrs here
-      r = -CEPHFS_ENODATA; // no such attribute
+      r = -ENODATA; // no such attribute
     }
   } else {
     // otherwise respond as invalid request
     // since we only handle ceph vxattrs here
-    r = -CEPHFS_ENODATA; // no such attribute
+    r = -ENODATA; // no such attribute
   }
 
   if (r == 0) {
@@ -7116,7 +7116,7 @@ void Server::handle_client_mknod(const MDRequestRef& mdr)
   ceph_assert(dn->get_projected_linkage()->is_null());
   if (req->get_alternate_name().size() > alternate_name_max) {
     dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
-    respond_to_request(mdr, -CEPHFS_ENAMETOOLONG);
+    respond_to_request(mdr, -ENAMETOOLONG);
     return;
   }
   dn->set_alternate_name(req->get_alternate_name());
@@ -7129,7 +7129,7 @@ void Server::handle_client_mknod(const MDRequestRef& mdr)
     layout = mdcache->default_file_layout;
 
   if (!is_valid_layout(&layout)) {
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
@@ -7220,7 +7220,7 @@ void Server::handle_client_mkdir(const MDRequestRef& mdr)
   ceph_assert(dn->get_projected_linkage()->is_null());
   if (req->get_alternate_name().size() > alternate_name_max) {
     dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
-    respond_to_request(mdr, -CEPHFS_ENAMETOOLONG);
+    respond_to_request(mdr, -ENAMETOOLONG);
     return;
   }
   dn->set_alternate_name(req->get_alternate_name());
@@ -7312,7 +7312,7 @@ void Server::handle_client_symlink(const MDRequestRef& mdr)
   ceph_assert(dn->get_projected_linkage()->is_null());
   if (req->get_alternate_name().size() > alternate_name_max) {
     dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
-    respond_to_request(mdr, -CEPHFS_ENAMETOOLONG);
+    respond_to_request(mdr, -ENAMETOOLONG);
   }
   dn->set_alternate_name(req->get_alternate_name());
 
@@ -7373,7 +7373,7 @@ void Server::handle_client_link(const MDRequestRef& mdr)
   if (req->get_filepath2().depth() == 0) {
     targeti = mdcache->get_inode(req->get_filepath2().get_ino());
     if (!targeti) {
-      dout(10) << "CEPHFS_ESTALE on path2, attempting recovery" << dendl;
+      dout(10) << "ESTALE on path2, attempting recovery" << dendl;
       inodeno_t ino = req->get_filepath2().get_ino();
       mdcache->find_ino_peers(ino, new C_MDS_TryFindInode(this, mdr, mdcache, ino));
       return;
@@ -7384,7 +7384,7 @@ void Server::handle_client_link(const MDRequestRef& mdr)
       CDentry *pdn = targeti->get_projected_parent_dn();
       if (!pdn) {
 	dout(7) << "target has no parent dn, failing..." << dendl;
-	respond_to_request(mdr, -CEPHFS_EINVAL);
+	respond_to_request(mdr, -EINVAL);
 	return;
       }
       if (!mds->locker->try_rdlock_snap_layout(pdn->get_dir()->get_inode(), mdr, 1))
@@ -7402,7 +7402,7 @@ void Server::handle_client_link(const MDRequestRef& mdr)
       return;
 
     if (!destdn->get_projected_linkage()->is_null()) {
-      respond_to_request(mdr, -CEPHFS_EEXIST);
+      respond_to_request(mdr, -EEXIST);
       return;
     }
 
@@ -7412,14 +7412,14 @@ void Server::handle_client_link(const MDRequestRef& mdr)
   ceph_assert(destdn->get_projected_linkage()->is_null());
   if (req->get_alternate_name().size() > alternate_name_max) {
     dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
-    respond_to_request(mdr, -CEPHFS_ENAMETOOLONG);
+    respond_to_request(mdr, -ENAMETOOLONG);
     return;
   }
   destdn->set_alternate_name(req->get_alternate_name());
 
   if (targeti->is_dir()) {
     dout(7) << "target is a dir, failing..." << dendl;
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
@@ -7440,7 +7440,7 @@ void Server::handle_client_link(const MDRequestRef& mdr)
 
   if (targeti->get_projected_inode()->nlink == 0) {
     dout(7) << "target has no link, failing..." << dendl;
-    respond_to_request(mdr, -CEPHFS_ENOENT);
+    respond_to_request(mdr, -ENOENT);
     return;
   }
 
@@ -7466,7 +7466,7 @@ void Server::handle_client_link(const MDRequestRef& mdr)
       /* The inode is temporarily located in the stray dir pending reintegration */
       !target_pin->is_stray()) {
     dout(7) << "target is in different subvolume, failing..." << dendl;
-    respond_to_request(mdr, -CEPHFS_EXDEV);
+    respond_to_request(mdr, -EXDEV);
     return;
   }
 
@@ -8087,19 +8087,19 @@ void Server::handle_client_unlink(const MDRequestRef& mdr)
     if (rmdir) {
       // do empty directory checks
       if (_dir_is_nonempty_unlocked(mdr, in)) {
-	respond_to_request(mdr, -CEPHFS_ENOTEMPTY);
+	respond_to_request(mdr, -ENOTEMPTY);
 	return;
       }
     } else {
       dout(7) << "handle_client_unlink on dir " << *in << ", returning error" << dendl;
-      respond_to_request(mdr, -CEPHFS_EISDIR);
+      respond_to_request(mdr, -EISDIR);
       return;
     }
   } else {
     if (rmdir) {
       // unlink
       dout(7) << "handle_client_rmdir on non-dir " << *in << ", returning error" << dendl;
-      respond_to_request(mdr, -CEPHFS_ENOTDIR);
+      respond_to_request(mdr, -ENOTDIR);
       return;
     }
   }
@@ -8145,7 +8145,7 @@ void Server::handle_client_unlink(const MDRequestRef& mdr)
 
   if (in->is_dir() &&
       _dir_is_nonempty(mdr, in)) {
-    respond_to_request(mdr, -CEPHFS_ENOTEMPTY);
+    respond_to_request(mdr, -ENOTEMPTY);
     return;
   }
 
@@ -8437,7 +8437,7 @@ void Server::handle_peer_rmdir_prep(const MDRequestRef& mdr)
 				 MDS_TRAVERSE_DISCOVER | MDS_TRAVERSE_PATH_LOCKED,
 				 &trace, &in);
   if (r > 0) return;
-  if (r == -CEPHFS_ESTALE) {
+  if (r == -ESTALE) {
     mdcache->find_ino_peers(srcpath.get_ino(), new C_MDS_RetryRequest(mdcache, mdr),
 			    mdr->peer_to_mds, true);
     return;
@@ -8802,13 +8802,13 @@ void Server::handle_client_rename(const MDRequestRef& mdr)
   filepath destpath = req->get_filepath();
   filepath srcpath = req->get_filepath2();
   if (srcpath.is_last_dot_or_dotdot() || destpath.is_last_dot_or_dotdot()) {
-    respond_to_request(mdr, -CEPHFS_EBUSY);
+    respond_to_request(mdr, -EBUSY);
     return;
   }
 
   if (req->get_alternate_name().size() > alternate_name_max) {
     dout(10) << " alternate_name longer than " << alternate_name_max << dendl;
-    respond_to_request(mdr, -CEPHFS_ENAMETOOLONG);
+    respond_to_request(mdr, -ENAMETOOLONG);
     return;
   }
 
@@ -8838,7 +8838,7 @@ void Server::handle_client_rename(const MDRequestRef& mdr)
   // e.g. mv /usr /usr/foo
   if (srci->is_dir() && srci->is_projected_ancestor_of(destdir->get_inode())) {
     dout(7) << "cannot rename item to be a child of itself" << dendl;
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
@@ -8848,7 +8848,7 @@ void Server::handle_client_rename(const MDRequestRef& mdr)
 	MDS_INO_IS_STRAY(destpath.get_ino())) &&
       !(destdnl->is_remote() &&
 	destdnl->get_remote_ino() == srci->ino())) {
-    respond_to_request(mdr, -CEPHFS_EINVAL);  // actually, this won't reply, but whatev.
+    respond_to_request(mdr, -EINVAL);  // actually, this won't reply, but whatev.
     return;
   }
 
@@ -8861,17 +8861,17 @@ void Server::handle_client_rename(const MDRequestRef& mdr)
 
     // non-empty dir? do trivial fast unlocked check, do another check later with read locks
     if (oldin->is_dir() && _dir_is_nonempty_unlocked(mdr, oldin)) {
-      respond_to_request(mdr, -CEPHFS_ENOTEMPTY);
+      respond_to_request(mdr, -ENOTEMPTY);
       return;
     }
 
     // mv /some/thing /to/some/existing_other_thing
     if (oldin->is_dir() && !srci->is_dir()) {
-      respond_to_request(mdr, -CEPHFS_EISDIR);
+      respond_to_request(mdr, -EISDIR);
       return;
     }
     if (!oldin->is_dir() && srci->is_dir()) {
-      respond_to_request(mdr, -CEPHFS_ENOTDIR);
+      respond_to_request(mdr, -ENOTDIR);
       return;
     }
     if (srci == oldin && !srcdir->inode->is_stray()) {
@@ -8880,7 +8880,7 @@ void Server::handle_client_rename(const MDRequestRef& mdr)
     }
     if (destdn->get_alternate_name() != req->get_alternate_name()) {
       /* the dentry exists but the alternate_names do not match, fail... */
-      respond_to_request(mdr, -CEPHFS_EINVAL);
+      respond_to_request(mdr, -EINVAL);
       return;
     }
   }
@@ -8997,7 +8997,7 @@ void Server::handle_client_rename(const MDRequestRef& mdr)
   if (oldin &&
       oldin->is_dir() &&
       _dir_is_nonempty(mdr, oldin)) {
-    respond_to_request(mdr, -CEPHFS_ENOTEMPTY);
+    respond_to_request(mdr, -ENOTEMPTY);
     return;
   }
 
@@ -9027,7 +9027,7 @@ void Server::handle_client_rename(const MDRequestRef& mdr)
       src_realm = srcdir->inode->find_snaprealm();
     if (src_realm != dest_realm &&
 	src_realm->get_subvolume_ino() != dest_realm->get_subvolume_ino()) {
-      respond_to_request(mdr, -CEPHFS_EXDEV);
+      respond_to_request(mdr, -EXDEV);
       return;
     }
   }
@@ -10009,7 +10009,7 @@ void Server::handle_peer_rename_prep(const MDRequestRef& mdr)
 				 MDS_TRAVERSE_DISCOVER | MDS_TRAVERSE_PATH_LOCKED | MDS_TRAVERSE_WANT_DENTRY,
 				 &trace);
   if (r > 0) return;
-  if (r == -CEPHFS_ESTALE) {
+  if (r == -ESTALE) {
     mdcache->find_ino_peers(destpath.get_ino(), new C_MDS_RetryRequest(mdcache, mdr),
 			    mdr->peer_to_mds, true);
     return;
@@ -10947,7 +10947,7 @@ void Server::handle_client_lssnap(const MDRequestRef& mdr)
     return;
 
   if (!diri->is_dir()) {
-    respond_to_request(mdr, -CEPHFS_ENOTDIR);
+    respond_to_request(mdr, -ENOTDIR);
     return;
   }
   dout(10) << "lssnap on " << *diri << dendl;
@@ -11057,7 +11057,7 @@ void Server::handle_client_mksnap(const MDRequestRef& mdr)
   if (!mds->mdsmap->allows_snaps()) {
     // you can't make snapshots until you set an option right now
     dout(5) << "new snapshots are disabled for this fs" << dendl;
-    respond_to_request(mdr, -CEPHFS_EPERM);
+    respond_to_request(mdr, -EPERM);
     return;
   }
 
@@ -11067,13 +11067,13 @@ void Server::handle_client_mksnap(const MDRequestRef& mdr)
 
   // dir only
   if (!diri->is_dir()) {
-    respond_to_request(mdr, -CEPHFS_ENOTDIR);
+    respond_to_request(mdr, -ENOTDIR);
     return;
   }
   if (diri->is_system() && !diri->is_root()) {
     // no snaps in system dirs (root is ok)
     dout(5) << "is an internal system dir" << dendl;
-    respond_to_request(mdr, -CEPHFS_EPERM);
+    respond_to_request(mdr, -EPERM);
     return;
   }
   
@@ -11081,7 +11081,7 @@ void Server::handle_client_mksnap(const MDRequestRef& mdr)
 
   if (mdr->client_request->get_caller_uid() < g_conf()->mds_snap_min_uid || mdr->client_request->get_caller_uid() > g_conf()->mds_snap_max_uid) {
     dout(20) << "mksnap " << snapname << " on " << *diri << " denied to uid " << mdr->client_request->get_caller_uid() << dendl;
-    respond_to_request(mdr, -CEPHFS_EPERM);
+    respond_to_request(mdr, -EPERM);
     return;
   }
   
@@ -11107,7 +11107,7 @@ void Server::handle_client_mksnap(const MDRequestRef& mdr)
   if (inodeno_t subvol_ino = diri->find_snaprealm()->get_subvolume_ino();
       (subvol_ino && subvol_ino != diri->ino())) {
     dout(5) << "is a descendent of a subvolume dir" << dendl;
-    respond_to_request(mdr, -CEPHFS_EPERM);
+    respond_to_request(mdr, -EPERM);
     return;
   }
 
@@ -11115,20 +11115,20 @@ void Server::handle_client_mksnap(const MDRequestRef& mdr)
   // we don't allow any more if we are already at or beyond the limit
   if (diri->snaprealm &&
       diri->snaprealm->get_snaps().size() >= max_snaps_per_dir) {
-    respond_to_request(mdr, -CEPHFS_EMLINK);
+    respond_to_request(mdr, -EMLINK);
     return;
   }
 
   // make sure name is unique
   if (diri->snaprealm &&
       diri->snaprealm->exists(snapname)) {
-    respond_to_request(mdr, -CEPHFS_EEXIST);
+    respond_to_request(mdr, -EEXIST);
     return;
   }
   if (snapname.length() == 0 ||
       snapname.length() > snapshot_name_max ||
       snapname[0] == '_') {
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
@@ -11251,7 +11251,7 @@ void Server::handle_client_rmsnap(const MDRequestRef& mdr)
     return;
 
   if (!diri->is_dir()) {
-    respond_to_request(mdr, -CEPHFS_ENOTDIR);
+    respond_to_request(mdr, -ENOTDIR);
     return;
   }
 
@@ -11259,7 +11259,7 @@ void Server::handle_client_rmsnap(const MDRequestRef& mdr)
 
   if (mdr->client_request->get_caller_uid() < g_conf()->mds_snap_min_uid || mdr->client_request->get_caller_uid() > g_conf()->mds_snap_max_uid) {
     dout(20) << "rmsnap " << snapname << " on " << *diri << " denied to uid " << mdr->client_request->get_caller_uid() << dendl;
-    respond_to_request(mdr, -CEPHFS_EPERM);
+    respond_to_request(mdr, -EPERM);
     return;
   }
 
@@ -11267,11 +11267,11 @@ void Server::handle_client_rmsnap(const MDRequestRef& mdr)
 
   // does snap exist?
   if (snapname.length() == 0 || snapname[0] == '_') {
-    respond_to_request(mdr, -CEPHFS_EINVAL);   // can't prune a parent snap, currently.
+    respond_to_request(mdr, -EINVAL);   // can't prune a parent snap, currently.
     return;
   }
   if (!diri->snaprealm || !diri->snaprealm->exists(snapname)) {
-    respond_to_request(mdr, -CEPHFS_ENOENT);
+    respond_to_request(mdr, -ENOENT);
     return;
   }
   snapid_t snapid = diri->snaprealm->resolve_snapname(snapname, diri->ino());
@@ -11375,7 +11375,7 @@ void Server::handle_client_renamesnap(const MDRequestRef& mdr)
 {
   const cref_t<MClientRequest> &req = mdr->client_request;
   if (req->get_filepath().get_ino() != req->get_filepath2().get_ino()) {
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 
@@ -11384,13 +11384,13 @@ void Server::handle_client_renamesnap(const MDRequestRef& mdr)
     return;
 
   if (!diri->is_dir()) { // dir only
-    respond_to_request(mdr, -CEPHFS_ENOTDIR);
+    respond_to_request(mdr, -ENOTDIR);
     return;
   }
 
   if (mdr->client_request->get_caller_uid() < g_conf()->mds_snap_min_uid ||
       mdr->client_request->get_caller_uid() > g_conf()->mds_snap_max_uid) {
-    respond_to_request(mdr, -CEPHFS_EPERM);
+    respond_to_request(mdr, -EPERM);
     return;
   }
 
@@ -11399,19 +11399,19 @@ void Server::handle_client_renamesnap(const MDRequestRef& mdr)
   dout(10) << "renamesnap " << srcname << "->" << dstname << " on " << *diri << dendl;
 
   if (srcname.length() == 0 || srcname[0] == '_') {
-    respond_to_request(mdr, -CEPHFS_EINVAL);   // can't rename a parent snap.
+    respond_to_request(mdr, -EINVAL);   // can't rename a parent snap.
     return;
   }
   if (!diri->snaprealm || !diri->snaprealm->exists(srcname)) {
-    respond_to_request(mdr, -CEPHFS_ENOENT);
+    respond_to_request(mdr, -ENOENT);
     return;
   }
   if (dstname.length() == 0 || dstname[0] == '_') {
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    respond_to_request(mdr, -EINVAL);
     return;
   }
   if (diri->snaprealm->exists(dstname)) {
-    respond_to_request(mdr, -CEPHFS_EEXIST);
+    respond_to_request(mdr, -EEXIST);
     return;
   }
 
@@ -11511,8 +11511,8 @@ void Server::handle_client_readdir_snapdiff(const MDRequestRef& mdr)
   // it's a directory, right?
   if (!diri->is_dir()) {
     // not a dir
-    dout(10) << "reply to " << *req << " snapdiff -CEPHFS_ENOTDIR" << dendl;
-    respond_to_request(mdr, -CEPHFS_ENOTDIR);
+    dout(10) << "reply to " << *req << " snapdiff -ENOTDIR" << dendl;
+    respond_to_request(mdr, -ENOTDIR);
     return;
   }
 
@@ -11604,8 +11604,8 @@ void Server::handle_client_readdir_snapdiff(const MDRequestRef& mdr)
   if (mdr->snapid_diff_other == mdr->snapid ||
       mdr->snapid == CEPH_NOSNAP ||
       mdr->snapid_diff_other == CEPH_NOSNAP) {
-    dout(10) << "reply to " << *req << " snapdiff -CEPHFS_EINVAL" << dendl;
-    respond_to_request(mdr, -CEPHFS_EINVAL);
+    dout(10) << "reply to " << *req << " snapdiff -EINVAL" << dendl;
+    respond_to_request(mdr, -EINVAL);
   }
 
   dout(10) << __func__

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -527,7 +527,7 @@ private:
   MDLog *mdlog;
   PerfCounters *logger = nullptr;
 
-  // OSDMap full status, used to generate CEPHFS_ENOSPC on some operations
+  // OSDMap full status, used to generate ENOSPC on some operations
   bool is_full = false;
 
   // State for while in reconnect

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1084,14 +1084,14 @@ int Session::check_access(CInode *in, unsigned mask,
       inode->layout.pool_ns.length() &&
       !connection->has_feature(CEPH_FEATURE_FS_FILE_LAYOUT_V2)) {
     dout(10) << __func__ << " client doesn't support FS_FILE_LAYOUT_V2" << dendl;
-    return -CEPHFS_EIO;
+    return -EIO;
   }
 
   if (!auth_caps.is_capable(path, inode->uid, inode->gid, inode->mode,
 			    caller_uid, caller_gid, caller_gid_list, mask,
 			    new_uid, new_gid,
 			    info.inst.addr)) {
-    return -CEPHFS_EACCES;
+    return -EACCES;
   }
   return 0;
 }
@@ -1214,7 +1214,7 @@ int SessionFilter::parse(
       id = strict_strtoll(s.c_str(), 10, &err);
       if (!err.empty()) {
 	*ss << "Invalid filter '" << s << "'";
-	return -CEPHFS_EINVAL;
+	return -EINVAL;
       }
       return 0;
     }
@@ -1246,18 +1246,18 @@ int SessionFilter::parse(
         return 0;
       } else if (v == "0") {
         *ss << "Invalid value";
-        return -CEPHFS_EINVAL;
+        return -EINVAL;
       }
       id = strict_strtoll(v.c_str(), 10, &err);
       if (!err.empty()) {
         *ss << err;
-        return -CEPHFS_EINVAL;
+        return -EINVAL;
       }
     } else if (k == "reconnecting") {
 
       /**
        * Strict boolean parser.  Allow true/false/0/1.
-       * Anything else is -CEPHFS_EINVAL.
+       * Anything else is -EINVAL.
        */
       auto is_true = [](std::string_view bstr, bool *out) -> bool
       {
@@ -1270,7 +1270,7 @@ int SessionFilter::parse(
           *out = false;
           return 0;
         } else {
-          return -CEPHFS_EINVAL;
+          return -EINVAL;
         }
       };
 
@@ -1280,11 +1280,11 @@ int SessionFilter::parse(
         set_reconnecting(bval);
       } else {
         *ss << "Invalid boolean value '" << v << "'";
-        return -CEPHFS_EINVAL;
+        return -EINVAL;
       }
     } else {
       *ss << "Invalid filter key '" << k << "'";
-      return -CEPHFS_EINVAL;
+      return -EINVAL;
     }
   }
 

--- a/src/mds/SnapClient.cc
+++ b/src/mds/SnapClient.cc
@@ -282,7 +282,7 @@ int SnapClient::dump_cache(Formatter *f) const
 {
   if (!is_synced()) {
     dout(5) << "dump_cache: not synced" << dendl;
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
 
   map<snapid_t, const SnapInfo*> snaps;

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -81,7 +81,7 @@ public:
   C_IO_PurgeStrayPurged(StrayManager *sm_, CDentry *d, bool oh) : 
     StrayManagerIOContext(sm_), dn(d), only_head(oh) { }
   void finish(int r) override {
-    ceph_assert(r == 0 || r == -CEPHFS_ENOENT);
+    ceph_assert(r == 0 || r == -ENOENT);
     sm->_purge_stray_purged(dn, only_head);
   }
   void print(ostream& out) const override {
@@ -484,7 +484,7 @@ bool StrayManager::_eval_stray(CDentry *dn)
 	if (in->state_test(CInode::STATE_MISSINGOBJS)) {
 	  mds->clog->error() << "previous attempt at committing dirfrag of ino "
 			     << in->ino() << " has failed, missing object";
-	  mds->handle_write_error(-CEPHFS_ENOENT);
+	  mds->handle_write_error(-ENOENT);
 	}
 	return false;  // not until some snaps are deleted.
       }

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -336,21 +336,17 @@ public:
   epoch_t get_mdsmap_epoch() const { return head.mdsmap_epoch; }
 
   int get_result() const {
-    #ifdef _WIN32
-    // libclient and libcephfs return CEPHFS_E* errors, which are basically
-    // Linux errno codes. If we convert mds errors to host errno values, we
-    // end up mixing error codes.
-    //
-    // For Windows, we'll preserve the original error value, which is expected
-    // to be a linux (CEPHFS_E*) error. It may be worth doing the same for
-    // other platforms.
+    // MDS now uses host errors, as defined in errno.cc, for current platform.
+    // errorcode32_t is converting, internally, the error code from host to ceph, when encoding, and vice versa,
+    // when decoding, resulting having LINUX codes on the wire, and HOST code on the receiver.
+    // assumes this code is executing after decode_payload() function has been called
     return head.result;
-    #else
-    return ceph_to_hostos_errno((__s32)(__u32)head.result);
-    #endif
   }
 
-  void set_result(int r) { head.result = r; }
+  // errorcode32_t is used in decode/encode methods
+  void set_result(int r) {
+    head.result = r;
+  }
 
   void set_unsafe() { head.safe = 0; }
 
@@ -363,8 +359,8 @@ protected:
     memset(&head, 0, sizeof(head));
     header.tid = req.get_tid();
     head.op = req.get_op();
-    head.result = result;
     head.safe = 1;
+    set_result(result);
   }
   ~MClientReply() final {}
 
@@ -390,6 +386,13 @@ public:
     using ceph::decode;
     auto p = payload.cbegin();
     decode(head, p);
+    // errorcode32_t implements conversion from/to different host error codes
+    // casting needed since error codes are signed int32 and head.result is unsigned int32
+    // errortype_t::code_t is alias for __s32, which is signed
+    // ceph_mds_reply_head::code_t is alias for __le32 which is unsigned
+    errorcode32_t temp;
+    temp.set_wire_to_host(static_cast<errorcode32_t::code_t>(head.result));
+    head.result = static_cast<ceph_mds_reply_head::code_t>(temp.code);
     decode(trace_bl, p);
     decode(extra_bl, p);
     decode(snapbl, p);
@@ -397,7 +400,16 @@ public:
   }
   void encode_payload(uint64_t features) override {
     using ceph::encode;
-    encode(head, payload);
+    // errorcode32_t implements conversion from/to different host error codes
+    // casting needed since error codes are signed int32 and head.result is unsigned int32
+    // errortype_t::code_t is alias for __s32, which is signed
+    // ceph_mds_reply_head::code_t is alias for __le32 which is unsigned
+    // the Messenger layer expects to be able to call encode_payload multiple times on message retries
+    // this is the reason we must copy the head and to modify the copy's 'result' field
+    auto temp_head = head;
+    errorcode32_t temp{static_cast<errorcode32_t::code_t>(temp_head.result)};
+    temp_head.result = static_cast<ceph_mds_reply_head::code_t>(temp.get_host_to_wire());
+    encode(temp_head, payload);
     encode(trace_bl, payload);
     encode(extra_bl, payload);
     encode(snapbl, payload);

--- a/src/messages/MCommandReply.h
+++ b/src/messages/MCommandReply.h
@@ -31,6 +31,9 @@ public:
     : Message{MSG_COMMAND_REPLY}, r(_r) {
     header.tid = m->get_tid();
   }
+  // MDS now uses host errors, as defined in errno.cc, for current platform.
+  // errorcode32_t is converting, internally, the error code from host to ceph, when encoding, and vice versa,
+  // when decoding, resulting having LINUX codes on the wire, and HOST code on the receiver.
   MCommandReply(int _r, std::string_view s)
     : Message{MSG_COMMAND_REPLY},
       r(_r), rs(s) { }

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -61,45 +61,45 @@ CEPH_NOSNAP = -2
 
 # errno definitions
 cdef enum:
-    CEPHFS_EBLOCKLISTED = 108
-    CEPHFS_EPERM = 1
-    CEPHFS_ESTALE = 116
-    CEPHFS_ENOSPC = 28
-    CEPHFS_ETIMEDOUT = 110
-    CEPHFS_EIO = 5
-    CEPHFS_ENOTCONN = 107
-    CEPHFS_EEXIST = 17
-    CEPHFS_EINTR = 4
-    CEPHFS_EINVAL = 22
-    CEPHFS_EBADF = 9
-    CEPHFS_EROFS = 30
-    CEPHFS_EAGAIN = 11
-    CEPHFS_EACCES = 13
-    CEPHFS_ELOOP = 40
-    CEPHFS_EISDIR = 21
-    CEPHFS_ENOENT = 2
-    CEPHFS_ENOTDIR = 20
-    CEPHFS_ENAMETOOLONG = 36
-    CEPHFS_EBUSY = 16
-    CEPHFS_EDQUOT = 122
-    CEPHFS_EFBIG = 27
-    CEPHFS_ERANGE = 34
-    CEPHFS_ENXIO = 6
-    CEPHFS_ECANCELED = 125
-    CEPHFS_ENODATA = 61
-    CEPHFS_EOPNOTSUPP = 95
-    CEPHFS_EXDEV = 18
-    CEPHFS_ENOMEM = 12
-    CEPHFS_ENOTRECOVERABLE = 131
-    CEPHFS_ENOSYS = 38
-    CEPHFS_EWOULDBLOCK = CEPHFS_EAGAIN
-    CEPHFS_ENOTEMPTY = 39
-    CEPHFS_EDEADLK = 35
-    CEPHFS_EDEADLOCK = CEPHFS_EDEADLK
-    CEPHFS_EDOM = 33
-    CEPHFS_EMLINK = 31
-    CEPHFS_ETIME = 62
-    CEPHFS_EOLDSNAPC = 85
+    EBLOCKLISTED = 108
+    EPERM = 1
+    ESTALE = 116
+    ENOSPC = 28
+    ETIMEDOUT = 110
+    EIO = 5
+    ENOTCONN = 107
+    EEXIST = 17
+    EINTR = 4
+    EINVAL = 22
+    EBADF = 9
+    EROFS = 30
+    EAGAIN = 11
+    EACCES = 13
+    ELOOP = 40
+    EISDIR = 21
+    ENOENT = 2
+    ENOTDIR = 20
+    ENAMETOOLONG = 36
+    EBUSY = 16
+    EDQUOT = 122
+    EFBIG = 27
+    ERANGE = 34
+    ENXIO = 6
+    ECANCELED = 125
+    ENODATA = 61
+    EOPNOTSUPP = 95
+    EXDEV = 18
+    ENOMEM = 12
+    ENOTRECOVERABLE = 131
+    ENOSYS = 38
+    EWOULDBLOCK = EAGAIN
+    ENOTEMPTY = 39
+    EDEADLK = 35
+    EDEADLOCK = EDEADLK
+    EDOM = 33
+    EMLINK = 31
+    ETIME = 62
+    EOLDSNAPC = 85
 
 cdef extern from "Python.h":
     # These are in cpython/string.pxd, but use "object" types instead of
@@ -186,20 +186,20 @@ class PermissionDenied(OSError):
     pass
 
 cdef errno_to_exception =  {
-    CEPHFS_EPERM      : PermissionError,
-    CEPHFS_ENOENT     : ObjectNotFound,
-    CEPHFS_EIO        : IOError,
-    CEPHFS_ENOSPC     : NoSpace,
-    CEPHFS_EEXIST     : ObjectExists,
-    CEPHFS_ENODATA    : NoData,
-    CEPHFS_EINVAL     : InvalidValue,
-    CEPHFS_EOPNOTSUPP : OperationNotSupported,
-    CEPHFS_ERANGE     : OutOfRange,
-    CEPHFS_EWOULDBLOCK: WouldBlock,
-    CEPHFS_ENOTEMPTY  : ObjectNotEmpty,
-    CEPHFS_ENOTDIR    : NotDirectory,
-    CEPHFS_EDQUOT     : DiskQuotaExceeded,
-    CEPHFS_EACCES     : PermissionDenied,
+    EPERM      : PermissionError,
+    ENOENT     : ObjectNotFound,
+    EIO        : IOError,
+    ENOSPC     : NoSpace,
+    EEXIST     : ObjectExists,
+    ENODATA    : NoData,
+    EINVAL     : InvalidValue,
+    EOPNOTSUPP : OperationNotSupported,
+    ERANGE     : OutOfRange,
+    EWOULDBLOCK: WouldBlock,
+    ENOTEMPTY  : ObjectNotEmpty,
+    ENOTDIR    : NotDirectory,
+    EDQUOT     : DiskQuotaExceeded,
+    EACCES     : PermissionDenied,
 }
 
 
@@ -256,7 +256,7 @@ cdef class DirResult(object):
 
     def __enter__(self):
         if not self.handle:
-            raise make_ex(CEPHFS_EBADF, "dir is not open")
+            raise make_ex(EBADF, "dir is not open")
         self.lib.require_state("mounted")
         with nogil:
             ceph_rewinddir(self.lib.cluster, self.handle)
@@ -300,14 +300,14 @@ cdef class DirResult(object):
 
     def rewinddir(self):
         if not self.handle:
-            raise make_ex(CEPHFS_EBADF, "dir is not open")
+            raise make_ex(EBADF, "dir is not open")
         self.lib.require_state("mounted")
         with nogil:
             ceph_rewinddir(self.lib.cluster, self.handle)
 
     def telldir(self):
         if not self.handle:
-            raise make_ex(CEPHFS_EBADF, "dir is not open")
+            raise make_ex(EBADF, "dir is not open")
         self.lib.require_state("mounted")
         with nogil:
             ret = ceph_telldir(self.lib.cluster, self.handle)
@@ -317,7 +317,7 @@ cdef class DirResult(object):
 
     def seekdir(self, offset):
         if not self.handle:
-            raise make_ex(CEPHFS_EBADF, "dir is not open")
+            raise make_ex(EBADF, "dir is not open")
         if not isinstance(offset, int):
             raise TypeError('offset must be an int')
         self.lib.require_state("mounted")
@@ -486,7 +486,7 @@ cdef class LibCephFS(object):
         self.state = "uninitialized"
         if rados_inst is not None:
             if auth_id is not None or conffile is not None or conf is not None:
-                raise make_ex(CEPHFS_EINVAL,
+                raise make_ex(EINVAL,
                               "May not pass RADOS instance as well as other configuration")
 
             self.create_with_rados(rados_inst)
@@ -663,9 +663,9 @@ cdef class LibCephFS(object):
                     ret = ceph_conf_get(self.cluster, _option, ret_buf, length)
                 if ret == 0:
                     return decode_cstr(ret_buf)
-                elif ret == -CEPHFS_ENAMETOOLONG:
+                elif ret == -ENAMETOOLONG:
                     length = length * 2
-                elif ret == -CEPHFS_ENOENT:
+                elif ret == -ENOENT:
                     return None
                 else:
                     raise make_ex(ret, "error calling conf_get")
@@ -702,7 +702,7 @@ cdef class LibCephFS(object):
         if not isinstance(timeout, int):
             raise TypeError('timeout must be an integer')
         if timeout < 0:
-            raise make_ex(CEPHFS_EINVAL, 'timeout must be greater than or equal to 0')
+            raise make_ex(EINVAL, 'timeout must be greater than or equal to 0')
         cdef:
             uint32_t _timeout = timeout
         with nogil:
@@ -1390,7 +1390,7 @@ cdef class LibCephFS(object):
                     elif access_flags > 0 and c == '+':
                         access_flags = 3;
                     else:
-                        raise make_ex(CEPHFS_EOPNOTSUPP,
+                        raise make_ex(EOPNOTSUPP,
                                       "open flags doesn't support %s" % c)
 
                 if access_flags == 1:
@@ -2735,7 +2735,7 @@ cdef class LibCephFS(object):
                 if ret > 0:
                     dict_result["pool_name"] = decode_cstr(buf)
                     return dict_result
-                elif ret == -CEPHFS_ERANGE:
+                elif ret == -ERANGE:
                     buflen = buflen * 2
                 else:
                     raise make_ex(ret, "error in get_file_pool_name")
@@ -2761,7 +2761,7 @@ cdef class LibCephFS(object):
                 if ret > 0:
                     dict_result["pool_name"] = decode_cstr(buf)
                     break
-                elif ret == -CEPHFS_ERANGE:
+                elif ret == -ERANGE:
                     buflen = buflen * 2
                 else:
                     raise make_ex(ret, "error in get_default_data_pool_name")

--- a/src/test/client/TestClient.h
+++ b/src/test/client/TestClient.h
@@ -40,7 +40,7 @@ public:
     int check_dummy_op(const UserPerm& perms){
       RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
       if (!mref_reader.is_state_satisfied()) {
-        return -CEPHFS_ENOTCONN;
+        return -ENOTCONN;
       }
       std::scoped_lock l(client_lock);
       MetaRequest *req = new MetaRequest(CEPH_MDS_OP_DUMMY);
@@ -51,7 +51,7 @@ public:
     int send_unknown_session_op(int op) {
       RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
       if (!mref_reader.is_state_satisfied()) {
-        return -CEPHFS_ENOTCONN;
+        return -ENOTCONN;
       }
       std::scoped_lock l(client_lock);
       auto session = _get_or_open_mds_session(0);
@@ -63,7 +63,7 @@ public:
     bool check_client_blocklisted() {
       RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
       if (!mref_reader.is_state_satisfied()) {
-        return -CEPHFS_ENOTCONN;
+        return -ENOTCONN;
       }
       std::scoped_lock l(client_lock);
       bs::error_code ec;
@@ -76,7 +76,7 @@ public:
     bool check_unknown_reclaim_flag(uint32_t flag) {
       RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
       if (!mref_reader.is_state_satisfied()) {
-        return -CEPHFS_ENOTCONN;
+        return -ENOTCONN;
       }
       std::scoped_lock l(client_lock);
       char uuid[256];

--- a/src/test/client/nonblocking.cc
+++ b/src/test/client/nonblocking.cc
@@ -264,13 +264,13 @@ TEST_F(TestClient, LlreadvLlwritevOPathFileHandle) {
                                  nullptr);
   ASSERT_EQ(rc, 0);
   rc = writefinish->wait();
-  ASSERT_EQ(rc, -CEPHFS_EBADF);
+  ASSERT_EQ(rc, -EBADF);
 
   rc = client->ll_preadv_pwritev(fh, iov_in, 2, 0, false, readfinish.get(),
                                  &bl);
   ASSERT_EQ(rc, 0);
   rc = readfinish->wait();
-  ASSERT_EQ(rc, -CEPHFS_EBADF);
+  ASSERT_EQ(rc, -EBADF);
   ASSERT_EQ(bl.length(), 0);
 
   client->ll_release(fh);
@@ -327,7 +327,7 @@ TEST_F(TestClient, LlreadvLlwritevReadOnlyFile) {
                                  nullptr);
   ASSERT_EQ(rc, 0);
   rc = writefinish->wait();
-  ASSERT_EQ(rc, -CEPHFS_EBADF);
+  ASSERT_EQ(rc, -EBADF);
 
   rc = client->ll_preadv_pwritev(fh, iov_in, 2, 0, false, readfinish.get(),
                                  &bl);
@@ -392,12 +392,12 @@ TEST_F(TestClient, LlreadvLlwritevIOClientNotMounted) {
   rc = client->ll_preadv_pwritev(fh, iov_out, 2, 0, true, writefinish.get(), nullptr);
   ASSERT_EQ(rc, 0);
   rc = writefinish->wait();
-  ASSERT_EQ(rc, -CEPHFS_ENOTCONN);
+  ASSERT_EQ(rc, -ENOTCONN);
 
   rc = client->ll_preadv_pwritev(fh, iov_in, 2, 0, false, readfinish.get(), &bl);
   ASSERT_EQ(rc, 0);
   rc = readfinish->wait();
-  ASSERT_EQ(rc, -CEPHFS_ENOTCONN);
+  ASSERT_EQ(rc, -ENOTCONN);
 }
 
 TEST_F(TestClient, LlreadvLlwritevNegativeIOVCount) {
@@ -449,13 +449,13 @@ TEST_F(TestClient, LlreadvLlwritevNegativeIOVCount) {
                                  nullptr);
   ASSERT_EQ(rc, 0);
   ssize_t bytes_written = writefinish->wait();
-  ASSERT_EQ(bytes_written, -CEPHFS_EINVAL);
+  ASSERT_EQ(bytes_written, -EINVAL);
 
   rc = client->ll_preadv_pwritev(fh, iov_in, -2, 0, false, readfinish.get(),
                                  &bl);
   ASSERT_EQ(rc, 0);
   ssize_t bytes_read = readfinish->wait();
-  ASSERT_EQ(bytes_read, -CEPHFS_EINVAL);
+  ASSERT_EQ(bytes_read, -EINVAL);
   ASSERT_EQ(bl.length(), 0);
 
   client->ll_release(fh);
@@ -512,7 +512,7 @@ TEST_F(TestClient, LlreadvLlwritevZeroBytes) {
                                  nullptr);
   ASSERT_EQ(rc, 0);
   ssize_t bytes_written = writefinish->wait();
-  ASSERT_EQ(bytes_written, -CEPHFS_EINVAL);
+  ASSERT_EQ(bytes_written, -EINVAL);
 
   rc = client->ll_preadv_pwritev(fh, iov_in, 2, 0, false, readfinish.get(),
                                  &bl);
@@ -566,13 +566,13 @@ TEST_F(TestClient, LlreadvLlwritevInvalidFileHandle) {
                                  writefinish.get(), nullptr);
   ASSERT_EQ(rc, 0);
   bytes_written = writefinish->wait();
-  ASSERT_EQ(bytes_written, -CEPHFS_EBADF);
+  ASSERT_EQ(bytes_written, -EBADF);
 
   rc = client->ll_preadv_pwritev(fh_null, iov_in, 2, 0, false,
                                  readfinish.get(), &bl);
   ASSERT_EQ(rc, 0);
   bytes_read = readfinish->wait();
-  ASSERT_EQ(bytes_read, -CEPHFS_EBADF);
+  ASSERT_EQ(bytes_read, -EBADF);
   ASSERT_EQ(bl.length(), 0);
 
   // test after closing the file handle
@@ -606,13 +606,13 @@ TEST_F(TestClient, LlreadvLlwritevInvalidFileHandle) {
                                  nullptr);
   ASSERT_EQ(rc, 0);
   bytes_written = writefinish->wait();
-  ASSERT_EQ(bytes_written, -CEPHFS_EBADF);
+  ASSERT_EQ(bytes_written, -EBADF);
 
   rc = client->ll_preadv_pwritev(fh, iov_in, 2, 0, false, readfinish.get(),
                                  &bl);
   ASSERT_EQ(rc, 0);
   bytes_read = readfinish->wait();
-  ASSERT_EQ(bytes_read, -CEPHFS_EBADF);
+  ASSERT_EQ(bytes_read, -EBADF);
   ASSERT_EQ(bl.length(), 0);
 }
 

--- a/src/test/client/syncio.cc
+++ b/src/test/client/syncio.cc
@@ -42,10 +42,10 @@ TEST_F(TestClient, LlreadvLlwritevInvalidFileHandleSync) {
     int64_t rc;
 
     rc = client->ll_writev(fh_null, iov_out, 2, 0);
-    ASSERT_EQ(rc, -CEPHFS_EBADF);
+    ASSERT_EQ(rc, -EBADF);
 
     rc = client->ll_readv(fh_null, iov_in, 2, 0);
-    ASSERT_EQ(rc, -CEPHFS_EBADF);
+    ASSERT_EQ(rc, -EBADF);
 
     // test after closing the file handle
     int mypid = getpid();
@@ -72,8 +72,8 @@ TEST_F(TestClient, LlreadvLlwritevInvalidFileHandleSync) {
     ASSERT_EQ(0, client->ll_unlink(root, filename, myperm));
 
     rc = client->ll_writev(fh, iov_out, 2, 0);
-    ASSERT_EQ(rc, -CEPHFS_EBADF);
+    ASSERT_EQ(rc, -EBADF);
 
     rc = client->ll_readv(fh, iov_in, 2, 0);
-    ASSERT_EQ(rc, -CEPHFS_EBADF);
+    ASSERT_EQ(rc, -EBADF);
 }

--- a/src/test/libcephfs/access.cc
+++ b/src/test/libcephfs/access.cc
@@ -64,7 +64,7 @@ int do_mon_command(string s, string *key)
     std::cout << "key: " << *key << std::endl;
     free(outbuf);
   } else {
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
   if (outs_len) {
     string s(outs, outs_len);
@@ -198,9 +198,9 @@ TEST(AccessTest, Path) {
   ASSERT_EQ(ceph_rename(admin, string(good + "/renameme").c_str(),
 			string(bad + "/asdf").c_str()), 0);
   ASSERT_GE(ceph_write(cmount, fd, "foo", 3, 0), 0);
-  ASSERT_GE(ceph_fchmod(cmount, fd, 0777), -CEPHFS_EACCES);
-  ASSERT_GE(ceph_ftruncate(cmount, fd, 0), -CEPHFS_EACCES);
-  ASSERT_GE(ceph_fsetxattr(cmount, fd, "user.any", "bar", 3, 0), -CEPHFS_EACCES);
+  ASSERT_GE(ceph_fchmod(cmount, fd, 0777), -EACCES);
+  ASSERT_GE(ceph_ftruncate(cmount, fd, 0), -EACCES);
+  ASSERT_GE(ceph_fsetxattr(cmount, fd, "user.any", "bar", 3, 0), -EACCES);
   ceph_close(cmount, fd);
 
   ceph_shutdown(cmount);
@@ -283,7 +283,7 @@ TEST(AccessTest, User) {
   ASSERT_EQ(0, ceph_conf_read_file(cmount, NULL));
   ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
   ASSERT_EQ(0, ceph_conf_set(cmount, "key", key.c_str()));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_mount(cmount, "/"));
+  ASSERT_EQ(-EACCES, ceph_mount(cmount, "/"));
   ASSERT_EQ(0, ceph_init(cmount));
 
   UserPerm *perms = ceph_userperm_new(123, 456, 0, NULL);
@@ -299,35 +299,35 @@ TEST(AccessTest, User) {
   ASSERT_EQ(0, ceph_chown(admin, dir.c_str(), 123, 456));
   ASSERT_EQ(0, ceph_mkdir(cmount, string(dir + "/u1").c_str(), 0755));
   ASSERT_EQ(0, ceph_chown(admin, dir.c_str(), 1, 456));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
+  ASSERT_EQ(-EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
 
   // group bits
   ASSERT_EQ(0, ceph_chmod(admin, dir.c_str(), 0770));
   ASSERT_EQ(0, ceph_chown(admin, dir.c_str(), 1, 456));
   ASSERT_EQ(0, ceph_mkdir(cmount, string(dir + "/u2").c_str(), 0755));
   ASSERT_EQ(0, ceph_chown(admin, dir.c_str(), 1, 2));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
+  ASSERT_EQ(-EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
 
   // user overrides group
   ASSERT_EQ(0, ceph_chmod(admin, dir.c_str(), 0470));
   ASSERT_EQ(0, ceph_chown(admin, dir.c_str(), 123, 456));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
+  ASSERT_EQ(-EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
 
   // other
   ASSERT_EQ(0, ceph_chmod(admin, dir.c_str(), 0777));
   ASSERT_EQ(0, ceph_chown(admin, dir.c_str(), 1, 1));
   ASSERT_EQ(0, ceph_mkdir(cmount, string(dir + "/u3").c_str(), 0755));
   ASSERT_EQ(0, ceph_chmod(admin, dir.c_str(), 0770));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
+  ASSERT_EQ(-EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
 
   // user and group overrides other
   ASSERT_EQ(0, ceph_chmod(admin, dir.c_str(), 07));
   ASSERT_EQ(0, ceph_chown(admin, dir.c_str(), 1, 456));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
+  ASSERT_EQ(-EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
   ASSERT_EQ(0, ceph_chown(admin, dir.c_str(), 123, 1));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
+  ASSERT_EQ(-EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
   ASSERT_EQ(0, ceph_chown(admin, dir.c_str(), 123, 456));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
+  ASSERT_EQ(-EACCES, ceph_mkdir(cmount, string(dir + "/no").c_str(), 0755));
 
   // chown and chgrp
   ASSERT_EQ(0, ceph_chmod(admin, dir.c_str(), 0700));
@@ -337,18 +337,18 @@ TEST(AccessTest, User) {
   ASSERT_EQ(0, ceph_chown(cmount, dir.c_str(), 123, 456));
   // ASSERT_EQ(0, ceph_chown(cmount, dir.c_str(), -1, 789));
   ASSERT_EQ(0, ceph_chown(cmount, dir.c_str(), -1, 456));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_chown(cmount, dir.c_str(), 123, 1));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_chown(cmount, dir.c_str(), 1, 456));
+  ASSERT_EQ(-EACCES, ceph_chown(cmount, dir.c_str(), 123, 1));
+  ASSERT_EQ(-EACCES, ceph_chown(cmount, dir.c_str(), 1, 456));
 
   ASSERT_EQ(0, ceph_chown(admin, dir.c_str(), 1, 1));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_chown(cmount, dir.c_str(), 123, 456));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_chown(cmount, dir.c_str(), 123, -1));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_chown(cmount, dir.c_str(), -1, 456));
+  ASSERT_EQ(-EACCES, ceph_chown(cmount, dir.c_str(), 123, 456));
+  ASSERT_EQ(-EACCES, ceph_chown(cmount, dir.c_str(), 123, -1));
+  ASSERT_EQ(-EACCES, ceph_chown(cmount, dir.c_str(), -1, 456));
 
   ASSERT_EQ(0, ceph_chown(admin, dir.c_str(), 1, 456));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_chown(cmount, dir.c_str(), 123, 456));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_chown(cmount, dir.c_str(), 123, -1));
-  ASSERT_EQ(-CEPHFS_EACCES, ceph_chown(cmount, dir.c_str(), -1, 456));
+  ASSERT_EQ(-EACCES, ceph_chown(cmount, dir.c_str(), 123, 456));
+  ASSERT_EQ(-EACCES, ceph_chown(cmount, dir.c_str(), 123, -1));
+  ASSERT_EQ(-EACCES, ceph_chown(cmount, dir.c_str(), -1, 456));
 
   ASSERT_EQ(0, ceph_chown(admin, dir.c_str(), 123, 1));
   ASSERT_EQ(0, ceph_chown(cmount, dir.c_str(), -1, 456));

--- a/src/test/libcephfs/deleg.cc
+++ b/src/test/libcephfs/deleg.cc
@@ -53,7 +53,7 @@ static int ceph_ll_delegation_wait(struct ceph_mount_info *cmount, Fh *fh,
   do {
     ret = ceph_ll_delegation(cmount, fh, cmd, cb, priv);
     usleep(10000);
-  } while (ret == -CEPHFS_EAGAIN && retry++ < 1000);
+  } while (ret == -EAGAIN && retry++ < 1000);
 
   return ret;
 }
@@ -95,7 +95,7 @@ static void open_breaker_func(struct ceph_mount_info *cmount, const char *filena
   for (;;) {
     ASSERT_EQ(ceph_ll_getattr(cmount, file, &stx, CEPH_STATX_ALL_STATS, 0, perms), 0);
     ret = ceph_ll_open(cmount, file, flags, &fh, perms);
-    if (ret != -CEPHFS_EAGAIN)
+    if (ret != -EAGAIN)
       break;
     ASSERT_LT(i++, MAX_WAIT);
     usleep(1000);
@@ -152,7 +152,7 @@ static void namespace_breaker_func(struct ceph_mount_info *cmount, int cmd, cons
       // Bad command
       ceph_abort();
     }
-    if (ret != -CEPHFS_EAGAIN)
+    if (ret != -EAGAIN)
       break;
     ASSERT_LT(i++, MAX_WAIT);
     usleep(1000);
@@ -337,7 +337,7 @@ TEST(LibCephFS, DelegTimeout) {
    * in the mounter in main thread has already timedout.
    */
   sleep(3);
-  ASSERT_EQ(ceph_ll_getattr(cmount, root, &stx, 0, 0, perms), -CEPHFS_ENOTCONN);
+  ASSERT_EQ(ceph_ll_getattr(cmount, root, &stx, 0, 0, perms), -ENOTCONN);
   ceph_release(cmount);
 }
 

--- a/src/test/libcephfs/flock.cc
+++ b/src/test/libcephfs/flock.cc
@@ -91,12 +91,12 @@ TEST(LibCephFS, BasicLocking) {
 
   // Lock exclusively twice
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_EX, 42));
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 43));
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 44));
+  ASSERT_EQ(-EAGAIN, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 43));
+  ASSERT_EQ(-EAGAIN, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 44));
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_UN, 42));
 
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 43));
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 44));
+  ASSERT_EQ(-EAGAIN, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 44));
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_UN, 43));
 
   // Lock shared three times
@@ -104,14 +104,14 @@ TEST(LibCephFS, BasicLocking) {
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_SH, 43));
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_SH, 44));
   // And then attempt to lock exclusively
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 45));
+  ASSERT_EQ(-EAGAIN, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 45));
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_UN, 42));
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 45));
+  ASSERT_EQ(-EAGAIN, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 45));
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_UN, 44));
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 45));
+  ASSERT_EQ(-EAGAIN, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 45));
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_UN, 43));
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, 45));
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK, ceph_flock(cmount, fd, LOCK_SH | LOCK_NB, 42));
+  ASSERT_EQ(-EAGAIN, ceph_flock(cmount, fd, LOCK_SH | LOCK_NB, 42));
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_UN, 45));
 
   // Lock shared with upgrade to exclusive (POSIX) 
@@ -182,7 +182,7 @@ static void thread_ConcurrentLocking(str_ConcurrentLocking& s) {
   const int fd = ceph_open(cmount, s.file, O_RDWR | O_CREAT, fileMode);
   ASSERT_GE(fd, 0); 
 
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK,
+  ASSERT_EQ(-EAGAIN,
 	    ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, ceph_pthread_self()));
   PING_MAIN(1); // (1)
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_EX, ceph_pthread_self()));
@@ -252,7 +252,7 @@ TEST(LibCephFS, ConcurrentLocking) {
 
   // Wait for thread to share lock
   WAIT_WORKER(4); // (4)
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK,
+  ASSERT_EQ(-EAGAIN,
 	    ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, ceph_pthread_self()));
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_SH | LOCK_NB, ceph_pthread_self()));
 
@@ -275,9 +275,9 @@ TEST(LibCephFS, ConcurrentLocking) {
   WAIT_WORKER(6); // (6)
 
   // We no longer have the lock
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK,
+  ASSERT_EQ(-EAGAIN,
 	    ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, ceph_pthread_self()));
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK,
+  ASSERT_EQ(-EAGAIN,
 	    ceph_flock(cmount, fd, LOCK_SH | LOCK_NB, ceph_pthread_self()));
 
   // Wake up thread to unlock exclusive lock
@@ -336,7 +336,7 @@ TEST(LibCephFS, ThreesomeLocking) {
   
   // Wait for thread to share lock
   TWICE(WAIT_WORKER(4)); // (4)
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK,
+  ASSERT_EQ(-EAGAIN,
 	    ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, ceph_pthread_self()));
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_SH | LOCK_NB, ceph_pthread_self()));
 
@@ -359,9 +359,9 @@ TEST(LibCephFS, ThreesomeLocking) {
   TWICE(WAIT_WORKER(6); // (6)
 	
 	// We no longer have the lock
-	ASSERT_EQ(-CEPHFS_EWOULDBLOCK,
+	ASSERT_EQ(-EAGAIN,
 		  ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, ceph_pthread_self()));
-	ASSERT_EQ(-CEPHFS_EWOULDBLOCK,
+	ASSERT_EQ(-EAGAIN,
 		  ceph_flock(cmount, fd, LOCK_SH | LOCK_NB, ceph_pthread_self()));
 	
 	// Wake up thread to unlock exclusive lock
@@ -406,7 +406,7 @@ static void process_ConcurrentLocking(str_ConcurrentLocking& s) {
   ASSERT_GE(fd, 0); 
   WAIT_MAIN(1); // (R1)
 
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK,
+  ASSERT_EQ(-EAGAIN,
 	    ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, mypid));
   PING_MAIN(1); // (1)
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_EX, mypid));
@@ -491,7 +491,7 @@ TEST(LibCephFS, DISABLED_InterProcessLocking) {
 
   // Wait for process to share lock
   WAIT_WORKER(4); // (4)
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, mypid));
+  ASSERT_EQ(-EAGAIN, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, mypid));
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_SH | LOCK_NB, mypid));
 
   // Wake up process to unlock shared lock
@@ -513,8 +513,8 @@ TEST(LibCephFS, DISABLED_InterProcessLocking) {
   WAIT_WORKER(6); // (6)
 
   // We no longer have the lock
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, mypid));
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK, ceph_flock(cmount, fd, LOCK_SH | LOCK_NB, mypid));
+  ASSERT_EQ(-EAGAIN, ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, mypid));
+  ASSERT_EQ(-EAGAIN, ceph_flock(cmount, fd, LOCK_SH | LOCK_NB, mypid));
 
   // Wake up process to unlock exclusive lock
   PING_WORKER(4); // (R4)
@@ -600,7 +600,7 @@ TEST(LibCephFS, DISABLED_ThreesomeInterProcessLocking) {
   
   // Wait for process to share lock
   TWICE(WAIT_WORKER(4)); // (4)
-  ASSERT_EQ(-CEPHFS_EWOULDBLOCK,
+  ASSERT_EQ(-EAGAIN,
 	    ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, mypid));
   ASSERT_EQ(0, ceph_flock(cmount, fd, LOCK_SH | LOCK_NB, mypid));
 
@@ -623,9 +623,9 @@ TEST(LibCephFS, DISABLED_ThreesomeInterProcessLocking) {
   TWICE(WAIT_WORKER(6); // (6)
 	
 	// We no longer have the lock
-	ASSERT_EQ(-CEPHFS_EWOULDBLOCK,
+	ASSERT_EQ(-EAGAIN,
 		  ceph_flock(cmount, fd, LOCK_EX | LOCK_NB, mypid));
-	ASSERT_EQ(-CEPHFS_EWOULDBLOCK,
+	ASSERT_EQ(-EAGAIN,
 		  ceph_flock(cmount, fd, LOCK_SH | LOCK_NB, mypid));
 	
 	// Wake up process to unlock exclusive lock

--- a/src/test/libcephfs/monconfig.cc
+++ b/src/test/libcephfs/monconfig.cc
@@ -68,7 +68,7 @@ TEST_F(MonConfig, MonAddrsMissing) {
   ASSERT_NE(nullptr, cct);
   clear_mon_config(cct);
 
-  ASSERT_EQ(-CEPHFS_ENOENT, ceph_mount(ca, NULL));
+  ASSERT_EQ(-ENOENT, ceph_mount(ca, NULL));
 }
 
 TEST_F(MonConfig, MonAddrsInConfigProxy) {

--- a/src/test/libcephfs/newops.cc
+++ b/src/test/libcephfs/newops.cc
@@ -63,8 +63,8 @@ TEST(LibCephFS, NewOPs)
   {
     char value[1024] = "";
     int r = ceph_getxattr(cmount, test_path, "ceph.dir.pin.random", (void*)value, sizeof(value));
-    // Clients will return -CEPHFS_ENODATA if new getvxattr op not support yet.
-    EXPECT_THAT(r, AnyOf(Gt(0), Eq(-CEPHFS_ENODATA)));
+    // Clients will return -ENODATA if new getvxattr op not support yet.
+    EXPECT_THAT(r, AnyOf(Gt(0), Eq(-ENODATA)));
   }
 
   {
@@ -72,13 +72,13 @@ TEST(LibCephFS, NewOPs)
     std::stringstream ss;
     ss << val;
     int r = ceph_setxattr(cmount, test_path, "ceph.dir.pin.random", (void*)ss.str().c_str(), strlen(ss.str().c_str()), XATTR_CREATE);
-    // Old cephs will return -CEPHFS_EINVAL if not support "ceph.dir.pin.random" yet.
-    EXPECT_THAT(r, AnyOf(Eq(0), Eq(-CEPHFS_EINVAL)));
+    // Old cephs will return -EINVAL if not support "ceph.dir.pin.random" yet.
+    EXPECT_THAT(r, AnyOf(Eq(0), Eq(-EINVAL)));
 
     char value[1024] = "";
     r = ceph_getxattr(cmount, test_path, "ceph.dir.pin.random", (void*)value, sizeof(value));
-    // Clients will return -CEPHFS_ENODATA if new getvxattr op not support yet.
-    EXPECT_THAT(r, AnyOf(Gt(0), Eq(-CEPHFS_ENODATA)));
+    // Clients will return -ENODATA if new getvxattr op not support yet.
+    EXPECT_THAT(r, AnyOf(Gt(0), Eq(-ENODATA)));
   }
 
   ASSERT_EQ(0, ceph_rmdir(cmount, test_path));

--- a/src/test/libcephfs/quota.cc
+++ b/src/test/libcephfs/quota.cc
@@ -90,7 +90,7 @@ TEST(LibCephFS, SnapQuota) {
 
   // ensure subdir noquota xattr under snap
   sprintf(c_temp, "/.snap/test_snap_dir_quota_xattr_snap_%d/test_snap_dir_quota_xattr_%d/subdir_noquota", mypid, mypid);
-  EXPECT_EQ(-CEPHFS_ENODATA, ceph_getxattr(cmount, c_temp, "ceph.quota.max_bytes", (void *)gxattrv, xbuflen));
+  EXPECT_EQ(-ENODATA, ceph_getxattr(cmount, c_temp, "ceph.quota.max_bytes", (void *)gxattrv, xbuflen));
 
   // listxattr() shouldn't return ceph.quota.max_bytes vxattr
   sprintf(c_temp, "/.snap/test_snap_dir_quota_xattr_snap_%d/test_snap_dir_quota_xattr_%d", mypid, mypid);

--- a/src/test/libcephfs/readdir_r_cb.cc
+++ b/src/test/libcephfs/readdir_r_cb.cc
@@ -50,7 +50,7 @@ TEST(LibCephFS, ReaddirRCB) {
   // check correctness if buffer is too small
   ASSERT_LE(0, ceph_closedir(cmount, dirp));
   ASSERT_GE(0, ceph_opendir(cmount, c_dir, &dirp));
-  ASSERT_EQ(-CEPHFS_ERANGE, ceph_getdnames(cmount, dirp, buf, 1));
+  ASSERT_EQ(-ERANGE, ceph_getdnames(cmount, dirp, buf, 1));
 
   //check correctness if it needs to split listing
   ASSERT_LE(0, ceph_closedir(cmount, dirp));

--- a/src/test/libcephfs/reclaim.cc
+++ b/src/test/libcephfs/reclaim.cc
@@ -60,7 +60,7 @@ static int dying_client(int argc, char **argv)
 
   ceph_set_session_timeout(cmount, CEPHFS_RECLAIM_TIMEOUT);
 
-  if (ceph_start_reclaim(cmount, argv[1], CEPH_RECLAIM_RESET) != -CEPHFS_ENOENT)
+  if (ceph_start_reclaim(cmount, argv[1], CEPH_RECLAIM_RESET) != -ENOENT)
     return 1;
 
   ceph_set_uuid(cmount, argv[1]);

--- a/src/test/libcephfs/recordlock.cc
+++ b/src/test/libcephfs/recordlock.cc
@@ -118,7 +118,7 @@ TEST(LibCephFS, BasicRecordLocking) {
   lock2.l_start = 0;
   lock2.l_len = 1024;
   lock2.l_pid = getpid();
-  ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock2, 43, false));
+  ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock2, 43, false));
 
   // Now try a conflicting read lock
   lock2.l_type = F_RDLCK;
@@ -126,7 +126,7 @@ TEST(LibCephFS, BasicRecordLocking) {
   lock2.l_start = 100;
   lock2.l_len = 100;
   lock2.l_pid = getpid();
-  ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock2, 43, false));
+  ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock2, 43, false));
 
   // Now do a getlk
   ASSERT_EQ(0, ceph_ll_getlk(cmount, fh, &lock2, 43));
@@ -313,7 +313,7 @@ static void thread_ConcurrentRecordLocking(str_ConcurrentRecordLocking& s) {
   lock1.l_start = 0;
   lock1.l_len = 1024;
   lock1.l_pid = getpid();
-  ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
+  ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
 
   PING_MAIN(1); // (1)
   lock1.l_type = F_WRLCK;
@@ -443,7 +443,7 @@ TEST(LibCephFS, ConcurrentRecordLocking) {
   lock1.l_start = 0;
   lock1.l_len = 1024;
   lock1.l_pid = getpid();
-  ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
+  ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
   lock1.l_type = F_RDLCK;
   lock1.l_whence = SEEK_SET;
   lock1.l_start = 0;
@@ -485,13 +485,13 @@ TEST(LibCephFS, ConcurrentRecordLocking) {
   lock1.l_start = 0;
   lock1.l_len = 1024;
   lock1.l_pid = getpid();
-  ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
+  ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
   lock1.l_type = F_RDLCK;
   lock1.l_whence = SEEK_SET;
   lock1.l_start = 0;
   lock1.l_len = 1024;
   lock1.l_pid = getpid();
-  ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
+  ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
 
   // Wake up thread to unlock exclusive lock
   PING_WORKER(3); // (R3)
@@ -587,7 +587,7 @@ TEST(LibCephFS, ThreesomeRecordLocking) {
   lock1.l_start = 0;
   lock1.l_len = 1024;
   lock1.l_pid = getpid();
-  ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
+  ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
   lock1.l_type = F_RDLCK;
   lock1.l_whence = SEEK_SET;
   lock1.l_start = 0;
@@ -629,13 +629,13 @@ TEST(LibCephFS, ThreesomeRecordLocking) {
 	lock1.l_start = 0;
 	lock1.l_len = 1024;
 	lock1.l_pid = getpid();
-	ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
+	ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
 	lock1.l_type = F_RDLCK;
 	lock1.l_whence = SEEK_SET;
 	lock1.l_start = 0;
 	lock1.l_len = 1024;
 	lock1.l_pid = getpid();
-	ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
+	ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
 	
 	// Wake up thread to unlock exclusive lock
 	PING_WORKER(3); // (R3)
@@ -706,7 +706,7 @@ static void process_ConcurrentRecordLocking(str_ConcurrentRecordLocking& s) {
   lock1.l_start = 0;
   lock1.l_len = 1024;
   lock1.l_pid = getpid();
-  ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, mypid, false));
+  ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, mypid, false));
   PING_MAIN(1); // (1)
   lock1.l_type = F_WRLCK;
   lock1.l_whence = SEEK_SET;
@@ -848,7 +848,7 @@ TEST(LibCephFS, DISABLED_InterProcessRecordLocking) {
   lock1.l_start = 0;
   lock1.l_len = 1024;
   lock1.l_pid = getpid();
-  ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, mypid, false));
+  ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, mypid, false));
   lock1.l_type = F_RDLCK;
   lock1.l_whence = SEEK_SET;
   lock1.l_start = 0;
@@ -890,13 +890,13 @@ TEST(LibCephFS, DISABLED_InterProcessRecordLocking) {
   lock1.l_start = 0;
   lock1.l_len = 1024;
   lock1.l_pid = getpid();
-  ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, mypid, false));
+  ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, mypid, false));
   lock1.l_type = F_RDLCK;
   lock1.l_whence = SEEK_SET;
   lock1.l_start = 0;
   lock1.l_len = 1024;
   lock1.l_pid = getpid();
-  ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, mypid, false));
+  ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, mypid, false));
 
   // Wake up process to unlock exclusive lock
   PING_WORKER(4); // (R4)
@@ -1019,7 +1019,7 @@ TEST(LibCephFS, DISABLED_ThreesomeInterProcessRecordLocking) {
   lock1.l_start = 0;
   lock1.l_len = 1024;
   lock1.l_pid = getpid();
-  ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, mypid, false));
+  ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, mypid, false));
   lock1.l_type = F_RDLCK;
   lock1.l_whence = SEEK_SET;
   lock1.l_start = 0;
@@ -1061,13 +1061,13 @@ TEST(LibCephFS, DISABLED_ThreesomeInterProcessRecordLocking) {
 	lock1.l_start = 0;
 	lock1.l_len = 1024;
 	lock1.l_pid = getpid();
-	ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
+	ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
 	lock1.l_type = F_RDLCK;
 	lock1.l_whence = SEEK_SET;
 	lock1.l_start = 0;
 	lock1.l_len = 1024;
 	lock1.l_pid = getpid();
-	ASSERT_EQ(-CEPHFS_EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
+	ASSERT_EQ(-EAGAIN, ceph_ll_setlk(cmount, fh, &lock1, ceph_pthread_self(), false));
 	
 	// Wake up process to unlock exclusive lock
 	PING_WORKER(4); // (R4)

--- a/src/test/libcephfs/suidsgid.cc
+++ b/src/test/libcephfs/suidsgid.cc
@@ -84,7 +84,7 @@ int do_mon_command(string s, string *key)
     std::cout << "key: " << *key << std::endl;
     free(outbuf);
   } else {
-    return -CEPHFS_EINVAL;
+    return -EINVAL;
   }
   if (outs_len) {
     string s(outs, outs_len);

--- a/src/test/libcephfs/vxattr.cc
+++ b/src/test/libcephfs/vxattr.cc
@@ -197,7 +197,7 @@ TEST(LibCephFS, LayoutSetBadJSON) {
       "\"pool_name\": \"cephfs.a.data\", "
       "}";
     // try to set a malformed JSON, eg. without an open brace
-    ASSERT_EQ(-CEPHFS_EINVAL, ceph_setxattr(cmount, "test/d0", "ceph.dir.layout.json", (void*)new_layout, strlen(new_layout), XATTR_CREATE));
+    ASSERT_EQ(-EINVAL, ceph_setxattr(cmount, "test/d0", "ceph.dir.layout.json", (void*)new_layout, strlen(new_layout), XATTR_CREATE));
   }
 
   ASSERT_EQ(0, ceph_rmdir(cmount, "test/d0/subdir"));
@@ -219,7 +219,7 @@ TEST(LibCephFS, LayoutSetBadPoolName) {
 
   {
     // try setting a bad pool name
-    ASSERT_EQ(-CEPHFS_EINVAL, ceph_setxattr(cmount, "test/d0", "ceph.dir.layout.pool_name", (void*)"UglyPoolName", 12, XATTR_CREATE));
+    ASSERT_EQ(-EINVAL, ceph_setxattr(cmount, "test/d0", "ceph.dir.layout.pool_name", (void*)"UglyPoolName", 12, XATTR_CREATE));
   }
 
   ASSERT_EQ(0, ceph_rmdir(cmount, "test/d0/subdir"));
@@ -241,7 +241,7 @@ TEST(LibCephFS, LayoutSetBadPoolId) {
 
   {
     // try setting a bad pool id
-    ASSERT_EQ(-CEPHFS_EINVAL, ceph_setxattr(cmount, "test/d0", "ceph.dir.layout.pool_id", (void*)"300", 3, XATTR_CREATE));
+    ASSERT_EQ(-EINVAL, ceph_setxattr(cmount, "test/d0", "ceph.dir.layout.pool_id", (void*)"300", 3, XATTR_CREATE));
   }
 
   ASSERT_EQ(0, ceph_rmdir(cmount, "test/d0/subdir"));
@@ -263,7 +263,7 @@ TEST(LibCephFS, LayoutSetInvalidFieldName) {
 
   {
     // try to set in invalid field
-    ASSERT_EQ(-CEPHFS_ENODATA, ceph_setxattr(cmount, "test/d0", "ceph.dir.layout.bad_field", (void*)"300", 3, XATTR_CREATE));
+    ASSERT_EQ(-ENODATA, ceph_setxattr(cmount, "test/d0", "ceph.dir.layout.bad_field", (void*)"300", 3, XATTR_CREATE));
   }
 
   ASSERT_EQ(0, ceph_rmdir(cmount, "test/d0/subdir"));
@@ -433,12 +433,12 @@ TEST(LibCephFS, Removexattr) {
   ASSERT_GT(fd, 0);
 
   // remove xattr
-  ASSERT_EQ(-CEPHFS_ENODATA, ceph_fremovexattr(cmount, fd, "user.remove.xattr"));
+  ASSERT_EQ(-ENODATA, ceph_fremovexattr(cmount, fd, "user.remove.xattr"));
   ASSERT_EQ(0, ceph_fsetxattr(cmount, fd, "user.remove.xattr", "foo", 3, XATTR_CREATE));
   ASSERT_EQ(0, ceph_fremovexattr(cmount, fd, "user.remove.xattr"));
 
   // remove xattr via setxattr & XATTR_REPLACE
-  ASSERT_EQ(-CEPHFS_ENODATA, ceph_fsetxattr(cmount, fd, "user.remove.xattr", nullptr, 0, XATTR_REPLACE));
+  ASSERT_EQ(-ENODATA, ceph_fsetxattr(cmount, fd, "user.remove.xattr", nullptr, 0, XATTR_REPLACE));
   ASSERT_EQ(0, ceph_fsetxattr(cmount, fd, "user.remove.xattr", "foo", 3, XATTR_CREATE));
   ASSERT_EQ(0, ceph_fsetxattr(cmount, fd, "user.remove.xattr", nullptr, 0, XATTR_REPLACE));
 

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -143,7 +143,7 @@ int JournalTool::main(std::vector<const char*> &argv)
   stringstream (rank_str.substr(rank_str.find(':') + 1)) >> rank;
   if (fs.get_mds_map().is_active(rank)) {
     derr << "Cannot run cephfs-journal-tool on an active file system!" << dendl;
-    return -CEPHFS_EPERM;
+    return -EPERM;
   }
 
   int64_t const pool_id = fs.get_mds_map().get_metadata_pool();
@@ -203,7 +203,7 @@ int JournalTool::validate_type(const std::string &type)
   if (type == "mdlog" || type == "purge_queue") {
     return 0;
   }
-  return -CEPHFS_EPERM;
+  return -EPERM;
 }
 
 std::string JournalTool::gen_dump_file_path(const std::string &prefix) {


### PR DESCRIPTION
Use `errorcode32_t` struct in `MClientReply` message
-  This struct enforces converting error code from host to ceph and back, while encoding and decoding messages, respectelvly.

Enforce usage of  E* error codes in the cephfs code instead of CEPHFS_E* error codes
-  cephfs code now use host error codes instead of CEPHFS_* error codes

Fixes https://tracker.ceph.com/issues/64611

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
