### PR TITLE
s390x: SMCD cluster network: option 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,6 +505,11 @@ if(WITH_DPDK)
   set(HAVE_DPDK TRUE)
 endif()
 
+option(WITH_SMCD "Enable SMCD in async messenger" ON)
+if(WITH_SMCD)
+  set(HAVE_SMCD TRUE)
+endif(WITH_SMCD)
+
 option(WITH_BLKIN "Use blkin to emit LTTng tracepoints for Zipkin" OFF)
 if(WITH_BLKIN)
   find_package(LTTngUST REQUIRED)

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -920,7 +920,7 @@ options:
   level: advanced
   desc: Messenger implementation to use for network communication
   fmt_desc: Transport type used by Async Messenger. Can be ``async+posix``,
-    ``async+dpdk`` or ``async+rdma``. Posix uses standard TCP/IP networking and is
+    ``async+dpdk``, ``async+rdma``, or ``async+smcd``. Posix uses standard TCP/IP networking and is
     default. Other transports may be experimental and support may be limited.
   default: async+posix
   flags:

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -124,6 +124,9 @@
 /* AsyncMessenger RDMA conditional compilation */
 #cmakedefine HAVE_RDMA
 
+/* AsyncMessenger SMCD conditional compilation */
+#cmakedefine HAVE_SMCD
+
 /* ibverbs experimental conditional compilation */
 #cmakedefine HAVE_IBV_EXP
 

--- a/src/msg/CMakeLists.txt
+++ b/src/msg/CMakeLists.txt
@@ -44,6 +44,12 @@ if(HAVE_RDMA)
     async/rdma/RDMAStack.cc)
 endif()
 
