### PR TITLE
osd/scrub: make sched-targets comparator transitive

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -212,11 +212,8 @@ options:
   long_desc: Use osd_scrub_begin_hour=0 and osd_scrub_end_hour=0 for the entire day.
   fmt_desc: This restricts scrubbing to this hour of the day or later.
     Use ``osd_scrub_begin_hour = 0`` and ``osd_scrub_end_hour = 0``
-    to allow scrubbing the entire day.  Along with ``osd_scrub_end_hour``, they define a time
-    window, in which the scrubs can happen.
-    But a scrub will be performed
-    no matter whether the time window allows or not, as long as the placement
-    group's scrub interval exceeds ``osd_scrub_max_interval``.
+    to allow scrubbing the entire day.  Along with ``osd_scrub_end_hour`` they define a time
+    window, only in which will periodic scrubs be initiated.
   default: 0
   see_also:
   - osd_scrub_end_hour
@@ -228,12 +225,10 @@ options:
   level: advanced
   desc: Restrict scrubbing to hours of the day earlier than this
   long_desc: Use osd_scrub_begin_hour=0 and osd_scrub_end_hour=0 for the entire day.
-  fmt_desc: This restricts scrubbing to the hour earlier than this.
+  fmt_desc: This restricts scrubbing to the hours earlier than this.
     Use ``osd_scrub_begin_hour = 0`` and ``osd_scrub_end_hour = 0`` to allow scrubbing
     for the entire day.  Along with ``osd_scrub_begin_hour``, they define a time
-    window, in which the scrubs can happen. But a scrub will be performed
-    no matter whether the time window allows or not, as long as the placement
-    group's scrub interval exceeds ``osd_scrub_max_interval``.
+    window, only in which can periodic scrubs be automatically initiated.
   default: 0
   see_also:
   - osd_scrub_begin_hour
@@ -250,9 +245,7 @@ options:
     0  = Sunday, 1 = Monday, etc. Use ``osd_scrub_begin_week_day = 0``
     and ``osd_scrub_end_week_day = 0`` to allow scrubbing for the entire week.
     Along with ``osd_scrub_end_week_day``, they define a time window in which
-    scrubs can happen. But a scrub will be performed
-    no matter whether the time window allows or not, when the PG's
-    scrub interval exceeds ``osd_scrub_max_interval``.
+    periodic scrubs can be automatically initiated.
   default: 0
   see_also:
   - osd_scrub_end_week_day
@@ -269,9 +262,7 @@ options:
     0 = Sunday, 1 = Monday, etc.  Use ``osd_scrub_begin_week_day = 0``
     and ``osd_scrub_end_week_day = 0`` to allow scrubbing for the entire week.
     Along with ``osd_scrub_begin_week_day``, they define a time
-    window, in which the scrubs can happen. But a scrub will be performed
-    no matter whether the time window allows or not, as long as the placement
-    group's scrub interval exceeds ``osd_scrub_max_interval``.
+    window, in which periodic scrubs can be automatically initiated.
   default: 0
   see_also:
   - osd_scrub_begin_week_day
@@ -282,8 +273,9 @@ options:
   type: float
   level: advanced
   desc: Allow scrubbing when system load divided by number of CPUs is below this value
-  fmt_desc: The normalized maximum load. Ceph will not scrub when the system load
-    (as defined by ``getloadavg() / number of online CPUs``) is higher than this number.
+  fmt_desc: The normalized maximum load. Ceph will not initiate periodic (regular)
+    scrubs when the system load (as defined by ``getloadavg() / number of online CPUs``)
+    is higher than this number.
     Default is ``0.5``.
   default: 0.5
   with_legacy: true
@@ -292,8 +284,7 @@ options:
   type: float
   level: advanced
   desc: The desired interval between scrubs of a specific PG.
-  fmt_desc: The desired interval in seconds between scrubs of a specific PG
-    when the Ceph Storage Cluster load is low.
+  fmt_desc: The desired interval in seconds between scrubs of a specific PG.
   default: 1_day
   see_also:
   - osd_scrub_max_interval
@@ -303,8 +294,7 @@ options:
   type: float
   level: advanced
   desc: Scrub each PG no less often than this interval
-  fmt_desc: The maximum interval in seconds for scrubbing the Ceph OSD Daemon
-    irrespective of cluster load.
+  fmt_desc: The maximum interval in seconds for scrubbing each PG.
   default: 7_day
   see_also:
   - osd_scrub_min_interval
@@ -315,7 +305,7 @@ options:
   level: advanced
   desc: Ratio of scrub interval to randomly vary
   long_desc: This prevents a scrub 'stampede' by randomly varying the scrub intervals
-    so that they are soon uniformly distributed over the week
+    so that they are uniformly distributed over time.
   fmt_desc: Add a random delay to ``osd_scrub_min_interval`` when scheduling
     the next scrub job for a PG. The delay is a random
     value less than ``osd_scrub_min_interval`` \*

--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -220,8 +220,6 @@ Scrub::OSDRestrictions OsdScrub::restrictions_on_scrubbing(
     env_conditions.restricted_time = !scrub_time_permit(scrub_clock_now);
     env_conditions.cpu_overloaded =
 	!m_load_tracker.scrub_load_below_threshold();
-    env_conditions.only_deadlined =
-	env_conditions.restricted_time || env_conditions.cpu_overloaded;
   }
 
   return env_conditions;

--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -86,8 +86,6 @@ std::optional<Scrub::SchedEntry> ScrubQueue::pop_ready_entry(
     OSDRestrictions restrictions,
     utime_t time_now)
 {
-  /// \todo must handle 'only_deadlined'!
-
   auto eligible_filtr = [&, rst = restrictions](
 				  const SchedEntry& e) -> bool {
       return eligibility_pred(e, rst, time_now);

--- a/src/osd/scrubber/scrub_queue_entry.h
+++ b/src/osd/scrubber/scrub_queue_entry.h
@@ -98,11 +98,6 @@ static inline std::weak_ordering cmp_ripe_entries(
   if (auto cmp = r.urgency <=> l.urgency; cmp != 0) {
     return cmp;
   }
-  // if we are comparing the two targets of the same PG, once both are
-  // ripe - the 'deep' scrub is considered 'higher' than the 'shallow' one.
-  if (l.pgid == r.pgid && r.level < l.level) {
-    return std::weak_ordering::less;
-  }
   // the 'utime_t' operator<=> is 'partial_ordering', it seems.
   if (auto cmp = std::weak_order(
 	  double(l.schedule.scheduled_at), double(r.schedule.scheduled_at));

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -92,10 +92,10 @@ struct OSDRestrictions {
   /// the OSD is performing recovery & osd_repair_during_recovery is 'true'
   bool allow_requested_repair_only:1{false};
 
-  /// the load is high, or the time is not right. For periodic scrubs,
-  /// only the overdue ones are allowed.
-  bool only_deadlined:1{false};
+  /// the CPU load is high. No regular scrubs are allowed.
   bool cpu_overloaded:1{false};
+
+  /// outside of allowed scrubbing hours/days
   bool restricted_time:1{false};
 
   /// the OSD is performing a recovery, osd_scrub_during_recovery is 'false',


### PR DESCRIPTION
The comparator used to sort the scrub targets wasn't transitive, which
can lead to undefined behavior (and likely - to a crash of the _sort_
algorithm in some implementations).  That - due to the clause comparing
the two targets of the same PG.

This commit fixes the comparator.  The sorted queue is no longer
guaranteed to have a ripe deep target before the corresponding
shallow one, which is less than optimal - but it won't crash.

Also included are minor fixes to the - now dead - code involving
overdue scrub jobs. As we no longer allow overdue targets to
ignore time/load constraints, the relevant flag is removed.
The documentation for the relevant configuration
options is fixed to reflect the change.


