### PR TITLE
rgw/reshard: process source shards in parallel

### DIFF
--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -517,21 +517,24 @@ void cls_rgw_bi_put_entries(librados::ObjectWriteOperation& op,
 /* nb: any entries passed in are replaced with the results of the cls
  * call, so caller does not need to clear entries between calls
  */
-int cls_rgw_bi_list(librados::IoCtx& io_ctx, const std::string& oid,
-		    const std::string& name_filter, const std::string& marker, uint32_t max,
-		    std::list<rgw_cls_bi_entry> *entries, bool *is_truncated, bool reshardlog)
+void cls_rgw_bi_list(librados::ObjectReadOperation& op,
+                     std::string name_filter, std::string marker,
+                     uint32_t max, bool reshardlog, bufferlist& out)
 {
-  bufferlist in, out;
+  bufferlist in;
   rgw_cls_bi_list_op call;
-  call.name_filter = name_filter;
-  call.marker = marker;
+  call.name_filter = std::move(name_filter);
+  call.marker = std::move(marker);
   call.max = max;
   call.reshardlog = reshardlog;
   encode(call, in);
-  int r = io_ctx.exec(oid, RGW_CLASS, RGW_BI_LIST, in, out);
-  if (r < 0)
-    return r;
+  op.exec(RGW_CLASS, RGW_BI_LIST, in, &out, nullptr);
+}
 
+int cls_rgw_bi_list_decode(const bufferlist& out,
+                           std::list<rgw_cls_bi_entry>& entries,
+                           bool& is_truncated)
+{
   rgw_cls_bi_list_ret op_ret;
   auto iter = out.cbegin();
   try {
@@ -540,8 +543,8 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const std::string& oid,
     return -EIO;
   }
 
-  entries->swap(op_ret.entries);
-  *is_truncated = op_ret.is_truncated;
+  entries.swap(op_ret.entries);
+  is_truncated = op_ret.is_truncated;
 
   return 0;
 }

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -490,7 +490,7 @@ int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string oid, const rgw_cls_bi_e
   return 0;
 }
 
