### PR TITLE
rgw: build with WITH_RADOSGW_SELECT_PARQUET=OFF

### DIFF
--- a/src/rgw/rgw_s3select.cc
+++ b/src/rgw/rgw_s3select.cc
@@ -745,6 +745,7 @@ void RGWSelectObj_ObjStore_S3::execute(optional_yield y)
   }
 
   if (m_parquet_type) {
+    # ifdef _ARROW_EXIST
     //parquet processing
     range_request(0, 4, parquet_magic, y);
     if (memcmp(parquet_magic, parquet_magic1, 4) && memcmp(parquet_magic, parquet_magicE, 4)) {
@@ -772,6 +773,7 @@ void RGWSelectObj_ObjStore_S3::execute(optional_yield y)
        
       ldout(s->cct, 10) << "S3select: complete parquet query with success " << dendl;
     }
+    # endif
     } else { 
 	//CSV or JSON processing
 	if (m_scan_range_ind) {


### PR DESCRIPTION
When the `WITH_RADOSGW_SELECT_PARQUET` flag is set to OFF, the `_ARROW_EXIST` directive is set to `false`. When the directive is set to `false`, the `m_s3_parquet_object` doesn't get declared (see [here]( https://github.com/ceph/ceph/blob/406e52faef1c14feba767dc5df653fb836c7040a/src/rgw/rgw_s3select_private.h#L195)). This causes an issue in `rgw_s3select.cc` where this [line](https://github.com/ceph/ceph/blob/406e52faef1c14feba767dc5df653fb836c7040a/src/rgw/rgw_s3select.cc#L765) fails to compile. Added the directives around this code block to check if `_ARROW_EXIST` is set to `true` to allow for compilation.


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
