### PR TITLE
reef: qa/rgw/sts: keycloak task installs java manually

### DIFF
--- a/qa/suites/rgw/sts/tasks/first.yaml
+++ b/qa/suites/rgw/sts/tasks/first.yaml
@@ -9,6 +9,13 @@ tasks:
       rgw_server: client.0
       extra_attrs: ['webidentity_test']
 overrides:
+  install:
+    ceph:
+      extra_system_packages:
+        rpm:
+        - java-17-openjdk-headless
+        deb:
+        - openjdk-17-jdk-headless
   ceph:
     conf:
       client:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/63024

---

backport of https://github.com/ceph/ceph/pull/53608
parent tracker: https://tracker.ceph.com/issues/62536

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh