### PR TITLE
reef: qa/tasks/fwd_scrub: remove unnecessary traceback

### DIFF
--- a/qa/tasks/fwd_scrub.py
+++ b/qa/tasks/fwd_scrub.py
@@ -36,6 +36,8 @@ class ForwardScrubber(Thrasher, Greenlet):
     def _run(self):
         try:
             self.do_scrub()
+        except ThrasherGreenlet.Stopped:
+            pass
         except Exception as e:
             self.set_thrasher_exception(e)
             self.logger.exception("exception:")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68700

---

backport of https://github.com/ceph/ceph/pull/59002
parent tracker: https://tracker.ceph.com/issues/65820

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh