### PR TITLE
CodingStyle: allow C++ forward declarations

### DIFF
--- a/CodingStyle
+++ b/CodingStyle
@@ -108,6 +108,12 @@ by section.
    portability since `#pragma once` is widely supported and is known
    to work on GCC and Clang.
 
+* Header Files -> Forward declarations:
+
+    Forward declarations of structs, unions, classes and enums can be
+    used to reduce header dependencies.  This speeds up compile times
+    because the compiler has to process less code.
+
 
 The following guidelines have not been followed in the legacy code,
 but are worth mentioning and should be followed strictly for new code:


### PR DESCRIPTION
The Google coding guide opposes to forward declarations, but I disagree with that opinion.  In my opinion, forward declarations are useful.  Ceph build times are miserable due to header dependency bloat and template bloat, both of which can be reduced using forward declarations.

All cons listed in https://google.github.io/styleguide/cppguide.html

> Forward declarations can hide a dependency, allowing user code to
> skip necessary recompilation when headers change.

That is a pro, not a con.  Skipping (unnecessary) recompilation is a good thing, it's the goal of forward declarations.

> A forward declaration as opposed to an #include statement makes it
> difficult for automatic tooling to discover the module defining the
> symbol.

That certainly depends on the tools one uses, but I cannot imagine today's IDEs are limited to one compilation unit.

> A forward declaration may be broken by subsequent changes to the
> library.

True, and that will lead to a compiler error.

> Forward declarations of functions and templates can prevent the
> header owners from making otherwise-compatible changes to their
> APIs, such as widening a parameter type, adding a template parameter
> with a default value, or migrating to a new namespace.

Forward declarations do not prevent any of that.  But if you change the "real" declaration, all incompatible forward declarations will cause a compiler error.

> Forward declaring symbols from namespace std:: yields undefined
> behavior.

Sad, but true.  But that is not an argument against forward declarations for Ceph's own types.

> It can be difficult to determine whether a forward declaration or a
> full #include is needed.

If it compiles without the `#include`, then the forward declaration is fine.  (Or the primary header happened to be already included by somebody else.)

> Replacing an #include with a forward declaration can silently change
> the meaning of code: [...] If the #include was replaced with forward
> decls for B and D, test() would call f(void*).

True, but this is a contrived example, and is bad coding style because it is error prone.  Casts to `void*` can and should be avoided.  There are rare examples where such casts are necessary (boundary to C APIs), and then it's very unusual to pass derived incomplete types.

> Forward declaring multiple symbols from a header can be more verbose
> than simply #includeing the header.

True, but that misses the point of forward declarations.

> Structuring code to enable forward declarations (e.g., using pointer
> members instead of object members) can make the code slower and more
> complex.

True, but that is not a property of forward declarations.  I don't suggest doing such a thing.

(See https://github.com/ceph/ceph/pull/60253#issuecomment-2414107764)

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [X] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [X] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
