### PR TITLE
doc/rgw/notification: add missing admin commands

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -476,26 +476,19 @@ as follows:
   Cancel resharding a bucket
 
 :command:`topic list`
-  List bucket notifications/pubsub topics                                                   
+  List bucket notifications topics
 
 :command:`topic get`
-  Get a bucket notifications/pubsub topic                                                   
-  
+  Get a bucket notification topic 
+
 :command:`topic rm`
-  Remove a bucket notifications/pubsub topic                                                
+  Remove a bucket notifications topic 
 
-:command:`subscription get`
-  Get a pubsub subscription definition
+:command:`topic stats`
+  Get a bucket notifications persistent topic stats (i.e. reservations, entries & size)
 
-:command:`subscription rm`
-  Remove a pubsub subscription
-
-:command:`subscription pull`
-  Show events in a pubsub subscription
-             
-:command:`subscription ack`
-  Acknowledge (remove) events in a pubsub subscription
-
+:command:`topic dump`
+  Dump (in JSON format) all pending bucket notifications of a persistent topic
 
 Options
 =======

--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -104,6 +104,18 @@ Remove a topic by running the following command:
 
    radosgw-admin topic rm --topic={topic-name} [--tenant={tenant}]
 
+Fetch persistent topic stats (i.e. reservations, entries and size) by running the following command: 
+
+.. prompt:: bash #
+
+   radosgw-admin topic stats --topic={topic-name} [--tenant={tenant}]
+
+Dump (in JSON format) all pending bucket notifications of a persistent topic by running the following command: 
+
+.. prompt:: bash #
+
+   radosgw-admin topic dump --topic={topic-name} [--tenant={tenant}] [--max-entries={max-entries}]
+
 
 Notification Performance Statistics
 -----------------------------------


### PR DESCRIPTION
also remove obsolete admin commands

Fixes: https://tracker.ceph.com/issues/68818

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
