### PR TITLE
<rgw> Ensure the ETag format is consistent with AWS S3 API

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2782,7 +2782,7 @@ void RGWPutObj_ObjStore_S3::send_response()
       if (strftime(buf, sizeof(buf), "%Y-%m-%dT%T.000Z", &tmp) > 0) {
         s->formatter->dump_string("LastModified", buf);
       }
-      s->formatter->dump_string("ETag", etag);
+      s->formatter->dump_format("ETag", "\"%s\"", etag.c_str());
       s->formatter->close_section();
       rgw_flush_formatter_and_reset(s, s->formatter);
       return;
@@ -3419,7 +3419,7 @@ done:
     }
     s->formatter->dump_string("Bucket", s->bucket_name);
     s->formatter->dump_string("Key", s->object->get_name());
-    s->formatter->dump_string("ETag", etag);
+    s->formatter->dump_format("ETag", "\"%s\"", etag.c_str());
     s->formatter->close_section();
   }
   s->err.message = err_msg;
@@ -4225,7 +4225,7 @@ void RGWCompleteMultipart_ObjStore_S3::send_response()
     }
     s->formatter->dump_string("Bucket", s->bucket_name);
     s->formatter->dump_string("Key", s->object->get_name());
-    s->formatter->dump_string("ETag", etag);
+    s->formatter->dump_format("ETag", "\"%s\"", etag.c_str());
     if (armored_cksum) {
       s->formatter->dump_string(cksum->element_name(), *armored_cksum);
     }


### PR DESCRIPTION
 https://tracker.ceph.com/issues/68712

Most ETags returned by RGW are quoted, but some are still not. This can cause false positives during consistency checks when comparing ETags returned by different interfaces.

checked with following cmd.
```
$ rg -i "dump.*\"ETag\"" ceph
./src/rgw/rgw_rest_s3.cc
1863:        s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
1955:      s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
2030:        s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
2099:      s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
2785:      s->formatter->dump_format("ETag", "\"%s\"", etag.c_str());
3422:    s->formatter->dump_string("ETag", etag);
3725:      s->formatter->dump_format("ETag", "\"%s\"",etag.c_str());
4228:    s->formatter->dump_string("ETag", etag);
4298:      s->formatter->dump_format("ETag", "\"%s\"", part->get_etag().c_str());

./src/rgw/rgw_rest.cc
421:    return dump_header(s, "etag", etag);
423:    return dump_header_quoted(s, "ETag", etag);

./src/rgw/driver/rados/rgw_sync_module_es_rest.cc
347:      s->formatter->dump_format("ETag", "\"%s\"", e.meta.etag.c_str());

./src/rgw/rgw_admin.cc
8612:        handled = dump_string("etag", bl, formatter.get());
```





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket 
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