-void cls_rgw_bi_put(ObjectWriteOperation& op, const string oid, const rgw_cls_bi_entry& entry)
+void cls_rgw_bi_put(ObjectWriteOperation& op, const rgw_cls_bi_entry& entry)
 {
   bufferlist in, out;
   rgw_cls_bi_put_op call;

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -1158,18 +1158,22 @@ void cls_rgw_reshard_add(librados::ObjectWriteOperation& op,
   op.exec(RGW_CLASS, RGW_RESHARD_ADD, in);
 }
 
-int cls_rgw_reshard_list(librados::IoCtx& io_ctx, const string& oid, string& marker, uint32_t max,
-                         list<cls_rgw_reshard_entry>& entries, bool* is_truncated)
+void cls_rgw_reshard_list(librados::ObjectReadOperation& op,
+                          std::string marker, uint32_t max,
+                          bufferlist& out)
 {
-  bufferlist in, out;
+  bufferlist in;
   cls_rgw_reshard_list_op call;
-  call.marker = marker;
+  call.marker = std::move(marker);
   call.max = max;
   encode(call, in);
-  int r = io_ctx.exec(oid, RGW_CLASS, RGW_RESHARD_LIST, in, out);
-  if (r < 0)
-    return r;
+  op.exec(RGW_CLASS, RGW_RESHARD_LIST, in, &out, nullptr);
+}
 
+int cls_rgw_reshard_list_decode(const bufferlist& out,
+                                std::list<cls_rgw_reshard_entry>& entries,
+                                bool* is_truncated)
+{
   cls_rgw_reshard_list_ret op_ret;
   auto iter = out.cbegin();
   try {
@@ -1184,16 +1188,21 @@ int cls_rgw_reshard_list(librados::IoCtx& io_ctx, const string& oid, string& mar
   return 0;
 }
 
-int cls_rgw_reshard_get(librados::IoCtx& io_ctx, const string& oid, cls_rgw_reshard_entry& entry)
+void cls_rgw_reshard_get(librados::ObjectReadOperation& op,
+                         std::string tenant, std::string bucket_name,
+                         bufferlist& out)
 {
-  bufferlist in, out;
+  bufferlist in;
   cls_rgw_reshard_get_op call;
-  call.entry = entry;
+  call.entry.tenant = std::move(tenant);
+  call.entry.bucket_name = std::move(bucket_name);
   encode(call, in);
-  int r = io_ctx.exec(oid, RGW_CLASS, RGW_RESHARD_GET, in, out);
-  if (r < 0)
-    return r;
+  op.exec(RGW_CLASS, RGW_RESHARD_GET, in, &out, nullptr);
+}
 
+int cls_rgw_reshard_get_decode(const bufferlist& out,
+                               cls_rgw_reshard_entry& entry)
+{
   cls_rgw_reshard_get_ret op_ret;
   auto iter = out.cbegin();
   try {
@@ -1202,7 +1211,7 @@ int cls_rgw_reshard_get(librados::IoCtx& io_ctx, const string& oid, cls_rgw_resh
     return -EIO;
   }
 
-  entry = op_ret.entry;
+  entry = std::move(op_ret.entry);
 
   return 0;
 }

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -1171,7 +1171,7 @@ void cls_rgw_reshard_list(librados::ObjectReadOperation& op,
 }
 
 int cls_rgw_reshard_list_decode(const bufferlist& out,
-                                std::list<cls_rgw_reshard_entry>& entries,
+                                std::vector<cls_rgw_reshard_entry>& entries,
                                 bool* is_truncated)
 {
   cls_rgw_reshard_list_ret op_ret;

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -475,11 +475,11 @@ int cls_rgw_bi_get(librados::IoCtx& io_ctx, const string oid,
   return 0;
 }
 
-int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string oid, const rgw_cls_bi_entry& entry)
+int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string& oid, rgw_cls_bi_entry entry)
 {
   bufferlist in, out;
   rgw_cls_bi_put_op call;
-  call.entry = entry;
+  call.entry = std::move(entry);
   encode(call, in);
   librados::ObjectWriteOperation op;
   op.exec(RGW_CLASS, RGW_BI_PUT, in);
@@ -490,11 +490,11 @@ int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string oid, const rgw_cls_bi_e
   return 0;
 }
 
-void cls_rgw_bi_put(ObjectWriteOperation& op, const rgw_cls_bi_entry& entry)
+void cls_rgw_bi_put(ObjectWriteOperation& op, rgw_cls_bi_entry entry)
 {
   bufferlist in, out;
   rgw_cls_bi_put_op call;
-  call.entry = entry;
+  call.entry = std::move(entry);
   encode(call, in);
   op.exec(RGW_CLASS, RGW_BI_PUT, in);
 }

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -385,7 +385,7 @@ int cls_rgw_bi_get(librados::IoCtx& io_ctx, const std::string oid,
                    BIIndexType index_type, const cls_rgw_obj_key& key,
                    rgw_cls_bi_entry *entry);
 int cls_rgw_bi_put(librados::IoCtx& io_ctx, const std::string oid, const rgw_cls_bi_entry& entry);
-void cls_rgw_bi_put(librados::ObjectWriteOperation& op, const std::string oid, const rgw_cls_bi_entry& entry);
+void cls_rgw_bi_put(librados::ObjectWriteOperation& op, const rgw_cls_bi_entry& entry);
 // Write the given array of index entries and update bucket stats accordingly.
 // If existing entries may be overwritten, pass check_existing=true to decrement
 // their stats first.

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -665,15 +665,20 @@ void cls_rgw_mp_upload_part_info_update(librados::ObjectWriteOperation& op, cons
 /* resharding */
 void cls_rgw_reshard_add(librados::ObjectWriteOperation& op,
 			 const cls_rgw_reshard_entry& entry,
-			 const bool create_only);
-void cls_rgw_reshard_remove(librados::ObjectWriteOperation& op, const cls_rgw_reshard_entry& entry);
-// these overloads which call io_ctx.operate() should not be called in the rgw.
-// rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
-#ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_rgw_reshard_list(librados::IoCtx& io_ctx, const std::string& oid, std::string& marker, uint32_t max,
-                         std::list<cls_rgw_reshard_entry>& entries, bool* is_truncated);
-int cls_rgw_reshard_get(librados::IoCtx& io_ctx, const std::string& oid, cls_rgw_reshard_entry& entry);
-#endif
+			 bool create_only);
+void cls_rgw_reshard_remove(librados::ObjectWriteOperation& op,
+                            const cls_rgw_reshard_entry& entry);
+void cls_rgw_reshard_list(librados::ObjectReadOperation& op,
+                          std::string marker, uint32_t max,
+                          bufferlist& bl);
+int cls_rgw_reshard_list_decode(const bufferlist& bl,
+                                std::list<cls_rgw_reshard_entry>& entries,
+                                bool* is_truncated);
+void cls_rgw_reshard_get(librados::ObjectReadOperation& op,
+                         std::string tenant, std::string bucket_name,
+                         bufferlist& bl);
+int cls_rgw_reshard_get_decode(const bufferlist& bl,
+                               cls_rgw_reshard_entry& entry);
 
 // If writes to the bucket index should be blocked during resharding, fail with
 // the given error code. RGWRados::guard_reshard() calls this in a loop to retry

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -392,9 +392,12 @@ void cls_rgw_bi_put(librados::ObjectWriteOperation& op, rgw_cls_bi_entry entry);
 void cls_rgw_bi_put_entries(librados::ObjectWriteOperation& op,
                             std::vector<rgw_cls_bi_entry> entries,
                             bool check_existing);
-int cls_rgw_bi_list(librados::IoCtx& io_ctx, const std::string& oid,
-                   const std::string& name, const std::string& marker, uint32_t max,
-                   std::list<rgw_cls_bi_entry> *entries, bool *is_truncated, bool reshardlog = false);
+void cls_rgw_bi_list(librados::ObjectReadOperation& op,
+                     std::string name, std::string marker,
+                     uint32_t max, bool reshardlog, bufferlist& bl);
+int cls_rgw_bi_list_decode(const bufferlist& bl,
+                           std::list<rgw_cls_bi_entry>& entries,
+                           bool& is_truncated);
 
 void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op,
                             const cls_rgw_obj_key& key, const ceph::buffer::list& olh_tag,

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -384,8 +384,8 @@ void cls_rgw_obj_check_mtime(librados::ObjectOperation& o, const ceph::real_time
 int cls_rgw_bi_get(librados::IoCtx& io_ctx, const std::string oid,
                    BIIndexType index_type, const cls_rgw_obj_key& key,
                    rgw_cls_bi_entry *entry);
-int cls_rgw_bi_put(librados::IoCtx& io_ctx, const std::string oid, const rgw_cls_bi_entry& entry);
-void cls_rgw_bi_put(librados::ObjectWriteOperation& op, const rgw_cls_bi_entry& entry);
+int cls_rgw_bi_put(librados::IoCtx& io_ctx, const std::string& oid, rgw_cls_bi_entry entry);
+void cls_rgw_bi_put(librados::ObjectWriteOperation& op, rgw_cls_bi_entry entry);
 // Write the given array of index entries and update bucket stats accordingly.
 // If existing entries may be overwritten, pass check_existing=true to decrement
 // their stats first.

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -672,7 +672,7 @@ void cls_rgw_reshard_list(librados::ObjectReadOperation& op,
                           std::string marker, uint32_t max,
                           bufferlist& bl);
 int cls_rgw_reshard_list_decode(const bufferlist& bl,
-                                std::list<cls_rgw_reshard_entry>& entries,
+                                std::vector<cls_rgw_reshard_entry>& entries,
                                 bool* is_truncated);
 void cls_rgw_reshard_get(librados::ObjectReadOperation& op,
                          std::string tenant, std::string bucket_name,

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -495,8 +495,6 @@ struct rgw_cls_bucket_update_stats_op
   std::map<RGWObjCategory, rgw_bucket_category_stats> stats;
   std::map<RGWObjCategory, rgw_bucket_category_stats> dec_stats;
 
-  rgw_cls_bucket_update_stats_op() {}
-
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(2, 1, bl);
     encode(absolute, bl);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1574,7 +1574,7 @@ WRITE_CLASS_ENCODER(cls_rgw_reshard_list_op)
 
 
 struct cls_rgw_reshard_list_ret {
-  std::list<cls_rgw_reshard_entry> entries;
+  std::vector<cls_rgw_reshard_entry> entries;
   bool is_truncated{false};
 
   cls_rgw_reshard_list_ret() {}

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -788,12 +788,10 @@ struct rgw_cls_bi_put_entries_op {
 WRITE_CLASS_ENCODER(rgw_cls_bi_put_entries_op)
 
 struct rgw_cls_bi_list_op {
-  uint32_t max;
+  uint32_t max = 0;
   std::string name_filter; // limit result to one object and its instances
   std::string marker;
-  bool reshardlog;
-
-  rgw_cls_bi_list_op() : max(0), reshardlog(false) {}
+  bool reshardlog = false;
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -734,8 +734,6 @@ WRITE_CLASS_ENCODER(rgw_cls_bi_get_ret)
 struct rgw_cls_bi_put_op {
   rgw_cls_bi_entry entry;
 
-  rgw_cls_bi_put_op() {}
-
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode(entry, bl);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -688,12 +688,10 @@ struct rgw_bi_log_entry {
 WRITE_CLASS_ENCODER(rgw_bi_log_entry)
 
 struct rgw_bucket_category_stats {
-  uint64_t total_size;
-  uint64_t total_size_rounded;
-  uint64_t num_entries;
+  uint64_t total_size = 0;
+  uint64_t total_size_rounded = 0;
+  uint64_t num_entries = 0;
   uint64_t actual_size{0}; //< account for compression, encryption
-
-  rgw_bucket_category_stats() : total_size(0), total_size_rounded(0), num_entries(0) {}
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(3, 2, bl);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -730,6 +730,49 @@ inline bool operator!=(const rgw_bucket_category_stats& lhs,
   return !(lhs == rhs);
 }
 
+inline auto operator+(const rgw_bucket_category_stats& lhs,
+                      const rgw_bucket_category_stats& rhs)
+  -> rgw_bucket_category_stats
+{
+  return rgw_bucket_category_stats{
+    .total_size = lhs.total_size + rhs.total_size,
+    .total_size_rounded = lhs.total_size_rounded + rhs.total_size_rounded,
+    .num_entries = lhs.num_entries + rhs.num_entries,
+    .actual_size = lhs.actual_size + rhs.actual_size
+  };
+}
+inline auto operator+=(rgw_bucket_category_stats& lhs,
+                       const rgw_bucket_category_stats& rhs)
+  -> rgw_bucket_category_stats&
+{
+  lhs.total_size += rhs.total_size;
+  lhs.total_size_rounded += rhs.total_size_rounded;
+  lhs.num_entries += rhs.num_entries;
+  lhs.actual_size += rhs.actual_size;
+  return lhs;
+}
+inline auto operator-(const rgw_bucket_category_stats& lhs,
+                      const rgw_bucket_category_stats& rhs)
+  -> rgw_bucket_category_stats
+{
+  return rgw_bucket_category_stats{
+    .total_size = lhs.total_size - rhs.total_size,
+    .total_size_rounded = lhs.total_size_rounded - rhs.total_size_rounded,
+    .num_entries = lhs.num_entries - rhs.num_entries,
+    .actual_size = lhs.actual_size - rhs.actual_size
+  };
+}
+inline auto operator-=(rgw_bucket_category_stats& lhs,
+                       const rgw_bucket_category_stats& rhs)
+  -> rgw_bucket_category_stats&
+{
+  lhs.total_size -= rhs.total_size;
+  lhs.total_size_rounded -= rhs.total_size_rounded;
+  lhs.num_entries -= rhs.num_entries;
+  lhs.actual_size -= rhs.actual_size;
+  return lhs;
+}
+
 enum class cls_rgw_reshard_status : uint8_t {
   NOT_RESHARDING  = 0,
   IN_PROGRESS     = 1,

--- a/src/common/async/co_waiter.h
+++ b/src/common/async/co_waiter.h
@@ -72,6 +72,8 @@ class co_waiter {
     ceph_assert(handler);
     auto h = boost::asio::append(std::move(*handler), eptr, std::move(value));
     handler.reset();
+    auto slot = boost::asio::get_associated_cancellation_slot(h);
+    slot.clear(); // remove our cancellation handler
     boost::asio::dispatch(std::move(h));
   }
 
@@ -142,6 +144,8 @@ class co_waiter<void, Executor> {
     ceph_assert(handler);
     auto h = boost::asio::append(std::move(*handler), eptr);
     handler.reset();
+    auto slot = boost::asio::get_associated_cancellation_slot(h);
+    slot.clear(); // remove our cancellation handler
     boost::asio::dispatch(std::move(h));
   }
 

--- a/src/common/async/completion.h
+++ b/src/common/async/completion.h
@@ -197,12 +197,13 @@ class CompletionImpl final : public Completion<void(Args...), T> {
 
   void destroy_defer(std::tuple<Args...>&& args) override {
     auto w = std::move(work);
+    auto ex1 = w.first.get_executor();
     auto ex2 = w.second.get_executor();
     RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler, DefaultAlloc{});
     auto f = bind_and_forward(ex2, std::move(handler), std::move(args));
     RebindTraits2::destroy(alloc2, this);
     RebindTraits2::deallocate(alloc2, this, 1);
-    boost::asio::defer(std::move(f));
+    boost::asio::defer(ex1, std::move(f));
   }
   void destroy_dispatch(std::tuple<Args...>&& args) override {
     auto w = std::move(work);
@@ -215,12 +216,13 @@ class CompletionImpl final : public Completion<void(Args...), T> {
   }
   void destroy_post(std::tuple<Args...>&& args) override {
     auto w = std::move(work);
+    auto ex1 = w.first.get_executor();
     auto ex2 = w.second.get_executor();
     RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler, DefaultAlloc{});
     auto f = bind_and_forward(ex2, std::move(handler), std::move(args));
     RebindTraits2::destroy(alloc2, this);
     RebindTraits2::deallocate(alloc2, this, 1);
-    boost::asio::post(std::move(f));
+    boost::asio::post(ex1, std::move(f));
   }
   void destroy() override {
     RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler, DefaultAlloc{});

--- a/src/common/async/detail/lease_state.h
+++ b/src/common/async/detail/lease_state.h
@@ -1,0 +1,143 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <optional>
+#include <utility>
+#include <boost/asio/append.hpp>
+#include <boost/asio/basic_waitable_timer.hpp>
+#include <boost/asio/bind_cancellation_slot.hpp>
+#include <boost/asio/cancellation_signal.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
+#include "common/ceph_time.h"
+
+namespace ceph::async::detail {
+
+using lease_clock = ceph::coarse_mono_clock;
+using lease_timer = boost::asio::basic_waitable_timer<lease_clock>;
+
+// base class for the lease completion state. this contains everything that
+// doesn't depend on the coroutine's return type
+class lease_state {
+  lease_timer timer;
+  boost::asio::cancellation_signal signal;
+  std::exception_ptr eptr;
+
+ public:
+  lease_state(boost::asio::any_io_executor ex) : timer(ex) {}
+
+  lease_timer& get_timer() { return timer; }
+
+  boost::asio::any_io_executor get_executor() { return timer.get_executor(); }
+  boost::asio::cancellation_slot get_cancellation_slot() { return signal.slot(); }
+
+  void complete()
+  {
+    timer.cancel(); // wake the renewal loop
+  }
+
+  void abort(std::exception_ptr e)
+  {
+    if (!eptr) { // only the first exception is reported
+      eptr = e;
+      cancel();
+    }
+  }
+
+  void rethrow()
+  {
+    if (eptr) {
+      std::rethrow_exception(eptr);
+    }
+  }
+
+  void cancel()
+  {
+    signal.emit(boost::asio::cancellation_type::terminal);
+    timer.cancel();
+  }
+};
+
+// capture and return the arguments to cr's completion handler
+template <typename T>
+class lease_completion_state : public lease_state,
+    public boost::intrusive_ref_counter<lease_completion_state<T>,
+        boost::thread_unsafe_counter>
+{
+  using result_type = std::pair<std::exception_ptr, T>;
+  std::optional<result_type> result;
+ public:
+  lease_completion_state(boost::asio::any_io_executor ex) : lease_state(ex) {}
+
+  bool completed() const { return result.has_value(); }
+
+  auto completion_handler()
+  {
+    return bind_cancellation_slot(get_cancellation_slot(),
+                                  bind_executor(get_executor(),
+        [self = boost::intrusive_ptr{this}] (std::exception_ptr eptr, T val) {
+          self->result.emplace(eptr, std::move(val));
+          self->complete();
+        }));
+  }
+
+  T get() // precondition: completed()
+  {
+    rethrow(); // rethrow exceptions from renewal
+    if (auto eptr = std::get<0>(*result); eptr) {
+      std::rethrow_exception(eptr);
+    }
+    return std::get<1>(std::move(*result));
+  }
+};
+
+// specialization for void return type
+template<>
+class lease_completion_state<void> : public lease_state,
+    public boost::intrusive_ref_counter<lease_completion_state<void>,
+        boost::thread_unsafe_counter>
+{
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+ public:
+  lease_completion_state(boost::asio::any_io_executor ex) : lease_state(ex) {}
+
+  bool completed() const { return result.has_value(); }
+
+  auto completion_handler()
+  {
+    return bind_cancellation_slot(get_cancellation_slot(),
+                                  bind_executor(get_executor(),
+        [self = boost::intrusive_ptr{this}] (std::exception_ptr eptr) {
+          self->result = eptr;
+          self->complete();
+        }));
+  }
+
+  void get() // precondition: completed()
+  {
+    rethrow(); // rethrow exceptions from renewal
+    if (*result) {
+      std::rethrow_exception(*result);
+    }
+  }
+};
+
+template <typename T>
+auto make_lease_completion_state(boost::asio::any_io_executor ex)
+{
+  return boost::intrusive_ptr{new lease_completion_state<T>(ex)};
+}
+
+} // namespace ceph::async::detail

--- a/src/common/async/detail/spawn_throttle_impl.h
+++ b/src/common/async/detail/spawn_throttle_impl.h
@@ -169,7 +169,7 @@ struct spawn_throttle_handler {
   }
 };
 
-spawn_throttle_handler spawn_throttle_impl::get()
+inline spawn_throttle_handler spawn_throttle_impl::get()
 {
   report_exception(); // throw unreported exception
 
@@ -345,8 +345,8 @@ class async_spawn_throttle_impl final :
   }
 };
 
-auto spawn_throttle_impl::create(optional_yield y, size_t limit,
-                                 cancel_on_error on_error)
+inline auto spawn_throttle_impl::create(optional_yield y, size_t limit,
+                                        cancel_on_error on_error)
     -> boost::intrusive_ptr<spawn_throttle_impl>
 {
   if (y) {

--- a/src/common/async/detail/spawn_throttle_impl.h
+++ b/src/common/async/detail/spawn_throttle_impl.h
@@ -307,7 +307,7 @@ class async_spawn_throttle_impl final :
 
       boost::asio::async_initiate<boost::asio::yield_context, WaitSignature>(
           [this] (auto handler) {
-            auto slot = get_associated_cancellation_slot(handler);
+            auto slot = boost::asio::get_associated_cancellation_slot(handler);
             if (slot.is_connected()) {
               slot.template emplace<op_cancellation>(this);
             }
@@ -323,6 +323,8 @@ class async_spawn_throttle_impl final :
   {
     auto w = std::move(*waiter);
     waiter.reset();
+    auto slot = boost::asio::get_associated_cancellation_slot(w.handler);
+    slot.clear(); // remove our cancellation handler
     boost::asio::dispatch(boost::asio::append(std::move(w.handler), ec));
   }
 

--- a/src/common/async/lease.h
+++ b/src/common/async/lease.h
@@ -1,0 +1,292 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <exception>
+#include <boost/asio/any_completion_handler.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/redirect_error.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <boost/system.hpp>
+#include "include/scope_guard.h"
+#include "common/ceph_time.h"
+#include "detail/lease_state.h"
+
+namespace ceph::async {
+
+/// \brief Client interface for a specific timed exclusive lock.
+class LockClient {
+ protected:
+  using Signature = void(boost::system::error_code);
+  using Handler = boost::asio::any_completion_handler<Signature>;
+
+  virtual void acquire(ceph::timespan duration, Handler handler) = 0;
+  virtual void renew(ceph::timespan duration, Handler handler) = 0;
+  virtual void release(Handler handler) = 0;
+
+ public:
+  virtual ~LockClient() {}
+
+  /// Acquire a timed lock for the given duration.
+  template <boost::asio::completion_token_for<Signature> CompletionToken>
+  auto async_acquire(ceph::timespan duration, CompletionToken&& token) {
+    return boost::asio::async_initiate<CompletionToken, Signature>(
+        [this, duration] (auto h) { acquire(duration, std::move(h)); }, token);
+  }
+  /// Renew an acquired lock for the given duration.
+  template <boost::asio::completion_token_for<Signature> CompletionToken>
+  auto async_renew(ceph::timespan duration, CompletionToken&& token) {
+    return boost::asio::async_initiate<CompletionToken, Signature>(
+        [this, duration] (auto h) { renew(duration, std::move(h)); }, token);
+  }
+  /// Release an acquired lock.
+  template <boost::asio::completion_token_for<Signature> CompletionToken>
+  auto async_release(CompletionToken&& token) {
+    return boost::asio::async_initiate<CompletionToken, Signature>(
+        [this] (auto h) { release(std::move(h)); }, token);
+  }
+};
+
+
+/// Exception thrown by with_lease() whenever the wrapped coroutine is
+/// canceled due to a renewal failure.
+class lease_aborted : public std::runtime_error {
+  boost::system::error_code ec;
+ public:
+  lease_aborted(boost::system::error_code ec)
+    : runtime_error("lease aborted"), ec(ec)
+  {}
+
+  /// Return the original error that triggered the cancellation.
+  boost::system::error_code code() const { return ec; }
+};
+
+
+/// \brief Call a coroutine under the protection of a continuous lease.
+///
+/// Acquires exclusive access to a timed lock, then spawns the given coroutine
+/// \ref cr. The lock is renewed at intervals of \ref duration / 2, and released
+/// after the coroutine's completion.
+///
+/// Exceptions from acquire() propagate directly to the caller. Exceptions from
+/// release() are ignored in favor of the result of \ref cr.
+///
+/// If renew() is delayed long enough for the timed lock to expire, that results
+/// in an error code matching boost::system::errc::timed_out. That error, along
+/// with any error from renew() itself, gets wrapped in a lease_aborted
+/// exception when reported to the caller. Any failure to renew the lock will
+/// also result in the cancellation of \ref cr.
+///
+/// Cancellation of the parent coroutine also cancels the child coroutine
+/// without releasing the lock.
+///
+/// Otherwise, the result of \ref cr is returned to the caller, whether by
+/// exception or return value.
+///
+/// \relates LockClient
+///
+/// \param lock A client that can send lock requests
+/// \param duration Duration of the lock
+/// \param cr The coroutine to call under lease
+///
+/// \tparam T The return type of the coroutine \ref cr
+template <typename T>
+auto with_lease(LockClient& lock,
+                ceph::timespan duration,
+                boost::asio::awaitable<T> cr)
+    -> boost::asio::awaitable<T>
+{
+  auto ex = co_await boost::asio::this_coro::executor;
+
+  // acquire the lock. exceptions propagate directly to the caller
+  co_await lock.async_acquire(duration, boost::asio::use_awaitable);
+  auto expires_at = detail::lease_clock::now() + duration;
+
+  // the LockClient may not support cancellation, so check after it returns
+  if (auto cs = co_await boost::asio::this_coro::cancellation_state;
+      cs.cancelled() != boost::asio::cancellation_type::none) {
+    throw boost::system::system_error(boost::asio::error::operation_aborted);
+  }
+
+  // allocate the lease state with scoped cancellation so that with_lease()'s
+  // cancellation triggers cancellation of the spawned coroutine
+  auto state = detail::make_lease_completion_state<T>(ex);
+  const auto state_guard = make_scope_guard([&state] { state->cancel(); });
+
+  // spawn the coroutine with a waitable/cancelable completion handler
+  boost::asio::co_spawn(ex, std::move(cr), state->completion_handler());
+
+  // lock renewal loop
+  auto& timer = state->get_timer();
+  const ceph::timespan interval = duration / 2;
+  boost::system::error_code ec;
+
+  while (!state->completed()) {
+    // sleep until the next lock interval
+    timer.expires_after(interval);
+    co_await timer.async_wait(boost::asio::redirect_error(
+            boost::asio::use_awaitable, ec));
+    if (ec) {
+      if (auto cs = co_await boost::asio::this_coro::cancellation_state;
+          cs.cancelled() != boost::asio::cancellation_type::none) {
+        // if cancellation was requested by the caller, let the timer's
+        // operation_aborted exception propagate. state_guard will cancel the
+        // wrapped coroutine immediately on unwind
+        throw boost::system::system_error(ec);
+      }
+      break; // timer canceled by cr's completion
+    }
+
+    // arm a timeout for the renew request
+    timer.expires_at(expires_at);
+    timer.async_wait([state] (boost::system::error_code ec) {
+          if (!ec) {
+            state->abort(std::make_exception_ptr(lease_aborted{
+                make_error_code(std::errc::timed_out)}));
+          }
+        });
+
+    co_await lock.async_renew(duration, boost::asio::redirect_error(
+            boost::asio::use_awaitable, ec));
+    timer.cancel();
+    if (auto cs = co_await boost::asio::this_coro::cancellation_state;
+        cs.cancelled() != boost::asio::cancellation_type::none) {
+      ec = boost::asio::error::operation_aborted;
+    }
+    if (ec) {
+      state->rethrow(); // may already have a timeout error to return
+      throw lease_aborted{ec};
+    }
+    expires_at = detail::lease_clock::now() + duration;
+  }
+
+  // release the lock, ignoring errors
+  co_await lock.async_release(boost::asio::redirect_error(
+          boost::asio::use_awaitable, ec));
+
+  // return the spawned coroutine's result
+  co_return state->get();
+}
+
+namespace detail {
+
+template <typename T>
+void renew(LockClient& lock,
+           lease_clock::time_point expires_at,
+           ceph::timespan duration,
+           boost::asio::yield_context yield,
+           boost::intrusive_ptr<lease_completion_state<T>>& state);
+
+} // namespace detail
+
+/// \overload
+///
+/// \param lock A client that can send lock requests
+/// \param duration Duration of the lock
+/// \param yield The calling coroutine's yield context
+/// \param cr The coroutine to call under lease, taking a newly-spawned
+///           yield context as its only argument.
+template <std::invocable<boost::asio::yield_context> Func>
+auto with_lease(LockClient& lock,
+                ceph::timespan duration,
+                boost::asio::yield_context yield,
+                Func&& cr)
+    -> std::invoke_result_t<Func, boost::asio::yield_context>
+{
+  auto ex = yield.get_executor();
+
+  // acquire the lock. exceptions propagate directly to the caller
+  lock.async_acquire(duration, yield);
+  auto expires_at = detail::lease_clock::now() + duration;
+
+  // the LockClient may not support cancellation, so check after it returns
+  if (yield.cancelled() != boost::asio::cancellation_type::none) {
+    throw boost::system::system_error(boost::asio::error::operation_aborted);
+  }
+
+  // allocate the lease state with scoped cancellation so that with_lease()'s
+  // cancellation triggers cancellation of the spawned coroutine
+  using T = std::invoke_result_t<Func, boost::asio::yield_context>;
+  auto state = detail::make_lease_completion_state<T>(ex);
+  const auto state_guard = make_scope_guard([&state] { state->cancel(); });
+
+  // spawn the coroutine with a waitable/cancelable completion handler
+  boost::asio::spawn(ex, std::forward<Func>(cr), state->completion_handler());
+
+  detail::renew(lock, expires_at, duration, yield, state);
+
+  // release the lock, ignoring errors
+  boost::system::error_code ec;
+  lock.async_release(yield[ec]);
+
+  // return the spawned coroutine's result
+  return state->get();
+}
+
+namespace detail {
+
+// the renewal loop only depends on the coroutine's return type T, so doesn't
+// need to be reinstantiated for every Func
+template <typename T>
+void renew(LockClient& lock,
+           lease_clock::time_point expires_at,
+           ceph::timespan duration,
+           boost::asio::yield_context yield,
+           boost::intrusive_ptr<lease_completion_state<T>>& state)
+{
+  // lock renewal loop
+  auto& timer = state->get_timer();
+  const ceph::timespan interval = duration / 2;
+  boost::system::error_code ec;
+
+  while (!state->completed()) {
+    // sleep until the next lock interval
+    timer.expires_after(interval);
+    timer.async_wait(yield[ec]);
+    if (ec) {
+      if (yield.cancelled() != boost::asio::cancellation_type::none) {
+        // if cancellation was requested by the caller, let the timer's
+        // operation_aborted exception propagate. state_guard will cancel the
+        // wrapped coroutine immediately on unwind
+        throw boost::system::system_error(ec);
+      }
+      break; // timer canceled by cr's completion
+    }
+
+    // arm a timeout for the renew request
+    timer.expires_at(expires_at);
+    timer.async_wait([state] (boost::system::error_code ec) {
+          if (!ec) {
+            state->abort(std::make_exception_ptr(lease_aborted{
+                make_error_code(std::errc::timed_out)}));
+          }
+        });
+
+    lock.async_renew(duration, yield[ec]);
+    timer.cancel();
+    if (yield.cancelled() != boost::asio::cancellation_type::none) {
+      ec = boost::asio::error::operation_aborted;
+    }
+    if (ec) {
+      state->rethrow(); // may already have a timeout error to return
+      throw lease_aborted{ec};
+    }
+    expires_at = lease_clock::now() + duration;
+  }
+}
+
+} // namespace detail
+
+} // namespace ceph::async

--- a/src/common/async/lease_rados.h
+++ b/src/common/async/lease_rados.h
@@ -1,0 +1,81 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <boost/asio/any_io_executor.hpp>
+#include "librados/librados_asio.h"
+#include "librados/redirect_version.h"
+#include "cls/lock/cls_lock_client.h"
+#include "lease.h"
+
+namespace ceph::async {
+
+/// A LockClient for with_lease() based on librados and cls_lock.
+class RadosLockClient : public LockClient {
+ public:
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const { return ex; }
+
+  RadosLockClient(executor_type ex,
+                  librados::IoCtx ioctx,
+                  std::string oid,
+                  rados::cls::lock::Lock lock,
+                  bool ephemeral)
+    : ex(std::move(ex)),
+      ioctx(std::move(ioctx)),
+      oid(std::move(oid)),
+      lock(std::move(lock)),
+      ephemeral(ephemeral)
+  {}
+
+ private:
+  executor_type ex;
+  librados::IoCtx ioctx;
+  std::string oid;
+  rados::cls::lock::Lock lock;
+  bool ephemeral = false;
+
+  void acquire(ceph::timespan dur, Handler h) override {
+    librados::ObjectWriteOperation op;
+    lock.set_duration(dur);
+    if (ephemeral) {
+      lock.lock_exclusive_ephemeral(&op);
+    } else {
+      lock.lock_exclusive(&op);
+    }
+    librados::async_operate(*this, ioctx, oid, &op, 0, nullptr,
+                            librados::redirect_version(std::move(h)));
+  }
+  void renew(ceph::timespan dur, Handler h) override {
+    librados::ObjectWriteOperation op;
+    op.assert_exists();
+    lock.set_must_renew(true);
+    lock.set_duration(dur);
+    if (ephemeral) {
+      lock.lock_exclusive_ephemeral(&op);
+    } else {
+      lock.lock_exclusive(&op);
+    }
+    librados::async_operate(*this, ioctx, oid, &op, 0, nullptr,
+                            librados::redirect_version(std::move(h)));
+  }
+  void release(Handler h) override {
+    librados::ObjectWriteOperation op;
+    op.assert_exists();
+    lock.unlock(&op);
+    librados::async_operate(*this, ioctx, oid, &op, 0, nullptr,
+                            librados::redirect_version(std::move(h)));
+  }
+};
+
+} // namespace ceph::async

--- a/src/common/async/lease_rados.h
+++ b/src/common/async/lease_rados.h
@@ -53,7 +53,7 @@ class RadosLockClient : public LockClient {
     } else {
       lock.lock_exclusive(&op);
     }
-    librados::async_operate(*this, ioctx, oid, &op, 0, nullptr,
+    librados::async_operate(ex, ioctx, oid, &op, 0, nullptr,
                             librados::redirect_version(std::move(h)));
   }
   void renew(ceph::timespan dur, Handler h) override {
@@ -66,14 +66,14 @@ class RadosLockClient : public LockClient {
     } else {
       lock.lock_exclusive(&op);
     }
-    librados::async_operate(*this, ioctx, oid, &op, 0, nullptr,
+    librados::async_operate(ex, ioctx, oid, &op, 0, nullptr,
                             librados::redirect_version(std::move(h)));
   }
   void release(Handler h) override {
     librados::ObjectWriteOperation op;
     op.assert_exists();
     lock.unlock(&op);
-    librados::async_operate(*this, ioctx, oid, &op, 0, nullptr,
+    librados::async_operate(ex, ioctx, oid, &op, 0, nullptr,
                             librados::redirect_version(std::move(h)));
   }
 };

--- a/src/common/async/lease_rados.h
+++ b/src/common/async/lease_rados.h
@@ -53,7 +53,7 @@ class RadosLockClient : public LockClient {
     } else {
       lock.lock_exclusive(&op);
     }
-    librados::async_operate(ex, ioctx, oid, &op, 0, nullptr,
+    librados::async_operate(ex, ioctx, oid, std::move(op), 0, nullptr,
                             librados::redirect_version(std::move(h)));
   }
   void renew(ceph::timespan dur, Handler h) override {
@@ -66,14 +66,14 @@ class RadosLockClient : public LockClient {
     } else {
       lock.lock_exclusive(&op);
     }
-    librados::async_operate(ex, ioctx, oid, &op, 0, nullptr,
+    librados::async_operate(ex, ioctx, oid, std::move(op), 0, nullptr,
                             librados::redirect_version(std::move(h)));
   }
   void release(Handler h) override {
     librados::ObjectWriteOperation op;
     op.assert_exists();
     lock.unlock(&op);
-    librados::async_operate(ex, ioctx, oid, &op, 0, nullptr,
+    librados::async_operate(ex, ioctx, oid, std::move(op), 0, nullptr,
                             librados::redirect_version(std::move(h)));
   }
 };

--- a/src/common/async/yield_context.h
+++ b/src/common/async/yield_context.h
@@ -14,12 +14,7 @@
 
 #pragma once
 
-#include <boost/range/begin.hpp>
-#include <boost/range/end.hpp>
-#include <boost/asio/io_context.hpp>
 #include <boost/asio/spawn.hpp>
-
-#include "acconfig.h"
 
 /// optional-like wrapper for a boost::asio::yield_context. operations that take
 /// an optional_yield argument will, when passed a non-empty yield context,
@@ -39,6 +34,15 @@ class optional_yield {
 
   /// return a reference to the yield_context. only valid if non-empty
   boost::asio::yield_context& get_yield_context() const noexcept { return *y; }
+
+  /// return the cancellation type of the yield_context, or none
+  boost::asio::cancellation_type cancelled() const {
+    if (y) {
+      return y->cancelled();
+    } else {
+      return boost::asio::cancellation_type::none;
+    }
+  }
 };
 
 // type tag object to construct an empty optional_yield

--- a/src/common/async/yield_waiter.h
+++ b/src/common/async/yield_waiter.h
@@ -48,7 +48,7 @@ class yield_waiter {
   {
     return boost::asio::async_initiate<CompletionToken, Signature>(
         [this] (handler_type h) {
-          auto slot = get_associated_cancellation_slot(h);
+          auto slot = boost::asio::get_associated_cancellation_slot(h);
           if (slot.is_connected()) {
             slot.template emplace<op_cancellation>(this);
           }
@@ -62,6 +62,8 @@ class yield_waiter {
     auto s = std::move(*state);
     state.reset();
     auto h = boost::asio::append(std::move(s.handler), ec, std::move(value));
+    auto slot = boost::asio::get_associated_cancellation_slot(h);
+    slot.clear(); // remove our cancellation handler
     boost::asio::dispatch(std::move(h));
   }
 
@@ -130,7 +132,7 @@ class yield_waiter<void> {
   {
     return boost::asio::async_initiate<CompletionToken, Signature>(
         [this] (handler_type h) {
-          auto slot = get_associated_cancellation_slot(h);
+          auto slot = boost::asio::get_associated_cancellation_slot(h);
           if (slot.is_connected()) {
             slot.template emplace<op_cancellation>(this);
           }
@@ -143,6 +145,8 @@ class yield_waiter<void> {
   {
     auto s = std::move(*state);
     state.reset();
+    auto slot = boost::asio::get_associated_cancellation_slot(s.handler);
+    slot.clear(); // remove our cancellation handler
     boost::asio::dispatch(boost::asio::append(std::move(s.handler), ec));
   }
 

--- a/src/librados/redirect_version.h
+++ b/src/librados/redirect_version.h
@@ -1,0 +1,130 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include <boost/asio/associator.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/system/error_code.hpp>
+#include "include/types.h"
+
+namespace librados {
+
+template <typename CompletionToken>
+struct redirect_version_t {
+  [[no_unique_address]] CompletionToken token;
+  version_t* ver = nullptr;
+};
+
+/// A completion token adapter that modifies the completion signature by
+/// removing the version_t argument, optionally redirecting its value into
+/// the given pointer.
+template <typename CompletionToken>
+auto redirect_version(CompletionToken&& token, version_t* ver = nullptr)
+    -> redirect_version_t<CompletionToken> {
+  return {std::forward<CompletionToken>(token), ver};
+}
+
+namespace detail {
+
+template <typename Handler>
+struct redirect_version_handler {
+  [[no_unique_address]] Handler handler;
+  version_t* ver = nullptr;
+
+  void operator()(boost::system::error_code ec, version_t v) {
+    if (ver) {
+      *ver = v;
+    }
+    std::move(handler)(ec);
+  }
+  void operator()(boost::system::error_code ec, version_t v, bufferlist bl) {
+    if (ver) {
+      *ver = v;
+    }
+    std::move(handler)(ec, std::move(bl));
+  }
+};
+
+template <typename Signature>
+struct redirect_version_signature {};
+template <>
+struct redirect_version_signature<void(boost::system::error_code, version_t)> {
+  using type = void(boost::system::error_code);
+};
+template <>
+struct redirect_version_signature<void(boost::system::error_code, version_t, bufferlist)> {
+  using type = void(boost::system::error_code, bufferlist);
+};
+template <typename Signature>
+using redirect_version_signature_t = typename redirect_version_signature<Signature>::type;
+
+} // namespace detail
+
+} // namespace librados
+
+namespace boost::asio {
+
+template <template <typename, typename> class Associator,
+    typename Handler, typename DefaultCandidate>
+struct associator<Associator,
+    librados::detail::redirect_version_handler<Handler>, DefaultCandidate>
+  : Associator<Handler, DefaultCandidate>
+{
+  static auto get(const librados::detail::redirect_version_handler<Handler>& h) noexcept {
+    return Associator<Handler, DefaultCandidate>::get(h.handler);
+  }
+  static auto get(const librados::detail::redirect_version_handler<Handler>& h,
+                  const DefaultCandidate& c) noexcept {
+    return Associator<Handler, DefaultCandidate>::get(h.handler, c);
+  }
+};
+
+template <typename CompletionToken, typename Signature>
+struct async_result<librados::redirect_version_t<CompletionToken>, Signature>
+  : async_result<CompletionToken,
+      librados::detail::redirect_version_signature_t<Signature>>
+{
+  template <typename Initiation>
+  struct init_wrapper {
+    [[no_unique_address]] Initiation init;
+
+    template <typename Handler, typename... Args>
+    void operator()(Handler&& handler, version_t* ver, Args&&... args) && {
+      std::move(init)(
+          librados::detail::redirect_version_handler<decay_t<Handler>>{
+              std::forward<Handler>(handler), ver},
+          std::forward<Args>(args)...);
+    }
+
+    template <typename Handler, typename... Args>
+    void operator()(Handler&& handler, version_t* ver, Args&&... args) const & {
+      init(
+          librados::detail::redirect_version_handler<decay_t<Handler>>{
+              std::forward<Handler>(handler), ver},
+          std::forward<Args>(args)...);
+    }
+  };
+
+  template <typename Initiation, typename RawCompletionToken, typename... Args>
+  static auto initiate(Initiation&& init,
+                       RawCompletionToken&& token,
+                       Args&&... args) {
+    return async_initiate<
+      conditional_t<is_const<remove_reference_t<RawCompletionToken>>::value,
+          const CompletionToken, CompletionToken>,
+      librados::detail::redirect_version_signature_t<Signature>>(
+        init_wrapper<decay_t<Initiation>>{std::forward<Initiation>(init)},
+        token.token, token.ver, std::forward<Args>(args)...);
+  }
+};
+
+} // namespace boost::asio

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -201,6 +201,7 @@ set(librgw_common_srcs
   driver/rados/rgw_trim_mdlog.cc
   driver/rados/rgw_user.cc
   driver/rados/rgw_zone.cc
+  driver/rados/reshard_writer.cc
   driver/rados/role.cc
   driver/rados/roles.cc
   driver/rados/sync_fairness.cc

--- a/src/rgw/driver/rados/reshard_writer.cc
+++ b/src/rgw/driver/rados/reshard_writer.cc
@@ -1,0 +1,197 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "reshard_writer.h"
+#include <boost/asio/execution.hpp>
+#include <boost/asio/query.hpp>
+#include "librados/librados_asio.h"
+#include "cls/rgw/cls_rgw_client.h"
+
+namespace rgwrados::reshard {
+
+BaseWriter::BaseWriter(const executor_type& ex, uint64_t max_aio)
+  : svc(boost::asio::use_service<service_type>(
+          boost::asio::query(ex, boost::asio::execution::context))),
+    ex(ex), max_aio(max_aio)
+{
+  // register for service_shutdown() notifications
+  svc.add(*this);
+}
+
+BaseWriter::~BaseWriter()
+{
+  svc.remove(*this);
+}
+
+void BaseWriter::drain(boost::asio::yield_context yield)
+{
+  if (outstanding > 0) {
+    Waiter waiter;
+    drain_waiters.push_back(waiter);
+    waiter.async_wait(yield); // may rethrow error from previous completion
+  } else if (error) {
+    // make sure errors get reported to the caller
+    throw boost::system::system_error(error);
+  }
+}
+
+void BaseWriter::on_complete(boost::system::error_code ec)
+{
+  --outstanding;
+
+  constexpr auto complete_all = [] (boost::intrusive::list<Waiter>& waiters,
+                                    boost::system::error_code ec) {
+      while (!waiters.empty()) {
+        Waiter& waiter = waiters.front();
+        waiters.pop_front();
+        waiter.complete(ec);
+      }
+    };
+  constexpr auto complete_one = [] (boost::intrusive::list<Waiter>& waiters,
+                                    boost::system::error_code ec) {
+      if (!waiters.empty()) {
+        Waiter& waiter = waiters.front();
+        waiters.pop_front();
+        waiter.complete(ec);
+      }
+    };
+
+  if (ec) {
+    if (!error) {
+      error = ec;
+    }
+    // fail all waiting calls to write()
+    complete_all(write_waiters, ec);
+  } else {
+    // wake one waiting call to write()
+    complete_one(write_waiters, {});
+  }
+
+  if (outstanding == 0) {
+    // wake all waiting calls to drain()
+    complete_all(drain_waiters, error);
+  }
+}
+
+void BaseWriter::service_shutdown()
+{
+  // release any outstanding completion handlers
+  constexpr auto shutdown = [] (boost::intrusive::list<Waiter>& waiters) {
+      while (!waiters.empty()) {
+        Waiter& waiter = waiters.front();
+        waiters.pop_front();
+        waiter.shutdown();
+      }
+    };
+  shutdown(write_waiters);
+  shutdown(drain_waiters);
+}
+
+
+PutBatch::PutBatch(boost::asio::io_context& ctx,
+                   librados::IoCtx ioctx,
+                   std::string object,
+                   size_t batch_size)
+  : ctx(ctx),
+    ioctx(std::move(ioctx)),
+    object(std::move(object)),
+    batch_size(batch_size)
+{
+  entries.reserve(batch_size); // preallocate the batch
+}
+
+[[nodiscard]] bool PutBatch::empty() const
+{
+  return entries.empty();
+}
+
+[[nodiscard]] bool PutBatch::add(rgw_cls_bi_entry entry,
+                                 std::optional<RGWObjCategory> category,
+                                 rgw_bucket_category_stats entry_stats)
+{
+  entries.push_back(std::move(entry));
+
+  if (category) {
+    stats[*category] += entry_stats;
+  }
+
+  return entries.size() >= batch_size;
+}
+
+void PutBatch::flush(Completion completion)
+{
+  librados::ObjectWriteOperation op;
+
+  // issue a separate bi_put() call for each entry
+  for (auto& entry : entries) {
+    cls_rgw_bi_put(op, std::move(entry));
+  }
+  entries.clear();
+
+  constexpr bool absolute = false; // add to existing stats
+  cls_rgw_bucket_update_stats(op, absolute, stats);
+  stats.clear();
+
+  constexpr int flags = 0;
+  constexpr jspan_context* trace = nullptr;
+  librados::async_operate(ctx, ioctx, object, &op, flags,
+                          trace, std::move(completion));
+}
+
+PutEntriesBatch::PutEntriesBatch(boost::asio::io_context& ctx,
+                                 librados::IoCtx ioctx,
+                                 std::string object,
+                                 size_t batch_size,
+                                 bool check_existing)
+  : ctx(ctx),
+    ioctx(std::move(ioctx)),
+    object(std::move(object)),
+    batch_size(batch_size),
+    check_existing(check_existing)
+{
+  entries.reserve(batch_size); // preallocate the batch
+}
+
+[[nodiscard]] bool PutEntriesBatch::empty() const
+{
+  return entries.empty();
+}
+
+[[nodiscard]] bool PutEntriesBatch::add(rgw_cls_bi_entry entry,
+                                        std::optional<RGWObjCategory> category,
+                                        rgw_bucket_category_stats stats)
+{
+  entries.push_back(std::move(entry));
+  // bi_put_entries() handles stats on the server side
+  std::ignore = category;
+  std::ignore = stats;
+
+  return entries.size() >= batch_size;
+}
+
+void PutEntriesBatch::flush(Completion completion)
+{
+  librados::ObjectWriteOperation op;
+
+  cls_rgw_bi_put_entries(op, std::move(entries), check_existing);
+  entries.clear();
+
+  constexpr int flags = 0;
+  constexpr jspan_context* trace = nullptr;
+  librados::async_operate(ctx, ioctx, object, &op, flags,
+                          trace, std::move(completion));
+}
+
+} // namespace rgwrados::reshard

--- a/src/rgw/driver/rados/reshard_writer.cc
+++ b/src/rgw/driver/rados/reshard_writer.cc
@@ -16,8 +16,6 @@
 #include "reshard_writer.h"
 #include <boost/asio/execution.hpp>
 #include <boost/asio/query.hpp>
-#include "librados/librados_asio.h"
-#include "cls/rgw/cls_rgw_client.h"
 
 namespace rgwrados::reshard {
 
@@ -100,101 +98,6 @@ void BaseWriter::service_shutdown()
     };
   shutdown(std::move(write_waiters));
   shutdown(std::move(drain_waiters));
-}
-
-
-PutBatch::PutBatch(const boost::asio::any_io_executor& ex,
-                   librados::IoCtx ioctx,
-                   std::string object,
-                   size_t batch_size)
-  : ex(ex),
-    ioctx(std::move(ioctx)),
-    object(std::move(object)),
-    batch_size(batch_size)
-{
-  entries.reserve(batch_size); // preallocate the batch
-}
-
-[[nodiscard]] bool PutBatch::empty() const
-{
-  return entries.empty();
-}
-
-[[nodiscard]] bool PutBatch::add(rgw_cls_bi_entry entry,
-                                 std::optional<RGWObjCategory> category,
-                                 rgw_bucket_category_stats entry_stats)
-{
-  entries.push_back(std::move(entry));
-
-  if (category) {
-    stats[*category] += entry_stats;
-  }
-
-  return entries.size() >= batch_size;
-}
-
-void PutBatch::flush(Completion completion)
-{
-  librados::ObjectWriteOperation op;
-
-  // issue a separate bi_put() call for each entry
-  for (auto& entry : entries) {
-    cls_rgw_bi_put(op, std::move(entry));
-  }
-  entries.clear();
-
-  constexpr bool absolute = false; // add to existing stats
-  cls_rgw_bucket_update_stats(op, absolute, stats);
-  stats.clear();
-
-  constexpr int flags = 0;
-  constexpr jspan_context* trace = nullptr;
-  librados::async_operate(ex, ioctx, object, &op, flags,
-                          trace, std::move(completion));
-}
-
-PutEntriesBatch::PutEntriesBatch(const boost::asio::any_io_executor& ex,
-                                 librados::IoCtx ioctx,
-                                 std::string object,
-                                 size_t batch_size,
-                                 bool check_existing)
-  : ex(ex),
-    ioctx(std::move(ioctx)),
-    object(std::move(object)),
-    batch_size(batch_size),
-    check_existing(check_existing)
-{
-  entries.reserve(batch_size); // preallocate the batch
-}
-
-[[nodiscard]] bool PutEntriesBatch::empty() const
-{
-  return entries.empty();
-}
-
-[[nodiscard]] bool PutEntriesBatch::add(rgw_cls_bi_entry entry,
-                                        std::optional<RGWObjCategory> category,
-                                        rgw_bucket_category_stats stats)
-{
-  entries.push_back(std::move(entry));
-  // bi_put_entries() handles stats on the server side
-  std::ignore = category;
-  std::ignore = stats;
-
-  return entries.size() >= batch_size;
-}
-
-void PutEntriesBatch::flush(Completion completion)
-{
-  librados::ObjectWriteOperation op;
-
-  cls_rgw_bi_put_entries(op, std::move(entries), check_existing);
-  entries.clear();
-
-  constexpr int flags = 0;
-  constexpr jspan_context* trace = nullptr;
-  librados::async_operate(ex, ioctx, object, &op, flags,
-                          trace, std::move(completion));
 }
 
 } // namespace rgwrados::reshard

--- a/src/rgw/driver/rados/reshard_writer.cc
+++ b/src/rgw/driver/rados/reshard_writer.cc
@@ -100,11 +100,11 @@ void BaseWriter::service_shutdown()
 }
 
 
-PutBatch::PutBatch(boost::asio::io_context& ctx,
+PutBatch::PutBatch(const boost::asio::any_io_executor& ex,
                    librados::IoCtx ioctx,
                    std::string object,
                    size_t batch_size)
-  : ctx(ctx),
+  : ex(ex),
     ioctx(std::move(ioctx)),
     object(std::move(object)),
     batch_size(batch_size)
@@ -146,16 +146,16 @@ void PutBatch::flush(Completion completion)
 
   constexpr int flags = 0;
   constexpr jspan_context* trace = nullptr;
-  librados::async_operate(ctx, ioctx, object, &op, flags,
+  librados::async_operate(ex, ioctx, object, &op, flags,
                           trace, std::move(completion));
 }
 
-PutEntriesBatch::PutEntriesBatch(boost::asio::io_context& ctx,
+PutEntriesBatch::PutEntriesBatch(const boost::asio::any_io_executor& ex,
                                  librados::IoCtx ioctx,
                                  std::string object,
                                  size_t batch_size,
                                  bool check_existing)
-  : ctx(ctx),
+  : ex(ex),
     ioctx(std::move(ioctx)),
     object(std::move(object)),
     batch_size(batch_size),
@@ -190,7 +190,7 @@ void PutEntriesBatch::flush(Completion completion)
 
   constexpr int flags = 0;
   constexpr jspan_context* trace = nullptr;
-  librados::async_operate(ctx, ioctx, object, &op, flags,
+  librados::async_operate(ex, ioctx, object, &op, flags,
                           trace, std::move(completion));
 }
 

--- a/src/rgw/driver/rados/reshard_writer.h
+++ b/src/rgw/driver/rados/reshard_writer.h
@@ -1,0 +1,201 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/intrusive/list.hpp>
+#include <boost/system.hpp>
+
+#include "include/rados/librados.hpp"
+#include "cls/rgw/cls_rgw_types.h"
+#include "common/async/service.h"
+#include "common/async/yield_waiter.h"
+
+namespace rgwrados::reshard {
+
+// base class for Writer that contains everything that doesn't
+// depend on the Batch template type
+class BaseWriter : public ceph::async::service_list_base_hook {
+ public:
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const noexcept { return ex; }
+
+  // wait for all outstanding flush completions
+  void drain(boost::asio::yield_context yield);
+
+  void service_shutdown();
+
+ protected:
+  BaseWriter(const executor_type& ex, uint64_t max_aio);
+  ~BaseWriter();
+
+  using service_type = ceph::async::service<BaseWriter>;
+  service_type& svc;
+  executor_type ex;
+
+  const uint64_t max_aio;
+  uint64_t outstanding = 0;
+  boost::system::error_code error;
+
+  struct Waiter : boost::intrusive::list_base_hook<>,
+                  ceph::async::yield_waiter<void> {};
+  boost::intrusive::list<Waiter> write_waiters;
+  boost::intrusive::list<Waiter> drain_waiters;
+
+  friend struct Completion;
+  void on_complete(boost::system::error_code ec);
+};
+
+// handler that notifies the writer on completion of a flushed batch
+struct Completion {
+  BaseWriter& writer;
+
+  using executor_type = BaseWriter::executor_type;
+  boost::asio::executor_work_guard<executor_type> work =
+      make_work_guard(writer.get_executor());
+
+  executor_type get_executor() const { return work.get_executor(); }
+
+  void operator()(boost::system::error_code ec, version_t=0)
+  {
+    work.reset();
+    writer.on_complete(ec);
+  }
+};
+
+// example Batch type for Writer
+struct BatchArchetype final {
+  // return true if there are entries to flush
+  bool empty() const;
+  // append an entry to the batch and return whether a flush is necessary
+  bool add(rgw_cls_bi_entry entry,
+           std::optional<RGWObjCategory> category,
+           rgw_bucket_category_stats stats);
+  // flush the batch to storage, calling the given handler upon completion
+  void flush(Completion completion);
+};
+
+// Writes index entries in batches to a given target shard object
+template <typename Batch>
+class Writer : public BaseWriter {
+ public:
+  template <typename ...BatchArgs>
+  Writer(const executor_type& ex, uint64_t max_aio, BatchArgs&& ...args)
+    : BaseWriter(ex, max_aio), batch(std::forward<BatchArgs>(args)...) {}
+
+  // add the given entry to its batch. if the batch is full, send an
+  // async write request to flush it in the background. write() only
+  // suspends once we reach the limit of outstanding write requests to
+  // avoid buffering additional entries. this is important to bound
+  // the overall memory usage of index entries
+  void write(rgw_cls_bi_entry entry,
+             std::optional<RGWObjCategory> category,
+             rgw_bucket_category_stats stats,
+             boost::asio::yield_context yield)
+  {
+    if (error) {
+      // fail new writes once we're in the error state
+      throw boost::system::system_error(error);
+    }
+
+    while (outstanding >= max_aio) {
+      Waiter waiter;
+      write_waiters.push_back(waiter);
+      waiter.async_wait(yield); // may rethrow error from previous completion
+    }
+
+    const bool full = batch.add(entry, category, std::move(stats));
+    if (full) {
+      ++outstanding;
+      batch.flush(Completion{*this});
+    }
+  }
+
+  // if there's an incomplete batch, flush it
+  void flush()
+  {
+    if (!batch.empty()) {
+      ++outstanding;
+      batch.flush(Completion{*this});
+    }
+  }
+
+  // wait for all outstanding flush completions
+  using BaseWriter::drain;
+
+ private:
+  Batch batch;
+};
+
+template <typename Batch>
+Writer(const boost::asio::any_io_executor&, uint64_t, Batch&&) -> Writer<Batch>;
+template <typename Batch>
+Writer(const boost::asio::any_io_executor&, uint64_t, Batch&) -> Writer<Batch&>;
+
+// a target shard batch that must be flushed with several bi_put() calls
+class PutBatch {
+ public:
+  PutBatch(boost::asio::io_context& ctx,
+           librados::IoCtx ioctx,
+           std::string object,
+           size_t batch_size);
+
+  [[nodiscard]] bool empty() const;
+  [[nodiscard]] bool add(rgw_cls_bi_entry entry,
+                         std::optional<RGWObjCategory> category,
+                         rgw_bucket_category_stats stats);
+  void flush(Completion completion);
+
+ private:
+  boost::asio::io_context& ctx;
+  librados::IoCtx ioctx;
+  std::string object;
+  const size_t batch_size;
+  std::vector<rgw_cls_bi_entry> entries;
+  std::map<RGWObjCategory, rgw_bucket_category_stats> stats;
+};
+
+// a target shard batch that can be flushed with one bi_put_entries() call
+class PutEntriesBatch {
+ public:
+  PutEntriesBatch(boost::asio::io_context& ctx,
+                  librados::IoCtx ioctx,
+                  std::string object,
+                  size_t batch_size,
+                  bool check_existing);
+
+  [[nodiscard]] bool empty() const;
+  [[nodiscard]] bool add(rgw_cls_bi_entry entry,
+                         std::optional<RGWObjCategory> category,
+                         rgw_bucket_category_stats stats);
+  void flush(Completion completion);
+
+ private:
+  boost::asio::io_context& ctx;
+  librados::IoCtx ioctx;
+  std::string object;
+  const size_t batch_size;
+  const bool check_existing;
+  std::vector<rgw_cls_bi_entry> entries;
+};
+
+} // namespace rgwrados::reshard

--- a/src/rgw/driver/rados/reshard_writer.h
+++ b/src/rgw/driver/rados/reshard_writer.h
@@ -26,6 +26,7 @@
 
 #include "common/async/service.h"
 #include "common/async/yield_waiter.h"
+#include "cls/rgw/cls_rgw_types.h"
 
 namespace rgwrados::reshard {
 

--- a/src/rgw/driver/rados/reshard_writer.h
+++ b/src/rgw/driver/rados/reshard_writer.h
@@ -24,8 +24,6 @@
 #include <boost/intrusive/list.hpp>
 #include <boost/system.hpp>
 
-#include "include/rados/librados.hpp"
-#include "cls/rgw/cls_rgw_types.h"
 #include "common/async/service.h"
 #include "common/async/yield_waiter.h"
 
@@ -149,52 +147,5 @@ template <typename Batch>
 Writer(const boost::asio::any_io_executor&, uint64_t, Batch&&) -> Writer<Batch>;
 template <typename Batch>
 Writer(const boost::asio::any_io_executor&, uint64_t, Batch&) -> Writer<Batch&>;
-
-// a target shard batch that must be flushed with several bi_put() calls
-class PutBatch {
- public:
-  PutBatch(const boost::asio::any_io_executor& ex,
-           librados::IoCtx ioctx,
-           std::string object,
-           size_t batch_size);
-
-  [[nodiscard]] bool empty() const;
-  [[nodiscard]] bool add(rgw_cls_bi_entry entry,
-                         std::optional<RGWObjCategory> category,
-                         rgw_bucket_category_stats stats);
-  void flush(Completion completion);
-
- private:
-  boost::asio::any_io_executor ex;
-  librados::IoCtx ioctx;
-  std::string object;
-  const size_t batch_size;
-  std::vector<rgw_cls_bi_entry> entries;
-  std::map<RGWObjCategory, rgw_bucket_category_stats> stats;
-};
-
-// a target shard batch that can be flushed with one bi_put_entries() call
-class PutEntriesBatch {
- public:
-  PutEntriesBatch(const boost::asio::any_io_executor& ex,
-                  librados::IoCtx ioctx,
-                  std::string object,
-                  size_t batch_size,
-                  bool check_existing);
-
-  [[nodiscard]] bool empty() const;
-  [[nodiscard]] bool add(rgw_cls_bi_entry entry,
-                         std::optional<RGWObjCategory> category,
-                         rgw_bucket_category_stats stats);
-  void flush(Completion completion);
-
- private:
-  boost::asio::any_io_executor ex;
-  librados::IoCtx ioctx;
-  std::string object;
-  const size_t batch_size;
-  const bool check_existing;
-  std::vector<rgw_cls_bi_entry> entries;
-};
 
 } // namespace rgwrados::reshard

--- a/src/rgw/driver/rados/reshard_writer.h
+++ b/src/rgw/driver/rados/reshard_writer.h
@@ -20,7 +20,6 @@
 
 #include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/executor_work_guard.hpp>
-#include <boost/asio/io_context.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/intrusive/list.hpp>
 #include <boost/system.hpp>
@@ -154,7 +153,7 @@ Writer(const boost::asio::any_io_executor&, uint64_t, Batch&) -> Writer<Batch&>;
 // a target shard batch that must be flushed with several bi_put() calls
 class PutBatch {
  public:
-  PutBatch(boost::asio::io_context& ctx,
+  PutBatch(const boost::asio::any_io_executor& ex,
            librados::IoCtx ioctx,
            std::string object,
            size_t batch_size);
@@ -166,7 +165,7 @@ class PutBatch {
   void flush(Completion completion);
 
  private:
-  boost::asio::io_context& ctx;
+  boost::asio::any_io_executor ex;
   librados::IoCtx ioctx;
   std::string object;
   const size_t batch_size;
@@ -177,7 +176,7 @@ class PutBatch {
 // a target shard batch that can be flushed with one bi_put_entries() call
 class PutEntriesBatch {
  public:
-  PutEntriesBatch(boost::asio::io_context& ctx,
+  PutEntriesBatch(const boost::asio::any_io_executor& ex,
                   librados::IoCtx ioctx,
                   std::string object,
                   size_t batch_size,
@@ -190,7 +189,7 @@ class PutEntriesBatch {
   void flush(Completion completion);
 
  private:
-  boost::asio::io_context& ctx;
+  boost::asio::any_io_executor ex;
   librados::IoCtx ioctx;
   std::string object;
   const size_t batch_size;

--- a/src/rgw/driver/rados/rgw_bucket.cc
+++ b/src/rgw/driver/rados/rgw_bucket.cc
@@ -370,7 +370,7 @@ static int check_bad_index_multipart(rgw::sal::RadosStore* const rados_store,
   std::string prev_entry_prefix;
   do {
     entries_read.clear();
-    ret = store->bi_list(bs, "", marker, -1,
+    ret = store->bi_list(dpp, bs, "", marker, -1,
 			 &entries_read, &is_truncated, false, y);
     if (ret < 0) {
       ldpp_dout(dpp, -1) << "ERROR bi_list(): " << cpp_strerror(-ret) <<
@@ -632,7 +632,7 @@ static int check_index_olh(rgw::sal::RadosStore* const rados_store,
   *count_out = 0;
   do {
     entries.clear();
-    ret = store->bi_list(bs, "", marker, -1, &entries, &is_truncated, false, y);
+    ret = store->bi_list(dpp, bs, "", marker, -1, &entries, &is_truncated, false, y);
     if (ret < 0) {
       ldpp_dout(dpp, -1) << "ERROR bi_list(): " << cpp_strerror(-ret) << dendl;
       break;
@@ -859,7 +859,7 @@ static int check_index_unlinked(rgw::sal::RadosStore* const rados_store,
   *count_out = 0;
   do {
     entries.clear();
-    ret = store->bi_list(bs, "", marker, -1, &entries, &is_truncated, false, y);
+    ret = store->bi_list(dpp, bs, "", marker, -1, &entries, &is_truncated, false, y);
     if (ret < 0) {
       ldpp_dout(dpp, -1) << "ERROR bi_list(): " << cpp_strerror(-ret) << dendl;
       break;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9601,39 +9601,23 @@ int RGWRados::bi_put(const DoutPrefixProvider *dpp, rgw_bucket& bucket, rgw_obj&
   return bi_put(bs, entry, y);
 }
 
-int RGWRados::bi_list(const DoutPrefixProvider *dpp, rgw_bucket& bucket,
-		      const string& obj_name_filter, const string& marker, uint32_t max,
-		      list<rgw_cls_bi_entry> *entries, bool *is_truncated,
-		      bool reshardlog, optional_yield y)
+int RGWRados::bi_list(const DoutPrefixProvider *dpp,
+                      BucketShard& bs, const string& obj_name_filter, const string& marker, uint32_t max,
+		      list<rgw_cls_bi_entry> *entries, bool *is_truncated, bool reshardlog, optional_yield y)
 {
-  rgw_obj obj(bucket, obj_name_filter);
-  BucketShard bs(this);
-  int ret = bs.init(bucket, obj, nullptr /* no RGWBucketInfo */, dpp, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 5) << "bs.init() returned ret=" << ret << dendl;
-    return ret;
-  }
+  librados::ObjectReadOperation op;
+  bufferlist bl;
+  cls_rgw_bi_list(op, obj_name_filter, marker, max, reshardlog, bl);
 
   auto& ref = bs.bucket_obj;
-  ret = cls_rgw_bi_list(ref.ioctx, ref.obj.oid, obj_name_filter, marker, max, entries, is_truncated, reshardlog);
+  int ret = rgw_rados_operate(dpp, ref.ioctx, ref.obj.oid, &op, nullptr, y);
   if (ret == -ENOENT) {
     *is_truncated = false;
   }
   if (ret < 0)
     return ret;
 
-  return 0;
-}
-
-int RGWRados::bi_list(BucketShard& bs, const string& obj_name_filter, const string& marker, uint32_t max,
-		      list<rgw_cls_bi_entry> *entries, bool *is_truncated, bool reshardlog, optional_yield y)
-{
-  auto& ref = bs.bucket_obj;
-  int ret = cls_rgw_bi_list(ref.ioctx, ref.obj.oid, obj_name_filter, marker, max, entries, is_truncated, reshardlog);
-  if (ret < 0)
-    return ret;
-
-  return 0;
+  return cls_rgw_bi_list_decode(bl, *entries, *is_truncated);
 }
 
 int RGWRados::bi_list(const DoutPrefixProvider *dpp,
@@ -9649,7 +9633,7 @@ int RGWRados::bi_list(const DoutPrefixProvider *dpp,
     return ret;
   }
 
-  return bi_list(bs, obj_name_filter, marker, max, entries, is_truncated, reshardlog, y);
+  return bi_list(dpp, bs, obj_name_filter, marker, max, entries, is_truncated, reshardlog, y);
 }
 
 int RGWRados::bi_remove(const DoutPrefixProvider *dpp, BucketShard& bs)

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9572,12 +9572,6 @@ int RGWRados::bi_get(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_
   return cls_rgw_bi_get(ref.ioctx, ref.obj.oid, index_type, key, entry);
 }
 
-void RGWRados::bi_put(ObjectWriteOperation& op, BucketShard& bs, rgw_cls_bi_entry& entry, optional_yield y)
-{
-  auto& ref = bs.bucket_obj;
-  cls_rgw_bi_put(op, ref.obj.oid, entry);
-}
-
 int RGWRados::bi_put(BucketShard& bs, rgw_cls_bi_entry& entry, optional_yield y)
 {
   auto& ref = bs.bucket_obj;

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <functional>
+#include <future>
 #include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>
 
@@ -58,7 +59,6 @@ class RGWSyncLogTrimThread;
 class RGWSyncTraceManager;
 struct RGWZoneGroup;
 struct RGWZoneParams;
-class RGWReshard;
 class RGWReshardWait;
 namespace rgw { class SiteConfig; }
 
@@ -556,7 +556,8 @@ public:
    */
   std::string host_id;
 
-  RGWReshard* reshard{nullptr};
+  boost::asio::cancellation_signal reshard_cancel;
+  std::future<void> reshard_future;
   std::shared_ptr<RGWReshardWait> reshard_wait;
 
   virtual ~RGWRados() = default;
@@ -599,7 +600,8 @@ public:
   /** Initialize the RADOS instance and prepare to do other ops */
   int init_svc(bool raw, const DoutPrefixProvider *dpp, const rgw::SiteConfig& site);
   virtual int init_rados();
-  int init_complete(const DoutPrefixProvider *dpp, optional_yield y);
+  int init_complete(const DoutPrefixProvider *dpp, optional_yield y,
+                    boost::asio::io_context& io_context);
   void finalize();
 
   int register_to_service_map(const DoutPrefixProvider *dpp, const std::string& daemon_type, const std::map<std::string, std::string>& meta);

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1556,10 +1556,9 @@ public:
 	      uint32_t max,
 	      std::list<rgw_cls_bi_entry> *entries,
 	      bool *is_truncated, bool reshardlog, optional_yield y);
-  int bi_list(BucketShard& bs, const std::string& filter_obj, const std::string& marker, uint32_t max, std::list<rgw_cls_bi_entry> *entries,
+  int bi_list(const DoutPrefixProvider *dpp,
+	      BucketShard& bs, const std::string& filter_obj, const std::string& marker, uint32_t max, std::list<rgw_cls_bi_entry> *entries,
               bool *is_truncated, bool reshardlog, optional_yield y);
-  int bi_list(const DoutPrefixProvider *dpp, rgw_bucket& bucket, const std::string& obj_name, const std::string& marker, uint32_t max,
-              std::list<rgw_cls_bi_entry> *entries, bool *is_truncated, bool reshardlog, optional_yield y);
   int bi_remove(const DoutPrefixProvider *dpp, BucketShard& bs);
 
   int trim_reshard_log_entries(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, optional_yield y);

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1546,7 +1546,6 @@ public:
   int bi_get_instance(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_bucket_dir_entry *dirent, optional_yield y);
   int bi_get_olh(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_bucket_olh_entry *olh, optional_yield y);
   int bi_get(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw_obj& obj, BIIndexType index_type, rgw_cls_bi_entry *entry, optional_yield y);
-  void bi_put(librados::ObjectWriteOperation& op, BucketShard& bs, rgw_cls_bi_entry& entry, optional_yield y);
   int bi_put(BucketShard& bs, rgw_cls_bi_entry& entry, optional_yield y);
   int bi_put(const DoutPrefixProvider *dpp, rgw_bucket& bucket, rgw_obj& obj, rgw_cls_bi_entry& entry, optional_yield y);
   int bi_list(const DoutPrefixProvider *dpp,

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -1443,7 +1443,7 @@ int RGWReshard::update(const DoutPrefixProvider* dpp,
 
 int RGWReshard::list(const DoutPrefixProvider *dpp, optional_yield y,
                      int logshard_num, string& marker, uint32_t max,
-                     std::list<cls_rgw_reshard_entry>& entries,
+                     std::vector<cls_rgw_reshard_entry>& entries,
                      bool *is_truncated)
 {
   string logshard_oid;
@@ -1770,7 +1770,7 @@ int RGWReshard::process_single_logshard(int logshard_num, const DoutPrefixProvid
   }
   
   do {
-    std::list<cls_rgw_reshard_entry> entries;
+    std::vector<cls_rgw_reshard_entry> entries;
     ret = list(dpp, y, logshard_num, marker, max_op_entries, entries, &is_truncated);
     if (ret < 0) {
       ldpp_dout(dpp, 10) << "cannot list all reshards in logshard oid=" <<

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -1440,7 +1440,7 @@ int RGWReshard::get(const DoutPrefixProvider *dpp, optional_yield y,
 {
   string logshard_oid;
 
-  get_bucket_logshard_oid(entry.tenant, entry.bucket_name, &logshard_oid);
+  get_bucket_logshard_oid(bucket.tenant, bucket.name, &logshard_oid);
 
   bufferlist bl;
   librados::ObjectReadOperation op;

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -257,7 +257,7 @@ public:
       cls_rgw_bi_put_entries(op, std::move(entries), check_existing);
     } else {
       for (auto& entry : entries) {
-        store->getRados()->bi_put(op, bs, entry, null_yield);
+        cls_rgw_bi_put(op, entry);
       }
       cls_rgw_bucket_update_stats(op, false, stats);
     }

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -1253,9 +1253,9 @@ int RGWBucketReshard::execute(int num_shards,
   } catch (const ceph::async::lease_aborted& e) {
     ldpp_dout(dpp, 1) << "bucket reshard lease aborted with " << e.code() << dendl;
     return ceph::from_error_code(e.code());
-  } catch (const std::exception& e) {
+  } catch (const boost::system::system_error& e) {
     ldpp_dout(dpp, 1) << "bucket reshard failed with " << e.what() << dendl;
-    return -EIO;
+    return ceph::from_error_code(e.code());
   }
 }
 

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -1258,7 +1258,7 @@ int RGWBucketReshard::execute(int num_shards,
     return ceph::async::with_lease(client, lock.get_duration(), y,
         [&] (boost::asio::yield_context yield) {
           if (reshard_log) {
-            // update initiator once the last is acquired
+            // update initiator once the lock is acquired
             int ret = reshard_log->update(dpp, yield, bucket_info.bucket, initiator);
             if (ret < 0) {
               return ret;

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -214,7 +214,7 @@ class ShardBatch {
 
     constexpr int flags = 0;
     constexpr jspan_context* trace = nullptr;
-    librados::async_operate(ex, ioctx, object, &op, flags,
+    librados::async_operate(ex, ioctx, object, std::move(op), flags,
                             trace, std::move(completion));
   }
 

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -243,7 +243,7 @@ public:
   int remove(const DoutPrefixProvider *dpp, const cls_rgw_reshard_entry& entry, optional_yield y);
   int list(const DoutPrefixProvider *dpp, optional_yield y,
            int logshard_num, std::string& marker, uint32_t max,
-           std::list<cls_rgw_reshard_entry>& entries, bool *is_truncated);
+           std::vector<cls_rgw_reshard_entry>& entries, bool *is_truncated);
   int clear_bucket_resharding(const DoutPrefixProvider *dpp, const std::string& bucket_instance_oid, cls_rgw_reshard_entry& entry);
 
   /* reshard thread */

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -29,6 +29,7 @@
 class RGWReshard;
 
 
+namespace ceph::async { class RadosLockClient; }
 class BucketReshardManager;
 namespace rgw { namespace sal {
   class RadosStore;
@@ -70,6 +71,11 @@ public:
   bool should_renew(const Clock::time_point& now) const {
     return now >= renew_thresh;
   }
+  ceph::timespan get_duration() const { return duration; }
+
+  // return a LockClient for with_lease()
+  auto make_client(boost::asio::yield_context yield)
+    -> ceph::async::RadosLockClient;
 }; // class RGWBucketReshardLock
 
 class RGWBucketReshard {
@@ -227,9 +233,12 @@ public:
 
   /* reshard thread */
   int process_entry(const cls_rgw_reshard_entry& entry, int max_entries,
-                    const DoutPrefixProvider *dpp, optional_yield y);
-  int process_single_logshard(int logshard_num, const DoutPrefixProvider *dpp, optional_yield y);
-  int process_all_logshards(const DoutPrefixProvider *dpp, optional_yield y);
+                    const DoutPrefixProvider *dpp,
+                    boost::asio::yield_context y);
+  int process_single_logshard(int logshard_num, const DoutPrefixProvider *dpp,
+                              boost::asio::yield_context y);
+  int process_all_logshards(const DoutPrefixProvider *dpp,
+                            boost::asio::yield_context y);
 };
 
 class RGWReshardWait {

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -236,10 +236,14 @@ protected:
 public:
   RGWReshard(rgw::sal::RadosStore* _store, bool _verbose = false, std::ostream *_out = nullptr, Formatter *_formatter = nullptr);
   int add(const DoutPrefixProvider *dpp, cls_rgw_reshard_entry& entry, optional_yield y);
-  int update(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const cls_rgw_reshard_initiator initiator, optional_yield y);
-  int get(const DoutPrefixProvider *dpp, cls_rgw_reshard_entry& entry);
+  int update(const DoutPrefixProvider *dpp, optional_yield y,
+             const rgw_bucket& bucket, cls_rgw_reshard_initiator initiator);
+  int get(const DoutPrefixProvider *dpp, optional_yield y,
+          const rgw_bucket& bucket, cls_rgw_reshard_entry& entry);
   int remove(const DoutPrefixProvider *dpp, const cls_rgw_reshard_entry& entry, optional_yield y);
-  int list(const DoutPrefixProvider *dpp, int logshard_num, std::string& marker, uint32_t max, std::list<cls_rgw_reshard_entry>& entries, bool *is_truncated);
+  int list(const DoutPrefixProvider *dpp, optional_yield y,
+           int logshard_num, std::string& marker, uint32_t max,
+           std::list<cls_rgw_reshard_entry>& entries, bool *is_truncated);
   int clear_bucket_resharding(const DoutPrefixProvider *dpp, const std::string& bucket_instance_oid, cls_rgw_reshard_entry& entry);
 
   /* reshard thread */

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -112,6 +112,11 @@ class RGWBucketReshard {
 		 Formatter *formatter,
                  ReshardFaultInjector& fault,
                  const DoutPrefixProvider *dpp, optional_yield y);
+  // execute the bucket reshard while the bucket's reshard lock is held
+  int execute_locked(int num_shards, ReshardFaultInjector& fault,
+                     int max_op_entries, const DoutPrefixProvider *dpp,
+                     boost::asio::yield_context yield, bool verbose,
+                     std::ostream *out, ceph::Formatter *formatter);
 public:
 
   // pass nullptr for the final parameter if no outer reshard lock to
@@ -122,7 +127,7 @@ public:
 		   RGWBucketReshardLock* _outer_reshard_lock);
   int execute(int num_shards, ReshardFaultInjector& f,
               int max_op_entries, const cls_rgw_reshard_initiator initiator,
-	      const DoutPrefixProvider *dpp, optional_yield y,
+	      const DoutPrefixProvider *dpp, boost::asio::yield_context yield,
               bool verbose = false, std::ostream *out = nullptr,
               ceph::Formatter *formatter = nullptr,
 	      RGWReshard *reshard_log = nullptr);

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -80,7 +80,7 @@ class RGWBucketReshard {
   static const std::initializer_list<uint16_t> reshard_primes;
 
   int reshard_process(const rgw::bucket_index_layout_generation& current,
-                      int& max_entries,
+                      int max_entries,
                       BucketReshardManager& target_shards_mgr,
                       bool verbose_json_out,
                       std::ostream *out,

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -87,6 +87,7 @@ class RGWBucketReshard {
                       bool verbose_json_out,
                       std::ostream *out,
                       Formatter *formatter, rgw::BucketReshardState reshard_stage,
+                      ReshardFaultInjector& fault,
                       const DoutPrefixProvider *dpp,
                       boost::asio::yield_context yield);
 

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -79,8 +79,6 @@ class RGWBucketReshard {
   // allocated in at once
   static const std::initializer_list<uint16_t> reshard_primes;
 
-  int calc_target_shard(const RGWBucketInfo& bucket_info, const rgw_obj_key& key,
-                        int& shard, const DoutPrefixProvider *dpp);
   int reshard_process(const rgw::bucket_index_layout_generation& current,
                       int& max_entries,
                       BucketReshardManager& target_shards_mgr,

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -81,11 +81,14 @@ class RGWBucketReshard {
 
   int reshard_process(const rgw::bucket_index_layout_generation& current,
                       int max_entries,
-                      BucketReshardManager& target_shards_mgr,
+                      librados::IoCtx& pool,
+                      const std::map<int, std::string>& oids,
+                      bool can_put_entries,
                       bool verbose_json_out,
                       std::ostream *out,
                       Formatter *formatter, rgw::BucketReshardState reshard_stage,
-                      const DoutPrefixProvider *dpp, optional_yield y);
+                      const DoutPrefixProvider *dpp,
+                      boost::asio::yield_context yield);
 
   int do_reshard(const rgw::bucket_index_layout_generation& current,
                  const rgw::bucket_index_layout_generation& target,
@@ -94,7 +97,8 @@ class RGWBucketReshard {
                  std::ostream *os,
 		 Formatter *formatter,
                  ReshardFaultInjector& fault,
-                 const DoutPrefixProvider *dpp, optional_yield y);
+                 const DoutPrefixProvider *dpp,
+                 boost::asio::yield_context yield);
   // execute the bucket reshard while the bucket's reshard lock is held
   int execute_locked(int num_shards, ReshardFaultInjector& fault,
                      int max_op_entries, const DoutPrefixProvider *dpp,

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -8669,7 +8669,7 @@ next:
       bool is_truncated = true;
       std::string marker;
       do {
-	std::list<cls_rgw_reshard_entry> entries;
+	std::vector<cls_rgw_reshard_entry> entries;
         ret = reshard.list(dpp(), null_yield, i, marker, max_entries - count,
                            entries, &is_truncated);
         if (ret < 0) {

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -8617,10 +8617,19 @@ next:
     } else if (inject_delay_at) {
       fault.inject(*inject_delay_at, InjectDelay{inject_delay, dpp()});
     }
-    ret = br.execute(num_shards, fault, max_entries,
-		     cls_rgw_reshard_initiator::Admin,
-		     dpp(), null_yield,
-                     verbose, &cout, formatter.get());
+
+    // spawn execute() as a coroutine
+    boost::asio::io_context ctx;
+    boost::asio::spawn(ctx,
+        [&] (boost::asio::yield_context yield) {
+          ret = br.execute(num_shards, fault, max_entries,
+                           cls_rgw_reshard_initiator::Admin,
+                           dpp(), yield,
+                           verbose, &cout, formatter.get());
+        }, [] (std::exception_ptr eptr) {
+          if (eptr) { std::rethrow_exception(eptr); }
+        });
+    ctx.run();
     return -ret;
   }
 

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -8600,8 +8600,7 @@ next:
     }
 
     RGWBucketReshard br(static_cast<rgw::sal::RadosStore*>(driver),
-			bucket->get_info(), bucket->get_attrs(),
-			nullptr /* no callback */);
+			bucket->get_info(), bucket->get_attrs());
 
 #define DEFAULT_RESHARD_MAX_ENTRIES 1000
     if (max_entries < 1) {
@@ -8719,8 +8718,7 @@ next:
     }
 
     RGWBucketReshard br(static_cast<rgw::sal::RadosStore*>(driver),
-			bucket->get_info(), bucket->get_attrs(),
-			nullptr /* no callback */);
+			bucket->get_info(), bucket->get_attrs());
     list<cls_rgw_bucket_instance_entry> status;
     int r = br.get_status(dpp(), &status);
     if (r < 0) {
@@ -8782,8 +8780,7 @@ next:
     if (bucket_initable) {
       // we did not encounter an error, so let's work with the bucket
 	RGWBucketReshard br(static_cast<rgw::sal::RadosStore*>(driver),
-			    bucket->get_info(), bucket->get_attrs(),
-			    nullptr /* no callback */);
+			    bucket->get_info(), bucket->get_attrs());
       int ret = br.cancel(dpp(), null_yield);
       if (ret < 0) {
         if (ret == -EBUSY) {

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -8670,7 +8670,8 @@ next:
       std::string marker;
       do {
 	std::list<cls_rgw_reshard_entry> entries;
-        ret = reshard.list(dpp(), i, marker, max_entries - count, entries, &is_truncated);
+        ret = reshard.list(dpp(), null_yield, i, marker, max_entries - count,
+                           entries, &is_truncated);
         if (ret < 0) {
           cerr << "Error listing resharding buckets: " << cpp_strerror(-ret) << std::endl;
           return ret;

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -8724,12 +8724,28 @@ next:
   }
 
   if (opt_cmd == OPT::RESHARD_PROCESS) {
-    RGWReshard reshard(static_cast<rgw::sal::RadosStore*>(driver), true, &cout);
+    auto rados_driver = dynamic_cast<rgw::sal::RadosStore*>(driver);
+    if (!rados_driver) {
+      cerr << "ERROR: this command can only work when the cluster "
+          "has a RADOS backing store." << std::endl;
+      return EPERM;
+    }
 
-    int ret = reshard.process_all_logshards(dpp(), null_yield);
-    if (ret < 0) {
-      cerr << "ERROR: failed to process reshard logs, error=" << cpp_strerror(-ret) << std::endl;
-      return -ret;
+    RGWReshard reshard(rados_driver, true, &cout);
+
+    // spawn process_all_logshards() as a coroutine
+    boost::asio::io_context ctx;
+    boost::asio::spawn(ctx,
+        [&reshard] (boost::asio::yield_context yield) {
+          reshard.process_all_logshards(dpp(), yield);
+        }, [] (std::exception_ptr eptr) {
+          if (eptr) { std::rethrow_exception(eptr); }
+        });
+    try {
+      ctx.run();
+    } catch (const std::exception& e) {
+      cerr << "ERROR: failed to process reshard logs with " << e.what() << std::endl;
+      return -1;
     }
   }
 

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -8178,7 +8178,7 @@ next:
       do {
         entries.clear();
 	// if object is specified, we use that as a filter to only retrieve some entries
-        ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->bi_list(bs, object, marker, max_entries, &entries, &is_truncated, false, null_yield);
+        ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->bi_list(dpp(), bs, object, marker, max_entries, &entries, &is_truncated, false, null_yield);
         if (ret < 0) {
           ldpp_dout(dpp(), 0) << "ERROR: bi_list(): " << cpp_strerror(-ret) << dendl;
           return -ret;
@@ -11388,7 +11388,7 @@ next:
       marker.clear();
       do {
         entries.clear();
-        ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->bi_list(bs, "", marker, max_entries,
+        ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->bi_list(dpp(), bs, "", marker, max_entries,
                                                                               &entries, &is_truncated,
                                                                               true, null_yield);
         if (ret < 0) {

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -104,7 +104,7 @@ rgw::sal::Driver* DriverManager::init_storage_provider(const DoutPrefixProvider*
       delete driver;
       return nullptr;
     }
-    if (rados->init_complete(dpp, y) < 0) {
+    if (rados->init_complete(dpp, y, io_context) < 0) {
       delete driver;
       return nullptr;
     }
@@ -131,7 +131,7 @@ rgw::sal::Driver* DriverManager::init_storage_provider(const DoutPrefixProvider*
       delete driver;
       return nullptr;
     }
-    if (rados->init_complete(dpp, y) < 0) {
+    if (rados->init_complete(dpp, y, io_context) < 0) {
       delete driver;
       return nullptr;
     }

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -390,6 +390,10 @@ add_executable(unittest_async_spawn_throttle test_async_spawn_throttle.cc)
 add_ceph_unittest(unittest_async_spawn_throttle)
 target_link_libraries(unittest_async_spawn_throttle ceph-common Boost::system Boost::context)
 
+add_executable(unittest_async_lease test_async_lease.cc)
+add_ceph_unittest(unittest_async_lease)
+target_link_libraries(unittest_async_lease ceph-common Boost::system Boost::context)
+
 add_executable(unittest_async_yield_waiter test_async_yield_waiter.cc)
 add_ceph_unittest(unittest_async_yield_waiter)
 target_link_libraries(unittest_async_yield_waiter ceph-common Boost::system Boost::context)

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -392,7 +392,7 @@ target_link_libraries(unittest_async_spawn_throttle ceph-common Boost::system Bo
 
 add_executable(unittest_async_lease test_async_lease.cc)
 add_ceph_unittest(unittest_async_lease)
-target_link_libraries(unittest_async_lease ceph-common Boost::system Boost::context)
+target_link_libraries(unittest_async_lease ceph-common Boost::system Boost::context librados)
 
 add_executable(unittest_async_yield_waiter test_async_yield_waiter.cc)
 add_ceph_unittest(unittest_async_yield_waiter)

--- a/src/test/common/test_async_lease.cc
+++ b/src/test/common/test_async_lease.cc
@@ -1,0 +1,1730 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+//#define BOOST_ASIO_ENABLE_HANDLER_TRACKING
+#include "common/async/lease.h"
+
+#include <optional>
+#include <utility>
+#include <vector>
+#include <boost/asio/any_completion_executor.hpp>
+#include <boost/asio/append.hpp>
+#include <boost/asio/associated_cancellation_slot.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <gtest/gtest.h>
+#include "common/async/co_waiter.h"
+#include "common/async/yield_waiter.h"
+
+namespace ceph::async {
+
+namespace asio = boost::asio;
+using executor_type = asio::any_io_executor;
+
+using namespace std::chrono_literals;
+
+enum class event { acquire, renew, release };
+
+// a LockClient that logs events and injects delays and exceptions
+class MockClient : public LockClient {
+  Handler waiter;
+  using Work = asio::executor_work_guard<asio::any_completion_executor>;
+  std::optional<Work> work;
+ public:
+  std::vector<event> events; // tracks the sequence of LockClient calls
+
+  void acquire(ceph::timespan, Handler handler) override {
+    events.push_back(event::acquire);
+    work.emplace(asio::make_work_guard(handler));
+    waiter = std::move(handler);
+  }
+  void renew(ceph::timespan, Handler handler) override {
+    events.push_back(event::renew);
+    work.emplace(asio::make_work_guard(handler));
+    waiter = std::move(handler);
+  }
+  void release(Handler handler) override {
+    events.push_back(event::release);
+    work.emplace(asio::make_work_guard(handler));
+    waiter = std::move(handler);
+  }
+
+  void complete(boost::system::error_code ec = {}) {
+    auto w = std::move(*work);
+    work = std::nullopt;
+    asio::dispatch(asio::append(std::move(waiter), ec));
+  }
+};
+
+// a MockClient that supports per-op cancellation
+class CancelableMockClient : public MockClient {
+  struct op_cancellation {
+    MockClient* self;
+    op_cancellation(MockClient* self) : self(self) {}
+    void operator()(asio::cancellation_type_t type) {
+      if (type != asio::cancellation_type::none) {
+        self->complete(make_error_code(asio::error::operation_aborted));
+      }
+    }
+  };
+ public:
+  void acquire(ceph::timespan dur, Handler handler) override {
+    auto slot = get_associated_cancellation_slot(handler);
+    if (slot.is_connected()) {
+      slot.template emplace<op_cancellation>(this);
+    }
+    MockClient::acquire(dur, std::move(handler));
+  }
+  void renew(ceph::timespan dur, Handler handler) override {
+    auto slot = get_associated_cancellation_slot(handler);
+    if (slot.is_connected()) {
+      slot.template emplace<op_cancellation>(this);
+    }
+    MockClient::renew(dur, std::move(handler));
+  }
+  void release(Handler handler) override {
+    auto slot = get_associated_cancellation_slot(handler);
+    if (slot.is_connected()) {
+      slot.template emplace<op_cancellation>(this);
+    }
+    MockClient::release(std::move(handler));
+  }
+};
+
+template <typename T>
+auto capture(std::optional<T>& opt)
+{
+  return [&opt] (T value) {
+    opt = std::move(value);
+  };
+}
+
+template <typename T>
+auto capture(asio::cancellation_signal& signal, std::optional<T>& opt)
+{
+  return asio::bind_cancellation_slot(signal.slot(), capture(opt));
+}
+
+template <typename ...Args>
+auto capture(std::optional<std::tuple<Args...>>& opt)
+{
+  return [&opt] (Args ...args) {
+    opt = std::forward_as_tuple(std::forward<Args>(args)...);
+  };
+}
+
+
+TEST(co_spawn, return_void)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(spawn, return_void)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&locker] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, [] (asio::yield_context) {});
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll();
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+}
+
+TEST(co_spawn, return_value)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  using ptr = std::unique_ptr<int>; // test a move-only return type
+  auto cr = [] () -> asio::awaitable<ptr> { co_return std::make_unique<int>(42); };
+
+  using result_type = std::tuple<std::exception_ptr, ptr>;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  EXPECT_FALSE(result);
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(std::get<0>(*result));
+  ASSERT_TRUE(std::get<1>(*result));
+  EXPECT_EQ(42, *std::get<1>(*result));
+}
+
+TEST(spawn, return_value)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  /// using ptr = std::unique_ptr<int>;
+  // XXX: spawn() doesn't support move-only return values, see
+  // https://github.com/chriskohlhoff/asio/issues/1543
+  using ptr = std::shared_ptr<int>;
+  auto cr = [] (asio::yield_context) { return std::make_shared<int>(42); };
+
+  using result_type = std::tuple<std::exception_ptr, ptr>;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        return with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  EXPECT_FALSE(result);
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(std::get<0>(*result));
+  ASSERT_TRUE(std::get<1>(*result));
+  EXPECT_EQ(42, *std::get<1>(*result));
+}
+
+TEST(co_spawn, spawned_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> {
+    throw std::domain_error{"oops"};
+    co_return;
+  };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  EXPECT_THROW(std::rethrow_exception(*result), std::domain_error);
+}
+
+TEST(spawn, spawned_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) { throw std::domain_error{"oops"}; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  EXPECT_THROW(std::rethrow_exception(*result), std::domain_error);
+}
+
+TEST(co_spawn, acquire_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::invalid_argument);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(spawn, acquire_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::invalid_argument);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_spawn, acquire_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+  // shut down before acquire completes
+}
+
+TEST(spawn, acquire_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+  // shut down before acquire completes
+}
+
+TEST(co_spawn, acquire_cancel_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  // cancel before acquire completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(spawn, acquire_cancel_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  // cancel before acquire completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_spawn, acquire_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  // cancel before acquire completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(spawn, acquire_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  // cancel before acquire completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_spawn, acquired_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // start cr and renewal timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  // shut down before renewal timer
+}
+
+TEST(spawn, acquired_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // start cr and renewal timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  // shut down before renewal timer
+}
+
+TEST(co_spawn, acquired_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)),
+                 capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // wait for acquire to finish
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renewal timer
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(spawn, acquired_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  asio::cancellation_signal signal;
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // wait for acquire to finish
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renewal timer
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception& e) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(co_spawn, renew_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  // inject an exception on renew
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), std::errc::invalid_argument);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  // inject an exception on renew
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), std::errc::invalid_argument);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete(); // unblock renew
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(3, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete(); // unblock renew
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(3, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  locker.complete(); // unblock release
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_exception_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // inject an exception on renew
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_exception_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // inject an exception on renew
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_cancel_after_timeout_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)),
+                 capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size()); // no release
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_cancel_after_timeout_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size()); // no release
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_cancel_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)),
+                 capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size()); // no release
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_cancel_after_timeout)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  ctx.run_one(); // wait for renew timeout
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size()); // no release
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result);
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), boost::system::errc::timed_out);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, renew_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 10ms, std::move(cr)), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+  // shut down before renew completes
+}
+
+TEST(spawn, renew_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 10ms, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~5ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+  // shut down before renew completes
+}
+
+TEST(co_spawn, renew_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::co_waiter<void, executor_type> waiter;
+  auto cr = waiter.get(); // cr is a wait that never completes
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 50ms, std::move(cr)),
+                 capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~25ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(spawn, renew_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  ceph::async::yield_waiter<void> waiter;
+  auto cr = [&waiter] (asio::yield_context yield) { waiter.async_wait(yield); };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 50ms, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until renew timer blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  ctx.run_one(); // wait ~25ms for renew timer
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::renew, locker.events.back());
+
+  // cancel before renew completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(*result); // throws on cancellation
+  try {
+    std::rethrow_exception(*result);
+  } catch (const lease_aborted& e) {
+    EXPECT_EQ(e.code(), asio::error::operation_aborted);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, lease_aborted);
+  }
+}
+
+TEST(co_spawn, release_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // inject an exception on release
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result); // release exceptions are ignored
+}
+
+TEST(spawn, release_exception)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // inject an exception on release
+  locker.complete(make_error_code(std::errc::invalid_argument));
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result); // release exceptions are ignored
+}
+
+TEST(co_spawn, release_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+  // shut down before release completes
+}
+
+TEST(spawn, release_shutdown)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+  // shut down before release completes
+}
+
+TEST(co_spawn, release_cancel_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // cancel before release completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_FALSE(*result); // exception is ignored
+}
+
+TEST(spawn, release_cancel_supported)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = CancelableMockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // cancel before release completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_FALSE(*result); // exception is ignored
+}
+
+TEST(co_spawn, release_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] () -> asio::awaitable<void> { co_return; };
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::co_spawn(ex, with_lease(locker, 30s, cr()), capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // cancel before release completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_FALSE(*result); // exception is ignored
+}
+
+TEST(spawn, release_cancel)
+{
+  asio::io_context ctx;
+  executor_type ex = ctx.get_executor();
+  auto locker = MockClient{};
+
+  auto cr = [] (asio::yield_context) {};
+
+  using result_type = std::exception_ptr;
+  std::optional<result_type> result;
+  asio::cancellation_signal signal;
+  asio::spawn(ex, [&] (asio::yield_context yield) {
+        with_lease(locker, 30s, yield, cr);
+      }, capture(signal, result));
+
+  ctx.poll(); // run until acquire blocks
+  ASSERT_FALSE(ctx.stopped());
+  ASSERT_EQ(1, locker.events.size());
+  EXPECT_EQ(event::acquire, locker.events.back());
+
+  locker.complete(); // unblock acquire
+
+  ctx.poll(); // run until release blocks
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+  ASSERT_EQ(2, locker.events.size());
+  EXPECT_EQ(event::release, locker.events.back());
+
+  // cancel before release completes
+  signal.emit(asio::cancellation_type::terminal);
+
+  ctx.poll();
+  ASSERT_FALSE(ctx.stopped());
+  EXPECT_FALSE(result);
+
+  locker.complete();
+
+  ctx.poll(); // run to completion
+  ASSERT_TRUE(ctx.stopped());
+  ASSERT_TRUE(result);
+  ASSERT_FALSE(*result); // exception is ignored
+}
+
+} // namespace ceph::async

--- a/src/test/common/test_async_lease.cc
+++ b/src/test/common/test_async_lease.cc
@@ -12,6 +12,7 @@
 
 //#define BOOST_ASIO_ENABLE_HANDLER_TRACKING
 #include "common/async/lease.h"
+#include "common/async/lease_rados.h"
 
 #include <optional>
 #include <utility>

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -114,6 +114,10 @@ add_executable(unittest_rgw_reshard_wait test_rgw_reshard_wait.cc)
 add_ceph_unittest(unittest_rgw_reshard_wait)
 target_link_libraries(unittest_rgw_reshard_wait ${rgw_libs})
 
+add_executable(unittest_rgw_reshard_writer test_rgw_reshard_writer.cc)
+add_ceph_unittest(unittest_rgw_reshard_writer)
+target_link_libraries(unittest_rgw_reshard_writer ${rgw_libs})
+
 set(test_rgw_a_src test_rgw_common.cc)
 add_library(test_rgw_a STATIC ${test_rgw_a_src})
 target_link_libraries(test_rgw_a ${rgw_libs})

--- a/src/test/rgw/test_rgw_reshard_writer.cc
+++ b/src/test/rgw/test_rgw_reshard_writer.cc
@@ -1,0 +1,709 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright contributors to the Ceph project
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "reshard_writer.h"
+
+#include <functional>
+#include <optional>
+#include <vector>
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/spawn.hpp>
+#include <gtest/gtest.h>
+
+namespace rgwrados::reshard {
+
+template <typename T>
+auto capture(std::optional<T>& val)
+{
+  return [&val] (T value) { val = std::move(value); };
+}
+
+template <typename Batch>
+auto call_write(Writer<Batch>& writer)
+{
+  return [&writer] (boost::asio::yield_context yield) {
+    writer.write({}, {}, {}, yield);
+  };
+}
+
+template <typename Batch>
+auto call_drain(Writer<Batch>& writer)
+{
+  return [&writer] (boost::asio::yield_context yield) {
+    writer.drain(yield);
+  };
+}
+
+// mock Batch captures flush() completions for test cases to invoke manually
+class MockBatch {
+ public:
+  MockBatch(size_t batch_size, std::vector<Completion>& completions)
+    : batch_size(batch_size), completions(completions)
+  {}
+
+  bool empty() const
+  {
+    return count == 0;
+  }
+
+  bool add(rgw_cls_bi_entry entry,
+           std::optional<RGWObjCategory> category,
+           rgw_bucket_category_stats stats)
+  {
+    ++count;
+    return count == batch_size;
+  }
+
+  void flush(Completion completion)
+  {
+    completions.push_back(std::move(completion));
+    count = 0;
+  }
+
+ private:
+  const size_t batch_size;
+  size_t count = 0;
+  std::vector<Completion>& completions;
+};
+
+TEST(Writer, empty_flush)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  ASSERT_TRUE(batch.empty());
+  auto writer = Writer{ex, 1, batch};
+
+  writer.flush();
+  EXPECT_TRUE(completions.empty());
+}
+
+TEST(Writer, empty_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  ASSERT_TRUE(batch.empty());
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result;
+  boost::asio::spawn(ex, call_drain(writer), capture(result));
+  EXPECT_FALSE(result);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+  EXPECT_TRUE(completions.empty());
+}
+
+TEST(Writer, write_no_flush)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{8, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result;
+  boost::asio::spawn(ex, call_write(writer), capture(result));
+  EXPECT_FALSE(result);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+  EXPECT_TRUE(completions.empty());
+}
+
+TEST(Writer, write_no_flush_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{8, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_write(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+    ctx.restart();
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+    EXPECT_TRUE(completions.empty());
+  }
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_drain(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+    EXPECT_TRUE(completions.empty());
+  }
+}
+
+TEST(Writer, write_flush)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{8, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result;
+  boost::asio::spawn(ex, call_write(writer), capture(result));
+  EXPECT_FALSE(result);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+
+  writer.flush();
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  EXPECT_EQ(1, completions.size());
+}
+
+TEST(Writer, write_flush_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{8, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_write(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+    ctx.restart();
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+  }
+
+  writer.flush();
+  ASSERT_EQ(1, completions.size());
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_drain(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    std::invoke(completions[0], boost::system::error_code{});
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+  }
+}
+
+TEST(Writer, write_batch)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result;
+  boost::asio::spawn(ex, call_write(writer), capture(result));
+  EXPECT_FALSE(result);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result);
+  EXPECT_FALSE(*result);
+  EXPECT_EQ(1, completions.size());
+}
+
+TEST(Writer, write_batch_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_write(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+    EXPECT_EQ(1, completions.size());
+  }
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_drain(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    std::invoke(completions[0], boost::system::error_code{});
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+  }
+}
+
+TEST(Writer, write_batch_multi_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  {
+    std::optional<std::exception_ptr> result;
+    boost::asio::spawn(ex, call_write(writer), capture(result));
+    EXPECT_FALSE(result);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    ASSERT_TRUE(result);
+    EXPECT_FALSE(*result);
+    EXPECT_EQ(1, completions.size());
+  }
+  {
+    std::optional<std::exception_ptr> result1;
+    boost::asio::spawn(ex, call_drain(writer), capture(result1));
+    EXPECT_FALSE(result1);
+
+    std::optional<std::exception_ptr> result2;
+    boost::asio::spawn(ex, call_drain(writer), capture(result2));
+    EXPECT_FALSE(result2);
+
+    ctx.poll();
+    EXPECT_FALSE(ctx.stopped());
+
+    std::invoke(completions[0], boost::system::error_code{});
+
+    ctx.poll();
+    EXPECT_TRUE(ctx.stopped());
+
+    ASSERT_TRUE(result1);
+    EXPECT_FALSE(*result1);
+    ASSERT_TRUE(result2);
+    EXPECT_FALSE(*result2);
+  }
+}
+
+TEST(Writer, multi_write_batch)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::spawn(ex, call_write(writer), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::spawn(ex, call_write(writer), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  std::optional<std::exception_ptr> result3;
+  boost::asio::spawn(ex, call_write(writer), capture(result3));
+  EXPECT_FALSE(result3);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  EXPECT_FALSE(result2);
+  ASSERT_EQ(1, completions.size());
+  std::invoke(completions[0], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result2);
+  EXPECT_FALSE(*result2);
+  EXPECT_FALSE(result3);
+  ASSERT_EQ(2, completions.size());
+  std::invoke(completions[1], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result3);
+  EXPECT_FALSE(*result3);
+  ASSERT_EQ(3, completions.size());
+  std::invoke(completions[2], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+}
+
+TEST(Writer, concurrent_multi_write_batch)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 2, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::spawn(ex, call_write(writer), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::spawn(ex, call_write(writer), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result2);
+  EXPECT_FALSE(*result2);
+  EXPECT_EQ(2, completions.size());
+
+  std::optional<std::exception_ptr> result3;
+  boost::asio::spawn(ex, call_write(writer), capture(result3));
+  EXPECT_FALSE(result3);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  std::optional<std::exception_ptr> result4;
+  boost::asio::spawn(ex, call_write(writer), capture(result4));
+  EXPECT_FALSE(result4);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  EXPECT_FALSE(result3);
+  ASSERT_EQ(2, completions.size());
+  std::invoke(completions[0], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result3);
+  EXPECT_FALSE(*result3);
+  EXPECT_FALSE(result4);
+  ASSERT_EQ(3, completions.size());
+  std::invoke(completions[1], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result4);
+  EXPECT_FALSE(*result4);
+  ASSERT_EQ(4, completions.size());
+  std::invoke(completions[2], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_EQ(4, completions.size());
+  std::invoke(completions[3], boost::system::error_code{});
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+}
+
+TEST(Writer, write_batch_write_error)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::spawn(ex, call_write(writer), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::spawn(ex, call_write(writer), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+  std::invoke(completions[0], make_error_code(std::errc::no_such_file_or_directory));
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  ASSERT_TRUE(result2);
+  ASSERT_TRUE(*result2);
+  try {
+    std::rethrow_exception(*result2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+
+  std::optional<std::exception_ptr> result3;
+  boost::asio::spawn(ex, call_write(writer), capture(result3));
+  EXPECT_FALSE(result3);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result3);
+  ASSERT_TRUE(*result3);
+  try {
+    std::rethrow_exception(*result3);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(Writer, write_batch_error_write)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::spawn(ex, call_write(writer), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+  std::invoke(completions[0], make_error_code(std::errc::no_such_file_or_directory));
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::spawn(ex, call_write(writer), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result2);
+  ASSERT_TRUE(*result2);
+  try {
+    std::rethrow_exception(*result2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(Writer, write_batch_drain_error)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::spawn(ex, call_write(writer), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::spawn(ex, call_drain(writer), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+  std::invoke(completions[0], make_error_code(std::errc::no_such_file_or_directory));
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  ASSERT_TRUE(result2);
+  ASSERT_TRUE(*result2);
+  try {
+    std::rethrow_exception(*result2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+
+  std::optional<std::exception_ptr> result3;
+  boost::asio::spawn(ex, call_write(writer), capture(result3));
+  EXPECT_FALSE(result3);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result3);
+  ASSERT_TRUE(*result3);
+  try {
+    std::rethrow_exception(*result3);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+TEST(Writer, write_batch_error_drain)
+{
+  boost::asio::io_context ctx;
+  boost::asio::any_io_executor ex = ctx.get_executor();
+
+  std::vector<Completion> completions;
+  auto batch = MockBatch{1, completions};
+  auto writer = Writer{ex, 1, batch};
+
+  std::optional<std::exception_ptr> result1;
+  boost::asio::spawn(ex, call_write(writer), capture(result1));
+  EXPECT_FALSE(result1);
+
+  ctx.poll();
+  EXPECT_FALSE(ctx.stopped());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+
+  ASSERT_TRUE(result1);
+  EXPECT_FALSE(*result1);
+  EXPECT_EQ(1, completions.size());
+  std::invoke(completions[0], make_error_code(std::errc::no_such_file_or_directory));
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+  ctx.restart();
+
+  std::optional<std::exception_ptr> result2;
+  boost::asio::spawn(ex, call_drain(writer), capture(result2));
+  EXPECT_FALSE(result2);
+
+  ctx.poll();
+  EXPECT_TRUE(ctx.stopped());
+
+  ASSERT_TRUE(result2);
+  ASSERT_TRUE(*result2);
+  try {
+    std::rethrow_exception(*result2);
+  } catch (const boost::system::system_error& e) {
+    EXPECT_EQ(e.code(), std::errc::no_such_file_or_directory);
+  } catch (const std::exception&) {
+    EXPECT_THROW(throw, boost::system::system_error);
+  }
+}
+
+} // namespace rgwrados::reshard

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -915,6 +915,7 @@ $CCLIENTDEBUG
         rgw crypt require ssl = false
         rgw sts key = abcdefghijklmnop
         rgw s3 auth use sts = true
+        rgw reshard progress judge interval = 10 ; for test_rgw_reshard.py
         ; uncomment the following to set LC days as the value in seconds;
         ; needed for passing lc time based s3-tests (can be verbose)
         ; rgw lc debug interval = 10


### PR DESCRIPTION
builds on top of https://github.com/ceph/ceph/pull/60475 and https://github.com/ceph/ceph/pull/60329. also depends on commits from https://github.com/ceph/ceph/pull/60379 and https://github.com/ceph/ceph/pull/60576

## stackful coroutines for with_lease()
replaces dynamic resharding's background thread `ReshardWorker` with a stackful coroutine function that's spawned on rgw's io_context thread pool. functions `RGWReshard::process_all_logshards()` through `RGWBucketReshard::execute()` now take `asio::yield_context` instead of `optional_yield` and must be called in a coroutine

this allows us to wrap `process_single_logshard()` and `execute()` in `ceph::async::with_lease()` calls to handle locking/renewal of the reshard log shard lock and per-bucket reshard lock respectively

because `with_lease()` hides all of the locking and renewal, the wrapped functions no longer need to call `renew_lock_if_needed()` repeatedly

## parallel processing of source shards
uses `ceph::async::spawn_throttle` to spawn a separate stackful coroutine for each call to `process_source_shard()`, with concurrency limited by `rgw_bucket_index_max_aio`

replaces blocking `BucketReshardShard` with new coroutine-aware template class `reshard::Writer<Batch>` that writes entries in batches to the target index shards

several source shards may add entries to a given target shard at the same time. once a target shard reaches its limit of in-flight write requests (given by `rgw_reshard_max_aio`), any `process_source_shard()` coroutines that try to add more entries will suspend until we get the next response

## cancellation
asio's [per-op cancellation](https://www.boost.org/doc/libs/1_85_0/doc/html/boost_asio/overview/core/cancellation.html) becomes very important in this design:
* `with_lease()` signals cancellation of the wrapped coroutine if lock renewal fails or times out
* on error from any `process_source_shard()` coroutine, `spawn_throttle` cancels the processing of remaining shards
* on shutdown, `RGWRados::finalize()` cancels the background `reshard_worker()` coroutine

when a coroutine's cancellation is requested, that signal calls the 'cancellation handler' of whatever the coroutine was suspended on. when this is a librados request, we'll rely on https://github.com/ceph/ceph/pull/60379 to fail the request immediately with -ECANCELED. without that support, the librados request would succeed and we'd only notice the cancellation if we check `yield_context.cancelled()` manually

reshard already has special handling to retry ECANCELED errors from cls_version on racing writes to bucket instance metadata. we now need to consult `yield_context.cancelled()` to determine whether or not this error came from the coroutine's cancellation, and return the error directly without retry

## exceptions
because `asio::spawn()`/`co_spawn()` return errors to the caller as `std::exception_ptr` instead of `boost::system::error_code`, `with_lease()` and `spawn_throttle` also use exceptions to communicate errors. in general, integer error codes are thrown as `boost::system::system_error` exceptions, and are converted back to integers with `ceph::from_error_code(e.code())`

## todo
- [ ] enable async calls to:
  * RGWRados::trim_reshard_log_entries
  * RGWRados::bucket_set_reshard
  * RGWSI_BucketIndex_RADOS::init_index
  * RGWSI_BucketIndex_RADOS::clean_index
  * RGWSI_BILog_RADOS::log_start
  * RGWSI_BILog_RADOS::log_stop
- [x] add error injection in `process_source_shard()` to test cancellation

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
