### PR TITLE
systemd: use CMake install prefix in templates

### DIFF
--- a/systemd/ceph-crash.service.in
+++ b/systemd/ceph-crash.service.in
@@ -3,7 +3,7 @@ Description=Ceph crash dump collector
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/ceph-crash
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/ceph-crash
 Restart=always
 RestartSec=10
 StartLimitInterval=10min

--- a/systemd/ceph-exporter.service.in
+++ b/systemd/ceph-exporter.service.in
@@ -7,7 +7,7 @@ Wants=network-online.target local-fs.target ceph.target ceph-mon.target
 
 [Service]
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/ceph-exporter -f --id %i --setuser ceph --setgroup ceph
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/ceph-exporter -f --id %i --setuser ceph --setgroup ceph
 LockPersonality=true
 NoNewPrivileges=true
 PrivateDevices=yes

--- a/systemd/ceph-fuse@.service.in
+++ b/systemd/ceph-fuse@.service.in
@@ -7,7 +7,7 @@ PartOf=ceph-fuse.target
 
 [Service]
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
-ExecStart=/usr/bin/ceph-fuse -f %I
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/ceph-fuse -f %I
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true

--- a/systemd/ceph-immutable-object-cache@.service.in
+++ b/systemd/ceph-immutable-object-cache@.service.in
@@ -7,7 +7,7 @@ PartOf=ceph-immutable-object-cache.target
 [Service]
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/ceph-immutable-object-cache -f --id %i --setuser ceph --setgroup ceph
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/ceph-immutable-object-cache -f --id %i --setuser ceph --setgroup ceph
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true

--- a/systemd/ceph-mds@.service.in
+++ b/systemd/ceph-mds@.service.in
@@ -8,7 +8,7 @@ Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.targe
 [Service]
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/ceph-mds -f --id %i --setuser ceph --setgroup ceph
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/ceph-mds -f --id %i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LockPersonality=true

--- a/systemd/ceph-mgr@.service.in
+++ b/systemd/ceph-mgr@.service.in
@@ -8,7 +8,7 @@ Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.targe
 [Service]
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/ceph-mgr -f --id %i --setuser ceph --setgroup ceph
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/ceph-mgr -f --id %i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LockPersonality=true

--- a/systemd/ceph-mon@.service.in
+++ b/systemd/ceph-mon@.service.in
@@ -12,7 +12,7 @@ Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.targe
 [Service]
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/ceph-mon -f --id %i --setuser ceph --setgroup ceph
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/ceph-mon -f --id %i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LockPersonality=true

--- a/systemd/ceph-osd@.service.in
+++ b/systemd/ceph-osd@.service.in
@@ -8,7 +8,7 @@ Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.targe
 [Service]
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/ceph-osd -f --id %i --setuser ceph --setgroup ceph
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/ceph-osd -f --id %i --setuser ceph --setgroup ceph
 ExecStartPre=@CMAKE_INSTALL_FULL_LIBEXECDIR@/ceph/ceph-osd-prestart.sh --id %i
 LimitNOFILE=1048576
 LimitNPROC=1048576

--- a/systemd/ceph-radosgw@.service.in
+++ b/systemd/ceph-radosgw@.service.in
@@ -7,7 +7,7 @@ Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.targe
 
 [Service]
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
-ExecStart=/usr/bin/radosgw -f --name client.%i --setuser ceph --setgroup ceph
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/radosgw -f --name client.%i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LockPersonality=true

--- a/systemd/ceph-rbd-mirror@.service.in
+++ b/systemd/ceph-rbd-mirror@.service.in
@@ -7,7 +7,7 @@ PartOf=ceph-rbd-mirror.target
 [Service]
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/rbd-mirror -f --id %i --setuser ceph --setgroup ceph
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/rbd-mirror -f --id %i --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LockPersonality=true

--- a/systemd/ceph-volume@.service
+++ b/systemd/ceph-volume@.service
@@ -7,7 +7,7 @@ Wants=local-fs.target
 Type=oneshot
 KillMode=none
 Environment=CEPH_VOLUME_TIMEOUT=10000
-ExecStart=/bin/sh -c 'timeout $CEPH_VOLUME_TIMEOUT /usr/sbin/ceph-volume-systemd %i'
+ExecStart=/bin/sh -c 'timeout $CEPH_VOLUME_TIMEOUT @CMAKE_INSTALL_PREFIX@/sbin/ceph-volume-systemd %i'
 TimeoutSec=0
 
 [Install]

--- a/systemd/cephfs-mirror@.service.in
+++ b/systemd/cephfs-mirror@.service.in
@@ -6,7 +6,7 @@ PartOf=cephfs-mirror.target
 
 [Service]
 EnvironmentFile=-@SYSTEMD_ENV_FILE@
-ExecStart=/usr/bin/cephfs-mirror --id %i -f --setuser ceph --setgroup ceph
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/cephfs-mirror --id %i -f --setuser ceph --setgroup ceph
 LimitNOFILE=1048576
 LimitNPROC=1048576
 LockPersonality=true

--- a/systemd/rbdmap.service.in
+++ b/systemd/rbdmap.service.in
@@ -9,9 +9,9 @@ EnvironmentFile=-@SYSTEMD_ENV_FILE@
 Environment=RBDMAPFILE=/etc/ceph/rbdmap
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/rbdmap map
-ExecReload=/usr/bin/rbdmap map
-ExecStop=/usr/bin/rbdmap unmap-all
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/rbdmap map
+ExecReload=@CMAKE_INSTALL_PREFIX@/bin/rbdmap map
+ExecStop=@CMAKE_INSTALL_PREFIX@/bin/rbdmap unmap-all
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The current systemd services use hard-coded paths. This commit uses the CMake install prefix in the templates to set up paths to executables where they are actually installed.