+if(HAVE_SMCD)
+  list(APPEND msg_srcs
+    async/smcd/SMCDStack.cc
+    async/smcd/SMCDNetHandler.cc)
+endif()
+
 add_library(common-msg-objs OBJECT ${msg_srcs})
 target_compile_definitions(common-msg-objs PRIVATE
   $<TARGET_PROPERTY:${FMT_LIB},INTERFACE_COMPILE_DEFINITIONS>)

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -288,6 +288,8 @@ AsyncMessenger::AsyncMessenger(CephContext *cct, entity_name_t name,
     transport_type = "rdma";
   else if (type.find("dpdk") != std::string::npos)
     transport_type = "dpdk";
+  else if (type.find("smcd") != std::string::npos)
+    transport_type = "smcd";
 
   auto single = &cct->lookup_or_create_singleton_object<StackSingleton>(
     "AsyncMessenger::NetworkStack::" + transport_type, true, cct);

--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -26,6 +26,9 @@
 #ifdef HAVE_DPDK
 #include "dpdk/DPDKStack.h"
 #endif
+#ifdef HAVE_SMCD
+#include "smcd/SMCDStack.h"
+#endif
 
 #include "common/dout.h"
 #include "include/ceph_assert.h"
@@ -74,6 +77,10 @@ std::shared_ptr<NetworkStack> NetworkStack::create(CephContext *c,
 #ifdef HAVE_DPDK
   else if (t == "dpdk")
     stack.reset(new DPDKStack(c));
+#endif
+#ifdef HAVE_SMCD
+  else if (t == "smcd")
+    stack.reset(new SMCDStack(c));
 #endif
 
   if (stack == nullptr) {

--- a/src/msg/async/smcd/SMCDNetHandler.cc
+++ b/src/msg/async/smcd/SMCDNetHandler.cc
@@ -1,0 +1,264 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2014 UnitedStack <haomai@unitedstack.com>
+ *
+ * Author: Haomai Wang <haomaiwang@gmail.com>
+ *
+ * Copyright (C) IBM Corp. 2024
+ *
+ * Author: Aliaksei Makarau <aliaksei.makarau@ibm.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+
+#include "common/debug.h"
+#include "common/errno.h"
+#include "include/compat.h"
+#include "include/sock_compat.h"
+
+#include "SMCDNetHandler.h"
+
+#define dout_subsys ceph_subsys_ms
+#undef dout_prefix
+#define dout_prefix *_dout << "SMCDNetHandler "
+
+#ifdef HAVE_SMCD
+  #ifndef SMCPROTO_SMC
+    #define SMCPROTO_SMC           0       /* SMC protocol, IPv4 */
+    #define SMCPROTO_SMC6          1       /* SMC protocol, IPv6 */
+  #endif
+#endif
+
+namespace ceph {
+namespace smcd {
+
+int SMCDNetHandler::create_socket(int domain, bool reuse_addr) {
+  int s;
+  int r = 0;
+  int protocol = IPPROTO_TCP;
+
+#ifdef HAVE_SMCD
+  /* check if socket is eligible for AF_SMC */
+  if (domain == AF_INET || domain == AF_INET6) {
+    if (domain == AF_INET)
+      protocol = SMCPROTO_SMC;
+    else /* AF_INET6 */
+      protocol = SMCPROTO_SMC6;
+    domain = AF_SMC;
+  }
+#endif 
+
+  if ((s = socket_cloexec(domain, SOCK_STREAM, protocol)) == -1) {
+    r = ceph_sock_errno();
+    lderr(cct) << __func__ << " couldn't create socket " << cpp_strerror(r) << dendl;
+    return -r;
+  }
+
+#if !defined(__FreeBSD__)
+  /* Make sure connection-intensive things like the benchmark
+   * will be able to close/open sockets a zillion of times */
+  if (reuse_addr) {
+    int on = 1;
+    if (::setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (SOCKOPT_VAL_TYPE)&on, sizeof(on)) == -1) {
+      r = ceph_sock_errno();
+      lderr(cct) << __func__ << " setsockopt SO_REUSEADDR failed: "
+                 << strerror(r) << dendl;
+      compat_closesocket(s);
+      return -r;
+    }
+  }
+#endif
+
+  return s;
+}
+
+int SMCDNetHandler::set_nonblock(int sd) {
+  int r = 0;
+#ifdef _WIN32
+  ULONG mode = 1;
+  r = ioctlsocket(sd, FIONBIO, &mode);
+  if (r) {
+    lderr(cct) << __func__ << " ioctlsocket(FIONBIO) failed: " << r
+                           << " " << WSAGetLastError() << dendl;
+    return -r;
+  }
+#else
+  int flags;
+
+  /* Set the socket nonblocking.
+   * Note that fcntl(2) for F_GETFL and F_SETFL can't be
+   * interrupted by a signal. */
+  if ((flags = fcntl(sd, F_GETFL)) < 0 ) {
+    r = ceph_sock_errno();
+    lderr(cct) << __func__ << " fcntl(F_GETFL) failed: " << cpp_strerror(r) << dendl;
+    return -r;
+  }
+  if (fcntl(sd, F_SETFL, flags | O_NONBLOCK) < 0) {
+    r = ceph_sock_errno();
+    lderr(cct) << __func__ << " fcntl(F_SETFL,O_NONBLOCK): " << cpp_strerror(r) << dendl;
+    return -r;
+  }
+#endif
+
+  return 0;
+}
+
+int SMCDNetHandler::set_socket_options(int sd, bool nodelay, int size) {
+  int r = 0;
+  // disable Nagle algorithm?
+  if (nodelay) {
+    int flag = 1;
+    r = ::setsockopt(sd, IPPROTO_TCP, TCP_NODELAY, (SOCKOPT_VAL_TYPE)&flag, sizeof(flag));
+    if (r < 0) {
+      r = ceph_sock_errno();
+      ldout(cct, 0) << "couldn't set TCP_NODELAY: " << cpp_strerror(r) << dendl;
+    }
+  }
+  if (size) {
+    r = ::setsockopt(sd, SOL_SOCKET, SO_RCVBUF, (SOCKOPT_VAL_TYPE)&size, sizeof(size));
+    if (r < 0)  {
+      r = ceph_sock_errno();
+      ldout(cct, 0) << "couldn't set SO_RCVBUF to " << size << ": " << cpp_strerror(r) << dendl;
+    }
+  }
+
+  // block ESIGPIPE
+#ifdef CEPH_USE_SO_NOSIGPIPE
+  int val = 1;
+  r = ::setsockopt(sd, SOL_SOCKET, SO_NOSIGPIPE, (SOCKOPT_VAL_TYPE)&val, sizeof(val));
+  if (r) {
+    r = ceph_sock_errno();
+    ldout(cct,0) << "couldn't set SO_NOSIGPIPE: " << cpp_strerror(r) << dendl;
+  }
+#endif
+  return -r;
+}
+
+void SMCDNetHandler::set_priority(int sd, int prio, int domain) {
+#ifdef SO_PRIORITY
+  if (prio < 0) {
+    return;
+  }
+  int r = -1;
+#ifdef IPTOS_CLASS_CS6
+  int iptos = IPTOS_CLASS_CS6;
+    switch (domain) {
+    case AF_INET:
+      r = ::setsockopt(sd, IPPROTO_IP, IP_TOS, (SOCKOPT_VAL_TYPE)&iptos, sizeof(iptos));
+      break;
+    case AF_INET6:
+      r = ::setsockopt(sd, IPPROTO_IPV6, IPV6_TCLASS, (SOCKOPT_VAL_TYPE)&iptos, sizeof(iptos));
+      break;
+    default:
+      lderr(cct) << "couldn't set ToS of unknown family (" << domain << ")"
+          << " to " << iptos << dendl;
+      return;
+  }
+  if (r < 0) {
+    r = ceph_sock_errno();
+    ldout(cct,0) << "couldn't set TOS to " << iptos
+		 << ": " << cpp_strerror(r) << dendl;
+  }
+
+#endif	// IPTOS_CLASS_CS6
+  // setsockopt(IPTOS_CLASS_CS6) sets the priority of the socket as 0.
+  // See http://goo.gl/QWhvsD and http://goo.gl/laTbjT
+  // We need to call setsockopt(SO_PRIORITY) after it.
+  r = ::setsockopt(sd, SOL_SOCKET, SO_PRIORITY, (SOCKOPT_VAL_TYPE)&prio, sizeof(prio));
+  if (r < 0) {
+    r = ceph_sock_errno();
+    ldout(cct, 0) << __func__ << " couldn't set SO_PRIORITY to " << prio
+		  << ": " << cpp_strerror(r) << dendl;
+  }
+#else
+  return;
+#endif	// SO_PRIORITY
+}
+
+int SMCDNetHandler::generic_connect(const entity_addr_t& addr, const entity_addr_t &bind_addr, bool nonblock) {
+  int ret;
+  int s = create_socket(addr.get_family());
+  if (s < 0)
+    return s;
+
+  if (nonblock) {
+    ret = set_nonblock(s);
+    if (ret < 0) {
+      compat_closesocket(s);
+      return ret;
+    }
+  }
+
+  set_socket_options(s, cct->_conf->ms_tcp_nodelay, cct->_conf->ms_tcp_rcvbuf);
+
+  {
+    entity_addr_t addr = bind_addr;
+    if (cct->_conf->ms_bind_before_connect && (!addr.is_blank_ip())) {
+      addr.set_port(0);
+      ret = ::bind(s, addr.get_sockaddr(), addr.get_sockaddr_len());
+      if (ret < 0) {
+        ret = ceph_sock_errno();
+        ldout(cct, 2) << __func__ << " client bind error " << ", " << cpp_strerror(ret) << dendl;
+        compat_closesocket(s);
+        return -ret;
+      }
+    }
+  }
+
+  ret = ::connect(s, addr.get_sockaddr(), addr.get_sockaddr_len());
+  if (ret < 0) {
+    ret = ceph_sock_errno();
+    // Windows can return WSAEWOULDBLOCK (converted to EAGAIN).
+    if ((ret == EINPROGRESS || ret == EAGAIN) && nonblock)
+      return s;
+
+    ldout(cct, 10) << __func__ << " connect: " << cpp_strerror(ret) << dendl;
+    compat_closesocket(s);
+    return -ret;
+  }
+
+  return s;
+}
+
+int SMCDNetHandler::reconnect(const entity_addr_t &addr, int sd) {
+  int r = 0;
+  int ret = ::connect(sd, addr.get_sockaddr(), addr.get_sockaddr_len());
+
+  if (ret < 0 && ceph_sock_errno() != EISCONN) {
+    r = ceph_sock_errno();
+    ldout(cct, 10) << __func__ << " reconnect: " << r
+                   << " " << strerror(r) << dendl;
+    if (r == EINPROGRESS || r == EALREADY || r == EAGAIN)
+      return 1;
+    return -r;
+  }
+
+  return 0;
+}
+
+int SMCDNetHandler::connect(const entity_addr_t &addr, const entity_addr_t& bind_addr)
+{
+  return generic_connect(addr, bind_addr, false);
+}
+
+int SMCDNetHandler::nonblock_connect(const entity_addr_t &addr, const entity_addr_t& bind_addr)
+{
+  return generic_connect(addr, bind_addr, true);
+}
+
+}
+}

--- a/src/msg/async/smcd/SMCDNetHandler.h
+++ b/src/msg/async/smcd/SMCDNetHandler.h
@@ -1,0 +1,53 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2014 UnitedStack <haomai@unitedstack.com>
+ *
+ * Author: Haomai Wang <haomaiwang@gmail.com>
+ *
+ * Copyright (C) IBM Corp. 2024
+ *
+ * Author: Aliaksei Makarau <aliaksei.makarau@ibm.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_MSG_ASYNC_SMCDSTACK_NETHANDLER_H
+#define CEPH_MSG_ASYNC_SMCDSTACK_NETHANDLER_H
+
+#include "common/config.h"
+
+namespace ceph {
+  namespace smcd {
+    class SMCDNetHandler {
+      int generic_connect(const entity_addr_t& addr, const entity_addr_t& bind_addr, bool nonblock);
+
+      CephContext *cct;
+    public:
+      int create_socket(int domain, bool reuse_addr=false);
+      explicit SMCDNetHandler(CephContext *c): cct(c) {}
+      int set_nonblock(int sd);
+      int set_socket_options(int sd, bool nodelay, int size);
+      int connect(const entity_addr_t &addr, const entity_addr_t& bind_addr);
+      
+      /**
+       * Try to reconnect the socket.
+       *
+       * @return    0         success
+       *            > 0       just break, and wait for event
+       *            < 0       need to goto fail
+       */
+      int reconnect(const entity_addr_t &addr, int sd);
+      int nonblock_connect(const entity_addr_t &addr, const entity_addr_t& bind_addr);
+      void set_priority(int sd, int priority, int domain);
+    };
+  }
+}
+
+#endif

--- a/src/msg/async/smcd/SMCDStack.cc
+++ b/src/msg/async/smcd/SMCDStack.cc
@@ -1,0 +1,308 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 XSKY <haomai@xsky.com>
+ *
+ * Author: Haomai Wang <haomaiwang@gmail.com>
+ *
+ * Copyright (C) IBM Corp. 2024
+ *
+ * Author: Aliaksei Makarau <aliaksei.makarau@ibm.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <errno.h>
+
+#include <algorithm>
+
+#include "SMCDStack.h"
+
+#include "include/buffer.h"
+#include "include/str_list.h"
+#include "common/errno.h"
+#include "common/strtol.h"
+#include "common/dout.h"
+#include "msg/Messenger.h"
+#include "include/compat.h"
+#include "include/sock_compat.h"
+
+#define dout_subsys ceph_subsys_ms
+#undef dout_prefix
+#define dout_prefix *_dout << "SMCDStack "
+
+class SMCDConnectedSocketImpl final : public ConnectedSocketImpl {
+  ceph::smcd::SMCDNetHandler &handler;
+  int _fd;
+  entity_addr_t sa;
+  bool connected;
+
+ public:
+  explicit SMCDConnectedSocketImpl(ceph::smcd::SMCDNetHandler &h, const entity_addr_t &sa,
+                                   int f, bool connected)
+      : handler(h), _fd(f), sa(sa), connected(connected) {}
+
+  int is_connected() override {
+    if (connected)
+      return 1;
+
+    int r = handler.reconnect(sa, _fd);
+    if (r == 0) {
+      connected = true;
+      return 1;
+    } else if (r < 0) {
+      return r;
+    } else {
+      return 0;
+    }
+  }
+
+  ssize_t read(char *buf, size_t len) override {
+    ssize_t r = ::read(_fd, buf, len);
+    if (r < 0)
+      r = -ceph_sock_errno();
+    return r;
+  }
+
+  // return the sent length
+  // < 0 means error occurred
+  static ssize_t do_sendmsg(int fd, struct msghdr &msg, unsigned len, bool more) {
+    size_t sent = 0;
+    while (1) {
+      MSGR_SIGPIPE_STOPPER;
+      ssize_t r;
+      r = ::sendmsg(fd, &msg, MSG_NOSIGNAL | (more ? MSG_MORE : 0));
+      if (r < 0) {
+        int err = ceph_sock_errno();
+        if (err == EINTR) {
+          continue;
+        } else if (err == EAGAIN) {
+          break;
+        }
+        return -err;
+      }
+
+      sent += r;
+      if (len == sent) break;
+
+      while (r > 0) {
+        if (msg.msg_iov[0].iov_len <= (size_t)r) {
+          // drain this whole item
+          r -= msg.msg_iov[0].iov_len;
+          msg.msg_iov++;
+          msg.msg_iovlen--;
+        } else {
+          msg.msg_iov[0].iov_base = (char *)msg.msg_iov[0].iov_base + r;
+          msg.msg_iov[0].iov_len -= r;
+          break;
+        }
+      }
+    }
+    return (ssize_t)sent;
+  }
+
+  ssize_t send(ceph::buffer::list &bl, bool more) override {
+    size_t sent_bytes = 0;
+    auto pb = std::cbegin(bl.buffers());
+    uint64_t left_pbrs = bl.get_num_buffers();
+
+    while (left_pbrs) {
+      struct msghdr msg;
+      struct iovec msgvec[IOV_MAX];
+      uint64_t size = std::min<uint64_t>(left_pbrs, IOV_MAX);
+      left_pbrs -= size;
+      // FIPS zeroization audit 20191115: this memset is not security related.
+      memset(&msg, 0, sizeof(msg));
+      msg.msg_iovlen = size;
+      msg.msg_iov = msgvec;
+      unsigned msglen = 0;
+
+      for (auto iov = msgvec; iov != msgvec + size; iov++) {
+        iov->iov_base = (void*)(pb->c_str());
+        iov->iov_len = pb->length();
+        msglen += pb->length();
+        ++pb;
+      }
+
+      ssize_t r = do_sendmsg(_fd, msg, msglen, left_pbrs || more);
+
+      if (r < 0)
+        return r;
+
+      // "r" is the remaining length
+      sent_bytes += r;
+
+      if (static_cast<unsigned>(r) < msglen)
+        break;
+      // only "r" == 0 continue
+    }
+
+    if (sent_bytes) {
+      ceph::buffer::list swapped;
+      if (sent_bytes < bl.length()) {
+        bl.splice(sent_bytes, bl.length()-sent_bytes, &swapped);
+        bl.swap(swapped);
+      } else {
+        bl.clear();
+      }
+    }
+
+    return static_cast<ssize_t>(sent_bytes);
+  }
+
+  void shutdown() override {
+    ::shutdown(_fd, SHUT_RDWR);
+  }
+
+  void close() override {
+    compat_closesocket(_fd);
+  }
+
+  void set_priority(int sd, int prio, int domain) override {
+    handler.set_priority(sd, prio, domain);
+  }
+
+  int fd() const override {
+    return _fd;
+  }
+
+  friend class SMCDServerSocketImpl;
+  friend class SMCDStack;
+};
+
+class SMCDServerSocketImpl : public ServerSocketImpl {
+  ceph::smcd::SMCDNetHandler &handler;
+  int _fd;
+
+ public:
+  explicit SMCDServerSocketImpl(ceph::smcd::SMCDNetHandler &h, int f,
+                                const entity_addr_t& listen_addr, unsigned slot)
+    : ServerSocketImpl(listen_addr.get_type(), slot),
+      handler(h), _fd(f) {}
+
+  int accept(ConnectedSocket *sock, const SocketOptions &opts, entity_addr_t *out, Worker *w) override;
+
+  void abort_accept() override {
+    ::close(_fd);
+    _fd = -1;
+  }
+
+  int fd() const override {
+    return _fd;
+  }
+};
+
+int SMCDServerSocketImpl::accept(ConnectedSocket *sock, const SocketOptions &opt, entity_addr_t *out, Worker *w) {
+  ceph_assert(sock);
+  sockaddr_storage ss;
+  socklen_t slen = sizeof(ss);
+  int sd = accept_cloexec(_fd, (sockaddr*)&ss, &slen);
+  if (sd < 0) {
+    return -ceph_sock_errno();
+  }
+
+  int r = handler.set_nonblock(sd);
+  if (r < 0) {
+    ::close(sd);
+    return -ceph_sock_errno();
+  }
+
+  r = handler.set_socket_options(sd, opt.nodelay, opt.rcbuf_size);
+  if (r < 0) {
+    ::close(sd);
+    return -ceph_sock_errno();
+  }
+
+  ceph_assert(NULL != out); //out should not be NULL in accept connection
+
+  out->set_type(addr_type);
+  out->set_sockaddr((sockaddr*)&ss);
+  handler.set_priority(sd, opt.priority, out->get_family());
+
+  std::unique_ptr<SMCDConnectedSocketImpl> csi(new SMCDConnectedSocketImpl(handler, *out, sd, true));
+  *sock = ConnectedSocket(std::move(csi));
+  return 0;
+}
+
+void SMCDWorker::initialize()
+{
+}
+
+int SMCDWorker::listen(entity_addr_t &sa,
+                       unsigned addr_slot,
+                       const SocketOptions &opt,
+                       ServerSocket *sock) {
+  int listen_sd = net.create_socket(sa.get_family(), true);
+
+  if (listen_sd < 0) {
+    return -ceph_sock_errno();
+  }
+
+  int r = net.set_nonblock(listen_sd);
+  if (r < 0) {
+    ::close(listen_sd);
+    return -ceph_sock_errno();
+  }
+
+  r = net.set_socket_options(listen_sd, opt.nodelay, opt.rcbuf_size);
+  if (r < 0) {
+    ::close(listen_sd);
+    return -ceph_sock_errno();
+  }
+
+  r = ::bind(listen_sd, sa.get_sockaddr(), sa.get_sockaddr_len());
+  if (r < 0) {
+    r = -ceph_sock_errno();
+    ldout(cct, 10) << __func__ << " unable to bind to " << sa.get_sockaddr()
+                   << ": " << cpp_strerror(r) << dendl;
+    ::close(listen_sd);
+    return r;
+  }
+
+  r = ::listen(listen_sd, cct->_conf->ms_tcp_listen_backlog);
+  if (r < 0) {
+    r = -ceph_sock_errno();
+    lderr(cct) << __func__ << " unable to listen on " << sa << ": " << cpp_strerror(r) << dendl;
+    ::close(listen_sd);
+    return r;
+  }
+
+  *sock = ServerSocket(
+          std::unique_ptr<SMCDServerSocketImpl>(
+          new SMCDServerSocketImpl(net, listen_sd, sa, addr_slot)));
+  return 0;
+}
+
+int SMCDWorker::connect(const entity_addr_t &addr, const SocketOptions &opts, ConnectedSocket *socket) {
+  int sd;
+
+  if (opts.nonblock) {
+    sd = net.nonblock_connect(addr, opts.connect_bind_addr);
+  } else {
+    sd = net.connect(addr, opts.connect_bind_addr);
+  }
+
+  if (sd < 0) {
+    return -ceph_sock_errno();
+  }
+
+  net.set_priority(sd, opts.priority, addr.get_family());
+  *socket = ConnectedSocket(
+      std::unique_ptr<SMCDConnectedSocketImpl>(new SMCDConnectedSocketImpl(net, addr, sd, !opts.nonblock)));
+  return 0;
+}
+
+SMCDStack::SMCDStack(CephContext *c)
+    : NetworkStack(c)
+{
+}

--- a/src/msg/async/smcd/SMCDStack.h
+++ b/src/msg/async/smcd/SMCDStack.h
@@ -1,0 +1,63 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 XSKY <haomai@xsky.com>
+ *
+ * Author: Haomai Wang <haomaiwang@gmail.com>
+ *
+ * Copyright (C) IBM Corp. 2024
+ *
+ * Author: Aliaksei Makarau <aliaksei.makarau@ibm.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_MSG_ASYNC_SMCDSTACK_H
+#define CEPH_MSG_ASYNC_SMCDSTACK_H
+
+#include <thread>
+
+#include "msg/msg_types.h"
+#include "msg/async/Stack.h"
+#include "SMCDNetHandler.h"
+
+class SMCDWorker : public Worker {
+  ceph::smcd::SMCDNetHandler net;
+  void initialize() override;
+
+ public:
+  SMCDWorker(CephContext *c, unsigned i)
+      : Worker(c, i), net(c) {}
+  int listen(entity_addr_t &sa,
+             unsigned addr_slot,
+             const SocketOptions &opt,
+             ServerSocket *socks) override;
+  int connect(const entity_addr_t &addr, const SocketOptions &opts, ConnectedSocket *socket) override;
+};
+
+class SMCDStack : public NetworkStack {
+  std::vector<std::thread> threads;
+
+  virtual Worker* create_worker(CephContext *c, unsigned worker_id) override {
+    return new SMCDWorker(c, worker_id);
+  }
+
+ public:
+  explicit SMCDStack(CephContext *c);
+
+  void spawn_worker(std::function<void ()> &&func) override {
+    threads.emplace_back(std::move(func));
+  }
+  void join_worker(unsigned i) override {
+    ceph_assert(threads.size() > i && threads[i].joinable());
+    threads[i].join();
+  }
+};
+
+#endif //CEPH_MSG_ASYNC_SMCDSTACK_H


### PR DESCRIPTION
This change introduces the shared memory communication (SMC-D) for the cluster network.

SMC-D is faster than ethernet in IBM Z LPARs and/or VMs (zVM or KVM).

Fixes: https://tracker.ceph.com/issues/66702





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
