### PR TITLE
mgr/dashboard: fix total objects/Avg object size in RGW Overview Page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-bucket.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/models/rgw-bucket.ts
@@ -1,0 +1,37 @@
+export interface Bucket {
+  bucket: string;
+  tenant: string;
+  versioning: string;
+  zonegroup: string;
+  placement_rule: string;
+  explicit_placement: {
+    data_pool: string;
+    data_extra_pool: string;
+    index_pool: string;
+  };
+  id: string;
+  marker: string;
+  index_type: string;
+  index_generation: number;
+  num_shards: number;
+  reshard_status: string;
+  judge_reshard_lock_time: string;
+  object_lock_enabled: boolean;
+  mfa_enabled: boolean;
+  owner: string;
+  ver: string;
+  master_ver: string;
+  mtime: string;
+  creation_time: string;
+  max_marker: string;
+  usage: Record<string, any>;
+  bucket_quota: {
+    enabled: boolean;
+    check_on_raw: boolean;
+    max_size: number;
+    max_size_kb: number;
+    max_objects: number;
+  };
+  read_tracker: number;
+  bid: string;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-overview-dashboard/rgw-overview-dashboard.component.spec.ts
@@ -1,24 +1,33 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { of, BehaviorSubject, combineLatest } from 'rxjs';
 import { RgwOverviewDashboardComponent } from './rgw-overview-dashboard.component';
-import { of } from 'rxjs';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RgwBucketService } from '~/app/shared/api/rgw-bucket.service';
 import { RgwDaemonService } from '~/app/shared/api/rgw-daemon.service';
 import { RgwDaemon } from '../models/rgw-daemon';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
-import { RgwRealmService } from '~/app/shared/api/rgw-realm.service';
-import { RgwZonegroupService } from '~/app/shared/api/rgw-zonegroup.service';
-import { RgwZoneService } from '~/app/shared/api/rgw-zone.service';
-import { RgwBucketService } from '~/app/shared/api/rgw-bucket.service';
-import { HealthService } from '~/app/shared/api/health.service';
-import { CardRowComponent } from '~/app/shared/components/card-row/card-row.component';
 import { CardComponent } from '~/app/shared/components/card/card.component';
