### PR TITLE
squid: qa/cephfs: ignore when specific OSD is reported down during upgrade

### DIFF
--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/overrides/ignorelist_upgrade.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/overrides/ignorelist_upgrade.yaml
@@ -3,3 +3,4 @@ overrides:
     log-ignorelist:
       - OSD_DOWN
       - osds down
+      - osd.*is down


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68617

---

backport of https://github.com/ceph/ceph/pull/58486
parent tracker: https://tracker.ceph.com/issues/66877

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh