### PR TITLE
mgr/dashboard: carbonize tabs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -9,7 +9,8 @@ import {
   CheckboxModule,
   ButtonModule,
   GridModule,
-  ProgressIndicatorModule
+  ProgressIndicatorModule,
+  TabsModule
 } from 'carbon-components-angular';
 
 import { TreeModule } from '@circlon/angular-tree-component';
@@ -102,7 +103,8 @@ import { MultiClusterDetailsComponent } from './multi-cluster/multi-cluster-deta
     CheckboxModule,
     GridModule,
     ProgressIndicatorModule,
-    ButtonModule
+    ButtonModule,
+    TabsModule
   ],
   declarations: [
     HostsComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-list/multi-cluster-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/multi-cluster/multi-cluster-list/multi-cluster-list.component.html
@@ -22,38 +22,33 @@
 
 <ng-container *ngIf="managedByConfig$ | async as managedByConfig">
   <div *ngIf="managedByConfig['MANAGED_BY_CLUSTERS'].length === 0; else emptyCluster">
-    <nav ngbNav
-         #nav="ngbNav"
-         class="nav-tabs">
-      <ng-container ngbNavItem>
-        <a ngbNavLink
-           i18n>Clusters List</a>
-        <ng-template ngbNavContent>
-          <cd-table #table
-                    [data]="data"
-                    [columns]="columns"
-                    columnMode="flex"
-                    selectionType="single"
-                    (fetchData)="refresh()"
-                    [hasDetails]="true"
-                    (setExpandedRow)="setExpandedRow($event)"
-                    [maxLimit]="25"
-                    (updateSelection)="updateSelection($event)">
-            <cd-table-actions [permission]="permissions.user"
-                              [selection]="selection"
-                              class="table-actions"
-                              id="cluster-actions"
-                              [tableActions]="tableActions">
-            </cd-table-actions>
-            <cd-multi-cluster-details *cdTableDetail
-                                      [permissions]="permissions"
-                                      [selection]="expandedRow">
-            </cd-multi-cluster-details>
-          </cd-table>
-        </ng-template>
-      </ng-container>
-    </nav>
-    <div [ngbNavOutlet]="nav"></div>
+    <cds-tabs
+      type="contained"
+      theme="light">
+      <cds-tab heading="Clusters List">
+        <cd-table #table
+                [data]="data"
+                [columns]="columns"
+                columnMode="flex"
+                selectionType="single"
+                (fetchData)="refresh()"
+                [hasDetails]="true"
+                (setExpandedRow)="setExpandedRow($event)"
+                [maxLimit]="25"
+                (updateSelection)="updateSelection($event)">
+          <cd-table-actions [permission]="permissions.user"
+                            [selection]="selection"
+                            class="table-actions"
+                            id="cluster-actions"
+                            [tableActions]="tableActions">
+          </cd-table-actions>
+          <cd-multi-cluster-details *cdTableDetail
+                                    [permissions]="permissions"
+                                    [selection]="expandedRow">
+          </cd-multi-cluster-details>
+        </cd-table>
+      </cds-tab>
+    </cds-tabs>
   </div>
 </ng-container>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
@@ -1,11 +1,8 @@
-<nav ngbNav
-     #nav="ngbNav"
-     class="nav-tabs">
-  <ng-container ngbNavItem>
-    <a ngbNavLink
-       i18n>Pools List</a>
-    <ng-template ngbNavContent>
-      <cd-table #table
+<cds-tabs
+      type="contained"
+      theme="light">
+      <cds-tab heading="Pools List">
+        <cd-table #table
                 id="pool-list"
                 [data]="pools"
                 [columns]="columns"
@@ -16,39 +13,30 @@
                 (fetchData)="taskListService.fetch()"
                 (setExpandedRow)="setExpandedRow($event)"
                 (updateSelection)="updateSelection($event)">
-        <cd-table-actions id="pool-list-actions"
-                          class="table-actions"
-                          [permission]="permissions.pool"
-                          [selection]="selection"
-                          [tableActions]="tableActions">
-        </cd-table-actions>
-        <cd-pool-details *cdTableDetail
-                         id="pool-list-details"
-                         [selection]="expandedRow"
-                         [permissions]="permissions"
-                         [cacheTiers]="cacheTiers">
-        </cd-pool-details>
-      </cd-table>
-    </ng-template>
-  </ng-container>
-
-  <ng-container ngbNavItem
-                *cdScope="'grafana'">
-    <a ngbNavLink
-       i18n>Overall Performance</a>
-    <ng-template ngbNavContent>
-      <cd-grafana i18n-title
+          <cd-table-actions id="pool-list-actions"
+                            class="table-actions"
+                            [permission]="permissions.pool"
+                            [selection]="selection"
+                            [tableActions]="tableActions">
+          </cd-table-actions>
+          <cd-pool-details *cdTableDetail
+                          id="pool-list-details"
+                          [selection]="expandedRow"
+                          [permissions]="permissions"
+                          [cacheTiers]="cacheTiers">
+          </cd-pool-details>
+        </cd-table>
+      </cds-tab>
+      <cds-tab heading="Overall Performance">
+        <cd-grafana i18n-title
                   title="Ceph pools overview"
                   [grafanaPath]="'ceph-pools-overview?'"
                   [type]="'metrics'"
                   uid="z99hzWtmk"
                   grafanaStyle="two">
-      </cd-grafana>
-    </ng-template>
-  </ng-container>
-</nav>
-
-<div [ngbNavOutlet]="nav"></div>
+        </cd-grafana>
+      </cds-tab>
+    </cds-tabs>
 
 <ng-template #poolUsageTpl
              let-row="data.row">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
@@ -2,6 +2,9 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
+import {
+  TabsModule
+} from 'carbon-components-angular';
 
 import { NgbNavModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 
@@ -24,7 +27,8 @@ import { PoolListComponent } from './pool-list/pool-list.component';
     RouterModule,
     ReactiveFormsModule,
     NgbTooltipModule,
-    BlockModule
+    BlockModule,
+    TabsModule
   ],
   exports: [PoolListComponent, PoolFormComponent],
   declarations: [

--- a/src/pybind/mgr/dashboard/frontend/src/styles/themes/_content.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/themes/_content.scss
@@ -35,7 +35,8 @@ $content-theme: map-merge(
     text-disabled: vv.$gray-500,
     icon-secondary: vv.$body-bg-alt,
     field-01: colors.$gray-10,
-    interactive: vv.$primary
+    interactive: vv.$primary,
+    border-interactive: vv.$primary // for selected tabs
   )
 );
 


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/68257

* Using `contained` type for tabs https://carbondesignsystem.com/components/tabs/usage/#contained-tabs for following list as for tables that fits our usage criteria.
  - multi cluster table
  - pools table

* Top border of selected tab was in carbon primary(blue) so overriding that will dashboard primary.

![Screenshot from 2024-10-16 14-16-28](https://github.com/user-attachments/assets/486374d9-724f-4d8e-8a55-428f14a244a8)
![Screenshot from 2024-10-16 14-16-41](https://github.com/user-attachments/assets/9bd62f7a-fbaf-4608-9800-ece267089b69)

### Todo:
-  a long list


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [x] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
