### PR TITLE
librados: dont duplicate class names in member definitions

### DIFF
--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -978,128 +978,127 @@ uint32_t librados::NObjectIterator::get_pg_hash_position() const
 const librados::NObjectIterator librados::NObjectIterator::__EndObjectIterator(NULL);
 
 ///////////////////////////// PoolAsyncCompletion //////////////////////////////
-librados::PoolAsyncCompletion::PoolAsyncCompletion::~PoolAsyncCompletion()
+librados::PoolAsyncCompletion::~PoolAsyncCompletion()
 {
   auto c = reinterpret_cast<PoolAsyncCompletionImpl *>(pc);
   c->release();
 }
 
-int librados::PoolAsyncCompletion::PoolAsyncCompletion::set_callback(void *cb_arg,
-								     rados_callback_t cb)
+int librados::PoolAsyncCompletion::set_callback(void *cb_arg, rados_callback_t cb)
 {
   PoolAsyncCompletionImpl *c = (PoolAsyncCompletionImpl *)pc;
   return c->set_callback(cb_arg, cb);
 }
 
-int librados::PoolAsyncCompletion::PoolAsyncCompletion::wait()
+int librados::PoolAsyncCompletion::wait()
 {
   PoolAsyncCompletionImpl *c = (PoolAsyncCompletionImpl *)pc;
   return c->wait();
 }
 
-bool librados::PoolAsyncCompletion::PoolAsyncCompletion::is_complete()
+bool librados::PoolAsyncCompletion::is_complete()
 {
   PoolAsyncCompletionImpl *c = (PoolAsyncCompletionImpl *)pc;
   return c->is_complete();
 }
 
-int librados::PoolAsyncCompletion::PoolAsyncCompletion::get_return_value()
+int librados::PoolAsyncCompletion::get_return_value()
 {
   PoolAsyncCompletionImpl *c = (PoolAsyncCompletionImpl *)pc;
   return c->get_return_value();
 }
 
-void librados::PoolAsyncCompletion::PoolAsyncCompletion::release()
+void librados::PoolAsyncCompletion::release()
 {
   delete this;
 }
 
 ///////////////////////////// AioCompletion //////////////////////////////
-librados::AioCompletion::AioCompletion::~AioCompletion()
+librados::AioCompletion::~AioCompletion()
 {
   auto c = reinterpret_cast<AioCompletionImpl *>(pc);
   c->release();
 }
 
-int librados::AioCompletion::AioCompletion::set_complete_callback(void *cb_arg, rados_callback_t cb)
+int librados::AioCompletion::set_complete_callback(void *cb_arg, rados_callback_t cb)
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->set_complete_callback(cb_arg, cb);
 }
 
-int librados::AioCompletion::AioCompletion::set_safe_callback(void *cb_arg, rados_callback_t cb)
+int librados::AioCompletion::set_safe_callback(void *cb_arg, rados_callback_t cb)
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->set_safe_callback(cb_arg, cb);
 }
 
-int librados::AioCompletion::AioCompletion::wait_for_complete()
+int librados::AioCompletion::wait_for_complete()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->wait_for_complete();
 }
 
-int librados::AioCompletion::AioCompletion::wait_for_safe()
+int librados::AioCompletion::wait_for_safe()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->wait_for_complete();
 }
 
-bool librados::AioCompletion::AioCompletion::is_complete()
+bool librados::AioCompletion::is_complete()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->is_complete();
 }
 
-bool librados::AioCompletion::AioCompletion::is_safe()
+bool librados::AioCompletion::is_safe()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->is_safe();
 }
 
-int librados::AioCompletion::AioCompletion::wait_for_complete_and_cb()
+int librados::AioCompletion::wait_for_complete_and_cb()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->wait_for_complete_and_cb();
 }
 
-int librados::AioCompletion::AioCompletion::wait_for_safe_and_cb()
+int librados::AioCompletion::wait_for_safe_and_cb()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->wait_for_safe_and_cb();
 }
 
-bool librados::AioCompletion::AioCompletion::is_complete_and_cb()
+bool librados::AioCompletion::is_complete_and_cb()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->is_complete_and_cb();
 }
 
-bool librados::AioCompletion::AioCompletion::is_safe_and_cb()
+bool librados::AioCompletion::is_safe_and_cb()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->is_safe_and_cb();
 }
 
-int librados::AioCompletion::AioCompletion::get_return_value()
+int librados::AioCompletion::get_return_value()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->get_return_value();
 }
 
-int librados::AioCompletion::AioCompletion::get_version()
+int librados::AioCompletion::get_version()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->get_version();
 }
 
-uint64_t librados::AioCompletion::AioCompletion::get_version64()
+uint64_t librados::AioCompletion::get_version64()
 {
   AioCompletionImpl *c = (AioCompletionImpl *)pc;
   return c->get_version();
 }
 
-void librados::AioCompletion::AioCompletion::release()
+void librados::AioCompletion::release()
 {
   delete this;
 }


### PR DESCRIPTION
i'm not sure why this compiles in the first place. but a lot of librados function definitions name the class twice

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
