### PR TITLE
rgw: return MalformedXML for empty objects list in DeleteObjects

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7319,6 +7319,12 @@ void RGWDeleteMultiObj::execute(optional_yield y)
     return;
   }
 
+  if (multi_delete->objects.empty()) {
+    s->err.message = "Missing required element Object";
+    op_ret = -ERR_MALFORMED_XML;
+    return;
+  }
+
   constexpr int DEFAULT_MAX_NUM = 1000;
   int max_num = s->cct->_conf->rgw_delete_multi_obj_max_num;
   if (max_num < 0) {


### PR DESCRIPTION
When a request contains an empty list of objects, the current implementation returns a 200 OK. However, this behavior may raise security concerns, as it could imply the user has access to the bucket, even though access policies are only evaluated per object. To mitigate this risk, returning a 400 Bad Request would be a more secure approach. This ensures that no assumption is made about the user’s access to the bucket or its objects. Furthermore, this adjustment aligns with AWS behavior, enhancing compatibility.

Fixes: https://tracker.ceph.com/issues/68799