### PR TITLE
rgw/reshard: use with_lease() for reshard locks

### DIFF
--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -1169,7 +1169,7 @@ void cls_rgw_reshard_list(librados::ObjectReadOperation& op,
 }
 
 int cls_rgw_reshard_list_decode(const bufferlist& out,
-                                std::list<cls_rgw_reshard_entry>& entries,
+                                std::vector<cls_rgw_reshard_entry>& entries,
                                 bool* is_truncated)
 {
   cls_rgw_reshard_list_ret op_ret;

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -665,15 +665,20 @@ void cls_rgw_mp_upload_part_info_update(librados::ObjectWriteOperation& op, cons
 /* resharding */
 void cls_rgw_reshard_add(librados::ObjectWriteOperation& op,
 			 const cls_rgw_reshard_entry& entry,
-			 const bool create_only);
-void cls_rgw_reshard_remove(librados::ObjectWriteOperation& op, const cls_rgw_reshard_entry& entry);
-// these overloads which call io_ctx.operate() should not be called in the rgw.
-// rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
-#ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_rgw_reshard_list(librados::IoCtx& io_ctx, const std::string& oid, std::string& marker, uint32_t max,
-                         std::list<cls_rgw_reshard_entry>& entries, bool* is_truncated);
-int cls_rgw_reshard_get(librados::IoCtx& io_ctx, const std::string& oid, cls_rgw_reshard_entry& entry);
-#endif
+			 bool create_only);
+void cls_rgw_reshard_remove(librados::ObjectWriteOperation& op,
+                            const cls_rgw_reshard_entry& entry);
+void cls_rgw_reshard_list(librados::ObjectReadOperation& op,
+                          std::string marker, uint32_t max,
+                          bufferlist& bl);
+int cls_rgw_reshard_list_decode(const bufferlist& bl,
+                                std::list<cls_rgw_reshard_entry>& entries,
+                                bool* is_truncated);
+void cls_rgw_reshard_get(librados::ObjectReadOperation& op,
+                         std::string tenant, std::string bucket_name,
+                         bufferlist& bl);
+int cls_rgw_reshard_get_decode(const bufferlist& bl,
+                               cls_rgw_reshard_entry& entry);
 
 // If writes to the bucket index should be blocked during resharding, fail with
 // the given error code. RGWRados::guard_reshard() calls this in a loop to retry

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -672,7 +672,7 @@ void cls_rgw_reshard_list(librados::ObjectReadOperation& op,
                           std::string marker, uint32_t max,
                           bufferlist& bl);
 int cls_rgw_reshard_list_decode(const bufferlist& bl,
-                                std::list<cls_rgw_reshard_entry>& entries,
+                                std::vector<cls_rgw_reshard_entry>& entries,
                                 bool* is_truncated);
 void cls_rgw_reshard_get(librados::ObjectReadOperation& op,
                          std::string tenant, std::string bucket_name,

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1574,7 +1574,7 @@ WRITE_CLASS_ENCODER(cls_rgw_reshard_list_op)
 
 
 struct cls_rgw_reshard_list_ret {
-  std::list<cls_rgw_reshard_entry> entries;
+  std::vector<cls_rgw_reshard_entry> entries;
   bool is_truncated{false};
 
   cls_rgw_reshard_list_ret() {}

--- a/src/common/async/completion.h
+++ b/src/common/async/completion.h
@@ -195,12 +195,13 @@ class CompletionImpl final : public Completion<void(Args...), T> {
 
   void destroy_defer(std::tuple<Args...>&& args) override {
     auto w = std::move(work);
+    auto ex1 = w.first.get_executor();
     auto ex2 = w.second.get_executor();
     RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler);
     auto f = bind_and_forward(ex2, std::move(handler), std::move(args));
     RebindTraits2::destroy(alloc2, this);
     RebindTraits2::deallocate(alloc2, this, 1);
-    boost::asio::defer(boost::asio::bind_executor(ex2, std::move(f)));
+    boost::asio::defer(ex1, std::move(f));
   }
   void destroy_dispatch(std::tuple<Args...>&& args) override {
     auto w = std::move(work);
@@ -213,12 +214,13 @@ class CompletionImpl final : public Completion<void(Args...), T> {
   }
   void destroy_post(std::tuple<Args...>&& args) override {
     auto w = std::move(work);
+    auto ex1 = w.first.get_executor();
     auto ex2 = w.second.get_executor();
     RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler);
     auto f = bind_and_forward(ex2, std::move(handler), std::move(args));
     RebindTraits2::destroy(alloc2, this);
     RebindTraits2::deallocate(alloc2, this, 1);
-    boost::asio::post(std::move(f));
+    boost::asio::post(ex1, std::move(f));
   }
   void destroy() override {
     RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler);

--- a/src/common/async/detail/lease_state.h
+++ b/src/common/async/detail/lease_state.h
@@ -1,0 +1,143 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <optional>
+#include <utility>
+#include <boost/asio/append.hpp>
+#include <boost/asio/basic_waitable_timer.hpp>
+#include <boost/asio/bind_cancellation_slot.hpp>
+#include <boost/asio/cancellation_signal.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+#include "common/ceph_time.h"
+
+namespace ceph::async::detail {
+
+using lease_clock = ceph::coarse_mono_clock;
+using lease_timer = boost::asio::basic_waitable_timer<lease_clock>;
+
+// base class for the lease completion state. this contains everything that
+// doesn't depend on the coroutine's return type
+class lease_state {
+  lease_timer timer;
+  boost::asio::cancellation_signal signal;
+  std::exception_ptr eptr;
+
+ public:
+  lease_state(boost::asio::any_io_executor ex) : timer(ex) {}
+
+  lease_timer& get_timer() { return timer; }
+
+  boost::asio::any_io_executor get_executor() { return timer.get_executor(); }
+  boost::asio::cancellation_slot get_cancellation_slot() { return signal.slot(); }
+
+  void complete()
+  {
+    timer.cancel(); // wake the renewal loop
+  }
+
+  void abort(std::exception_ptr e)
+  {
+    if (!eptr) { // only the first exception is reported
+      eptr = e;
+      cancel();
+    }
+  }
+
+  void rethrow()
+  {
+    if (eptr) {
+      std::rethrow_exception(eptr);
+    }
+  }
+
+  void cancel()
+  {
+    signal.emit(boost::asio::cancellation_type::terminal);
+    timer.cancel();
+  }
+};
+
+// capture and return the arguments to cr's completion handler
+template <typename T>
+class lease_completion_state : public lease_state,
+    public boost::intrusive_ref_counter<lease_completion_state<T>,
+        boost::thread_unsafe_counter>
+{
+  using result_type = std::pair<std::exception_ptr, T>;
+  std::optional<result_type> result;
+ public:
+  lease_completion_state(boost::asio::any_io_executor ex) : lease_state(ex) {}
+
+  bool completed() const { return result.has_value(); }
+
+  auto completion_handler()
+  {
+    return bind_cancellation_slot(get_cancellation_slot(),
+                                  bind_executor(get_executor(),
+        [self = boost::intrusive_ptr{this}] (std::exception_ptr eptr, T val) {
+          self->result.emplace(eptr, std::move(val));
+          self->complete();
+        }));
+  }
+
+  T get() // precondition: completed()
+  {
+    rethrow(); // rethrow exceptions from renewal
+    if (auto eptr = std::get<0>(*result); eptr) {
+      std::rethrow_exception(eptr);
+    }
+    return std::get<1>(std::move(*result));
+  }
+};
+
+// specialization for void return type
+template<>
+class lease_completion_state<void> : public lease_state,
+    public boost::intrusive_ref_counter<lease_completion_state<void>,
+        boost::thread_unsafe_counter>
+{
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+ public:
+  lease_completion_state(boost::asio::any_io_executor ex) : lease_state(ex) {}
+
+  bool completed() const { return result.has_value(); }
+
+  auto completion_handler()
+  {
+    return bind_cancellation_slot(get_cancellation_slot(),
+                                  bind_executor(get_executor(),
+        [self = boost::intrusive_ptr{this}] (std::exception_ptr eptr) {
+          self->result = eptr;
+          self->complete();
+        }));
+  }
+
+  void get() // precondition: completed()
+  {
+    rethrow(); // rethrow exceptions from renewal
+    if (*result) {
+      std::rethrow_exception(*result);
+    }
+  }
+};
+
+template <typename T>
+auto make_lease_completion_state(boost::asio::any_io_executor ex)
+{
+  return boost::intrusive_ptr{new lease_completion_state<T>(ex)};
+}
+
+} // namespace ceph::async::detail

--- a/src/common/async/lease.h
+++ b/src/common/async/lease.h
@@ -1,0 +1,292 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <exception>
+#include <boost/asio/any_completion_handler.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/system.hpp>
+#include "include/scope_guard.h"
+#include "common/ceph_time.h"
+#include "detail/lease_state.h"
+
+namespace ceph::async {
+
+/// \brief Client interface for a specific timed exclusive lock.
+class LockClient {
+ protected:
+  using Signature = void(boost::system::error_code);
+  using Handler = boost::asio::any_completion_handler<Signature>;
+
+  virtual void acquire(ceph::timespan duration, Handler handler) = 0;
+  virtual void renew(ceph::timespan duration, Handler handler) = 0;
+  virtual void release(Handler handler) = 0;
+
+ public:
+  virtual ~LockClient() {}
+
+  /// Acquire a timed lock for the given duration.
+  template <boost::asio::completion_token_for<Signature> CompletionToken>
+  auto async_acquire(ceph::timespan duration, CompletionToken&& token) {
+    return boost::asio::async_initiate<CompletionToken, Signature>(
+        [this, duration] (auto h) { acquire(duration, std::move(h)); }, token);
+  }
+  /// Renew an acquired lock for the given duration.
+  template <boost::asio::completion_token_for<Signature> CompletionToken>
+  auto async_renew(ceph::timespan duration, CompletionToken&& token) {
+    return boost::asio::async_initiate<CompletionToken, Signature>(
+        [this, duration] (auto h) { renew(duration, std::move(h)); }, token);
+  }
+  /// Release an acquired lock.
+  template <boost::asio::completion_token_for<Signature> CompletionToken>
+  auto async_release(CompletionToken&& token) {
+    return boost::asio::async_initiate<CompletionToken, Signature>(
+        [this] (auto h) { release(std::move(h)); }, token);
+  }
+};
+
+
+/// Exception thrown by with_lease() whenever the wrapped coroutine is
+/// canceled due to a renewal failure.
+class lease_aborted : public std::runtime_error {
+  boost::system::error_code ec;
+ public:
+  lease_aborted(boost::system::error_code ec)
+    : runtime_error("lease aborted"), ec(ec)
+  {}
+
+  /// Return the original error that triggered the cancellation.
+  boost::system::error_code code() const { return ec; }
+};
+
+
+/// \brief Call a coroutine under the protection of a continuous lease.
+///
+/// Acquires exclusive access to a timed lock, then spawns the given coroutine
+/// \ref cr. The lock is renewed at intervals of \ref duration / 2, and released
+/// after the coroutine's completion.
+///
+/// Exceptions from acquire() propagate directly to the caller. Exceptions from
+/// release() are ignored in favor of the result of \ref cr.
+///
+/// If renew() is delayed long enough for the timed lock to expire, that results
+/// in an error code matching boost::system::errc::timed_out. That error, along
+/// with any error from renew() itself, gets wrapped in a lease_aborted
+/// exception when reported to the caller. Any failure to renew the lock will
+/// also result in the cancellation of \ref cr.
+///
+/// Cancellation of the parent coroutine also cancels the child coroutine
+/// without releasing the lock.
+///
+/// Otherwise, the result of \ref cr is returned to the caller, whether by
+/// exception or return value.
+///
+/// \relates LockClient
+///
+/// \param lock A client that can send lock requests
+/// \param duration Duration of the lock
+/// \param cr The coroutine to call under lease
+///
+/// \tparam T The return type of the coroutine \ref cr
+template <typename T>
+auto with_lease(LockClient& lock,
+                ceph::timespan duration,
+                boost::asio::awaitable<T> cr)
+    -> boost::asio::awaitable<T>
+{
+  auto ex = co_await boost::asio::this_coro::executor;
+
+  // acquire the lock. exceptions propagate directly to the caller
+  co_await lock.async_acquire(duration, boost::asio::use_awaitable);
+  auto expires_at = detail::lease_clock::now() + duration;
+
+  // the LockClient may not support cancellation, so check after it returns
+  if (auto cs = co_await boost::asio::this_coro::cancellation_state;
+      cs.cancelled() != boost::asio::cancellation_type::none) {
+    throw boost::system::system_error(boost::asio::error::operation_aborted);
+  }
+
+  // allocate the lease state with scoped cancellation so that with_lease()'s
+  // cancellation triggers cancellation of the spawned coroutine
+  auto state = detail::make_lease_completion_state<T>(ex);
+  const auto state_guard = make_scope_guard([&state] { state->cancel(); });
+
+  // spawn the coroutine with a waitable/cancelable completion handler
+  boost::asio::co_spawn(ex, std::move(cr), state->completion_handler());
+
+  // lock renewal loop
+  auto& timer = state->get_timer();
+  const ceph::timespan interval = duration / 2;
+  boost::system::error_code ec;
+
+  while (!state->completed()) {
+    // sleep until the next lock interval
+    timer.expires_after(interval);
+    co_await timer.async_wait(boost::asio::redirect_error(
+            boost::asio::use_awaitable, ec));
+    if (ec) {
+      if (auto cs = co_await boost::asio::this_coro::cancellation_state;
+          cs.cancelled() != boost::asio::cancellation_type::none) {
+        // if cancellation was requested by the caller, let the timer's
+        // operation_aborted exception propagate. state_guard will cancel the
+        // wrapped coroutine immediately on unwind
+        throw boost::system::system_error(ec);
+      }
+      break; // timer canceled by cr's completion
+    }
+
+    // arm a timeout for the renew request
+    timer.expires_at(expires_at);
+    timer.async_wait([state] (boost::system::error_code ec) {
+          if (!ec) {
+            state->abort(std::make_exception_ptr(lease_aborted{
+                make_error_code(std::errc::timed_out)}));
+          }
+        });
+
+    co_await lock.async_renew(duration, boost::asio::redirect_error(
+            boost::asio::use_awaitable, ec));
+    timer.cancel();
+    if (auto cs = co_await boost::asio::this_coro::cancellation_state;
+        cs.cancelled() != boost::asio::cancellation_type::none) {
+      ec = boost::asio::error::operation_aborted;
+    }
+    if (ec) {
+      state->rethrow(); // may already have a timeout error to return
+      throw lease_aborted{ec};
+    }
+    expires_at = detail::lease_clock::now() + duration;
+  }
+
+  // release the lock, ignoring errors
+  co_await lock.async_release(boost::asio::redirect_error(
+          boost::asio::use_awaitable, ec));
+
+  // return the spawned coroutine's result
+  co_return state->get();
+}
+
+namespace detail {
+
+template <typename T>
+void renew(LockClient& lock,
+           lease_clock::time_point expires_at,
+           ceph::timespan duration,
+           boost::asio::yield_context yield,
+           boost::intrusive_ptr<lease_completion_state<T>>& state);
+
+} // namespace detail
+
+/// \overload
+///
+/// \param lock A client that can send lock requests
+/// \param duration Duration of the lock
+/// \param yield The calling coroutine's yield context
+/// \param cr The coroutine to call under lease, taking a newly-spawned
+///           yield context as its only argument.
+template <std::invocable<boost::asio::yield_context> Func>
+auto with_lease(LockClient& lock,
+                ceph::timespan duration,
+                boost::asio::yield_context yield,
+                Func&& cr)
+    -> std::invoke_result_t<Func, boost::asio::yield_context>
+{
+  auto ex = yield.get_executor();
+
+  // acquire the lock. exceptions propagate directly to the caller
+  lock.async_acquire(duration, yield);
+  auto expires_at = detail::lease_clock::now() + duration;
+
+  // the LockClient may not support cancellation, so check after it returns
+  if (yield.cancelled() != boost::asio::cancellation_type::none) {
+    throw boost::system::system_error(boost::asio::error::operation_aborted);
+  }
+
+  // allocate the lease state with scoped cancellation so that with_lease()'s
+  // cancellation triggers cancellation of the spawned coroutine
+  using T = std::invoke_result_t<Func, boost::asio::yield_context>;
+  auto state = detail::make_lease_completion_state<T>(ex);
+  const auto state_guard = make_scope_guard([&state] { state->cancel(); });
+
+  // spawn the coroutine with a waitable/cancelable completion handler
+  boost::asio::spawn(ex, std::forward<Func>(cr), state->completion_handler());
+
+  detail::renew(lock, expires_at, duration, yield, state);
+
+  // release the lock, ignoring errors
+  boost::system::error_code ec;
+  lock.async_release(yield[ec]);
+
+  // return the spawned coroutine's result
+  return state->get();
+}
+
+namespace detail {
+
+// the renewal loop only depends on the coroutine's return type T, so doesn't
+// need to be reinstantiated for every Func
+template <typename T>
+void renew(LockClient& lock,
+           lease_clock::time_point expires_at,
+           ceph::timespan duration,
+           boost::asio::yield_context yield,
+           boost::intrusive_ptr<lease_completion_state<T>>& state)
+{
+  // lock renewal loop
+  auto& timer = state->get_timer();
+  const ceph::timespan interval = duration / 2;
+  boost::system::error_code ec;
+
+  while (!state->completed()) {
+    // sleep until the next lock interval
+    timer.expires_after(interval);
+    timer.async_wait(yield[ec]);
+    if (ec) {
+      if (yield.cancelled() != boost::asio::cancellation_type::none) {
+        // if cancellation was requested by the caller, let the timer's
+        // operation_aborted exception propagate. state_guard will cancel the
+        // wrapped coroutine immediately on unwind
+        throw boost::system::system_error(ec);
+      }
+      break; // timer canceled by cr's completion
+    }
+
+    // arm a timeout for the renew request
+    timer.expires_at(expires_at);
+    timer.async_wait([state] (boost::system::error_code ec) {
+          if (!ec) {
+            state->abort(std::make_exception_ptr(lease_aborted{
+                make_error_code(std::errc::timed_out)}));
+          }
+        });
+
+    lock.async_renew(duration, yield[ec]);
+    timer.cancel();
+    if (yield.cancelled() != boost::asio::cancellation_type::none) {
+      ec = boost::asio::error::operation_aborted;
+    }
+    if (ec) {
+      state->rethrow(); // may already have a timeout error to return
+      throw lease_aborted{ec};
+    }
+    expires_at = lease_clock::now() + duration;
+  }
+}
+
+} // namespace detail
+
+} // namespace ceph::async

--- a/src/common/async/lease_rados.h
+++ b/src/common/async/lease_rados.h
@@ -1,0 +1,81 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <boost/asio/any_io_executor.hpp>
+#include "librados/librados_asio.h"
+#include "librados/redirect_version.h"
+#include "cls/lock/cls_lock_client.h"
+#include "lease.h"
+
+namespace ceph::async {
+
+/// A LockClient for with_lease() based on librados and cls_lock.
+class RadosLockClient : public LockClient {
+ public:
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const { return ex; }
+
+  RadosLockClient(executor_type ex,
+                  librados::IoCtx ioctx,
+                  std::string oid,
+                  rados::cls::lock::Lock lock,
+                  bool ephemeral)
+    : ex(std::move(ex)),
+      ioctx(std::move(ioctx)),
+      oid(std::move(oid)),
+      lock(std::move(lock)),
+      ephemeral(ephemeral)
+  {}
+
+ private:
+  executor_type ex;
+  librados::IoCtx ioctx;
+  std::string oid;
+  rados::cls::lock::Lock lock;
+  bool ephemeral = false;
+
+  void acquire(ceph::timespan dur, Handler h) override {
+    librados::ObjectWriteOperation op;
+    lock.set_duration(dur);
+    if (ephemeral) {
+      lock.lock_exclusive_ephemeral(&op);
+    } else {
+      lock.lock_exclusive(&op);
+    }
+    librados::async_operate(*this, ioctx, oid, &op, 0, nullptr,
+                            librados::redirect_version(std::move(h)));
+  }
+  void renew(ceph::timespan dur, Handler h) override {
+    librados::ObjectWriteOperation op;
+    op.assert_exists();
+    lock.set_must_renew(true);
+    lock.set_duration(dur);
+    if (ephemeral) {
+      lock.lock_exclusive_ephemeral(&op);
+    } else {
+      lock.lock_exclusive(&op);
+    }
+    librados::async_operate(*this, ioctx, oid, &op, 0, nullptr,
+                            librados::redirect_version(std::move(h)));
+  }
+  void release(Handler h) override {
+    librados::ObjectWriteOperation op;
+    op.assert_exists();
+    lock.unlock(&op);
+    librados::async_operate(*this, ioctx, oid, &op, 0, nullptr,
+                            librados::redirect_version(std::move(h)));
+  }
+};
+
+} // namespace ceph::async

--- a/src/common/async/yield_context.h
+++ b/src/common/async/yield_context.h
@@ -14,12 +14,7 @@
 
 #pragma once
 
-#include <boost/range/begin.hpp>
-#include <boost/range/end.hpp>
-#include <boost/asio/io_context.hpp>
 #include <boost/asio/spawn.hpp>
-
-#include "acconfig.h"
 
 /// optional-like wrapper for a boost::asio::yield_context. operations that take
 /// an optional_yield argument will, when passed a non-empty yield context,
@@ -39,6 +34,15 @@ class optional_yield {
 
   /// return a reference to the yield_context. only valid if non-empty
   boost::asio::yield_context& get_yield_context() const noexcept { return *y; }
+
+  /// return the cancellation type of the yield_context, or none
+  boost::asio::cancellation_type cancelled() const {
+    if (y) {
+      return y->cancelled();
+    } else {
+      return boost::asio::cancellation_type::none;
+    }
+  }
 };
 
 // type tag object to construct an empty optional_yield

--- a/src/librados/redirect_version.h
+++ b/src/librados/redirect_version.h
@@ -1,0 +1,130 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include <boost/asio/associator.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/system/error_code.hpp>
+#include "include/types.h"
+
+namespace librados {
+
+template <typename CompletionToken>
+struct redirect_version_t {
+  [[no_unique_address]] CompletionToken token;
+  version_t* ver = nullptr;
+};
+
+/// A completion token adapter that modifies the completion signature by
+/// removing the version_t argument, optionally redirecting its value into
+/// the given pointer.
+template <typename CompletionToken>
+auto redirect_version(CompletionToken&& token, version_t* ver = nullptr)
+    -> redirect_version_t<CompletionToken> {
+  return {std::forward<CompletionToken>(token), ver};
+}
+
+namespace detail {
+
+template <typename Handler>
+struct redirect_version_handler {
+  [[no_unique_address]] Handler handler;
+  version_t* ver = nullptr;
+
+  void operator()(boost::system::error_code ec, version_t v) {
+    if (ver) {
+      *ver = v;
+    }
+    std::move(handler)(ec);
+  }
+  void operator()(boost::system::error_code ec, version_t v, bufferlist bl) {
+    if (ver) {
+      *ver = v;
+    }
+    std::move(handler)(ec, std::move(bl));
+  }
+};
+
+template <typename Signature>
+struct redirect_version_signature {};
+template <>
+struct redirect_version_signature<void(boost::system::error_code, version_t)> {
+  using type = void(boost::system::error_code);
+};
+template <>
+struct redirect_version_signature<void(boost::system::error_code, version_t, bufferlist)> {
+  using type = void(boost::system::error_code, bufferlist);
+};
+template <typename Signature>
+using redirect_version_signature_t = typename redirect_version_signature<Signature>::type;
+
+} // namespace detail
+
+} // namespace librados
+
+namespace boost::asio {
+
+template <template <typename, typename> class Associator,
+    typename Handler, typename DefaultCandidate>
+struct associator<Associator,
+    librados::detail::redirect_version_handler<Handler>, DefaultCandidate>
+  : Associator<Handler, DefaultCandidate>
+{
+  static auto get(const librados::detail::redirect_version_handler<Handler>& h) noexcept {
+    return Associator<Handler, DefaultCandidate>::get(h.handler);
+  }
+  static auto get(const librados::detail::redirect_version_handler<Handler>& h,
+                  const DefaultCandidate& c) noexcept {
+    return Associator<Handler, DefaultCandidate>::get(h.handler, c);
+  }
+};
+
+template <typename CompletionToken, typename Signature>
+struct async_result<librados::redirect_version_t<CompletionToken>, Signature>
+  : async_result<CompletionToken,
+      librados::detail::redirect_version_signature_t<Signature>>
+{
+  template <typename Initiation>
+  struct init_wrapper {
+    [[no_unique_address]] Initiation init;
+
+    template <typename Handler, typename... Args>
+    void operator()(Handler&& handler, version_t* ver, Args&&... args) && {
+      std::move(init)(
+          librados::detail::redirect_version_handler<decay_t<Handler>>{
+              std::forward<Handler>(handler), ver},
+          std::forward<Args>(args)...);
+    }
+
+    template <typename Handler, typename... Args>
+    void operator()(Handler&& handler, version_t* ver, Args&&... args) const & {
+      init(
+          librados::detail::redirect_version_handler<decay_t<Handler>>{
+              std::forward<Handler>(handler), ver},
+          std::forward<Args>(args)...);
+    }
+  };
+
+  template <typename Initiation, typename RawCompletionToken, typename... Args>
+  static auto initiate(Initiation&& init,
+                       RawCompletionToken&& token,
+                       Args&&... args) {
+    return async_initiate<
+      conditional_t<is_const<remove_reference_t<RawCompletionToken>>::value,
+          const CompletionToken, CompletionToken>,
+      librados::detail::redirect_version_signature_t<Signature>>(
+        init_wrapper<decay_t<Initiation>>{std::forward<Initiation>(init)},
+        token.token, token.ver, std::forward<Args>(args)...);
+  }
+};
+
+} // namespace boost::asio

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <functional>
+#include <future>
 #include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>
 
@@ -58,7 +59,6 @@ class RGWSyncLogTrimThread;
 class RGWSyncTraceManager;
 struct RGWZoneGroup;
 struct RGWZoneParams;
-class RGWReshard;
 class RGWReshardWait;
 namespace rgw { class SiteConfig; }
 
@@ -556,7 +556,8 @@ public:
    */
   std::string host_id;
 
-  RGWReshard* reshard{nullptr};
+  boost::asio::cancellation_signal reshard_cancel;
+  std::future<void> reshard_future;
   std::shared_ptr<RGWReshardWait> reshard_wait;
 
   virtual ~RGWRados() = default;
@@ -599,7 +600,8 @@ public:
   /** Initialize the RADOS instance and prepare to do other ops */
   int init_svc(bool raw, const DoutPrefixProvider *dpp, const rgw::SiteConfig& site);
   virtual int init_rados();
-  int init_complete(const DoutPrefixProvider *dpp, optional_yield y);
+  int init_complete(const DoutPrefixProvider *dpp, optional_yield y,
+                    boost::asio::io_context& io_context);
   void finalize();
 
   int register_to_service_map(const DoutPrefixProvider *dpp, const std::string& daemon_type, const std::map<std::string, std::string>& meta);

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -1443,7 +1443,7 @@ int RGWReshard::update(const DoutPrefixProvider* dpp,
 
 int RGWReshard::list(const DoutPrefixProvider *dpp, optional_yield y,
                      int logshard_num, string& marker, uint32_t max,
-                     std::list<cls_rgw_reshard_entry>& entries,
+                     std::vector<cls_rgw_reshard_entry>& entries,
                      bool *is_truncated)
 {
   string logshard_oid;
@@ -1770,7 +1770,7 @@ int RGWReshard::process_single_logshard(int logshard_num, const DoutPrefixProvid
   }
   
   do {
-    std::list<cls_rgw_reshard_entry> entries;
+    std::vector<cls_rgw_reshard_entry> entries;
     ret = list(dpp, y, logshard_num, marker, max_op_entries, entries, &is_truncated);
     if (ret < 0) {
       ldpp_dout(dpp, 10) << "cannot list all reshards in logshard oid=" <<

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -243,7 +243,7 @@ public:
   int remove(const DoutPrefixProvider *dpp, const cls_rgw_reshard_entry& entry, optional_yield y);
   int list(const DoutPrefixProvider *dpp, optional_yield y,
            int logshard_num, std::string& marker, uint32_t max,
-           std::list<cls_rgw_reshard_entry>& entries, bool *is_truncated);
+           std::vector<cls_rgw_reshard_entry>& entries, bool *is_truncated);
   int clear_bucket_resharding(const DoutPrefixProvider *dpp, const std::string& bucket_instance_oid, cls_rgw_reshard_entry& entry);
 
   /* reshard thread */

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -29,6 +29,7 @@
 class RGWReshard;
 
 
+namespace ceph::async { class RadosLockClient; }
 class BucketReshardManager;
 namespace rgw { namespace sal {
   class RadosStore;
@@ -70,6 +71,11 @@ public:
   bool should_renew(const Clock::time_point& now) const {
     return now >= renew_thresh;
   }
+  ceph::timespan get_duration() const { return duration; }
+
+  // return a LockClient for with_lease()
+  auto make_client(boost::asio::yield_context yield)
+    -> ceph::async::RadosLockClient;
 }; // class RGWBucketReshardLock
 
 class RGWBucketReshard {
@@ -227,9 +233,12 @@ public:
 
   /* reshard thread */
   int process_entry(const cls_rgw_reshard_entry& entry, int max_entries,
-                    const DoutPrefixProvider *dpp, optional_yield y);
-  int process_single_logshard(int logshard_num, const DoutPrefixProvider *dpp, optional_yield y);
-  int process_all_logshards(const DoutPrefixProvider *dpp, optional_yield y);
+                    const DoutPrefixProvider *dpp,
+                    boost::asio::yield_context y);
+  int process_single_logshard(int logshard_num, const DoutPrefixProvider *dpp,
+                              boost::asio::yield_context y);
+  int process_all_logshards(const DoutPrefixProvider *dpp,
+                            boost::asio::yield_context y);
 };
 
 class RGWReshardWait {

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -236,10 +236,14 @@ protected:
 public:
   RGWReshard(rgw::sal::RadosStore* _store, bool _verbose = false, std::ostream *_out = nullptr, Formatter *_formatter = nullptr);
   int add(const DoutPrefixProvider *dpp, cls_rgw_reshard_entry& entry, optional_yield y);
-  int update(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const cls_rgw_reshard_initiator initiator, optional_yield y);
-  int get(const DoutPrefixProvider *dpp, cls_rgw_reshard_entry& entry);
+  int update(const DoutPrefixProvider *dpp, optional_yield y,
+             const rgw_bucket& bucket, cls_rgw_reshard_initiator initiator);
+  int get(const DoutPrefixProvider *dpp, optional_yield y,
+          const rgw_bucket& bucket, cls_rgw_reshard_entry& entry);
   int remove(const DoutPrefixProvider *dpp, const cls_rgw_reshard_entry& entry, optional_yield y);
-  int list(const DoutPrefixProvider *dpp, int logshard_num, std::string& marker, uint32_t max, std::list<cls_rgw_reshard_entry>& entries, bool *is_truncated);
+  int list(const DoutPrefixProvider *dpp, optional_yield y,
+           int logshard_num, std::string& marker, uint32_t max,
+           std::list<cls_rgw_reshard_entry>& entries, bool *is_truncated);
   int clear_bucket_resharding(const DoutPrefixProvider *dpp, const std::string& bucket_instance_oid, cls_rgw_reshard_entry& entry);
 
   /* reshard thread */

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -112,6 +112,11 @@ class RGWBucketReshard {
 		 Formatter *formatter,
                  ReshardFaultInjector& fault,
                  const DoutPrefixProvider *dpp, optional_yield y);
+  // execute the bucket reshard while the bucket's reshard lock is held
+  int execute_locked(int num_shards, ReshardFaultInjector& fault,
+                     int max_op_entries, const DoutPrefixProvider *dpp,
+                     boost::asio::yield_context yield, bool verbose,
+                     std::ostream *out, ceph::Formatter *formatter);
 public:
 
   // pass nullptr for the final parameter if no outer reshard lock to
@@ -122,7 +127,7 @@ public:
 		   RGWBucketReshardLock* _outer_reshard_lock);
   int execute(int num_shards, ReshardFaultInjector& f,
               int max_op_entries, const cls_rgw_reshard_initiator initiator,
-	      const DoutPrefixProvider *dpp, optional_yield y,
+	      const DoutPrefixProvider *dpp, boost::asio::yield_context yield,
               bool verbose = false, std::ostream *out = nullptr,
               ceph::Formatter *formatter = nullptr,
 	      RGWReshard *reshard_log = nullptr);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8429,7 +8429,8 @@ next:
       std::string marker;
       do {
 	std::list<cls_rgw_reshard_entry> entries;
-        ret = reshard.list(dpp(), i, marker, max_entries - count, entries, &is_truncated);
+        ret = reshard.list(dpp(), null_yield, i, marker, max_entries - count,
+                           entries, &is_truncated);
         if (ret < 0) {
           cerr << "Error listing resharding buckets: " << cpp_strerror(-ret) << std::endl;
           return ret;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8428,7 +8428,7 @@ next:
       bool is_truncated = true;
       std::string marker;
       do {
-	std::list<cls_rgw_reshard_entry> entries;
+	std::vector<cls_rgw_reshard_entry> entries;
         ret = reshard.list(dpp(), null_yield, i, marker, max_entries - count,
                            entries, &is_truncated);
         if (ret < 0) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8359,8 +8359,7 @@ next:
     }
 
     RGWBucketReshard br(static_cast<rgw::sal::RadosStore*>(driver),
-			bucket->get_info(), bucket->get_attrs(),
-			nullptr /* no callback */);
+			bucket->get_info(), bucket->get_attrs());
 
 #define DEFAULT_RESHARD_MAX_ENTRIES 1000
     if (max_entries < 1) {
@@ -8478,8 +8477,7 @@ next:
     }
 
     RGWBucketReshard br(static_cast<rgw::sal::RadosStore*>(driver),
-			bucket->get_info(), bucket->get_attrs(),
-			nullptr /* no callback */);
+			bucket->get_info(), bucket->get_attrs());
     list<cls_rgw_bucket_instance_entry> status;
     int r = br.get_status(dpp(), &status);
     if (r < 0) {
@@ -8541,8 +8539,7 @@ next:
     if (bucket_initable) {
       // we did not encounter an error, so let's work with the bucket
 	RGWBucketReshard br(static_cast<rgw::sal::RadosStore*>(driver),
-			    bucket->get_info(), bucket->get_attrs(),
-			    nullptr /* no callback */);
+			    bucket->get_info(), bucket->get_attrs());
       int ret = br.cancel(dpp(), null_yield);
       if (ret < 0) {
         if (ret == -EBUSY) {

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -104,7 +104,7 @@ rgw::sal::Driver* DriverManager::init_storage_provider(const DoutPrefixProvider*
       delete driver;
       return nullptr;
     }
-    if (rados->init_complete(dpp, y) < 0) {
+    if (rados->init_complete(dpp, y, io_context) < 0) {
       delete driver;
       return nullptr;
     }
@@ -131,7 +131,7 @@ rgw::sal::Driver* DriverManager::init_storage_provider(const DoutPrefixProvider*
       delete driver;
       return nullptr;
     }
-    if (rados->init_complete(dpp, y) < 0) {
+    if (rados->init_complete(dpp, y, io_context) < 0) {
       delete driver;
       return nullptr;
     }

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -386,7 +386,7 @@ target_link_libraries(unittest_async_spawn_throttle ceph-common Boost::system Bo
 
 add_executable(unittest_async_lease test_async_lease.cc)
 add_ceph_unittest(unittest_async_lease)
-target_link_libraries(unittest_async_lease ceph-common Boost::system Boost::context)
+target_link_libraries(unittest_async_lease ceph-common Boost::system Boost::context librados)
 
 add_executable(unittest_async_yield_waiter test_async_yield_waiter.cc)
 add_ceph_unittest(unittest_async_yield_waiter)

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -384,6 +384,10 @@ add_executable(unittest_async_spawn_throttle test_async_spawn_throttle.cc)
 add_ceph_unittest(unittest_async_spawn_throttle)
 target_link_libraries(unittest_async_spawn_throttle ceph-common Boost::system Boost::context)
 
+add_executable(unittest_async_lease test_async_lease.cc)
+add_ceph_unittest(unittest_async_lease)
+target_link_libraries(unittest_async_lease ceph-common Boost::system Boost::context)
+
 add_executable(unittest_async_yield_waiter test_async_yield_waiter.cc)
 add_ceph_unittest(unittest_async_yield_waiter)
 target_link_libraries(unittest_async_yield_waiter ceph-common Boost::system Boost::context)

--- a/src/test/common/test_async_lease.cc
+++ b/src/test/common/test_async_lease.cc
@@ -1,0 +1,1730 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+//#define BOOST_ASIO_ENABLE_HANDLER_TRACKING
+#include "common/async/lease.h"
+
+#include <optional>
+#include <utility>
+#include <vector>
+#include <boost/asio/any_completion_executor.hpp>
+#include <boost/asio/append.hpp>
+#include <boost/asio/associated_cancellation_slot.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <gtest/gtest.h>
+#include "common/async/co_waiter.h"
+#include "common/async/yield_waiter.h"
+
+namespace ceph::async {
+
+namespace asio = boost::asio;
+using executor_type = asio::any_io_executor;
+
+using namespace std::chrono_literals;
+
+enum class event { acquire, renew, release };
+
+// a LockClient that logs events and injects delays and exceptions
+class MockClient : public LockClient {
+  Handler waiter;
+  using Work = asio::executor_work_guard<asio::any_completion_executor>;
+  std::optional<Work> work;
+ public:
+  std::vector<event> events; // tracks the sequence of LockClient calls
+
+  void acquire(ceph::timespan, Handler handler) override {
+    events.push_back(event::acquire);
+    work.emplace(asio::make_work_guard(handler));
+    waiter = std::move(handler);
+  }
+  void renew(ceph::timespan, Handler handler) override {
+    events.push_back(event::renew);
+    work.emplace(asio::make_work_guard(handler));
+    waiter = std::move(handler);
+  }
+  void release(Handler handler) override {
+    events.push_back(event::release);
+    work.emplace(asio::make_work_guard(handler));
+    waiter = std::move(handler);
+  }
+
+  void complete(boost::system::error_code ec = {}) {
+    auto w = std::move(*work);
+    work = std::nullopt;
+    asio::dispatch(asio::append(std::move(waiter), ec));
+  }
+};
+
+// a MockClient that supports per-op cancellation
+class CancelableMockClient : public MockClient {
+  struct op_cancellation {
+    MockClient* self;
+    op_cancellation(MockClient* self) : self(self) {}
+    void operator()(asio::cancellation_type_t type) {
+      if (type != asio::cancellation_type::none) {
+        self->complete(make_error_code(asio::error::operation_aborted));
+      }
+    }
+  };
+ public:
+  void acquire(ceph::timespan dur, Handler handler) override {
+    auto slot = get_associated_cancellation_slot(handler);
+    if (slot.is_connected()) {
+      slot.template emplace<op_cancellation>(this);
+    }
+    MockClient::acquire(dur, std::move(handler));
+  }
+  void renew(ceph::timespan dur, Handler handler) override {
+    auto slot = get_associated_cancellation_slot(handler);
+    if (slot.is_connected()) {
+      slot.template emplace<op_cancellation>(this);
+    }
+    MockClient::renew(dur, std::move(handler));
+  }
+  void release(Handler handler) override {
+    auto slot = get_associated_cancellation_slot(handler);
+    if (slot.is_connected()) {
+      slot.template emplace<op_cancellation>(this);
+    }
+    MockClient::release(std::move(handler));
+  }
+};
+
+template <typename T>
+auto capture(std::optional<T>& opt)
+{
+  return [&opt] (T value) {
+    opt = std::move(value);
+  };
+}
+
+template <typename T>
+auto capture(asio::cancellation_signal& signal, std::optional<T>& opt)
+{
+  return asio::bind_cancellation_slot(signal.slot(), capture(opt));
+}
+
+template <typename ...Args>
+auto capture(std::optional<std::tuple<Args...>>& opt)
+{
+  return [&opt] (Args ...args) {
+    opt = std::forward_as_tuple(std::forward<Args>(args)...);
+  };
+}
+
+
+TEST(co_spawn, return_void)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(spawn, return_void)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&locker] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, [] (asio::yield_context) {});
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(co_spawn, return_value)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  using ptr = std::unique_ptr<int>; // test a move-only return type
+  auto cr = [] () -> asio::awaitable<ptr> { co_return std::make_unique<int>(42); };
+
+  using result_type = std::tuple<std::exception_ptr, ptr>;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  EXPECT_FALSE(result);
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(std::get<0>(*result));
+  ASSERT_TRUE(std::get<1>(*result));
+  EXPECT_EQ(42, *std::get<1>(*result));
+}
+
+TEST(spawn, return_value)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  /// using ptr = std::unique_ptr<int>;
+  // XXX: spawn() doesn't support move-only return values, see
+  // https://github.com/chriskohlhoff/asio/issues/1543
+  using ptr = std::shared_ptr<int>;
+  auto cr = [] (asio::yield_context) { return std::make_shared<int>(42); };
+
+  using result_type = std::tuple<std::exception_ptr, ptr>;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        return with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  EXPECT_FALSE(result);
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(std::get<0>(*result));
+  ASSERT_TRUE(std::get<1>(*result));
+  EXPECT_EQ(42, *std::get<1>(*result));
+}
+
+TEST(co_spawn, spawned_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> {
+    throw std::domain_error{"oops"};
+    co_return;
+  };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  EXPECT_THROW(std::rethrow_exception(*result), std::domain_error);
+}
+
+TEST(spawn, spawned_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) { throw std::domain_error{"oops"}; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  EXPECT_THROW(std::rethrow_exception(*result), std::domain_error);
+}
+
+TEST(co_spawn, acquire_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::invalid_argument);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(spawn, acquire_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::invalid_argument);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_spawn, acquire_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+  // shut down before acquire completes
+}
+
+TEST(spawn, acquire_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+  // shut down before acquire completes
+}
+
+TEST(co_spawn, acquire_cancel_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  // cancel before acquire completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(spawn, acquire_cancel_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  // cancel before acquire completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_spawn, acquire_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  // cancel before acquire completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(spawn, acquire_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  // cancel before acquire completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_spawn, acquired_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // start cr and renewal timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  // shut down before renewal timer
+}
+
+TEST(spawn, acquired_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // start cr and renewal timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  // shut down before renewal timer
+}
+
+TEST(co_spawn, acquired_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)),
+                 capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // wait for acquire to finish
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renewal timer
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(spawn, acquired_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // wait for acquire to finish
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renewal timer
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_spawn, renew_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  // inject an exception on renew
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), std::errc::invalid_argument);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  // inject an exception on renew
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), std::errc::invalid_argument);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete(); // unblock renew
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(3, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete(); // unblock renew
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(3, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_exception_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // inject an exception on renew
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_exception_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // inject an exception on renew
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_cancel_after_timeout_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)),
+                 capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size()); // no release
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_cancel_after_timeout_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size()); // no release
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_cancel_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)),
+                 capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size()); // no release
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_cancel_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size()); // no release
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+  // shut down before renew completes
+}
+
+TEST(spawn, renew_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+  // shut down before renew completes
+}
+
+TEST(co_spawn, renew_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 50ms, std::move(cr)),
+                 capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~25ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 50ms, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~25ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, release_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // inject an exception on release
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result); // release exceptions are ignored
+}
+
+TEST(spawn, release_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // inject an exception on release
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result); // release exceptions are ignored
+}
+
+TEST(co_spawn, release_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+  // shut down before release completes
+}
+
+TEST(spawn, release_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+  // shut down before release completes
+}
+
+TEST(co_spawn, release_cancel_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // cancel before release completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_FALSE(*result); // exception is ignored
+}
+
+TEST(spawn, release_cancel_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // cancel before release completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_FALSE(*result); // exception is ignored
+}
+
+TEST(co_spawn, release_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // cancel before release completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_FALSE(*result); // exception is ignored
+}
+
+TEST(spawn, release_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // cancel before release completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_FALSE(*result); // exception is ignored
+}
+
+} // namespace ceph::async

--- a/src/test/common/test_async_lease.cc
+++ b/src/test/common/test_async_lease.cc
@@ -12,6 +12,7 @@
 
 //#define BOOST_ASIO_ENABLE_HANDLER_TRACKING
 #include "common/async/lease.h"
+#include "common/async/lease_rados.h"
 
 #include <optional>
 #include <utility>

--- a/src/test/librados/asio.cc
+++ b/src/test/librados/asio.cc
@@ -12,6 +12,7 @@
  */
 
 #include "librados/librados_asio.h"
+#include "librados/redirect_version.h"
 #include <gtest/gtest.h>
 
 #include "common/ceph_argparse.h"
@@ -89,6 +90,13 @@ TEST_F(AsioRados, AsyncReadCallback)
   };
   librados::async_read(service, io, "exist", 256, 0, success_cb);
 
+  auto success_nover_cb = [&] (error_code ec, bufferlist bl) {
+    EXPECT_FALSE(ec);
+    EXPECT_EQ("hello", bl.to_str());
+  };
+  librados::async_read(service, io, "exist", 256, 0,
+                       librados::redirect_version(success_nover_cb));
+
   auto failure_cb = [&] (error_code ec, version_t ver, bufferlist bl) {
     EXPECT_EQ(boost::system::errc::no_such_file_or_directory, ec);
     EXPECT_EQ(0, ver);
@@ -105,7 +113,11 @@ TEST_F(AsioRados, AsyncReadFuture)
 
   auto f1 = librados::async_read(service, io, "exist", 256,
                                  0, boost::asio::use_future);
-  auto f2 = librados::async_read(service, io, "noexist", 256,
+  version_t ver2 = 0;
+  auto f2 = librados::async_read(service, io, "exist", 256, 0,
+                                 librados::redirect_version(
+                                     boost::asio::use_future, &ver2));
+  auto f3 = librados::async_read(service, io, "noexist", 256,
                                  0, boost::asio::use_future);
 
   service.run();
@@ -114,7 +126,10 @@ TEST_F(AsioRados, AsyncReadFuture)
   EXPECT_LT(0, ver);
   EXPECT_EQ("hello", bl.to_str());
 
-  EXPECT_THROW(f2.get(), boost::system::system_error);
+  EXPECT_LT(0, ver2);
+  EXPECT_EQ("hello", f2.get().to_str());
+
+  EXPECT_THROW(f3.get(), boost::system::system_error);
 }
 
 TEST_F(AsioRados, AsyncReadYield)
@@ -130,6 +145,17 @@ TEST_F(AsioRados, AsyncReadYield)
     EXPECT_EQ("hello", bl.to_str());
   };
   boost::asio::spawn(service, success_cr, rethrow);
