### PR TITLE
[3AZ] src/mon : Allow user to specify crush_rule, size and min_size when unsetting a stretch pool

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -840,7 +840,7 @@ To move the pool back to non-stretch, run a command of the following form:
 
 .. prompt:: bash $
 
-   ceph osd pool stretch unset {pool-name}
+   ceph osd pool stretch unset {pool-name} {crush_rule} {size} {min_size}
 
 Here are the breakdowns of the arguments:
 
@@ -850,6 +850,28 @@ Here are the breakdowns of the arguments:
    i.e., set with the command `ceph osd pool stretch set`.
 
    :Type: String
+   :Required: Yes.
+
+.. describe:: {crush_rule}
+      
+   The crush rule to use after exiting the stretch pool. The type of pool must match the type of crush_rule
+   (replicated or erasure).
+
+   :Type: String
+   :Required: Yes.
+
+.. describe:: {size}
+         
+   The number of replicas for objects after exiting stretch pool.
+   
+   :Type: Integer
+   :Required: Yes.
+
+.. describe:: {min_size}
+            
+   The minimum number of replicas required for I/O after exiting stretch pool.
+
+   :Type: Integer
    :Required: Yes.
 
 Showing values of a stretch pool

--- a/qa/tasks/test_netsplit_3az_stretch_pool.py
+++ b/qa/tasks/test_netsplit_3az_stretch_pool.py
@@ -21,6 +21,7 @@ class TestNetSplit(CephTestCase):
     PEERING_CRUSH_BUCKET_BARRIER = 'datacenter'
     POOL = 'pool_stretch'
     CRUSH_RULE = 'replicated_rule_custom'
+    DEFAULT_CRUSH_RULE = 'replicated_rule'
     SIZE = 6
     MIN_SIZE = 3
     BUCKET_MAX = SIZE // PEERING_CRUSH_BUCKET_TARGET
@@ -273,6 +274,16 @@ class TestNetSplit(CephTestCase):
         # wait for the PGs to recover
         time.sleep(self.RECOVERY_PERIOD)
         # check if all PGs are active+clean
