### PR TITLE
mgr/telemetry: add stretch cluster data

### DIFF
--- a/doc/mgr/telemetry.rst
+++ b/doc/mgr/telemetry.rst
@@ -190,6 +190,7 @@ List all collections with::
   basic_pool_options_bluestore    NOT REPORTING: NOT OPTED-IN                          Per-pool bluestore config options
   basic_pool_usage                NOT REPORTING: NOT OPTED-IN                          Default pool application and usage statistics
   basic_rook_v01                  NOT REPORTING: NOT OPTED-IN                          Basic Rook deployment data
+  basic_stretch_cluster           NOT REPORTING: NOT OPTED-IN                          Stretch Mode information for stretch clusters deployments
   basic_usage_by_class            NOT REPORTING: NOT OPTED-IN                          Default device class usage statistics
   crash_base                      NOT REPORTING: NOT OPTED-IN                          Information about daemon crashes (daemon type and version, backtrace, etc.)
   device_base                     NOT REPORTING: NOT OPTED-IN                          Information about device health metrics

--- a/qa/workunits/test_telemetry_reef_x.sh
+++ b/qa/workunits/test_telemetry_reef_x.sh
@@ -20,7 +20,7 @@ REPORTED_COLLECTIONS=$(ceph telemetry collection ls)
 NUM_REPORTED_COLLECTIONS=$(echo "$REPORTED_COLLECTIONS" | awk '/^NAME/ {flag=1; next} flag' | wc -l)
 KNOWN_COLLECTIONS=("basic_base" "basic_mds_metadata" "basic_pool_flags" "basic_pool_options_bluestore"
 	           "basic_pool_usage" "basic_rook_v01" "basic_usage_by_class" "crash_base" "device_base"
-		   "ident_base" "perf_memory_metrics" "perf_perf")
+		   "ident_base" "perf_memory_metrics" "perf_perf" "basic_stretch_cluster")
 
 if ! [[ $NUM_REPORTED_COLLECTIONS == "${#KNOWN_COLLECTIONS[@]}" ]];
 then

--- a/qa/workunits/test_telemetry_squid_x.sh
+++ b/qa/workunits/test_telemetry_squid_x.sh
@@ -20,7 +20,7 @@ REPORTED_COLLECTIONS=$(ceph telemetry collection ls)
 NUM_REPORTED_COLLECTIONS=$(echo "$REPORTED_COLLECTIONS" | awk '/^NAME/ {flag=1; next} flag' | wc -l)
 KNOWN_COLLECTIONS=("basic_base" "basic_mds_metadata" "basic_pool_flags" "basic_pool_options_bluestore"
 	           "basic_pool_usage" "basic_rook_v01" "basic_usage_by_class" "crash_base" "device_base"
-		   "ident_base" "perf_memory_metrics" "perf_perf")
+		   "ident_base" "perf_memory_metrics" "perf_perf" "basic_stretch_cluster")
 
 if ! [[ $NUM_REPORTED_COLLECTIONS == "${#KNOWN_COLLECTIONS[@]}" ]];
 then

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -72,6 +72,7 @@ class Collection(str, enum.Enum):
     perf_memory_metrics = 'perf_memory_metrics'
     basic_pool_options_bluestore = 'basic_pool_options_bluestore'
     basic_pool_flags = 'basic_pool_flags'
