### PR TITLE
osd: revert PR#57582

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3033,9 +3033,7 @@ void PeeringState::proc_primary_info(
   ceph_assert(!is_primary());
 
   update_history(oinfo.history);
-  bool has_scrub_error = (!info.stats.stats_invalid && info.stats.stats.sum.num_scrub_errors);
-  info.stats = oinfo.stats;
-  if (has_scrub_error) {
+  if (!info.stats.stats_invalid && info.stats.stats.sum.num_scrub_errors) {
     info.stats.stats.sum.num_scrub_errors = 0;
     info.stats.stats.sum.num_shallow_scrub_errors = 0;
     info.stats.stats.sum.num_deep_scrub_errors = 0;


### PR DESCRIPTION
The reverted commit unconditionally copies the Info data from the primary-info message to the replica, causing multiple tests failures.

For example:
compare the failures in
https://pulpito.ceph.com/?branch=wip-rf-store2-steps to
https://pulpito.ceph.com/?branch=wip-rf-store2-steps-reverted (with said PR reverted).

Revert "src/osd: pg stat are not synced between osds after deep-scrub. So if primary osd is killed, next primary osd has wrong stats. Reason behind it is PeeringState::proc_primary_info does not process or update any pg stats."

This reverts commit a24f3cf1e9088c30899ee6f4a8cbda6b0f350518.

Fixes: https://tracker.ceph.com/issues/68589