+import { CardRowComponent } from '~/app/shared/components/card-row/card-row.component';
+import { DimlessBinaryPipe } from '~/app/shared/pipes/dimless-binary.pipe';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { configureTestBed } from '~/testing/unit-test-helper';
+import { RgwRealmService } from '~/app/shared/api/rgw-realm.service';
+import { RgwZoneService } from '~/app/shared/api/rgw-zone.service';
+import { RgwZonegroupService } from '~/app/shared/api/rgw-zonegroup.service';
 
 describe('RgwOverviewDashboardComponent', () => {
   let component: RgwOverviewDashboardComponent;
   let fixture: ComponentFixture<RgwOverviewDashboardComponent>;
+  let listDaemonsSpy: jest.SpyInstance;
+  let listRealmsSpy: jest.SpyInstance;
+  let listZonegroupsSpy: jest.SpyInstance;
+  let listZonesSpy: jest.SpyInstance;
+  let fetchAndTransformBucketsSpy: jest.SpyInstance;
+  let totalBucketsAndUsersSpy: jest.SpyInstance;
+
+  const totalNumObjectsSubject = new BehaviorSubject<number>(290);
+  const totalUsedCapacitySubject = new BehaviorSubject<number>(9338880);
+  const averageObjectSizeSubject = new BehaviorSubject<number>(1280);
+  const bucketsCount = 2;
+  const usersCount = 5;
   const daemon: RgwDaemon = {
     id: '8000',
     service_map_id: '4803',
@@ -47,38 +56,44 @@ describe('RgwOverviewDashboardComponent', () => {
     zones: ['zone4', 'zone5', 'zone6', 'zone7']
   };
 
-  const bucketAndUserList = {
-    buckets_count: 2,
-    users_count: 2
-  };
-
-  const healthData = {
-    total_objects: '290',
-    total_pool_bytes_used: 9338880
-  };
-
-  let listDaemonsSpy: jest.SpyInstance;
-  let listZonesSpy: jest.SpyInstance;
-  let listZonegroupsSpy: jest.SpyInstance;
-  let listRealmsSpy: jest.SpyInstance;
-  let listBucketsSpy: jest.SpyInstance;
-  let healthDataSpy: jest.SpyInstance;
-
-  configureTestBed({
-    declarations: [
-      RgwOverviewDashboardComponent,
-      CardComponent,
-      CardRowComponent,
-      DimlessBinaryPipe
-    ],
-    schemas: [NO_ERRORS_SCHEMA],
-    imports: [HttpClientTestingModule]
-  });
-
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        RgwOverviewDashboardComponent,
+        CardComponent,
+        CardRowComponent,
+        DimlessBinaryPipe
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        { provide: RgwDaemonService, useValue: { list: jest.fn() } },
+        { provide: RgwRealmService, useValue: { list: jest.fn() } },
+        { provide: RgwZonegroupService, useValue: { list: jest.fn() } },
+        { provide: RgwZoneService, useValue: { list: jest.fn() } },
+        {
+          provide: RgwBucketService,
+          useValue: {
+            fetchAndTransformBuckets: jest.fn(),
+            totalNumObjects$: totalNumObjectsSubject.asObservable(),
+            totalUsedCapacity$: totalUsedCapacitySubject.asObservable(),
+            averageObjectSize$: averageObjectSizeSubject.asObservable(),
+            getTotalBucketsAndUsersLength: jest.fn()
+          }
+        }
+      ],
+      imports: [HttpClientTestingModule]
+    }).compileComponents();
+    fixture = TestBed.createComponent(RgwOverviewDashboardComponent);
+    component = fixture.componentInstance;
     listDaemonsSpy = jest
       .spyOn(TestBed.inject(RgwDaemonService), 'list')
       .mockReturnValue(of([daemon]));
+    fetchAndTransformBucketsSpy = jest
+      .spyOn(TestBed.inject(RgwBucketService), 'fetchAndTransformBuckets')
+      .mockReturnValue(of(null));
+    totalBucketsAndUsersSpy = jest
+      .spyOn(TestBed.inject(RgwBucketService), 'getTotalBucketsAndUsersLength')
+      .mockReturnValue(of({ buckets_count: bucketsCount, users_count: usersCount }));
     listRealmsSpy = jest
       .spyOn(TestBed.inject(RgwRealmService), 'list')
       .mockReturnValue(of(realmList));
@@ -86,56 +101,60 @@ describe('RgwOverviewDashboardComponent', () => {
       .spyOn(TestBed.inject(RgwZonegroupService), 'list')
       .mockReturnValue(of(zonegroupList));
     listZonesSpy = jest.spyOn(TestBed.inject(RgwZoneService), 'list').mockReturnValue(of(zoneList));
-    listBucketsSpy = jest
-      .spyOn(TestBed.inject(RgwBucketService), 'getTotalBucketsAndUsersLength')
-      .mockReturnValue(of(bucketAndUserList));
-    healthDataSpy = jest
-      .spyOn(TestBed.inject(HealthService), 'getClusterCapacity')
-      .mockReturnValue(of(healthData));
-    fixture = TestBed.createComponent(RgwOverviewDashboardComponent);
-    component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create the component', () => {
     expect(component).toBeTruthy();
   });
 
   it('should render all cards', () => {
-    fixture.detectChanges();
     const dashboardCards = fixture.debugElement.nativeElement.querySelectorAll('cd-card');
     expect(dashboardCards.length).toBe(5);
   });
 
-  it('should get corresponding data into Daemons', () => {
-    expect(listDaemonsSpy).toHaveBeenCalled();
-    expect(component.rgwDaemonCount).toEqual(1);
-  });
-
-  it('should get corresponding data into Realms', () => {
+  it('should get data for Realms', () => {
     expect(listRealmsSpy).toHaveBeenCalled();
     expect(component.rgwRealmCount).toEqual(2);
   });
 
-  it('should get corresponding data into Zonegroups', () => {
+  it('should get data for Zonegroups', () => {
     expect(listZonegroupsSpy).toHaveBeenCalled();
     expect(component.rgwZonegroupCount).toEqual(3);
   });
 
-  it('should get corresponding data into Zones', () => {
+  it('should get data for Zones', () => {
     expect(listZonesSpy).toHaveBeenCalled();
     expect(component.rgwZoneCount).toEqual(4);
   });
 
-  it('should get corresponding data into Buckets', () => {
-    expect(listBucketsSpy).toHaveBeenCalled();
-    expect(component.rgwBucketCount).toEqual(2);
-    expect(component.UserCount).toEqual(2);
-  });
-
-  it('should get corresponding data into Objects and capacity', () => {
-    expect(healthDataSpy).toHaveBeenCalled();
-    expect(component.objectCount).toEqual('290');
+  it('should set component properties from services using combineLatest', fakeAsync(() => {
+    component.interval = of(null).subscribe(() => {
+      component.fetchDataSub = combineLatest([
+        TestBed.inject(RgwDaemonService).list(),
+        TestBed.inject(RgwBucketService).fetchAndTransformBuckets(),
+        totalNumObjectsSubject.asObservable(),
+        totalUsedCapacitySubject.asObservable(),
+        averageObjectSizeSubject.asObservable(),
+        TestBed.inject(RgwBucketService).getTotalBucketsAndUsersLength()
+      ]).subscribe(([daemonData, _, objectCount, usedCapacity, averageSize, bucketData]) => {
+        component.rgwDaemonCount = daemonData.length;
+        component.objectCount = objectCount;
+        component.totalPoolUsedBytes = usedCapacity;
+        component.averageObjectSize = averageSize;
+        component.rgwBucketCount = bucketData.buckets_count;
+        component.UserCount = bucketData.users_count;
+      });
+    });
+    tick();
+    expect(listDaemonsSpy).toHaveBeenCalled();
+    expect(fetchAndTransformBucketsSpy).toHaveBeenCalled();
+    expect(totalBucketsAndUsersSpy).toHaveBeenCalled();
+    expect(component.rgwDaemonCount).toEqual(1);
+    expect(component.objectCount).toEqual(290);
     expect(component.totalPoolUsedBytes).toEqual(9338880);
-  });
+    expect(component.averageObjectSize).toEqual(1280);
+    expect(component.rgwBucketCount).toEqual(bucketsCount);
+    expect(component.UserCount).toEqual(usersCount);
+  }));
 });

--- a/src/pybind/mgr/dashboard/services/cluster.py
+++ b/src/pybind/mgr/dashboard/services/cluster.py
@@ -9,9 +9,6 @@ class ClusterCapacity(NamedTuple):
     total_avail_bytes: int
     total_bytes: int
     total_used_raw_bytes: int
-    total_objects: int
-    total_pool_bytes_used: int
-    average_object_size: int
 
 
 class ClusterModel:
@@ -47,33 +44,9 @@ class ClusterModel:
     @classmethod
     def get_capacity(cls) -> ClusterCapacity:
         df = mgr.get('df')
-        total_pool_bytes_used = 0
-        average_object_size = 0
-        total_data_pool_objects = 0
-        total_data_pool_bytes_used = 0
-        rgw_pools_data = cls.get_rgw_pools()
-
-        for pool in df['pools']:
-            pool_name = str(pool['name'])
-            if pool_name in rgw_pools_data:
-                if pool_name.endswith('.data'):
-                    objects = pool['stats']['objects']
-                    pool_bytes_used = pool['stats']['bytes_used']
-                    total_pool_bytes_used += pool_bytes_used
-                    total_data_pool_objects += objects
-                    replica = rgw_pools_data[pool_name]
-                    total_data_pool_bytes_used += pool_bytes_used / replica
-
-        average_object_size = total_data_pool_bytes_used / total_data_pool_objects if total_data_pool_objects != 0 else 0  # noqa E501  #pylint: disable=line-too-long
-
-        return ClusterCapacity(
-            total_avail_bytes=df['stats']['total_avail_bytes'],
-            total_bytes=df['stats']['total_bytes'],
-            total_used_raw_bytes=df['stats']['total_used_raw_bytes'],
-            total_objects=total_data_pool_objects,
-            total_pool_bytes_used=total_pool_bytes_used,
-            average_object_size=average_object_size
-        )._asdict()
+        return ClusterCapacity(total_avail_bytes=df['stats']['total_avail_bytes'],
+                               total_bytes=df['stats']['total_bytes'],
+                               total_used_raw_bytes=df['stats']['total_used_raw_bytes'])._asdict()
 
     @classmethod
     def get_rgw_pools(cls):


### PR DESCRIPTION
Till now we are calculating the total number of objects and the average object size in the RGW Overview Page using `ceph df` command's output. As per the discussion with RGW team, this data is not correct as S3 objects in rgw can occupy more than one rados object. This PR tends to make the overview page's info in sync with the RGW bucket page's info by using s3 api's buckets related data.
Also fixes the issue where For a version enabled bucket every single new object upload, object count got doubled in overview page.

Fixes: https://tracker.ceph.com/issues/68733


https://github.com/user-attachments/assets/ceca26fa-b121-40ad-a9a4-2f398c4ca335

Signed-off-by: Aashish Sharma <aasharma@redhat.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
