### PR TITLE
doc/start: add vstart install guide

### DIFF
--- a/doc/start/beginners-guide.rst
+++ b/doc/start/beginners-guide.rst
@@ -8,6 +8,9 @@ Ceph is a clustered and distributed storage manager. If that's too cryptic,
 then just think of Ceph as a computer program that stores data and uses a
 network to make sure that there is a backup copy of the data.
 
+Components of Ceph
+==================
+
 Storage Interfaces
 ------------------
 
@@ -93,6 +96,89 @@ MDS
 ---
 A metadata server (MDS) is necessary for the proper functioning of CephFS.
 See :ref:`orchestrator-cli-cephfs` and :ref:`arch-cephfs`.
+
+Vstart Cluster Installation and Configuration Procedure
+=======================================================
+
+#. Clone the ``ceph/ceph`` repository:
+
+   .. prompt:: bash #
+
+      git clone git@github.com:ceph/ceph
+
+#. Update the submodules in the ``ceph/ceph`` repository:
+
+   .. prompt:: bash #
+    
+      git submodule update --init --recursive --progress
+
+#. Run ``install-deps.sh`` from within the directory into which you cloned the
+   ``ceph/ceph`` repository:
+
+   .. prompt:: bash #
+
+      ./install-deps.sh
+
+#. Install the ``python3-routes`` package:
+
+   .. prompt:: bash #
+
+      apt install python3-routes
+
+#. Move into the ``ceph`` directory. You will know that you are in the correct
+   directory if it contains the file ``do_cmake.sh``:
+
+   .. prompt:: bash #
+
+      cd ceph
+
+#. Run the ``do_cmake.sh`` script:
+
+   .. prompt:: bash #
+
+      ./do_cmake.sh
+
+#. The ``do_cmake.sh`` script creates a ``build/`` directory. Move into the
+   ``build/`` directory:
+
+   .. prompt:: bash #
+
+      cd build
+
+#. Use ``ninja`` to build the development environment:
+
+   .. prompt:: bash #
+
+      ninja -j3
+
+   .. note:: This step takes a long time to run. The ``ninja -j3`` command
+      kicks off a process consisting of 2289 steps. This step took over three
+      hours when I ran it on an Intel NUC with an i7 in September of 2024.
+
+#. Install the Ceph development environment:
+
+   .. prompt:: bash #
+
+      ninja install
+
+   This step does not take as long as the previous step.
+
+#. Build the vstart cluster:
+
+   .. prompt:: bash #
+
+      ninja vstart
+
+#. Start the vstart cluster:
+
+   .. prompt:: bash #
+      
+      ../src/vstart.sh --debug --new -x --localhost --bluestore
+
+   .. note:: Run this command from within the ``ceph/build`` directory.
+
+
+
 
 LINKS
 -----


### PR DESCRIPTION
Add "vstart Cluster Installation and Configuration Procedure" to the Beginner's Guide.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>