+    basic_stretch_cluster = 'basic_stretch_cluster'
 
 MODULE_COLLECTION : List[Dict] = [
     {
@@ -143,6 +144,12 @@ MODULE_COLLECTION : List[Dict] = [
     {
         "name": Collection.basic_pool_flags,
         "description": "Per-pool flags",
+        "channel": "basic",
+        "nag": False
+    },
+    {
+        "name": Collection.basic_stretch_cluster,
+        "description": "Stretch mode information for stretch clusters",
         "channel": "basic",
         "nag": False
     },
@@ -1317,6 +1324,17 @@ class Module(MgrModule):
 
             # Rook
             self.get_rook_data(report)
+
+            # Stretch Mode
+            if self.is_enabled_collection(Collection.basic_stretch_cluster):
+                stretch_mode = osd_map.get("stretch_mode", {})
+                report['stretch_cluster'] = {
+                    'stretch_mode_enabled': stretch_mode.get("stretch_mode_enabled", {}),
+                    'stretch_bucket_count': stretch_mode.get("stretch_bucket_count", {}),
+                    'degraded_stretch_mode': stretch_mode.get("degraded_stretch_mode", {}),
+                    'recovering_stretch_mode': stretch_mode.get("recovering_stretch_mode", {}),
+                    'stretch_mode_bucket': stretch_mode.get("stretch_mode_bucket", {}),
+                }
 
         if 'crash' in channels:
             report['crashes'] = self.gather_crashinfo()


### PR DESCRIPTION
Closes: https://tracker.ceph.com/issues/67812

[Stretch Mode](https://docs.ceph.com/en/reef/rados/operations/stretch-mode/) information helps us learn how deployments are done for stretch clusters. We add a `basic_stretch_cluster` collection to the `basic` channel for this purpose.

The newly added `basic_stretch_cluster` collection in the `basic` channel looks like:
```json
"stretch_cluster": {
        "degraded_stretch_mode": 0,
        "recovering_stretch_mode": 0,
        "stretch_bucket_count": 2,
        "stretch_mode_bucket": 9,
        "stretch_mode_enabled": true
    },
```

### Things I learned (click on details to expand)
<details>

Telemetry module is used to send anonymous data about the Ceph cluster to us which helps us understand how Ceph is being used in the wild. The code for this is present in [here](https://github.com/ceph/ceph/blob/main/src/pybind/mgr/telemetry/module.py)

As mentioned in the [docs](https://docs.ceph.com/en/latest/mgr/telemetry/), there are two main concepts to telemetry:
* **Channels**: The telemetry data is broken down into different channels and each channel holds a different kind of information. This categorization is useful to group related data for easier access
* **Collections**: These are different parts of data that are collected within a channel. Any new data that is added into a channel will be added as a new collection, this helps our users understand the diff (_what new data is added_) between different versions of telemetry releases.

The telemetry module is written is python and this code is extended with the C++ functions of our Ceph source code present in the `src/` directory. The reason for writing telemetry module in python is to ease the development of adding new data to telemetry. Refer [this](https://docs.python.org/3/extending/extending.html) to understand more about Python extensions.  

#### Code details

To add `stretch_mode` data into telemetry, we need to do the following:
1. Fetch the osdmap information
2. Extract `stretch_mode` data from the map
3. Add it to the telemetry report only when the collection is enabled

The [OSDMap class](https://github.com/ceph/ceph/blob/c8e3946117c9c26068870ba4a4bc6b3d361c4e4f/src/osd/OSDMap.h#L356) and it's information is present in the C code of ceph. We would need to invoke the dump function of the OSDMap class to get the required information. The telemetry module has a helper function called as `self.get('osd_map')` to do exactly this. The list of all the cluster wide object that you are fetch are listed in the [pydoc comment](https://github.com/ceph/ceph/blob/c8e3946117c9c26068870ba4a4bc6b3d361c4e4f/src/pybind/mgr/mgr_module.py#L1485).

The OSDMap cluster object we get is a dictionary. To fetch the stretch mode information, the stretch mode key is required. The name of this key can be found in the implementation of the `dump` method of OSDMap class. Depending on [how the data is being dumped](https://github.com/ceph/ceph/blob/c8e3946117c9c26068870ba4a4bc6b3d361c4e4f/src/osd/OSDMap.cc#L4113-L4121), you will need to extract the data accordingly.

For eg: Stretch mode is dumped like this:

```
f->open_object_section("stretch_mode");
  {
    f->dump_bool("stretch_mode_enabled", stretch_mode_enabled);
    f->dump_unsigned("stretch_bucket_count", stretch_bucket_count);
    f->dump_unsigned("degraded_stretch_mode", degraded_stretch_mode);
    f->dump_unsigned("recovering_stretch_mode", recovering_stretch_mode);
    f->dump_int("stretch_mode_bucket", stretch_mode_bucket);
  }
  f->close_section();
```

i.e it;s a JSON object with key `stretch_mode` :
```
{
	"stretch_cluster": 
		{
	        "degraded_stretch_mode": 0,
	        "recovering_stretch_mode": 0,
	        "stretch_bucket_count": 0,
	        "stretch_mode_bucket": 0,
	        "stretch_mode_enabled": false
		 }
}
```

To extract this data in telemetry python module you would do this and add it only when collection is enabled, you would do this:
```
# Stretch Mode
if self.is_enabled_collection(Collection.basic_stretch_cluster):
	stretch_mode = osd_map['stretch_mode']
	report['stretch_cluster'] = {
		'stretch_mode_enabled': stretch_mode['stretch_mode_enabled'],
		 ....
	}

```
</details>


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>


