### PR TITLE
debian packaging: fix overly broad lua dependency declaration for librgw2 package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -944,10 +944,10 @@ Package: librgw2
 Architecture: linux-any
 Section: libs
 Depends: librados2 (= ${binary:Version}),
+         liblua5.3-0,
          ${misc:Depends},
          ${shlibs:Depends},
-         liblua5.3-dev,
-         luarocks,
+Suggests: luarocks,
 Description: RADOS Gateway client library
  RADOS is a distributed object store used by the Ceph distributed
  storage system.  This package provides a REST gateway to the


### PR DESCRIPTION
One can attach lua scripts as sort of hooks to implement dynamic checks or transformations of RGW requests since Ceph Pacific. Thus, a lua library is now required for base support and optionally one can use the luarocks deployment and management system for Lua modules to use more advanced scripts/modules.

With commit 46500cace6c ("rgw/test/lua: add lua integration tests suite") the dependency relations got cleaned up, as the respective entries were missing completely from debian/control.

But that commit is pulling in much more than required due to adding the devel package `liblua5.3-dev` instead of the library-only `liblua5.3-0` one, and having `luarocks` as hard dependency compared to an optional Suggests. Fixing that avoids pulling in a whole build/compiler/autotools/... stack with 65 new packages just when one wants to use librgw2 or python3-rgw for simple RGW requests, or just needs the ceph-common package, which pulls in librgw2 transitively.

This was reported by prolific community member Neobin on the Proxmox forum [0], and then discussed on the original PR, adding the dependencies [1].

[0]: https://forum.proxmox.com/threads/156433/post-715148
[1]: https://github.com/ceph/ceph/pull/52931#issuecomment-2441253989

Fixes: https://tracker.ceph.com/issues/68873

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
