### PR TITLE
quincy: qa/cephfs: ignore when specific OSD is reported down during upgrade

### DIFF
--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/overrides/ignorelist_upgrade.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/overrides/ignorelist_upgrade.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - OSD_DOWN
+      - osd.*is down


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68618

---

backport of https://github.com/ceph/ceph/pull/58486
parent tracker: https://tracker.ceph.com/issues/66877

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh