### PR TITLE
os/bluestore: Disable invoking unittest_deferred

### DIFF
--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -112,12 +112,11 @@ if(WITH_BLUESTORE)
   add_ceph_unittest(unittest_bdev)
   target_link_libraries(unittest_bdev os global)
 
-  # unittest_deferred
-  add_executable(unittest_deferred
+  # test_corrupt_deferred
+  add_executable(test_corrupt_deferred
     test_deferred.cc
     )
-  add_ceph_unittest(unittest_deferred)
-  target_link_libraries(unittest_deferred os global)
+  target_link_libraries(test_corrupt_deferred os global)
 
 endif(WITH_BLUESTORE)
 

--- a/src/test/objectstore/run_test_deferred.sh
+++ b/src/test/objectstore/run_test_deferred.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 
-if [[ ! (-x ./bin/unittest_deferred) || ! (-x ./bin/ceph-kvstore-tool) || ! (-x ./bin/ceph-bluestore-tool)]]
+if [[ ! (-x ./bin/test_corrupt_deferred) || ! (-x ./bin/ceph-kvstore-tool) || ! (-x ./bin/ceph-bluestore-tool)]]
 then
     echo Test must be run from ceph build directory
-    echo with unittest_deferred, ceph-kvstore-tool and ceph-bluestore-tool compiled
+    echo with test_corrupt_deferred, ceph-kvstore-tool and ceph-bluestore-tool compiled
     exit 1
 fi
 
@@ -21,7 +21,7 @@ fi
 # Repeat for Object-0 to Object-8.
 
 # Right after getting notification on_complete for all 9 transactions, immediately exit(1).
-./bin/unittest_deferred --log-to-stderr=false
+./bin/test_corrupt_deferred --log-to-stderr=false
 
 # Now we should have a considerable amount of pending deferred writes.
 # They do refer disk regions that do not belong to any object.


### PR DESCRIPTION
There is no value in invoking unittest_deferred expect via run_test_deferred.sh script.

Fixes: https://tracker.ceph.com/issues/68718





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
