### PR TITLE
squid: client: return EOPNOTSUPP for fallocate with mode 0

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,53 @@
+>=20.0.0
+
+* RBD: All Python APIs that produce timestamps now return "aware" `datetime`
+  objects instead of "naive" ones (i.e. those including time zone information
+  instead of those not including it).  All timestamps remain to be in UTC but
+  including `timezone.utc` makes it explicit and avoids the potential of the
+  returned timestamp getting misinterpreted -- in Python 3, many `datetime`
+  methods treat "naive" `datetime` objects as local times.
+* RBD: `rbd group info` and `rbd group snap info` commands are introduced to
+  show information about a group and a group snapshot respectively.
+* RBD: `rbd group snap ls` output now includes the group snap IDs. The header
+  of the column showing the state of a group snapshot in the unformatted CLI
+  output is changed from 'STATUS' to 'STATE'. The state of a group snapshot
+  that was shown as 'ok' is now shown as 'complete', which is more descriptive.
+* Based on tests performed at scale on a HDD based Ceph cluster, it was found
+  that scheduling with mClock was not optimal with multiple OSD shards. For
+  example, in the test cluster with multiple OSD node failures, the client
+  throughput was found to be inconsistent across test runs coupled with multiple
+  reported slow requests. However, the same test with a single OSD shard and
+  with multiple worker threads yielded significantly better results in terms of
+  consistency of client and recovery throughput across multiple test runs.
+  Therefore, as an interim measure until the issue with multiple OSD shards
+  (or multiple mClock queues per OSD) is investigated and fixed, the following
+  change to the default HDD OSD shard configuration is made:
+   - osd_op_num_shards_hdd = 1 (was 5)
+   - osd_op_num_threads_per_shard_hdd = 5 (was 1)
+  For more details see https://tracker.ceph.com/issues/66289.
+* MGR: MGR's always-on modulues/plugins can now be force-disabled. This can be
+  necessary in cases where MGR(s) needs to be prevented from being flooded by
+  the module commands when coresponding Ceph service is down/degraded.
+
+* CephFS: Modifying the FS setting variable "max_mds" when a cluster is
+  unhealthy now requires users to pass the confirmation flag
+  (--yes-i-really-mean-it). This has been added as a precaution to tell the
+  users that modifying "max_mds" may not help with troubleshooting or recovery
+  effort. Instead, it might further destabilize the cluster.
+
+* mgr/restful, mgr/zabbix: both modules, already deprecated since 2020, have been
+  finally removed. They have not been actively maintenance in the last years,
+  and started suffering from vulnerabilities in their dependency chain (e.g.:
+  CVE-2023-46136).  As alternatives, for the `restful` module, the `dashboard` module
+  provides a richer and better maintained RESTful API. Regarding the `zabbix` module,
+  there are alternative monitoring solutions, like `prometheus`, which is the most
+  widely adopted among the Ceph user community.
+
+* CephFS: EOPNOTSUPP (Operation not supported ) is now returned by the CephFS
+  fuse client for `fallocate` for the default case (i.e. mode == 0) since
+  CephFS does not support disk space reservation. The only flags supported are
+  `FALLOC_FL_KEEP_SIZE` and `FALLOC_FL_PUNCH_HOLE`.
+
 >=19.0.0
 
 * RGW: GetObject and HeadObject requests now return a x-rgw-replicated-at

--- a/qa/workunits/fs/misc/fallocate.sh
+++ b/qa/workunits/fs/misc/fallocate.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -x
+
+# fallocate with mode 0 should fail with EOPNOTSUPP
+set -e
+mkdir -p testdir
+cd testdir
+
+expect_failure() {
+	if "$@"; then return 1; else return 0; fi
+}
+
+expect_failure fallocate -l 1M preallocated.txt
+rm -f preallocated.txt
+
+cd ..
+rmdir testdir
+echo OK

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -16155,7 +16155,7 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
   if (offset < 0 || length <= 0)
     return -CEPHFS_EINVAL;
 
-  if (mode & ~(FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE))
+  if (mode == 0 || (mode & ~(FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE)))
     return -CEPHFS_EOPNOTSUPP;
 
   if ((mode & FALLOC_FL_PUNCH_HOLE) && !(mode & FALLOC_FL_KEEP_SIZE))

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -923,12 +923,12 @@ cdef class LibCephFS(object):
 
         :param fd: the file descriptor of the file to fallocate.
         :param mode: the flags determines the operation to be performed on the given
-                     range. default operation (0) allocate and initialize to zero
-                     the file in the byte range, and the file size will be changed
-                     if offset + length is greater than the file size. if the
-                     FALLOC_FL_KEEP_SIZE flag is specified in the mode, the file size
-                     will not be changed. if the FALLOC_FL_PUNCH_HOLE flag is specified
-                     in the mode, the operation is deallocate space and zero the byte range.
+                     range. default operation (0) is to return -EOPNOTSUPP since
+                     cephfs does not allocate disk blocks to provide write guarantees.
+                     if the FALLOC_FL_KEEP_SIZE flag is specified in the mode,
+                     the file size will not be changed.  if the FALLOC_FL_PUNCH_HOLE
+                     flag is specified in the mode, the operation is deallocate
+                     space and zero the byte range.
         :param offset: the byte range starting.
         :param length: the length of the range.
         """

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -610,10 +610,10 @@ def test_ftruncate(testdir):
 def test_fallocate(testdir):
     fd = cephfs.open(b'/file-fallocate', 'w', 0o755)
     assert_raises(TypeError, cephfs.fallocate, b'/file-fallocate', 0, 10)
-    cephfs.fallocate(fd, 0, 10)
+    assert_raises(libcephfs.OperationNotSupported, cephfs.fallocate, fd, 0, 10)
     stat = cephfs.fsync(fd, 0)
     st = cephfs.fstat(fd)
-    assert_equal(st.st_size, 10)
+    assert_equal(st.st_size, 0)
     cephfs.close(fd)
     cephfs.unlink(b'/file-fallocate')
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68816

---

backport of https://github.com/ceph/ceph/pull/59725
parent tracker: https://tracker.ceph.com/issues/68026

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh