### PR TITLE
rgw/dbstore: Cleanup - use unique_ptr instead of new/delete in DBZone

### DIFF
--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -268,22 +268,22 @@ protected:
   class DBZone : public StoreZone {
     protected:
       DBStore* store;
-      RGWRealm *realm{nullptr};
-      DBZoneGroup *zonegroup{nullptr};
-      RGWZone *zone_public_config{nullptr}; /* external zone params, e.g., entrypoints, log flags, etc. */
-      RGWZoneParams *zone_params{nullptr}; /* internal zone params, e.g., rados pools */
-      RGWPeriod *current_period{nullptr};
+	std::unique_ptr<RGWRealm> realm;
+	std::unique_ptr<DBZoneGroup> zonegroup;
+	std::unique_ptr<RGWZone> zone_public_config; /* external zone params, e.g., entrypoints, log flags, etc. */
+	std::unique_ptr<RGWZoneParams> zone_params; /* internal zone params, e.g., rados pools */
+	std::unique_ptr<RGWPeriod> current_period;
 
     public:
       DBZone(DBStore* _store) : store(_store) {
-	realm = new RGWRealm();
+	realm = std::make_unique<RGWRealm>();
 	std::unique_ptr<RGWZoneGroup> rzg = std::make_unique<RGWZoneGroup>("default", "default");
 	rzg->api_name = "default";
 	rzg->is_master = true;
-        zonegroup = new DBZoneGroup(store, std::move(rzg));
-        zone_public_config = new RGWZone();
-        zone_params = new RGWZoneParams();
-        current_period = new RGWPeriod();
+	zonegroup = std::make_unique<DBZoneGroup>(store, std::move(rzg));
+	zone_public_config = std::make_unique<RGWZone>();
+	zone_params = std::make_unique<RGWZoneParams>();
+	current_period = std::make_unique<RGWPeriod>();
 
         // XXX: only default and STANDARD supported for now
         RGWZonePlacementInfo info;
@@ -292,13 +292,7 @@ protected:
         info.storage_classes = sc;
         zone_params->placement_pools["default"] = info;
       }
-      ~DBZone() {
-	delete realm;
-	delete zonegroup;
-	delete zone_public_config;
-	delete zone_params;
-	delete current_period;
-      }
+	~DBZone() = default;
 
       virtual std::unique_ptr<Zone> clone() override {
 	return std::make_unique<DBZone>(store);


### PR DESCRIPTION
This commit refactors the 'DBZone' class to utilize 'std::unique_ptr' instead of raw pointers and manual memory management with 'new' and 'delete'.

Fixes: https://tracker.ceph.com/issues/57501

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
