### PR TITLE
monitoring: add 2 nvmeof alerts to prometheus_alerts.yaml

### DIFF
--- a/monitoring/ceph-mixin/prometheus_alerts.libsonnet
+++ b/monitoring/ceph-mixin/prometheus_alerts.libsonnet
@@ -936,6 +936,26 @@
           },
         },
         {
+          alert: 'NVMeoFMissingListener',
+          'for': '10m',
+          expr: 'ceph_nvmeof_subsystem_listener_count == 0 and on(nqn) sum(ceph_nvmeof_subsystem_listener_count) by (nqn) > 0',
+          labels: { severity: 'warning', type: 'ceph_default' },
+          annotations: {
+            summary: 'No listener added for {{ $labels.instance }} NVMe-oF Gateway to {{ $labels.nqn }} subsystem',
+            description: 'For every subsystem, each gateway should have a listener to balance traffic between gateways.',
+          },
+        },
+        {
+          alert: 'NVMeoFZeroListenerSubsystem',
+          'for': '10m',
+          expr: 'sum(ceph_nvmeof_subsystem_listener_count) by (nqn) == 0',
+          labels: { severity: 'warning', type: 'ceph_default' },
+          annotations: {
+            summary: 'No listeners added to {{ $labels.nqn }} subsystem',
+            description: 'NVMeoF gateway configuration incomplete; one of the subsystems have zero listeners.',
+          },
+        },
+        {
           alert: 'NVMeoFHighHostCPU',
           'for': '10m',
           expr: '100-((100*(avg by(cluster,host) (label_replace(rate(node_cpu_seconds_total{mode="idle"}[5m]),"host","$1","instance","(.*):.*")) * on(cluster, host) group_right label_replace(ceph_nvmeof_gateway_info,"host","$1","instance","(.*):.*")))) >= %.2f' % [$._config.NVMeoFHighHostCPU],

--- a/monitoring/ceph-mixin/prometheus_alerts.yml
+++ b/monitoring/ceph-mixin/prometheus_alerts.yml
@@ -837,6 +837,24 @@ groups:
         labels:
           severity: "warning"
           type: "ceph_default"
+      - alert: "NVMeoFMissingListener"
+        annotations:
+          description: "For every subsystem, each gateway should have a listener to balance traffic between gateways."
+          summary: "No listener added for {{ $labels.instance }} NVMe-oF Gateway to {{ $labels.nqn }} subsystem"
+        expr: "ceph_nvmeof_subsystem_listener_count == 0 and on(nqn) sum(ceph_nvmeof_subsystem_listener_count) by (nqn) > 0"
+        for: "10m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
+      - alert: "NVMeoFZeroListenerSubsystem"
+        annotations:
+          description: "NVMeoF gateway configuration incomplete; one of the subsystems have zero listeners."
+          summary: "No listeners added to {{ $labels.nqn }} subsystem"
+        expr: "sum(ceph_nvmeof_subsystem_listener_count) by (nqn) == 0"
+        for: "10m"
+        labels:
+          severity: "warning"
+          type: "ceph_default"
       - alert: "NVMeoFHighHostCPU"
         annotations:
           description: "High CPU on a gateway host can lead to CPU contention and performance degradation"

--- a/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
+++ b/monitoring/ceph-mixin/tests_alerts/test_alerts.yml
@@ -2522,6 +2522,75 @@ tests:
         exp_annotations:
           summary: "The number of clients connected to nqn1 is too high on cluster mycluster"
           description: "The supported limit for clients connecting to a subsystem is 32"
+ 
+ # NVMeoFMissingListener
+ - interval: 1m
+   input_series:
+    - series: 'ceph_nvmeof_subsystem_listener_count{nqn="nqn1", instance="node-1:9100"}'
+      values: '0 0 0 0 0 0 0 0 0 0 0'
+    - series: 'ceph_nvmeof_subsystem_listener_count{nqn="nqn1", instance="node-2:9100"}'
+      values: '1 1 1 1 1 1 1 1 1 1 1'
+    - series: 'ceph_nvmeof_subsystem_listener_count{nqn="nqn1", instance="node-3:9100"}'
+      values: '1 1 1 1 1 1 1 1 1 1 1'
+    - series: 'ceph_nvmeof_gateway_info{addr="1.1.1.1", instance="node-1:9100"}'
+      values: '1+0x20'
+    - series: 'ceph_nvmeof_gateway_info{addr="1.1.1.2", instance="node-2:9100"}'
+      values: '1+0x20'
+    - series: 'ceph_nvmeof_gateway_info{addr="1.1.1.3", instance="node-3:9100"}'
+      values: '1+0x20'      
+    - series: 'ceph_nvmeof_gateway_info{addr="1.1.1.4", instance="node-4:9100"}'
+      values: '1+0x20'
+   promql_expr_test:
+     - expr: ceph_nvmeof_subsystem_listener_count == 0 and on(nqn) sum(ceph_nvmeof_subsystem_listener_count) by (nqn) > 0
+       eval_time: 1m
+       exp_samples:
+         - labels: '{__name__="ceph_nvmeof_subsystem_listener_count", instance="node-1:9100", nqn="nqn1"}'
+           value: 0
+   alert_rule_test:
+    - eval_time: 10m
+      alertname: NVMeoFMissingListener
+      exp_alerts:
+      - exp_labels:
+          instance: node-1:9100
+          nqn: nqn1
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          summary: "No listener added for node-1:9100 NVMe-oF Gateway to nqn1 subsystem"
+          description: "For every subsystem, each gateway should have a listener to balance traffic between gateways." 
+
+ # NVMeoFZeroListenerSubsystem
+ - interval: 1m
+   input_series:
+    - series: 'ceph_nvmeof_subsystem_listener_count{nqn="nqn1"}'
+      values: '0 0 0 0 0 0 0 0'
+    - series: 'ceph_nvmeof_subsystem_listener_count{nqn="nqn2"}'
+      values: '0 1 1 1 2 2 3 4'
+    - series: 'ceph_nvmeof_gateway_info{addr="1.1.1.1"}'
+      values: '1+0x20'
+    - series: 'ceph_nvmeof_gateway_info{addr="1.1.1.2"}'
+      values: '1+0x20'
+    - series: 'ceph_nvmeof_gateway_info{addr="1.1.1.3"}'
+      values: '1+0x20'      
+    - series: 'ceph_nvmeof_gateway_info{addr="1.1.1.4"}'
+      values: '1+0x20'
+   promql_expr_test:
+     - expr: ceph_nvmeof_subsystem_listener_count == 0
+       eval_time: 1m
+       exp_samples:
+         - labels: '{__name__="ceph_nvmeof_subsystem_listener_count",nqn="nqn1"}'
+           value: 0
+   alert_rule_test:
+    - eval_time: 10m
+      alertname: NVMeoFZeroListenerSubsystem
+      exp_alerts:
+      - exp_labels:
+          nqn: nqn1
+          severity: warning
+          type: ceph_default
+        exp_annotations:
+          summary: "No listeners added to nqn1 subsystem"
+          description: "NVMeoF gateway configuration incomplete; one of the subsystems have zero listeners."
 
  # NVMeoFHighHostCPU
  - interval: 1m


### PR DESCRIPTION
This PR adds two alerts:
1. `NVMeoFMissingListener`: Raised if a subsystem doesn't have a listener for each gateway.
2. `NVMeoFZeroListenerSubsystem`: Raised if a subsystem has 0 listeners.

Output (alert example): https://github.com/ceph/ceph-nvmeof/issues/565#issuecomment-2468729003
Fixes: https://github.com/ceph/ceph-nvmeof/issues/565


(Test Build: https://shaman.ceph.com/builds/ceph/wip-nvmeof-listeners-prometheus-alerts-debug-centos9-only/56bd5dd029bda9c0824c9723140a22d1bf3491ad/default/415096/)

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
