### PR TITLE
rgw/multisite: revert "rgw/multisite: avoid redundant error repo entry logging

### DIFF
--- a/src/rgw/driver/rados/rgw_data_sync.cc
+++ b/src/rgw/driver/rados/rgw_data_sync.cc
@@ -6052,13 +6052,12 @@ int RGWSyncBucketCR::operate(const DoutPrefixProvider *dpp)
               } else {
                 tn->log(20, SSTR("logged prev gen entry (bucket=" << source_bs.bucket << ", shard_id=" << source_bs.shard_id << ", gen=" << current_gen << " in error repo: retcode=" << retcode));
 	      }
-	    } else {
+	    }
             retcode = -EAGAIN;
             tn->log(10, SSTR("ERROR: requested sync of future generation "
                              << *gen << " > " << current_gen
                              << ", returning " << retcode << " for later retry"));
             return set_cr_error(retcode);
-            }
           } else if (*gen < current_gen) {
             tn->log(10, SSTR("WARNING: requested sync of past generation "
                              << *gen << " < " << current_gen


### PR DESCRIPTION
Pass the requested gen than the bucket_status.incremental_gen to RGWSyncBucketShardCR as the old gen (bucket_status.incremental_gen) is stored in the error repo and will retried later.

Fixes: https://tracker.ceph.com/issues/68805