### PR TITLE
ceph.spec.in,debian/rules: aio-max-nr for Crimson

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2340,11 +2340,7 @@ fi
 if [ $1 -eq 1 ] ; then
 /usr/bin/systemctl start ceph-osd.target >/dev/null 2>&1 || :
 fi
-%if 0%{?sysctl_apply}
-    %sysctl_apply 90-ceph-osd.conf
-%else
-    /usr/lib/systemd/systemd-sysctl %{_sysctldir}/90-ceph-osd.conf > /dev/null 2>&1 || :
-%endif
+%sysctl_apply 90-ceph-osd.conf
 
 %preun osd
 %if 0%{?suse_version}

--- a/etc/sysctl/90-crimson-osd.conf.in
+++ b/etc/sysctl/90-crimson-osd.conf.in
@@ -1,0 +1,3 @@
+fs.aio-max-nr = 2097152
+@sysctl_pid_max@
+

--- a/etc/sysctl/CMakeLists.txt
+++ b/etc/sysctl/CMakeLists.txt
@@ -4,6 +4,12 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(sysctl_pid_max "kernel.pid_max = 4194304")
 endif()
 
-configure_file(90-ceph-osd.conf.in
-  ${CMAKE_CURRENT_SOURCE_DIR}/90-ceph-osd.conf
-  @ONLY)
+if(WITH_SEASTAR)
+  configure_file(90-crimson-osd.conf.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/90-ceph-osd.conf
+    @ONLY)
+else()
+  configure_file(90-ceph-osd.conf.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/90-ceph-osd.conf
+    @ONLY)
+endif()


### PR DESCRIPTION
See https://github.com/ceph/ceph/commit/36326dc7104fc2f20f19d51b6f618a029ba072d7.
Clasical osd packages are adjusting the aio-max-nr value
from the default of 65536 to 1048576 as the default is too low
for some deployments. The same should be applied for Crimson's
packages.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
