### PR TITLE
rgw/reshard: add async bi entry writer for target index shards

### DIFF
--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -488,7 +488,7 @@ int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string oid, const rgw_cls_bi_e
   return 0;
 }
 
-void cls_rgw_bi_put(ObjectWriteOperation& op, const string oid, const rgw_cls_bi_entry& entry)
+void cls_rgw_bi_put(ObjectWriteOperation& op, const rgw_cls_bi_entry& entry)
 {
   bufferlist in, out;
   rgw_cls_bi_put_op call;

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -475,11 +475,11 @@ int cls_rgw_bi_get(librados::IoCtx& io_ctx, const string oid,
   return 0;
 }
 
-int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string oid, const rgw_cls_bi_entry& entry)
+int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string& oid, rgw_cls_bi_entry entry)
 {
   bufferlist in, out;
   rgw_cls_bi_put_op call;
-  call.entry = entry;
+  call.entry = std::move(entry);
   encode(call, in);
   int r = io_ctx.exec(oid, RGW_CLASS, RGW_BI_PUT, in, out);
   if (r < 0)
@@ -488,11 +488,11 @@ int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string oid, const rgw_cls_bi_e
   return 0;
 }
 
-void cls_rgw_bi_put(ObjectWriteOperation& op, const rgw_cls_bi_entry& entry)
+void cls_rgw_bi_put(ObjectWriteOperation& op, rgw_cls_bi_entry entry)
 {
   bufferlist in, out;
   rgw_cls_bi_put_op call;
-  call.entry = entry;
+  call.entry = std::move(entry);
   encode(call, in);
   op.exec(RGW_CLASS, RGW_BI_PUT, in);
 }

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -385,7 +385,7 @@ int cls_rgw_bi_get(librados::IoCtx& io_ctx, const std::string oid,
                    BIIndexType index_type, const cls_rgw_obj_key& key,
                    rgw_cls_bi_entry *entry);
 int cls_rgw_bi_put(librados::IoCtx& io_ctx, const std::string oid, const rgw_cls_bi_entry& entry);
-void cls_rgw_bi_put(librados::ObjectWriteOperation& op, const std::string oid, const rgw_cls_bi_entry& entry);
+void cls_rgw_bi_put(librados::ObjectWriteOperation& op, const rgw_cls_bi_entry& entry);
 // Write the given array of index entries and update bucket stats accordingly.
 // If existing entries may be overwritten, pass check_existing=true to decrement
 // their stats first.

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -392,9 +392,12 @@ void cls_rgw_bi_put(librados::ObjectWriteOperation& op, rgw_cls_bi_entry entry);
 void cls_rgw_bi_put_entries(librados::ObjectWriteOperation& op,
                             std::vector<rgw_cls_bi_entry> entries,
                             bool check_existing);
