### PR TITLE
blk/CMakeLists.txt: generate interface library if `libblk` is disabled

### DIFF
--- a/src/blk/CMakeLists.txt
+++ b/src/blk/CMakeLists.txt
@@ -23,6 +23,8 @@ endif()
 if(libblk_srcs)
   add_library(blk STATIC ${libblk_srcs})
   target_include_directories(blk PRIVATE "./")
+else()
+  add_library(blk INTERFACE)
 endif()
 
 if(HAVE_LIBAIO)


### PR DESCRIPTION
If all the libraries which `libblk` wraps (i.e. Bluestore, AIO, SPDK, ZBD) are disabled, then the build aborts with a linker failure:

```
 c++ [...] -o bin/ceph-mon [...] -lblk [...]
 mold: fatal: library not found: blk
 collect2: error: ld returned 1 exit status
```

This is because `blk` is used (via `os`) but if the `add_library()` directive is skipped, `cmake` attempts to look up a library with that name.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
