### PR TITLE
qa/cephadm: add timeouts to checks that daemons have been upgraded

### DIFF
--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/3-upgrade-mgr-staggered.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/3-upgrade-mgr-staggered.yaml
@@ -11,8 +11,8 @@ upgrade-tasks:
           - ceph config set global log_to_journald false --force
           - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types mgr
           - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
-          - ceph versions | jq -e '.mgr | length == 1'
-          - ceph versions | jq -e '.mgr | keys' | grep $sha1
-          - ceph versions | jq -e '.overall | length == 2'
-          - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 2'
+          - time timeout 60 bash -c "until ceph versions | jq -e '.mgr | length == 1'; do sleep 2; done"
+          - time timeout 60 bash -c "until ceph versions | jq -e '.mgr | keys' | grep $sha1; do sleep 2; done"
+          - time timeout 60 bash -c "until ceph versions | jq -e '.overall | length == 2'; do sleep 2; done"
+          - time timeout 60 bash -c "until ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 2'; do sleep 2; done"
           - ceph orch ps

--- a/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/5-upgrade-with-workload.yaml
+++ b/qa/suites/fs/upgrade/mds_upgrade_sequence/tasks/5-upgrade-with-workload.yaml
@@ -24,8 +24,8 @@ upgrade-tasks:
           - sleep 60
           - ceph orch ps
           - ceph versions
-          - ceph versions | jq -e '.overall | length == 1'
-          - ceph versions | jq -e '.overall | keys' | grep $sha1
+          - time timeout 60 bash -c "until ceph versions | jq -e '.overall | length == 1'; do sleep 2; done"
+          - time timeout 60 bash -c "until ceph versions | jq -e '.overall | keys' | grep $sha1; do sleep 2; done"
 
 workload-tasks:
   sequential:

--- a/qa/suites/orch/cephadm/mgr-nfs-upgrade/3-upgrade-with-workload.yaml
+++ b/qa/suites/orch/cephadm/mgr-nfs-upgrade/3-upgrade-with-workload.yaml
@@ -25,8 +25,8 @@ upgrade-tasks:
         - ceph orch upgrade status
         - ceph health detail
         - ceph versions
-        - ceph versions | jq -e '.overall | length == 1'
-        - ceph versions | jq -e '.overall | keys' | grep $sha1
+        - time timeout 60 bash -c "until ceph versions | jq -e '.overall | length == 1'; do sleep 2; done"
+        - time timeout 60 bash -c "until ceph versions | jq -e '.overall | keys' | grep $sha1; do sleep 2; done"
 
   # this should be a no-op, but confirms nfs.ganesha-foo was remapped to nfs.foo
   - cephadm.wait_for_service:

--- a/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
+++ b/qa/suites/orch/cephadm/upgrade/3-upgrade/staggered.yaml
@@ -40,7 +40,7 @@ tasks:
       - ceph -s
       - ceph health detail
       # check that there are two different versions found for mgr daemon (which implies we upgraded one)
-      - ceph versions | jq -e '.mgr | length == 2'
+      - time timeout 60 bash -c "until ceph versions | jq -e '.mgr | length == 2'; do sleep 2; done"
       - ceph mgr fail
       - sleep 180
       # now try upgrading the other mgr
@@ -60,7 +60,7 @@ tasks:
       - ceph -s
       - ceph health detail
       # now that both mgrs should have been redeployed with the new version, we should be back on only 1 version for the mgrs
-      - ceph versions | jq -e '.mgr | length == 1'
+      - time timeout 60 bash -c "until ceph versions | jq -e '.mgr | length == 1'; do sleep 2; done"
       - ceph mgr fail
       - sleep 180
       # debugging info
@@ -72,12 +72,12 @@ tasks:
       - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types mgr
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       # verify only one version found for mgrs and that their version hash matches what we are upgrading to
-      - ceph versions | jq -e '.mgr | length == 1'
-      - ceph versions | jq -e '.mgr | keys' | grep $sha1
+      - time timeout 60 bash -c "until ceph versions | jq -e '.mgr | length == 1'; do sleep 2; done"
+      - time timeout 60 bash -c "until ceph versions | jq -e '.mgr | keys' | grep $sha1; do sleep 2; done"
       # verify overall we still see two versions, basically to make sure --daemon-types wasn't ignored and all daemons upgraded
-      - ceph versions | jq -e '.overall | length == 2'
+      - time timeout 60 bash -c "until ceph versions | jq -e '.overall | length == 2'; do sleep 2; done"
       # check that exactly two daemons have been upgraded to the new image (our 2 mgr daemons)
-      - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 2'
+      - time timeout 60 bash -c "until ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 2'; do sleep 2; done"
       - ceph orch upgrade status
       - ceph health detail
       # upgrade only the mons on one of the two hosts
@@ -85,7 +85,7 @@ tasks:
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       - ceph orch ps
       # verify two different version seen for mons
-      - ceph versions | jq -e '.mon | length == 2'
+      - time timeout 60 bash -c "until ceph versions | jq -e '.mon | length == 2'; do sleep 2; done"
       - ceph orch upgrade status
       - ceph health detail
       # upgrade mons on the other hosts
@@ -93,10 +93,10 @@ tasks:
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       - ceph orch ps
       # verify all mons now on same version and version hash matches what we are upgrading to
-      - ceph versions | jq -e '.mon | length == 1'
-      - ceph versions | jq -e '.mon | keys' | grep $sha1
+      - time timeout 60 bash -c "until ceph versions | jq -e '.mon | length == 1'; do sleep 2; done"
+      - time timeout 60 bash -c "until ceph versions | jq -e '.mon | keys' | grep $sha1; do sleep 2; done"
       # verify exactly 5 daemons are now upgraded (2 mgrs, 3 mons)
-      - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 5'
+      - time timeout 60 bash -c "until ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 5'; do sleep 2; done"
       - ceph orch upgrade status
       - ceph health detail
       # upgrade exactly 2 osd daemons
@@ -104,18 +104,18 @@ tasks:
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       - ceph orch ps
       # verify two different versions now seen for osds
-      - ceph versions | jq -e '.osd | length == 2'
+      - time timeout 60 bash -c "until ceph versions | jq -e '.osd | length == 2'; do sleep 2; done"
       # verify exactly 7 daemons have been upgraded (2 mgrs, 3 mons, 2 osds)
-      - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 7'
+      - time timeout 60 bash -c "until ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 7'; do sleep 2; done"
       - ceph orch upgrade status
       - ceph health detail
       # upgrade one more osd
       - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1 --daemon-types crash,osd --limit 1
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       - ceph orch ps
-      - ceph versions | jq -e '.osd | length == 2'
+      - time timeout 60 bash -c "until ceph versions | jq -e '.osd | length == 2'; do sleep 2; done"
       # verify now 8 daemons have been upgraded
-      - ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 8'
+      - time timeout 60 bash -c "until ceph orch upgrade check quay.ceph.io/ceph-ci/ceph:$sha1 | jq -e '.up_to_date | length == 8'; do sleep 2; done"
       # upgrade the rest of the osds
       - ceph orch upgrade status
       - ceph health detail
@@ -123,7 +123,7 @@ tasks:
       - while ceph orch upgrade status | jq '.in_progress' | grep true && ! ceph orch upgrade status | jq '.message' | grep Error ; do ceph orch ps ; ceph versions ; ceph orch upgrade status ; sleep 30 ; done
       - ceph orch ps
       # verify all osds are now on same version and version hash matches what we are upgrading to
-      - ceph versions | jq -e '.osd | length == 1'
+      - time timeout 60 bash -c "until ceph versions | jq -e '.osd | length == 1'; do sleep 2; done"
       - ceph versions | jq -e '.osd | keys' | grep $sha1
       - ceph orch upgrade status
       - ceph health detail

--- a/qa/suites/orch/cephadm/upgrade/4-wait.yaml
+++ b/qa/suites/orch/cephadm/upgrade/4-wait.yaml
@@ -11,6 +11,6 @@ tasks:
       - ceph versions
       - ceph orch upgrade status
       - ceph health detail
-      - ceph versions | jq -e '.overall | length == 1'
-      - ceph versions | jq -e '.overall | keys' | grep $sha1
+      - time timeout 60 bash -c "until ceph versions | jq -e '.overall | length == 1'; do sleep 2; done"
+      - time timeout 60 bash -c "until ceph versions | jq -e '.overall | keys' | grep $sha1; do sleep 2; done"
       - ceph orch ls | grep '^osd '


### PR DESCRIPTION
There was another patch earlier that did this for a specific check because we saw `ceph orch ps` reporting an RGW daemon as upgraded faster than `ceph versions` did. This patch extends this to all our current upgrade checks. The hope is it makes the tests more consistent and we no longer have to worry about small timing differences between what cephadm knows and the ceph cluster knows.

This should probably also be done in a more controlled way than just having to run "time timeout 60..." in a whole bunch of differnet spots but this is at least a start and allows us to see if it makes any notable differece





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
