### PR TITLE
osd/scrub: improve scrub information conveyed in standard

### DIFF
--- a/src/osd/scrubber/pg_scrubber.h
+++ b/src/osd/scrubber/pg_scrubber.h
@@ -164,7 +164,7 @@ template <>
 struct formatter<scrub_flags_t> {
   constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
   template <typename FormatContext>
-  auto format(scrub_flags_t& sf, FormatContext& ctx) const
+  auto format(const scrub_flags_t& sf, FormatContext& ctx) const
   {
     std::string txt;
     bool sep{false};
@@ -528,7 +528,7 @@ class PgScrubber : public ScrubPgIF,
   /// to complete (in order to perform an 'after-repair' scrub)
   bool m_after_repair_scrub_required{false};
 
-  ostream& show(ostream& out) const override;
+  ostream& show_concise(ostream& out) const override;
 
  public:
   //  ------------------  the I/F used by the ScrubBackend (ScrubBeListener)
@@ -741,6 +741,12 @@ class PgScrubber : public ScrubPgIF,
   bool m_publish_sessions{false};  //< will the counter be part of 'query'
 				   //output?
 
+  /**
+   * the scrub operation flags.
+   * Set at scrub start. Checked in multiple locations - mostly
+   * at finish.
+   * Note: replicas only use the 'priority' field.
+   */
   scrub_flags_t m_flags;
 
   bool m_active{false};

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -299,12 +299,11 @@ struct ScrubPgIF {
 
   virtual ~ScrubPgIF() = default;
 
-  friend std::ostream& operator<<(std::ostream& out, const ScrubPgIF& s)
-  {
-    return s.show(out);
+  friend std::ostream& operator<<(std::ostream& out, const ScrubPgIF& s) {
+    return s.show_concise(out);
   }
 
-  virtual std::ostream& show(std::ostream& out) const = 0;
+  virtual std::ostream& show_concise(std::ostream& out) const = 0;
 
   // --------------- triggering state-machine events:
 


### PR DESCRIPTION
... PG log line references

When "mentioning" a PG in a log message, a set of data items is included.
That set contains some scrub related information. This commit improves the scrubber information conveyed,
as required following changes to the scrub scheduler.

