### PR TITLE
rgw: fix json output for bucket layout

### DIFF
--- a/src/rgw/rgw_bucket_layout.cc
+++ b/src/rgw/rgw_bucket_layout.cc
@@ -376,9 +376,9 @@ void encode_json_impl(const char *name, const BucketLayout& l, ceph::Formatter *
   for (const auto& log : l.logs) {
     encode_json("log", log, f);
   }
+  f->close_section(); // logs[]
   utime_t jt(l.judge_reshard_lock_time);
   encode_json("judge_reshard_lock_time", jt, f);
-  f->close_section(); // logs[]
   f->close_section();
 }
 void decode_json_obj(BucketLayout& l, JSONObj *obj)


### PR DESCRIPTION
f19347d43b7cd4bb1e009e66305f6e736c4c5d89 has broken the bucket layout JSON output by printing `judge_reshard_lock_time` inside the logs array.

Fixes: https://tracker.ceph.com/issues/68726