### PR TITLE
osd: avoid costly md_config_t::get_val<>() when preparing stats

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -3930,8 +3930,7 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
   // when there is no change in osdmap,
   // update info.stats.reported_epoch by the number of time seconds.
   utime_t cutoff_time = now;
-  cutoff_time -=
-      cct->_conf.get_val<int64_t>("osd_pg_stat_report_interval_max_seconds");
+  cutoff_time -= *osd_pg_stat_report_interval_max_seconds;
   const bool is_time_expired = cutoff_time > info.stats.last_fresh;
 
   // 500 epoch osdmaps are also the minimum number of osdmaps that mon must retain.
@@ -3939,8 +3938,7 @@ std::optional<pg_stat_t> PeeringState::prepare_stats_for_publish(
   // it can be considered that the one reported by pgid is too old and needs to be updated.
   // to facilitate mon trim osdmaps
   epoch_t cutoff_epoch = info.stats.reported_epoch;
-  cutoff_epoch +=
-      cct->_conf.get_val<int64_t>("osd_pg_stat_report_interval_max_epochs");
+  cutoff_epoch += *osd_pg_stat_report_interval_max_epochs;
   const bool is_epoch_behind = cutoff_epoch < get_osdmap_epoch();
 
   if (pg_stats_publish && pre_publish == *pg_stats_publish &&

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -25,6 +25,7 @@
 #include "OSDMap.h"
 #include "MissingLoc.h"
 #include "osd/osd_perf_counters.h"
+#include "common/config_cacher.h"
 #include "common/ostream_temp.h"
 
 struct PGPool {
@@ -1391,6 +1392,10 @@ public:
 
   PGStateHistory state_history;
   CephContext* cct;
+  md_config_cacher_t<int64_t> osd_pg_stat_report_interval_max_seconds{
+    cct->_conf, "osd_pg_stat_report_interval_max_seconds" };
+  md_config_cacher_t<int64_t> osd_pg_stat_report_interval_max_epochs{
+    cct->_conf, "osd_pg_stat_report_interval_max_epochs" };
   spg_t spgid;
   DoutPrefixProvider *dpp;
   PeeringListener *pl;


### PR DESCRIPTION
It's know that the `md_config_t::get_val<>()` method template is costly and should be avoided on hot paths.

Recent profiling[1] by Mark Kogan has shown that, on RGW's bucket listing, an OSD had burnt 2,87% of CPU cycles on `get_val<long>()` in `PG::prepare_stats_for_publish()`.

[1]: https://github.com/ceph/ceph/pull/60278#issuecomment-2415718353





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
