### PR TITLE
msg/async: use io_uring instead of sendmsg()

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -473,6 +473,17 @@ CHECK_C_COMPILER_FLAG("-fvar-tracking-assignments" HAS_VTA)
 add_subdirectory(auth)
 add_subdirectory(common)
 add_subdirectory(crush)
+
+set(DEFAULT_WITH_URING OFF)
+if(LINUX)
+  set(DEFAULT_WITH_URING ON)
+endif(LINUX)
+
+option(WITH_URING "build with io_uring support" ${DEFAULT_WITH_URING})
+if(WITH_URING)
+  add_subdirectory(io/uring)
+endif(WITH_URING)
+
 add_subdirectory(msg)
 add_subdirectory(arch)
 add_subdirectory(extblkdev)
@@ -565,6 +576,10 @@ target_link_libraries(common
 if(WITH_JAEGER)
 add_dependencies(common jaeger_base)
 endif()
+
+if(WITH_URING)
+  target_link_libraries(common io_uring)
+endif(WITH_URING)
 
 if (WIN32)
   # Statically building ceph-common on Windows fails. We're temporarily

--- a/src/io/FileDescriptor.hxx
+++ b/src/io/FileDescriptor.hxx
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// author: Max Kellermann <max.kellermann@gmail.com>
+
+#pragma once
+
+#include <cstddef>
+#include <span>
+#include <utility>
+
+#include <unistd.h>
+#include <sys/types.h>
+
+#ifdef _WIN32
+#include <wchar.h>
+#endif
+
+class UniqueFileDescriptor;
+
+/**
+ * An OO wrapper for a UNIX file descriptor.
+ *
+ * This class is unmanaged and trivial; for a managed version, see
+ * #UniqueFileDescriptor.
+ */
+class FileDescriptor {
+protected:
+	int fd;
+
+public:
+	[[nodiscard]]
+	FileDescriptor() = default;
+
+	[[nodiscard]]
+	explicit constexpr FileDescriptor(int _fd) noexcept:fd(_fd) {}
+
+	constexpr bool operator==(FileDescriptor other) const noexcept {
+		return fd == other.fd;
+	}
+
+	constexpr bool IsDefined() const noexcept {
+		return fd >= 0;
+	}
+
+#ifndef _WIN32
+	/**
+	 * Ask the kernel whether this is a valid file descriptor.
+	 */
+	[[gnu::pure]]
+	bool IsValid() const noexcept;
+
+	/**
+	 * Ask the kernel whether this is a regular file.
+	 */
+	[[gnu::pure]]
+	bool IsRegularFile() const noexcept;
+
+	/**
+	 * Ask the kernel whether this is a pipe.
+	 */
+	[[gnu::pure]]
+	bool IsPipe() const noexcept;
+
+	/**
+	 * Ask the kernel whether this is a socket descriptor.
+	 */
+	[[gnu::pure]]
+	bool IsSocket() const noexcept;
+#endif
+
+	/**
+	 * Returns the file descriptor.  This may only be called if
+	 * IsDefined() returns true.
+	 */
+	constexpr int Get() const noexcept {
+		return fd;
+	}
+
+	void Set(int _fd) noexcept {
+		fd = _fd;
+	}
+
+	[[nodiscard]]
+	int Steal() noexcept {
+		return std::exchange(fd, -1);
+	}
+
+	void SetUndefined() noexcept {
+		fd = -1;
+	}
+
+	[[nodiscard]]
+	static constexpr FileDescriptor Undefined() noexcept {
+		return FileDescriptor(-1);
+	}
+
+#ifdef __linux__
+	[[nodiscard]]
+	bool Open(FileDescriptor dir, const char *pathname,
+		  int flags, mode_t mode=0666) noexcept;
+#endif
+
+	[[nodiscard]]
+	bool Open(const char *pathname, int flags, mode_t mode=0666) noexcept;
+
+#ifdef _WIN32
+	[[nodiscard]]
+	bool Open(const wchar_t *pathname, int flags, mode_t mode=0666) noexcept;
+#endif
+
+	[[nodiscard]]
+	bool OpenReadOnly(const char *pathname) noexcept;
+
+#ifdef __linux__
+	[[nodiscard]]
+	bool OpenReadOnly(FileDescriptor dir,
+			  const char *pathname) noexcept;
+#endif
+
+#ifndef _WIN32
+	[[nodiscard]]
+	bool OpenNonBlocking(const char *pathname) noexcept;
+#endif
+
+#ifdef __linux__
+	[[nodiscard]]
+	static bool CreatePipe(FileDescriptor &r, FileDescriptor &w,
+			       int flags) noexcept;
+#endif
+
+	[[nodiscard]]
+	static bool CreatePipe(FileDescriptor &r, FileDescriptor &w) noexcept;
+
+#ifdef _WIN32
+	void EnableCloseOnExec() const noexcept {}
+	void DisableCloseOnExec() const noexcept {}
+	void SetBinaryMode() const noexcept;
+#else
+	[[nodiscard]]
+	static bool CreatePipeNonBlock(FileDescriptor &r,
+				       FileDescriptor &w) noexcept;
+
+	void SetBinaryMode() const noexcept {}
+
+	/**
+	 * Enable non-blocking mode on this file descriptor.
+	 */
+	void SetNonBlocking() const noexcept;
+
+	/**
+	 * Enable blocking mode on this file descriptor.
+	 */
+	void SetBlocking() const noexcept;
+
+	/**
+	 * Auto-close this file descriptor when a new program is
+	 * executed.
+	 */
+	void EnableCloseOnExec() const noexcept;
+
+	/**
+	 * Do not auto-close this file descriptor when a new program
+	 * is executed.
+	 */
+	void DisableCloseOnExec() const noexcept;
+
+#ifdef __linux__
+	/**
+	 * Set the capacity of the pipe.
+	 *
+	 * This method ignores errors.
+	 */
+	void SetPipeCapacity(unsigned capacity) const noexcept;
+#endif
+
+	/**
+	 * Duplicate this file descriptor.
+	 *
+	 * @return the new file descriptor or UniqueFileDescriptor{}
+	 * on error
+	 */
+	[[nodiscard]]
+	UniqueFileDescriptor Duplicate() const noexcept;
+
+	/**
+	 * Duplicate the file descriptor onto the given file descriptor.
+	 */
+	[[nodiscard]]
+	bool Duplicate(FileDescriptor new_fd) const noexcept {
+		return ::dup2(Get(), new_fd.Get()) != -1;
+	}
+
+	/**
+	 * Similar to Duplicate(), but if destination and source file
+	 * descriptor are equal, clear the close-on-exec flag.  Use
+	 * this method to inject file descriptors into a new child
+	 * process, to be used by a newly executed program.
+	 */
+	bool CheckDuplicate(FileDescriptor new_fd) const noexcept;
+#endif
+
+	/**
+	 * Close the file descriptor.  It should not be called on an
+	 * "undefined" object.  After this call, IsDefined() is guaranteed
+	 * to return false, and this object may be reused.
+	 */
+	bool Close() noexcept {
+		return ::close(Steal()) == 0;
+	}
+
+	/**
+	 * Rewind the pointer to the beginning of the file.
+	 */
+	[[nodiscard]]
+	bool Rewind() const noexcept;
+
+	[[nodiscard]]
+	off_t Seek(off_t offset) const noexcept {
+		return lseek(Get(), offset, SEEK_SET);
+	}
+
+	[[nodiscard]]
+	off_t Skip(off_t offset) const noexcept {
+		return lseek(Get(), offset, SEEK_CUR);
+	}
+
+	[[gnu::pure]]
+	off_t Tell() const noexcept {
+		return lseek(Get(), 0, SEEK_CUR);
+	}
+
+	/**
+	 * Returns the size of the file in bytes, or -1 on error.
+	 */
+	[[gnu::pure]]
+	off_t GetSize() const noexcept;
+
+#ifndef _WIN32
+	[[nodiscard]]
+	ssize_t ReadAt(off_t offset, std::span<std::byte> dest) const noexcept {
+		return ::pread(fd, dest.data(), dest.size(), offset);
+	}
+#endif
+
+	[[nodiscard]]
+	ssize_t Read(std::span<std::byte> dest) const noexcept {
+		return ::read(fd, dest.data(), dest.size());
+	}
+
+	[[nodiscard]]
+	ssize_t Read(void *buffer, std::size_t length) const noexcept {
+		return ::read(fd, buffer, length);
+	}
+
+	/**
+	 * Read until all of the given buffer has been filled.  Throws
+	 * on error.
+	 */
+	void FullRead(std::span<std::byte> dest) const;
+
+#ifndef _WIN32
+	[[nodiscard]]
+	ssize_t WriteAt(off_t offset, std::span<const std::byte> src) const noexcept {
+		return ::pwrite(fd, src.data(), src.size(), offset);
+	}
+#endif
+
+	[[nodiscard]]
+	ssize_t Write(std::span<const std::byte> src) const noexcept {
+		return ::write(fd, src.data(), src.size());
+	}
+
+	[[nodiscard]]
+	ssize_t Write(const void *buffer, std::size_t length) const noexcept {
+		return ::write(fd, buffer, length);
+	}
+
+	/**
+	 * Write until all of the given buffer has been written.
+	 * Throws on error.
+	 */
+	void FullWrite(std::span<const std::byte> src) const;
+
+#ifndef _WIN32
+	[[nodiscard]]
+	int Poll(short events, int timeout) const noexcept;
+
+	[[nodiscard]]
+	int WaitReadable(int timeout) const noexcept;
+
+	[[nodiscard]]
+	int WaitWritable(int timeout) const noexcept;
+
+	[[gnu::pure]]
+	bool IsReadyForWriting() const noexcept;
+#endif
+};

--- a/src/io/uring/CMakeLists.txt
+++ b/src/io/uring/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(io_uring STATIC Ring.cxx Queue.cxx Operation.cxx)
+
+pkg_check_modules(LIBURING REQUIRED liburing)
+target_link_libraries(io_uring ${LIBURING_LIBRARIES})
+target_include_directories(io_uring PUBLIC ${LIBURING_INCLUDE_DIRS})
+target_compile_options(io_uring PUBLIC ${LIBURING_CFLAGS_OTHER})

--- a/src/io/uring/CancellableOperation.hxx
+++ b/src/io/uring/CancellableOperation.hxx
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Copyright CM4all GmbH
+// author: Max Kellermann <mk@cm4all.com>
+
+#pragma once
+
+#include "Operation.hxx"
+#include "util/IntrusiveList.hxx"
+
+#include <cassert>
+#include <utility>
+
+namespace Uring {
+
+class CancellableOperation
+	: public IntrusiveListHook<IntrusiveHookMode::NORMAL>
+{
+	Operation *operation;
+
+public:
+	CancellableOperation(Operation &_operation) noexcept
+		:operation(&_operation)
+	{
+		assert(operation->cancellable == nullptr);
+		operation->cancellable = this;
+	}
+
+	~CancellableOperation() noexcept {
+		assert(operation == nullptr);
+	}
+
+	void Cancel(Operation &_operation) noexcept {
+		(void)_operation;
+		assert(operation == &_operation);
+
+		operation = nullptr;
+
+		// TODO: io_uring_prep_cancel()
+	}
+
+	void Replace(Operation &old_operation,
+		     Operation &new_operation) noexcept {
+		assert(operation == &old_operation);
+		assert(old_operation.cancellable == this);
+
+		old_operation.cancellable = nullptr;
+		operation = &new_operation;
+		new_operation.cancellable = this;
+	}
+
+	void OnUringCompletion(int res) noexcept {
+		if (operation == nullptr)
+			return;
+
+		assert(operation->cancellable == this);
+		operation->cancellable = nullptr;
+
+		std::exchange(operation, nullptr)->OnUringCompletion(res);
+	}
+};
+
+} // namespace Uring

--- a/src/io/uring/Operation.cxx
+++ b/src/io/uring/Operation.cxx
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Copyright CM4all GmbH
+// author: Max Kellermann <mk@cm4all.com>
+
+#include "Operation.hxx"
+#include "CancellableOperation.hxx"
+
+#include <cassert>
+#include <utility>
+
+namespace Uring {
+
+void
+Operation::CancelUring() noexcept
+{
+	if (cancellable == nullptr)
+		return;
+
+	std::exchange(cancellable, nullptr)->Cancel(*this);
+}
+
+void
+Operation::ReplaceUring(Operation &new_operation) noexcept
+{
+	assert(IsUringPending());
+
+	cancellable->Replace(*this, new_operation);
+
+	assert(cancellable == nullptr);
+}
+
+} // namespace Uring

--- a/src/io/uring/Operation.hxx
+++ b/src/io/uring/Operation.hxx
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Copyright CM4all GmbH
+// author: Max Kellermann <mk@cm4all.com>
+
+#pragma once
+
+namespace Uring {
+
+class CancellableOperation;
+
+/**
+ * An asynchronous I/O operation to be queued in a #Queue instance.
+ */
+class Operation {
+	friend class CancellableOperation;
+
+	CancellableOperation *cancellable = nullptr;
+
+public:
+	Operation() noexcept = default;
+
+	~Operation() noexcept {
+		CancelUring();
+	}
+
+	Operation(const Operation &) = delete;
+	Operation &operator=(const Operation &) = delete;
+
+	/**
+	 * Are we waiting for the operation to complete?
+	 */
+	bool IsUringPending() const noexcept {
+		return cancellable != nullptr;
+	}
+
+	/**
+	 * Cancel the operation.  OnUringCompletion() will not be
+	 * invoked.  This is a no-op if none is pending.
+	 */
+	void CancelUring() noexcept;
+
+	/**
+	 * Replace this pending operation with a new one.  This method
+	 * is only legal if IsUringPending().
+	 */
+	void ReplaceUring(Operation &new_operation) noexcept;
+
+	/**
+	 * This method is called when the operation completes.
+	 *
+	 * @param res the result code; the meaning is specific to the
+	 * operation, but negative values usually mean an error has
+	 * occurred
+	 */
+	virtual void OnUringCompletion(int res) noexcept = 0;
+};
+
+} // namespace Uring

--- a/src/io/uring/Queue.cxx
+++ b/src/io/uring/Queue.cxx
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Copyright CM4all GmbH
+// author: Max Kellermann <mk@cm4all.com>
+
+#include "Queue.hxx"
+#include "CancellableOperation.hxx"
+#include "util/DeleteDisposer.hxx"
+
+#include <stdexcept>
+
+namespace Uring {
+
+Queue::Queue(unsigned entries, unsigned flags)
+	:ring(entries, flags)
+{
+}
+
+Queue::~Queue() noexcept
+{
+	operations.clear_and_dispose(DeleteDisposer{});
+}
+
+struct io_uring_sqe &
+Queue::RequireSubmitEntry()
+{
+	auto *sqe = GetSubmitEntry();
+	if (sqe == nullptr) {
+		/* the submit queue is full; submit it to the kernel
+		   and try again */
+		ring.Submit();
+
+		sqe = GetSubmitEntry();
+		if (sqe == nullptr)
+			throw std::runtime_error{"io_uring_get_sqe() failed"};
+	}
+
+	return *sqe;
+}
+
+void
+Queue::AddPending(struct io_uring_sqe &sqe,
+		  Operation &operation) noexcept
+{
+	auto *c = new CancellableOperation(operation);
+	operations.push_back(*c);
+	io_uring_sqe_set_data(&sqe, c);
+}
+
+void
+Queue::DispatchOneCompletion(struct io_uring_cqe &cqe) noexcept
+{
+	void *data = io_uring_cqe_get_data(&cqe);
+	if (data != nullptr) {
+		auto *c = (CancellableOperation *)data;
+		c->OnUringCompletion(cqe.res);
+		c->unlink();
+		delete c;
+	}
+
+	ring.SeenCompletion(cqe);
+}
+
+bool
+Queue::DispatchOneCompletion()
+{
+	auto *cqe = ring.PeekCompletion();
+	if (cqe == nullptr)
+		return false;
+
+	DispatchOneCompletion(*cqe);
+	return true;
+}
+
+bool
+Queue::WaitDispatchOneCompletion()
+{
+	auto *cqe = ring.WaitCompletion();
+	if (cqe == nullptr)
+		return false;
+
+	DispatchOneCompletion(*cqe);
+	return true;
+}
+
+} // namespace Uring

--- a/src/io/uring/Queue.hxx
+++ b/src/io/uring/Queue.hxx
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Copyright CM4all GmbH
+// author: Max Kellermann <mk@cm4all.com>
+
+#pragma once
+
+#include "Ring.hxx"
+#include "util/IntrusiveList.hxx"
+
+#include <liburing.h>
+
+namespace Uring {
+
+class Operation;
+class CancellableOperation;
+
+/**
+ * High-level C++ wrapper for a `struct io_uring`.  It supports a
+ * handler class, cancellation, ...
+ */
+class Queue {
+	Ring ring;
+
+	IntrusiveList<CancellableOperation> operations;
+
+public:
+	Queue(unsigned entries, unsigned flags);
+	~Queue() noexcept;
+
+	FileDescriptor GetFileDescriptor() const noexcept {
+		return ring.GetFileDescriptor();
+	}
+
+	struct io_uring_sqe *GetSubmitEntry() noexcept {
+		return ring.GetSubmitEntry();
+	}
+
+	/**
+	 * Like GetSubmitEntry(), but call Submit() if the submit
+	 * queue is full.
+	 *
+	 * May throw exceptions if Submit() fails.
+	 */
+	struct io_uring_sqe &RequireSubmitEntry();
+
+	bool HasPending() const noexcept {
+		return !operations.empty();
+	}
+
+protected:
+	void AddPending(struct io_uring_sqe &sqe,
+			Operation &operation) noexcept;
+
+public:
+	void Push(struct io_uring_sqe &sqe,
+		  Operation &operation) noexcept {
+		AddPending(sqe, operation);
+		Submit();
+	}
+
+	virtual void Submit() {
+		ring.Submit();
+	}
+
+	bool DispatchOneCompletion();
+
+	void DispatchCompletions() {
+		while (DispatchOneCompletion()) {}
+	}
+
+	bool WaitDispatchOneCompletion();
+
+	void WaitDispatchCompletions() {
+		while (WaitDispatchOneCompletion()) {}
+	}
+
+private:
+	void DispatchOneCompletion(struct io_uring_cqe &cqe) noexcept;
+};
+
+} // namespace Uring

--- a/src/io/uring/Ring.cxx
+++ b/src/io/uring/Ring.cxx
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Copyright CM4all GmbH
+// author: Max Kellermann <mk@cm4all.com>
+
+#include "Ring.hxx"
+#include "system/Error.hxx"
+
+namespace Uring {
+
+Ring::Ring(unsigned entries, unsigned flags)
+{
+	int error = io_uring_queue_init(entries, &ring, flags);
+	if (error < 0)
+		throw MakeErrno(-error, "io_uring_queue_init() failed");
+}
+
+void
+Ring::Submit()
+{
+	int error = io_uring_submit(&ring);
+	if (error < 0)
+		throw MakeErrno(-error, "io_uring_submit() failed");
+}
+
+struct io_uring_cqe *
+Ring::WaitCompletion()
+{
+	struct io_uring_cqe *cqe;
+	int error = io_uring_wait_cqe(&ring, &cqe);
+	if (error < 0) {
+		if (error == -EAGAIN)
+			return nullptr;
+
+		throw MakeErrno(-error, "io_uring_wait_cqe() failed");
+	}
+
+	return cqe;
+}
+
+struct io_uring_cqe *
+Ring::PeekCompletion()
+{
+	struct io_uring_cqe *cqe;
+	int error = io_uring_peek_cqe(&ring, &cqe);
+	if (error < 0) {
+		if (error == -EAGAIN)
+			return nullptr;
+
+		throw MakeErrno(-error, "io_uring_peek_cqe() failed");
+	}
+
+	return cqe;
+}
+
+} // namespace Uring

--- a/src/io/uring/Ring.hxx
+++ b/src/io/uring/Ring.hxx
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Copyright CM4all GmbH
+// author: Max Kellermann <mk@cm4all.com>
+
+#pragma once
+
+#include "io/FileDescriptor.hxx"
+
+#include <liburing.h>
+
+namespace Uring {
+
+/**
+ * Low-level C++ wrapper for a `struct io_uring`.  It provides simple
+ * wrappers to liburing functions and throws std::system_error on
+ * errors.
+ */
+class Ring {
+	struct io_uring ring;
+
+public:
+	Ring(unsigned entries, unsigned flags);
+
+	~Ring() noexcept {
+		io_uring_queue_exit(&ring);
+	}
+
+	Ring(const Ring &) = delete;
+	Ring &operator=(const Ring &) = delete;
+
+	FileDescriptor GetFileDescriptor() const noexcept {
+		return FileDescriptor(ring.ring_fd);
+	}
+
+	struct io_uring_sqe *GetSubmitEntry() noexcept {
+		return io_uring_get_sqe(&ring);
+	}
+
+	void Submit();
+
+	struct io_uring_cqe *WaitCompletion();
+
+	/**
+	 * @return a completion queue entry or nullptr on EAGAIN
+	 */
+	struct io_uring_cqe *PeekCompletion();
+
+	void SeenCompletion(struct io_uring_cqe &cqe) noexcept {
+		io_uring_cqe_seen(&ring, &cqe);
+	}
+};
+
+} // namespace Uring

--- a/src/msg/CMakeLists.txt
+++ b/src/msg/CMakeLists.txt
@@ -44,6 +44,10 @@ if(HAVE_RDMA)
     async/rdma/RDMAStack.cc)
 endif()
 
+if(WITH_URING)
+  list(APPEND msg_srcs async/UringManager.cc)
+endif(WITH_URING)
+
 add_library(common-msg-objs OBJECT ${msg_srcs})
 target_compile_definitions(common-msg-objs PRIVATE
   $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)
@@ -51,6 +55,10 @@ target_include_directories(common-msg-objs PRIVATE ${OPENSSL_INCLUDE_DIR})
 target_link_libraries(common-msg-objs
   PUBLIC
     legacy-option-headers)
+
+if(WITH_URING)
+  target_compile_definitions(common-msg-objs PUBLIC WITH_URING=1)
+endif(WITH_URING)
 
 if(WITH_DPDK)
   set(async_dpdk_srcs

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -36,6 +36,10 @@
 #include "Event.h"
 #include "Stack.h"
 
+#ifdef WITH_URING
+#include "util/IntrusiveList.hxx"
+#endif
+
 class AsyncMessenger;
 class DispatchQueue;
 class Worker;
@@ -182,6 +186,12 @@ public:
 private:
 
   DispatchQueue *dispatch_queue;
+
+#ifdef WITH_URING
+  class SendOperation;
+  IntrusiveList<SendOperation> send_operations;
+  void OnSendComplete(SendOperation &operation, int res) noexcept;
+#endif
 
   // lockfree, only used in own thread
   ceph::buffer::list outgoing_bl;

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -53,6 +53,7 @@
 #define EVENT_READABLE 1
 #define EVENT_WRITABLE 2
 
+class UringManager;
 class EventCenter;
 
 class EventCallback {
@@ -176,6 +177,10 @@ class EventCenter {
   unsigned center_id;
   AssociatedCenters *global_centers = nullptr;
 
+#ifdef WITH_URING
+  std::unique_ptr<UringManager> uring;
+#endif
+
   int process_time_events();
   FileEvent *_get_file_event(int fd) {
     ceph_assert(fd < nevent);
@@ -198,6 +203,11 @@ class EventCenter {
   unsigned get_id() const { return center_id; }
 
   EventDriver *get_driver() { return driver; }
+
+#ifdef WITH_URING
+  [[gnu::pure]]
+  UringManager *get_uring() noexcept;
+#endif
 
   // Used by internal thread
   int create_file_event(int fd, int mask, EventCallbackRef ctxt);

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -318,7 +318,11 @@ void ProtocolV1::write_event() {
     bool more;
     do {
       if (connection->is_queued()) {
-	if (r = connection->_try_send(); r!= 0) {
+	connection->write_lock.unlock();
+	r = connection->_try_send();
+	connection->write_lock.lock();
+
+	if (r!= 0) {
 	  // either fails to send or not all queued buffer is sent
 	  break;
 	}

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -1179,17 +1179,6 @@ ssize_t ProtocolV1::write_message(Message *m, ceph::buffer::list &bl, bool more)
   m->trace.event("async writing message");
   ldout(cct, 2) << __func__ << " sending message m=" << m
                 << " seq=" << m->get_seq() << " " << *m << dendl;
-  ssize_t total_send_size = connection->outgoing_bl.length();
-  ssize_t rc = connection->_try_send(more);
-  if (rc < 0) {
-    ldout(cct, 1) << __func__ << " error sending " << m << ", "
-                  << cpp_strerror(rc) << dendl;
-  } else {
-    connection->logger->inc(
-        l_msgr_send_bytes, total_send_size - connection->outgoing_bl.length());
-    ldout(cct, 10) << __func__ << " sending " << m
-                   << (rc ? " continuely." : " done.") << dendl;
-  }
 
 #if defined(WITH_EVENTTRACE)
   if (m->get_type() == CEPH_MSG_OSD_OP)
@@ -1199,7 +1188,7 @@ ssize_t ProtocolV1::write_message(Message *m, ceph::buffer::list &bl, bool more)
 #endif
   m->put();
 
-  return rc;
+  return 0;
 }
 
 void ProtocolV1::requeue_sent() {

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -660,7 +660,10 @@ void ProtocolV2::write_event() {
     bool more;
     do {
       if (connection->is_queued()) {
-	if (r = connection->_try_send(); r!= 0) {
+	connection->write_lock.unlock();
+	r = connection->_try_send();
+	connection->write_lock.lock();
+	if (r!= 0) {
 	  // either fails to send or not all queued buffer is sent
 	  break;
 	}

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -559,20 +559,6 @@ ssize_t ProtocolV2::write_message(Message *m, bool more) {
                  << " src=" << entity_name_t(messenger->get_myname())
                  << " off=" << header2.data_off
                  << dendl;
-  ssize_t total_send_size = connection->outgoing_bl.length();
-  ssize_t rc = connection->_try_send(more);
-  if (rc < 0) {
-    ldout(cct, 1) << __func__ << " error sending " << m << ", "
-                  << cpp_strerror(rc) << dendl;
-  } else {
-    const auto sent_bytes = total_send_size - connection->outgoing_bl.length();
-    connection->logger->inc(l_msgr_send_bytes, sent_bytes);
-    if (session_stream_handlers.tx) {
-      connection->logger->inc(l_msgr_send_encrypted_bytes, sent_bytes);
-    }
-    ldout(cct, 10) << __func__ << " sending " << m
-                   << (rc ? " continuely." : " done.") << dendl;
-  }
 
 #if defined(WITH_EVENTTRACE)
   if (m->get_type() == CEPH_MSG_OSD_OP)
@@ -582,7 +568,7 @@ ssize_t ProtocolV2::write_message(Message *m, bool more) {
 #endif
   m->put();
 
-  return rc;
+  return 0;
 }
 
 template <class F>

--- a/src/msg/async/UringManager.cc
+++ b/src/msg/async/UringManager.cc
@@ -1,0 +1,72 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2014 UnitedStack <haomai@unitedstack.com>
+ *
+ * Author: Haomai Wang <haomaiwang@gmail.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "UringManager.h"
+#include "Event.h"
+
+class UringManager::SubmitCallback final : public EventCallback {
+  UringManager &uring;
+
+public:
+  explicit SubmitCallback(UringManager &_uring) noexcept:uring(_uring) {}
+
+  void do_request(uint64_t fd_or_id) override {
+    uring.submit_timer_id = 0;
+    uring.DoSubmit();
+  }
+};
+
+class UringManager::CompletionCallback final : public EventCallback {
+  UringManager &uring;
+
+public:
+  explicit CompletionCallback(UringManager &_uring) noexcept:uring(_uring) {}
+
+  void do_request(uint64_t fd_or_id) override {
+    uring.DispatchCompletions();
+  }
+};
+
+UringManager::UringManager(EventCenter &_center)
+  :Uring::Queue(1024, IORING_SETUP_SUBMIT_ALL|IORING_SETUP_COOP_TASKRUN|IORING_SETUP_TASKRUN_FLAG|IORING_SETUP_SINGLE_ISSUER|IORING_SETUP_DEFER_TASKRUN), center(_center),
+   submit_handler(new SubmitCallback(*this)),
+   completion_handler(new CompletionCallback(*this))
+{
+  center.create_file_event(GetFileDescriptor().Get(), EVENT_READABLE, completion_handler);
+}
+
+UringManager::~UringManager() noexcept
+{
+  center.delete_file_event(GetFileDescriptor().Get(), EVENT_READABLE);
+  delete submit_handler;
+
+  if (submit_timer_id != 0)
+    center.delete_time_event(submit_timer_id);
+  delete completion_handler;
+}
+
+void UringManager::Submit() {
+  if (submit_timer_id != 0)
+    return;
+
+  submit_timer_id = center.create_time_event(0, submit_handler);
+}
+
+inline void UringManager::DoSubmit() noexcept try {
+  Uring::Queue::Submit();
+} catch (...) {
+  // TODO?
+}

--- a/src/msg/async/UringManager.h
+++ b/src/msg/async/UringManager.h
@@ -1,0 +1,45 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2014 UnitedStack <haomai@unitedstack.com>
+ *
+ * Author: Haomai Wang <haomaiwang@gmail.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_URING_MANAGER_H
+#define CEPH_URING_MANAGER_H
+
+#include "Event.h"
+#include "io/uring/Queue.hxx"
+
+class EventCenter;
+
+class UringManager final : public Uring::Queue {
+  EventCenter &center;
+
+  class SubmitCallback;
+  class CompletionCallback;
+  const EventCallbackRef submit_handler, completion_handler;
+
+  uint64_t submit_timer_id = 0;
+
+public:
+  explicit UringManager(EventCenter &_center);
+  ~UringManager() noexcept;
+
+  // virtual methods from class Uring::Queue
+  void Submit() override;
+
+private:
+  void DoSubmit() noexcept;
+};
+
+#endif

--- a/src/system/Error.hxx
+++ b/src/system/Error.hxx
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// author: Max Kellermann <max.kellermann@gmail.com>
+
+#pragma once
+
+#include <system_error> // IWYU pragma: export
+#include <utility>
+
+#ifdef _WIN32
+
+#include <errhandlingapi.h> // for GetLastError()
+#include <winerror.h>
+
+/**
+ * Returns the error_category to be used to wrap WIN32 GetLastError()
+ * values.  The C++ standard does not define this well, and this value
+ * is mostly guessed.
+ *
+ * TODO: verify
+ */
+[[gnu::const]]
+static inline const std::error_category &
+LastErrorCategory() noexcept
+{
+	return std::system_category();
+}
+
+[[gnu::pure]]
+inline bool
+IsLastError(const std::system_error &e, DWORD code) noexcept
+{
+	return e.code().category() == LastErrorCategory() &&
+		(DWORD)e.code().value() == code;
+}
+
+static inline std::system_error
+MakeLastError(DWORD code, const char *msg) noexcept
+{
+	return std::system_error(std::error_code(code, LastErrorCategory()),
+				 msg);
+}
+
+static inline std::system_error
+MakeLastError(const char *msg) noexcept
+{
+	return MakeLastError(GetLastError(), msg);
+}
+
+#endif /* _WIN32 */
+
+#include <cerrno> // IWYU pragma: export
+
+/**
+ * Returns the error_category to be used to wrap errno values.  The
+ * C++ standard does not define this well, so this code is based on
+ * observations what C++ standard library implementations actually
+ * use.
+ *
+ * @see https://stackoverflow.com/questions/28746372/system-error-categories-and-standard-system-error-codes
+ */
+[[gnu::const]]
+static inline const std::error_category &
+ErrnoCategory() noexcept
+{
+#ifdef _WIN32
+	/* on Windows, the generic_category() is used for errno
+	   values */
+	return std::generic_category();
+#else
+	/* on POSIX, system_category() appears to be the best
+	   choice */
+	return std::system_category();
+#endif
+}
+
+static inline std::system_error
+MakeErrno(int code, const char *msg) noexcept
+{
+	return std::system_error(std::error_code(code, ErrnoCategory()),
+				 msg);
+}
+
+static inline std::system_error
+MakeErrno(const char *msg) noexcept
+{
+	return MakeErrno(errno, msg);
+}
+
+[[gnu::pure]]
+inline bool
+IsErrno(const std::system_error &e, int code) noexcept
+{
+	return e.code().category() == ErrnoCategory() &&
+		e.code().value() == code;
+}
+
+[[gnu::pure]]
+static inline bool
+IsFileNotFound(const std::system_error &e) noexcept
+{
+#ifdef _WIN32
+	return IsLastError(e, ERROR_FILE_NOT_FOUND);
+#else
+	return IsErrno(e, ENOENT);
+#endif
+}
+
+[[gnu::pure]]
+static inline bool
+IsPathNotFound(const std::system_error &e) noexcept
+{
+#ifdef _WIN32
+	return IsLastError(e, ERROR_PATH_NOT_FOUND);
+#else
+	return IsErrno(e, ENOTDIR);
+#endif
+}
+
+[[gnu::pure]]
+static inline bool
+IsAccessDenied(const std::system_error &e) noexcept
+{
+#ifdef _WIN32
+	return IsLastError(e, ERROR_ACCESS_DENIED);
+#else
+	return IsErrno(e, EACCES);
+#endif
+}

--- a/src/util/Cast.hxx
+++ b/src/util/Cast.hxx
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// author: Max Kellermann <max.kellermann@gmail.com>
+
+#pragma once
+
+#include "OffsetPointer.hxx"
+
+#include <cstddef>
+
+template<typename T, typename U>
+constexpr T *
+OffsetCast(U *p, std::ptrdiff_t offset)
+{
+	return reinterpret_cast<T *>(OffsetPointer(p, offset));
+}
+
+template<typename T, typename U>
+constexpr T *
+OffsetCast(const U *p, std::ptrdiff_t offset)
+{
+	return reinterpret_cast<const T *>(OffsetPointer(p, offset));
+}
+
+template<class C, class A>
+constexpr std::ptrdiff_t
+ContainerAttributeOffset(const C *null_c, const A C::*p)
+{
+	return std::ptrdiff_t((const char *)&(null_c->*p) - (const char *)null_c);
+}
+
+template<class C, class A>
+constexpr std::ptrdiff_t
+ContainerAttributeOffset(const A C::*p)
+{
+	return ContainerAttributeOffset<C, A>(nullptr, p);
+}
+
+/**
+ * Cast the given pointer to a struct member to its parent structure.
+ */
+template<class C, class A>
+constexpr C &
+ContainerCast(A &a, const A C::*member)
+{
+	return *OffsetCast<C, A>(&a, -ContainerAttributeOffset<C, A>(member));
+}
+
+/**
+ * Cast the given pointer to a struct member to its parent structure.
+ */
+template<class C, class A>
+constexpr const C &
+ContainerCast(const A &a, const A C::*member)
+{
+	return *OffsetCast<const C, const A>(&a, -ContainerAttributeOffset<C, A>(member));
+}

--- a/src/util/Concepts.hxx
+++ b/src/util/Concepts.hxx
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// author: Max Kellermann <max.kellermann@gmail.com>
+
+#pragma once
+
+#include <concepts>
+
+template<typename F, typename T>
+concept Disposer = std::invocable<F, T *>;

--- a/src/util/DeleteDisposer.hxx
+++ b/src/util/DeleteDisposer.hxx
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// author: Max Kellermann <max.kellermann@gmail.com>
+
+#pragma once
+
+/**
+ * A disposer for boost::intrusive that invokes the "delete" operator
+ * on the given pointer.
+ */
+class DeleteDisposer {
+public:
+	template<typename T>
+	void operator()(T *t) const noexcept {
+		delete t;
+	}
+};

--- a/src/util/IntrusiveHookMode.hxx
+++ b/src/util/IntrusiveHookMode.hxx
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// author: Max Kellermann <max.kellermann@gmail.com>
+
+#pragma once
+
+/**
+ * Specifies the mode in which a hook for intrusive containers
+ * operates.  This is meant to be used as a template argument to the
+ * hook class (e.g. #IntrusiveListHook).
+ */
+enum class IntrusiveHookMode {
+	/**
+	 * No implicit initialization.
+	 */
+	NORMAL,
+
+	/**
+	 * Keep track of whether the item is currently linked, allows
+	 * using method is_linked().  This requires implicit
+	 * initialization and requires iterating all items when
+	 * deleting them which adds a considerable amount of overhead.
+	 */
+	TRACK,
+
+	/**
+	 * Automatically unlinks the item in the destructor.  This
+	 * implies #TRACK and adds code to the destructor.
+	 */
+	AUTO_UNLINK,
+};

--- a/src/util/IntrusiveList.hxx
+++ b/src/util/IntrusiveList.hxx
@@ -1,0 +1,653 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// author: Max Kellermann <max.kellermann@gmail.com>
+
+#pragma once
+
+#include "Cast.hxx"
+#include "Concepts.hxx"
+#include "IntrusiveHookMode.hxx" // IWYU pragma: export
+#include "MemberPointer.hxx"
+#include "OptionalCounter.hxx"
+
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+/**
+ * Template parameter for #IntrusiveList with compile-time options.
+ */
+struct IntrusiveListOptions {
+	/**
+	 * @param constant_time_size make size() constant-time by caching the
+	 * number of items in a field?
+	 */
+	bool constant_time_size = false;
+
+	/**
+	 * Initialize the list head with nullptr (all zeroes) which
+	 * adds some code for checking nullptr, but may reduce the
+	 * data section for statically allocated lists.  It's a
+	 * trade-off.
+	 */
+	bool zero_initialized = false;
+};
+
+struct IntrusiveListNode {
+	IntrusiveListNode *next, *prev;
+
+	static constexpr void Connect(IntrusiveListNode &a,
+				      IntrusiveListNode &b) noexcept {
+		a.next = &b;
+		b.prev = &a;
+	}
+};
+
+/**
+ * @param Tag an arbitrary tag type to allow using multiple base hooks
+ */
+template<IntrusiveHookMode _mode=IntrusiveHookMode::NORMAL,
+	 typename Tag=void>
+class IntrusiveListHook {
+	template<typename, typename> friend struct IntrusiveListBaseHookTraits;
+	template<auto member> friend struct IntrusiveListMemberHookTraits;
+	template<typename T, typename HookTraits, IntrusiveListOptions> friend class IntrusiveList;
+
+protected:
+	IntrusiveListNode siblings;
+
+public:
+	static constexpr IntrusiveHookMode mode = _mode;
+
+	IntrusiveListHook() noexcept {
+		if constexpr (mode >= IntrusiveHookMode::TRACK)
+			siblings.next = nullptr;
+	}
+
+	~IntrusiveListHook() noexcept {
+		if constexpr (mode >= IntrusiveHookMode::AUTO_UNLINK)
+			if (is_linked())
+				unlink();
+	}
+
+	IntrusiveListHook(const IntrusiveListHook &) = delete;
+	IntrusiveListHook &operator=(const IntrusiveListHook &) = delete;
+
+	void unlink() noexcept {
+		IntrusiveListNode::Connect(*siblings.prev, *siblings.next);
+
+		if constexpr (mode >= IntrusiveHookMode::TRACK)
+			siblings.next = nullptr;
+	}
+
+	bool is_linked() const noexcept
+		requires(mode >= IntrusiveHookMode::TRACK) {
+		return siblings.next != nullptr;
+	}
+
+private:
+	static constexpr auto &Cast(IntrusiveListNode &node) noexcept {
+		return ContainerCast(node, &IntrusiveListHook::siblings);
+	}
+
+	static constexpr const auto &Cast(const IntrusiveListNode &node) noexcept {
+		return ContainerCast(node, &IntrusiveListHook::siblings);
+	}
+};
+
+using SafeLinkIntrusiveListHook =
+	IntrusiveListHook<IntrusiveHookMode::TRACK>;
+using AutoUnlinkIntrusiveListHook =
+	IntrusiveListHook<IntrusiveHookMode::AUTO_UNLINK>;
+
+/**
+ * For classes which embed #IntrusiveListHook as base class.
+ *
+ * @param Tag selector for which #IntrusiveHashSetHook to use
+ */
+template<typename T, typename Tag=void>
+struct IntrusiveListBaseHookTraits {
+	/* a never-called helper function which is used by _Cast() */
+	template<IntrusiveHookMode mode>
+	static constexpr IntrusiveListHook<mode, Tag> _Identity(const IntrusiveListHook<mode, Tag> &) noexcept;
+
+	/* another never-called helper function which "calls"
+	   _Identity(), implicitly casting the item to the
+	   IntrusiveListHook specialization; we use this to detect
+	   which IntrusiveListHook specialization is used */
+	template<typename U>
+	static constexpr auto _Cast(const U &u) noexcept {
+		return decltype(_Identity(u))();
+	}
+
+	template<typename U>
+	using Hook = decltype(_Cast(std::declval<U>()));
+
+	static constexpr T *Cast(IntrusiveListNode *node) noexcept {
+		auto *hook = &Hook<T>::Cast(*node);
+		return static_cast<T *>(hook);
+	}
+
+	static constexpr auto &ToHook(T &t) noexcept {
+		return static_cast<Hook<T> &>(t);
+	}
+};
+
+/**
+ * For classes which embed #IntrusiveListHook as member.
+ */
+template<auto member>
+struct IntrusiveListMemberHookTraits {
+	using T = MemberPointerContainerType<decltype(member)>;
+	using _Hook = MemberPointerType<decltype(member)>;
+
+	template<typename Dummy>
+	using Hook = _Hook;
+
+	static constexpr T *Cast(IntrusiveListNode *node) noexcept {
+		auto &hook = Hook<T>::Cast(*node);
+		return &ContainerCast(hook, member);
+	}
+
+	static constexpr auto &ToHook(T &t) noexcept {
+		return t.*member;
+	}
+};
+
+/**
+ * An intrusive doubly-linked circular list.
+ */
+template<typename T,
+	 typename HookTraits=IntrusiveListBaseHookTraits<T>,
+	 IntrusiveListOptions options=IntrusiveListOptions{}>
+class IntrusiveList {
+	static constexpr bool constant_time_size = options.constant_time_size;
+
+	IntrusiveListNode head = options.zero_initialized
+		? IntrusiveListNode{nullptr, nullptr}
+		: IntrusiveListNode{&head, &head};
+
+	[[no_unique_address]]
+	OptionalCounter<constant_time_size> counter;
+
+	static constexpr auto GetHookMode() noexcept {
+		return HookTraits::template Hook<T>::mode;
+	}
+
+	static constexpr T *Cast(IntrusiveListNode *node) noexcept {
+		return HookTraits::Cast(node);
+	}
+
+	static constexpr const T *Cast(const IntrusiveListNode *node) noexcept {
+		return HookTraits::Cast(const_cast<IntrusiveListNode *>(node));
+	}
+
+	static constexpr auto &ToHook(T &t) noexcept {
+		return HookTraits::ToHook(t);
+	}
+
+	static constexpr const auto &ToHook(const T &t) noexcept {
+		return HookTraits::ToHook(const_cast<T &>(t));
+	}
+
+	static constexpr IntrusiveListNode &ToNode(T &t) noexcept {
+		return ToHook(t).siblings;
+	}
+
+	static constexpr const IntrusiveListNode &ToNode(const T &t) noexcept {
+		return ToHook(t).siblings;
+	}
+
+public:
+	using value_type = T;
+	using reference = T &;
+	using const_reference = const T &;
+	using pointer = T *;
+	using const_pointer = const T *;
+	using size_type = std::size_t;
+
+	constexpr IntrusiveList() noexcept = default;
+
+	IntrusiveList(IntrusiveList &&src) noexcept {
+		if (src.empty())
+			return;
+
+		head = src.head;
+		head.next->prev = &head;
+		head.prev->next = &head;
+
+		src.head.next = &src.head;
+		src.head.prev = &src.head;
+
+		using std::swap;
+		swap(counter, src.counter);
+	}
+
+	~IntrusiveList() noexcept {
+		if constexpr (GetHookMode() >= IntrusiveHookMode::TRACK)
+			clear();
+	}
+
+	IntrusiveList &operator=(IntrusiveList &&) = delete;
+
+	friend void swap(IntrusiveList &a, IntrusiveList &b) noexcept {
+		using std::swap;
+
+		if (a.empty()) {
+			if (b.empty())
+				return;
+
+			a.head = b.head;
+			a.head.next->prev = &a.head;
+			a.head.prev->next = &a.head;
+
+			b.head = {&b.head, &b.head};
+		} else if (b.empty()) {
+			b.head = a.head;
+			b.head.next->prev = &b.head;
+			b.head.prev->next = &b.head;
+
+			a.head = {&a.head, &a.head};
+		} else {
+			swap(a.head, b.head);
+
+			a.head.next->prev = &a.head;
+			a.head.prev->next = &a.head;
+
+			b.head.next->prev = &b.head;
+			b.head.prev->next = &b.head;
+		}
+
+		swap(a.counter, b.counter);
+	}
+
+	constexpr bool empty() const noexcept {
+		if constexpr (options.zero_initialized)
+			if (head.next == nullptr)
+				return true;
+
+		return head.next == &head;
+	}
+
+	constexpr size_type size() const noexcept {
+		if constexpr (constant_time_size)
+			return counter;
+		else
+			return std::distance(begin(), end());
+	}
+
+	/**
+	 * Remove all items from the linked list.
+	 */
+	void clear() noexcept {
+		if constexpr (GetHookMode() >= IntrusiveHookMode::TRACK) {
+			/* for SafeLinkIntrusiveListHook, we need to
+			   remove each item manually, or else its
+			   is_linked() method will not work */
+			while (!empty())
+				pop_front();
+		} else {
+			head = {&head, &head};
+			counter.reset();
+		}
+	}
+
+	/**
+	 * Like clear(), but invoke a disposer function on each item.
+	 *
+	 * The disposer is not allowed to destruct the list.
+	 */
+	void clear_and_dispose(Disposer<value_type> auto disposer) noexcept {
+		while (!empty()) {
+			disposer(&pop_front());
+		}
+	}
+
+	/**
+	 * Remove all items matching the given predicate and invoke
+	 * the given disposer on it.
+	 *
+	 * Neither the predicate nor the disposer are allowed to
+	 * modify the list (or destruct it).
+	 *
+	 * @return the number of removed items
+	 */
+	std::size_t remove_and_dispose_if(std::predicate<const_reference> auto pred,
+					  Disposer<value_type> auto dispose) noexcept {
+		std::size_t result = 0;
+
+		auto *n = head.next;
+
+		while (n != &head) {
+			auto *i = Cast(n);
+			n = n->next;
+
+			if (pred(*i)) {
+				ToHook(*i).unlink();
+				--counter;
+				dispose(i);
+				++result;
+			}
+		}
+
+		return result;
+	}
+
+	const_reference front() const noexcept {
+		return *Cast(head.next);
+	}
+
+	reference front() noexcept {
+		return *Cast(head.next);
+	}
+
+	reference pop_front() noexcept {
+		auto &i = front();
+		ToHook(i).unlink();
+		--counter;
+		return i;
+	}
+
+	void pop_front_and_dispose(Disposer<value_type> auto disposer) noexcept {
+		auto &i = pop_front();
+		disposer(&i);
+	}
+
+	reference back() noexcept {
+		return *Cast(head.prev);
+	}
+
+	void pop_back() noexcept {
+		auto &i = back();
+		ToHook(i).unlink();
+		--counter;
+	}
+
+	class const_iterator;
+
+	class iterator final {
+		friend IntrusiveList;
+		friend const_iterator;
+
+		IntrusiveListNode *cursor;
+
+		constexpr iterator(IntrusiveListNode *_cursor) noexcept
+			:cursor(_cursor) {}
+
+	public:
+		using iterator_category = std::bidirectional_iterator_tag;
+		using value_type = T;
+		using difference_type = std::ptrdiff_t;
+		using pointer = value_type *;
+		using reference = value_type &;
+
+		iterator() noexcept = default;
+
+		constexpr bool operator==(const iterator &other) const noexcept {
+			return cursor == other.cursor;
+		}
+
+		constexpr bool operator!=(const iterator &other) const noexcept {
+			return !(*this == other);
+		}
+
+		constexpr reference operator*() const noexcept {
+			return *Cast(cursor);
+		}
+
+		constexpr pointer operator->() const noexcept {
+			return Cast(cursor);
+		}
+
+		auto &operator++() noexcept {
+			cursor = cursor->next;
+			return *this;
+		}
+
+		auto operator++(int) noexcept {
+			auto old = *this;
+			cursor = cursor->next;
+			return old;
+		}
+
+		auto &operator--() noexcept {
+			cursor = cursor->prev;
+			return *this;
+		}
+
+		auto operator--(int) noexcept {
+			auto old = *this;
+			cursor = cursor->prev;
+			return old;
+		}
+	};
+
+	constexpr iterator begin() noexcept {
+		if constexpr (options.zero_initialized)
+			if (head.next == nullptr)
+				return end();
+
+		return {head.next};
+	}
+
+	constexpr iterator end() noexcept {
+		return {&head};
+	}
+
+	static constexpr iterator iterator_to(reference t) noexcept {
+		return {&ToNode(t)};
+	}
+
+	using reverse_iterator = std::reverse_iterator<iterator>;
+
+	constexpr reverse_iterator rbegin() noexcept {
+		return reverse_iterator{end()};
+	}
+
+	constexpr reverse_iterator rend() noexcept {
+		return reverse_iterator{begin()};
+	}
+
+	class const_iterator final {
+		friend IntrusiveList;
+
+		const IntrusiveListNode *cursor;
+
+		constexpr const_iterator(const IntrusiveListNode *_cursor) noexcept
+			:cursor(_cursor) {}
+
+	public:
+		using iterator_category = std::bidirectional_iterator_tag;
+		using value_type = const T;
+		using difference_type = std::ptrdiff_t;
+		using pointer = value_type *;
+		using reference = value_type &;
+
+		const_iterator() noexcept = default;
+
+		const_iterator(iterator src) noexcept
+			:cursor(src.cursor) {}
+
+		constexpr bool operator==(const const_iterator &other) const noexcept {
+			return cursor == other.cursor;
+		}
+
+		constexpr bool operator!=(const const_iterator &other) const noexcept {
+			return !(*this == other);
+		}
+
+		constexpr reference operator*() const noexcept {
+			return *Cast(cursor);
+		}
+
+		constexpr pointer operator->() const noexcept {
+			return Cast(cursor);
+		}
+
+		auto &operator++() noexcept {
+			cursor = cursor->next;
+			return *this;
+		}
+
+		auto operator++(int) noexcept {
+			auto old = *this;
+			cursor = cursor->next;
+			return old;
+		}
+
+		auto &operator--() noexcept {
+			cursor = cursor->prev;
+			return *this;
+		}
+
+		auto operator--(int) noexcept {
+			auto old = *this;
+			cursor = cursor->prev;
+			return old;
+		}
+	};
+
+	constexpr const_iterator begin() const noexcept {
+		if constexpr (options.zero_initialized)
+			if (head.next == nullptr)
+				return end();
+
+		return {head.next};
+	}
+
+	constexpr const_iterator end() const noexcept {
+		return {&head};
+	}
+
+	static constexpr const_iterator iterator_to(const_reference t) noexcept {
+		return {&ToNode(t)};
+	}
+
+	using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+	constexpr const_reverse_iterator rbegin() const noexcept {
+		return reverse_iterator{end()};
+	}
+
+	constexpr const_reverse_iterator rend() const noexcept {
+		return reverse_iterator{begin()};
+	}
+
+	/**
+	 * @return an iterator to the item following the specified one
+	 */
+	iterator erase(iterator i) noexcept {
+		auto result = std::next(i);
+		ToHook(*i).unlink();
+		--counter;
+		return result;
+	}
+
+	/**
+	 * @return an iterator to the item following the specified one
+	 */
+	iterator erase_and_dispose(iterator i,
+				   Disposer<value_type> auto disposer) noexcept {
+		auto result = erase(i);
+		disposer(&*i);
+		return result;
+	}
+
+	iterator push_front(reference t) noexcept {
+		return insert(begin(), t);
+	}
+
+	iterator push_back(reference t) noexcept {
+		return insert(end(), t);
+	}
+
+	/**
+	 * Insert a new item before the given position.
+	 *
+	 * @param p a valid iterator (end() is allowed)for this list
+	 * describing the position where to insert
+	 *
+	 * @return an iterator to the new item
+	 */
+	iterator insert(iterator p, reference t) noexcept {
+		static_assert(!constant_time_size ||
+			      GetHookMode() < IntrusiveHookMode::AUTO_UNLINK,
+			      "Can't use auto-unlink hooks with constant_time_size");
+
+		if constexpr (options.zero_initialized)
+			if (head.next == nullptr)
+				head = {&head, &head};
+
+		auto &existing_node = *p.cursor;
+		auto &new_node = ToNode(t);
+
+		IntrusiveListNode::Connect(*existing_node.prev,
+					   new_node);
+		IntrusiveListNode::Connect(new_node, existing_node);
+
+		++counter;
+
+		return iterator_to(t);
+	}
+
+	/**
+	 * Like insert(), but insert after the given position.
+	 */
+	iterator insert_after(iterator p, reference t) noexcept {
+		if constexpr (options.zero_initialized)
+			if (head.next == nullptr)
+				head = {&head, &head};
+
+		return insert(std::next(p), t);
+	}
+
+	/**
+	 * Move one item of the given list to this one before the
+	 * given position.
+	 */
+	void splice(iterator position,
+		    IntrusiveList &from, iterator i) noexcept {
+		auto &item = *i;
+		from.erase(i);
+		insert(position, item);
+	}
+
+	/**
+	 * Move the given range of items of the given list to this one
+	 * before the given position.
+	 */
+	void splice(iterator position, IntrusiveList &from,
+		    iterator _begin, iterator _end, size_type n) noexcept {
+		if (_begin == _end)
+			return;
+
+		if constexpr (options.zero_initialized)
+			if (head.next == nullptr)
+				head = {&head, &head};
+
+		auto &next_node = *position.cursor;
+		auto &prev_node = *std::prev(position).cursor;
+
+		auto &first_node = *_begin.cursor;
+		auto &before_first_node = *std::prev(_begin).cursor;
+		auto &last_node = *std::prev(_end).cursor;
+		auto &after_last_node = *_end.cursor;
+
+		/* remove from the other list */
+		IntrusiveListNode::Connect(before_first_node, after_last_node);
+		from.counter -= n;
+
+		/* insert into this list */
+		IntrusiveListNode::Connect(prev_node, first_node);
+		IntrusiveListNode::Connect(last_node, next_node);
+		counter += n;
+	}
+
+	/**
+	 * Move all items of the given list to this one before the
+	 * given position.
+	 */
+	void splice(iterator position, IntrusiveList &from) noexcept {
+		splice(position, from, from.begin(), from.end(),
+		       constant_time_size ? from.size() : 1);
+	}
+};

--- a/src/util/MemberPointer.hxx
+++ b/src/util/MemberPointer.hxx
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Copyright CM4all GmbH
+// author: Max Kellermann <mk@cm4all.com>
+
+#pragma once
+
+template<typename T>
+struct MemberPointerHelper;
+
+template<typename C, typename M>
+struct MemberPointerHelper<M C::*> {
+	using ContainerType = C;
+	using MemberType = M;
+};
+
+/**
+ * Given a member pointer, this determines the member type.
+ */
+template<typename T>
+using MemberPointerType =
+	typename MemberPointerHelper<T>::MemberType;
+
+/**
+ * Given a member pointer, this determines the container type.
+ */
+template<typename T>
+using MemberPointerContainerType =
+	typename MemberPointerHelper<T>::ContainerType;

--- a/src/util/OffsetPointer.hxx
+++ b/src/util/OffsetPointer.hxx
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// author: Max Kellermann <max.kellermann@gmail.com>
+
+#pragma once
+
+#include <cstddef>
+
+/**
+ * Offset the given pointer by the specified number of bytes.
+ */
+constexpr void *
+OffsetPointer(void *p, std::ptrdiff_t offset) noexcept
+{
+	return static_cast<std::byte *>(p) + offset;
+}
+
+/**
+ * Offset the given pointer by the specified number of bytes.
+ */
+constexpr const void *
+OffsetPointer(const void *p, std::ptrdiff_t offset) noexcept
+{
+	return static_cast<const std::byte *>(p) + offset;
+}

--- a/src/util/OptionalCounter.hxx
+++ b/src/util/OptionalCounter.hxx
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BSD-2-Clause
+// Copyright CM4all GmbH
+// author: Max Kellermann <mk@cm4all.com>
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+
+template<bool enable> class OptionalCounter;
+
+template<>
+class OptionalCounter<false>
+{
+public:
+	constexpr void reset() noexcept {}
+	constexpr auto &operator++() noexcept { return *this; }
+	constexpr auto &operator--() noexcept { return *this; }
+	constexpr auto &operator+=(std::size_t) noexcept { return *this; }
+	constexpr auto &operator-=(std::size_t) noexcept { return *this; }
+};
+
+template<>
+class OptionalCounter<true>
+{
+	std::size_t value = 0;
+
+public:
+	constexpr operator std::size_t() const noexcept {
+		return value;
+	}
+
+	constexpr void reset() noexcept {
+		value = 0;
+	}
+
+	constexpr auto &operator++() noexcept {
+		++value;
+		return *this;
+	}
+
+	constexpr auto &operator--() noexcept {
+		assert(value > 0);
+
+		--value;
+		return *this;
+	}
+
+	constexpr auto &operator+=(std::size_t n) noexcept {
+		value += n;
+		return *this;
+	}
+
+	constexpr auto &operator-=(std::size_t n) noexcept {
+		assert(value >= n);
+
+		value -= n;
+		return *this;
+	}
+};


### PR DESCRIPTION
Even after https://github.com/ceph/ceph/pull/60307 the `sendmsg()` system call is still dominant in the `perf report`. This draft PR attempts to optimize this using `io_uring`. This needs more tuning, because it's not yet faster, but will be. Right now, every worker thread has its own ring, but we could combine all rings into one. And it would be possible to offload `recvmsg()` to `io_uring`, and the more syscalls we accumulate there, the faster it'll be.

This pulls a lot of `io_uring` glue code from https://github.com/CM4all/libcommon (a library which is used by many of our C++ projects). I hate to repeat myself, but I guess this means this feature may never be merged (at least not my implementation).

But maybe maybe you like some of the abstractions in this library, for example:
- the classes `FileDescriptor` and `SocketDescriptor` which are a type-safe wrapper for low-level file descriptors and sockets (sockets are not file descriptors on Windows, therefore for real safety and portability, you need two different classes); right now, Ceph passes raw `int`s around
- the `EventLoop` class is an extremely efficient and light-weight non-blocking I/O event loop which you may find useful to replace `msg/async/Event`; the version in libcommon is Linux-only (epoll), but a portable implementation is also available (part of the [MPD project](https://github.com/MusicPlayerDaemon/MPD/); it's lighter/faster than `boost::asio` and Seastar (no memory allocations), and unlike these two, it comes with very light header dependencies -> very fast compile times
- the `EventLoop` can easily integrate C++20 coroutines, and also integrates Lua coroutines with C++20 coroutines (imagine no unnatural `std::function` or `EventCallback` completion handlers, just `co_await`)

I believe in upstreaming all the stuff I do, therefore I submit this, and if you happen to be interested, let me know; or else I just keep this feature in our private fork.