### PR TITLE
librados/asio: support 'deferred' and 'use_awaitable' completions

### DIFF
--- a/src/common/io_exerciser/RadosIo.cc
+++ b/src/common/io_exerciser/RadosIo.cc
@@ -114,8 +114,8 @@ void RadosIo::applyIoOp(IoOp& op) {
         ceph_assert(ec == boost::system::errc::success);
         finish_io();
       };
-      librados::async_operate(asio, io, oid, &op_info->wop, 0, nullptr,
-                              create_cb);
+      librados::async_operate(asio.get_executor(), io, oid,
+                              &op_info->wop, 0, nullptr, create_cb);
       break;
     }
 
@@ -127,8 +127,8 @@ void RadosIo::applyIoOp(IoOp& op) {
         ceph_assert(ec == boost::system::errc::success);
         finish_io();
       };
-      librados::async_operate(asio, io, oid, &op_info->wop, 0, nullptr,
-                              remove_cb);
+      librados::async_operate(asio.get_executor(), io, oid,
+                              &op_info->wop, 0, nullptr, remove_cb);
       break;
     }
     case OpType::Read:
@@ -185,7 +185,8 @@ void RadosIo::applyReadWriteOp(IoOp& op) {
       }
       finish_io();
     };
-    librados::async_operate(asio, io, oid, &op_info->rop, 0, nullptr, read_cb);
+    librados::async_operate(asio.get_executor(), io, oid,
+                            &op_info->rop, 0, nullptr, read_cb);
     num_io++;
   };
 
@@ -203,7 +204,8 @@ void RadosIo::applyReadWriteOp(IoOp& op) {
       ceph_assert(ec == boost::system::errc::success);
       finish_io();
     };
-    librados::async_operate(asio, io, oid, &op_info->wop, 0, nullptr, write_cb);
+    librados::async_operate(asio.get_executor(), io, oid,
+                            &op_info->wop, 0, nullptr, write_cb);
     num_io++;
   };
 
@@ -222,7 +224,8 @@ void RadosIo::applyReadWriteOp(IoOp& op) {
       ceph_assert(ec != boost::system::errc::success);
       finish_io();
     };
-    librados::async_operate(asio, io, oid, &op_info->wop, 0, nullptr, write_cb);
+    librados::async_operate(asio.get_executor(), io, oid,
+                            &op_info->wop, 0, nullptr, write_cb);
     num_io++;
   };
 

