### PR TITLE
quincy: client: return EOPNOTSUPP for fallocate with mode 0

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -87,6 +87,35 @@
 --------
 >=19.0.0
 
+* mgr/restful, mgr/zabbix: both modules, already deprecated since 2020, have been
+  finally removed. They have not been actively maintenance in the last years,
+  and started suffering from vulnerabilities in their dependency chain (e.g.:
+  CVE-2023-46136).  As alternatives, for the `restful` module, the `dashboard` module
+  provides a richer and better maintained RESTful API. Regarding the `zabbix` module,
+  there are alternative monitoring solutions, like `prometheus`, which is the most
+  widely adopted among the Ceph user community.
+
+* CephFS: EOPNOTSUPP (Operation not supported ) is now returned by the CephFS
+  fuse client for `fallocate` for the default case (i.e. mode == 0) since
+  CephFS does not support disk space reservation. The only flags supported are
+  `FALLOC_FL_KEEP_SIZE` and `FALLOC_FL_PUNCH_HOLE`.
+
+>=19.0.0
+
+* cephx: key rotation is now possible using `ceph auth rotate`. Previously,
+  this was only possible by deleting and then recreating the key.
+* ceph: a new --daemon-output-file switch is available for `ceph tell` commands
+  to dump output to a file local to the daemon. For commands which produce
+  large amounts of output, this avoids a potential spike in memory usage on the
+  daemon, allows for faster streaming writes to a file local to the daemon, and
+  reduces time holding any locks required to execute the command. For analysis,
+  it is necessary to retrieve the file from the host running the daemon
+  manually. Currently, only --format=json|json-pretty are supported.
+* RGW: GetObject and HeadObject requests now return a x-rgw-replicated-at
+  header for replicated objects. This timestamp can be compared against the
+  Last-Modified header to determine how long the object took to replicate.
+* The cephfs-shell utility is now packaged for RHEL 9 / CentOS 9 as required
+  python dependencies are now available in EPEL9.
 * RGW: S3 multipart uploads using Server-Side Encryption now replicate correctly in
   multi-site. Previously, the replicas of such objects were corrupted on decryption.
   A new tool, ``radosgw-admin bucket resync encrypted multipart``, can be used to

--- a/qa/workunits/fs/misc/fallocate.sh
+++ b/qa/workunits/fs/misc/fallocate.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -x
+
+# fallocate with mode 0 should fail with EOPNOTSUPP
+set -e
+mkdir -p testdir
+cd testdir
+
+expect_failure() {
+	if "$@"; then return 1; else return 0; fi
+}
+
+expect_failure fallocate -l 1M preallocated.txt
+rm -f preallocated.txt
+
+cd ..
+rmdir testdir
+echo OK

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -15032,7 +15032,7 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
   if (offset < 0 || length <= 0)
     return -CEPHFS_EINVAL;
 
-  if (mode & ~(FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE))
+  if (mode == 0 || (mode & ~(FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE)))
     return -CEPHFS_EOPNOTSUPP;
 
   if ((mode & FALLOC_FL_PUNCH_HOLE) && !(mode & FALLOC_FL_KEEP_SIZE))

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -869,12 +869,12 @@ cdef class LibCephFS(object):
 
         :param fd: the file descriptor of the file to fallocate.
         :param mode: the flags determines the operation to be performed on the given
-                     range. default operation (0) allocate and initialize to zero
-                     the file in the byte range, and the file size will be changed
-                     if offset + length is greater than the file size. if the
-                     FALLOC_FL_KEEP_SIZE flag is specified in the mode, the file size
-                     will not be changed. if the FALLOC_FL_PUNCH_HOLE flag is specified
-                     in the mode, the operation is deallocate space and zero the byte range.
+                     range. default operation (0) is to return -EOPNOTSUPP since
+                     cephfs does not allocate disk blocks to provide write guarantees.
+                     if the FALLOC_FL_KEEP_SIZE flag is specified in the mode,
+                     the file size will not be changed.  if the FALLOC_FL_PUNCH_HOLE
+                     flag is specified in the mode, the operation is deallocate
+                     space and zero the byte range.
         :param offset: the byte range starting.
         :param length: the length of the range.
         """

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -591,10 +591,10 @@ def test_ftruncate(testdir):
 def test_fallocate(testdir):
     fd = cephfs.open(b'/file-fallocate', 'w', 0o755)
     assert_raises(TypeError, cephfs.fallocate, b'/file-fallocate', 0, 10)
-    cephfs.fallocate(fd, 0, 10)
+    assert_raises(libcephfs.OperationNotSupported, cephfs.fallocate, fd, 0, 10)
     stat = cephfs.fsync(fd, 0)
     st = cephfs.fstat(fd)
-    assert_equal(st.st_size, 10)
+    assert_equal(st.st_size, 0)
     cephfs.close(fd)
     cephfs.unlink(b'/file-fallocate')
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68814

---

backport of https://github.com/ceph/ceph/pull/59725
parent tracker: https://tracker.ceph.com/issues/68026

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh