### PR TITLE
common/perf_counters: enabling 'find()' by logger name

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -538,17 +538,18 @@ int CephContext::_do_command(
     std::string counter;
     cmd_getval(cmdmap, "logger", logger);
     cmd_getval(cmdmap, "counter", counter);
-    _perf_counters_collection->dump_formatted(f, false, false, logger, counter);
+    _perf_counters_collection->dump_formatted(f, false, select_labeled_t::unlabeled,
+                                              logger, counter);
   }
   else if (command == "perfcounters_schema" || command == "2" ||
     command == "perf schema") {
-    _perf_counters_collection->dump_formatted(f, true, false);
+    _perf_counters_collection->dump_formatted(f, true, select_labeled_t::unlabeled);
   }
   else if (command == "counter dump") {
-    _perf_counters_collection->dump_formatted(f, false, true);
+    _perf_counters_collection->dump_formatted(f, false, select_labeled_t::labeled);
   }
   else if (command == "counter schema") {
-    _perf_counters_collection->dump_formatted(f, true, true);
+    _perf_counters_collection->dump_formatted(f, true, select_labeled_t::labeled);
   }
   else if (command == "perf histogram dump") {
     std::string logger;

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -54,6 +54,12 @@ enum unit_t : uint8_t
   UNIT_NONE
 };
 
+/// Used to specify whether to dump the labeled counters
+enum class select_labeled_t {
+  labeled,
+  unlabeled
+};
+
 /* Class for constructing a PerfCounters object.
  *
  * This class performs some validation that the parameters we have supplied are
@@ -249,13 +255,18 @@ public:
   void hinc(int idx, int64_t x, int64_t y);
 
   void reset();
-  void dump_formatted(ceph::Formatter *f, bool schema, bool dump_labeled,
-                      const std::string &counter = "") const {
+  void dump_formatted(
+      ceph::Formatter *f,
+      bool schema,
+      select_labeled_t dump_labeled,
+      const std::string &counter = "") const {
     dump_formatted_generic(f, schema, false, dump_labeled, counter);
   }
-  void dump_formatted_histograms(ceph::Formatter *f, bool schema,
-                                 const std::string &counter = "") const {
-    dump_formatted_generic(f, schema, true, false, counter);
+  void dump_formatted_histograms(
+      ceph::Formatter *f,
+      bool schema,
+      const std::string &counter = "") const {
+    dump_formatted_generic(f, schema, true, select_labeled_t::unlabeled, counter);
   }
   std::pair<uint64_t, uint64_t> get_tavg_ns(int idx) const;
 
@@ -281,7 +292,7 @@ private:
   PerfCounters(const PerfCounters &rhs);
   PerfCounters& operator=(const PerfCounters &rhs);
   void dump_formatted_generic(ceph::Formatter *f, bool schema, bool histograms,
-                              bool dump_labeled,
+                              select_labeled_t dump_labeled,
                               const std::string &counter = "") const;
 
   typedef std::vector<perf_counter_data_any_d> perf_counter_data_vec_t;
@@ -334,16 +345,23 @@ public:
   // a parameter of "all" resets all counters
   bool reset(std::string_view name);
 
-  void dump_formatted(ceph::Formatter *f, bool schema, bool dump_labeled,
-                      const std::string &logger = "",
-                      const std::string &counter = "") const {
-    dump_formatted_generic(f, schema, false, dump_labeled, logger, counter);
+  void dump_formatted(
+      ceph::Formatter *f,
+      bool schema,
+      select_labeled_t dump_labeled,
+      const std::string &logger = "",
+      const std::string &counter = "") const {
+    dump_formatted_generic(
+	f, schema, false, dump_labeled, logger, counter);
   }
 
-  void dump_formatted_histograms(ceph::Formatter *f, bool schema,
-                                 const std::string &logger = "",
-                                 const std::string &counter = "") const {
-    dump_formatted_generic(f, schema, true, false, logger, counter);
+  void dump_formatted_histograms(
+      ceph::Formatter *f,
+      bool schema,
+      const std::string &logger = "",
+      const std::string &counter = "") const {
+    dump_formatted_generic(
+	f, schema, true, select_labeled_t::unlabeled, logger, counter);
   }
 
   // A reference to a perf_counter_data_any_d, with an accompanying
@@ -361,10 +379,13 @@ public:
   void with_counters(std::function<void(const CounterMap &)>) const;
 
 private:
-  void dump_formatted_generic(ceph::Formatter *f, bool schema, bool histograms,
-                              bool dump_labeled,
-                              const std::string &logger = "",
-                              const std::string &counter = "") const;
+  void dump_formatted_generic(
+      Formatter *f,
+      bool schema,
+      bool histograms,
+      select_labeled_t dump_labeled,
+      const std::string &logger,
+      const std::string &counter) const;
 
   perf_counters_set_t m_loggers;
 

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -85,30 +85,30 @@ public:
     PRIO_DEBUGONLY = 0,
   };
   void add_u64(int key, const char *name,
-	       const char *description=NULL, const char *nick = NULL,
+	       const char *description=nullptr, const char *nick = nullptr,
 	       int prio=0, int unit=UNIT_NONE);
   void add_u64_counter(int key, const char *name,
-		       const char *description=NULL,
-		       const char *nick = NULL,
+		       const char *description=nullptr,
+		       const char *nick = nullptr,
 		       int prio=0, int unit=UNIT_NONE);
   void add_u64_avg(int key, const char *name,
-		   const char *description=NULL,
-		   const char *nick = NULL,
+		   const char *description=nullptr,
+		   const char *nick = nullptr,
 		   int prio=0, int unit=UNIT_NONE);
   void add_time(int key, const char *name,
-		const char *description=NULL,
-		const char *nick = NULL,
+		const char *description=nullptr,
+		const char *nick = nullptr,
 		int prio=0);
   void add_time_avg(int key, const char *name,
-		    const char *description=NULL,
-		    const char *nick = NULL,
+		    const char *description=nullptr,
+		    const char *nick = nullptr,
 		    int prio=0);
   void add_u64_counter_histogram(
     int key, const char* name,
     PerfHistogramCommon::axis_config_d x_axis_config,
     PerfHistogramCommon::axis_config_d y_axis_config,
-    const char *description=NULL,
-    const char* nick = NULL,
+    const char *description=nullptr,
+    const char* nick = nullptr,
     int prio=0, int unit=UNIT_NONE);
 
   void set_prio_default(int prio_)
@@ -160,9 +160,9 @@ public:
   /** Represents a PerfCounters data element. */
   struct perf_counter_data_any_d {
     perf_counter_data_any_d()
-      : name(NULL),
-        description(NULL),
-        nick(NULL),
+      : name(nullptr),
+        description(nullptr),
+        nick(nullptr),
 	 type(PERFCOUNTER_NONE),
 	 unit(UNIT_NONE)
     {}

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -305,10 +305,16 @@ private:
   friend class PerfCountersCollectionImpl;
 };
 
-class SortPerfCountersByName {
-public:
+struct SortPerfCountersByName {
+  using is_transparent = void;
   bool operator()(const PerfCounters* lhs, const PerfCounters* rhs) const {
-    return (lhs->get_name() < rhs->get_name());
+    return lhs->get_name() < rhs->get_name();
+  }
+  bool operator()(std::string_view lhs, const PerfCounters* rhs) const {
+    return lhs < rhs->get_name();
+  }
+  bool operator()(const PerfCounters* lhs, std::string_view rhs) const {
+    return lhs->get_name() < rhs;
   }
 };
 
@@ -325,7 +331,8 @@ public:
   void add(PerfCounters *l);
   void remove(PerfCounters *l);
   void clear();
-  bool reset(const std::string &name);
+  // a parameter of "all" resets all counters
+  bool reset(std::string_view name);
 
   void dump_formatted(ceph::Formatter *f, bool schema, bool dump_labeled,
                       const std::string &logger = "",

--- a/src/common/perf_counters_collection.cc
+++ b/src/common/perf_counters_collection.cc
@@ -34,7 +34,7 @@ bool PerfCountersCollection::reset(const std::string &name)
   return perf_impl.reset(name);
 }
 void PerfCountersCollection::dump_formatted(ceph::Formatter *f, bool schema,
-                      bool dump_labeled,
+                      select_labeled_t dump_labeled,
                       const std::string &logger,
                       const std::string &counter)
 {

--- a/src/common/perf_counters_collection.h
+++ b/src/common/perf_counters_collection.h
@@ -20,7 +20,8 @@ public:
   void clear();
   bool reset(const std::string &name);
 
-  void dump_formatted(ceph::Formatter *f, bool schema, bool dump_labeled,
+  void dump_formatted(ceph::Formatter *f, bool schema,
+                      select_labeled_t dump_labeled,
                       const std::string &logger = "",
                       const std::string &counter = "");
   void dump_formatted_histograms(ceph::Formatter *f, bool schema,

--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -279,7 +279,8 @@ public:
     cmd_getval(cmdmap, "logger", logger);
     cmd_getval(cmdmap, "counter", counter);
 
-    crimson::common::local_perf_coll().dump_formatted(f.get(), false, false, logger, counter);
+    crimson::common::local_perf_coll().dump_formatted(f.get(), false,
+      select_labeled_t::unlabeled, logger, counter);
     return seastar::make_ready_future<tell_result_t>(std::move(f));
   }
 };

--- a/src/crimson/common/perf_counters_collection.cc
+++ b/src/crimson/common/perf_counters_collection.cc
@@ -20,7 +20,7 @@ PerfCountersCollectionImpl* PerfCountersCollection:: get_perf_collection()
 }
 
 void PerfCountersCollection::dump_formatted(ceph::Formatter *f, bool schema,
-                                            bool dump_labeled,
+                                            select_labeled_t dump_labeled,
                                             const std::string &logger,
                                             const std::string &counter)
 {

--- a/src/crimson/common/perf_counters_collection.h
+++ b/src/crimson/common/perf_counters_collection.h
@@ -23,7 +23,8 @@ public:
   PerfCountersCollection();
   ~PerfCountersCollection();
   PerfCountersCollectionImpl* get_perf_collection();
-  void dump_formatted(ceph::Formatter *f, bool schema, bool dump_labeled,
+  void dump_formatted(ceph::Formatter *f, bool schema,
+                      select_labeled_t dump_labeled,
                       const std::string &logger = "",
                       const std::string &counter = "");
 };

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1469,7 +1469,7 @@ void RocksDBStore::get_statistics(Formatter *f)
       f->close_section();
     }
     f->open_object_section("rocksdbstore_perf_counters");
-    logger->dump_formatted(f, false, false);
+    logger->dump_formatted(f, false, select_labeled_t::unlabeled);
     f->close_section();
   }
   if (cct->_conf->rocksdb_collect_memory_stats) {

--- a/src/libcephsqlite.cc
+++ b/src/libcephsqlite.cc
@@ -809,8 +809,8 @@ static void f_perf(sqlite3_context* ctx, int argc, sqlite3_value** argv)
   auto&& appd = getdata(vfs);
   JSONFormatter f(false);
   f.open_object_section("ceph_perf");
-  appd.logger->dump_formatted(&f, false, false);
-  appd.striper_logger->dump_formatted(&f, false, false);
+  appd.logger->dump_formatted(&f, false, select_labeled_t::unlabeled);
+  appd.striper_logger->dump_formatted(&f, false, select_labeled_t::unlabeled);
   f.close_section();
   {
     CachedStackStringStream css;

--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -301,7 +301,8 @@ void AbstractWriteLog<I>::log_perf() {
   ss << "\"image\": \"" << m_image_ctx.name << "\",";
   bl.append(ss);
   bl.append("\"stats\": ");
-  m_image_ctx.cct->get_perfcounters_collection()->dump_formatted(f, false, false);
+  m_image_ctx.cct->get_perfcounters_collection()->dump_formatted(
+      f, false, select_labeled_t::unlabeled);
   f->flush(bl);
   bl.append(",\n\"histograms\": ");
   m_image_ctx.cct->get_perfcounters_collection()->dump_formatted_histograms(f, 0);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -625,7 +625,7 @@ uint64_t BlueFS::get_free(unsigned id)
 void BlueFS::dump_perf_counters(Formatter *f)
 {
   f->open_object_section("bluefs_perf_counters");
-  logger->dump_formatted(f, false, false);
+  logger->dump_formatted(f, false, select_labeled_t::unlabeled);
   f->close_section();
 }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3195,7 +3195,7 @@ public:
   int flush_cache(std::ostream *os = NULL) override;
   void dump_perf_counters(ceph::Formatter *f) override {
     f->open_object_section("perf_counters");
-    logger->dump_formatted(f, false, false);
+    logger->dump_formatted(f, false, select_labeled_t::unlabeled);
     f->close_section();
   }
 

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -442,7 +442,7 @@ public:
   }
   void dump_perf_counters(ceph::Formatter *f) override {
     f->open_object_section("perf_counters");
-    logger->dump_formatted(f, false, false);
+    logger->dump_formatted(f, false, select_labeled_t::unlabeled);
     f->close_section();
   }
   void get_db_statistics(ceph::Formatter *f) override {

--- a/src/test/fio/fio_ceph_messenger.cc
+++ b/src/test/fio/fio_ceph_messenger.cc
@@ -132,7 +132,8 @@ static void put_ceph_context(void)
     Formatter* f;
 
     f = Formatter::create("json-pretty");
-    g_ceph_context->get_perfcounters_collection()->dump_formatted(f, false, false);
+    g_ceph_context->get_perfcounters_collection()->dump_formatted(
+	f, false, select_labeled_t::unlabeled);
     ostr << ">>>>>>>>>>>>> PERFCOUNTERS BEGIN <<<<<<<<<<<<" << std::endl;
     f->flush(ostr);
     ostr << ">>>>>>>>>>>>>  PERFCOUNTERS END  <<<<<<<<<<<<" << std::endl;

--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -345,7 +345,8 @@ struct Engine {
       Formatter* f = Formatter::create(
 	"json-pretty", "json-pretty", "json-pretty");
       f->open_object_section("perf_output");
-      cct->get_perfcounters_collection()->dump_formatted(f, false, false);
+      cct->get_perfcounters_collection()->dump_formatted(
+	  f, false, select_labeled_t::unlabeled);
       if (g_conf()->rocksdb_perf) {
 	f->open_object_section("rocksdb_perf");
         os->get_db_statistics(f);

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -4872,7 +4872,8 @@ out:
   if (debug) {
     ostringstream ostr;
     Formatter* f = Formatter::create("json-pretty", "json-pretty", "json-pretty");
-    cct->get_perfcounters_collection()->dump_formatted(f, false, false);
+    cct->get_perfcounters_collection()->dump_formatted(
+	f, false, select_labeled_t::unlabeled);
     ostr << "ceph-objectstore-tool ";
     f->flush(ostr);
     delete f;


### PR DESCRIPTION
Multiple style and performance tweaks. The important one:
Modifying reset() to directly locate the named logger.
As most of the code here predates C++14, "transparent
comparators" were not used. Instead, we looped through
the list of loggers.
With the updated C++ we are using today, the comparator
can be fixed to allow a find() based on the name.

Also: avoiding the use of 3 consecutive 'bool's as arguments to
some dump functions.