--- a/src/common/io_exerciser/RadosIo.h
+++ b/src/common/io_exerciser/RadosIo.h
@@ -51,8 +51,6 @@ class RadosIo : public Model {
   template <int N>
   class AsyncOpInfo {
    public:
-    librados::ObjectReadOperation rop;
-    librados::ObjectWriteOperation wop;
     std::array<ceph::bufferlist, N> bufferlist;
     std::array<uint64_t, N> offset;
     std::array<uint64_t, N> length;

--- a/src/librados/librados_asio.h
+++ b/src/librados/librados_asio.h
@@ -159,12 +159,13 @@ auto async_read(IoExecutor ex, IoCtx& io, const std::string& oid,
   using Op = detail::AsyncOp<bufferlist>;
   using Signature = typename Op::Signature;
   return boost::asio::async_initiate<CompletionToken, Signature>(
-      [] (auto handler, IoExecutor ex, IoCtx& io, const std::string& oid,
-          size_t len, uint64_t off) {
+      [] (auto handler, IoExecutor ex, const IoCtx& i,
+          const std::string& oid, size_t len, uint64_t off) {
         constexpr bool is_read = true;
         auto p = Op::create(ex, is_read, std::move(handler));
         auto& op = p->user_data;
 
+        IoCtx& io = const_cast<IoCtx&>(i);
         int ret = io.aio_read(oid, op.aio_completion.get(), &op.result, len, off);
         if (ret < 0) {
           auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
@@ -188,12 +189,13 @@ auto async_write(IoExecutor ex, IoCtx& io, const std::string& oid,
   using Op = detail::AsyncOp<void>;
   using Signature = typename Op::Signature;
   return boost::asio::async_initiate<CompletionToken, Signature>(
-      [] (auto handler, IoExecutor ex, IoCtx& io, const std::string& oid,
+      [] (auto handler, IoExecutor ex, const IoCtx& i, const std::string& oid,
           const bufferlist &bl, size_t len, uint64_t off) {
         constexpr bool is_read = false;
         auto p = Op::create(ex, is_read, std::move(handler));
         auto& op = p->user_data;
 
+        IoCtx& io = const_cast<IoCtx&>(i);
         int ret = io.aio_write(oid, op.aio_completion.get(), bl, len, off);
         if (ret < 0) {
           auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
@@ -217,12 +219,13 @@ auto async_operate(IoExecutor ex, IoCtx& io, const std::string& oid,
   using Op = detail::AsyncOp<bufferlist>;
   using Signature = typename Op::Signature;
   return boost::asio::async_initiate<CompletionToken, Signature>(
-      [] (auto handler, IoExecutor ex, IoCtx& io, const std::string& oid,
+      [] (auto handler, IoExecutor ex, const IoCtx& i, const std::string& oid,
           ObjectReadOperation *read_op, int flags) {
         constexpr bool is_read = true;
         auto p = Op::create(ex, is_read, std::move(handler));
         auto& op = p->user_data;
 
+        IoCtx& io = const_cast<IoCtx&>(i);
         int ret = io.aio_operate(oid, op.aio_completion.get(), read_op,
                                  flags, &op.result);
         if (ret < 0) {
@@ -247,13 +250,14 @@ auto async_operate(IoExecutor ex, IoCtx& io, const std::string& oid,
   using Op = detail::AsyncOp<void>;
   using Signature = typename Op::Signature;
   return boost::asio::async_initiate<CompletionToken, Signature>(
-      [] (auto handler, IoExecutor ex, IoCtx& io, const std::string& oid,
+      [] (auto handler, IoExecutor ex, const IoCtx& i, const std::string& oid,
           ObjectWriteOperation *write_op, int flags,
           const jspan_context* trace_ctx) {
         constexpr bool is_read = false;
         auto p = Op::create(ex, is_read, std::move(handler));
         auto& op = p->user_data;
 
+        IoCtx& io = const_cast<IoCtx&>(i);
         int ret = io.aio_operate(oid, op.aio_completion.get(), write_op, flags, trace_ctx);
         if (ret < 0) {
           auto ec = boost::system::error_code{-ret, librados::detail::err_category()};
@@ -276,12 +280,14 @@ auto async_notify(IoExecutor ex, IoCtx& io, const std::string& oid,
   using Op = detail::AsyncOp<bufferlist>;
   using Signature = typename Op::Signature;
   return boost::asio::async_initiate<CompletionToken, Signature>(
-      [] (auto handler, IoExecutor ex, IoCtx& io, const std::string& oid,
-          bufferlist& bl, uint64_t timeout_ms) {
+      [] (auto handler, IoExecutor ex, const IoCtx& i, const std::string& oid,
+          const bufferlist& b, uint64_t timeout_ms) {
         constexpr bool is_read = false;
         auto p = Op::create(ex, is_read, std::move(handler));
         auto& op = p->user_data;
 
+        IoCtx& io = const_cast<IoCtx&>(i);
+        bufferlist& bl = const_cast<bufferlist&>(b);
         int ret = io.aio_notify(oid, op.aio_completion.get(),
                                 bl, timeout_ms, &op.result);
         if (ret < 0) {

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -208,7 +208,7 @@ int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, con
     auto& yield = y.get_yield_context();
     auto ex = yield.get_executor();
     boost::system::error_code ec;
-    auto [ver, bl] = librados::async_operate(ex, ioctx, oid, op,
+    auto [ver, bl] = librados::async_operate(ex, ioctx, oid, std::move(*op),
                                              flags, trace_info, yield[ec]);
     if (pbl) {
       *pbl = std::move(bl);
@@ -234,7 +234,7 @@ int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, con
     auto& yield = y.get_yield_context();
     auto ex = yield.get_executor();
     boost::system::error_code ec;
-    version_t ver = librados::async_operate(ex, ioctx, oid, op,
+    version_t ver = librados::async_operate(ex, ioctx, oid, std::move(*op),
                                             flags, trace_info, yield[ec]);
     if (pver) {
       *pver = ver;

--- a/src/rgw/driver/rados/rgw_tools.cc
+++ b/src/rgw/driver/rados/rgw_tools.cc
@@ -206,9 +206,10 @@ int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, con
   // of blocking
   if (y) {
     auto& yield = y.get_yield_context();
+    auto ex = yield.get_executor();
     boost::system::error_code ec;
-    auto [ver, bl] = librados::async_operate(
-      yield, ioctx, oid, op, flags, trace_info, yield[ec]);
+    auto [ver, bl] = librados::async_operate(ex, ioctx, oid, op,
+                                             flags, trace_info, yield[ec]);
     if (pbl) {
       *pbl = std::move(bl);
     }
@@ -231,9 +232,10 @@ int rgw_rados_operate(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, con
 {
   if (y) {
     auto& yield = y.get_yield_context();
+    auto ex = yield.get_executor();
     boost::system::error_code ec;
-    version_t ver = librados::async_operate(yield, ioctx, oid, op, flags,
-                                            trace_info, yield[ec]);
+    version_t ver = librados::async_operate(ex, ioctx, oid, op,
+                                            flags, trace_info, yield[ec]);
     if (pver) {
       *pver = ver;
     }
@@ -254,8 +256,8 @@ int rgw_rados_notify(const DoutPrefixProvider *dpp, librados::IoCtx& ioctx, cons
   if (y) {
     auto& yield = y.get_yield_context();
     boost::system::error_code ec;
-    auto [ver, reply] = librados::async_notify(yield, ioctx, oid,
-                                               bl, timeout_ms, yield[ec]);
+    auto [ver, reply] = librados::async_notify(
+        yield.get_executor(), ioctx, oid, bl, timeout_ms, yield[ec]);
     if (pbl) {
       *pbl = std::move(reply);
     }

--- a/src/rgw/rgw_aio.cc
+++ b/src/rgw/rgw_aio.cc
@@ -97,7 +97,7 @@ Aio::OpFunc aio_abstract(librados::IoCtx ctx, Op&& op,
       // executor so it can safely call back into Aio without locking
       auto ex = yield.get_executor();
 
-      librados::async_operate(yield, ctx, r.obj.oid, &op, 0, trace_ctx,
+      librados::async_operate(ex, ctx, r.obj.oid, &op, 0, trace_ctx,
                               bind_executor(ex, Handler{aio, ctx, r}));
     };
 }

--- a/src/rgw/rgw_aio.cc
+++ b/src/rgw/rgw_aio.cc
@@ -97,7 +97,7 @@ Aio::OpFunc aio_abstract(librados::IoCtx ctx, Op&& op,
       // executor so it can safely call back into Aio without locking
       auto ex = yield.get_executor();
 
-      librados::async_operate(ex, ctx, r.obj.oid, &op, 0, trace_ctx,
+      librados::async_operate(ex, ctx, r.obj.oid, std::move(op), 0, trace_ctx,
                               bind_executor(ex, Handler{aio, ctx, r}));
     };
 }


### PR DESCRIPTION
when called with [boost::asio::use_awaitable](https://www.boost.org/doc/libs/1_85_0/doc/html/boost_asio/reference/use_awaitable.html) for c++20 coroutines, these functions fail to compile because async_initiate() tries to pass the IoCtx argument by rvalue reference, but our lambda expects lvalue reference:
```
src/librados/librados_asio.h:196:7: note:   template argument deduction/substitution failed:
boost/asio/impl/use_awaitable.hpp:276:26: note:   cannot convert ‘std::move<librados::v14_2_0::IoCtx&>((* & args#1))’ (type ‘std::remove_reference<librados::v14_2_0::IoCtx&>::type’ {aka ‘librados::v14_2_0::IoCtx’}) to type ‘librados::v14_2_0::IoCtx&’
 276 |     std::move(initiation)(std::move(handler), std::move(args)...);
     |     ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
async_initiate() for [boost::asio::deferred](https://www.boost.org/doc/libs/1_85_0/doc/html/boost_asio/reference/deferred_t.html) shows the same issue:
```
src/librados/librados_asio.h:196:7: note:   template argument deduction/substitution failed:
boost/asio/async_result.hpp:322:9: note:   cannot convert ‘args#1’ (type ‘const librados::v14_2_0::IoCtx’) to type ‘librados::v14_2_0::IoCtx&’
 322 |         static_cast<Args&&>(args)...);
     |         ^~~~~~~~~~~~~~~~~~~~~~~~~
```    
in both cases, async_initiate() has to copy the arguments for deferred/lazy initiation, then move them into our lambda when invoked. asio documentation doesn't really cover how this works, but i did find this [release note from boost 1.70](https://www.boost.org/doc/libs/1_85_0/doc/html/boost_asio/history.html#boost_asio.history.asio_1_14_0___boost_1_70):

> The `initiate` member function must: (a) transform the token into a completion handler object `handler`; (b) cause the invocation of the function object `initiation` as if by calling `std::forward<Initiation>(initiation)(std::move(handler), std::forward<Args>(args)...)`. Note that the invocation of `initiation` may be deferred (e.g. lazily evaluated), in which case `initiation` and `args` must be decay-copied and moved as required. 

because our lambdas take mutable references, they won't accept these rvalue references. taking them as const references instead allows the caller to pass either lvalue- or rvalue references

this requires internal const_casts to convert them back to mutable references. while casting away const risks undefined behavior, these casts are safe because:
- in the deferred/lazy case, the arguments were decay-copied (const removed) into temporary storage
- in the normal case, the initial arguments were passed as mutable refs

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
