### PR TITLE
Squid:Revert PR#59065 merge-A series of optimizations for kerneldevice discard

### DIFF
--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -292,7 +292,7 @@ public:
     int write_hint = WRITE_LIFE_NOT_SET) = 0;
   virtual int flush() = 0;
   virtual bool try_discard(interval_set<uint64_t> &to_release, bool async=true) { return false; }
-  virtual int discard_drain(uint32_t timeout_msec = 0) { return 0; }
+  virtual void discard_drain() { return; }
 
   // for managing buffered readers/writers
   virtual int invalidate_cache(uint64_t off, uint64_t len) = 0;

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -292,8 +292,8 @@ public:
     int write_hint = WRITE_LIFE_NOT_SET) = 0;
   virtual int flush() = 0;
   virtual bool try_discard(interval_set<uint64_t> &to_release, bool async=true) { return false; }
-  virtual void discard_drain() { return; }
-  virtual const interval_set<uint64_t>* get_discard_queued() { return nullptr;}
+  virtual int discard_drain(uint32_t timeout_msec = 0) { return 0; }
+
   // for managing buffered readers/writers
   virtual int invalidate_cache(uint64_t off, uint64_t len) = 0;
   virtual int open(const std::string& path) = 0;

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -293,7 +293,7 @@ public:
   virtual int flush() = 0;
   virtual bool try_discard(interval_set<uint64_t> &to_release, bool async=true) { return false; }
   virtual void discard_drain() { return; }
-  virtual void swap_discard_queued(interval_set<uint64_t>& other)  { other.clear(); }
+  virtual const interval_set<uint64_t>* get_discard_queued() { return nullptr;}
   // for managing buffered readers/writers
   virtual int invalidate_cache(uint64_t off, uint64_t len) = 0;
   virtual int open(const std::string& path) = 0;

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -65,10 +65,12 @@ KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, ai
     discard_callback(d_cb),
     discard_callback_priv(d_cbpriv),
     aio_stop(false),
+    discard_started(false),
+    discard_stop(false),
     aio_thread(this),
+    discard_thread(this),
     injecting_crash(0)
 {
-  cct->_conf.add_observer(this);
   fd_directs.resize(WRITE_LIFE_MAX, -1);
   fd_buffereds.resize(WRITE_LIFE_MAX, -1);
 
@@ -88,11 +90,6 @@ KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, ai
     }
     io_queue = std::make_unique<aio_queue_t>(iodepth);
   }
-}
-
-KernelDevice::~KernelDevice()
-{
-  cct->_conf.remove_observer(this);
 }
 
 int KernelDevice::_lock()
