### PR TITLE
crimson/os/seastore: support partial read for data extents

### DIFF
--- a/src/common/options/crimson.yaml.in
+++ b/src/common/options/crimson.yaml.in
@@ -105,8 +105,8 @@ options:
 - name: seastore_max_data_allocation_size
   type: size
   level: advanced
-  desc: Max size in bytes that an extent can be
-  default: 32_K
+  desc: Max size in bytes that an extent can be, 0 to disable
+  default: 0
 - name: seastore_cache_lru_size
   type: size
   level: advanced

--- a/src/crimson/common/fixed_kv_node_layout.h
+++ b/src/crimson/common/fixed_kv_node_layout.h
@@ -360,10 +360,15 @@ public:
   }
 
 
-  FixedKVNodeLayout(char *buf) :
-    buf(buf) {}
+  FixedKVNodeLayout() : buf(nullptr) {}
 
   virtual ~FixedKVNodeLayout() = default;
+
+  void set_layout_buf(char *_buf) {
+    assert(buf == nullptr);
+    assert(_buf != nullptr);
+    buf = _buf;
+  }
 
   const_iterator begin() const {
     return const_iterator(

--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -4,6 +4,7 @@ set(crimson_seastore_srcs
   segment_manager.cc
   segment_manager/ephemeral.cc
   segment_manager/block.cc
+  transaction_interruptor.cc
   transaction_manager.cc
   transaction.cc
   cache.cc

--- a/src/crimson/os/seastore/backref/btree_backref_manager.cc
+++ b/src/crimson/os/seastore/backref/btree_backref_manager.cc
@@ -28,28 +28,22 @@ const get_phy_tree_root_node_ret get_phy_tree_root_node<
     ceph_assert(backref_root->is_initial_pending()
       == root_block->is_pending());
     return {true,
-	    trans_intr::make_interruptible(
-	      c.cache.get_extent_viewable_by_trans(c.trans, backref_root))};
+            c.cache.get_extent_viewable_by_trans(c.trans, backref_root)};
   } else if (root_block->is_pending()) {
     auto &prior = static_cast<RootBlock&>(*root_block->get_prior_instance());
     backref_root = prior.backref_root_node;
     if (backref_root) {
       return {true,
-	      trans_intr::make_interruptible(
-		c.cache.get_extent_viewable_by_trans(c.trans, backref_root))};
+              c.cache.get_extent_viewable_by_trans(c.trans, backref_root)};
     } else {
       c.cache.account_absent_access(c.trans.get_src());
       return {false,
-	      trans_intr::make_interruptible(
-		Cache::get_extent_ertr::make_ready_future<
-		  CachedExtentRef>())};
+              Cache::get_extent_iertr::make_ready_future<CachedExtentRef>()};
     }
   } else {
     c.cache.account_absent_access(c.trans.get_src());
     return {false,
-	    trans_intr::make_interruptible(
-	      Cache::get_extent_ertr::make_ready_future<
-		CachedExtentRef>())};
+            Cache::get_extent_iertr::make_ready_future<CachedExtentRef>()};
   }
 }
 

