### PR TITLE
mon/MDSMonitor: send reply to beacons with `state=DNE`

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -758,6 +758,14 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
 
     if (state == MDSMap::STATE_DNE) {
       dout(1) << __func__ << ": DNE from " << info << dendl;
+
+      /* send a beacon reply so MDSDaemon::suicide() finishes the
+         Beacon::send_and_wait() call */
+      auto beacon = make_message<MMDSBeacon>(mon.monmap->fsid,
+          m->get_global_id(), m->get_name(), get_fsmap().get_epoch(),
+          m->get_state(), m->get_seq(), CEPH_FEATURES_SUPPORTED_DEFAULT);
+      mon.send_reply(op, beacon.detach());
+
       goto evict;
     }
 


### PR DESCRIPTION
During shutdown, the MDS sends a `MSG_MDS_BEACON` with `MDSMap::STATE_DNE` (in `MDSDaemon::suicide()`) and then waits for a `MSG_MDS_BEACON` reply from the MON.

The MON, however, suppresses replies to `STATE_DNE`; in `MDSMonitor::preprocess_beacon()`, it returns early on `STATE_DNE` and `MDSMonitor::prepare_beacon()` silently evicts the dying MDS without any reply.

This delays the MDS shutdown until the MDS times out.

Since `MDSDaemon::suicide()` has code to wait for a beacon reply, I figure that the MON reply was suppressed accidently, therefore I suggest adding it.


This used to be part of https://github.com/ceph/ceph/pull/60320

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
