### PR TITLE
squid: ceph-volume: drop unnecessary call to `get_single_lv()`

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -191,8 +191,7 @@ class Zap(object):
         Device examples: vg-name/lv-name, /dev/vg-name/lv-name
         Requirements: Must be a logical volume (LV)
         """
-        lv = api.get_single_lv(filters={'lv_name': device.lv_name, 'vg_name':
-                                        device.vg_name})
+        lv: api.Volume = device.lv_api
         self.unmount_lv(lv)
 
         zap_device(device.path)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68566

---

backport of https://github.com/ceph/ceph/pull/60055
parent tracker: https://tracker.ceph.com/issues/68312

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh