### PR TITLE
qa/cephfs: override testing kernel with -k option

### DIFF
--- a/qa/cephfs/begin/3-kernel.yaml
+++ b/qa/cephfs/begin/3-kernel.yaml
@@ -1,0 +1,23 @@
+# When the --kernel option is given to teuthology-suite, the kernel is set for
+# all nodes (also, the kernel is "distro" when the --kernel option is not set).
+# We don't generally want to use a custom kernel for all tests, so unset it.
+# The k-testing.yaml will set it, if given, for only the client nodes.
+#
+# Allow overriding this by using a branch ending in "-all".
+
+teuthology:
+  postmerge:
+    - |
+      local branch = yaml.kernel.branch
+      if branch and not yaml.kernel.branch:find "-all$" then
+        log.debug("removing default kernel specification: %s", yaml.kernel)
+        py_attrgetter(yaml.kernel).pop('branch', nil)
+        py_attrgetter(yaml.kernel).pop('deb', nil)
+        py_attrgetter(yaml.kernel).pop('flavor', nil)
+        py_attrgetter(yaml.kernel).pop('kdb', nil)
+        py_attrgetter(yaml.kernel).pop('koji', nil)
+        py_attrgetter(yaml.kernel).pop('koji_task', nil)
+        py_attrgetter(yaml.kernel).pop('rpm', nil)
+        py_attrgetter(yaml.kernel).pop('sha1', nil)
+        py_attrgetter(yaml.kernel).pop('tag', nil)
+      end

--- a/qa/cephfs/mount/kclient/overrides/distro/testing/k-testing.yaml
+++ b/qa/cephfs/mount/kclient/overrides/distro/testing/k-testing.yaml
@@ -1,3 +1,12 @@
+teuthology:
+  premerge: |
+    log.debug("base kernel %s", base_config.kernel)
+    local kernel = base_config.kernel
+    if kernel.branch ~= "distro" then
+      log.debug("overriding testing kernel with %s", kernel)
+      yaml_fragment.kernel.client = kernel
+    end
+
 kernel:
   client:
     branch: testing

--- a/qa/suites/fs/upgrade/featureful_client/old_client/kernel.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/kernel.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin/3-kernel.yaml

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/kernel.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/kernel.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin/3-kernel.yaml

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/kernel.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/kernel.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin/3-kernel.yaml

--- a/qa/suites/fs/upgrade/nofs/kernel.yaml
+++ b/qa/suites/fs/upgrade/nofs/kernel.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin/3-kernel.yaml

--- a/qa/suites/fs/upgrade/upgraded_client/kernel.yaml
+++ b/qa/suites/fs/upgrade/upgraded_client/kernel.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin/3-kernel.yaml

--- a/qa/suites/fs/workload/begin/3-kernel.yaml
+++ b/qa/suites/fs/workload/begin/3-kernel.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin/3-kernel.yaml


### PR DESCRIPTION
Normally, the fs suite overrides the kernel branch whenever the kernel client
is used, according to the matrix of configs. This prevents easily testing a new
kernel with the -k option to teuthology-suite. So, using the base config passed
to the script, detect if an alternate testing kernel is desired and use that
instead.

The scheduler still needs to do some work:

    $ teuthology-suite ... --verbose -k wip-pdonnell-i66704 --filter k-testing
    ...
    2024-10-18 00:29:43,875.875 DEBUG:teuthology.suite.merge:base kernel {'branch': 'wip-pdonnell-i66704', 'kdb': 1, 'sha1': '745cacd8f31e50d7f3b6039bbd8c9a8dfc07bf03', 'flavor': 'default'}
    2024-10-18 00:29:43,875.875 DEBUG:teuthology.suite.merge:overriding testing kernel with {'branch': 'wip-pdonnell-i66704', 'kdb': 1, 'sha1': '745cacd8f31e50d7f3b6039bbd8c9a8dfc07bf03', 'flavor': 'default'}

vs.

    $ teuthology-suite ... --verbose --filter k-testing
    ...
    2024-10-17 20:04:52,265.265 DEBUG:teuthology.suite.merge:base kernel {'branch': 'distro', 'kdb': 1, 'sha1': 'distro'}

Which will only select jobs using the "testing" kernel.

See-also: https://github.com/ceph/teuthology/pull/2008
Fixes: https://tracker.ceph.com/issues/68603
Signed-off-by: Patrick Donnelly <pdonnell@ibm.com>






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