@@ -134,7 +131,6 @@ int KernelDevice::open(const string& p)
 {
   path = p;
   int r = 0, i = 0;
-  uint64_t num_discard_threads = 0;
   dout(1) << __func__ << " path " << path << dendl;
 
   struct stat statbuf;
@@ -285,9 +281,7 @@ int KernelDevice::open(const string& p)
   if (r < 0) {
     goto out_fail;
   }
-
-  num_discard_threads = cct->_conf.get_val<uint64_t>("bdev_async_discard_threads");
-  if (support_discard && cct->_conf->bdev_enable_discard && num_discard_threads > 0) {
+  if (support_discard && cct->_conf->bdev_enable_discard && cct->_conf->bdev_async_discard) {
     _discard_start();
   }
 
@@ -336,7 +330,7 @@ void KernelDevice::close()
 {
   dout(1) << __func__ << dendl;
   _aio_stop();
-  if (_discard_started()) {
+  if (discard_thread.is_started()) {
     _discard_stop();
   }
   _pre_close();
@@ -538,53 +532,26 @@ void KernelDevice::_aio_stop()
 
 void KernelDevice::_discard_start()
 {
-  uint64_t num = cct->_conf.get_val<uint64_t>("bdev_async_discard_threads");
-  dout(10) << __func__ << " starting " << num << " threads" << dendl;
-
-  std::unique_lock l(discard_lock);
-
-  target_discard_threads = num;
-  discard_threads.reserve(num);
-  for(uint64_t i = 0; i < num; i++)
-  {
-    // All threads created with the same name
-    discard_threads.emplace_back(new DiscardThread(this, i));
-    discard_threads.back()->create("bstore_discard");
-  }
-
-  dout(10) << __func__ << " started " << num << " threads" << dendl;
+    discard_thread.create("bstore_discard");
 }
 
 void KernelDevice::_discard_stop()
 {
   dout(10) << __func__ << dendl;
-
-  // Signal threads to stop, then wait for them to join
   {
     std::unique_lock l(discard_lock);
-    while (discard_threads.empty()) {
+    while (!discard_started) {
       discard_cond.wait(l);
     }
-
-    for(auto &t : discard_threads) {
-      t->stop = true;
-    }
-
+    discard_stop = true;
     discard_cond.notify_all();
   }
-
-  // Threads are shared pointers and are cleaned up for us
-  for(auto &t : discard_threads)
-    t->join();
-  discard_threads.clear();
-
+  discard_thread.join();
+  {
+    std::lock_guard l(discard_lock);
+    discard_stop = false;
+  }
   dout(10) << __func__ << " stopped" << dendl;
-}
-
-bool KernelDevice::_discard_started()
-{
-  std::unique_lock l(discard_lock);
-  return !discard_threads.empty();
 }
 
 void KernelDevice::discard_drain()
@@ -600,7 +567,7 @@ static bool is_expected_ioerr(const int r)
 {
   // https://lxr.missinglinkelectronics.com/linux+v4.15/block/blk-core.c#L135
   return (r == -EOPNOTSUPP || r == -ETIMEDOUT || r == -ENOSPC ||
-	  r == -ENOLINK || r == -EREMOTEIO || r == -EAGAIN || r == -EIO ||
+	  r == -ENOLINK || r == -EREMOTEIO  || r == -EAGAIN || r == -EIO ||
 	  r == -ENODATA || r == -EILSEQ || r == -ENOMEM ||
 #if defined(__linux__)
 	  r == -EREMCHG || r == -EBADE
@@ -731,57 +698,44 @@ void KernelDevice::_aio_thread()
   dout(10) << __func__ << " end" << dendl;
 }
 
-void KernelDevice::_discard_thread(uint64_t tid)
+void KernelDevice::_discard_thread()
 {
-  dout(10) << __func__ << " thread " << tid << " start" << dendl;
-
-  // Thread-local list of processing discards
-  interval_set<uint64_t> discard_processing;
-
   std::unique_lock l(discard_lock);
+  ceph_assert(!discard_started);
+  discard_started = true;
   discard_cond.notify_all();
-
-  // Keeps the shared pointer around until erased from the vector
-  // and until we leave this function
-  auto thr = discard_threads[tid];
-
   while (true) {
-    ceph_assert(discard_processing.empty());
+    ceph_assert(discard_finishing.empty());
     if (discard_queued.empty()) {
-      if (thr->stop)
+      if (discard_stop)
 	break;
       dout(20) << __func__ << " sleep" << dendl;
       discard_cond.notify_all(); // for the thread trying to drain...
       discard_cond.wait(l);
       dout(20) << __func__ << " wake" << dendl;
     } else {
-      // Swap the queued discards for a local list we'll process here
-      // without caring about thread fairness.  This allows the current
-      // thread to wait on the discard running while other threads pick
-      // up the next-in-queue, and do the same, ultimately issuing more
-      // discards in parallel, which is the goal.
-      discard_processing.swap(discard_queued);
+      discard_finishing.swap(discard_queued);
       discard_running = true;
       l.unlock();
       dout(20) << __func__ << " finishing" << dendl;
-      for (auto p = discard_processing.begin(); p != discard_processing.end(); ++p) {
-        _discard(p.get_start(), p.get_len());
+      for (auto p = discard_finishing.begin();p != discard_finishing.end(); ++p) {
+	_discard(p.get_start(), p.get_len());
       }
 
-      discard_callback(discard_callback_priv, static_cast<void*>(&discard_processing));
-      discard_processing.clear();
+      discard_callback(discard_callback_priv, static_cast<void*>(&discard_finishing));
+      discard_finishing.clear();
       l.lock();
       discard_running = false;
     }
   }
-
-  dout(10) << __func__ << " thread " << tid << " finish" << dendl;
+  dout(10) << __func__ << " finish" << dendl;
+  discard_started = false;
 }
 
 int KernelDevice::_queue_discard(interval_set<uint64_t> &to_release)
 {
   // if bdev_async_discard enabled on the fly, discard_thread is not started here, fallback to sync discard
-  if (!_discard_started())
+  if (!discard_thread.is_started())
     return -1;
 
   if (to_release.empty())
@@ -789,7 +743,7 @@ int KernelDevice::_queue_discard(interval_set<uint64_t> &to_release)
 
   std::lock_guard l(discard_lock);
   discard_queued.insert(to_release);
-  discard_cond.notify_one();
+  discard_cond.notify_all();
   return 0;
 }
 
@@ -800,7 +754,7 @@ bool KernelDevice::try_discard(interval_set<uint64_t> &to_release, bool async)
   if (!support_discard || !cct->_conf->bdev_enable_discard)
     return false;
 
-  if (async) {
+  if (async && discard_thread.is_started()) {
     return 0 == _queue_discard(to_release);
   } else {
     for (auto p = to_release.begin(); p != to_release.end(); ++p) {
@@ -1496,52 +1450,4 @@ int KernelDevice::invalidate_cache(uint64_t off, uint64_t len)
 	 << " error: " << cpp_strerror(r) << dendl;
   }
   return r;
-}
-
-const char** KernelDevice::get_tracked_conf_keys() const
-{
-  static const char* KEYS[] = {
-    "bdev_async_discard_threads",
-    NULL
-  };
-  return KEYS;
-}
-
-void KernelDevice::handle_conf_change(const ConfigProxy& conf,
-			     const std::set <std::string> &changed)
-{
-  if (changed.count("bdev_async_discard_threads")) {
-    std::unique_lock l(discard_lock);
-
-    uint64_t oldval = target_discard_threads;
-    uint64_t newval = cct->_conf.get_val<uint64_t>("bdev_async_discard_threads");
-
-    target_discard_threads = newval;
-
-    // Increase? Spawn now, it's quick
-    if (newval > oldval) {
-      dout(10) << __func__ << " starting " << (newval - oldval) << " additional discard threads" << dendl;
-      discard_threads.reserve(target_discard_threads);
-      for(uint64_t i = oldval; i < newval; i++)
-      {
-        // All threads created with the same name
-        discard_threads.emplace_back(new DiscardThread(this, i));
-        discard_threads.back()->create("bstore_discard");
-      }
-    } else {
-      // Decrease? Signal threads after telling them to stop
-      dout(10) << __func__ << " stopping " << (oldval - newval) << " existing discard threads" << dendl;
-
-      // Signal the last threads to quit, and stop tracking them
-      for(uint64_t i = oldval - 1; i >= newval; i--)
-      {
-        // Also detach the thread so we no longer need to join
-        discard_threads[i]->stop = true;
-        discard_threads[i]->detach();
-        discard_threads.erase(discard_threads.begin() + i);
-      }
-
-      discard_cond.notify_all();
-    }
-  }
 }

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -65,7 +65,6 @@ KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, ai
     discard_callback(d_cb),
     discard_callback_priv(d_cbpriv),
     aio_stop(false),
-    discard_stop(false),
     aio_thread(this),
     injecting_crash(0)
 {

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -587,13 +587,35 @@ bool KernelDevice::_discard_started()
   return !discard_threads.empty();
 }
 
-void KernelDevice::discard_drain()
+int KernelDevice::discard_drain(uint32_t timeout_msec = 0)
 {
   dout(10) << __func__ << dendl;
+  bool check_timeout = false;
+  utime_t end_time;
+  if (timeout_msec) {
+    check_timeout = true;
+    uint32_t timeout_sec = 0;
+    if (timeout_msec >= 1000) {
+      timeout_sec = (timeout_msec / 1000);
+      timeout_msec = (timeout_msec % 1000);
+    }
+    end_time = ceph_clock_now();
+    // add the timeout after converting from msec to nsec
+    end_time.tv.tv_nsec += (timeout_msec * (1000*1000));
+    if (end_time.tv.tv_nsec > (1000*1000*1000)) {
+      end_time.tv.tv_nsec -= (1000*1000*1000);
+      end_time.tv.tv_sec += 1;
+    }
+    end_time.tv.tv_sec += timeout_sec;
+  }
   std::unique_lock l(discard_lock);
   while (!discard_queued.empty() || discard_running) {
     discard_cond.wait(l);
+    if (check_timeout && ceph_clock_now() > end_time) {
+      return -1;
+    }
   }
+  return 0;
 }
 
 static bool is_expected_ioerr(const int r)

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -765,7 +765,7 @@ void KernelDevice::_discard_thread(uint64_t tid)
       // This will allow threads to work in parallel
       //      instead of a single thread taking over the whole discard_queued.
       // It will also allow threads to finish in a timely manner.
-      constexpr unsigned MAX_LOCAL_DISCARD = 32;
+      constexpr unsigned MAX_LOCAL_DISCARD = 10;
       unsigned count = 0;
       for (auto p = discard_queued.begin();
 	   p != discard_queued.end() && count < MAX_LOCAL_DISCARD;

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -55,7 +55,7 @@ private:
 
   ceph::mutex discard_lock = ceph::make_mutex("KernelDevice::discard_lock");
   ceph::condition_variable discard_cond;
-  int discard_running = 0;
+  bool discard_running = false;
   interval_set<uint64_t> discard_queued;
 
   struct AioCompletionThread : public Thread {
@@ -124,7 +124,7 @@ public:
 
   void aio_submit(IOContext *ioc) override;
   void discard_drain() override;
-  void swap_discard_queued(interval_set<uint64_t>& other) override;
+  const interval_set<uint64_t>* get_discard_queued() override { return &discard_queued;}
   int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const override;
   int get_devname(std::string *s) const override {
     if (devname.empty()) {

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -123,8 +123,8 @@ public:
   ~KernelDevice();
 
   void aio_submit(IOContext *ioc) override;
-  void discard_drain() override;
-  const interval_set<uint64_t>* get_discard_queued() override { return &discard_queued;}
+  int discard_drain(uint32_t timeout_msec) override;
+
   int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const override;
   int get_devname(std::string *s) const override {
     if (devname.empty()) {

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -52,7 +52,6 @@ private:
   aio_callback_t discard_callback;
   void *discard_callback_priv;
   bool aio_stop;
-  bool discard_stop;
 
   ceph::mutex discard_lock = ceph::make_mutex("KernelDevice::discard_lock");
   ceph::condition_variable discard_cond;
@@ -79,6 +78,7 @@ private:
     }
   };
   std::vector<std::shared_ptr<DiscardThread>> discard_threads;
+  uint64_t target_discard_threads = 0;
 
   std::atomic_int injecting_crash;
 
@@ -93,7 +93,7 @@ private:
   int _aio_start();
   void _aio_stop();
 
-  void _discard_update_threads();
+  void _discard_start();
   void _discard_stop();
   bool _discard_started();
 

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -123,7 +123,7 @@ public:
   ~KernelDevice();
 
   void aio_submit(IOContext *ioc) override;
-  int discard_drain(uint32_t timeout_msec) override;
+  void discard_drain() override;
 
   int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const override;
   int get_devname(std::string *s) const override {

--- a/src/blk/kernel/KernelDevice.h
+++ b/src/blk/kernel/KernelDevice.h
@@ -87,7 +87,7 @@ private:
 
   void _aio_thread();
   void _discard_thread(uint64_t tid);
-  void _queue_discard(interval_set<uint64_t> &to_release);
+  int _queue_discard(interval_set<uint64_t> &to_release);
   bool try_discard(interval_set<uint64_t> &to_release, bool async = true) override;
 
   int _aio_start();

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4023,18 +4023,31 @@ options:
   flags:
   - runtime
   see_also:
+  - bdev_async_discard
   - bdev_async_discard_threads
-- name: bdev_async_discard_threads
-  desc: number of discard threads used to issue discards to the device
+- name: bdev_async_discard
+  desc: send discards to the block device in one or more threads
   type: uint
   level: advanced
-  default: 0
-  min: 0
+  default: false
   with_legacy: false
   flags:
   - runtime
   see_also:
   - bdev_enable_discard
+  - bdev_async_discard_threads
+- name: bdev_async_discard_threads
+  desc: number of discard threads used to issue discards to the device
+  type: uint
+  level: advanced
+  default: 1
+  min: 1
+  with_legacy: false
+  flags:
+  - runtime
+  see_also:
+  - bdev_enable_discard
+  - bdev_async_discard
 - name: bdev_flock_retry_interval
   type: float
   level: advanced

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4015,39 +4015,15 @@ options:
   default: false
   with_legacy: true
 - name: bdev_enable_discard
-  desc: send discards to the block device
   type: bool
   level: advanced
   default: false
   with_legacy: true
-  flags:
-  - runtime
-  see_also:
-  - bdev_async_discard
-  - bdev_async_discard_threads
 - name: bdev_async_discard
-  desc: send discards to the block device in one or more threads
-  type: uint
+  type: bool
   level: advanced
   default: false
-  with_legacy: false
-  flags:
-  - runtime
-  see_also:
-  - bdev_enable_discard
-  - bdev_async_discard_threads
-- name: bdev_async_discard_threads
-  desc: number of discard threads used to issue discards to the device
-  type: uint
-  level: advanced
-  default: 1
-  min: 1
-  with_legacy: false
-  flags:
-  - runtime
-  see_also:
-  - bdev_enable_discard
-  - bdev_async_discard
+  with_legacy: true
 - name: bdev_flock_retry_interval
   type: float
   level: advanced

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8043,20 +8043,16 @@ void BlueStore::_close_db()
       bdev->discard_drain();
     }
 
-    interval_set<uint64_t> discard_queued;
-    bdev->swap_discard_queued(discard_queued);
-    if (discard_queued.num_intervals() > 0) {
-      dout(10) << __func__ << "::discard_drain: size=" << discard_queued.size()
-	       << " num_intervals=" << discard_queued.num_intervals() << dendl;
+    auto discard_queued = bdev->get_discard_queued();
+    if (discard_queued && (discard_queued->num_intervals() > 0)) {
+      dout(10) << __func__ << "::discard_drain: size=" << discard_queued->size()
+	       << " num_intervals=" << discard_queued->num_intervals() << dendl;
       // copy discard_queued to the allocator before storing it
-      for (auto p = discard_queued.begin(); p != discard_queued.end(); ++p) {
+      for (auto p = discard_queued->begin(); p != discard_queued->end(); ++p) {
 	dout(20) << __func__ << "::discarded-extent=[" << p.get_start() << ", " << p.get_len() << "]" << dendl;
 	alloc->init_add_free(p.get_start(), p.get_len());
       }
     }
-    // drain the items in the threads local discard_processing queues
-    // There are only a few items in those queues so it is fine to do so in fast shutdown
-    bdev->discard_drain();
     int ret = store_allocator(alloc);
     if (unlikely(ret != 0)) {
       derr << __func__ << "::NCB::store_allocator() failed (we will need to rebuild it on startup)" << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8038,17 +8038,9 @@ void BlueStore::_close_db()
   db = nullptr;
 
   if (do_destage && fm && fm->is_null_manager()) {
-    // force all backgrounds discards to be committed before storing allocator
-    // set timeout to 500msec
-    int ret = bdev->discard_drain(500);
-    if (ret == 0) {
-      ret = store_allocator(alloc);
-      if (unlikely(ret != 0)) {
-	derr << __func__ << "::NCB::store_allocator() failed (we will need to rebuild it on startup)" << dendl;
-      }
-    }
-    else {
-      derr << __func__ << "::NCB::discard_drain() exceeded timeout (abort!)" << dendl;
+    int ret = store_allocator(alloc);
+    if (ret != 0) {
+      derr << __func__ << "::NCB::store_allocator() failed (continue with bitmapFreelistManager)" << dendl;
     }
   }
 


### PR DESCRIPTION

I accidentally merged the PR#59065pull request. To rectify this, I have created a new pull request to revert the merge and restore the previous, correct state of the codebase.

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [x] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