--- a/src/crimson/os/seastore/btree/fixed_kv_btree.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_btree.h
@@ -32,10 +32,6 @@ inline ChildableCachedExtent* get_reserved_ptr() {
 template <typename T>
 phy_tree_root_t& get_phy_tree_root(root_t& r);
 
-using get_child_iertr =
-  ::crimson::interruptible::interruptible_errorator<
-    typename trans_intr::condition,
-    get_child_ertr>;
 using get_phy_tree_root_node_ret =
   std::pair<bool, get_child_iertr::future<CachedExtentRef>>;
 
@@ -1501,7 +1497,7 @@ private:
     // checking the lba child must be atomic with creating
     // and linking the absent child
     if (v.has_child()) {
-      return trans_intr::make_interruptible(std::move(v.get_child_fut())
+      return std::move(v.get_child_fut()
       ).si_then([on_found=std::move(on_found), node_iter, c,
                 parent_entry](auto child) {
         LOG_PREFIX(FixedKVBtree::lookup_internal_level);
@@ -1571,7 +1567,7 @@ private:
     // checking the lba child must be atomic with creating
     // and linking the absent child
     if (v.has_child()) {
-      return trans_intr::make_interruptible(std::move(v.get_child_fut())
+      return std::move(v.get_child_fut()
       ).si_then([on_found=std::move(on_found), node_iter, c,
                 parent_entry](auto child) {
         LOG_PREFIX(FixedKVBtree::lookup_leaf);
@@ -2126,7 +2122,7 @@ private:
     // checking the lba child must be atomic with creating
     // and linking the absent child
     if (v.has_child()) {
-      return trans_intr::make_interruptible(std::move(v.get_child_fut())
+      return std::move(v.get_child_fut()
       ).si_then([do_merge=std::move(do_merge), &pos,
                 donor_iter, donor_is_left, c, parent_pos](auto child) {
         LOG_PREFIX(FixedKVBtree::merge_level);

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -165,6 +165,11 @@ struct FixedKVNode : ChildableCachedExtent {
     : ChildableCachedExtent(std::move(ptr)),
       children(capacity, nullptr),
       capacity(capacity) {}
+  // Must be identical with FixedKVNode(capacity, ptr) after on_fully_loaded()
+  explicit FixedKVNode(uint16_t capacity, extent_len_t length)
+    : ChildableCachedExtent(length),
+      children(capacity, nullptr),
+      capacity(capacity) {}
   FixedKVNode(const FixedKVNode &rhs)
     : ChildableCachedExtent(rhs),
       range(rhs.range),
@@ -708,12 +713,17 @@ struct FixedKVInternalNode
     node_size,
     node_type_t>;
 
-  FixedKVInternalNode(ceph::bufferptr &&ptr)
-    : FixedKVNode<NODE_KEY>(CAPACITY, std::move(ptr)),
-      node_layout_t(this->get_bptr().c_str()) {}
+  explicit FixedKVInternalNode(ceph::bufferptr &&ptr)
+    : FixedKVNode<NODE_KEY>(CAPACITY, std::move(ptr)) {
+    this->set_layout_buf(this->get_bptr().c_str());
+  }
+  // Must be identical with FixedKVInternalNode(ptr) after on_fully_loaded()
+  explicit FixedKVInternalNode(extent_len_t length)
+    : FixedKVNode<NODE_KEY>(CAPACITY, length) {}
   FixedKVInternalNode(const FixedKVInternalNode &rhs)
-    : FixedKVNode<NODE_KEY>(rhs),
-      node_layout_t(this->get_bptr().c_str()) {}
+    : FixedKVNode<NODE_KEY>(rhs) {
+    this->set_layout_buf(this->get_bptr().c_str());
+  }
 
   bool have_children() const final {
     return true;
@@ -985,6 +995,10 @@ struct FixedKVInternalNode
       pivot);
   }
 
+  void on_fully_loaded() final {
+    this->set_layout_buf(this->get_bptr().c_str());
+  }
+
   /**
    * Internal relative addresses on read or in memory prior to commit
    * are either record or block relative depending on whether this
@@ -1121,13 +1135,18 @@ struct FixedKVLeafNode
     node_type_t,
     has_children>;
   using base_t = FixedKVNode<NODE_KEY>;
-  FixedKVLeafNode(ceph::bufferptr &&ptr)
-    : FixedKVNode<NODE_KEY>(has_children ? CAPACITY : 0, std::move(ptr)),
-      node_layout_t(this->get_bptr().c_str()) {}
+  explicit FixedKVLeafNode(ceph::bufferptr &&ptr)
+    : FixedKVNode<NODE_KEY>(has_children ? CAPACITY : 0, std::move(ptr)) {
+    this->set_layout_buf(this->get_bptr().c_str());
+  }
+  // Must be identical with FixedKVLeafNode(ptr) after on_fully_loaded()
+  explicit FixedKVLeafNode(extent_len_t length)
+    : FixedKVNode<NODE_KEY>(has_children ? CAPACITY : 0, length) {}
   FixedKVLeafNode(const FixedKVLeafNode &rhs)
     : FixedKVNode<NODE_KEY>(rhs),
-      node_layout_t(this->get_bptr().c_str()),
-      modifications(rhs.modifications) {}
+      modifications(rhs.modifications) {
+    this->set_layout_buf(this->get_bptr().c_str());
+  }
 
   static constexpr bool do_has_children = has_children;
   // for the stable extent, modifications is always 0;
@@ -1232,6 +1251,10 @@ struct FixedKVLeafNode
 	parent->children[off] = nullptr;
       }
     }
+  }
+
+  void on_fully_loaded() final {
+    this->set_layout_buf(this->get_bptr().c_str());
   }
 
   void prepare_commit() final {

--- a/src/crimson/os/seastore/btree/fixed_kv_node.h
+++ b/src/crimson/os/seastore/btree/fixed_kv_node.h
@@ -994,8 +994,7 @@ struct FixedKVInternalNode
    * resolve_relative_addrs fixes up relative internal references
    * based on base.
    */
-  void resolve_relative_addrs(paddr_t base)
-  {
+  void resolve_relative_addrs(paddr_t base) final {
     LOG_PREFIX(FixedKVInternalNode::resolve_relative_addrs);
     for (auto i: *this) {
       if (i->get_val().is_relative()) {

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -2003,7 +2003,8 @@ Cache::replay_delta(
         [this](CachedExtent &ext) {
           // replay is not included by the cache hit metrics
           touch_extent(ext, nullptr);
-        }) :
+        },
+        nullptr) :
       _get_extent_if_cached(
 	delta.paddr)
     ).handle_error(
@@ -2166,7 +2167,8 @@ Cache::do_get_caching_extent_by_type(
   laddr_t laddr,
   extent_len_t length,
   extent_init_func_t &&extent_init_func,
-  extent_init_func_t &&on_cache)
+  extent_init_func_t &&on_cache,
+  const Transaction::src_t* p_src)
 {
   return [=, this, extent_init_func=std::move(extent_init_func)]() mutable {
     switch (type) {
@@ -2175,61 +2177,61 @@ Cache::do_get_caching_extent_by_type(
       return get_extent_ertr::make_ready_future<CachedExtentRef>();
     case extent_types_t::BACKREF_INTERNAL:
       return do_get_caching_extent<backref::BackrefInternalNode>(
-	offset, length, std::move(extent_init_func), std::move(on_cache)
+	offset, length, std::move(extent_init_func), std::move(on_cache), p_src
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::BACKREF_LEAF:
       return do_get_caching_extent<backref::BackrefLeafNode>(
-	offset, length, std::move(extent_init_func), std::move(on_cache)
+	offset, length, std::move(extent_init_func), std::move(on_cache), p_src
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::LADDR_INTERNAL:
       return do_get_caching_extent<lba_manager::btree::LBAInternalNode>(
-	offset, length, std::move(extent_init_func), std::move(on_cache)
+	offset, length, std::move(extent_init_func), std::move(on_cache), p_src
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::LADDR_LEAF:
       return do_get_caching_extent<lba_manager::btree::LBALeafNode>(
-	offset, length, std::move(extent_init_func), std::move(on_cache)
+	offset, length, std::move(extent_init_func), std::move(on_cache), p_src
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::ROOT_META:
       return do_get_caching_extent<RootMetaBlock>(
-	offset, length, std::move(extent_init_func), std::move(on_cache)
+	offset, length, std::move(extent_init_func), std::move(on_cache), p_src
       ).safe_then([](auto extent) {
         return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::OMAP_INNER:
       return do_get_caching_extent<omap_manager::OMapInnerNode>(
-          offset, length, std::move(extent_init_func), std::move(on_cache)
+        offset, length, std::move(extent_init_func), std::move(on_cache), p_src
       ).safe_then([](auto extent) {
         return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::OMAP_LEAF:
       return do_get_caching_extent<omap_manager::OMapLeafNode>(
-          offset, length, std::move(extent_init_func), std::move(on_cache)
+        offset, length, std::move(extent_init_func), std::move(on_cache), p_src
       ).safe_then([](auto extent) {
         return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::COLL_BLOCK:
       return do_get_caching_extent<collection_manager::CollectionNode>(
-          offset, length, std::move(extent_init_func), std::move(on_cache)
+        offset, length, std::move(extent_init_func), std::move(on_cache), p_src
       ).safe_then([](auto extent) {
         return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::ONODE_BLOCK_STAGED:
       return do_get_caching_extent<onode::SeastoreNodeExtent>(
-          offset, length, std::move(extent_init_func), std::move(on_cache)
+        offset, length, std::move(extent_init_func), std::move(on_cache), p_src
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::OBJECT_DATA_BLOCK:
       return do_get_caching_extent<ObjectDataBlock>(
-          offset, length, std::move(extent_init_func), std::move(on_cache)
+        offset, length, std::move(extent_init_func), std::move(on_cache), p_src
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
@@ -2238,13 +2240,13 @@ Cache::do_get_caching_extent_by_type(
       return get_extent_ertr::make_ready_future<CachedExtentRef>();
     case extent_types_t::TEST_BLOCK:
       return do_get_caching_extent<TestBlock>(
-          offset, length, std::move(extent_init_func), std::move(on_cache)
+        offset, length, std::move(extent_init_func), std::move(on_cache), p_src
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::TEST_BLOCK_PHYSICAL:
       return do_get_caching_extent<TestBlockPhysical>(
-          offset, length, std::move(extent_init_func), std::move(on_cache)
+        offset, length, std::move(extent_init_func), std::move(on_cache), p_src
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -1826,7 +1826,7 @@ void Cache::init()
     remove_extent(root, nullptr);
     root = nullptr;
   }
-  root = new RootBlock();
+  root = CachedExtent::make_cached_extent_ref<RootBlock>();
   root->init(CachedExtent::extent_state_t::CLEAN,
              P_ADDR_ROOT,
              PLACEMENT_HINT_NULL,

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -411,7 +411,7 @@ public:
 	assert(!ret->is_mutable());
         SUBDEBUGT(seastore_cache, "{} {}~{} is present on t without been \
           fully loaded, reading ... {}", t, T::TYPE, offset, length, *ret);
-        auto bp = alloc_cache_buf(ret->get_length());
+        auto bp = create_extent_ptr_rand(ret->get_length());
         ret->set_bptr(std::move(bp));
         return read_extent<T>(
           ret->cast<T>());
@@ -592,7 +592,7 @@ public:
         "{} {}~{} is present without been fully loaded, reading ... -- {}",
         p_extent->get_type(), p_extent->get_paddr(),p_extent->get_length(),
         *p_extent);
-      auto bp = alloc_cache_buf(p_extent->get_length());
+      auto bp = create_extent_ptr_rand(p_extent->get_length());
       p_extent->set_bptr(std::move(bp));
       return read_extent<CachedExtent>(CachedExtentRef(p_extent));
     }
@@ -647,7 +647,7 @@ private:
     auto cached = query_cache(offset);
     if (!cached) {
       auto ret = CachedExtent::make_cached_extent_ref<T>(
-        alloc_cache_buf(length));
+        create_extent_ptr_rand(length));
       ret->init(CachedExtent::extent_state_t::CLEAN_PENDING,
                 offset,
                 PLACEMENT_HINT_NULL,
@@ -667,7 +667,7 @@ private:
     // extent PRESENT in cache
     if (is_retired_placeholder_type(cached->get_type())) {
       auto ret = CachedExtent::make_cached_extent_ref<T>(
-        alloc_cache_buf(length));
+        create_extent_ptr_rand(length));
       ret->init(CachedExtent::extent_state_t::CLEAN_PENDING,
                 offset,
                 PLACEMENT_HINT_NULL,
@@ -695,7 +695,7 @@ private:
       SUBDEBUG(seastore_cache,
         "{} {}~{} is present without been fully loaded, reading ... -- {}",
         T::TYPE, offset, length, *ret);
-      auto bp = alloc_cache_buf(length);
+      auto bp = create_extent_ptr_rand(length);
       ret->set_bptr(std::move(bp));
       return read_extent<T>(
         std::move(ret));
@@ -791,7 +791,7 @@ private:
 	assert(!ret->is_mutable());
         SUBDEBUGT(seastore_cache, "{} {}~{} {} is present on t without been \
                   fully loaded, reading ...", t, type, offset, length, laddr);
-        auto bp = alloc_cache_buf(ret->get_length());
+        auto bp = create_extent_ptr_rand(ret->get_length());
         ret->set_bptr(std::move(bp));
         return read_extent<CachedExtent>(
           std::move(ret));
@@ -1762,15 +1762,6 @@ private:
 
   seastar::metrics::metric_group metrics;
   void register_metrics();
-
-  /// alloc buffer for cached extent
-  bufferptr alloc_cache_buf(size_t size) {
-    // TODO: memory pooling etc
-    auto bp = ceph::bufferptr(
-      buffer::create_page_aligned(size));
-    bp.zero();
-    return bp;
-  }
 
   void backref_batch_update(
     std::vector<backref_entry_ref> &&,

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -1068,7 +1068,7 @@ public:
       // (relative/temp) paddr, so make extent directly
       ext = CachedExtent::make_cached_extent_ref<T>(std::move(nbp));
     } else {
-      ext = CachedExtent::make_placeholder_cached_extent_ref<T>(remap_length);
+      ext = CachedExtent::make_cached_extent_ref<T>(remap_length);
     }
 
     ext->init(CachedExtent::extent_state_t::EXIST_CLEAN,

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -182,4 +182,183 @@ std::ostream &operator<<(std::ostream &out, const lba_pin_list_t &rhs)
   return out << ']';
 }
 
+bool BufferSpace::is_range_loaded(extent_len_t offset, extent_len_t length) const
+{
+  assert(length > 0);
+  auto i = buffer_map.upper_bound(offset);
+  if (i == buffer_map.begin()) {
+    return false;
+  }
+  --i;
+  auto& [i_offset, i_bl] = *i;
+  assert(offset >= i_offset);
+  assert(i_bl.length() > 0);
+  if (offset + length > i_offset + i_bl.length()) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+ceph::bufferlist BufferSpace::get_buffer(extent_len_t offset, extent_len_t length) const
+{
+  assert(length > 0);
+  auto i = buffer_map.upper_bound(offset);
+  assert(i != buffer_map.begin());
+  --i;
+  auto& [i_offset, i_bl] = *i;
+  assert(offset >= i_offset);
+  assert(i_bl.length() > 0);
+  assert(offset + length <= i_offset + i_bl.length());
+  ceph::bufferlist res;
+  res.substr_of(i_bl, offset - i_offset, length);
+  return res;
+}
+
+load_ranges_t BufferSpace::load_ranges(extent_len_t offset, extent_len_t length)
+{
+  assert(length > 0);
+  load_ranges_t ret;
+  auto next = buffer_map.upper_bound(offset);
+
+  // must be assigned for the main-loop
+  map_t::iterator previous;
+  extent_len_t range_offset;
+  extent_len_t range_length;
+
+  // returns whether to proceed main-loop or not
+  auto f_merge_next_check_hole = [this, &next, &range_offset, &range_length](
+      ceph::bufferlist& previous_bl,
+      extent_len_t hole_length,
+      extent_len_t next_offset,
+      const ceph::bufferlist& next_bl) {
+    range_length -= hole_length;
+    previous_bl.append(next_bl);
+    if (range_length <= next_bl.length()) {
+      // "next" end includes or beyonds the range
+      buffer_map.erase(next);
+      return false;
+    } else {
+      range_offset = next_offset + next_bl.length();
+      range_length -= next_bl.length();
+      // erase next should destruct next_bl
+      next = buffer_map.erase(next);
+      return true;
+    }
+  };
+
+  // returns whether to proceed main-loop or not
+  auto f_prepare_without_merge_previous = [
+      this, offset, length,
+      &ret, &previous, &next, &range_length,
+      &f_merge_next_check_hole]() {
+    if (next == buffer_map.end()) {
+      // "next" reaches end,
+      // range has no "next" to merge
+      create_hole_insert_map(ret, offset, length, next);
+      return false;
+    }
+    // "next" is valid
+    auto& [n_offset, n_bl] = *next;
+    // next is from upper_bound()
+    assert(offset < n_offset);
+    extent_len_t hole_length = n_offset - offset;
+    if (length < hole_length) {
+      // "next" is beyond the range end,
+      // range has no "next" to merge
+      create_hole_insert_map(ret, offset, length, next);
+      return false;
+    }
+    // length >= hole_length
+    // insert hole as "previous"
+    previous = create_hole_insert_map(ret, offset, hole_length, next);
+    auto& p_bl = previous->second;
+    range_length = length;
+    return f_merge_next_check_hole(p_bl, hole_length, n_offset, n_bl);
+  };
+
+  /*
+   * prepare main-loop
+   */
+  if (next == buffer_map.begin()) {
+    // "previous" is invalid
+    if (!f_prepare_without_merge_previous()) {
+      return ret;
+    }
+  } else {
+    // "previous" is valid
+    previous = std::prev(next);
+    auto& [p_offset, p_bl] = *previous;
+    assert(offset >= p_offset);
+    extent_len_t p_end = p_offset + p_bl.length();
+    if (offset <= p_end) {
+      // "previous" is adjacent or overlaps the range
+      range_offset = p_end;
+      assert(offset + length > p_end);
+      range_length = offset + length - p_end;
+      // start the main-loop (merge "previous")
+    } else {
+      // "previous" is not adjacent to the range
+      // range and buffer_map should not overlap
+      assert(offset > p_end);
+      if (!f_prepare_without_merge_previous()) {
+        return ret;
+      }
+    }
+  }
+
+  /*
+   * main-loop: merge the range with "previous" and look at "next"
+   *
+   * "previous": the previous buffer_map entry, must be valid, must be mergable
+   * "next": the next buffer_map entry, maybe end, maybe mergable
+   * range_offset/length: the current range right after "previous"
+   */
+  assert(std::next(previous) == next);
+  auto& [p_offset, p_bl] = *previous;
+  assert(range_offset == p_offset + p_bl.length());
+  assert(range_length > 0);
+  while (next != buffer_map.end()) {
+    auto& [n_offset, n_bl] = *next;
+    assert(range_offset < n_offset);
+    extent_len_t hole_length = n_offset - range_offset;
+    if (range_length < hole_length) {
+      // "next" offset is beyond the range end
+      break;
+    }
+    // range_length >= hole_length
+    create_hole_append_bl(ret, p_bl, range_offset, hole_length);
+    if (!f_merge_next_check_hole(p_bl, hole_length, n_offset, n_bl)) {
+      return ret;
+    }
+    assert(std::next(previous) == next);
+    assert(range_offset == p_offset + p_bl.length());
+    assert(range_length > 0);
+  }
+  // range has no "next" to merge:
+  // 1. "next" reaches end
+  // 2. "next" offset is beyond the range end
+  create_hole_append_bl(ret, p_bl, range_offset, range_length);
+  return ret;
+}
+
+ceph::bufferptr BufferSpace::to_full_ptr(extent_len_t length)
+{
+  assert(length > 0);
+  assert(buffer_map.size() == 1);
+  auto it = buffer_map.begin();
+  auto& [i_off, i_buf] = *it;
+  assert(i_off == 0);
+  if (!i_buf.is_contiguous()) {
+    // Allocate page aligned ptr, also see create_extent_ptr_*()
+    i_buf.rebuild();
+  }
+  assert(i_buf.get_num_buffers() == 1);
+  ceph::bufferptr ptr(i_buf.front());
+  assert(ptr.is_page_aligned());
+  assert(ptr.length() == length);
+  buffer_map.clear();
+  return ptr;
+}
+
 }

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -94,15 +94,15 @@ CachedExtent* CachedExtent::get_transactional_view(transaction_id_t tid) {
 }
 
 std::ostream &operator<<(std::ostream &out, const parent_tracker_t &tracker) {
-  return out << "parent_tracker=" << (void*)&tracker
-	     << ", parent=" << (void*)tracker.get_parent().get();
+  return out << "tracker_ptr=" << (void*)&tracker
+	     << ", parent_ptr=" << (void*)tracker.get_parent().get();
 }
 
 std::ostream &ChildableCachedExtent::print_detail(std::ostream &out) const {
   if (parent_tracker) {
-    out << *parent_tracker;
+    out << ", parent_tracker(" << *parent_tracker << ")";
   } else {
-    out << ", parent_tracker=" << (void*)nullptr;
+    out << ", parent_tracker(nullptr)";
   }
   _print_detail(out);
   return out;

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -824,16 +824,16 @@ protected:
   }
 
   // 0 length is only possible for the RootBlock
-  struct zero_length_t {};
-  CachedExtent(zero_length_t)
+  struct root_construct_t {};
+  CachedExtent(root_construct_t)
     : ptr(ceph::bufferptr(0)),
       length(0) {
     assert(is_fully_loaded());
     // must call init() to fully initialize
   }
 
-  struct retired_placeholder_t{};
-  CachedExtent(retired_placeholder_t, extent_len_t _length)
+  struct retired_placeholder_construct_t {};
+  CachedExtent(retired_placeholder_construct_t, extent_len_t _length)
     : state(extent_state_t::CLEAN),
       length(_length) {
     assert(length > 0);
@@ -1254,7 +1254,7 @@ class RetiredExtentPlaceholder : public CachedExtent {
 
 public:
   RetiredExtentPlaceholder(extent_len_t length)
-    : CachedExtent(CachedExtent::retired_placeholder_t{}, length) {}
+    : CachedExtent(CachedExtent::retired_placeholder_construct_t{}, length) {}
 
   CachedExtentRef duplicate_for_write(Transaction&) final {
     ceph_assert(0 == "Should never happen for a placeholder");

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -816,9 +816,8 @@ protected:
   }
 
   template <typename T>
-  static TCachedExtentRef<T> make_placeholder_cached_extent_ref(
-    extent_len_t length) {
-    return new T(length);
+  static TCachedExtentRef<T> make_cached_extent_ref() {
+    return new T();
   }
 
   void reset_prior_instance() {

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -41,6 +41,18 @@ void intrusive_ptr_release(CachedExtent *);
 
 #endif
 
+inline ceph::bufferptr create_extent_ptr_rand(extent_len_t len) {
+  assert(is_aligned(len, CEPH_PAGE_SIZE));
+  assert(len > 0);
+  return ceph::bufferptr(buffer::create_page_aligned(len));
+}
+
+inline ceph::bufferptr create_extent_ptr_zero(extent_len_t len) {
+  auto bp = create_extent_ptr_rand(len);
+  bp.zero();
+  return bp;
+}
+
 template <typename T>
 using TCachedExtentRef = boost::intrusive_ptr<T>;
 
@@ -762,7 +774,7 @@ protected:
       poffset(other.poffset) {
       assert((length % CEPH_PAGE_SIZE) == 0);
       if (other.is_fully_loaded()) {
-        ptr.emplace(buffer::create_page_aligned(length));
+        ptr = create_extent_ptr_rand(length);
         other.ptr->copy_out(0, length, ptr->c_str());
       } else {
         // the extent must be fully loaded before CoW

--- a/src/crimson/os/seastore/collection_manager/collection_flat_node.h
+++ b/src/crimson/os/seastore/collection_manager/collection_flat_node.h
@@ -96,6 +96,8 @@ struct CollectionNode
 
   explicit CollectionNode(ceph::bufferptr &&ptr)
     : LogicalCachedExtent(std::move(ptr)) {}
+  explicit CollectionNode(extent_len_t length)
+    : LogicalCachedExtent(length) {}
   explicit CollectionNode(const CollectionNode &other)
     : LogicalCachedExtent(other),
       decoded(other.decoded) {}

--- a/src/crimson/os/seastore/collection_manager/flat_collection_manager.cc
+++ b/src/crimson/os/seastore/collection_manager/flat_collection_manager.cc
@@ -51,8 +51,11 @@ FlatCollectionManager::get_coll_root(const coll_root_t &coll_root, Transaction &
     cc.t,
     coll_root.get_location(),
     coll_root.get_size()
-  ).si_then([](auto&& e) {
-    return get_root_iertr::make_ready_future<CollectionNodeRef>(std::move(e));
+  ).si_then([](auto maybe_indirect_extent) {
+    assert(!maybe_indirect_extent.is_indirect());
+    assert(!maybe_indirect_extent.is_clone);
+    return get_root_iertr::make_ready_future<CollectionNodeRef>(
+        std::move(maybe_indirect_extent.extent));
   });
 }
 

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -371,9 +371,7 @@ public:
 
     // XXX: bp might be extended to point to different memory (e.g. PMem)
     // according to the allocator.
-    auto bp = ceph::bufferptr(
-      buffer::create_page_aligned(length));
-    bp.zero();
+    auto bp = create_extent_ptr_zero(length);
 
     return alloc_result_t{addr, std::move(bp), gen};
   }
@@ -405,9 +403,7 @@ public:
 #ifdef UNIT_TESTS_BUILT
     if (unlikely(external_paddr.has_value())) {
       assert(external_paddr->is_fake());
-      auto bp = ceph::bufferptr(
-        buffer::create_page_aligned(length));
-      bp.zero();
+      auto bp = create_extent_ptr_zero(length);
       allocs.emplace_back(alloc_result_t{*external_paddr, std::move(bp), gen});
     } else {
 #else
@@ -419,8 +415,7 @@ public:
         auto left = ext.len;
         while (left > 0) {
           auto len = std::min(max_data_allocation_size, left);
-          auto bp = ceph::bufferptr(buffer::create_page_aligned(len));
-          bp.zero();
+          auto bp = create_extent_ptr_zero(len);
           auto start = ext.start.is_delayed()
                         ? ext.start
                         : ext.start + (ext.len - left);

--- a/src/crimson/os/seastore/extent_placement_manager.h
+++ b/src/crimson/os/seastore/extent_placement_manager.h
@@ -414,7 +414,10 @@ public:
       for (auto &ext : addrs) {
         auto left = ext.len;
         while (left > 0) {
-          auto len = std::min(max_data_allocation_size, left);
+          auto len = left;
+          if (max_data_allocation_size) {
+            len = std::min(max_data_allocation_size, len);
+          }
           auto bp = create_extent_ptr_zero(len);
           auto start = ext.start.is_delayed()
                         ? ext.start

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -52,28 +52,22 @@ const get_phy_tree_root_node_ret get_phy_tree_root_node<
     ceph_assert(lba_root->is_initial_pending()
       == root_block->is_pending());
     return {true,
-	    trans_intr::make_interruptible(
-	      c.cache.get_extent_viewable_by_trans(c.trans, lba_root))};
+            c.cache.get_extent_viewable_by_trans(c.trans, lba_root)};
   } else if (root_block->is_pending()) {
     auto &prior = static_cast<RootBlock&>(*root_block->get_prior_instance());
     lba_root = prior.lba_root_node;
     if (lba_root) {
       return {true,
-	      trans_intr::make_interruptible(
-		c.cache.get_extent_viewable_by_trans(c.trans, lba_root))};
+              c.cache.get_extent_viewable_by_trans(c.trans, lba_root)};
     } else {
       c.cache.account_absent_access(c.trans.get_src());
       return {false,
-	      trans_intr::make_interruptible(
-		Cache::get_extent_ertr::make_ready_future<
-		  CachedExtentRef>())};
+              Cache::get_extent_iertr::make_ready_future<CachedExtentRef>()};
     }
   } else {
     c.cache.account_absent_access(c.trans.get_src());
     return {false,
-	    trans_intr::make_interruptible(
-	      Cache::get_extent_ertr::make_ready_future<
-		CachedExtentRef>())};
+            Cache::get_extent_iertr::make_ready_future<CachedExtentRef>()};
   }
 }
 

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -259,7 +259,7 @@ struct LBALeafNode
   }
 
   // See LBAInternalNode, same concept
-  void resolve_relative_addrs(paddr_t base);
+  void resolve_relative_addrs(paddr_t base) final;
   void node_resolve_vals(
     internal_iterator_t from,
     internal_iterator_t to) const final

--- a/src/crimson/os/seastore/object_data_handler.cc
+++ b/src/crimson/os/seastore/object_data_handler.cc
@@ -50,6 +50,8 @@ struct extent_to_write_t {
 
   extent_to_write_t(const extent_to_write_t &) = delete;
   extent_to_write_t(extent_to_write_t &&) = default;
+  extent_to_write_t& operator=(const extent_to_write_t&) = delete;
+  extent_to_write_t& operator=(extent_to_write_t&&) = default;
 
   bool is_data() const {
     return type == type_t::DATA;
@@ -827,7 +829,7 @@ namespace crimson::os::seastore {
  */
 using operate_ret_bare = std::pair<
   std::optional<extent_to_write_t>,
-  std::optional<bufferptr>>;
+  std::optional<ceph::bufferlist>>;
 using operate_ret = get_iertr::future<operate_ret_bare>;
 operate_ret operate_left(context_t ctx, LBAMappingRef &pin, const overwrite_plan_t &overwrite_plan)
 {
@@ -839,19 +841,26 @@ operate_ret operate_left(context_t ctx, LBAMappingRef &pin, const overwrite_plan
 
   if (overwrite_plan.left_operation == overwrite_operation_t::OVERWRITE_ZERO) {
     assert(pin->get_val().is_zero());
+
     auto zero_extent_len = overwrite_plan.get_left_extent_size();
     assert_aligned(zero_extent_len);
+    std::optional<extent_to_write_t> extent_to_write;
+    if (zero_extent_len != 0) {
+      extent_to_write = extent_to_write_t::create_zero(
+         overwrite_plan.pin_begin, zero_extent_len);
+    }
+
     auto zero_prepend_len = overwrite_plan.get_left_alignment_size();
+    std::optional<ceph::bufferlist> prepend_bl;
+    if (zero_prepend_len != 0) {
+      ceph::bufferlist zero_bl;
+      zero_bl.append_zero(zero_prepend_len);
+      prepend_bl = std::move(zero_bl);
+    }
+
     return get_iertr::make_ready_future<operate_ret_bare>(
-      (zero_extent_len == 0
-       ? std::nullopt
-       : std::make_optional(extent_to_write_t::create_zero(
-           overwrite_plan.pin_begin, zero_extent_len))),
-      (zero_prepend_len == 0
-       ? std::nullopt
-       : std::make_optional(bufferptr(
-           ceph::buffer::create(zero_prepend_len, 0))))
-    );
+      std::move(extent_to_write),
+      std::move(prepend_bl));
   } else if (overwrite_plan.left_operation == overwrite_operation_t::MERGE_EXISTING) {
     auto prepend_len = overwrite_plan.get_left_size();
     if (prepend_len == 0) {
@@ -862,12 +871,12 @@ operate_ret operate_left(context_t ctx, LBAMappingRef &pin, const overwrite_plan
       return ctx.tm.read_pin<ObjectDataBlock>(
 	ctx.t, pin->duplicate()
       ).si_then([prepend_len](auto maybe_indirect_left_extent) {
+        auto read_bl = maybe_indirect_left_extent.get_bl();
+        ceph::bufferlist prepend_bl;
+        prepend_bl.substr_of(read_bl, 0, prepend_len);
         return get_iertr::make_ready_future<operate_ret_bare>(
           std::nullopt,
-          std::make_optional(bufferptr(
-            maybe_indirect_left_extent.get_bptr(),
-            0,
-            prepend_len)));
+          std::move(prepend_bl));
       });
     }
   } else {
@@ -892,12 +901,12 @@ operate_ret operate_left(context_t ctx, LBAMappingRef &pin, const overwrite_plan
       ).si_then([prepend_offset=extent_len, prepend_len,
                  left_to_write_extent=std::move(left_to_write_extent)]
                 (auto left_maybe_indirect_extent) mutable {
+        auto read_bl = left_maybe_indirect_extent.get_bl();
+        ceph::bufferlist prepend_bl;
+        prepend_bl.substr_of(read_bl, prepend_offset, prepend_len);
         return get_iertr::make_ready_future<operate_ret_bare>(
           std::move(left_to_write_extent),
-          std::make_optional(bufferptr(
-            left_maybe_indirect_extent.get_bptr(),
-            prepend_offset,
-            prepend_len)));
+          std::move(prepend_bl));
       });
     }
   }
@@ -920,19 +929,26 @@ operate_ret operate_right(context_t ctx, LBAMappingRef &pin, const overwrite_pla
   assert(overwrite_plan.data_end >= right_pin_begin);
   if (overwrite_plan.right_operation == overwrite_operation_t::OVERWRITE_ZERO) {
     assert(pin->get_val().is_zero());
+
     auto zero_suffix_len = overwrite_plan.get_right_alignment_size();
+    std::optional<ceph::bufferlist> suffix_bl;
+    if (zero_suffix_len != 0) {
+      ceph::bufferlist zero_bl;
+      zero_bl.append_zero(zero_suffix_len);
+      suffix_bl = std::move(zero_bl);
+    }
+
     auto zero_extent_len = overwrite_plan.get_right_extent_size();
     assert_aligned(zero_extent_len);
+    std::optional<extent_to_write_t> extent_to_write;
+    if (zero_extent_len != 0) {
+      extent_to_write = extent_to_write_t::create_zero(
+        overwrite_plan.aligned_data_end, zero_extent_len);
+    }
+
     return get_iertr::make_ready_future<operate_ret_bare>(
-      (zero_extent_len == 0
-       ? std::nullopt
-       : std::make_optional(extent_to_write_t::create_zero(
-           overwrite_plan.aligned_data_end, zero_extent_len))),
-      (zero_suffix_len == 0
-       ? std::nullopt
-       : std::make_optional(bufferptr(
-           ceph::buffer::create(zero_suffix_len, 0))))
-    );
+      std::move(extent_to_write),
+      std::move(suffix_bl));
   } else if (overwrite_plan.right_operation == overwrite_operation_t::MERGE_EXISTING) {
     auto append_len = overwrite_plan.get_right_size();
     if (append_len == 0) {
@@ -947,12 +963,12 @@ operate_ret operate_right(context_t ctx, LBAMappingRef &pin, const overwrite_pla
 	ctx.t, pin->duplicate()
       ).si_then([append_offset, append_len]
                 (auto right_maybe_indirect_extent) {
+        auto read_bl = right_maybe_indirect_extent.get_bl();
+        ceph::bufferlist suffix_bl;
+        suffix_bl.substr_of(read_bl, append_offset, append_len);
         return get_iertr::make_ready_future<operate_ret_bare>(
           std::nullopt,
-          std::make_optional(bufferptr(
-            right_maybe_indirect_extent.get_bptr(),
-            append_offset,
-            append_len)));
+          std::move(suffix_bl));
       });
     }
   } else {
@@ -980,12 +996,12 @@ operate_ret operate_right(context_t ctx, LBAMappingRef &pin, const overwrite_pla
       ).si_then([append_offset, append_len,
                  right_to_write_extent=std::move(right_to_write_extent)]
                 (auto maybe_indirect_right_extent) mutable {
+        auto read_bl = maybe_indirect_right_extent.get_bl();
+        ceph::bufferlist suffix_bl;
+        suffix_bl.substr_of(read_bl, append_offset, append_len);
         return get_iertr::make_ready_future<operate_ret_bare>(
           std::move(right_to_write_extent),
-          std::make_optional(bufferptr(
-            maybe_indirect_right_extent.get_bptr(),
-            append_offset,
-            append_len)));
+          std::move(suffix_bl));
       });
     }
   }
@@ -1134,21 +1150,17 @@ ObjectDataHandler::clear_ret ObjectDataHandler::trim_data_reservation(
               pin.duplicate()
             ).si_then([ctx, size, pin_offset, append_len, roundup_size,
                       &pin, &object_data, &to_write](auto maybe_indirect_extent) {
-              bufferlist bl;
-	      bl.append(
-	        bufferptr(
-	          maybe_indirect_extent.get_bptr(),
-	          0,
-	          size - pin_offset
-	      ));
-              bl.append_zero(append_len);
+              auto read_bl = maybe_indirect_extent.get_bl();
+              ceph::bufferlist write_bl;
+              write_bl.substr_of(read_bl, 0, size - pin_offset);
+              write_bl.append_zero(append_len);
               LOG_PREFIX(ObjectDataHandler::trim_data_reservation);
               TRACET("First pin overlaps the boundary and has unaligned data"
                 "create data at addr:{}, len:{}",
-                ctx.t, pin.get_key(), bl.length());
+                ctx.t, pin.get_key(), write_bl.length());
 	      to_write.push_back(extent_to_write_t::create_data(
 	        pin.get_key(),
-	        bl));
+	        write_bl));
 	      to_write.push_back(extent_to_write_t::create_zero(
 	        (object_data.get_reserved_data_base() + roundup_size).checked_to_laddr(),
 	        object_data.get_reserved_data_len() - roundup_size));
@@ -1181,44 +1193,45 @@ ObjectDataHandler::clear_ret ObjectDataHandler::trim_data_reservation(
  * get_to_writes_with_zero_buffer
  *
  * Returns extent_to_write_t's reflecting a zero region extending
- * from offset~len with headptr optionally on the left and tailptr
+ * from offset~len with headbl optionally on the left and tailbl
  * optionally on the right.
  */
 extent_to_write_list_t get_to_writes_with_zero_buffer(
   laddr_t data_base,
   const extent_len_t block_size,
   objaddr_t offset, extent_len_t len,
-  std::optional<bufferptr> &&headptr, std::optional<bufferptr> &&tailptr)
+  std::optional<ceph::bufferlist> &&headbl,
+  std::optional<ceph::bufferlist> &&tailbl)
 {
   auto zero_left = p2roundup(offset, (objaddr_t)block_size);
   auto zero_right = p2align(offset + len, (objaddr_t)block_size);
-  auto left = headptr ? (offset - headptr->length()) : offset;
-  auto right = tailptr ?
-    (offset + len + tailptr->length()) :
+  auto left = headbl ? (offset - headbl->length()) : offset;
+  auto right = tailbl ?
+    (offset + len + tailbl->length()) :
     (offset + len);
 
   assert(
-    (headptr && ((zero_left - left) ==
-		 p2roundup(headptr->length(), block_size))) ^
-    (!headptr && (zero_left == left)));
+    (headbl && ((zero_left - left) ==
+		 p2roundup(headbl->length(), block_size))) ^
+    (!headbl && (zero_left == left)));
   assert(
-    (tailptr && ((right - zero_right) ==
-		 p2roundup(tailptr->length(), block_size))) ^
-    (!tailptr && (right == zero_right)));
+    (tailbl && ((right - zero_right) ==
+		 p2roundup(tailbl->length(), block_size))) ^
+    (!tailbl && (right == zero_right)));
 
   assert(right > left);
 
   // zero region too small for a reserved section,
-  // headptr and tailptr in same extent
+  // headbl and tailbl in same extent
   if (zero_right <= zero_left) {
     bufferlist bl;
-    if (headptr) {
-      bl.append(*headptr);
+    if (headbl) {
+      bl.append(*headbl);
     }
     bl.append_zero(
-      right - left - bl.length() - (tailptr ? tailptr->length() : 0));
-    if (tailptr) {
-      bl.append(*tailptr);
+      right - left - bl.length() - (tailbl ? tailbl->length() : 0));
+    if (tailbl) {
+      bl.append(*tailbl);
     }
     assert(bl.length() % block_size == 0);
     assert(bl.length() == (right - left));
@@ -1227,16 +1240,16 @@ extent_to_write_list_t get_to_writes_with_zero_buffer(
       (data_base + left).checked_to_laddr(), bl));
     return ret;
   } else {
-    // reserved section between ends, headptr and tailptr in different extents
+    // reserved section between ends, headbl and tailbl in different extents
     extent_to_write_list_t ret;
-    if (headptr) {
-      bufferlist headbl;
-      headbl.append(*headptr);
-      headbl.append_zero(zero_left - left - headbl.length());
-      assert(headbl.length() % block_size == 0);
-      assert(headbl.length() > 0);
+    if (headbl) {
+      bufferlist head_zero_bl;
+      head_zero_bl.append(*headbl);
+      head_zero_bl.append_zero(zero_left - left - head_zero_bl.length());
+      assert(head_zero_bl.length() % block_size == 0);
+      assert(head_zero_bl.length() > 0);
       ret.push_back(extent_to_write_t::create_data(
-		      (data_base + left).checked_to_laddr(), headbl));
+        (data_base + left).checked_to_laddr(), head_zero_bl));
     }
     // reserved zero region
     ret.push_back(extent_to_write_t::create_zero(
@@ -1244,14 +1257,14 @@ extent_to_write_list_t get_to_writes_with_zero_buffer(
       zero_right - zero_left));
     assert(ret.back().len % block_size == 0);
     assert(ret.back().len > 0);
-    if (tailptr) {
-      bufferlist tailbl;
-      tailbl.append(*tailptr);
-      tailbl.append_zero(right - zero_right - tailbl.length());
-      assert(tailbl.length() % block_size == 0);
-      assert(tailbl.length() > 0);
+    if (tailbl) {
+      bufferlist tail_zero_bl;
+      tail_zero_bl.append(*tailbl);
+      tail_zero_bl.append_zero(right - zero_right - tail_zero_bl.length());
+      assert(tail_zero_bl.length() % block_size == 0);
+      assert(tail_zero_bl.length() > 0);
       ret.push_back(extent_to_write_t::create_data(
-        (data_base + zero_right).checked_to_laddr(), tailbl));
+        (data_base + zero_right).checked_to_laddr(), tail_zero_bl));
     }
     return ret;
   }
@@ -1303,13 +1316,13 @@ ObjectDataHandler::write_ret ObjectDataHandler::overwrite(
       overwrite_plan
     ).si_then([ctx, data_base, len, offset, overwrite_plan, bl=std::move(bl),
                &to_write, &pins, this](auto p) mutable {
-      auto &[left_extent, headptr] = p;
+      auto &[left_extent, headbl] = p;
       if (left_extent) {
         ceph_assert(left_extent->addr == overwrite_plan.pin_begin);
         append_extent_to_write(to_write, std::move(*left_extent));
       }
-      if (headptr) {
-        assert(headptr->length() > 0);
+      if (headbl) {
+        assert(headbl->length() > 0);
       }
       return operate_right(
         ctx,
@@ -1318,19 +1331,19 @@ ObjectDataHandler::write_ret ObjectDataHandler::overwrite(
       ).si_then([ctx, data_base, len, offset,
                  pin_begin=overwrite_plan.pin_begin,
                  pin_end=overwrite_plan.pin_end,
-                 bl=std::move(bl), headptr=std::move(headptr),
+                 bl=std::move(bl), headbl=std::move(headbl),
                  &to_write, &pins, this](auto p) mutable {
-        auto &[right_extent, tailptr] = p;
+        auto &[right_extent, tailbl] = p;
         if (bl.has_value()) {
           auto write_offset = offset;
           bufferlist write_bl;
-          if (headptr) {
-            write_bl.append(*headptr);
-            write_offset = write_offset - headptr->length();
+          if (headbl) {
+            write_bl.append(*headbl);
+            write_offset = write_offset - headbl->length();
           }
           write_bl.claim_append(*bl);
-          if (tailptr) {
-            write_bl.append(*tailptr);
+          if (tailbl) {
+            write_bl.append(*tailbl);
             assert_aligned(write_bl.length());
           }
           splice_extent_to_write(
@@ -1344,8 +1357,8 @@ ObjectDataHandler::write_ret ObjectDataHandler::overwrite(
               ctx.tm.get_block_size(),
               offset,
               len,
-              std::move(headptr),
-              std::move(tailptr)));
+              std::move(headbl),
+              std::move(tailbl)));
         }
         if (right_extent) {
           ceph_assert(right_extent->get_end_addr() == pin_end);

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node.h
@@ -48,7 +48,8 @@ struct OMapNode : LogicalCachedExtent {
       need_merge(n_merge) {}
   };
 
-  OMapNode(ceph::bufferptr &&ptr) : LogicalCachedExtent(std::move(ptr)) {}
+  explicit OMapNode(ceph::bufferptr &&ptr) : LogicalCachedExtent(std::move(ptr)) {}
+  explicit OMapNode(extent_len_t length) : LogicalCachedExtent(length) {}
   OMapNode(const OMapNode &other)
   : LogicalCachedExtent(other) {}
 

--- a/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
+++ b/src/crimson/os/seastore/omap_manager/btree/omap_btree_node_impl.h
@@ -31,10 +31,18 @@ struct OMapInnerNode
     StringKVInnerNodeLayout {
   using OMapInnerNodeRef = TCachedExtentRef<OMapInnerNode>;
   using internal_iterator_t = const_iterator;
-  template <typename... T>
-  OMapInnerNode(T&&... t) :
-    OMapNode(std::forward<T>(t)...),
-    StringKVInnerNodeLayout(get_bptr().c_str()) {}
+
+  explicit OMapInnerNode(ceph::bufferptr &&ptr)
+    : OMapNode(std::move(ptr)) {
+    this->set_layout_buf(this->get_bptr().c_str());
+  }
+  // Must be identical with OMapInnerNode(ptr) after on_fully_loaded()
+  explicit OMapInnerNode(extent_len_t length)
+    : OMapNode(length) {}
+  OMapInnerNode(const OMapInnerNode &rhs)
+    : OMapNode(rhs) {
+    this->set_layout_buf(this->get_bptr().c_str());
+  }
 
   omap_node_meta_t get_node_meta() const final { return get_meta(); }
   bool extent_will_overflow(size_t ksize, std::optional<size_t> vsize) const {
@@ -45,6 +53,10 @@ struct OMapInnerNode
   }
   bool extent_is_below_min() const { return below_min(); }
   uint32_t get_node_size() { return get_size(); }
+
+  void on_fully_loaded() final {
+    this->set_layout_buf(this->get_bptr().c_str());
+  }
 
   CachedExtentRef duplicate_for_write(Transaction&) final {
     assert(delta_buffer.empty());
@@ -148,10 +160,18 @@ struct OMapLeafNode
 
   using OMapLeafNodeRef = TCachedExtentRef<OMapLeafNode>;
   using internal_iterator_t = const_iterator;
-  template <typename... T>
-  OMapLeafNode(T&&... t) :
-    OMapNode(std::forward<T>(t)...),
-    StringKVLeafNodeLayout(get_bptr().c_str()) {}
+
+  explicit OMapLeafNode(ceph::bufferptr &&ptr)
+    : OMapNode(std::move(ptr)) {
+    this->set_layout_buf(this->get_bptr().c_str());
+  }
+  // Must be identical with OMapLeafNode(ptr) after on_fully_loaded()
+  explicit OMapLeafNode(extent_len_t length)
+    : OMapNode(length) {}
+  OMapLeafNode(const OMapLeafNode &rhs)
+    : OMapNode(rhs) {
+    this->set_layout_buf(this->get_bptr().c_str());
+  }
 
   omap_node_meta_t get_node_meta() const final { return get_meta(); }
   bool extent_will_overflow(
@@ -163,6 +183,10 @@ struct OMapLeafNode
   }
   bool extent_is_below_min() const { return below_min(); }
   uint32_t get_node_size() { return get_size(); }
+
+  void on_fully_loaded() final {
+    this->set_layout_buf(this->get_bptr().c_str());
+  }
 
   CachedExtentRef duplicate_for_write(Transaction&) final {
     assert(delta_buffer.empty());

--- a/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
+++ b/src/crimson/os/seastore/omap_manager/btree/string_kv_node_layout.h
@@ -504,8 +504,13 @@ public:
     inner_remove(iter);
   }
 
-  StringKVInnerNodeLayout(char *buf) :
-    buf(buf) {}
+  StringKVInnerNodeLayout() : buf(nullptr) {}
+
+  void set_layout_buf(char *_buf) {
+    assert(buf == nullptr);
+    assert(_buf != nullptr);
+    buf = _buf;
+  }
 
   uint32_t get_size() const {
     ceph_le32 &size = *layout.template Pointer<0>(buf);
@@ -1120,8 +1125,13 @@ public:
     leaf_remove(iter);
   }
 
-  StringKVLeafNodeLayout(char *buf) :
-    buf(buf) {}
+  StringKVLeafNodeLayout() : buf(nullptr) {}
+
+  void set_layout_buf(char *_buf) {
+    assert(buf == nullptr);
+    assert(_buf != nullptr);
+    buf = _buf;
+  }
 
   const_iterator iter_begin() const {
     return const_iterator(

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -111,10 +111,14 @@ class SeastoreNodeExtentManager final: public TransactionManagerHandle {
       }
     }
     return tm.read_extent<SeastoreNodeExtent>(t, addr
-    ).si_then([addr, &t](auto&& e) -> read_iertr::future<NodeExtentRef> {
+    ).si_then([addr, &t](auto maybe_indirect_extent)
+              -> read_iertr::future<NodeExtentRef> {
+      auto e = maybe_indirect_extent.extent;
       SUBTRACET(seastore_onode,
           "read {}B at {} -- {}",
           t, e->get_length(), e->get_laddr(), *e);
+      assert(!maybe_indirect_extent.is_indirect());
+      assert(!maybe_indirect_extent.is_clone);
       assert(e->get_laddr() == addr);
       std::ignore = addr;
       return read_iertr::make_ready_future<NodeExtentRef>(e);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -41,8 +41,10 @@ class SeastoreSuper final: public Super {
 
 class SeastoreNodeExtent final: public NodeExtent {
  public:
-  SeastoreNodeExtent(ceph::bufferptr &&ptr)
+  explicit SeastoreNodeExtent(ceph::bufferptr &&ptr)
     : NodeExtent(std::move(ptr)) {}
+  explicit SeastoreNodeExtent(extent_len_t length)
+    : NodeExtent(length) {}
   SeastoreNodeExtent(const SeastoreNodeExtent& other)
     : NodeExtent(other) {}
   ~SeastoreNodeExtent() override = default;

--- a/src/crimson/os/seastore/root_block.h
+++ b/src/crimson/os/seastore/root_block.h
@@ -41,7 +41,7 @@ struct RootBlock : CachedExtent {
   CachedExtent* lba_root_node = nullptr;
   CachedExtent* backref_root_node = nullptr;
 
-  RootBlock() : CachedExtent(zero_length_t()) {};
+  RootBlock() : CachedExtent(root_construct_t()) {};
 
   RootBlock(const RootBlock &rhs)
     : CachedExtent(rhs),

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -13,11 +13,11 @@
 #include "crimson/os/seastore/seastore_types.h"
 #include "crimson/os/seastore/cached_extent.h"
 #include "crimson/os/seastore/root_block.h"
+#include "crimson/os/seastore/transaction_interruptor.h"
 
 namespace crimson::os::seastore {
 
 class SeaStore;
-class Transaction;
 
 struct io_stat_t {
   uint64_t num = 0;
@@ -684,63 +684,6 @@ inline TransactionRef make_test_transaction() {
     ++next_id
   );
 }
-
-struct TransactionConflictCondition {
-  class transaction_conflict final : public std::exception {
-  public:
-    const char* what() const noexcept final {
-      return "transaction conflict detected";
-    }
-  };
-
-public:
-  TransactionConflictCondition(Transaction &t) : t(t) {}
-
-  template <typename Fut>
-  std::optional<Fut> may_interrupt() {
-    if (t.conflicted) {
-      return seastar::futurize<Fut>::make_exception_future(
-	transaction_conflict());
-    } else {
-      return std::optional<Fut>();
-    }
-  }
-
-  template <typename T>
-  static constexpr bool is_interruption_v =
-    std::is_same_v<T, transaction_conflict>;
-
-
-  static bool is_interruption(std::exception_ptr& eptr) {
-    return *eptr.__cxa_exception_type() == typeid(transaction_conflict);
-  }
-
-private:
-  Transaction &t;
-};
-
-using trans_intr = crimson::interruptible::interruptor<
-  TransactionConflictCondition
-  >;
-
-template <typename E>
-using trans_iertr =
-  crimson::interruptible::interruptible_errorator<
-    TransactionConflictCondition,
-    E
-  >;
-
-template <typename F, typename... Args>
-auto with_trans_intr(Transaction &t, F &&f, Args&&... args) {
-  return trans_intr::with_interruption_to_error<crimson::ct_error::eagain>(
-    std::move(f),
-    TransactionConflictCondition(t),
-    t,
-    std::forward<Args>(args)...);
-}
-
-template <typename T>
-using with_trans_ertr = typename T::base_ertr::template extend<crimson::ct_error::eagain>;
 
 }
 

--- a/src/crimson/os/seastore/transaction_interruptor.cc
+++ b/src/crimson/os/seastore/transaction_interruptor.cc
@@ -1,0 +1,15 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "crimson/os/seastore/transaction_interruptor.h"
+
+#include "crimson/os/seastore/transaction.h"
+
+namespace crimson::os::seastore {
+
+bool TransactionConflictCondition::is_conflicted() const
+{
+  return t.conflicted;
+}
+
+}

--- a/src/crimson/os/seastore/transaction_interruptor.h
+++ b/src/crimson/os/seastore/transaction_interruptor.h
@@ -1,0 +1,77 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <exception>
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+#include "crimson/common/errorator.h"
+#include "crimson/common/interruptible_future.h"
+
+namespace crimson::os::seastore {
+
+class Transaction;
+
+struct TransactionConflictCondition {
+  class transaction_conflict final : public std::exception {
+  public:
+    const char* what() const noexcept final {
+      return "transaction conflict detected";
+    }
+  };
+
+public:
+  TransactionConflictCondition(Transaction &t) : t(t) {}
+
+  template <typename Fut>
+  std::optional<Fut> may_interrupt() {
+    if (is_conflicted()) {
+      return seastar::futurize<Fut>::make_exception_future(
+	transaction_conflict());
+    } else {
+      return std::optional<Fut>();
+    }
+  }
+
+  template <typename T>
+  static constexpr bool is_interruption_v =
+    std::is_same_v<T, transaction_conflict>;
+
+
+  static bool is_interruption(std::exception_ptr& eptr) {
+    return *eptr.__cxa_exception_type() == typeid(transaction_conflict);
+  }
+
+private:
+  bool is_conflicted() const;
+
+  Transaction &t;
+};
+
+using trans_intr = crimson::interruptible::interruptor<
+  TransactionConflictCondition
+  >;
+
+template <typename E>
+using trans_iertr =
+  crimson::interruptible::interruptible_errorator<
+    TransactionConflictCondition,
+    E
+  >;
+
+template <typename F, typename... Args>
+auto with_trans_intr(Transaction &t, F &&f, Args&&... args) {
+  return trans_intr::with_interruption_to_error<crimson::ct_error::eagain>(
+    std::move(f),
+    TransactionConflictCondition(t),
+    t,
+    std::forward<Args>(args)...);
+}
+
+template <typename T>
+using with_trans_ertr = typename T::base_ertr::template extend<crimson::ct_error::eagain>;
+
+} // namespace crimson::os::seastore

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -137,14 +137,46 @@ public:
   }
 
   /**
+   * maybe_indirect_extent_t
+   *
+   * Contains necessary information in case the extent is loaded from an
+   * indirect pin.
+   */
+  struct indirect_info_t {
+    extent_len_t intermediate_offset = 0;
+    extent_len_t length = 0;
+  };
+  template <typename T>
+  struct maybe_indirect_extent_t {
+    TCachedExtentRef<T> extent;
+    std::optional<indirect_info_t> maybe_indirect_info;
+    bool is_clone = false;
+
+    bool is_indirect() const {
+      return maybe_indirect_info.has_value();
+    }
+
+    ceph::bufferptr get_bptr() const {
+      if (is_indirect()) {
+        return ceph::bufferptr(
+            extent->get_bptr(),
+            maybe_indirect_info->intermediate_offset,
+            maybe_indirect_info->length);
+      } else {
+        return extent->get_bptr();
+      }
+    }
+  };
+
+  /**
    * read_extent
    *
    * Read extent of type T at offset~length
    */
   using read_extent_iertr = get_pin_iertr;
   template <typename T>
-  using read_extent_ret = read_extent_iertr::future<
-    TCachedExtentRef<T>>;
+  using read_extent_ret =
+    read_extent_iertr::future<maybe_indirect_extent_t<T>>;
   template <typename T>
   read_extent_ret<T> read_extent(
     Transaction &t,
@@ -192,10 +224,16 @@ public:
   }
 
   template <typename T>
-  base_iertr::future<TCachedExtentRef<T>> read_pin(
+  base_iertr::future<maybe_indirect_extent_t<T>> read_pin(
     Transaction &t,
     LBAMappingRef pin)
   {
+    bool is_clone = pin->is_clone();
+    std::optional<indirect_info_t> maybe_indirect_info;
+    if (pin->is_indirect()) {
+      maybe_indirect_info = indirect_info_t{
+        pin->get_intermediate_offset(), pin->get_length()};
+    }
     LOG_PREFIX(TransactionManager::read_pin);
     SUBDEBUGT(seastore_tm, "{} {} ...", t, T::TYPE, *pin);
     auto fut = base_iertr::make_ready_future<LBAMappingRef>();
@@ -223,9 +261,16 @@ public:
       } else {
 	return this->pin_to_extent<T>(t, std::move(std::get<0>(ret)));
       }
-    }).si_then([FNAME, &t](TCachedExtentRef<T> ext) {
-      SUBDEBUGT(seastore_tm, "got {}", t, *ext);
-      return ext;
+    }).si_then([FNAME, maybe_indirect_info, is_clone, &t](TCachedExtentRef<T> ext) {
+      if (maybe_indirect_info.has_value()) {
+        SUBDEBUGT(seastore_tm, "got indirect +0x{:x}~0x{:x} is_clone={} {}",
+                  t, maybe_indirect_info->intermediate_offset,
+                  maybe_indirect_info->length, is_clone, *ext);
+      } else {
+        SUBDEBUGT(seastore_tm, "got direct is_clone={} {}",
+                  t, is_clone, *ext);
+      }
+      return maybe_indirect_extent_t<T>{ext, maybe_indirect_info, is_clone};
     });
   }
 
@@ -355,7 +400,8 @@ public:
   }
 
   template <typename T>
-  read_extent_ret<T> get_mutable_extent_by_laddr(
+  get_pin_iertr::future<TCachedExtentRef<T>>
+  get_mutable_extent_by_laddr(
       Transaction &t,
       laddr_t laddr,
       extent_len_t len) {
@@ -367,8 +413,11 @@ public:
       ceph_assert(!pin->is_clone());
       ceph_assert(pin->get_length() == len);
       return this->read_pin<T>(t, std::move(pin));
-    }).si_then([this, &t, FNAME](auto extent) {
-      auto ext = get_mutable_extent(t, extent)->template cast<T>();
+    }).si_then([this, &t, FNAME](auto maybe_indirect_extent) {
+      assert(!maybe_indirect_extent.is_indirect());
+      assert(!maybe_indirect_extent.is_clone);
+      auto ext = get_mutable_extent(
+          t, maybe_indirect_extent.extent)->template cast<T>();
       SUBDEBUGT(seastore_tm, "got mutable {}", t, *ext);
       return read_extent_iertr::make_ready_future<TCachedExtentRef<T>>(
 	std::move(ext));
@@ -431,6 +480,7 @@ public:
       // The according extent might be stable or pending.
       auto fut = base_iertr::now();
       if (!pin->is_indirect()) {
+        ceph_assert(!pin->is_clone());
 	if (!pin->is_parent_viewable()) {
 	  if (pin->is_parent_valid()) {
 	    pin = pin->refresh_with_pending_parent();
@@ -451,7 +501,12 @@ public:
 
 	fut = fut.si_then([this, &t, &pin] {
 	  if (full_extent_integrity_check) {
-	    return read_pin<T>(t, pin->duplicate());
+	    return read_pin<T>(t, pin->duplicate()
+            ).si_then([](auto maybe_indirect_extent) {
+              assert(!maybe_indirect_extent.is_indirect());
+              assert(!maybe_indirect_extent.is_clone);
+              return maybe_indirect_extent.extent;
+            });
 	  } else {
 	    auto ret = get_extent_if_linked<T>(t, pin->duplicate());
 	    if (ret.index() == 1) {
@@ -685,8 +740,11 @@ public:
       t
     ).si_then([&t, this](auto root) {
       return read_extent<RootMetaBlock>(t, root->root.meta);
-    }).si_then([key, &t](auto mblock) {
+    }).si_then([key, &t](auto maybe_indirect_extent) {
       LOG_PREFIX(TransactionManager::read_root_meta);
+      assert(!maybe_indirect_extent.is_indirect());
+      assert(!maybe_indirect_extent.is_clone);
+      auto& mblock = maybe_indirect_extent.extent;
       auto meta = mblock->get_meta();
       auto iter = meta.find(key);
       if (iter == meta.end()) {
@@ -744,7 +802,10 @@ public:
       t
     ).si_then([this, &t](RootBlockRef root) {
       return read_extent<RootMetaBlock>(t, root->root.meta);
-    }).si_then([this, key, value, &t](auto mblock) {
+    }).si_then([this, key, value, &t](auto maybe_indirect_extent) {
+      assert(!maybe_indirect_extent.is_indirect());
+      assert(!maybe_indirect_extent.is_clone);
+      auto& mblock = maybe_indirect_extent.extent;
       mblock = get_mutable_extent(t, mblock
 	)->template cast<RootMetaBlock>();
 
@@ -878,6 +939,8 @@ private:
     extent_types_t type)
   {
     ceph_assert(!pin->parent_modified());
+    assert(!pin->is_indirect());
+    // Note: pin might be a clone
     auto v = pin->get_logical_extent(t);
     // checking the lba child must be atomic with creating
     // and linking the absent child

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -954,7 +954,7 @@ private:
   shard_stats_t& shard_stats;
 
   template <typename T>
-  std::variant<LBAMappingRef, base_iertr::future<TCachedExtentRef<T>>>
+  std::variant<LBAMappingRef, get_child_ifut<T>>
   get_extent_if_linked(
     Transaction &t,
     LBAMappingRef pin)
@@ -964,7 +964,8 @@ private:
     // and linking the absent child
     auto v = pin->get_logical_extent(t);
     if (v.has_child()) {
-      return v.get_child_fut().safe_then([pin=std::move(pin)](auto extent) {
+      return v.get_child_fut(
+      ).si_then([pin=std::move(pin)](auto extent) {
 #ifndef NDEBUG
         auto lextent = extent->template cast<LogicalCachedExtent>();
         auto pin_laddr = pin->get_key();

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -920,12 +920,13 @@ private:
     static_assert(is_logical_type(T::TYPE));
     using ret = pin_to_extent_ret<T>;
     auto &pref = *pin;
+    auto direct_length = pref.is_indirect() ?
+      pref.get_intermediate_length() :
+      pref.get_length();
     return cache->get_absent_extent<T>(
       t,
       pref.get_val(),
-      pref.is_indirect() ?
-	pref.get_intermediate_length() :
-	pref.get_length(),
+      direct_length,
       [&pref]
       (T &extent) mutable {
 	assert(!extent.has_laddr());
@@ -984,14 +985,21 @@ private:
               t, *pin, type);
     assert(is_logical_type(type));
     auto &pref = *pin;
+    laddr_t direct_key;
+    extent_len_t direct_length;
+    if (pref.is_indirect()) {
+      direct_key = pref.get_intermediate_base();
+      direct_length = pref.get_intermediate_length();
+    } else {
+      direct_key = pref.get_key();
+      direct_length = pref.get_length();
+    }
     return cache->get_absent_extent_by_type(
       t,
       type,
       pref.get_val(),
-      pref.get_key(),
-      pref.is_indirect() ?
-	pref.get_intermediate_length() :
-	pref.get_length(),
+      direct_key,
+      direct_length,
       [&pref](CachedExtent &extent) mutable {
 	auto &lextent = static_cast<LogicalCachedExtent&>(extent);
 	assert(!lextent.has_laddr());

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -214,7 +214,7 @@ public:
       pin->maybe_fix_pos();
       fut = base_iertr::make_ready_future<LBAMappingRef>(std::move(pin));
     }
-    return fut.si_then([&t, this](auto npin) mutable {
+    return fut.si_then([&t, this](auto npin) {
       // checking the lba child must be atomic with creating
       // and linking the absent child
       auto ret = get_extent_if_linked<T>(t, std::move(npin));

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -82,11 +82,14 @@ TMDriver::read_extents_ret TMDriver::read_extents(
 	    return tm->read_pin<TestBlock>(
 	      t,
 	      std::move(pin)
-	    ).si_then([&ret](auto ref) mutable {
-	      ret.push_back(std::make_pair(ref->get_laddr(), ref));
+	    ).si_then([&ret](auto maybe_indirect_extent) mutable {
+	      assert(!maybe_indirect_extent.is_indirect());
+	      assert(!maybe_indirect_extent.is_clone);
+	      auto& e = maybe_indirect_extent.extent;
+	      ret.push_back(std::make_pair(e->get_laddr(), e));
 	      logger().debug(
 		"read_extents: got extent {}",
-		*ref);
+		*e);
 	      return seastar::now();
 	    });
 	  }).si_then([&ret] {

--- a/src/test/crimson/seastore/test_block.h
+++ b/src/test/crimson/seastore/test_block.h
@@ -51,12 +51,12 @@ struct TestBlock : crimson::os::seastore::LogicalCachedExtent {
 
   interval_set<extent_len_t> modified_region;
 
-  TestBlock(ceph::bufferptr &&ptr)
+  explicit TestBlock(ceph::bufferptr &&ptr)
     : LogicalCachedExtent(std::move(ptr)) {}
+  explicit TestBlock(extent_len_t length)
+    : LogicalCachedExtent(length) {}
   TestBlock(const TestBlock &other)
     : LogicalCachedExtent(other), modified_region(other.modified_region) {}
-  TestBlock(extent_len_t length)
-    : LogicalCachedExtent(length) {}
 
   CachedExtentRef duplicate_for_write(Transaction&) final {
     return CachedExtentRef(new TestBlock(*this));
@@ -113,8 +113,10 @@ struct TestBlockPhysical : crimson::os::seastore::CachedExtent{
 
   void on_rewrite(Transaction&, CachedExtent&, extent_len_t) final {}
 
-  TestBlockPhysical(ceph::bufferptr &&ptr)
+  explicit TestBlockPhysical(ceph::bufferptr &&ptr)
     : CachedExtent(std::move(ptr)) {}
+  explicit TestBlockPhysical(extent_len_t length)
+    : CachedExtent(length) {}
   TestBlockPhysical(const TestBlockPhysical &other)
     : CachedExtent(other) {}
 

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -264,10 +264,13 @@ struct object_data_handler_test_t:
     auto &layout = onode->get_layout();
     auto odata = layout.object_data.get();
     auto obase = odata.get_reserved_data_base();
-    auto ext = with_trans_intr(t, [&](auto& trans) {
+    auto maybe_indirect_ext = with_trans_intr(t, [&](auto& trans) {
       return tm->read_extent<ObjectDataBlock>(
 	trans, (obase + addr).checked_to_laddr(), len);
     }).unsafe_get();
+    EXPECT_FALSE(maybe_indirect_ext.is_clone);
+    EXPECT_FALSE(maybe_indirect_ext.is_indirect());
+    auto ext = maybe_indirect_ext.extent;
     EXPECT_EQ((obase + addr).checked_to_laddr(), ext->get_laddr());
     return ext;
   }

--- a/src/test/crimson/seastore/test_object_data_handler.cc
+++ b/src/test/crimson/seastore/test_object_data_handler.cc
@@ -871,6 +871,31 @@ TEST_P(object_data_handler_test_t, overwrite_then_read_within_transaction) {
   });
 }
 
+TEST_P(object_data_handler_test_t, parallel_partial_read) {
+  run_async([this] {
+    disable_max_extent_size();
+    enable_delta_based_overwrite();
+    auto t = create_mutate_transaction();
+    auto base = 0;
+    auto len = 4096 * 10;
+    write(*t, base, len, 'a');
+    submit_transaction(std::move(t));
+
+    restart();
+    epm->check_usage();
+    seastar::parallel_for_each(
+      boost::make_counting_iterator(0lu),
+      boost::make_counting_iterator(8lu),
+      [&](auto i) {
+        return seastar::async([&] {
+          read(i * 4096, 8192);
+        });
+      }).get();
+    disable_delta_based_overwrite();
+    enable_max_extent_size();
+  });
+}
+
 INSTANTIATE_TEST_SUITE_P(
   object_data_handler_test,
   object_data_handler_test_t,

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -506,9 +506,10 @@ struct transaction_manager_test_t :
     ceph_assert(test_mappings.contains(addr, t.mapping_delta));
     ceph_assert(test_mappings.get(addr, t.mapping_delta).desc.len == len);
 
-    auto ext = with_trans_intr(*(t.t), [&](auto& trans) {
+    auto maybe_indirect_ext = with_trans_intr(*(t.t), [&](auto& trans) {
       return tm->read_pin<TestBlock>(trans, std::move(pin));
     }).unsafe_get();
+    auto ext = maybe_indirect_ext.extent;
     EXPECT_EQ(addr, ext->get_laddr());
     return ext;
   }
@@ -520,9 +521,10 @@ struct transaction_manager_test_t :
     ceph_assert(test_mappings.contains(addr, t.mapping_delta));
     ceph_assert(test_mappings.get(addr, t.mapping_delta).desc.len == len);
 
-    auto ext = with_trans_intr(*(t.t), [&](auto& trans) {
+    auto maybe_indirect_ext = with_trans_intr(*(t.t), [&](auto& trans) {
       return tm->read_extent<TestBlock>(trans, addr, len);
     }).unsafe_get();
+    auto ext = maybe_indirect_ext.extent;
     EXPECT_EQ(addr, ext->get_laddr());
     return ext;
   }
@@ -533,11 +535,10 @@ struct transaction_manager_test_t :
     ceph_assert(test_mappings.contains(addr, t.mapping_delta));
 
     using ertr = with_trans_ertr<TransactionManager::read_extent_iertr>;
-    using ret = ertr::future<TestBlockRef>;
     auto ext = with_trans_intr(*(t.t), [&](auto& trans) {
       return tm->read_extent<TestBlock>(trans, addr);
-    }).safe_then([](auto ext) -> ret {
-      return ertr::make_ready_future<TestBlockRef>(ext);
+    }).safe_then([](auto ret) {
+      return ertr::make_ready_future<TestBlockRef>(ret.extent);
     }).handle_error(
       [](const crimson::ct_error::eagain &e) {
 	return seastar::make_ready_future<TestBlockRef>();
@@ -560,11 +561,10 @@ struct transaction_manager_test_t :
     ceph_assert(test_mappings.get(addr, t.mapping_delta).desc.len == len);
 
     using ertr = with_trans_ertr<TransactionManager::read_extent_iertr>;
-    using ret = ertr::future<TestBlockRef>;
     auto ext = with_trans_intr(*(t.t), [&](auto& trans) {
       return tm->read_extent<TestBlock>(trans, addr, len);
-    }).safe_then([](auto ext) -> ret {
-      return ertr::make_ready_future<TestBlockRef>(ext);
+    }).safe_then([](auto ret) {
+      return ertr::make_ready_future<TestBlockRef>(ret.extent);
     }).handle_error(
       [](const crimson::ct_error::eagain &e) {
 	return seastar::make_ready_future<TestBlockRef>();
@@ -583,14 +583,13 @@ struct transaction_manager_test_t :
     test_transaction_t &t,
     LBAMappingRef &&pin) {
     using ertr = with_trans_ertr<TransactionManager::base_iertr>;
-    using ret = ertr::future<TestBlockRef>;
     bool indirect = pin->is_indirect();
     auto addr = pin->get_key();
     auto im_addr = indirect ? pin->get_intermediate_base() : L_ADDR_NULL;
     auto ext = with_trans_intr(*(t.t), [&](auto& trans) {
       return tm->read_pin<TestBlock>(trans, std::move(pin));
-    }).safe_then([](auto ext) -> ret {
-      return ertr::make_ready_future<TestBlockRef>(ext);
+    }).safe_then([](auto ret) {
+      return ertr::make_ready_future<TestBlockRef>(ret.extent);
     }).handle_error(
       [](const crimson::ct_error::eagain &e) {
 	return seastar::make_ready_future<TestBlockRef>();

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -2188,7 +2188,7 @@ TEST_P(tm_single_device_test_t, invalid_lba_mapping_detect)
     using namespace crimson::os::seastore::lba_manager::btree;
     {
       auto t = create_transaction();
-      for (int i = 0; i < LEAF_NODE_CAPACITY; i++) {
+      for (unsigned i = 0; i < LEAF_NODE_CAPACITY; i++) {
 	auto extent = alloc_extent(
 	  t,
 	  get_laddr_hint(i * 4096),

--- a/src/test/crimson/test_fixed_kv_node_layout.cc
+++ b/src/test/crimson/test_fixed_kv_node_layout.cc
@@ -88,12 +88,14 @@ struct TestNode : FixedKVNodeLayout<
   uint32_t, ceph_le32,
   test_val_t, test_val_le_t> {
   char buf[4096];
-  TestNode() : FixedKVNodeLayout(buf) {
+  TestNode() : FixedKVNodeLayout() {
+    set_layout_buf(buf);
     memset(buf, 0, sizeof(buf));
     set_meta({0, std::numeric_limits<uint32_t>::max()});
   }
   TestNode(const TestNode &rhs)
-    : FixedKVNodeLayout(buf) {
+    : FixedKVNodeLayout() {
+    set_layout_buf(buf);
     ::memcpy(buf, rhs.buf, sizeof(buf));
   }
 


### PR DESCRIPTION
This PR supersedes https://github.com/ceph/ceph/pull/57787

The first 10 commits are cleanups and preparations, the rest commits are the implementation:

In `CachedExtent`, introduce a `BufferSpace` to maintain/index partially loaded buffers. And once fully loaded, convert to page aligned bptr.

`Cache` must tolerate that in LRU, extents may be partially loaded, and they may be read by concurrent transactions. This is also possible for EXIST_CLEAN extents.

This PR is expected to control/minimize read amplification to 1x when the data extent sizes are inconsistent with the read sizes.

CC @ljx023 @zhscn 

# Performance impacts
To roughly understand the impacts, the tests were simplified.

## Test scenarios
In the same local environment, based on main (d6dfc1c2b8c1fdee4b35000062e4f16340db9e31):
A. baseline_limit_32K: seastore max-alloc-size=32KB
B. baseline_unlimited: seastore max-alloc-size disabled
C. fine-grained-cache: seastore max-alloc-size disabled
D. classic+bluestore: osd_op_num_shards = 32 (no further tuning applied)

## Constraints
1. single OSD allocated 32 cores (the memory usage is tuned to be around 33GB)
2. pool/image: 128 pgs, single replication, 4GB x 32 images (totaly 128GB)
3. 32 fio-rbd clients running in another 32 cores concurrently
3.1. rampup: fill the image with 4KB sequential writes
3.2. workload: for each client, 60 seconds, depth=128, 4KB random reads

## Results
A. baseline_limit_32K:
* client read IOPS: ~338K
* disk read IOPS: ~240K; io-size: 31.1KB
* cpu: 3200%; reactor-utilization: 81%; memory: 32.9GB;
* seastore cache (per-shard): 31.1KB/extent, 28K extents; lru in&out: 7.7K extents/second (236MB/s)
* seastore cache hit ratio: ~28%

B. baseline_unlimited:
* client read IOPS: ~26K
* disk read IOPS: ~40.4K; io-size: 413KB
* cpu: 2520%; reactor-utilization: 19%; memory: 33.9GB;
* seastore cache (per-shard): 415KB/extent, 2K extents; lru in&out: 0.6K extents/second (263MB/s)
* seastore cache hit ratio: ~19.8%

C. fine-grained-cache:
* client read IOPS: ~427K
* disk read IOPS: ~278K; io-size: 4KB
* cpu: 3200%; reactor-utilization: 82%; memory: 33.1GB;
* seastore cache (per-shard): 2.4KB/extent (?somehow lower than 4KB), 333K extents; lru in&out: 8.9K extents/second (34.9MiB/s)
* seastore cache hit ratio: ~91.8%

D. classic+bluestore:
* client read IOPS: ~340K
* disk read IOPS: ~250K; io-size: 4KB
* cpu: 1522%; memory: 32.6GB;

## Short/rough conclusions
In this specifc setting, after this PR:
1. From A to C: IOPS 1.26x better, disk read size 8x smaller, hit ratio 3.3x better, 11.9x more extents cached.
2. From B to C: IOPS 16.4x better, disk read size 103x smaller, hit ratio 4.6x better, 555x more extents cached.
3. From D to C: IOPS 1.25x better, disk read same size (no internal information to compare).

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
