### PR TITLE
mds/MDSDaemon: unlock `mds_lock` while shutting down Beacon and others

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -896,6 +896,8 @@ void MDSDaemon::suicide()
 
   clean_up_admin_socket();
 
+  mds_lock.unlock();
+
   // Notify the Monitors (MDSMonitor) that we're dying, so that it doesn't have
   // to wait for us to go laggy. Only do this if we're actually in the MDSMap,
   // because otherwise the MDSMonitor will drop our message.
@@ -909,9 +911,11 @@ void MDSDaemon::suicide()
     mgrc.shutdown();
 
   if (mds_rank) {
+    mds_lock.lock();
     mds_rank->shutdown();
   } else {
     timer.shutdown();
+    mds_lock.lock();
 
     monc->shutdown();
     messenger->shutdown();


### PR DESCRIPTION
This fixes a deadlock bug during MDS shutdown.

This used to be part of https://github.com/ceph/ceph/pull/60320

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
