### PR TITLE
osd/scrub: fix 'schedule-deepscrub' test asok command

### DIFF
--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -766,8 +766,13 @@ void PgScrubber::on_operator_periodic_cmd(
   asok_response_section(f, true, scrub_level, stamp);
 
   if (scrub_level == scrub_level_t::deep) {
+    const auto saved_shallow_stamp = m_pg->info.history.last_scrub_stamp;
     // this call sets both stamps
     m_pg->set_last_deep_scrub_stamp(stamp);
+    // restore the shallow stamp, as otherwise it will be scheduled before
+    // the deep, failing whatever test code called us (this is a test-only
+    // interface).
+    m_pg->set_last_scrub_stamp(saved_shallow_stamp);
   } else {
     m_pg->set_last_scrub_stamp(stamp);
   }


### PR DESCRIPTION
The existing implementation of the 'schedule-deepscrub' Asok command uses the set_last_deep_scrub_stamp() method to "fake" the last-deep-scrub stamp. Unfortunately, this method also updates the last-scrub stamp (as required for non-test usage).

Commit 9f3e18b fixed the comparator used when sorting the scrub targets. An unintended side effect is that
following 'schedule-deepscrub' - the shallow target is the one to be scrubbed next, instead of the deep target.
This is fixed in the current PR.
