### PR TITLE
tests: add PID to object suffix during creation for better debugging

### DIFF
--- a/src/test/system/rados_delete_pools_parallel.cc
+++ b/src/test/system/rados_delete_pools_parallel.cc
@@ -74,7 +74,7 @@ int main(int argc, const char **argv)
   // first test: create a pool, then delete that pool
   {
     StRadosCreatePool r1(argc, argv, NULL, pool_setup_sem, NULL,
-			 pool, 50, ".obj");
+			 pool, 50, get_temp_suffix(".obj"));
     StRadosDeletePool r2(argc, argv, pool_setup_sem, deleted_pool_sem, pool);
     vector < SysTestRunnable* > vec;
     vec.push_back(&r1);
@@ -92,7 +92,7 @@ int main(int argc, const char **argv)
   RETURN1_IF_NONZERO(delete_pool_sem->reinit(0));
   {
     StRadosCreatePool r1(argc, argv, deleted_pool_sem, pool_setup_sem, NULL,
-			 pool, g_num_objects, ".obj");
+			 pool, g_num_objects, get_temp_suffix(".obj"));
     StRadosDeletePool r2(argc, argv, delete_pool_sem, NULL, pool);
     StRadosListObjects r3(argc, argv, pool, true, g_num_objects / 2,
 			  pool_setup_sem, NULL, delete_pool_sem);

--- a/src/test/system/rados_open_pools_parallel.cc
+++ b/src/test/system/rados_open_pools_parallel.cc
@@ -109,7 +109,7 @@ int main(int argc, const char **argv)
   CrossProcessSem *pool_setup_sem = NULL;
   RETURN1_IF_NONZERO(CrossProcessSem::create(0, &pool_setup_sem));
   StRadosCreatePool r1(argc, argv, NULL, pool_setup_sem, NULL,
-					   pool, 50, ".obj");
+					   pool, 50, get_temp_suffix(".obj"));
   StRadosOpenPool r2(argc, argv, pool_setup_sem, NULL, pool);
   vector < SysTestRunnable* > vec;
   vec.push_back(&r1);
@@ -127,7 +127,7 @@ int main(int argc, const char **argv)
   CrossProcessSem *open_pool_sem2 = NULL;
   RETURN1_IF_NONZERO(CrossProcessSem::create(0, &open_pool_sem2));
   StRadosCreatePool r3(argc, argv, NULL, pool_setup_sem2, open_pool_sem2,
-					   pool, 50, ".obj");
+					   pool, 50, get_temp_suffix(".obj"));
   StRadosOpenPool r4(argc, argv, pool_setup_sem2, open_pool_sem2, pool);
   vector < SysTestRunnable* > vec2;
   vec2.push_back(&r3);

--- a/src/test/system/st_rados_create_pool.cc
+++ b/src/test/system/st_rados_create_pool.cc
@@ -130,3 +130,18 @@ std::string get_temp_pool_name(const char* prefix)
   ceph_assert((unsigned int)ret < sizeof(poolname));
   return poolname;
 }
+
+std::string get_temp_suffix(const char* _suffix)
+{
+  ceph_assert(_suffix);
+  char hostname[80];
+  int ret = 0;
+  ret = gethostname(hostname, sizeof(hostname));
+  ceph_assert(!ret);
+  char suffix[256];
+  ret = snprintf(suffix, sizeof(suffix),
+                 "%s-%s-%d", _suffix, hostname, getpid());
+  ceph_assert(ret > 0);
+  ceph_assert((unsigned int)ret < sizeof(suffix));
+  return suffix;
+}

--- a/src/test/system/st_rados_create_pool.h
+++ b/src/test/system/st_rados_create_pool.h
@@ -49,5 +49,6 @@ private:
 };
 
 std::string get_temp_pool_name(const char* prefix);
+std::string get_temp_suffix(const char* prefix);
 
 #endif


### PR DESCRIPTION
In parallel tests, when creating many objects, if one of the objects returns an error, we need to find it quickly.
By making the names unique with a suffix and PID,
the debugging process will be clearer.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
