### PR TITLE
cephadm/smb: convert config object to use a dataclass

### DIFF
--- a/src/cephadm/cephadmlib/daemons/smb.py
+++ b/src/cephadm/cephadmlib/daemons/smb.py
@@ -1,3 +1,4 @@
+import dataclasses
 import enum
 import json
 import logging
@@ -67,83 +68,32 @@ class ClusterPublicIP(NamedTuple):
         return cls(address, destinations)
 
 
+@dataclasses.dataclass(frozen=True)
 class Config:
     identity: DaemonIdentity
     instance_id: str
     source_config: str
-    samba_debug_level: int
-    ctdb_log_level: str
-    debug_delay: int
     domain_member: bool
     clustered: bool
-    join_sources: List[str]
-    user_sources: List[str]
-    custom_dns: List[str]
-    smb_port: int
-    ceph_config_entity: str
-    vhostname: str
-    metrics_image: str
-    metrics_port: int
+    samba_debug_level: int = 0
+    ctdb_log_level: str = ''
+    debug_delay: int = 0
+    join_sources: List[str] = dataclasses.field(default_factory=list)
+    user_sources: List[str] = dataclasses.field(default_factory=list)
+    custom_dns: List[str] = dataclasses.field(default_factory=list)
+    smb_port: int = 0
+    ceph_config_entity: str = 'client.admin'
+    vhostname: str = ''
+    metrics_image: str = ''
+    metrics_port: int = 0
     # clustering related values
-    rank: int
-    rank_generation: int
-    cluster_meta_uri: str
-    cluster_lock_uri: str
-
-    def __init__(
-        self,
-        *,
-        identity: DaemonIdentity,
-        instance_id: str,
-        source_config: str,
-        domain_member: bool,
-        clustered: bool,
-        samba_debug_level: int = 0,
-        ctdb_log_level: str = '',
-        debug_delay: int = 0,
-        join_sources: Optional[List[str]] = None,
-        user_sources: Optional[List[str]] = None,
-        custom_dns: Optional[List[str]] = None,
-        smb_port: int = 0,
-        ceph_config_entity: str = 'client.admin',
-        vhostname: str = '',
-        metrics_image: str = '',
-        metrics_port: int = 0,
-        rank: int = -1,
-        rank_generation: int = -1,
-        cluster_meta_uri: str = '',
-        cluster_lock_uri: str = '',
-        cluster_public_addrs: Optional[List[ClusterPublicIP]] = None,
-    ) -> None:
-        self.identity = identity
-        self.instance_id = instance_id
-        self.source_config = source_config
-        self.domain_member = domain_member
-        self.clustered = clustered
-        self.samba_debug_level = samba_debug_level
-        self.ctdb_log_level = ctdb_log_level
-        self.debug_delay = debug_delay
-        self.join_sources = join_sources or []
-        self.user_sources = user_sources or []
-        self.custom_dns = custom_dns or []
-        self.smb_port = smb_port
-        self.ceph_config_entity = ceph_config_entity
-        self.vhostname = vhostname
-        self.metrics_image = metrics_image
-        self.metrics_port = metrics_port
-        self.rank = rank
-        self.rank_generation = rank_generation
-        self.cluster_meta_uri = cluster_meta_uri
-        self.cluster_lock_uri = cluster_lock_uri
-        self.cluster_public_addrs = cluster_public_addrs
-
-    def __str__(self) -> str:
-        return (
-            f'SMB Config[id={self.instance_id},'
-            f' source_config={self.source_config},'
-            f' domain_member={self.domain_member},'
-            f' clustered={self.clustered}]'
-        )
+    rank: int = -1
+    rank_generation: int = -1
+    cluster_meta_uri: str = ''
+    cluster_lock_uri: str = ''
+    cluster_public_addrs: List[ClusterPublicIP] = dataclasses.field(
+        default_factory=list
+    )
 
     def config_uris(self) -> List[str]:
         uris = [self.source_config]
@@ -432,7 +382,7 @@ class SMB(ContainerDaemonForm):
         self._raw_configs: Dict[str, Any] = context_getters.fetch_configs(ctx)
         self._config_keyring = context_getters.get_config_and_keyring(ctx)
         self._cached_layout: Optional[ContainerLayout] = None
-        self._rank_info = context_getters.fetch_rank_info(ctx)
+        self._rank_info = context_getters.fetch_rank_info(ctx) or (-1, -1)
         self.smb_port = 445
         self.metrics_port = 9922
         self._network_mapper = _NetworkMapper(ctx)
@@ -502,6 +452,7 @@ class SMB(ContainerDaemonForm):
             # cache the cephadm networks->devices mapping for later
             self._network_mapper.load()
 
+        rank, rank_gen = self._rank_info
         self._instance_cfg = Config(
             identity=self._identity,
             instance_id=instance_id,
@@ -516,15 +467,12 @@ class SMB(ContainerDaemonForm):
             vhostname=vhostname,
             metrics_image=metrics_image,
             metrics_port=metrics_port,
+            rank=rank,
+            rank_generation=rank_gen,
             cluster_meta_uri=cluster_meta_uri,
             cluster_lock_uri=cluster_lock_uri,
             cluster_public_addrs=_public_addrs,
         )
-        if self._rank_info:
-            (
-                self._instance_cfg.rank,
-                self._instance_cfg.rank_generation,
-            ) = self._rank_info
         self._files = files
         logger.debug('SMB Instance Config: %s', self._instance_cfg)
         logger.debug('Configured files: %s', self._files)


### PR DESCRIPTION
While working on the smb.py file I began to be annoyed at the Config class and the need to repeat myself. Now that cephadm is not expected to run on python versions older than 3.7 I think it's safe to convert Config to use a dataclass.

While making the change to a dataclass I also chose to make it a frozen dataclass to help eliminate any future bugs wrt mutating the config object.


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), <s>opened tracker ticket</s>
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests
  - [x] Existing tests should be sufficient

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
