### PR TITLE
mon: update mgr CLI command to display detailed output for disabled modules

### DIFF
--- a/qa/tasks/mgr/mgr_test_case.py
+++ b/qa/tasks/mgr/mgr_test_case.py
@@ -108,7 +108,8 @@ class MgrTestCase(CephTestCase):
         # Unload all non-default plugins
         loaded = json.loads(cls.mgr_cluster.mon_manager.raw_cluster_cmd(
                    "mgr", "module", "ls", "--format=json-pretty"))['enabled_modules']
-        unload_modules = set(loaded) - {"cephadm"}
+        module_names = {module['name'] for module in loaded}
+        unload_modules = module_names - {"cephadm"}
 
         for m in unload_modules:
             cls.mgr_cluster.mon_manager.raw_cluster_cmd(
@@ -149,7 +150,8 @@ class MgrTestCase(CephTestCase):
         def is_disabled():
             enabled_modules = json.loads(cls.mgr_cluster.mon_manager.raw_cluster_cmd(
                 'mgr', 'module', 'ls', "--format=json-pretty"))['enabled_modules']
-            return module_name not in enabled_modules
+            module_names = {module['name'] for module in enabled_modules}
+            return module_name not in module_names
 
         if is_disabled():
             return
@@ -162,7 +164,8 @@ class MgrTestCase(CephTestCase):
     def _load_module(cls, module_name):
         loaded = json.loads(cls.mgr_cluster.mon_manager.raw_cluster_cmd(
             "mgr", "module", "ls", "--format=json-pretty"))['enabled_modules']
-        if module_name in loaded:
+        module_names = {module['name'] for module in loaded}
+        if module_name in module_names:
             # The enable command is idempotent, but our wait for a restart
             # isn't, so let's return now if it's already loaded
             return


### PR DESCRIPTION
Related Trello card: https://trello.com/c/eDEORDHm/595-ceph-mgr-module-ls-should-display-detailed-output-for-enabled-modules-like-it-does-for-disabled-modules

This PR enhances the ceph mgr module ls -f json-pretty command to include detailed information about “enabled” and “always-on” modules. Previously, the command only displayed detailed information for disabled modules, and this update ensures comprehensive JSON output for all module states.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