+
+  auto success_nover_cr = [&] (boost::asio::yield_context yield) {
+    error_code ec;
+    version_t ver;
+    auto bl = librados::async_read(service, io, "exist", 256, 0,
+                                   librados::redirect_version(yield[ec], &ver));
+    EXPECT_FALSE(ec);
+    EXPECT_LT(0, ver);
+    EXPECT_EQ("hello", bl.to_str());
+  };
+  boost::asio::spawn(service, success_nover_cr, rethrow);
 
   auto failure_cr = [&] (boost::asio::yield_context yield) {
     error_code ec;
@@ -158,6 +184,12 @@ TEST_F(AsioRados, AsyncWriteCallback)
   librados::async_write(service, io, "exist", bl, bl.length(), 0,
                         success_cb);
 
+  auto success_nover_cb = [&] (error_code ec) {
+    EXPECT_FALSE(ec);
+  };
+  librados::async_write(service, io, "exist", bl, bl.length(), 0,
+                        librados::redirect_version(success_nover_cb));
+
   auto failure_cb = [&] (error_code ec, version_t ver) {
     EXPECT_EQ(boost::system::errc::read_only_file_system, ec);
     EXPECT_EQ(0, ver);
@@ -177,13 +209,19 @@ TEST_F(AsioRados, AsyncWriteFuture)
 
   auto f1 = librados::async_write(service, io, "exist", bl, bl.length(), 0,
                                   boost::asio::use_future);
-  auto f2 = librados::async_write(service, snapio, "exist", bl, bl.length(), 0,
+  version_t ver2 = 0;
+  std::future<void> f2 = librados::async_write(
+      service, io, "exist", bl, bl.length(), 0,
+      librados::redirect_version(boost::asio::use_future, &ver2));
+  auto f3 = librados::async_write(service, snapio, "exist", bl, bl.length(), 0,
                                   boost::asio::use_future);
 
   service.run();
 
   EXPECT_LT(0, f1.get());
-  EXPECT_THROW(f2.get(), boost::system::system_error);
+  f2.get();
+  EXPECT_LT(0, ver2);
+  EXPECT_THROW(f3.get(), boost::system::system_error);
 }
 
 TEST_F(AsioRados, AsyncWriteYield)
@@ -202,6 +240,17 @@ TEST_F(AsioRados, AsyncWriteYield)
     EXPECT_EQ("hello", bl.to_str());
   };
   boost::asio::spawn(service, success_cr, rethrow);
+
+  auto success_nover_cr = [&] (boost::asio::yield_context yield) {
+    error_code ec;
+    version_t ver;
+    librados::async_write(service, io, "exist", bl, bl.length(), 0,
+                          librados::redirect_version(yield[ec], &ver));
+    EXPECT_FALSE(ec);
+    EXPECT_LT(0, ver);
+    EXPECT_EQ("hello", bl.to_str());
+  };
+  boost::asio::spawn(service, success_nover_cr, rethrow);
 
   auto failure_cr = [&] (boost::asio::yield_context yield) {
     error_code ec;
@@ -231,6 +280,16 @@ TEST_F(AsioRados, AsyncReadOperationCallback)
   {
     librados::ObjectReadOperation op;
     op.read(0, 0, nullptr, nullptr);
+    auto success_nover_cb = [&] (error_code ec, bufferlist bl) {
+      EXPECT_FALSE(ec);
+      EXPECT_EQ("hello", bl.to_str());
+    };
+    librados::async_operate(service, io, "exist", &op, 0, nullptr,
+                            librados::redirect_version(success_nover_cb));
+  }
+  {
+    librados::ObjectReadOperation op;
+    op.read(0, 0, nullptr, nullptr);
     auto failure_cb = [&] (error_code ec, version_t ver, bufferlist bl) {
       EXPECT_EQ(boost::system::errc::no_such_file_or_directory, ec);
       EXPECT_EQ(0, ver);
@@ -251,11 +310,20 @@ TEST_F(AsioRados, AsyncReadOperationFuture)
     f1 = librados::async_operate(service, io, "exist", &op, 0, nullptr,
                                  boost::asio::use_future);
   }
-  std::future<read_result> f2;
+  std::future<bufferlist> f2;
+  version_t ver2 = 0;
   {
     librados::ObjectReadOperation op;
     op.read(0, 0, nullptr, nullptr);
-    f2 = librados::async_operate(service, io, "noexist", &op, 0, nullptr,
+    f2 = librados::async_operate(service, io, "exist", &op, 0, nullptr,
+                                 librados::redirect_version(
+                                     boost::asio::use_future, &ver2));
+  }
+  std::future<read_result> f3;
+  {
+    librados::ObjectReadOperation op;
+    op.read(0, 0, nullptr, nullptr);
+    f3 = librados::async_operate(service, io, "noexist", &op, 0, nullptr,
                                  boost::asio::use_future);
   }
   service.run();
@@ -264,7 +332,10 @@ TEST_F(AsioRados, AsyncReadOperationFuture)
   EXPECT_LT(0, ver);
   EXPECT_EQ("hello", bl.to_str());
 
-  EXPECT_THROW(f2.get(), boost::system::system_error);
+  EXPECT_EQ("hello", f2.get().to_str());
+  EXPECT_LT(0, ver2);
+
+  EXPECT_THROW(f3.get(), boost::system::system_error);
 }
 
 TEST_F(AsioRados, AsyncReadOperationYield)
@@ -317,6 +388,15 @@ TEST_F(AsioRados, AsyncWriteOperationCallback)
   {
     librados::ObjectWriteOperation op;
     op.write_full(bl);
+    auto success_nover_cb = [&] (error_code ec) {
+      EXPECT_FALSE(ec);
+    };
+    librados::async_operate(service, io, "exist", &op, 0, nullptr,
+                            librados::redirect_version(success_nover_cb));
+  }
+  {
+    librados::ObjectWriteOperation op;
+    op.write_full(bl);
     auto failure_cb = [&] (error_code ec, version_t ver) {
       EXPECT_EQ(boost::system::errc::read_only_file_system, ec);
       EXPECT_EQ(0, ver);
@@ -340,17 +420,28 @@ TEST_F(AsioRados, AsyncWriteOperationFuture)
     f1 = librados::async_operate(service, io, "exist", &op, 0, nullptr,
                                  boost::asio::use_future);
   }
-  std::future<version_t> f2;
+  std::future<void> f2;
+  version_t ver2 = 0;
   {
     librados::ObjectWriteOperation op;
     op.write_full(bl);
-    f2 = librados::async_operate(service, snapio, "exist", &op, 0, nullptr,
+    f2 = librados::async_operate(service, io, "exist", &op, 0, nullptr,
+                                 librados::redirect_version(
+                                     boost::asio::use_future, &ver2));
+  }
+  std::future<version_t> f3;
+  {
+    librados::ObjectWriteOperation op;
+    op.write_full(bl);
+    f3 = librados::async_operate(service, snapio, "exist", &op, 0, nullptr,
                                  boost::asio::use_future);
   }
   service.run();
 
   EXPECT_LT(0, f1.get());
-  EXPECT_THROW(f2.get(), boost::system::system_error);
+  f2.get();
+  EXPECT_LT(0, ver2);
+  EXPECT_THROW(f3.get(), boost::system::system_error);
 }
 
 TEST_F(AsioRados, AsyncWriteOperationYield)
@@ -370,6 +461,18 @@ TEST_F(AsioRados, AsyncWriteOperationYield)
     EXPECT_LT(0, ver);
   };
   boost::asio::spawn(service, success_cr, rethrow);
+
+  auto success_nover_cr = [&] (boost::asio::yield_context yield) {
+    librados::ObjectWriteOperation op;
+    op.write_full(bl);
+    error_code ec;
+    version_t ver;
+    librados::async_operate(service, io, "exist", &op, 0, nullptr,
+                            librados::redirect_version(yield[ec], &ver));
+    EXPECT_FALSE(ec);
+    EXPECT_LT(0, ver);
+  };
+  boost::asio::spawn(service, success_nover_cr, rethrow);
 
   auto failure_cr = [&] (boost::asio::yield_context yield) {
     librados::ObjectWriteOperation op;


### PR DESCRIPTION
(currently based on https://github.com/ceph/ceph/pull/60264 for the `with_lease()` algorithm)

a prelude to shard parallelism in bucket resharding

## stackful coroutines for with_lease()
replaces dynamic resharding's background thread `ReshardWorker` with a stackful coroutine function that's spawned on rgw's io_context thread pool. functions `RGWReshard::process_all_logshards()` through `RGWBucketReshard::execute()` now take `asio::yield_context` instead of `optional_yield` and must be called in a coroutine

this allows us to wrap `process_single_logshard()` and `execute()` in `with_lease()` calls to handle locking/renewal of the reshard log shard lock and per-bucket reshard lock respectively

because `with_lease()` hides all of the locking and renewal, the wrapped functions no longer need to call `renew_lock_if_needed()` repeatedly

## cancellation
coroutine cancellation becomes important in this design: 
* `with_lease()` signals cancellation of the wrapped coroutine if lock renewal fails or times out
* on shutdown, `RGWRados::finalize()` cancels the background `reshard_worker()` coroutine

when a coroutine's cancellation is requested, that signal calls the 'cancellation handler' of whatever the coroutine was suspended on. when this is a librados request, we'll rely on https://github.com/ceph/ceph/pull/60379 to fail the request immediately with -ECANCELED. without that support, the librados request would succeed and we'd only notice the cancellation if we check `yield_context.cancelled()` manually

reshard already has special handling to retry ECANCELED errors from cls_version on racing writes to bucket instance metadata. we now need to consult `yield_context.cancelled()` to determine whether or not this error came from the coroutine's cancellation, and return the error directly without retry

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
