### PR TITLE
quincy: doc/rados: add blaum_roth coding guidance

### DIFF
--- a/doc/rados/operations/erasure-code-jerasure.rst
+++ b/doc/rados/operations/erasure-code-jerasure.rst
@@ -60,6 +60,24 @@ Where:
               *blaum_roth*, *liber8tion* are *RAID6* equivalents in
               the sense that they can only be configured with *m=2*. 
 
+              .. note:: When using ``blaum_roth`` coding, the default 
+                 word size of ``w=7`` is suboptimal because ``blaum_roth`` 
+                 works best when ``w+1`` is prime. When creating a new 
+                 erasure-code profile with ``technique=blaum_roth``, 
+                 set ``w`` to a number that is one integer less than a prime 
+                 number (for example, ``6``). See `Loic Dachary's 
+                 commit f51d21b to ceph/ceph <https://github.com/ceph/ceph/commit/f51d21b53d26d4f27c950cb1ba3f989e713ab325>`_ for information about
+                 why this default cannot be changed easily in the
+                 source code, and see `the second bullet point on
+                 page 29 of Plank and Greenan's "Jerasure: A Library
+                 in C Facilitating Erasure Coding for Storage
+                 Applications" <https://github.com/ceph/jerasure/blob/master/Manual.pdf>`_ for an unequivocal statement of the restriction that applies 
+                 to ``w`` when using Blaum-Roth coding.
+                 (Information about the proper value of ``w`` when
+                 using ``blaum_roth`` coding was provided to the
+                 Ceph upstream in September of 2024 by Benjamin
+                 Mare.)
+
 :Type: String
 :Required: No.
 :Default: reed_sol_van


### PR DESCRIPTION
Direct Ceph administrators using blaum_roth coding for erasure-coded pools to change the default value of w=7 to a different value in order to ensure that w+1 is prime.

This information was provided to the Ceph upstream by Benjamin Mare in September of 2024.

Signed-off-by: Zac Dover <zac.dover@proton.me>
(cherry picked from commit 6648d94aed5ff5643f50fcd4f3f07d97b846e885)





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
