### PR TITLE
s390x: SMCD cluster network: option 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,6 +505,11 @@ if(WITH_DPDK)
   set(HAVE_DPDK TRUE)
 endif()
 
+option(WITH_SMCD "Enable SMCD in async messenger" ON)
+if(WITH_SMCD)
+  set(HAVE_SMCD TRUE)
+endif(WITH_SMCD)
+
 option(WITH_BLKIN "Use blkin to emit LTTng tracepoints for Zipkin" OFF)
 if(WITH_BLKIN)
   find_package(LTTngUST REQUIRED)

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -124,6 +124,9 @@
 /* AsyncMessenger RDMA conditional compilation */
 #cmakedefine HAVE_RDMA
 
+/* AsyncMessenger SMCD conditional compilation */
+#cmakedefine HAVE_SMCD
+
 /* ibverbs experimental conditional compilation */
 #cmakedefine HAVE_IBV_EXP
 

--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -31,14 +31,33 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "NetHandler "
 
+#ifdef HAVE_SMCD
+  #ifndef SMCPROTO_SMC
+    #define SMCPROTO_SMC           0       /* SMC protocol, IPv4 */
+    #define SMCPROTO_SMC6          1       /* SMC protocol, IPv6 */
+  #endif
+#endif
+
 namespace ceph{
 
 int NetHandler::create_socket(int domain, bool reuse_addr)
 {
   int s;
   int r = 0;
+  int protocol = IPPROTO_TCP;
 
-  if ((s = socket_cloexec(domain, SOCK_STREAM, 0)) == -1) {
+#ifdef HAVE_SMCD
+  /* check if socket is eligible for AF_SMC */
+  if (domain == AF_INET || domain == AF_INET6) {
+    if (domain == AF_INET)
+      protocol = SMCPROTO_SMC;
+    else /* AF_INET6 */
+      protocol = SMCPROTO_SMC6;
+    domain = AF_SMC;
+  }
+#endif
+
+  if ((s = socket_cloexec(domain, SOCK_STREAM, protocol)) == -1) {
     r = ceph_sock_errno();
     lderr(cct) << __func__ << " couldn't create socket " << cpp_strerror(r) << dendl;
     return -r;


### PR DESCRIPTION
This change introduces the shared memory communication (SMC-D) for the cluster network.

SMC-D is faster than ethernet in IBM Z LPARs and/or VMs (zVM or KVM).

Fixes: https://tracker.ceph.com/issues/66702





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