+        self.wait_until_true_and_hold(
+            lambda: self._pg_all_active_clean(),
+            timeout=self.RECOVERY_PERIOD,
+            success_hold_time=self.SUCCESS_HOLD_TIME
+        )
+        # Unset the pool back to replicated rule expects PGs to be 100% active+clean
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            'osd', 'pool', 'stretch', 'unset',
+            self.POOL, self.DEFAULT_CRUSH_RULE,
+            str(self.SIZE), str(self.MIN_SIZE))
         self.wait_until_true_and_hold(
             lambda: self._pg_all_active_clean(),
             timeout=self.RECOVERY_PERIOD,

--- a/qa/workunits/mon/mon-stretch-pool.sh
+++ b/qa/workunits/mon/mon-stretch-pool.sh
@@ -97,10 +97,12 @@ expect_false ceph osd pool stretch set non_exist_pool 2 3 datacenter $TEST_CRUSH
 expect_false ceph osd pool stretch set $TEST_POOL_STRETCH 2 3 non_exist_barrier $TEST_CRUSH_RULE 6 3
 # Non existence crush_rule should return appropriate error
 expect_false ceph osd pool stretch set $TEST_POOL_STRETCH 2 3 datacenter $TEST_CRUSH_RULE 6 3
-# Unsetting a non existence pool should return error
-expect_false ceph osd pool stretch unset non_exist_pool
-# Unsetting a non-stretch pool should return error
+# Unsetting a pool with missing arguments
 expect_false ceph osd pool stretch unset $TEST_POOL_STRETCH
+# Unsetting a non existence pool should return error
+expect_false ceph osd pool stretch unset non_exist_pool replicated_rule 6 3
+# Unsetting a non-stretch pool should return error
+expect_false ceph osd pool stretch unset $TEST_POOL_STRETCH replicated_rule 6 3
 
 # Create a custom crush rule
 ceph osd getcrushmap > crushmap
@@ -139,7 +141,7 @@ expect_true ceph osd pool stretch set $TEST_POOL_STRETCH 2 3 datacenter $TEST_CR
 expect_true ceph osd pool stretch show $TEST_POOL_STRETCH
 
 # Unset the stretch pool and expects it to work
-expect_true ceph osd pool stretch unset $TEST_POOL_STRETCH
+expect_true ceph osd pool stretch unset $TEST_POOL_STRETCH replicated_rule 6 3
 # try to show the stretch pool values again, should return error since
 # the pool is not a stretch pool anymore.
 expect_false ceph osd pool stretch show $TEST_POOL_STRETCH

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1234,7 +1234,10 @@ COMMAND("osd pool stretch set "
         "make the pool stretched across the specified number of CRUSH buckets",
         "osd", "rw")
 COMMAND("osd pool stretch unset "
-		"name=pool,type=CephPoolname",
+		"name=pool,type=CephPoolname "
+		"name=crush_rule,type=CephString "
+		"name=size,type=CephInt,range=0 "
+		"name=min_size,type=CephInt,range=0 ",
 		"unset the stretch mode for the pool",
 		"osd", "rw")
 COMMAND("osd utilization",

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -9237,11 +9237,44 @@ int OSDMonitor::prepare_command_pool_stretch_unset(const cmdmap_t& cmdmap,
     ss << "pool " << pool_name << " is not a stretch pool";
     return -ENOENT;
   }
+  CrushWrapper& crush = _get_stable_crush();
+  string crush_rule_str;
+  cmd_getval(cmdmap, "crush_rule", crush_rule_str);
+  if (crush_rule_str.empty()) {
+    ss << "crush_rule must be provided";
+    return -EINVAL;
+  }
+
+  int crush_rule = crush.get_rule_id(crush_rule_str);
+  if (crush_rule < 0) {
+    ss << "crush rule " << crush_rule_str << " does not exist";
+    return -ENOENT;
+  }
+
+  if (!crush.rule_valid_for_pool_type(crush_rule, p.get_type())) {
+    ss << "crush rule " << crush_rule << " type does not match pool";
+    return -EINVAL;
+  }
+
+  int64_t pool_size = cmd_getval_or<int64_t>(cmdmap, "size", 0);
+  if (pool_size < 0) {
+    ss << "pool size must be non-negative";
+    return -EINVAL;
+  }
+
+  int64_t pool_min_size = cmd_getval_or<int64_t>(cmdmap, "min_size", 0);
+  if (pool_min_size < 0) {
+    ss << "pool min_size must be non-negative";
+    return -EINVAL;
+  }
 
   // unset stretch values
   p.peering_crush_bucket_count = 0;
   p.peering_crush_bucket_target = 0;
   p.peering_crush_bucket_barrier = 0;
+  p.crush_rule = static_cast<__u8>(crush_rule);
+  p.size = static_cast<__u8>(pool_size);
+  p.min_size = static_cast<__u8>(pool_min_size);
   p.last_change = pending_inc.epoch;
   pending_inc.new_pools[pool] = p;
   ss << "pool " << pool_name


### PR DESCRIPTION
**Problem:**
 
    When we enable stretched mode on the pools,
    we modify 6 configs on the pool,
    namely peering_crush_bucket_count,
    peering_crush_bucket_target,
    peering_crush_bucket_barrier,
    crush_rule, size, min_size.
    
    Out of these, only 3 configs,
    namely peering_crush_bucket_count,
    peering_crush_bucket_target,
    peering_crush_bucket_barrier is reset to 0.
    
    The remaining 3 configs,
    namely crush_rule, size,
    min_size are not reverted back,
    and are still the values that were set with stretch set command.
    
**Solution:**
    
    The unset command now is required
    to specify `crush_rule`, `size`, `min_size`.
    
    New command:
    
    ceph osd pool stretch unset {pool-name} {crush_rule} {size} {min_size}


Fixes: https://tracker.ceph.com/issues/68842

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