-int cls_rgw_bi_list(librados::IoCtx& io_ctx, const std::string& oid,
-                   const std::string& name, const std::string& marker, uint32_t max,
-                   std::list<rgw_cls_bi_entry> *entries, bool *is_truncated, bool reshardlog = false);
+void cls_rgw_bi_list(librados::ObjectReadOperation& op,
+                     std::string name, std::string marker,
+                     uint32_t max, bool reshardlog, bufferlist& bl);
+int cls_rgw_bi_list_decode(const bufferlist& bl,
+                           std::list<rgw_cls_bi_entry>& entries,
+                           bool& is_truncated);
 
 void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op,
                             const cls_rgw_obj_key& key, const ceph::buffer::list& olh_tag,

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -384,8 +384,8 @@ void cls_rgw_obj_check_mtime(librados::ObjectOperation& o, const ceph::real_time
 int cls_rgw_bi_get(librados::IoCtx& io_ctx, const std::string oid,
                    BIIndexType index_type, const cls_rgw_obj_key& key,
                    rgw_cls_bi_entry *entry);
-int cls_rgw_bi_put(librados::IoCtx& io_ctx, const std::string oid, const rgw_cls_bi_entry& entry);
-void cls_rgw_bi_put(librados::ObjectWriteOperation& op, const rgw_cls_bi_entry& entry);
+int cls_rgw_bi_put(librados::IoCtx& io_ctx, const std::string& oid, rgw_cls_bi_entry entry);
+void cls_rgw_bi_put(librados::ObjectWriteOperation& op, rgw_cls_bi_entry entry);
 // Write the given array of index entries and update bucket stats accordingly.
 // If existing entries may be overwritten, pass check_existing=true to decrement
 // their stats first.

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -495,8 +495,6 @@ struct rgw_cls_bucket_update_stats_op
   std::map<RGWObjCategory, rgw_bucket_category_stats> stats;
   std::map<RGWObjCategory, rgw_bucket_category_stats> dec_stats;
 
-  rgw_cls_bucket_update_stats_op() {}
-
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(2, 1, bl);
     encode(absolute, bl);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -788,12 +788,10 @@ struct rgw_cls_bi_put_entries_op {
 WRITE_CLASS_ENCODER(rgw_cls_bi_put_entries_op)
 
 struct rgw_cls_bi_list_op {
-  uint32_t max;
+  uint32_t max = 0;
   std::string name_filter; // limit result to one object and its instances
   std::string marker;
-  bool reshardlog;
-
-  rgw_cls_bi_list_op() : max(0), reshardlog(false) {}
+  bool reshardlog = false;
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -734,8 +734,6 @@ WRITE_CLASS_ENCODER(rgw_cls_bi_get_ret)
 struct rgw_cls_bi_put_op {
   rgw_cls_bi_entry entry;
 
-  rgw_cls_bi_put_op() {}
-
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entry, bl);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -688,12 +688,10 @@ struct rgw_bi_log_entry {
 WRITE_CLASS_ENCODER(rgw_bi_log_entry)
 
 struct rgw_bucket_category_stats {
-  uint64_t total_size;
-  uint64_t total_size_rounded;
-  uint64_t num_entries;
+  uint64_t total_size = 0;
+  uint64_t total_size_rounded = 0;
+  uint64_t num_entries = 0;
   uint64_t actual_size{0}; //< account for compression, encryption
-
-  rgw_bucket_category_stats() : total_size(0), total_size_rounded(0), num_entries(0) {}
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(3, 2, bl);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -730,6 +730,49 @@ inline bool operator!=(const rgw_bucket_category_stats& lhs,
   return !(lhs == rhs);
 }
 
+inline auto operator+(const rgw_bucket_category_stats& lhs,
+                      const rgw_bucket_category_stats& rhs)
+  -> rgw_bucket_category_stats
+{
+  return rgw_bucket_category_stats{
+    .total_size = lhs.total_size + rhs.total_size,
+    .total_size_rounded = lhs.total_size_rounded + rhs.total_size_rounded,
+    .num_entries = lhs.num_entries + rhs.num_entries,
+    .actual_size = lhs.actual_size + rhs.actual_size
+  };
+}
+inline auto operator+=(rgw_bucket_category_stats& lhs,
+                       const rgw_bucket_category_stats& rhs)
+  -> rgw_bucket_category_stats&
+{
+  lhs.total_size += rhs.total_size;
+  lhs.total_size_rounded += rhs.total_size_rounded;
+  lhs.num_entries += rhs.num_entries;
+  lhs.actual_size += rhs.actual_size;
+  return lhs;
+}
+inline auto operator-(const rgw_bucket_category_stats& lhs,
+                      const rgw_bucket_category_stats& rhs)
+  -> rgw_bucket_category_stats
+{
+  return rgw_bucket_category_stats{
+    .total_size = lhs.total_size - rhs.total_size,
+    .total_size_rounded = lhs.total_size_rounded - rhs.total_size_rounded,
+    .num_entries = lhs.num_entries - rhs.num_entries,
+    .actual_size = lhs.actual_size - rhs.actual_size
+  };
+}
+inline auto operator-=(rgw_bucket_category_stats& lhs,
+                       const rgw_bucket_category_stats& rhs)
+  -> rgw_bucket_category_stats&
+{
+  lhs.total_size -= rhs.total_size;
+  lhs.total_size_rounded -= rhs.total_size_rounded;
+  lhs.num_entries -= rhs.num_entries;
+  lhs.actual_size -= rhs.actual_size;
+  return lhs;
+}
+
 enum class cls_rgw_reshard_status : uint8_t {
   NOT_RESHARDING  = 0,
   IN_PROGRESS     = 1,

--- a/src/common/async/detail/spawn_throttle_impl.h
+++ b/src/common/async/detail/spawn_throttle_impl.h
@@ -169,7 +169,7 @@ struct spawn_throttle_handler {
   }
 };
 
-spawn_throttle_handler spawn_throttle_impl::get()
+inline spawn_throttle_handler spawn_throttle_impl::get()
 {
   report_exception(); // throw unreported exception
 
@@ -345,8 +345,8 @@ class async_spawn_throttle_impl final :
   }
 };
 
-auto spawn_throttle_impl::create(optional_yield y, size_t limit,
-                                 cancel_on_error on_error)
+inline auto spawn_throttle_impl::create(optional_yield y, size_t limit,
+                                        cancel_on_error on_error)
     -> boost::intrusive_ptr<spawn_throttle_impl>
 {
   if (y) {

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -198,6 +198,7 @@ set(librgw_common_srcs
   driver/rados/rgw_trim_mdlog.cc
   driver/rados/rgw_user.cc
   driver/rados/rgw_zone.cc
+  driver/rados/reshard_writer.cc
   driver/rados/role.cc
   driver/rados/roles.cc
   driver/rados/sync_fairness.cc

--- a/src/rgw/driver/rados/reshard_writer.cc
+++ b/src/rgw/driver/rados/reshard_writer.cc
@@ -1,0 +1,197 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "reshard_writer.h"
+#include <boost/asio/execution.hpp>
+#include <boost/asio/query.hpp>
+#include "librados/librados_asio.h"
+#include "cls/rgw/cls_rgw_client.h"
+
+namespace rgwrados::reshard {
+
+BaseWriter::BaseWriter(const executor_type& ex, uint64_t max_aio)
+  : svc(boost::asio::use_service<service_type>(
+          boost::asio::query(ex, boost::asio::execution::context))),
+    ex(ex), max_aio(max_aio)
+{
+  // register for service_shutdown() notifications
+  svc.add(*this);
+}
+
+BaseWriter::~BaseWriter()
+{
+  svc.remove(*this);
+}
+
+void BaseWriter::drain(boost::asio::yield_context yield)
+{
+  if (outstanding > 0) {
+    Waiter waiter;
+    drain_waiters.push_back(waiter);
+    waiter.async_wait(yield); // may rethrow error from previous completion
+  } else if (error) {
+    // make sure errors get reported to the caller
+    throw boost::system::system_error(error);
+  }
+}
+
+void BaseWriter::on_complete(boost::system::error_code ec)
+{
+  --outstanding;
+
+  constexpr auto complete_all = [] (boost::intrusive::list<Waiter>& waiters,
+                                    boost::system::error_code ec) {
+      while (!waiters.empty()) {
+        Waiter& waiter = waiters.front();
+        waiters.pop_front();
+        waiter.complete(ec);
+      }
+    };
+  constexpr auto complete_one = [] (boost::intrusive::list<Waiter>& waiters,
+                                    boost::system::error_code ec) {
+      if (!waiters.empty()) {
+        Waiter& waiter = waiters.front();
+        waiters.pop_front();
+        waiter.complete(ec);
+      }
+    };
+
+  if (ec) {
+    if (!error) {
+      error = ec;
+    }
+    // fail all waiting calls to write()
+    complete_all(write_waiters, ec);
+  } else {
+    // wake one waiting call to write()
+    complete_one(write_waiters, {});
+  }
+
+  if (outstanding == 0) {
+    // wake all waiting calls to drain()
+    complete_all(drain_waiters, error);
+  }
+}
+
+void BaseWriter::service_shutdown()
+{
+  // release any outstanding completion handlers
+  constexpr auto shutdown = [] (boost::intrusive::list<Waiter>& waiters) {
+      while (!waiters.empty()) {
+        Waiter& waiter = waiters.front();
+        waiters.pop_front();
+        waiter.shutdown();
+      }
+    };
+  shutdown(write_waiters);
+  shutdown(drain_waiters);
+}
+
+
+PutBatch::PutBatch(boost::asio::io_context& ctx,
+                   librados::IoCtx ioctx,
+                   std::string object,
+                   size_t batch_size)
+  : ctx(ctx),
+    ioctx(std::move(ioctx)),
+    object(std::move(object)),
+    batch_size(batch_size)
+{
+  entries.reserve(batch_size); // preallocate the batch
+}
+
+[[nodiscard]] bool PutBatch::empty() const
+{
+  return entries.empty();
+}
+
+[[nodiscard]] bool PutBatch::add(rgw_cls_bi_entry entry,
+                                 std::optional<RGWObjCategory> category,
+                                 rgw_bucket_category_stats entry_stats)
+{
+  entries.push_back(std::move(entry));
+
+  if (category) {
+    stats[*category] += entry_stats;
+  }
+
+  return entries.size() >= batch_size;
+}
+
+void PutBatch::flush(Completion completion)
+{
+  librados::ObjectWriteOperation op;
+
+  // issue a separate bi_put() call for each entry
+  for (auto& entry : entries) {
+    cls_rgw_bi_put(op, std::move(entry));
+  }
+  entries.clear();
+
+  constexpr bool absolute = false; // add to existing stats
+  cls_rgw_bucket_update_stats(op, absolute, stats);
+  stats.clear();
+
+  constexpr int flags = 0;
+  constexpr jspan_context* trace = nullptr;
+  librados::async_operate(ctx, ioctx, object, &op, flags,
+                          trace, std::move(completion));
+}
+
+PutEntriesBatch::PutEntriesBatch(boost::asio::io_context& ctx,
+                                 librados::IoCtx ioctx,
+                                 std::string object,
+                                 size_t batch_size,
+                                 bool check_existing)
+  : ctx(ctx),
+    ioctx(std::move(ioctx)),
+    object(std::move(object)),
+    batch_size(batch_size),
+    check_existing(check_existing)
+{
+  entries.reserve(batch_size); // preallocate the batch
+}
+
+[[nodiscard]] bool PutEntriesBatch::empty() const
+{
+  return entries.empty();
+}
+
+[[nodiscard]] bool PutEntriesBatch::add(rgw_cls_bi_entry entry,
+                                        std::optional<RGWObjCategory> category,
+                                        rgw_bucket_category_stats stats)
+{
+  entries.push_back(std::move(entry));
+  // bi_put_entries() handles stats on the server side
+  std::ignore = category;
+  std::ignore = stats;
+
+  return entries.size() >= batch_size;
+}
+
+void PutEntriesBatch::flush(Completion completion)
+{
+  librados::ObjectWriteOperation op;
+
+  cls_rgw_bi_put_entries(op, std::move(entries), check_existing);
+  entries.clear();
+
+  constexpr int flags = 0;
+  constexpr jspan_context* trace = nullptr;
+  librados::async_operate(ctx, ioctx, object, &op, flags,
+                          trace, std::move(completion));
+}
+
+} // namespace rgwrados::reshard

--- a/src/rgw/driver/rados/reshard_writer.h
+++ b/src/rgw/driver/rados/reshard_writer.h
@@ -1,0 +1,201 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/intrusive/list.hpp>
+#include <boost/system.hpp>
+
+#include "include/rados/librados.hpp"
+#include "cls/rgw/cls_rgw_types.h"
+#include "common/async/service.h"
+#include "common/async/yield_waiter.h"
+
+namespace rgwrados::reshard {
+
+// base class for Writer that contains everything that doesn't
+// depend on the Batch template type
+class BaseWriter : public ceph::async::service_list_base_hook {
+ public:
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const noexcept { return ex; }
+
+  // wait for all outstanding flush completions
+  void drain(boost::asio::yield_context yield);
+
+  void service_shutdown();
+
+ protected:
+  BaseWriter(const executor_type& ex, uint64_t max_aio);
+  ~BaseWriter();
+
+  using service_type = ceph::async::service<BaseWriter>;
+  service_type& svc;
+  executor_type ex;
+
+  const uint64_t max_aio;
+  uint64_t outstanding = 0;
+  boost::system::error_code error;
+
+  struct Waiter : boost::intrusive::list_base_hook<>,
+                  ceph::async::yield_waiter<void> {};
+  boost::intrusive::list<Waiter> write_waiters;
+  boost::intrusive::list<Waiter> drain_waiters;
+
+  friend struct Completion;
+  void on_complete(boost::system::error_code ec);
+};
+
+// handler that notifies the writer on completion of a flushed batch
+struct Completion {
+  BaseWriter& writer;
+
+  using executor_type = BaseWriter::executor_type;
+  boost::asio::executor_work_guard<executor_type> work =
+      make_work_guard(writer.get_executor());
+
+  executor_type get_executor() const { return work.get_executor(); }
+
+  void operator()(boost::system::error_code ec, version_t=0)
+  {
+    work.reset();
+    writer.on_complete(ec);
+  }
+};
+
+// example Batch type for Writer
+struct BatchArchetype final {
+  // return true if there are entries to flush
+  bool empty() const;
+  // append an entry to the batch and return whether a flush is necessary
+  bool add(rgw_cls_bi_entry entry,
+           std::optional<RGWObjCategory> category,
+           rgw_bucket_category_stats stats);
+  // flush the batch to storage, calling the given handler upon completion
+  void flush(Completion completion);
+};
+
+// Writes index entries in batches to a given target shard object
+template <typename Batch>
+class Writer : public BaseWriter {
+ public:
+  template <typename ...BatchArgs>
+  Writer(const executor_type& ex, uint64_t max_aio, BatchArgs&& ...args)
+    : BaseWriter(ex, max_aio), batch(std::forward<BatchArgs>(args)...) {}
+
+  // add the given entry to its batch. if the batch is full, send an
+  // async write request to flush it in the background. write() only
+  // suspends once we reach the limit of outstanding write requests to
+  // avoid buffering additional entries. this is important to bound
+  // the overall memory usage of index entries
+  void write(rgw_cls_bi_entry entry,
+             std::optional<RGWObjCategory> category,
+             rgw_bucket_category_stats stats,
+             boost::asio::yield_context yield)
+  {
+    if (error) {
+      // fail new writes once we're in the error state
+      throw boost::system::system_error(error);
+    }
+
+    while (outstanding >= max_aio) {
+      Waiter waiter;
+      write_waiters.push_back(waiter);
+      waiter.async_wait(yield); // may rethrow error from previous completion
+    }
+
+    const bool full = batch.add(entry, category, std::move(stats));
+    if (full) {
+      ++outstanding;
+      batch.flush(Completion{*this});
+    }
+  }
+
+  // if there's an incomplete batch, flush it
+  void flush()
+  {
+    if (!batch.empty()) {
+      ++outstanding;
+      batch.flush(Completion{*this});
+    }
+  }
+
+  // wait for all outstanding flush completions
+  using BaseWriter::drain;
+
+ private:
+  Batch batch;
+};
+
+template <typename Batch>
+Writer(const boost::asio::any_io_executor&, uint64_t, Batch&&) -> Writer<Batch>;
+template <typename Batch>
+Writer(const boost::asio::any_io_executor&, uint64_t, Batch&) -> Writer<Batch&>;
+
+// a target shard batch that must be flushed with several bi_put() calls
+class PutBatch {
+ public:
+  PutBatch(boost::asio::io_context& ctx,
+           librados::IoCtx ioctx,
+           std::string object,
+           size_t batch_size);
+
+  [[nodiscard]] bool empty() const;
+  [[nodiscard]] bool add(rgw_cls_bi_entry entry,
+                         std::optional<RGWObjCategory> category,
+                         rgw_bucket_category_stats stats);
+  void flush(Completion completion);
+
+ private:
+  boost::asio::io_context& ctx;
+  librados::IoCtx ioctx;
+  std::string object;
+  const size_t batch_size;
+  std::vector<rgw_cls_bi_entry> entries;
+  std::map<RGWObjCategory, rgw_bucket_category_stats> stats;
+};
+
+// a target shard batch that can be flushed with one bi_put_entries() call
+class PutEntriesBatch {
+ public:
+  PutEntriesBatch(boost::asio::io_context& ctx,
+                  librados::IoCtx ioctx,
+                  std::string object,
+                  size_t batch_size,
+                  bool check_existing);
+
+  [[nodiscard]] bool empty() const;
+  [[nodiscard]] bool add(rgw_cls_bi_entry entry,
+                         std::optional<RGWObjCategory> category,
+                         rgw_bucket_category_stats stats);
+  void flush(Completion completion);
+
+ private:
+  boost::asio::io_context& ctx;
+  librados::IoCtx ioctx;
+  std::string object;
+  const size_t batch_size;
+  const bool check_existing;
+  std::vector<rgw_cls_bi_entry> entries;
+};
+
+} // namespace rgwrados::reshard

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -369,7 +369,7 @@ static int check_bad_index_multipart(rgw::sal::RadosStore* const rados_store,
   std::string prev_entry_prefix;
   do {
     entries_read.clear();
-    ret = store->bi_list(bs, "", marker, -1,
+    ret = store->bi_list(dpp, bs, "", marker, -1,
 			 &entries_read, &is_truncated, false, y);
     if (ret < 0) {
       ldpp_dout(dpp, -1) << "ERROR bi_list(): " << cpp_strerror(-ret) <<
@@ -631,7 +631,7 @@ static int check_index_olh(rgw::sal::RadosStore* const rados_store,
   *count_out = 0;
   do {
     entries.clear();
-    ret = store->bi_list(bs, "", marker, -1, &entries, &is_truncated, false, y);
+    ret = store->bi_list(dpp, bs, "", marker, -1, &entries, &is_truncated, false, y);
     if (ret < 0) {
       ldpp_dout(dpp, -1) << "ERROR bi_list(): " << cpp_strerror(-ret) << dendl;
       break;
@@ -858,7 +858,7 @@ static int check_index_unlinked(rgw::sal::RadosStore* const rados_store,
   *count_out = 0;
   do {
     entries.clear();
-    ret = store->bi_list(bs, "", marker, -1, &entries, &is_truncated, false, y);
+    ret = store->bi_list(dpp, bs, "", marker, -1, &entries, &is_truncated, false, y);
     if (ret < 0) {
       ldpp_dout(dpp, -1) << "ERROR bi_list(): " << cpp_strerror(-ret) << dendl;
       break;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9512,12 +9512,6 @@ int RGWRados::bi_get(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_
   return cls_rgw_bi_get(ref.ioctx, ref.obj.oid, index_type, key, entry);
 }
 
-void RGWRados::bi_put(ObjectWriteOperation& op, BucketShard& bs, rgw_cls_bi_entry& entry, optional_yield y)
-{
-  auto& ref = bs.bucket_obj;
-  cls_rgw_bi_put(op, ref.obj.oid, entry);
-}
-
 int RGWRados::bi_put(BucketShard& bs, rgw_cls_bi_entry& entry, optional_yield y)
 {
   auto& ref = bs.bucket_obj;

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1548,10 +1548,9 @@ public:
 	      uint32_t max,
 	      std::list<rgw_cls_bi_entry> *entries,
 	      bool *is_truncated, bool reshardlog, optional_yield y);
-  int bi_list(BucketShard& bs, const std::string& filter_obj, const std::string& marker, uint32_t max, std::list<rgw_cls_bi_entry> *entries,
+  int bi_list(const DoutPrefixProvider *dpp,
+	      BucketShard& bs, const std::string& filter_obj, const std::string& marker, uint32_t max, std::list<rgw_cls_bi_entry> *entries,
               bool *is_truncated, bool reshardlog, optional_yield y);
-  int bi_list(const DoutPrefixProvider *dpp, rgw_bucket& bucket, const std::string& obj_name, const std::string& marker, uint32_t max,
-              std::list<rgw_cls_bi_entry> *entries, bool *is_truncated, bool reshardlog, optional_yield y);
   int bi_remove(const DoutPrefixProvider *dpp, BucketShard& bs);
 
   int trim_reshard_log_entries(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, optional_yield y);

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1538,7 +1538,6 @@ public:
   int bi_get_instance(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_bucket_dir_entry *dirent, optional_yield y);
   int bi_get_olh(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_bucket_olh_entry *olh, optional_yield y);
   int bi_get(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj, BIIndexType index_type, rgw_cls_bi_entry *entry, optional_yield y);
-  void bi_put(librados::ObjectWriteOperation& op, BucketShard& bs, rgw_cls_bi_entry& entry, optional_yield y);
   int bi_put(BucketShard& bs, rgw_cls_bi_entry& entry, optional_yield y);
   int bi_put(const DoutPrefixProvider *dpp, rgw_bucket& bucket, rgw_obj& obj, rgw_cls_bi_entry& entry, optional_yield y);
   int bi_list(const DoutPrefixProvider *dpp,

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -251,7 +251,7 @@ public:
       cls_rgw_bi_put_entries(op, std::move(entries), check_existing);
     } else {
       for (auto& entry : entries) {
-        store->getRados()->bi_put(op, bs, entry, null_yield);
+        cls_rgw_bi_put(op, entry);
       }
       cls_rgw_bucket_update_stats(op, false, stats);
     }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7937,7 +7937,7 @@ next:
       do {
         entries.clear();
 	// if object is specified, we use that as a filter to only retrieve some entries
-        ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->bi_list(bs, object, marker, max_entries, &entries, &is_truncated, false, null_yield);
+        ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->bi_list(dpp(), bs, object, marker, max_entries, &entries, &is_truncated, false, null_yield);
         if (ret < 0) {
           ldpp_dout(dpp(), 0) << "ERROR: bi_list(): " << cpp_strerror(-ret) << dendl;
           return -ret;
@@ -11096,7 +11096,7 @@ next:
       marker.clear();
       do {
         entries.clear();
-        ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->bi_list(bs, "", marker, max_entries,
+        ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->bi_list(dpp(), bs, "", marker, max_entries,
                                                                               &entries, &is_truncated,
                                                                               true, null_yield);
         if (ret < 0) {

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -114,6 +114,10 @@ add_executable(unittest_rgw_reshard_wait test_rgw_reshard_wait.cc)
 add_ceph_unittest(unittest_rgw_reshard_wait)
 target_link_libraries(unittest_rgw_reshard_wait ${rgw_libs})
 
+add_executable(unittest_rgw_reshard_writer test_rgw_reshard_writer.cc)
+add_ceph_unittest(unittest_rgw_reshard_writer)
+target_link_libraries(unittest_rgw_reshard_writer ${rgw_libs})
+
 set(test_rgw_a_src test_rgw_common.cc)
 add_library(test_rgw_a STATIC ${test_rgw_a_src})
 target_link_libraries(test_rgw_a ${rgw_libs})

--- a/src/test/rgw/test_rgw_reshard_writer.cc
+++ b/src/test/rgw/test_rgw_reshard_writer.cc
@@ -1,0 +1,709 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "reshard_writer.h"
+
+#include <functional>
+#include <optional>
+#include <vector>
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/spawn.hpp>
+#include <gtest/gtest.h>
+
+namespace rgwrados::reshard {
+
+template <typename T>
+auto capture(std::optional<T>& val)
+{
+  return [&val] (T value) { val = std::move(value); };
+}
+
+template <typename Batch>
+auto call_write(Writer<Batch>& writer)
+{
+  return [&writer] (boost::asio::yield_context yield) {
+    writer.write({}, {}, {}, yield);
+  };
+}
+
+template <typename Batch>
+auto call_drain(Writer<Batch>& writer)
+{
+  return [&writer] (boost::asio::yield_context yield) {
+    writer.drain(yield);
+  };
+}
+
+// mock Batch captures flush() completions for test cases to invoke manually
+class MockBatch {
+ public:
+  MockBatch(size_t batch_size, std::vector<Completion>& completions)
+    : batch_size(batch_size), completions(completions)
+  {}
+
+  bool empty() const
+  {
+    return count == 0;
+  }
+
+  bool add(rgw_cls_bi_entry entry,
+           std::optional<RGWObjCategory> category,
+           rgw_bucket_category_stats stats)
+  {
+    ++count;
+    return count == batch_size;
+  }
+
+  void flush(Completion completion)
+  {
+    completions.push_back(std::move(completion));
+    count = 0;
+  }
+
+ private:
+  const size_t batch_size;
+  size_t count = 0;
+  std::vector<Completion>& completions;
+};
+
+TEST(Writer, empty_flush)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  ASSERT_TRUE(batch.empty());
+  auto writer = Writer{ex, 1, batch};
+
+  writer.flush();
+  EXPECT_TRUE(completions.empty());
+}
+
+TEST(Writer, empty_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  ASSERT_TRUE(batch.empty());
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result;
+  boost::asio::spawn(ex, call_drain(writer), capture(result));
+  EXPECT_FALSE(result);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+  EXPECT_TRUE(completions.empty());
+}
+
+TEST(Writer, write_no_flush)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{8, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result;
+  boost::asio::spawn(ex, call_write(writer), capture(result));
+  EXPECT_FALSE(result);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+  EXPECT_TRUE(completions.empty());
+}
+
+TEST(Writer, write_no_flush_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{8, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_write(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+    ctx.restart();
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+    EXPECT_TRUE(completions.empty());
+  }
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_drain(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+    EXPECT_TRUE(completions.empty());
+  }
+}
+
+TEST(Writer, write_flush)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{8, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result;
+  boost::asio::spawn(ex, call_write(writer), capture(result));
+  EXPECT_FALSE(result);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+
+  writer.flush();
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  EXPECT_EQ(1, completions.size());
+}
+
+TEST(Writer, write_flush_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{8, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_write(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+    ctx.restart();
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+  }
+
+  writer.flush();
+  ASSERT_EQ(1, completions.size());
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_drain(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    std::invoke(completions[0], boost::system::error_code{});
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+  }
+}
+
+TEST(Writer, write_batch)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result;
+  boost::asio::spawn(ex, call_write(writer), capture(result));
+  EXPECT_FALSE(result);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+  EXPECT_EQ(1, completions.size());
+}
+
+TEST(Writer, write_batch_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_write(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+    EXPECT_EQ(1, completions.size());
+  }
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_drain(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    std::invoke(completions[0], boost::system::error_code{});
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+  }
+}
+
+TEST(Writer, write_batch_multi_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_write(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+    EXPECT_EQ(1, completions.size());
+  }
+  {
+    std::optional<std::exception_ptr> result1;
+    boost::asio::spawn(ex, call_drain(writer), capture(result1));
+    EXPECT_FALSE(result1);
+
+    std::optional<std::exception_ptr> result2;
+    boost::asio::spawn(ex, call_drain(writer), capture(result2));
+    EXPECT_FALSE(result2);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    std::invoke(completions[0], boost::system::error_code{});
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+
+    ASSERT_TRUE(result1);
+    EXPECT_FALSE(*result1);
+    ASSERT_TRUE(result2);
+    EXPECT_FALSE(*result2);
+  }
+}
+
+TEST(Writer, multi_write_batch)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::spawn(ex, call_write(writer), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::spawn(ex, call_write(writer), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  std::optional<std::exception_ptr> result3;
+  boost::asio::spawn(ex, call_write(writer), capture(result3));
+  EXPECT_FALSE(result3);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  EXPECT_FALSE(result2);
+  ASSERT_EQ(1, completions.size());
+  std::invoke(completions[0], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result2);
+  EXPECT_FALSE(*result2);
+  EXPECT_FALSE(result3);
+  ASSERT_EQ(2, completions.size());
+  std::invoke(completions[1], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result3);
+  EXPECT_FALSE(*result3);
+  ASSERT_EQ(3, completions.size());
+  std::invoke(completions[2], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+}
+
+TEST(Writer, concurrent_multi_write_batch)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 2, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::spawn(ex, call_write(writer), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::spawn(ex, call_write(writer), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result2);
+  EXPECT_FALSE(*result2);
+  EXPECT_EQ(2, completions.size());
+
+  std::optional<std::exception_ptr> result3;
+  boost::asio::spawn(ex, call_write(writer), capture(result3));
+  EXPECT_FALSE(result3);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  std::optional<std::exception_ptr> result4;
+  boost::asio::spawn(ex, call_write(writer), capture(result4));
+  EXPECT_FALSE(result4);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  EXPECT_FALSE(result3);
+  ASSERT_EQ(2, completions.size());
+  std::invoke(completions[0], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result3);
+  EXPECT_FALSE(*result3);
+  EXPECT_FALSE(result4);
+  ASSERT_EQ(3, completions.size());
+  std::invoke(completions[1], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result4);
+  EXPECT_FALSE(*result4);
+  ASSERT_EQ(4, completions.size());
+  std::invoke(completions[2], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_EQ(4, completions.size());
+  std::invoke(completions[3], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+}
+
+TEST(Writer, write_batch_write_error)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::spawn(ex, call_write(writer), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::spawn(ex, call_write(writer), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+  std::invoke(completions[0], make_error_code(std::errc::no_such_file_or_directory));
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  ASSERT_TRUE(result2);
+  ASSERT_TRUE(*result2);
+  try {
+    std::rethrow_exception(*result2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+
+  std::optional<std::exception_ptr> result3;
+  boost::asio::spawn(ex, call_write(writer), capture(result3));
+  EXPECT_FALSE(result3);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result3);
+  ASSERT_TRUE(*result3);
+  try {
+    std::rethrow_exception(*result3);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(Writer, write_batch_error_write)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::spawn(ex, call_write(writer), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+  std::invoke(completions[0], make_error_code(std::errc::no_such_file_or_directory));
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::spawn(ex, call_write(writer), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result2);
+  ASSERT_TRUE(*result2);
+  try {
+    std::rethrow_exception(*result2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(Writer, write_batch_drain_error)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::spawn(ex, call_write(writer), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::spawn(ex, call_drain(writer), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+  std::invoke(completions[0], make_error_code(std::errc::no_such_file_or_directory));
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  ASSERT_TRUE(result2);
+  ASSERT_TRUE(*result2);
+  try {
+    std::rethrow_exception(*result2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+
+  std::optional<std::exception_ptr> result3;
+  boost::asio::spawn(ex, call_write(writer), capture(result3));
+  EXPECT_FALSE(result3);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result3);
+  ASSERT_TRUE(*result3);
+  try {
+    std::rethrow_exception(*result3);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(Writer, write_batch_error_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::spawn(ex, call_write(writer), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+  std::invoke(completions[0], make_error_code(std::errc::no_such_file_or_directory));
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::spawn(ex, call_drain(writer), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result2);
+  ASSERT_TRUE(*result2);
+  try {
+    std::rethrow_exception(*result2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+} // namespace rgwrados::reshard


### PR DESCRIPTION
(adapted from https://github.com/ceph/ceph/pull/59887, changing co_spawn() -> spawn() and neorados -> librados)

adds `rgwrados::reshard::Writer<Batch>` as a stackful coroutine version of rgw_reshard.cc's `class BucketReshardShard` which uses `aio_operate()` to flush batches of index entries to their target bucket index shard objects. that class can't be used with coroutines because it relies on blocking function `librados::AioCompletion::wait_for_complete()`. in contrast, this `Writer` uses `ceph::async::yield_waiter<>` to suspend the coroutine while waiting

the goal of coroutines in reshard is to enable the concurrent processing of several source shards at a time, so this `Writer` class needs to support multiple producers. `write()` and `drain()` accomodate this by using `boost::intrusive::list<Waiter>` to track multiple waiters. we avoid dynamic allocation of these waiters by storing them on the calling coroutine's stack

for backward compatibility with older osds that don't support the 'reshard log' feature, reshard needs to support two different `Batch` types:

* a legacy one that calls `cls_rgw_bi_put()` for each entry and `cls_rgw_bucket_update_stats()` to manually account for bucket stats, and
* a new one that calls `cls_rgw_bi_put_entries()` (from https://github.com/ceph/ceph/pull/59581) to write the vector of entries and handle bucket stats on the server side

the `Batch` template also enables mocking for unit testing without a rados client

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
