### PR TITLE
rgw/rados: add async algorithms for concurrent index operations

### DIFF
--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -21,67 +21,6 @@ using namespace librados;
 const string BucketIndexShardsManager::KEY_VALUE_SEPARATOR = "#";
 const string BucketIndexShardsManager::SHARDS_SEPARATOR = ",";
 
-
-int CLSRGWConcurrentIO::operator()() {
-  int ret = 0;
-  iter = objs_container.begin();
-  for (; iter != objs_container.end() && max_aio-- > 0; ++iter) {
-    ret = issue_op(iter->first, iter->second);
-    if (ret < 0)
-      break;
-  }
-
-  int num_completions = 0, r = 0;
-  std::map<int, std::string> completed_objs;
-  std::map<int, std::string> retry_objs;
-  while (manager.wait_for_completions(valid_ret_code(), &num_completions, &r,
-				      need_multiple_rounds() ? &completed_objs : nullptr,
-				      !need_multiple_rounds() ? &retry_objs : nullptr)) {
-    if (r >= 0 && ret >= 0) {
-      for (; num_completions && iter != objs_container.end(); --num_completions, ++iter) {
-	int issue_ret = issue_op(iter->first, iter->second);
-	if (issue_ret < 0) {
-	  ret = issue_ret;
-	  break;
-	}
-      }
-    } else if (ret >= 0) {
-      ret = r;
-    }
-
-    // if we're at the end with this round, see if another round is needed
-    if (iter == objs_container.end()) {
-      if (need_multiple_rounds() && !completed_objs.empty()) {
-	// For those objects which need another round, use them to reset
-	// the container
-	reset_container(completed_objs);
-	iter = objs_container.begin();
-      } else if (! need_multiple_rounds() && !retry_objs.empty()) {
-	reset_container(retry_objs);
-	iter = objs_container.begin();
-      }
-
-      // re-issue ops if container was reset above (i.e., iter !=
-      // objs_container.end()); if it was not reset above (i.e., iter
-      // == objs_container.end()) the loop will exit immediately
-      // without iterating
-      for (; num_completions && iter != objs_container.end(); --num_completions, ++iter) {
-	int issue_ret = issue_op(iter->first, iter->second);
-	if (issue_ret < 0) {
-	  ret = issue_ret;
-	  break;
-	}
-      }
-    }
-  }
-
-  if (ret < 0) {
-    cleanup();
-  }
-  return ret;
-} // CLSRGWConcurrentIO::operator()()
-
-
 /**
  * This class represents the bucket index object operation callback context.
  */
@@ -192,42 +131,10 @@ void cls_rgw_bucket_init_index(ObjectWriteOperation& o)
   o.exec(RGW_CLASS, RGW_BUCKET_INIT_INDEX, in);
 }
 
-static bool issue_bucket_index_init_op(librados::IoCtx& io_ctx,
-				       const int shard_id,
-				       const string& oid,
-				       BucketIndexAioManager *manager) {
-  bufferlist in;
-  librados::ObjectWriteOperation op;
-  op.create(true);
-  cls_rgw_bucket_init_index(op);
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
 void cls_rgw_bucket_init_index2(ObjectWriteOperation& o)
 {
   bufferlist in;
   o.exec(RGW_CLASS, RGW_BUCKET_INIT_INDEX2, in);
-}
-
-static bool issue_bucket_index_init_op2(librados::IoCtx& io_ctx,
-				       const int shard_id,
-				       const string& oid,
-				       BucketIndexAioManager *manager) {
-  bufferlist in;
-  librados::ObjectWriteOperation op;
-  op.create(true);
-  cls_rgw_bucket_init_index2(op);
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
-static bool issue_bucket_index_clean_op(librados::IoCtx& io_ctx,
-					const int shard_id,
-					const string& oid,
-					BucketIndexAioManager *manager) {
-  bufferlist in;
-  librados::ObjectWriteOperation op;
-  op.remove();
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
 }
 
 void cls_rgw_bucket_set_tag_timeout(librados::ObjectWriteOperation& op,
@@ -237,52 +144,6 @@ void cls_rgw_bucket_set_tag_timeout(librados::ObjectWriteOperation& op,
   bufferlist in;
   encode(call, in);
   op.exec(RGW_CLASS, RGW_BUCKET_SET_TAG_TIMEOUT, in);
-}
-
-static bool issue_bucket_set_tag_timeout_op(librados::IoCtx& io_ctx,
-					    const int shard_id,
-					    const string& oid,
-					    uint64_t timeout,
-					    BucketIndexAioManager *manager) {
-  ObjectWriteOperation op;
-  cls_rgw_bucket_set_tag_timeout(op, timeout);
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
-int CLSRGWIssueBucketIndexInit::issue_op(const int shard_id, const string& oid)
-{
-  return issue_bucket_index_init_op(io_ctx, shard_id, oid, &manager);
-}
-
-int CLSRGWIssueBucketIndexInit2::issue_op(const int shard_id, const string& oid)
-{
-  return issue_bucket_index_init_op2(io_ctx, shard_id, oid, &manager);
-}
-
-void CLSRGWIssueBucketIndexInit::cleanup()
-{
-  // Do best effort removal
-  for (auto citer = objs_container.begin(); citer != iter; ++citer) {
-    io_ctx.remove(citer->second);
-  }
-}
-
-void CLSRGWIssueBucketIndexInit2::cleanup()
-{
-  // Do best effort removal
-  for (auto citer = objs_container.begin(); citer != iter; ++citer) {
-    io_ctx.remove(citer->second);
-  }
-}
-
-int CLSRGWIssueBucketIndexClean::issue_op(const int shard_id, const string& oid)
-{
-  return issue_bucket_index_clean_op(io_ctx, shard_id, oid, &manager);
-}
-
-int CLSRGWIssueSetTagTimeout::issue_op(const int shard_id, const string& oid)
-{
-  return issue_bucket_set_tag_timeout_op(io_ctx, shard_id, oid, tag_timeout, &manager);
 }
 
 void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
@@ -362,54 +223,6 @@ void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
   op.exec(RGW_CLASS, RGW_BUCKET_LIST, in,
 	  new ClsBucketIndexOpCtx<rgw_cls_list_ret>(result, NULL));
 }
-
-static bool issue_bucket_list_op(librados::IoCtx& io_ctx,
-				 const int shard_id,
-				 const std::string& oid,
-				 const cls_rgw_obj_key& start_obj,
-				 const std::string& filter_prefix,
-				 const std::string& delimiter,
-				 uint32_t num_entries,
-				 bool list_versions,
-				 BucketIndexAioManager *manager,
-				 rgw_cls_list_ret *pdata)
-{
-  librados::ObjectReadOperation op;
-  cls_rgw_bucket_list_op(op,
-			 start_obj, filter_prefix, delimiter,
-                         num_entries, list_versions, pdata);
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
-int CLSRGWIssueBucketList::issue_op(const int shard_id, const string& oid)
-{
-  // set the marker depending on whether we've already queried this
-  // shard and gotten a RGWBIAdvanceAndRetryError (defined
-  // constant) return value; if we have use the marker in the return
-  // to advance the search, otherwise use the marker passed in by the
-  // caller
-  cls_rgw_obj_key marker;
-  auto iter = result.find(shard_id);
-  if (iter != result.end()) {
-    marker = iter->second.marker;
-  } else {
-    marker = start_obj;
-  }
-
-  return issue_bucket_list_op(io_ctx, shard_id, oid,
-			      marker, filter_prefix, delimiter,
-			      num_entries, list_versions, &manager,
-			      &result[shard_id]);
-}
-
-
-void CLSRGWIssueBucketList::reset_container(std::map<int, std::string>& objs)
-{
-  objs_container.swap(objs);
-  iter = objs_container.begin();
-  objs.clear();
-}
-
 
 void cls_rgw_remove_obj(librados::ObjectWriteOperation& o, list<string>& keep_attr_prefixes)
 {
@@ -687,21 +500,6 @@ void cls_rgw_bilog_list(librados::ObjectReadOperation& op,
   op.exec(RGW_CLASS, RGW_BI_LOG_LIST, in, new ClsBucketIndexOpCtx<cls_rgw_bi_log_list_ret>(pdata, ret));
 }
 
-static bool issue_bi_log_list_op(librados::IoCtx& io_ctx, const string& oid, const int shard_id,
-                                 BucketIndexShardsManager& marker_mgr, uint32_t max,
-                                 BucketIndexAioManager *manager,
-                                 cls_rgw_bi_log_list_ret *pdata)
-{
-  librados::ObjectReadOperation op;
-  cls_rgw_bilog_list(op, marker_mgr.get(shard_id, ""), max, pdata, nullptr);
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
-int CLSRGWIssueBILogList::issue_op(const int shard_id, const string& oid)
-{
-  return issue_bi_log_list_op(io_ctx, oid, shard_id, marker_mgr, max, &manager, &result[shard_id]);
-}
-
 void cls_rgw_bilog_trim(librados::ObjectWriteOperation& op,
                         const std::string& start_marker,
                         const std::string& end_marker)
@@ -715,37 +513,10 @@ void cls_rgw_bilog_trim(librados::ObjectWriteOperation& op,
   op.exec(RGW_CLASS, RGW_BI_LOG_TRIM, in);
 }
 
-static bool issue_bi_log_trim(librados::IoCtx& io_ctx, const string& oid, const int shard_id,
-                              BucketIndexShardsManager& start_marker_mgr,
-                              BucketIndexShardsManager& end_marker_mgr, BucketIndexAioManager *manager) {
-  cls_rgw_bi_log_trim_op call;
-  librados::ObjectWriteOperation op;
-  cls_rgw_bilog_trim(op, start_marker_mgr.get(shard_id, ""),
-                     end_marker_mgr.get(shard_id, ""));
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
-int CLSRGWIssueBILogTrim::issue_op(const int shard_id, const string& oid)
-{
-  return issue_bi_log_trim(io_ctx, oid, shard_id, start_marker_mgr, end_marker_mgr, &manager);
-}
-
 void cls_rgw_bucket_reshard_log_trim(librados::ObjectWriteOperation& op)
 {
   bufferlist in;
   op.exec(RGW_CLASS, RGW_RESHARD_LOG_TRIM, in);
-}
-
-static bool issue_reshard_log_trim(librados::IoCtx& io_ctx, const string& oid, int shard_id,
-                                   BucketIndexAioManager *manager) {
-  ObjectWriteOperation op;
-  cls_rgw_bucket_reshard_log_trim(op);
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
-int CLSRGWIssueReshardLogTrim::issue_op(int shard_id, const string& oid)
-{
-  return issue_reshard_log_trim(io_ctx, oid, shard_id, &manager);
 }
 
 void cls_rgw_bucket_check_index(librados::ObjectReadOperation& op,
@@ -762,36 +533,10 @@ void cls_rgw_bucket_check_index_decode(const bufferlist& out,
   decode(result, p);
 }
 
-static bool issue_bucket_check_index_op(IoCtx& io_ctx, const int shard_id, const string& oid, BucketIndexAioManager *manager,
-    rgw_cls_check_index_ret *pdata) {
-  bufferlist in;
-  librados::ObjectReadOperation op;
-  op.exec(RGW_CLASS, RGW_BUCKET_CHECK_INDEX, in, new ClsBucketIndexOpCtx<rgw_cls_check_index_ret>(
-        pdata, NULL));
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
-int CLSRGWIssueBucketCheck::issue_op(int shard_id, const string& oid)
-{
-  return issue_bucket_check_index_op(io_ctx, shard_id, oid, &manager, &result[shard_id]);
-}
-
 void cls_rgw_bucket_rebuild_index(librados::ObjectWriteOperation& op)
 {
   bufferlist in;
   op.exec(RGW_CLASS, RGW_BUCKET_REBUILD_INDEX, in);
-}
-
-static bool issue_bucket_rebuild_index_op(IoCtx& io_ctx, const int shard_id, const string& oid,
-    BucketIndexAioManager *manager) {
-  librados::ObjectWriteOperation op;
-  cls_rgw_bucket_rebuild_index(op);
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
-int CLSRGWIssueBucketRebuild::issue_op(const int shard_id, const string& oid)
-{
-  return issue_bucket_rebuild_index_op(io_ctx, shard_id, oid, &manager);
 }
 
 void cls_rgw_encode_suggestion(char op, rgw_bucket_dir_entry& dirent, bufferlist& updates)
@@ -805,50 +550,16 @@ void cls_rgw_suggest_changes(ObjectWriteOperation& o, bufferlist& updates)
   o.exec(RGW_CLASS, RGW_DIR_SUGGEST_CHANGES, updates);
 }
 
-int CLSRGWIssueGetDirHeader::issue_op(const int shard_id, const string& oid)
-{
-  cls_rgw_obj_key empty_key;
-  string empty_prefix;
-  string empty_delimiter;
-  return issue_bucket_list_op(io_ctx, shard_id, oid,
-			      empty_key, empty_prefix, empty_delimiter,
-			      0, false, &manager, &result[shard_id]);
-}
-
 void cls_rgw_bilog_start(ObjectWriteOperation& op)
 {
   bufferlist in;
   op.exec(RGW_CLASS, RGW_BI_LOG_RESYNC, in);
 }
 
-static bool issue_resync_bi_log(librados::IoCtx& io_ctx, const int shard_id, const string& oid, BucketIndexAioManager *manager)
-{
-  librados::ObjectWriteOperation op;
-  cls_rgw_bilog_start(op);
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
-int CLSRGWIssueResyncBucketBILog::issue_op(const int shard_id, const string& oid)
-{
-  return issue_resync_bi_log(io_ctx, shard_id, oid, &manager);
-}
-
 void cls_rgw_bilog_stop(ObjectWriteOperation& op)
 {
   bufferlist in;
   op.exec(RGW_CLASS, RGW_BI_LOG_STOP, in);
-}
-
-static bool issue_bi_log_stop(librados::IoCtx& io_ctx, const int shard_id, const string& oid, BucketIndexAioManager *manager)
-{
-  librados::ObjectWriteOperation op;
-  cls_rgw_bilog_stop(op);
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
-int CLSRGWIssueBucketBILogStop::issue_op(const int shard_id, const string& oid)
-{
-  return issue_bi_log_stop(io_ctx, shard_id, oid, &manager);
 }
 
 class GetDirHeaderCompletion : public ObjectOperationCompletion {
@@ -1300,18 +1011,3 @@ void cls_rgw_set_bucket_resharding(librados::ObjectWriteOperation& op,
   op.assert_exists(); // the shard must exist; if not fail rather than recreate
   op.exec(RGW_CLASS, RGW_SET_BUCKET_RESHARDING, in);
 }
-
-static bool issue_set_bucket_resharding(librados::IoCtx& io_ctx,
-					const int shard_id, const string& oid,
-                                        const cls_rgw_bucket_instance_entry& entry,
-                                        BucketIndexAioManager *manager) {
-  librados::ObjectWriteOperation op;
-  cls_rgw_set_bucket_resharding(op, entry.reshard_status);
-  return manager->aio_operate(io_ctx, shard_id, oid, &op);
-}
-
-int CLSRGWIssueSetBucketResharding::issue_op(const int shard_id, const string& oid)
-{
-  return issue_set_bucket_resharding(io_ctx, shard_id, oid, entry, &manager);
-}
-

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -266,100 +266,8 @@ public:
 void cls_rgw_bucket_init_index(librados::ObjectWriteOperation& o);
 void cls_rgw_bucket_init_index2(librados::ObjectWriteOperation& o);
 
-class CLSRGWConcurrentIO {
-protected:
-  librados::IoCtx& io_ctx;
-
-  // map of shard # to oid; the shards that are remaining to be processed
-  std::map<int, std::string>& objs_container;
-  // iterator to work through objs_container
-  std::map<int, std::string>::iterator iter;
-
-  uint32_t max_aio;
-  BucketIndexAioManager manager;
-
-  virtual int issue_op(int shard_id, const std::string& oid) = 0;
-
-  virtual void cleanup() {}
-  virtual int valid_ret_code() { return 0; }
-  // Return true if multiple rounds of OPs might be needed, this happens when
-  // OP needs to be re-send until a certain code is returned.
-  virtual bool need_multiple_rounds() { return false; }
-  // Add a new object to the end of the container.
-  virtual void add_object(int shard, const std::string& oid) {}
-  virtual void reset_container(std::map<int, std::string>& objs) {}
-
-public:
-
-  CLSRGWConcurrentIO(librados::IoCtx& ioc,
-		     std::map<int, std::string>& _objs_container,
-		     uint32_t _max_aio) :
-  io_ctx(ioc), objs_container(_objs_container), max_aio(_max_aio)
-  {}
-
-  virtual ~CLSRGWConcurrentIO() {}
-
-  int operator()();
-}; // class CLSRGWConcurrentIO
-
 void cls_rgw_bucket_set_tag_timeout(librados::ObjectWriteOperation& op,
                                     uint64_t timeout);
-
-class CLSRGWIssueBucketIndexInit : public CLSRGWConcurrentIO {
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-  int valid_ret_code() override { return -EEXIST; }
-  void cleanup() override;
-public:
-  CLSRGWIssueBucketIndexInit(librados::IoCtx& ioc,
-			     std::map<int, std::string>& _bucket_objs,
-			     uint32_t _max_aio) :
-    CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio) {}
-  virtual ~CLSRGWIssueBucketIndexInit() override {}
-};
-
-
-class CLSRGWIssueBucketIndexInit2 : public CLSRGWConcurrentIO {
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-  int valid_ret_code() override { return -EEXIST; }
-  void cleanup() override;
-public:
-  CLSRGWIssueBucketIndexInit2(librados::IoCtx& ioc,
-			     std::map<int, std::string>& _bucket_objs,
-			     uint32_t _max_aio) :
-    CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio) {}
-  virtual ~CLSRGWIssueBucketIndexInit2() override {}
-};
-
-
-class CLSRGWIssueBucketIndexClean : public CLSRGWConcurrentIO {
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-  int valid_ret_code() override {
-    return -ENOENT;
-  }
-
-public:
-  CLSRGWIssueBucketIndexClean(librados::IoCtx& ioc,
-			      std::map<int, std::string>& _bucket_objs,
-			      uint32_t _max_aio) :
-  CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio)
-  {}
-  virtual ~CLSRGWIssueBucketIndexClean() override {}
-};
-
-
-class CLSRGWIssueSetTagTimeout : public CLSRGWConcurrentIO {
-  uint64_t tag_timeout;
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-public:
-  CLSRGWIssueSetTagTimeout(librados::IoCtx& ioc, std::map<int, std::string>& _bucket_objs,
-                     uint32_t _max_aio, uint64_t _tag_timeout) :
-    CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio), tag_timeout(_tag_timeout) {}
-  virtual ~CLSRGWIssueSetTagTimeout() override {}
-};
 
 void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
                                  bool absolute,
@@ -426,54 +334,6 @@ int cls_rgw_usage_log_trim(librados::IoCtx& io_ctx, const std::string& oid, cons
                            uint64_t start_epoch, uint64_t end_epoch);
 #endif
 
-
-/**
- * Std::list the bucket with the starting object and filter prefix.
- * NOTE: this method do listing requests for each bucket index shards identified by
- *       the keys of the *list_results* std::map, which means the std::map should be populated
- *       by the caller to fill with each bucket index object id.
- *
- * io_ctx        - IO context for rados.
- * start_obj     - marker for the listing.
- * filter_prefix - filter prefix.
- * num_entries   - number of entries to request for each object (note the total
- *                 amount of entries returned depends on the number of shardings).
- * list_results  - the std::list results keyed by bucket index object id.
- * max_aio       - the maximum number of AIO (for throttling).
- *
- * Return 0 on success, a failure code otherwise.
-*/
-
-class CLSRGWIssueBucketList : public CLSRGWConcurrentIO {
-  cls_rgw_obj_key start_obj;
-  std::string filter_prefix;
-  std::string delimiter;
-  uint32_t num_entries;
-  bool list_versions;
-  std::map<int, rgw_cls_list_ret>& result; // request_id -> return value
-
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-  void reset_container(std::map<int, std::string>& objs) override;
-
-public:
-  CLSRGWIssueBucketList(librados::IoCtx& io_ctx,
-			const cls_rgw_obj_key& _start_obj,
-                        const std::string& _filter_prefix,
-			const std::string& _delimiter,
-			uint32_t _num_entries,
-                        bool _list_versions,
-                        std::map<int, std::string>& oids, // shard_id -> shard_oid
-			// shard_id -> return value
-                        std::map<int, rgw_cls_list_ret>& list_results,
-                        uint32_t max_aio) :
-  CLSRGWConcurrentIO(io_ctx, oids, max_aio),
-    start_obj(_start_obj), filter_prefix(_filter_prefix), delimiter(_delimiter),
-    num_entries(_num_entries), list_versions(_list_versions),
-    result(list_results)
-  {}
-};
-
 void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
                             const cls_rgw_obj_key& start_obj,
                             const std::string& filter_prefix,
@@ -486,63 +346,9 @@ void cls_rgw_bilog_list(librados::ObjectReadOperation& op,
                         const std::string& marker, uint32_t max,
                         cls_rgw_bi_log_list_ret *pdata, int *ret = nullptr);
 
-class CLSRGWIssueBILogList : public CLSRGWConcurrentIO {
-  std::map<int, cls_rgw_bi_log_list_ret>& result;
-  BucketIndexShardsManager& marker_mgr;
-  uint32_t max;
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-public:
-  CLSRGWIssueBILogList(librados::IoCtx& io_ctx, BucketIndexShardsManager& _marker_mgr, uint32_t _max,
-                       std::map<int, std::string>& oids,
-                       std::map<int, cls_rgw_bi_log_list_ret>& bi_log_lists, uint32_t max_aio) :
-    CLSRGWConcurrentIO(io_ctx, oids, max_aio), result(bi_log_lists),
-    marker_mgr(_marker_mgr), max(_max) {}
-  virtual ~CLSRGWIssueBILogList() override {}
-};
-
 void cls_rgw_bilog_trim(librados::ObjectWriteOperation& op,
                         const std::string& start_marker,
                         const std::string& end_marker);
-
-class CLSRGWIssueBILogTrim : public CLSRGWConcurrentIO {
-  BucketIndexShardsManager& start_marker_mgr;
-  BucketIndexShardsManager& end_marker_mgr;
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-  // Trim until -ENODATA is returned.
-  int valid_ret_code() override { return -ENODATA; }
-  bool need_multiple_rounds() override { return true; }
-  void add_object(int shard, const std::string& oid) override { objs_container[shard] = oid; }
-  void reset_container(std::map<int, std::string>& objs) override {
-    objs_container.swap(objs);
-    iter = objs_container.begin();
-    objs.clear();
-  }
-public:
-  CLSRGWIssueBILogTrim(librados::IoCtx& io_ctx, BucketIndexShardsManager& _start_marker_mgr,
-      BucketIndexShardsManager& _end_marker_mgr, std::map<int, std::string>& _bucket_objs, uint32_t max_aio) :
-    CLSRGWConcurrentIO(io_ctx, _bucket_objs, max_aio),
-    start_marker_mgr(_start_marker_mgr), end_marker_mgr(_end_marker_mgr) {}
-  virtual ~CLSRGWIssueBILogTrim() override {}
-};
-
-class CLSRGWIssueReshardLogTrim : public CLSRGWConcurrentIO {
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-  // Trim until -ENODATA is returned.
-  int valid_ret_code() override { return -ENODATA; }
-  bool need_multiple_rounds() override { return true; }
-  void add_object(int shard, const std::string& oid) override { objs_container[shard] = oid; }
-  void reset_container(std::map<int, std::string>& objs) override {
-    objs_container.swap(objs);
-    iter = objs_container.begin();
-    objs.clear();
-  }
-public:
-  CLSRGWIssueReshardLogTrim(librados::IoCtx& io_ctx, std::map<int, std::string>& _bucket_objs, uint32_t max_aio) :
-      CLSRGWConcurrentIO(io_ctx, _bucket_objs, max_aio) {}
-};
 
 void cls_rgw_bucket_check_index(librados::ObjectReadOperation& op,
                                 bufferlist& out);
@@ -550,80 +356,10 @@ void cls_rgw_bucket_check_index(librados::ObjectReadOperation& op,
 void cls_rgw_bucket_check_index_decode(const bufferlist& out,
                                        rgw_cls_check_index_ret& result);
 
-/**
- * Check the bucket index.
- *
- * io_ctx          - IO context for rados.
- * bucket_objs_ret - check result for all shards.
- * max_aio         - the maximum number of AIO (for throttling).
- *
- * Return 0 on success, a failure code otherwise.
- */
-class CLSRGWIssueBucketCheck : public CLSRGWConcurrentIO /*<std::map<std::string, rgw_cls_check_index_ret> >*/ {
-  std::map<int, rgw_cls_check_index_ret>& result;
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-public:
-  CLSRGWIssueBucketCheck(librados::IoCtx& ioc, std::map<int, std::string>& oids,
-			 std::map<int, rgw_cls_check_index_ret>& bucket_objs_ret,
-			 uint32_t _max_aio) :
-    CLSRGWConcurrentIO(ioc, oids, _max_aio), result(bucket_objs_ret) {}
-  virtual ~CLSRGWIssueBucketCheck() override {}
-};
-
 void cls_rgw_bucket_rebuild_index(librados::ObjectWriteOperation& op);
-
-class CLSRGWIssueBucketRebuild : public CLSRGWConcurrentIO {
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-public:
-  CLSRGWIssueBucketRebuild(librados::IoCtx& io_ctx, std::map<int, std::string>& bucket_objs,
-                           uint32_t max_aio) : CLSRGWConcurrentIO(io_ctx, bucket_objs, max_aio) {}
-  virtual ~CLSRGWIssueBucketRebuild() override {}
-};
-
-class CLSRGWIssueGetDirHeader : public CLSRGWConcurrentIO {
-  std::map<int, rgw_cls_list_ret>& result;
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-public:
-  CLSRGWIssueGetDirHeader(librados::IoCtx& io_ctx, std::map<int, std::string>& oids, std::map<int, rgw_cls_list_ret>& dir_headers,
-                          uint32_t max_aio) :
-    CLSRGWConcurrentIO(io_ctx, oids, max_aio), result(dir_headers) {}
-  virtual ~CLSRGWIssueGetDirHeader() override {}
-};
-
-class CLSRGWIssueSetBucketResharding : public CLSRGWConcurrentIO {
-  cls_rgw_bucket_instance_entry entry;
-protected:
-  int issue_op(int shard_id, const std::string& oid) override;
-public:
-  CLSRGWIssueSetBucketResharding(librados::IoCtx& ioc, std::map<int, std::string>& _bucket_objs,
-                                 const cls_rgw_bucket_instance_entry& _entry,
-                                 uint32_t _max_aio) : CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio), entry(_entry) {}
-  virtual ~CLSRGWIssueSetBucketResharding() override {}
-};
 
 void cls_rgw_bilog_start(librados::ObjectWriteOperation& op);
 void cls_rgw_bilog_stop(librados::ObjectWriteOperation& op);
-
-class CLSRGWIssueResyncBucketBILog : public CLSRGWConcurrentIO {
-protected:
-  int issue_op(int shard_id, const std::string& oid);
-public:
-  CLSRGWIssueResyncBucketBILog(librados::IoCtx& io_ctx, std::map<int, std::string>& _bucket_objs, uint32_t max_aio) :
-    CLSRGWConcurrentIO(io_ctx, _bucket_objs, max_aio) {}
-  virtual ~CLSRGWIssueResyncBucketBILog() override {}
-};
-
-class CLSRGWIssueBucketBILogStop : public CLSRGWConcurrentIO {
-protected:
-  int issue_op(int shard_id, const std::string& oid);
-public:
-  CLSRGWIssueBucketBILogStop(librados::IoCtx& io_ctx, std::map<int, std::string>& _bucket_objs, uint32_t max_aio) :
-    CLSRGWConcurrentIO(io_ctx, _bucket_objs, max_aio) {}
-  virtual ~CLSRGWIssueBucketBILogStop() override {}
-};
 
 int cls_rgw_get_dir_header_async(librados::IoCtx& io_ctx, const std::string& oid,
                                  boost::intrusive_ptr<RGWGetDirHeader_CB> cb);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -7,9 +7,7 @@
 
 struct rgw_cls_tag_timeout_op
 {
-  uint64_t tag_timeout;
-
-  rgw_cls_tag_timeout_op() : tag_timeout(0) {}
+  uint64_t tag_timeout = 0;
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(1, 1, bl);

--- a/src/rgw/driver/posix/rgw_sal_posix.cc
+++ b/src/rgw/driver/posix/rgw_sal_posix.cc
@@ -2468,7 +2468,7 @@ int POSIXBucket::set_acl(const DoutPrefixProvider* dpp,
   return write_attrs(dpp, y);
 }
 
-int POSIXBucket::read_stats(const DoutPrefixProvider *dpp,
+int POSIXBucket::read_stats(const DoutPrefixProvider *dpp, optional_yield y,
 			    const bucket_index_layout_generation& idx_layout,
 			    int shard_id, std::string* bucket_ver, std::string* master_ver,
 			    std::map<RGWObjCategory, RGWStorageStats>& stats,
@@ -2477,14 +2477,14 @@ int POSIXBucket::read_stats(const DoutPrefixProvider *dpp,
   auto& main = stats[RGWObjCategory::Main];
 
   // TODO: bucket stats shouldn't have to list all objects
-  return dir->for_each(dpp, [this, dpp, &main] (const char* name) {
+  return dir->for_each(dpp, [this, dpp, y, &main] (const char* name) {
     if (name[0] == '.') {
       /* Skip dotfiles */
       return 0;
     }
 
     std::unique_ptr<FSEnt> dent;
-    int ret = dir->get_ent(dpp, null_yield, name, std::string(), dent);
+    int ret = dir->get_ent(dpp, y, name, std::string(), dent);
     if (ret < 0) {
       ret = errno;
       ldpp_dout(dpp, 0) << "ERROR: could not get ent for object " << name << ": "
@@ -2617,17 +2617,19 @@ int POSIXBucket::remove_objs_from_index(const DoutPrefixProvider *dpp, std::list
   return 0;
 }
 
-int POSIXBucket::check_index(const DoutPrefixProvider *dpp, std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats)
+int POSIXBucket::check_index(const DoutPrefixProvider *dpp, optional_yield y,
+                             std::map<RGWObjCategory, RGWStorageStats>& existing_stats,
+                             std::map<RGWObjCategory, RGWStorageStats>& calculated_stats)
 {
   return 0;
 }
 
-int POSIXBucket::rebuild_index(const DoutPrefixProvider *dpp)
+int POSIXBucket::rebuild_index(const DoutPrefixProvider *dpp, optional_yield y)
 {
   return 0;
 }
 
-int POSIXBucket::set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout)
+int POSIXBucket::set_tag_timeout(const DoutPrefixProvider *dpp, optional_yield y, uint64_t timeout)
 {
   return 0;
 }
@@ -2905,6 +2907,12 @@ int POSIXObject::list_parts(const DoutPrefixProvider* dpp, CephContext* cct,
 			    optional_yield y)
 {
   return -EOPNOTSUPP;
+}
+
+bool POSIXObject::is_sync_completed(const DoutPrefixProvider* dpp, optional_yield y,
+                                    const ceph::real_time& obj_mtime)
+{
+  return false;
 }
 
 int POSIXObject::load_obj_state(const DoutPrefixProvider* dpp, optional_yield y, bool follow_olh)

--- a/src/rgw/driver/posix/rgw_sal_posix.h
+++ b/src/rgw/driver/posix/rgw_sal_posix.h
@@ -514,7 +514,7 @@ public:
   virtual RGWAccessControlPolicy& get_acl(void) override { return acls; }
   virtual int set_acl(const DoutPrefixProvider* dpp, RGWAccessControlPolicy& acl,
 		      optional_yield y) override;
-  virtual int read_stats(const DoutPrefixProvider *dpp,
+  virtual int read_stats(const DoutPrefixProvider *dpp, optional_yield y,
 			 const bucket_index_layout_generation& idx_layout,
 			 int shard_id, std::string* bucket_ver, std::string* master_ver,
 			 std::map<RGWObjCategory, RGWStorageStats>& stats,
@@ -538,9 +538,11 @@ public:
 			 RGWUsageIter& usage_iter, std::map<rgw_user_bucket, rgw_usage_log_entry>& usage) override;
   virtual int trim_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch, optional_yield y) override;
   virtual int remove_objs_from_index(const DoutPrefixProvider *dpp, std::list<rgw_obj_index_key>& objs_to_unlink) override;
-  virtual int check_index(const DoutPrefixProvider *dpp, std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) override;
-  virtual int rebuild_index(const DoutPrefixProvider *dpp) override;
-  virtual int set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout) override;
+  virtual int check_index(const DoutPrefixProvider *dpp, optional_yield y,
+                          std::map<RGWObjCategory, RGWStorageStats>& existing_stats,
+                          std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) override;
+  virtual int rebuild_index(const DoutPrefixProvider *dpp, optional_yield y) override;
+  virtual int set_tag_timeout(const DoutPrefixProvider *dpp, optional_yield y, uint64_t timeout) override;
   virtual int purge_instance(const DoutPrefixProvider* dpp, optional_yield y) override;
 
   virtual std::unique_ptr<Bucket> clone() override {
@@ -662,6 +664,8 @@ public:
 			 bool* truncated, list_parts_each_t each_func,
 			 optional_yield y) override;
 
+  bool is_sync_completed(const DoutPrefixProvider* dpp, optional_yield y,
+                         const ceph::real_time& obj_mtime) override;
   virtual int load_obj_state(const DoutPrefixProvider* dpp, optional_yield y, bool follow_olh = true) override;
   virtual int set_obj_attrs(const DoutPrefixProvider* dpp, Attrs* setattrs,
 			    Attrs* delattrs, optional_yield y, uint32_t flags) override;

--- a/src/rgw/driver/rados/rgw_bucket.h
+++ b/src/rgw/driver/rados/rgw_bucket.h
@@ -347,7 +347,7 @@ public:
   int check_index_unlinked(rgw::sal::RadosStore* rados_store, const DoutPrefixProvider *dpp, RGWBucketAdminOpState& op_state,
                            RGWFormatterFlusher& flusher);
 
-  int check_index(const DoutPrefixProvider *dpp,
+  int check_index(const DoutPrefixProvider *dpp, optional_yield y,
           RGWBucketAdminOpState& op_state,
           std::map<RGWObjCategory, RGWStorageStats>& existing_stats,
           std::map<RGWObjCategory, RGWStorageStats>& calculated_stats,

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9410,7 +9410,8 @@ int RGWRados::get_bucket_stats(const DoutPrefixProvider *dpp,
 {
   vector<rgw_bucket_dir_header> headers;
   map<int, string> bucket_instance_ids;
-  int r = cls_bucket_head(dpp, bucket_info, idx_layout, shard_id, headers, &bucket_instance_ids);
+  int r = svc.bi_rados->cls_bucket_head(dpp, bucket_info, idx_layout, shard_id,
+                                        &headers, &bucket_instance_ids, y);
   if (r < 0) {
     return r;
   }
@@ -10995,33 +10996,6 @@ int RGWRados::check_disk_state(const DoutPrefixProvider *dpp,
   ldout_bitx(bitx, dpp, 10) << "EXITING " << __func__ << dendl_bitx;
   return 0;
 } // RGWRados::check_disk_state
-
-int RGWRados::cls_bucket_head(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int shard_id, vector<rgw_bucket_dir_header>& headers, map<int, string> *bucket_instance_ids)
-{
-  librados::IoCtx index_pool;
-  map<int, string> oids;
-  map<int, struct rgw_cls_list_ret> list_results;
-  int r = svc.bi_rados->open_bucket_index(dpp, bucket_info, shard_id, idx_layout, &index_pool, &oids, bucket_instance_ids);
-  if (r < 0) {
-    ldpp_dout(dpp, 20) << "cls_bucket_head: open_bucket_index() returned "
-                   << r << dendl;
-    return r;
-  }
-
-  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
-  r = CLSRGWIssueGetDirHeader(index_pool, oids, list_results, cct->_conf->rgw_bucket_index_max_aio)();
-  if (r < 0) {
-    ldpp_dout(dpp, 20) << "cls_bucket_head: CLSRGWIssueGetDirHeader() returned "
-                   << r << dendl;
-    return r;
-  }
-
-  map<int, struct rgw_cls_list_ret>::iterator iter = list_results.begin();
-  for(; iter != list_results.end(); ++iter) {
-    headers.push_back(std::move(iter->second.dir.header));
-  }
-  return 0;
-}
 
 int RGWRados::cls_bucket_head_async(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
                                     const rgw::bucket_index_layout_generation& idx_layout, int shard_id,

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -6172,31 +6172,6 @@ int RGWRados::bucket_resync_encrypted_multipart(const DoutPrefixProvider* dpp,
   return 0;
 }
 
-int RGWRados::bucket_set_reshard(const DoutPrefixProvider *dpp,
-                                 const RGWBucketInfo& bucket_info,
-                                 const cls_rgw_bucket_instance_entry& entry)
-{
-  librados::IoCtx index_pool;
-  map<int, string> bucket_objs;
-
-  int r = svc.bi_rados->open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
-  if (r < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
-      ": unable to open bucket index, r=" << r << " (" <<
-      cpp_strerror(-r) << ")" << dendl;
-    return r;
-  }
-
-  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
-  r = CLSRGWIssueSetBucketResharding(index_pool, bucket_objs, entry, cct->_conf->rgw_bucket_index_max_aio)();
-  if (r < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
-      ": unable to issue set bucket resharding, r=" << r << " (" <<
-      cpp_strerror(-r) << ")" << dendl;
-  }
-  return r;
-}
-
 int RGWRados::defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx* octx, RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y)
 {
   std::string oid, key;

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -9938,18 +9938,6 @@ int RGWRados::bi_remove(const DoutPrefixProvider *dpp, BucketShard& bs)
   return 0;
 }
 
-int RGWRados::trim_reshard_log_entries(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, optional_yield y)
-{
-  librados::IoCtx index_pool;
-  map<int, string> bucket_objs;
-
-  int r = svc.bi_rados->open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
-  if (r < 0) {
-    return r;
-  }
-  return CLSRGWIssueReshardLogTrim(index_pool, bucket_objs, cct->_conf->rgw_bucket_index_max_aio)();
-}
-
 int RGWRados::gc_operate(const DoutPrefixProvider *dpp, string& oid, librados::ObjectWriteOperation&& op, optional_yield y)
 {
   return rgw_rados_operate(dpp, gc_pool_ctx, oid, std::move(op), y);

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -2449,7 +2449,7 @@ int RGWRados::create_bucket(const DoutPrefixProvider* dpp,
     }
 
     if (zone_placement) {
-      ret = svc.bi->init_index(dpp, info, info.layout.current_index);
+      ret = svc.bi->init_index(dpp, y, info, info.layout.current_index);
       if (ret < 0) {
         return ret;
       }
@@ -2475,7 +2475,7 @@ int RGWRados::create_bucket(const DoutPrefixProvider* dpp,
       /* only remove it if it's a different bucket instance */
       if (orig_info.bucket.bucket_id != bucket.bucket_id) {
         if (zone_placement) {
-          r = svc.bi->clean_index(dpp, info, info.layout.current_index);
+          r = svc.bi->clean_index(dpp, y, info, info.layout.current_index);
           if (r < 0) {
             ldpp_dout(dpp, 0) << "WARNING: could not remove bucket index (r=" << r << ")" << dendl;
           }
@@ -5988,7 +5988,8 @@ static void accumulate_raw_stats(const rgw_bucket_dir_header& header,
   }
 }
 
-int RGWRados::bucket_check_index(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info,
+int RGWRados::bucket_check_index(const DoutPrefixProvider *dpp, optional_yield y,
+                                 const RGWBucketInfo& bucket_info,
 				 map<RGWObjCategory, RGWStorageStats> *existing_stats,
 				 map<RGWObjCategory, RGWStorageStats> *calculated_stats)
 {
@@ -6024,7 +6025,8 @@ int RGWRados::bucket_check_index(const DoutPrefixProvider *dpp, RGWBucketInfo& b
   return 0;
 }
 
-int RGWRados::bucket_rebuild_index(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info)
+int RGWRados::bucket_rebuild_index(const DoutPrefixProvider *dpp, optional_yield y,
+                                   const RGWBucketInfo& bucket_info)
 {
   librados::IoCtx index_pool;
   map<int, string> bucket_objs;
@@ -9401,7 +9403,7 @@ int RGWRados::raw_obj_stat(const DoutPrefixProvider *dpp,
   return 0;
 }
 
-int RGWRados::get_bucket_stats(const DoutPrefixProvider *dpp,
+int RGWRados::get_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y,
 			       RGWBucketInfo& bucket_info,
 			       const rgw::bucket_index_layout_generation& idx_layout,
 			       int shard_id, string *bucket_ver, string *master_ver,

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1502,7 +1502,6 @@ public:
   int cls_obj_complete_cancel(BucketShard& bs, std::string& tag, rgw_obj& obj,
                               std::list<rgw_obj_index_key> *remove_objs,
                               uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr, bool log_op = true);
-  int cls_obj_set_bucket_tag_timeout(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, uint64_t timeout);
 
   using ent_map_t =
     boost::container::flat_map<std::string, rgw_bucket_dir_entry>;

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1610,8 +1610,6 @@ public:
                                         const std::string& marker,
                                         RGWFormatterFlusher& flusher);
 
-  int bucket_set_reshard(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
-                         const cls_rgw_bucket_instance_entry& entry);
   int remove_objs_from_index(const DoutPrefixProvider *dpp,
 			     RGWBucketInfo& bucket_info,
 			     const std::list<rgw_obj_index_key>& oid_list);

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1535,11 +1535,6 @@ public:
 				rgw_obj_index_key *last_entry,
                                 optional_yield y,
 				RGWBucketListNameFilter force_check_filter = {});
-  int cls_bucket_head(const DoutPrefixProvider *dpp,
-		      const RGWBucketInfo& bucket_info,
-		      const rgw::bucket_index_layout_generation& idx_layout,
-		      int shard_id, std::vector<rgw_bucket_dir_header>& headers,
-		      std::map<int, std::string> *bucket_instance_ids = NULL);
   int cls_bucket_head_async(const DoutPrefixProvider *dpp,
 			    const RGWBucketInfo& bucket_info,
 			    const rgw::bucket_index_layout_generation& idx_layout,

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1455,7 +1455,8 @@ public:
     rctx->set_compressed(obj);
   }
   int decode_policy(const DoutPrefixProvider *dpp, bufferlist& bl, ACLOwner *owner);
-  int get_bucket_stats(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int shard_id, std::string *bucket_ver, std::string *master_ver,
+  int get_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y,
+                       RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int shard_id, std::string *bucket_ver, std::string *master_ver,
       std::map<RGWObjCategory, RGWStorageStats>& stats, std::string *max_marker, bool* syncstopped = NULL);
   int get_bucket_stats_async(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int shard_id, boost::intrusive_ptr<rgw::sal::ReadStatsCB> cb);
 
@@ -1589,10 +1590,12 @@ public:
 
   int process_lc(const std::unique_ptr<rgw::sal::Bucket>& optional_bucket);
 
-  int bucket_check_index(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info,
+  int bucket_check_index(const DoutPrefixProvider *dpp, optional_yield y,
+                         const RGWBucketInfo& bucket_info,
                          std::map<RGWObjCategory, RGWStorageStats> *existing_stats,
                          std::map<RGWObjCategory, RGWStorageStats> *calculated_stats);
-  int bucket_rebuild_index(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info);
+  int bucket_rebuild_index(const DoutPrefixProvider *dpp, optional_yield y,
+                           const RGWBucketInfo& bucket_info);
 
   // Search the bucket for encrypted multipart uploads, and increase their mtime
   // slightly to generate a bilog entry to trigger a resync to repair any

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1594,8 +1594,6 @@ public:
                          const RGWBucketInfo& bucket_info,
                          std::map<RGWObjCategory, RGWStorageStats> *existing_stats,
                          std::map<RGWObjCategory, RGWStorageStats> *calculated_stats);
-  int bucket_rebuild_index(const DoutPrefixProvider *dpp, optional_yield y,
-                           const RGWBucketInfo& bucket_info);
 
   // Search the bucket for encrypted multipart uploads, and increase their mtime
   // slightly to generate a bilog entry to trigger a resync to repair any

--- a/src/rgw/driver/rados/rgw_rados.h
+++ b/src/rgw/driver/rados/rgw_rados.h
@@ -1564,7 +1564,6 @@ public:
               std::list<rgw_cls_bi_entry> *entries, bool *is_truncated, bool reshardlog, optional_yield y);
   int bi_remove(const DoutPrefixProvider *dpp, BucketShard& bs);
 
-  int trim_reshard_log_entries(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, optional_yield y);
 
   int cls_obj_usage_log_add(const DoutPrefixProvider *dpp, const std::string& oid, rgw_usage_log_info& info, optional_yield y);
   int cls_obj_usage_log_read(const DoutPrefixProvider *dpp, const std::string& oid, const std::string& user, const std::string& bucket, uint64_t start_epoch,

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -552,7 +552,7 @@ static int revert_target_layout(rgw::sal::RadosStore* store,
     ret = 0; // non-fatal error
   }
   // trim the reshard log entries written in logrecord state
-  ret = store->getRados()->trim_reshard_log_entries(dpp, bucket_info, y);
+  ret = store->svc()->bi_rados->trim_reshard_log(dpp, y, bucket_info);
   if (ret < 0) {
     ldpp_dout(dpp, 1) << "WARNING: " << __func__ << " failed to trim "
         "reshard log entries: " << cpp_strerror(ret) << dendl;
@@ -640,11 +640,11 @@ static int init_reshard(rgw::sal::RadosStore* store,
   if (support_logrecord) {
     if (ret = fault.check("trim_reshard_log_entries");
         ret == 0) { // no fault injected, trim reshard log entries
-      ret = store->getRados()->trim_reshard_log_entries(dpp, bucket_info, y);
+      ret = store->svc()->bi_rados->trim_reshard_log(dpp, y, bucket_info);
     }
     if (ret == -EOPNOTSUPP) {
       // not an error, logrecord is not supported, change to block reshard
-      ldpp_dout(dpp, 0) << "WARNING: " << "trim_reshard_log_entries() does not supported"
+      ldpp_dout(dpp, 0) << "WARNING: " << "trim_reshard_log() does not supported"
                         << " logrecord, falling back to block reshard mode." << dendl;
       bucket_info.layout.resharding = rgw::BucketReshardState::InProgress;
       support_logrecord = false;

--- a/src/rgw/driver/rados/rgw_reshard.cc
+++ b/src/rgw/driver/rados/rgw_reshard.cc
@@ -1499,17 +1499,6 @@ int RGWReshard::remove(const DoutPrefixProvider *dpp, const cls_rgw_reshard_entr
   return ret;
 }
 
-int RGWReshard::clear_bucket_resharding(const DoutPrefixProvider *dpp, const string& bucket_instance_oid, cls_rgw_reshard_entry& entry)
-{
-  int ret = cls_rgw_clear_bucket_resharding(store->getRados()->reshard_pool_ctx, bucket_instance_oid);
-  if (ret < 0) {
-    ldpp_dout(dpp, -1) << "ERROR: failed to clear bucket resharding, bucket_instance_oid=" << bucket_instance_oid << dendl;
-    return ret;
-  }
-
-  return 0;
-}
-
 int RGWReshardWait::wait(const DoutPrefixProvider* dpp, optional_yield y)
 {
   std::unique_lock lock(mutex);

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -117,7 +117,8 @@ public:
               bool verbose = false, std::ostream *out = nullptr,
               ceph::Formatter *formatter = nullptr,
 	      RGWReshard *reshard_log = nullptr);
-  int get_status(const DoutPrefixProvider *dpp, std::list<cls_rgw_bucket_instance_entry> *status);
+  int get_status(const DoutPrefixProvider *dpp, optional_yield y,
+                 std::list<cls_rgw_bucket_instance_entry> *status);
   int cancel(const DoutPrefixProvider* dpp, optional_yield y);
   int renew_lock_if_needed(const DoutPrefixProvider *dpp);
 

--- a/src/rgw/driver/rados/rgw_reshard.h
+++ b/src/rgw/driver/rados/rgw_reshard.h
@@ -238,7 +238,6 @@ public:
   int get(const DoutPrefixProvider *dpp, cls_rgw_reshard_entry& entry);
   int remove(const DoutPrefixProvider *dpp, const cls_rgw_reshard_entry& entry, optional_yield y);
   int list(const DoutPrefixProvider *dpp, int logshard_num, std::string& marker, uint32_t max, std::list<cls_rgw_reshard_entry>& entries, bool *is_truncated);
-  int clear_bucket_resharding(const DoutPrefixProvider *dpp, const std::string& bucket_instance_oid, cls_rgw_reshard_entry& entry);
 
   /* reshard thread */
   int process_entry(const cls_rgw_reshard_entry& entry, int max_entries,

--- a/src/rgw/driver/rados/rgw_rest_log.cc
+++ b/src/rgw/driver/rados/rgw_rest_log.cc
@@ -451,7 +451,7 @@ void RGWOp_BILog_List::execute(optional_yield y) {
   send_response();
   do {
     list<rgw_bi_log_entry> entries;
-    int ret = static_cast<rgw::sal::RadosStore*>(driver)->svc()->bilog_rados->log_list(s, bucket->get_info(), log_layout, shard_id,
+    int ret = static_cast<rgw::sal::RadosStore*>(driver)->svc()->bilog_rados->log_list(s, y, bucket->get_info(), log_layout, shard_id,
                                                marker, max_entries - count,
                                                entries, &truncated);
     if (ret < 0) {
@@ -557,7 +557,7 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
   map<RGWObjCategory, RGWStorageStats> stats;
   const auto& index = log_to_index_layout(logs.back());
 
-  int ret =  bucket->read_stats(s, index, shard_id, &bucket_ver, &master_ver, stats, &max_marker, &syncstopped);
+  int ret =  bucket->read_stats(s, y, index, shard_id, &bucket_ver, &master_ver, stats, &max_marker, &syncstopped);
   if (ret < 0 && ret != -ENOENT) {
     op_ret = ret;
     return;
@@ -641,7 +641,7 @@ void RGWOp_BILog_Delete::execute(optional_yield y) {
     return;
   }
 
-  op_ret = bilog_trim(this, static_cast<rgw::sal::RadosStore*>(driver),
+  op_ret = bilog_trim(this, y, static_cast<rgw::sal::RadosStore*>(driver),
 		      bucket->get_info(), gen, shard_id,
 		      start_marker, end_marker);
   if (op_ret < 0) {

--- a/src/rgw/driver/rados/rgw_sal_rados.cc
+++ b/src/rgw/driver/rados/rgw_sal_rados.cc
@@ -806,12 +806,12 @@ int RadosBucket::check_index(const DoutPrefixProvider *dpp, optional_yield y,
 
 int RadosBucket::rebuild_index(const DoutPrefixProvider *dpp, optional_yield y)
 {
-  return store->getRados()->bucket_rebuild_index(dpp, y, info);
+  return store->svc()->bi_rados->rebuild_index(dpp, y, info);
 }
 
 int RadosBucket::set_tag_timeout(const DoutPrefixProvider *dpp, optional_yield y, uint64_t timeout)
 {
-  return store->getRados()->cls_obj_set_bucket_tag_timeout(dpp, info, timeout);
+  return store->svc()->bi_rados->set_tag_timeout(dpp, y, info, timeout);
 }
 
 int RadosBucket::purge_instance(const DoutPrefixProvider* dpp, optional_yield y)

--- a/src/rgw/driver/rados/rgw_sal_rados.h
+++ b/src/rgw/driver/rados/rgw_sal_rados.h
@@ -598,8 +598,8 @@ class RadosObject : public StoreObject {
       StoreObject::set_compressed();
     }
 
-    virtual bool is_sync_completed(const DoutPrefixProvider* dpp,
-      const ceph::real_time& obj_mtime) override;
+    bool is_sync_completed(const DoutPrefixProvider* dpp, optional_yield y,
+                           const ceph::real_time& obj_mtime) override;
     /* For rgw_admin.cc */
     RGWObjState& get_state() { return state; }
     virtual int load_obj_state(const DoutPrefixProvider* dpp, optional_yield y, bool follow_olh = true) override;
@@ -735,7 +735,7 @@ class RadosBucket : public StoreBucket {
     int create(const DoutPrefixProvider* dpp, const CreateParams& params,
                optional_yield y) override;
     virtual int load_bucket(const DoutPrefixProvider* dpp, optional_yield y) override;
-    virtual int read_stats(const DoutPrefixProvider *dpp,
+    virtual int read_stats(const DoutPrefixProvider *dpp, optional_yield y,
                            const bucket_index_layout_generation& idx_layout,
                            int shard_id, std::string* bucket_ver, std::string* master_ver,
                            std::map<RGWObjCategory, RGWStorageStats>& stats,
@@ -759,9 +759,11 @@ class RadosBucket : public StoreBucket {
 			   std::map<rgw_user_bucket, rgw_usage_log_entry>& usage) override;
     virtual int trim_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch, optional_yield y) override;
     virtual int remove_objs_from_index(const DoutPrefixProvider *dpp, std::list<rgw_obj_index_key>& objs_to_unlink) override;
-    virtual int check_index(const DoutPrefixProvider *dpp, std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) override;
-    virtual int rebuild_index(const DoutPrefixProvider *dpp) override;
-    virtual int set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout) override;
+    virtual int check_index(const DoutPrefixProvider *dpp, optional_yield y,
+                            std::map<RGWObjCategory, RGWStorageStats>& existing_stats,
+                            std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) override;
+    virtual int rebuild_index(const DoutPrefixProvider *dpp, optional_yield y) override;
+    virtual int set_tag_timeout(const DoutPrefixProvider *dpp, optional_yield y, uint64_t timeout) override;
     virtual int purge_instance(const DoutPrefixProvider* dpp, optional_yield y) override;
     virtual std::unique_ptr<Bucket> clone() override {
       return std::make_unique<RadosBucket>(*this);

--- a/src/rgw/driver/rados/rgw_trim_bilog.cc
+++ b/src/rgw/driver/rados/rgw_trim_bilog.cc
@@ -1487,7 +1487,8 @@ std::ostream& BucketTrimManager::gen_prefix(std::ostream& out) const
 
 } // namespace rgw
 
-int bilog_trim(const DoutPrefixProvider* p, rgw::sal::RadosStore* store,
+int bilog_trim(const DoutPrefixProvider* p, optional_yield y,
+	       rgw::sal::RadosStore* store,
 	       RGWBucketInfo& bucket_info, uint64_t gen, int shard_id,
 	       std::string_view start_marker, std::string_view end_marker)
 {
@@ -1501,7 +1502,7 @@ int bilog_trim(const DoutPrefixProvider* p, rgw::sal::RadosStore* store,
 
   auto log_layout = *log;
 
-  auto r = store->svc()->bilog_rados->log_trim(p, bucket_info, log_layout, shard_id, start_marker, end_marker);
+  auto r = store->svc()->bilog_rados->log_trim(p, y, bucket_info, log_layout, shard_id, start_marker, end_marker);
   if (r < 0) {
     ldpp_dout(p, 5) << __PRETTY_FUNCTION__ << ":" << __LINE__
 		    << "ERROR: bilog_rados->log_trim returned r=" << r << dendl;

--- a/src/rgw/driver/rados/rgw_trim_bilog.h
+++ b/src/rgw/driver/rados/rgw_trim_bilog.h
@@ -21,6 +21,7 @@
 
 #include "include/common_fwd.h"
 #include "include/encoding.h"
+#include "common/async/yield_context.h"
 #include "common/ceph_time.h"
 #include "common/dout.h"
 #include "rgw_common.h"
@@ -116,6 +117,7 @@ struct BucketTrimStatus {
 
 WRITE_CLASS_ENCODER(rgw::BucketTrimStatus);
 
-int bilog_trim(const DoutPrefixProvider* p, rgw::sal::RadosStore* store,
+int bilog_trim(const DoutPrefixProvider* p, optional_yield y,
+	       rgw::sal::RadosStore* store,
 	       RGWBucketInfo& bucket_info, uint64_t gen, int shard_id,
 	       std::string_view start_marker, std::string_view end_marker);

--- a/src/rgw/driver/rados/shard_io.h
+++ b/src/rgw/driver/rados/shard_io.h
@@ -1,0 +1,735 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include <boost/asio/any_completion_handler.hpp>
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/associated_cancellation_slot.hpp>
+#include <boost/asio/associator.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/asio/cancellation_signal.hpp>
+#include <boost/asio/deferred.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/co_composed.hpp>
+#include <boost/intrusive/list.hpp>
+#include <boost/system/error_code.hpp>
+
+#include "librados/librados_asio.h"
+#include "common/dout.h"
+
+/// Concurrent io algorithms for data sharded across rados objects.
+namespace rgwrados::shard_io {
+
+using boost::system::error_code;
+
+/// Classify the result of a single shard operation.
+enum class Result { Success, Retry, Error };
+
+namespace detail {
+
+struct RevertibleWriteHandler;
+struct RevertHandler;
+struct WriteHandler;
+struct ReadHandler;
+
+} // namespace detail
+
+/// Interface for async_writes() that can initiate write operations and
+/// their inverse. The latter is used to restore the original state on
+/// error or cancellation.
+///
+/// \see RadosRevertibleWriter
+class RevertibleWriter : public DoutPrefixPipe {
+ public:
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const { return ex; }
+
+  RevertibleWriter(const DoutPrefixProvider& dpp, executor_type ex)
+    : DoutPrefixPipe(dpp), ex(std::move(ex)) {}
+
+  virtual ~RevertibleWriter() {}
+
+  /// Initiate an async write operation for the given shard object.
+  virtual void write(int shard, const std::string& object,
+                     detail::RevertibleWriteHandler&& handler) = 0;
+
+  /// Classify the result of a completed shard write operation.
+  virtual Result on_complete(int shard, error_code ec) {
+    return ec ? Result::Error : Result::Success;
+  }
+
+  /// Initiate an async operation to revert the side effects of write().
+  /// Revert operations do not call on_complete() on completion.
+  virtual void revert(int shard, const std::string& object,
+                      detail::RevertHandler&& handler) = 0;
+
+  void add_prefix(std::ostream& out) const override {
+    out << "shard writer: ";
+  }
+
+ private:
+  executor_type ex;
+};
+
+/// Interface for async_writes() that can initiate write operations.
+///
+/// \see RadosWriter
+class Writer : public DoutPrefixPipe {
+ public:
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const { return ex; }
+
+  Writer(const DoutPrefixProvider& dpp, executor_type ex)
+    : DoutPrefixPipe(dpp), ex(std::move(ex)) {}
+
+  virtual ~Writer() {}
+
+  /// Initiate an async write operation for the given shard object.
+  virtual void write(int shard, const std::string& object,
+                     detail::WriteHandler&& handler) = 0;
+
+  /// Classify the result of a completed shard write operation. Returning
+  /// Retry will trigger another write() and its corresponding on_complete().
+  virtual Result on_complete(int shard, error_code ec) {
+    return ec ? Result::Error : Result::Success;
+  }
+
+  void add_prefix(std::ostream& out) const override {
+    out << "shard writer: ";
+  }
+
+ private:
+  executor_type ex;
+};
+
+/// Interface for async_reads() that can initiate read operations.
+///
+/// \see RadosReader
+class Reader : public DoutPrefixPipe {
+ public:
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const { return ex; }
+
+  Reader(const DoutPrefixProvider& dpp, executor_type ex)
+    : DoutPrefixPipe(dpp), ex(std::move(ex)) {}
+
+  virtual ~Reader() {}
+
+  /// Initiate an async read operation for the given shard object.
+  virtual void read(int shard, const std::string& object,
+                    detail::ReadHandler&& handler) = 0;
+
+  /// Classify the result of a completed shard read operation. Returning
+  /// Retry will trigger another read() and its corresponding on_complete().
+  virtual Result on_complete(int shard, error_code ec) {
+    return ec ? Result::Error : Result::Success;
+  }
+
+  void add_prefix(std::ostream& out) const override {
+    out << "shard reader: ";
+  }
+
+ private:
+  executor_type ex;
+};
+
+namespace detail {
+
+struct Shard : boost::intrusive::list_base_hook<> {
+  boost::asio::cancellation_signal signal;
+  std::map<int, std::string>::const_iterator iter;
+  int id() const { return iter->first; }
+  const std::string& object() const { return iter->second; }
+};
+using ShardList = boost::intrusive::list<Shard>;
+
+inline auto make_shards(const std::map<int, std::string>& objects)
+  -> std::vector<Shard>
+{
+  // allocate the shards and assign an 'objects' iterator to each
+  auto shards = std::vector<Shard>(objects.size());
+  auto s = shards.begin();
+  for (auto o = objects.begin(); o != objects.end(); ++o, ++s) {
+    s->iter = o;
+  }
+  return shards;
+}
+
+// handler that wakes the caller of async_wait()
+using WaitHandler = boost::asio::any_completion_handler<void()>;
+
+// cancellation handler that forwards signals to all outstanding requests
+struct WaitCancellation {
+  ShardList& sending;
+  ShardList& outstanding;
+  ShardList* completed;
+  error_code& failure;
+  bool& terminal;
+
+  WaitCancellation(ShardList& sending, ShardList& outstanding,
+                   ShardList* completed, error_code& failure, bool& terminal)
+    : sending(sending), outstanding(outstanding), completed(completed),
+      failure(failure), terminal(terminal) {}
+
+  void operator()(boost::asio::cancellation_type type) {
+    if (type != boost::asio::cancellation_type::none) {
+      if (!!(type & boost::asio::cancellation_type::terminal)) {
+        terminal = true;
+      }
+      if (!failure) {
+        failure = make_error_code(boost::asio::error::operation_aborted);
+        if (completed) {
+          // for RevertibleWriter, schedule completed shards for reverts
+          sending = std::move(*completed);
+        }
+      }
+      auto i = outstanding.begin();
+      while (i != outstanding.end()) {
+        // emit() may dispatch the completion that removes i from outstanding
+        auto& shard = *i++;
+        shard.signal.emit(type);
+      }
+    }
+  }
+};
+
+// suspend the calling coroutine and capture a WaitHandler to resume it
+template <typename CompletionToken>
+auto async_wait(WaitHandler& wakeup, ShardList& sending, ShardList& outstanding,
+                ShardList* completed, error_code& failure, bool& terminal,
+                CompletionToken&& token)
+{
+  return boost::asio::async_initiate<CompletionToken, void()>(
+      [&, completed] (auto handler) {
+        wakeup = std::move(handler);
+        auto slot = boost::asio::get_associated_cancellation_slot(wakeup);
+        if (slot.is_connected()) {
+          slot.template emplace<WaitCancellation>(
+              sending, outstanding, completed, failure, terminal);
+        }
+      }, token);
+}
+
+inline void maybe_complete(WaitHandler& wakeup, ShardList& sending,
+                           ShardList& outstanding, bool terminal)
+{
+  const bool ready_to_send = !sending.empty() && !terminal;
+  const bool done_waiting = outstanding.empty();
+  if (wakeup && (ready_to_send || done_waiting)) {
+    auto slot = boost::asio::get_associated_cancellation_slot(wakeup);
+    slot.clear(); // remove async_wait()'s cancellation handler
+    boost::asio::dispatch(std::move(wakeup));
+  }
+}
+
+struct RevertibleWriteHandler {
+  RevertibleWriter& writer;
+  ShardList& sending;
+  ShardList& outstanding;
+  ShardList& completed;
+  WaitHandler& waiter;
+  error_code& failure;
+  bool& terminal;
+  Shard& shard;
+
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const { return writer.get_executor(); }
+
+  using cancellation_slot_type = boost::asio::cancellation_slot;
+  cancellation_slot_type get_cancellation_slot() const noexcept {
+    return shard.signal.slot();
+  }
+
+  void operator()(error_code ec, version_t = {}) {
+    outstanding.erase(outstanding.iterator_to(shard));
+
+    const auto result = writer.on_complete(shard.id(), ec);
+    switch (result) {
+      case Result::Retry:
+        ldpp_dout(&writer, 20) << "write on '" << shard.object()
+            << "' needs retry: " << ec.message() << dendl;
+        if (!failure) {
+          // reschedule the shard for sending
+          sending.push_back(shard);
+        }
+        break;
+      case Result::Success:
+        if (!failure) {
+          // track as 'completed' in case reverts are necessary
+          completed.push_back(shard);
+        } else if (!terminal) {
+          // add directly to 'sending' for revert
+          sending.push_back(shard);
+        }
+        break;
+      case Result::Error:
+        ldpp_dout(&writer, 4) << "write on '" << shard.object()
+            << "' failed: " << ec.message() << dendl;
+        if (!failure) {
+          failure = ec;
+          // schedule completed shards for reverts
+          sending = std::move(completed);
+        }
+        break;
+    }
+
+    maybe_complete(waiter, sending, outstanding, terminal);
+  }
+}; // struct RevertibleWriteHandler
+
+struct RevertHandler {
+  RevertibleWriter& writer;
+  ShardList& sending;
+  ShardList& outstanding;
+  WaitHandler& waiter;
+  bool& terminal;
+  Shard& shard;
+
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const { return writer.get_executor(); }
+
+  using cancellation_slot_type = boost::asio::cancellation_slot;
+  cancellation_slot_type get_cancellation_slot() const noexcept {
+    return shard.signal.slot();
+  }
+
+  void operator()(error_code ec, version_t = {}) {
+    outstanding.erase(outstanding.iterator_to(shard));
+
+    if (ec) {
+      ldpp_dout(&writer, 4) << "revert on '" << shard.object()
+          << "' failed: " << ec.message() << dendl;
+    }
+
+    maybe_complete(waiter, sending, outstanding, terminal);
+  }
+}; // struct RevertHandler
+
+} // namespace detail
+
+/// Try to apply concurrent write operations to the shard objects. Upon error
+/// or partial/total cancellation, revert any operations that succeeded.
+template <boost::asio::completion_token_for<void(error_code)> CompletionToken>
+auto async_writes(RevertibleWriter& writer,
+                  const std::map<int, std::string>& objects,
+                  size_t max_concurrent,
+                  CompletionToken&& token)
+{
+  return boost::asio::async_initiate<CompletionToken, void(error_code)>(
+      boost::asio::co_composed<void(error_code)>(
+          [] (auto state, RevertibleWriter& writer,
+              const std::map<int, std::string>& objects,
+              size_t max_concurrent) -> void
+          {
+            state.reset_cancellation_state(
+                boost::asio::enable_total_cancellation());
+
+            // initialize the shards array and schedule each for sending
+            auto shards = detail::make_shards(objects);
+            detail::ShardList sending{shards.begin(), shards.end()};
+            detail::ShardList outstanding;
+            detail::ShardList completed;
+            detail::WaitHandler waiter;
+            error_code failure;
+            bool terminal = false;
+
+            for (;;) {
+              while (!sending.empty() && !terminal) {
+                if (outstanding.size() >= max_concurrent) {
+                  // wait for the next completion before sending another
+                  co_await detail::async_wait(
+                      waiter, sending, outstanding, &completed,
+                      failure, terminal, boost::asio::deferred);
+
+                  if (!!state.cancelled()) {
+                    // once partial/total cancellation is requested, only
+                    // terminal cancellation can stop the reverts
+                    state.reset_cancellation_state(
+                        boost::asio::enable_terminal_cancellation());
+                  }
+                  continue; // recheck loop conditions
+                }
+
+                // prepare and send the next shard object operation
+                detail::Shard& shard = sending.front();
+                sending.pop_front();
+                outstanding.push_back(shard);
+
+                if (failure) {
+                  writer.revert(shard.id(), shard.object(),
+                                detail::RevertHandler{
+                                    writer, sending, outstanding,
+                                    waiter, terminal, shard});
+                } else {
+                  writer.write(shard.id(), shard.object(),
+                               detail::RevertibleWriteHandler{
+                                   writer, sending, outstanding, completed,
+                                   waiter, failure, terminal, shard});
+                }
+              } // while (!sending.empty() && !terminal)
+
+              if (outstanding.empty()) {
+                // nothing left to send or receive, we're done
+                co_return failure;
+              }
+
+              // wait for outstanding completions
+              co_await detail::async_wait(
+                  waiter, sending, outstanding, &completed,
+                  failure, terminal, boost::asio::deferred);
+
+              if (!!state.cancelled()) {
+                state.reset_cancellation_state(
+                    boost::asio::enable_terminal_cancellation());
+              }
+            } // for (;;)
+            // unreachable
+          }, writer),
+      token, std::ref(writer), objects, max_concurrent);
+} // async_writes(RevertibleWriter)
+
+namespace detail {
+
+struct WriteHandler {
+  Writer& writer;
+  ShardList& sending;
+  ShardList& outstanding;
+  WaitHandler& waiter;
+  error_code& failure;
+  bool& terminal;
+  Shard& shard;
+
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const { return writer.get_executor(); }
+
+  using cancellation_slot_type = boost::asio::cancellation_slot;
+  cancellation_slot_type get_cancellation_slot() const noexcept {
+    return shard.signal.slot();
+  }
+
+  void operator()(error_code ec, version_t = {}) {
+    outstanding.erase(outstanding.iterator_to(shard));
+
+    const auto result = writer.on_complete(shard.id(), ec);
+    switch (result) {
+      case Result::Retry:
+        ldpp_dout(&writer, 20) << "write on '" << shard.object()
+            << "' needs retry: " << ec.message() << dendl;
+        // reschedule the shard for sending
+        sending.push_back(shard);
+        break;
+      case Result::Success:
+        break;
+      case Result::Error:
+        ldpp_dout(&writer, 4) << "write on '" << shard.object()
+            << "' failed: " << ec.message() << dendl;
+        if (!failure) {
+          failure = ec;
+        }
+        break;
+    }
+
+    maybe_complete(waiter, sending, outstanding, terminal);
+  }
+}; // struct WriteHandler
+
+} // namespace detail
+
+/// Make an effort to apply a write operation to all shard objects. On error,
+/// finish the operations and retries on other shards before returning.
+template <boost::asio::completion_token_for<void(error_code)> CompletionToken>
+auto async_writes(Writer& writer,
+                  const std::map<int, std::string>& objects,
+                  size_t max_concurrent,
+                  CompletionToken&& token)
+{
+  return boost::asio::async_initiate<CompletionToken, void(error_code)>(
+      boost::asio::co_composed<void(error_code)>(
+          [] (auto state, Writer& writer,
+              const std::map<int, std::string>& objects,
+              size_t max_concurrent) -> void
+          {
+            state.reset_cancellation_state(
+                boost::asio::enable_terminal_cancellation());
+
+            // initialize the shards array and schedule each for sending
+            auto shards = detail::make_shards(objects);
+            detail::ShardList sending{shards.begin(), shards.end()};
+            detail::ShardList outstanding;
+            detail::WaitHandler waiter;
+            error_code failure;
+            bool terminal = false;
+
+            for (;;) {
+              while (!sending.empty() && !terminal) {
+                if (outstanding.size() >= max_concurrent) {
+                  // wait for the next completion before sending another
+                  co_await detail::async_wait(
+                      waiter, sending, outstanding, nullptr,
+                      failure, terminal, boost::asio::deferred);
+                  continue; // recheck loop conditions
+                }
+
+                // prepare and send the next shard object operation
+                detail::Shard& shard = sending.front();
+                sending.pop_front();
+                outstanding.push_back(shard);
+
+                writer.write(shard.id(), shard.object(),
+                    detail::WriteHandler{writer, sending, outstanding,
+                                         waiter, failure, terminal, shard});
+              } // while (!sending.empty() && !terminal)
+
+              if (outstanding.empty()) {
+                // nothing left to send or receive, we're done
+                co_return failure;
+              }
+
+              // await the next completion (it may schedule a retry)
+              co_await detail::async_wait(
+                  waiter, sending, outstanding, nullptr,
+                  failure, terminal, boost::asio::deferred);
+            } // for (;;)
+            // unreachable
+          }, writer),
+      token, std::ref(writer), objects, max_concurrent);
+} // async_writes(Writer)
+
+namespace detail {
+
+struct ReadHandler {
+  Reader& reader;
+  ShardList& sending;
+  ShardList& outstanding;
+  WaitHandler& waiter;
+  error_code& failure;
+  bool& terminal;
+  Shard& shard;
+
+  using executor_type = boost::asio::any_io_executor;
+  executor_type get_executor() const { return reader.get_executor(); }
+
+  using cancellation_slot_type = boost::asio::cancellation_slot;
+  cancellation_slot_type get_cancellation_slot() const noexcept {
+    return shard.signal.slot();
+  }
+
+  void operator()(error_code ec, version_t = {}, bufferlist = {}) {
+    outstanding.erase(outstanding.iterator_to(shard));
+
+    bool need_cancel = false;
+
+    const auto result = reader.on_complete(shard.id(), ec);
+    switch (result) {
+      case Result::Retry:
+        // reschedule the shard for sending
+        sending.push_back(shard);
+        ldpp_dout(&reader, 20) << "read on '" << shard.object()
+            << "' needs retry: " << ec.message() << dendl;
+        break;
+      case Result::Success:
+        break;
+      case Result::Error:
+        ldpp_dout(&reader, 4) << "read on '" << shard.object()
+            << "' failed: " << ec.message() << dendl;
+        if (!failure) {
+          failure = ec;
+          // trigger cancellations after our call to maybe_complete(). one of
+          // the cancellations may trigger completion and cause async_reads()
+          // to co_return. our call to maybe_complete() would then access
+          // variables that were destroyed with async_reads()'s stack
+          need_cancel = !outstanding.empty();
+        }
+        break;
+    }
+
+    maybe_complete(waiter, sending, outstanding, terminal);
+
+    if (need_cancel) {
+      // cancel outstanding requests
+      auto i = outstanding.begin();
+      while (i != outstanding.end()) {
+        // emit() may recurse and remove i
+        auto& s = *i++;
+        s.signal.emit(boost::asio::cancellation_type::terminal);
+      }
+    }
+  }
+}; // struct ReadHandler
+
+} // namespace detail
+
+/// Issue concurrent read operations to all shard objects, aborting on error.
+template <boost::asio::completion_token_for<void(error_code)> CompletionToken>
+auto async_reads(Reader& reader,
+                 const std::map<int, std::string>& objects,
+                 size_t max_concurrent,
+                 CompletionToken&& token)
+{
+  return boost::asio::async_initiate<CompletionToken, void(error_code)>(
+      boost::asio::co_composed<void(error_code)>(
+          [] (auto state, Reader& reader,
+              const std::map<int, std::string>& objects,
+              size_t max_concurrent) -> void
+          {
+            state.reset_cancellation_state(
+                boost::asio::enable_terminal_cancellation());
+
+            // initialize the shards array and schedule each for sending
+            auto shards = detail::make_shards(objects);
+            detail::ShardList sending{shards.begin(), shards.end()};
+            detail::ShardList outstanding;
+            detail::WaitHandler waiter;
+            error_code failure;
+            bool terminal = false;
+
+            for (;;) {
+              while (!sending.empty() && !failure) {
+                if (outstanding.size() >= max_concurrent) {
+                  // wait for the next completion before sending another
+                  co_await detail::async_wait(
+                      waiter, sending, outstanding, nullptr,
+                      failure, terminal, boost::asio::deferred);
+                  continue; // recheck loop conditions
+                }
+
+                // prepare and send the next shard object operation
+                detail::Shard& shard = sending.front();
+                sending.pop_front();
+                outstanding.push_back(shard);
+
+                reader.read(shard.id(), shard.object(),
+                    detail::ReadHandler{reader, sending, outstanding,
+                                        waiter, failure, terminal, shard});
+              } // while (!sending.empty() && !failure)
+
+              if (outstanding.empty()) {
+                // nothing left to send or receive, we're done
+                co_return failure;
+              }
+
+              // await the next completion (it may schedule a retry)
+              co_await detail::async_wait(
+                  waiter, sending, outstanding, nullptr,
+                  failure, terminal, boost::asio::deferred);
+            } // for (;;)
+            // unreachable
+          }, reader),
+      token, std::ref(reader), objects, max_concurrent);
+} // async_reads(Reader)
+
+
+/// Interface for async_writes() that can prepare rados write operations
+/// and their inverse.
+class RadosRevertibleWriter : public RevertibleWriter {
+ public:
+  RadosRevertibleWriter(const DoutPrefixProvider& dpp, executor_type ex,
+                        librados::IoCtx& ioctx)
+    : RevertibleWriter(dpp, std::move(ex)), ioctx(ioctx)
+  {}
+
+  /// Prepare a rados write operation for the given shard.
+  virtual void prepare_write(int shard, librados::ObjectWriteOperation& op) = 0;
+
+  /// Prepare a rados operation to revert the side effects of prepare_write().
+  /// Revert operations do not call on_complete() on completion.
+  virtual void prepare_revert(int shard, librados::ObjectWriteOperation& op) = 0;
+
+ private:
+  // implement write() and revert() in terms of prepare_write(),
+  // prepare_revert() and librados::async_operate()
+  void write(int shard, const std::string& object,
+            detail::RevertibleWriteHandler&& handler) final {
+    librados::ObjectWriteOperation op;
+    prepare_write(shard, op);
+
+    constexpr int flags = 0;
+    constexpr jspan_context* trace = nullptr;
+    librados::async_operate(get_executor(), ioctx, object, std::move(op),
+                            flags, trace, std::move(handler));
+  }
+
+  void revert(int shard, const std::string& object,
+              detail::RevertHandler&& handler) final {
+    librados::ObjectWriteOperation op;
+    prepare_revert(shard, op);
+
+    constexpr int flags = 0;
+    constexpr jspan_context* trace = nullptr;
+    librados::async_operate(get_executor(), ioctx, object, std::move(op),
+                            flags, trace, std::move(handler));
+  }
+
+  librados::IoCtx& ioctx;
+};
+
+/// Interface for async_writes() that can prepare rados write operations.
+class RadosWriter : public Writer {
+ public:
+  RadosWriter(const DoutPrefixProvider& dpp, executor_type ex,
+              librados::IoCtx& ioctx)
+    : Writer(dpp, std::move(ex)), ioctx(ioctx)
+  {}
+
+  /// Prepare a rados write operation for the given shard.
+  virtual void prepare_write(int shard, librados::ObjectWriteOperation& op) = 0;
+
+ private:
+  // implement write() in terms of prepare_write() and librados::async_operate()
+  void write(int shard, const std::string& object,
+            detail::WriteHandler&& handler) final {
+    librados::ObjectWriteOperation op;
+    prepare_write(shard, op);
+
+    constexpr int flags = 0;
+    constexpr jspan_context* trace = nullptr;
+    librados::async_operate(get_executor(), ioctx, object, std::move(op),
+                            flags, trace, std::move(handler));
+  }
+
+  librados::IoCtx& ioctx;
+};
+
+/// Interface for async_reads() that can prepare rados read operations.
+class RadosReader : public Reader {
+ public:
+  RadosReader(const DoutPrefixProvider& dpp, executor_type ex,
+              librados::IoCtx& ioctx)
+    : Reader(dpp, std::move(ex)), ioctx(ioctx)
+  {}
+
+  /// Prepare a rados read operation for the given shard.
+  virtual void prepare_read(int shard, librados::ObjectReadOperation& op) = 0;
+
+ private:
+  // implement read() in terms of prepare_read() and librados::async_operate()
+  void read(int shard, const std::string& object,
+            detail::ReadHandler&& handler) final {
+    librados::ObjectReadOperation op;
+    prepare_read(shard, op);
+
+    constexpr int flags = 0;
+    constexpr jspan_context* trace = nullptr;
+    librados::async_operate(get_executor(), ioctx, object, std::move(op),
+                            flags, trace, std::move(handler));
+  }
+
+  librados::IoCtx& ioctx;
+};
+
+} // namespace rgwrados::shard_io

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -11538,9 +11538,9 @@ next:
       cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret) << std::endl;
       return -ret;
     }
-    ret = static_cast<rgw::sal::RadosStore*>(driver)->getRados()->trim_reshard_log_entries(dpp(), bucket->get_info(), null_yield);
+    ret = static_cast<rgw::sal::RadosStore*>(driver)->svc()->bi_rados->trim_reshard_log(dpp(), null_yield, bucket->get_info());
     if (ret < 0) {
-      cerr << "ERROR: trim_reshard_log_entries(): " << cpp_strerror(-ret) << std::endl;
+      cerr << "ERROR: trim_reshard_log(): " << cpp_strerror(-ret) << std::endl;
       return -ret;
     }
   }

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -8770,7 +8770,7 @@ next:
 			bucket->get_info(), bucket->get_attrs(),
 			nullptr /* no callback */);
     list<cls_rgw_bucket_instance_entry> status;
-    int r = br.get_status(dpp(), &status);
+    int r = br.get_status(dpp(), null_yield, &status);
     if (r < 0) {
       cerr << "ERROR: could not get resharding status for bucket " <<
 	bucket_name << std::endl;
@@ -10314,7 +10314,7 @@ next:
 
     do {
       list<rgw_bi_log_entry> entries;
-      ret = static_cast<rgw::sal::RadosStore*>(driver)->svc()->bilog_rados->log_list(dpp(), bucket->get_info(), log_layout, shard_id, marker, max_entries - count, entries, &truncated);
+      ret = static_cast<rgw::sal::RadosStore*>(driver)->svc()->bilog_rados->log_list(dpp(), null_yield, bucket->get_info(), log_layout, shard_id, marker, max_entries - count, entries, &truncated);
       if (ret < 0) {
         cerr << "ERROR: list_bi_log_entries(): " << cpp_strerror(-ret) << std::endl;
         return -ret;
@@ -10808,7 +10808,7 @@ next:
     if (!gen) {
       gen = 0;
     }
-    ret = bilog_trim(dpp(), static_cast<rgw::sal::RadosStore*>(driver),
+    ret = bilog_trim(dpp(), null_yield, static_cast<rgw::sal::RadosStore*>(driver),
 		     bucket->get_info(), *gen,
 		     shard_id, start_marker, end_marker);
     if (ret < 0) {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -911,19 +911,19 @@ void rgw_build_iam_environment(rgw::sal::Driver* driver,
 }
 
 void handle_replication_status_header(
-    const DoutPrefixProvider *dpp,
+    const DoutPrefixProvider *dpp, optional_yield y,
     rgw::sal::Attrs& attrs,
     req_state* s,
     const ceph::real_time &obj_mtime) {
   auto attr_iter = attrs.find(RGW_ATTR_OBJ_REPLICATION_STATUS);
   if (attr_iter != attrs.end() && attr_iter->second.to_str() == "PENDING") {
-    if (s->object->is_sync_completed(dpp, obj_mtime)) {
+    if (s->object->is_sync_completed(dpp, y, obj_mtime)) {
       s->object->set_atomic();
       rgw::sal::Attrs setattrs, rmattrs;
       bufferlist bl;
       bl.append("COMPLETED");
       setattrs[RGW_ATTR_OBJ_REPLICATION_STATUS] = bl;
-      int ret = s->object->set_obj_attrs(dpp, &setattrs, &rmattrs, s->yield, 0);
+      int ret = s->object->set_obj_attrs(dpp, &setattrs, &rmattrs, y, 0);
       if (ret < 0) {
         ldpp_dout(dpp, 0) << "ERROR: failed to set object replication status to COMPLETED ret=" << ret << dendl;
         return;
@@ -2456,7 +2456,7 @@ void RGWGetObj::execute(optional_yield y)
     filter = &*decompress;
   }
 
-  handle_replication_status_header(this, attrs, s, lastmod);
+  handle_replication_status_header(this, y, attrs, s, lastmod);
 
   attr_iter = attrs.find(RGW_ATTR_OBJ_REPLICATION_TRACE);
   if (attr_iter != attrs.end()) {
@@ -3122,7 +3122,7 @@ static int load_bucket_stats(const DoutPrefixProvider* dpp, optional_yield y,
   std::string bver, mver; // ignored
   std::map<RGWObjCategory, RGWStorageStats> categories;
 
-  int r = bucket.read_stats(dpp, index, -1, &bver, &mver, categories);
+  int r = bucket.read_stats(dpp, y, index, -1, &bver, &mver, categories);
   if (r < 0) {
     return r;
   }

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -267,7 +267,7 @@ int RGWBucketStatsCache::fetch_stats_from_storage(const rgw_owner& owner, const 
   string master_ver;
 
   map<RGWObjCategory, RGWStorageStats> bucket_stats;
-  r = bucket->read_stats(dpp, index, RGW_NO_SHARD, &bucket_ver,
+  r = bucket->read_stats(dpp, y, index, RGW_NO_SHARD, &bucket_ver,
 			 &master_ver, bucket_stats, nullptr);
   if (r < 0) {
     ldpp_dout(dpp, 0) << "could not get bucket stats for bucket="

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -904,7 +904,7 @@ class Bucket {
     /** Load this bucket from the backing store.  Requires the key to be set, fills other fields. */
     virtual int load_bucket(const DoutPrefixProvider* dpp, optional_yield y) = 0;
     /** Read the bucket stats from the backing Store, synchronous */
-    virtual int read_stats(const DoutPrefixProvider *dpp,
+    virtual int read_stats(const DoutPrefixProvider *dpp, optional_yield y,
 			   const bucket_index_layout_generation& idx_layout,
 			   int shard_id, std::string* bucket_ver, std::string* master_ver,
 			   std::map<RGWObjCategory, RGWStorageStats>& stats,
@@ -946,11 +946,13 @@ class Bucket {
     /** Remove objects from the bucket index of this bucket.  May be removed from API */
     virtual int remove_objs_from_index(const DoutPrefixProvider *dpp, std::list<rgw_obj_index_key>& objs_to_unlink) = 0;
     /** Check the state of the bucket index, and get stats from it.  May be removed from API */
-    virtual int check_index(const DoutPrefixProvider *dpp, std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) = 0;
+    virtual int check_index(const DoutPrefixProvider *dpp, optional_yield y,
+                            std::map<RGWObjCategory, RGWStorageStats>& existing_stats,
+                            std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) = 0;
     /** Rebuild the bucket index.  May be removed from API */
-    virtual int rebuild_index(const DoutPrefixProvider *dpp) = 0;
+    virtual int rebuild_index(const DoutPrefixProvider *dpp, optional_yield y) = 0;
     /** Set a timeout on the check_index() call.  May be removed from API */
-    virtual int set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout) = 0;
+    virtual int set_tag_timeout(const DoutPrefixProvider *dpp, optional_yield y, uint64_t timeout) = 0;
     /** Remove this specific bucket instance from the backing store.  May be removed from API */
     virtual int purge_instance(const DoutPrefixProvider* dpp, optional_yield y) = 0;
 
@@ -1208,7 +1210,8 @@ class Object {
     virtual bool is_compressed() = 0;
     /** Check if object is synced */
     virtual bool is_sync_completed(const DoutPrefixProvider* dpp,
-      const ceph::real_time& obj_mtime) = 0;
+                                   optional_yield y,
+                                   const ceph::real_time& obj_mtime) = 0;
     /** Invalidate cached info about this object, except atomic, prefetch, and
      * compressed */
     virtual void invalidate() = 0;

--- a/src/rgw/rgw_sal_dbstore.cc
+++ b/src/rgw/rgw_sal_dbstore.cc
@@ -203,7 +203,7 @@ namespace rgw::sal {
   }
 
   /* stats - Not for first pass */
-  int DBBucket::read_stats(const DoutPrefixProvider *dpp,
+  int DBBucket::read_stats(const DoutPrefixProvider *dpp, optional_yield y,
       const bucket_index_layout_generation& idx_layout,
       int shard_id,
       std::string *bucket_ver, std::string *master_ver,
@@ -309,19 +309,21 @@ namespace rgw::sal {
     return 0;
   }
 
-  int DBBucket::check_index(const DoutPrefixProvider *dpp, std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats)
+  int DBBucket::check_index(const DoutPrefixProvider *dpp, optional_yield y,
+                            std::map<RGWObjCategory, RGWStorageStats>& existing_stats,
+                            std::map<RGWObjCategory, RGWStorageStats>& calculated_stats)
   {
     /* XXX: stats not supported yet */
     return 0;
   }
 
-  int DBBucket::rebuild_index(const DoutPrefixProvider *dpp)
+  int DBBucket::rebuild_index(const DoutPrefixProvider *dpp, optional_yield y)
   {
     /* there is no index table in dbstore. Not applicable */
     return 0;
   }
 
-  int DBBucket::set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout)
+  int DBBucket::set_tag_timeout(const DoutPrefixProvider *dpp, optional_yield y, uint64_t timeout)
   {
     /* XXX: CHECK: set tag timeout for all the bucket objects? */
     return 0;
@@ -494,6 +496,12 @@ namespace rgw::sal {
 			   optional_yield y)
   {
     return -EOPNOTSUPP;
+  }
+
+  bool DBObject::is_sync_completed(const DoutPrefixProvider* dpp, optional_yield y,
+                                   const ceph::real_time& obj_mtime)
+  {
+    return false;
   }
 
   int DBObject::load_obj_state(const DoutPrefixProvider* dpp, optional_yield y, bool follow_olh)

--- a/src/rgw/rgw_sal_dbstore.h
+++ b/src/rgw/rgw_sal_dbstore.h
@@ -152,7 +152,7 @@ protected:
                  const CreateParams& params,
                  optional_yield y) override;
       virtual int load_bucket(const DoutPrefixProvider *dpp, optional_yield y) override;
-      virtual int read_stats(const DoutPrefixProvider *dpp,
+      virtual int read_stats(const DoutPrefixProvider *dpp, optional_yield y,
 			     const bucket_index_layout_generation& idx_layout,
 			     int shard_id,
           std::string *bucket_ver, std::string *master_ver,
@@ -175,9 +175,11 @@ protected:
           std::map<rgw_user_bucket, rgw_usage_log_entry>& usage) override;
       virtual int trim_usage(const DoutPrefixProvider *dpp, uint64_t start_epoch, uint64_t end_epoch, optional_yield y) override;
       virtual int remove_objs_from_index(const DoutPrefixProvider *dpp, std::list<rgw_obj_index_key>& objs_to_unlink) override;
-      virtual int check_index(const DoutPrefixProvider *dpp, std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) override;
-      virtual int rebuild_index(const DoutPrefixProvider *dpp) override;
-      virtual int set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout) override;
+      virtual int check_index(const DoutPrefixProvider *dpp, optional_yield y,
+                              std::map<RGWObjCategory, RGWStorageStats>& existing_stats,
+                              std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) override;
+      virtual int rebuild_index(const DoutPrefixProvider *dpp, optional_yield y) override;
+      virtual int set_tag_timeout(const DoutPrefixProvider *dpp, optional_yield y, uint64_t timeout) override;
       virtual int purge_instance(const DoutPrefixProvider *dpp, optional_yield y) override;
       virtual std::unique_ptr<Bucket> clone() override {
         return std::make_unique<DBBucket>(*this);
@@ -564,6 +566,8 @@ protected:
 			   bool* truncated, list_parts_each_t each_func,
 			   optional_yield y) override;
 
+      bool is_sync_completed(const DoutPrefixProvider* dpp, optional_yield y,
+                             const ceph::real_time& obj_mtime) override;
       virtual int load_obj_state(const DoutPrefixProvider* dpp, optional_yield y, bool follow_olh = true) override;
       virtual int get_obj_attrs(optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj = NULL) override;
       virtual int modify_obj_attrs(const char* attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_sal_filter.cc
+++ b/src/rgw/rgw_sal_filter.cc
@@ -844,14 +844,14 @@ int FilterBucket::load_bucket(const DoutPrefixProvider* dpp, optional_yield y)
   return next->load_bucket(dpp, y);
 }
 
-int FilterBucket::read_stats(const DoutPrefixProvider *dpp,
+int FilterBucket::read_stats(const DoutPrefixProvider *dpp, optional_yield y,
 			     const bucket_index_layout_generation& idx_layout,
 			     int shard_id, std::string* bucket_ver,
 			     std::string* master_ver,
 			     std::map<RGWObjCategory, RGWStorageStats>& stats,
 			     std::string* max_marker, bool* syncstopped)
 {
-  return next->read_stats(dpp, idx_layout, shard_id, bucket_ver, master_ver,
+  return next->read_stats(dpp, y, idx_layout, shard_id, bucket_ver, master_ver,
 			  stats, max_marker, syncstopped);
 }
 
@@ -935,21 +935,21 @@ int FilterBucket::remove_objs_from_index(const DoutPrefixProvider *dpp,
   return next->remove_objs_from_index(dpp, objs_to_unlink);
 }
 
-int FilterBucket::check_index(const DoutPrefixProvider *dpp,
+int FilterBucket::check_index(const DoutPrefixProvider *dpp, optional_yield y,
 			      std::map<RGWObjCategory, RGWStorageStats>& existing_stats,
 			      std::map<RGWObjCategory, RGWStorageStats>& calculated_stats)
 {
-  return next->check_index(dpp, existing_stats, calculated_stats);
+  return next->check_index(dpp, y, existing_stats, calculated_stats);
 }
 
-int FilterBucket::rebuild_index(const DoutPrefixProvider *dpp)
+int FilterBucket::rebuild_index(const DoutPrefixProvider *dpp, optional_yield y)
 {
-  return next->rebuild_index(dpp);
+  return next->rebuild_index(dpp, y);
 }
 
-int FilterBucket::set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout)
+int FilterBucket::set_tag_timeout(const DoutPrefixProvider *dpp, optional_yield y, uint64_t timeout)
 {
-  return next->set_tag_timeout(dpp, timeout);
+  return next->set_tag_timeout(dpp, y, timeout);
 }
 
 int FilterBucket::purge_instance(const DoutPrefixProvider* dpp, optional_yield y)

--- a/src/rgw/rgw_sal_filter.h
+++ b/src/rgw/rgw_sal_filter.h
@@ -582,7 +582,7 @@ public:
 		     const CreateParams& params,
 		     optional_yield y) override;
   virtual int load_bucket(const DoutPrefixProvider* dpp, optional_yield y) override;
-  virtual int read_stats(const DoutPrefixProvider *dpp,
+  virtual int read_stats(const DoutPrefixProvider *dpp, optional_yield y,
 			 const bucket_index_layout_generation& idx_layout,
 			 int shard_id, std::string* bucket_ver, std::string* master_ver,
 			 std::map<RGWObjCategory, RGWStorageStats>& stats,
@@ -618,13 +618,13 @@ public:
   virtual int remove_objs_from_index(const DoutPrefixProvider *dpp,
 				     std::list<rgw_obj_index_key>&
 				     objs_to_unlink) override;
-  virtual int check_index(const DoutPrefixProvider *dpp,
+  virtual int check_index(const DoutPrefixProvider *dpp, optional_yield y,
 			  std::map<RGWObjCategory, RGWStorageStats>&
 			  existing_stats,
 			  std::map<RGWObjCategory, RGWStorageStats>&
 			  calculated_stats) override;
-  virtual int rebuild_index(const DoutPrefixProvider *dpp) override;
-  virtual int set_tag_timeout(const DoutPrefixProvider *dpp, uint64_t timeout) override;
+  virtual int rebuild_index(const DoutPrefixProvider *dpp, optional_yield y) override;
+  virtual int set_tag_timeout(const DoutPrefixProvider *dpp, optional_yield y, uint64_t timeout) override;
   virtual int purge_instance(const DoutPrefixProvider* dpp, optional_yield y) override;
   virtual bool empty() const override { return next->empty(); }
   virtual const std::string& get_name() const override { return next->get_name(); }
@@ -785,8 +785,10 @@ public:
   virtual bool is_prefetch_data() override { return next->is_prefetch_data(); }
   virtual void set_compressed() override { return next->set_compressed(); }
   virtual bool is_compressed() override { return next->is_compressed(); }
-  virtual bool is_sync_completed(const DoutPrefixProvider* dpp,
-    const ceph::real_time& obj_mtime) override { return next->is_sync_completed(dpp, obj_mtime); }
+  bool is_sync_completed(const DoutPrefixProvider* dpp, optional_yield y,
+                         const ceph::real_time& obj_mtime) override {
+    return next->is_sync_completed(dpp, y, obj_mtime);
+  }
   virtual void invalidate() override { return next->invalidate(); }
   virtual bool empty() const override { return next->empty(); }
   virtual const std::string &get_name() const override { return next->get_name(); }

--- a/src/rgw/rgw_sal_store.h
+++ b/src/rgw/rgw_sal_store.h
@@ -299,8 +299,6 @@ class StoreObject : public Object {
     virtual bool is_prefetch_data() override { return state.prefetch_data; }
     virtual void set_compressed() override { state.compressed = true; }
     virtual bool is_compressed() override { return state.compressed; }
-    virtual bool is_sync_completed(const DoutPrefixProvider* dpp,
-      const ceph::real_time& obj_mtime) override { return false; }
     virtual void invalidate() override {
       rgw_obj obj = state.obj;
       bool is_atomic = state.is_atomic;

--- a/src/rgw/services/svc_bi.h
+++ b/src/rgw/services/svc_bi.h
@@ -29,11 +29,11 @@ public:
   RGWSI_BucketIndex(CephContext *cct) : RGWServiceInstance(cct) {}
   virtual ~RGWSI_BucketIndex() {}
 
-  virtual int init_index(const DoutPrefixProvider *dpp,
+  virtual int init_index(const DoutPrefixProvider *dpp, optional_yield y,
                          const RGWBucketInfo& bucket_info,
                          const rgw::bucket_index_layout_generation& idx_layout,
                          bool judge_support_logrecord = false) = 0;
-  virtual int clean_index(const DoutPrefixProvider *dpp,
+  virtual int clean_index(const DoutPrefixProvider *dpp, optional_yield y,
                           const RGWBucketInfo& bucket_info,
                           const rgw::bucket_index_layout_generation& idx_layout) = 0;
 

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -355,6 +355,7 @@ int RGWSI_BucketIndex_RADOS::cls_bucket_head(const DoutPrefixProvider *dpp,
 }
 
 int RGWSI_BucketIndex_RADOS::init_index(const DoutPrefixProvider *dpp,
+                                        optional_yield y,
                                         const RGWBucketInfo& bucket_info,
                                         const rgw::bucket_index_layout_generation& idx_layout,
                                         bool judge_support_logrecord)
@@ -388,7 +389,9 @@ int RGWSI_BucketIndex_RADOS::init_index(const DoutPrefixProvider *dpp,
   }
 }
 
-int RGWSI_BucketIndex_RADOS::clean_index(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
+int RGWSI_BucketIndex_RADOS::clean_index(const DoutPrefixProvider *dpp,
+                                         optional_yield y,
+                                         const RGWBucketInfo& bucket_info,
                                          const rgw::bucket_index_layout_generation& idx_layout)
 {
   if (idx_layout.layout.type != rgw::BucketIndexType::Normal) {
@@ -449,7 +452,10 @@ int RGWSI_BucketIndex_RADOS::read_stats(const DoutPrefixProvider *dpp,
   return 0;
 }
 
-int RGWSI_BucketIndex_RADOS::get_reshard_status(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, list<cls_rgw_bucket_instance_entry> *status)
+int RGWSI_BucketIndex_RADOS::get_reshard_status(const DoutPrefixProvider *dpp,
+                                                optional_yield y,
+                                                const RGWBucketInfo& bucket_info,
+                                                list<cls_rgw_bucket_instance_entry> *status)
 {
   map<int, string> bucket_objs;
 
@@ -481,6 +487,7 @@ int RGWSI_BucketIndex_RADOS::get_reshard_status(const DoutPrefixProvider *dpp, c
 }
 
 int RGWSI_BucketIndex_RADOS::set_reshard_status(const DoutPrefixProvider *dpp,
+                                                optional_yield y,
                                                 const RGWBucketInfo& bucket_info,
                                                 cls_rgw_reshard_status status)
 {
@@ -543,9 +550,9 @@ int RGWSI_BucketIndex_RADOS::handle_overwrite(const DoutPrefixProvider *dpp,
 
   int ret;
   if (!new_sync_enabled) {
-    ret = svc.bilog->log_stop(dpp, info, bilog, -1);
+    ret = svc.bilog->log_stop(dpp, y, info, bilog, -1);
   } else {
-    ret = svc.bilog->log_start(dpp, info, bilog, -1);
+    ret = svc.bilog->log_start(dpp, y, info, bilog, -1);
   }
   if (ret < 0) {
     ldpp_dout(dpp, -1) << "ERROR: failed writing bilog (bucket=" << info.bucket << "); ret=" << ret << dendl;

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -1,6 +1,9 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
+#include <algorithm>
+#include <iterator>
+
 #include "svc_bi_rados.h"
 #include "svc_bilog_rados.h"
 #include "svc_zone.h"
@@ -10,12 +13,15 @@
 #include "rgw_zone.h"
 #include "rgw_datalog.h"
 
+#include "driver/rados/shard_io.h"
 #include "cls/rgw/cls_rgw_client.h"
+#include "common/async/blocked_completion.h"
 #include "common/errno.h"
 
 #define dout_subsys ceph_subsys_rgw
 
 using namespace std;
+using rgwrados::shard_io::Result;
 
 static string dir_oid_prefix = ".dir.";
 
@@ -322,6 +328,32 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const DoutPrefixProvider *d
   return 0;
 }
 
+struct IndexHeadReader : rgwrados::shard_io::RadosReader {
+  std::map<int, bufferlist>& buffers;
+
+  IndexHeadReader(const DoutPrefixProvider& dpp,
+                  boost::asio::any_io_executor ex,
+                  librados::IoCtx& ioctx,
+                  std::map<int, bufferlist>& buffers)
+    : RadosReader(dpp, std::move(ex), ioctx), buffers(buffers)
+  {}
+  void prepare_read(int shard, librados::ObjectReadOperation& op) override {
+    auto& bl = buffers[shard];
+    op.omap_get_header(&bl, nullptr);
+  }
+  Result on_complete(int, boost::system::error_code ec) override {
+    // ignore ENOENT
+    if (ec && ec != boost::system::errc::no_such_file_or_directory) {
+      return Result::Error;
+    } else {
+      return Result::Success;
+    }
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "read dir headers: ";
+  }
+};
+
 int RGWSI_BucketIndex_RADOS::cls_bucket_head(const DoutPrefixProvider *dpp,
                                              const RGWBucketInfo& bucket_info,
                                              const rgw::bucket_index_layout_generation& idx_layout,
@@ -336,23 +368,84 @@ int RGWSI_BucketIndex_RADOS::cls_bucket_head(const DoutPrefixProvider *dpp,
   if (r < 0)
     return r;
 
-  map<int, struct rgw_cls_list_ret> list_results;
-  for (auto& iter : oids) {
-    list_results.emplace(iter.first, rgw_cls_list_ret());
+  // read omap headers into bufferlists
+  std::map<int, bufferlist> buffers;
+
+  const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto reader = IndexHeadReader{*dpp, ex, index_pool, buffers};
+
+    rgwrados::shard_io::async_reads(reader, oids, max_aio, yield[ec]);
+  } else {
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto reader = IndexHeadReader{*dpp, ex, index_pool, buffers};
+
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_reads(reader, oids, max_aio,
+                                    ceph::async::use_blocked[ec]);
+  }
+  if (ec) {
+    return ceph::from_error_code(ec);
   }
 
-  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
-  r = CLSRGWIssueGetDirHeader(index_pool, oids, list_results,
-			      cct->_conf->rgw_bucket_index_max_aio)();
-  if (r < 0)
-    return r;
-
-  map<int, struct rgw_cls_list_ret>::iterator iter = list_results.begin();
-  for(; iter != list_results.end(); ++iter) {
-    headers->push_back(std::move(iter->second.dir.header));
+  try {
+    std::transform(buffers.begin(), buffers.end(),
+                   std::back_inserter(*headers),
+                   [] (const auto& kv) {
+                     rgw_bucket_dir_header header;
+                     auto p = kv.second.cbegin();
+                     decode(header, p);
+                     return header;
+                   });
+  } catch (const ceph::buffer::error&) {
+    return -EIO;
   }
   return 0;
 }
+
+// init_index() is all-or-nothing so if we fail to initialize all shards,
+// we undo the creation of others. RevertibleWriter provides these semantics
+struct IndexInitWriter : rgwrados::shard_io::RadosRevertibleWriter {
+  bool judge_support_logrecord;
+
+  IndexInitWriter(const DoutPrefixProvider& dpp,
+                  boost::asio::any_io_executor ex,
+                  librados::IoCtx& ioctx,
+                  bool judge_support_logrecord)
+    : RadosRevertibleWriter(dpp, std::move(ex), ioctx),
+      judge_support_logrecord(judge_support_logrecord)
+  {}
+  void prepare_write(int shard, librados::ObjectWriteOperation& op) override {
+    // don't overwrite. fail with EEXIST if a shard already exists
+    op.create(true);
+    if (judge_support_logrecord) {
+      // fail with EOPNOTSUPP if the osd doesn't support the reshard log
+      cls_rgw_bucket_init_index2(op);
+    } else {
+      cls_rgw_bucket_init_index(op);
+    }
+  }
+  void prepare_revert(int shard, librados::ObjectWriteOperation& op) override {
+    // on failure, remove any of the shards we successfully created
+    op.remove();
+  }
+  Result on_complete(int, boost::system::error_code ec) override {
+    // ignore EEXIST
+    if (ec && ec != boost::system::errc::file_exists) {
+      return Result::Error;
+    } else {
+      return Result::Success;
+    }
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "init index shards: ";
+  }
+};
 
 int RGWSI_BucketIndex_RADOS::init_index(const DoutPrefixProvider *dpp,
                                         optional_yield y,
@@ -377,17 +470,48 @@ int RGWSI_BucketIndex_RADOS::init_index(const DoutPrefixProvider *dpp,
   map<int, string> bucket_objs;
   get_bucket_index_objects(dir_oid, idx_layout.layout.normal.num_shards, idx_layout.gen, &bucket_objs);
 
-  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
-  if (judge_support_logrecord) {
-    return CLSRGWIssueBucketIndexInit2(index_pool,
-                                       bucket_objs,
-                                       cct->_conf->rgw_bucket_index_max_aio)();
+  const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto writer = IndexInitWriter{*dpp, ex, index_pool, judge_support_logrecord};
+
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
   } else {
-    return CLSRGWIssueBucketIndexInit(index_pool,
-                                      bucket_objs,
-                                      cct->_conf->rgw_bucket_index_max_aio)();
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto writer = IndexInitWriter{*dpp, ex, index_pool, judge_support_logrecord};
+
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
+                                     ceph::async::use_blocked[ec]);
   }
+  return ceph::from_error_code(ec);
 }
+
+struct IndexCleanWriter : rgwrados::shard_io::RadosWriter {
+  IndexCleanWriter(const DoutPrefixProvider& dpp,
+                   boost::asio::any_io_executor ex,
+                   librados::IoCtx& ioctx)
+    : RadosWriter(dpp, std::move(ex), ioctx)
+  {}
+  void prepare_write(int shard, librados::ObjectWriteOperation& op) override {
+    op.remove();
+  }
+  Result on_complete(int, boost::system::error_code ec) override {
+    // ignore ENOENT
+    if (ec && ec != boost::system::errc::no_such_file_or_directory) {
+      return Result::Error;
+    } else {
+      return Result::Success;
+    }
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "clean index shards: ";
+  }
+};
 
 int RGWSI_BucketIndex_RADOS::clean_index(const DoutPrefixProvider *dpp,
                                          optional_yield y,
@@ -412,10 +536,25 @@ int RGWSI_BucketIndex_RADOS::clean_index(const DoutPrefixProvider *dpp,
   get_bucket_index_objects(dir_oid, idx_layout.layout.normal.num_shards,
                            idx_layout.gen, &bucket_objs);
 
-  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
-  return CLSRGWIssueBucketIndexClean(index_pool,
-				     bucket_objs,
-				     cct->_conf->rgw_bucket_index_max_aio)();
+  const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto writer = IndexCleanWriter{*dpp, ex, index_pool};
+
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
+  } else {
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto writer = IndexCleanWriter{*dpp, ex, index_pool};
+
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
+                                     ceph::async::use_blocked[ec]);
+  }
+  return ceph::from_error_code(ec);
 }
 
 int RGWSI_BucketIndex_RADOS::read_stats(const DoutPrefixProvider *dpp,
@@ -452,6 +591,32 @@ int RGWSI_BucketIndex_RADOS::read_stats(const DoutPrefixProvider *dpp,
   return 0;
 }
 
+struct ReshardStatusReader : rgwrados::shard_io::RadosReader {
+  std::map<int, bufferlist>& buffers;
+
+  ReshardStatusReader(const DoutPrefixProvider& dpp,
+                      boost::asio::any_io_executor ex,
+                      librados::IoCtx& ioctx,
+                      std::map<int, bufferlist>& buffers)
+    : RadosReader(dpp, std::move(ex), ioctx), buffers(buffers)
+  {}
+  void prepare_read(int shard, librados::ObjectReadOperation& op) override {
+    auto& bl = buffers[shard];
+    cls_rgw_get_bucket_resharding(op, bl);
+  }
+  Result on_complete(int, boost::system::error_code ec) override {
+    // ignore ENOENT
+    if (ec && ec != boost::system::errc::no_such_file_or_directory) {
+      return Result::Error;
+    } else {
+      return Result::Success;
+    }
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "get resharding status: ";
+  }
+};
+
 int RGWSI_BucketIndex_RADOS::get_reshard_status(const DoutPrefixProvider *dpp,
                                                 optional_yield y,
                                                 const RGWBucketInfo& bucket_info,
@@ -471,28 +636,65 @@ int RGWSI_BucketIndex_RADOS::get_reshard_status(const DoutPrefixProvider *dpp,
     return r;
   }
 
-  for (auto i : bucket_objs) {
-    cls_rgw_bucket_instance_entry entry;
+  std::map<int, bufferlist> buffers;
+  const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto reader = ReshardStatusReader{*dpp, ex, index_pool, buffers};
 
-    int ret = cls_rgw_get_bucket_resharding(index_pool, i.second, &entry);
-    if (ret < 0 && ret != -ENOENT) {
-      ldpp_dout(dpp, -1) << "ERROR: " << __func__ << ": cls_rgw_get_bucket_resharding() returned ret=" << ret << dendl;
-      return ret;
-    }
+    rgwrados::shard_io::async_reads(reader, bucket_objs, max_aio, yield[ec]);
+  } else {
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto reader = ReshardStatusReader{*dpp, ex, index_pool, buffers};
 
-    status->push_back(entry);
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_reads(reader, bucket_objs, max_aio,
+                                    ceph::async::use_blocked[ec]);
+  }
+  if (ec) {
+    return ceph::from_error_code(ec);
+  }
+
+  try {
+    std::transform(buffers.begin(), buffers.end(),
+                   std::back_inserter(*status),
+                   [] (const auto& kv) {
+                     cls_rgw_bucket_instance_entry entry;
+                     cls_rgw_get_bucket_resharding_decode(kv.second, entry);
+                     return entry;
+                   });
+  } catch (const ceph::buffer::error&) {
+    return -EIO;
   }
 
   return 0;
 }
+
+struct ReshardStatusWriter : rgwrados::shard_io::RadosWriter {
+  cls_rgw_reshard_status status;
+  ReshardStatusWriter(const DoutPrefixProvider& dpp,
+                      boost::asio::any_io_executor ex,
+                      librados::IoCtx& ioctx,
+                      cls_rgw_reshard_status status)
+    : RadosWriter(dpp, std::move(ex), ioctx), status(status)
+  {}
+  void prepare_write(int, librados::ObjectWriteOperation& op) override {
+    cls_rgw_set_bucket_resharding(op, status);
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "set resharding status: ";
+  }
+};
 
 int RGWSI_BucketIndex_RADOS::set_reshard_status(const DoutPrefixProvider *dpp,
                                                 optional_yield y,
                                                 const RGWBucketInfo& bucket_info,
                                                 cls_rgw_reshard_status status)
 {
-  const auto entry = cls_rgw_bucket_instance_entry{.reshard_status = status};
-
   librados::IoCtx index_pool;
   map<int, string> bucket_objs;
 
@@ -504,15 +706,46 @@ int RGWSI_BucketIndex_RADOS::set_reshard_status(const DoutPrefixProvider *dpp,
     return r;
   }
 
-  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
-  r = CLSRGWIssueSetBucketResharding(index_pool, bucket_objs, entry, cct->_conf->rgw_bucket_index_max_aio)();
-  if (r < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
-      ": unable to issue set bucket resharding, r=" << r << " (" <<
-      cpp_strerror(-r) << ")" << dendl;
+  const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto writer = ReshardStatusWriter{*dpp, ex, index_pool, status};
+
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
+  } else {
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto writer = ReshardStatusWriter{*dpp, ex, index_pool, status};
+
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
+                                     ceph::async::use_blocked[ec]);
   }
-  return r;
+  return ceph::from_error_code(ec);
 }
+
+struct ReshardTrimWriter : rgwrados::shard_io::RadosWriter {
+  using RadosWriter::RadosWriter;
+  void prepare_write(int, librados::ObjectWriteOperation& op) override {
+    cls_rgw_bucket_reshard_log_trim(op);
+  }
+  Result on_complete(int, boost::system::error_code ec) override {
+    // keep trimming until ENODATA (no_message_available)
+    if (!ec) {
+      return Result::Retry;
+    } else if (ec == boost::system::errc::no_message_available) {
+      return Result::Success;
+    } else {
+      return Result::Error;
+    }
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "trim reshard logs: ";
+  }
+};
 
 int RGWSI_BucketIndex_RADOS::trim_reshard_log(const DoutPrefixProvider* dpp,
                                               optional_yield y,
@@ -525,7 +758,249 @@ int RGWSI_BucketIndex_RADOS::trim_reshard_log(const DoutPrefixProvider* dpp,
   if (r < 0) {
     return r;
   }
-  return CLSRGWIssueReshardLogTrim(index_pool, bucket_objs, cct->_conf->rgw_bucket_index_max_aio)();
+
+  const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto writer = ReshardTrimWriter{*dpp, ex, index_pool};
+
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
+  } else {
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto writer = ReshardTrimWriter{*dpp, ex, index_pool};
+
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
+                                     ceph::async::use_blocked[ec]);
+  }
+  return ceph::from_error_code(ec);
+}
+
+struct TagTimeoutWriter : rgwrados::shard_io::RadosWriter {
+  uint64_t timeout;
+  TagTimeoutWriter(const DoutPrefixProvider& dpp,
+                   boost::asio::any_io_executor ex,
+                   librados::IoCtx& ioctx,
+                   uint64_t timeout)
+    : RadosWriter(dpp, std::move(ex), ioctx), timeout(timeout)
+  {}
+  void prepare_write(int, librados::ObjectWriteOperation& op) override {
+    cls_rgw_bucket_set_tag_timeout(op, timeout);
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "set tag timeouts: ";
+  }
+};
+
+int RGWSI_BucketIndex_RADOS::set_tag_timeout(const DoutPrefixProvider* dpp,
+                                             optional_yield y,
+                                             const RGWBucketInfo& bucket_info,
+                                             uint64_t timeout)
+{
+  librados::IoCtx index_pool;
+  map<int, string> bucket_objs;
+
+  int r = open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto writer = TagTimeoutWriter{*dpp, ex, index_pool, timeout};
+
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
+  } else {
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto writer = TagTimeoutWriter{*dpp, ex, index_pool, timeout};
+
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
+                                     ceph::async::use_blocked[ec]);
+  }
+  return ceph::from_error_code(ec);
+}
+
+struct CheckReader : rgwrados::shard_io::RadosReader {
+  std::map<int, bufferlist>& buffers;
+
+  CheckReader(const DoutPrefixProvider& dpp,
+              boost::asio::any_io_executor ex,
+              librados::IoCtx& ioctx,
+              std::map<int, bufferlist>& buffers)
+    : RadosReader(dpp, std::move(ex), ioctx), buffers(buffers)
+  {}
+  void prepare_read(int shard, librados::ObjectReadOperation& op) override {
+    auto& bl = buffers[shard];
+    cls_rgw_bucket_check_index(op, bl);
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "check index shards: ";
+  }
+};
+
+int RGWSI_BucketIndex_RADOS::check_index(const DoutPrefixProvider *dpp, optional_yield y,
+                                         const RGWBucketInfo& bucket_info,
+                                         std::map<int, bufferlist>& buffers)
+{
+  librados::IoCtx index_pool;
+  std::map<int, std::string> bucket_objs;
+
+  int r = open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto reader = CheckReader{*dpp, ex, index_pool, buffers};
+
+    rgwrados::shard_io::async_reads(reader, bucket_objs, max_aio, yield[ec]);
+  } else {
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto reader = CheckReader{*dpp, ex, index_pool, buffers};
+
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_reads(reader, bucket_objs, max_aio,
+                                    ceph::async::use_blocked[ec]);
+  }
+  return ceph::from_error_code(ec);
+}
+
+struct RebuildWriter : rgwrados::shard_io::RadosWriter {
+  using RadosWriter::RadosWriter;
+  void prepare_write(int, librados::ObjectWriteOperation& op) override {
+    cls_rgw_bucket_rebuild_index(op);
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "rebuild index shards: ";
+  }
+};
+
+int RGWSI_BucketIndex_RADOS::rebuild_index(const DoutPrefixProvider *dpp,
+                                           optional_yield y,
+                                           const RGWBucketInfo& bucket_info)
+{
+  librados::IoCtx index_pool;
+  map<int, string> bucket_objs;
+
+  int r = open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
+  if (r < 0) {
+    return r;
+  }
+
+  const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto writer = RebuildWriter{*dpp, ex, index_pool};
+
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
+  } else {
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto writer = RebuildWriter{*dpp, ex, index_pool};
+
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
+                                     ceph::async::use_blocked[ec]);
+  }
+  return ceph::from_error_code(ec);
+}
+
+struct ListReader : rgwrados::shard_io::RadosReader {
+  const cls_rgw_obj_key& start_obj;
+  const std::string& prefix;
+  const std::string& delimiter;
+  uint32_t num_entries;
+  bool list_versions;
+  std::map<int, rgw_cls_list_ret>& results;
+
+  ListReader(const DoutPrefixProvider& dpp,
+             boost::asio::any_io_executor ex,
+             librados::IoCtx& ioctx,
+             const cls_rgw_obj_key& start_obj,
+             const std::string& prefix,
+             const std::string& delimiter,
+             uint32_t num_entries, bool list_versions,
+             std::map<int, rgw_cls_list_ret>& results)
+    : RadosReader(dpp, std::move(ex), ioctx),
+      start_obj(start_obj), prefix(prefix), delimiter(delimiter),
+      num_entries(num_entries), list_versions(list_versions),
+      results(results)
+  {}
+  void prepare_read(int shard, librados::ObjectReadOperation& op) override {
+    // set the marker depending on whether we've already queried this
+    // shard and gotten a RGWBIAdvanceAndRetryError (defined
+    // constant) return value; if we have use the marker in the return
+    // to advance the search, otherwise use the marker passed in by the
+    // caller
+    auto& result = results[shard];
+    const cls_rgw_obj_key& marker =
+        result.marker.empty() ? start_obj : result.marker;
+    cls_rgw_bucket_list_op(op, marker, prefix, delimiter,
+                           num_entries, list_versions, &result);
+  }
+  Result on_complete(int, boost::system::error_code ec) override {
+    if (ec.value() == -RGWBIAdvanceAndRetryError) {
+      return Result::Retry;
+    } else if (ec) {
+      return Result::Error;
+    } else {
+      return Result::Success;
+    }
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "sharded list objects: ";
+  }
+};
+
+int RGWSI_BucketIndex_RADOS::list_objects(const DoutPrefixProvider* dpp, optional_yield y,
+                                          librados::IoCtx& index_pool,
+                                          const std::map<int, string>& bucket_objs,
+                                          const cls_rgw_obj_key& start_obj,
+                                          const std::string& prefix,
+                                          const std::string& delimiter,
+                                          uint32_t num_entries, bool list_versions,
+                                          std::map<int, rgw_cls_list_ret>& results)
+{
+  const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto reader = ListReader{*dpp, ex, index_pool, start_obj, prefix, delimiter,
+                             num_entries, list_versions, results};
+
+    rgwrados::shard_io::async_reads(reader, bucket_objs, max_aio, yield[ec]);
+  } else {
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto reader = ListReader{*dpp, ex, index_pool, start_obj, prefix, delimiter,
+                             num_entries, list_versions, results};
+
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_reads(reader, bucket_objs, max_aio,
+                                    ceph::async::use_blocked[ec]);
+  }
+  return ceph::from_error_code(ec);
 }
 
 int RGWSI_BucketIndex_RADOS::handle_overwrite(const DoutPrefixProvider *dpp,

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -507,6 +507,20 @@ int RGWSI_BucketIndex_RADOS::set_reshard_status(const DoutPrefixProvider *dpp,
   return r;
 }
 
+int RGWSI_BucketIndex_RADOS::trim_reshard_log(const DoutPrefixProvider* dpp,
+                                              optional_yield y,
+                                              const RGWBucketInfo& bucket_info)
+{
+  librados::IoCtx index_pool;
+  map<int, string> bucket_objs;
+
+  int r = open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
+  if (r < 0) {
+    return r;
+  }
+  return CLSRGWIssueReshardLogTrim(index_pool, bucket_objs, cct->_conf->rgw_bucket_index_max_aio)();
+}
+
 int RGWSI_BucketIndex_RADOS::handle_overwrite(const DoutPrefixProvider *dpp,
                                               const RGWBucketInfo& info,
                                               const RGWBucketInfo& orig_info,

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -11,6 +11,7 @@
 #include "rgw_datalog.h"
 
 #include "cls/rgw/cls_rgw_client.h"
+#include "common/errno.h"
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -477,6 +478,33 @@ int RGWSI_BucketIndex_RADOS::get_reshard_status(const DoutPrefixProvider *dpp, c
   }
 
   return 0;
+}
+
+int RGWSI_BucketIndex_RADOS::set_reshard_status(const DoutPrefixProvider *dpp,
+                                                const RGWBucketInfo& bucket_info,
+                                                cls_rgw_reshard_status status)
+{
+  const auto entry = cls_rgw_bucket_instance_entry{.reshard_status = status};
+
+  librados::IoCtx index_pool;
+  map<int, string> bucket_objs;
+
+  int r = open_bucket_index(dpp, bucket_info, std::nullopt, bucket_info.layout.current_index, &index_pool, &bucket_objs, nullptr);
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+      ": unable to open bucket index, r=" << r << " (" <<
+      cpp_strerror(-r) << ")" << dendl;
+    return r;
+  }
+
+  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
+  r = CLSRGWIssueSetBucketResharding(index_pool, bucket_objs, entry, cct->_conf->rgw_bucket_index_max_aio)();
+  if (r < 0) {
+    ldpp_dout(dpp, 0) << "ERROR: " << __func__ <<
+      ": unable to issue set bucket resharding, r=" << r << " (" <<
+      cpp_strerror(-r) << ")" << dendl;
+  }
+  return r;
 }
 
 int RGWSI_BucketIndex_RADOS::handle_overwrite(const DoutPrefixProvider *dpp,

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -138,6 +138,9 @@ public:
 
   int get_reshard_status(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
                          std::list<cls_rgw_bucket_instance_entry> *status);
+  int set_reshard_status(const DoutPrefixProvider *dpp,
+                         const RGWBucketInfo& bucket_info,
+                         cls_rgw_reshard_status status);
 
   int handle_overwrite(const DoutPrefixProvider *dpp, const RGWBucketInfo& info,
                        const RGWBucketInfo& orig_info,

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -66,6 +66,8 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
                               uint64_t gen_id, const std::string& obj_key,
                               std::string* bucket_obj, int* shard_id);
 
+public:
+
   int cls_bucket_head(const DoutPrefixProvider *dpp,
 		      const RGWBucketInfo& bucket_info,
                       const rgw::bucket_index_layout_generation& idx_layout,
@@ -73,8 +75,6 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
                       std::vector<rgw_bucket_dir_header> *headers,
                       std::map<int, std::string> *bucket_instance_ids,
                       optional_yield y);
-
-public:
 
   librados::Rados* rados{nullptr};
 

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -24,6 +24,7 @@
 #include "svc_tier_rados.h"
 
 struct rgw_bucket_dir_header;
+struct rgw_cls_list_ret;
 
 class RGWSI_BILog_RADOS;
 
@@ -144,6 +145,26 @@ public:
                          cls_rgw_reshard_status status);
   int trim_reshard_log(const DoutPrefixProvider* dpp, optional_yield,
                        const RGWBucketInfo& bucket_info);
+
+  int set_tag_timeout(const DoutPrefixProvider *dpp, optional_yield y,
+                      const RGWBucketInfo& bucket_info, uint64_t timeout);
+
+  int check_index(const DoutPrefixProvider *dpp, optional_yield y,
+                  const RGWBucketInfo& bucket_info,
+                  std::map<int, bufferlist>& buffers);
+
+  int rebuild_index(const DoutPrefixProvider *dpp, optional_yield y,
+                    const RGWBucketInfo& bucket_info);
+
+  /// Read the requested number of entries from each index shard object.
+  int list_objects(const DoutPrefixProvider* dpp, optional_yield y,
+                   librados::IoCtx& index_pool,
+                   const std::map<int, std::string>& bucket_objs,
+                   const cls_rgw_obj_key& start_obj,
+                   const std::string& prefix,
+                   const std::string& delimiter,
+                   uint32_t num_entries, bool list_versions,
+                   std::map<int, rgw_cls_list_ret>& results);
 
   int handle_overwrite(const DoutPrefixProvider *dpp, const RGWBucketInfo& info,
                        const RGWBucketInfo& orig_info,

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -121,11 +121,11 @@ public:
     return bucket_shard_index(sharding_key, num_shards);
   }
 
-  int init_index(const DoutPrefixProvider *dpp,
+  int init_index(const DoutPrefixProvider *dpp, optional_yield y,
                  const RGWBucketInfo& bucket_info,
                  const rgw::bucket_index_layout_generation& idx_layout,
                  bool judge_support_logrecord = false) override;
-  int clean_index(const DoutPrefixProvider *dpp,
+  int clean_index(const DoutPrefixProvider *dpp, optional_yield y,
                   const RGWBucketInfo& bucket_info,
                   const rgw::bucket_index_layout_generation& idx_layout) override;
 
@@ -136,9 +136,10 @@ public:
                  RGWBucketEnt *stats,
                  optional_yield y) override;
 
-  int get_reshard_status(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
+  int get_reshard_status(const DoutPrefixProvider *dpp, optional_yield y,
+                         const RGWBucketInfo& bucket_info,
                          std::list<cls_rgw_bucket_instance_entry> *status);
-  int set_reshard_status(const DoutPrefixProvider *dpp,
+  int set_reshard_status(const DoutPrefixProvider *dpp, optional_yield y,
                          const RGWBucketInfo& bucket_info,
                          cls_rgw_reshard_status status);
   int trim_reshard_log(const DoutPrefixProvider* dpp, optional_yield,

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -141,6 +141,8 @@ public:
   int set_reshard_status(const DoutPrefixProvider *dpp,
                          const RGWBucketInfo& bucket_info,
                          cls_rgw_reshard_status status);
+  int trim_reshard_log(const DoutPrefixProvider* dpp, optional_yield,
+                       const RGWBucketInfo& bucket_info);
 
   int handle_overwrite(const DoutPrefixProvider *dpp, const RGWBucketInfo& info,
                        const RGWBucketInfo& orig_info,

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -5,11 +5,14 @@
 #include "svc_bi_rados.h"
 
 #include "rgw_asio_thread.h"
+#include "driver/rados/shard_io.h"
 #include "cls/rgw/cls_rgw_client.h"
+#include "common/async/blocked_completion.h"
 
 #define dout_subsys ceph_subsys_rgw
 
 using namespace std;
+using rgwrados::shard_io::Result;
 
 RGWSI_BILog_RADOS::RGWSI_BILog_RADOS(CephContext *cct) : RGWServiceInstance(cct)
 {
@@ -19,6 +22,35 @@ void RGWSI_BILog_RADOS::init(RGWSI_BucketIndex_RADOS *bi_rados_svc)
 {
   svc.bi = bi_rados_svc;
 }
+
+struct TrimWriter : rgwrados::shard_io::RadosWriter {
+  const BucketIndexShardsManager& start;
+  const BucketIndexShardsManager& end;
+
+  TrimWriter(const DoutPrefixProvider& dpp,
+             boost::asio::any_io_executor ex,
+             librados::IoCtx& ioctx,
+             const BucketIndexShardsManager& start,
+             const BucketIndexShardsManager& end)
+    : RadosWriter(dpp, std::move(ex), ioctx), start(start), end(end)
+  {}
+  void prepare_write(int shard, librados::ObjectWriteOperation& op) override {
+    cls_rgw_bilog_trim(op, start.get(shard, ""), end.get(shard, ""));
+  }
+  Result on_complete(int, boost::system::error_code ec) override {
+    // continue trimming until -ENODATA or other error
+    if (ec == boost::system::errc::no_message_available) {
+      return Result::Success;
+    } else if (ec) {
+      return Result::Error;
+    } else {
+      return Result::Retry;
+    }
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "trim bilog shards: ";
+  }
+};
 
 int RGWSI_BILog_RADOS::log_trim(const DoutPrefixProvider *dpp, optional_yield y,
 				const RGWBucketInfo& bucket_info,
@@ -49,10 +81,36 @@ int RGWSI_BILog_RADOS::log_trim(const DoutPrefixProvider *dpp, optional_yield y,
     return r;
   }
 
-  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
-  return CLSRGWIssueBILogTrim(index_pool, start_marker_mgr, end_marker_mgr, bucket_objs,
-			      cct->_conf->rgw_bucket_index_max_aio)();
+  const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto writer = TrimWriter{*dpp, ex, index_pool, start_marker_mgr, end_marker_mgr};
+
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
+  } else {
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto writer = TrimWriter{*dpp, ex, index_pool, start_marker_mgr, end_marker_mgr};
+
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
+                                     ceph::async::use_blocked[ec]);
+  }
+  return ceph::from_error_code(ec);
 }
+
+struct StartWriter : rgwrados::shard_io::RadosWriter {
+  using RadosWriter::RadosWriter;
+  void prepare_write(int, librados::ObjectWriteOperation& op) override {
+    cls_rgw_bilog_start(op);
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "restart bilog shards: ";
+  }
+};
 
 int RGWSI_BILog_RADOS::log_start(const DoutPrefixProvider *dpp, optional_yield y,
                                  const RGWBucketInfo& bucket_info,
@@ -66,9 +124,36 @@ int RGWSI_BILog_RADOS::log_start(const DoutPrefixProvider *dpp, optional_yield y
   if (r < 0)
     return r;
 
-  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
-  return CLSRGWIssueResyncBucketBILog(index_pool, bucket_objs, cct->_conf->rgw_bucket_index_max_aio)();
+  const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto writer = StartWriter{*dpp, ex, index_pool};
+
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
+  } else {
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto writer = StartWriter{*dpp, ex, index_pool};
+
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
+                                     ceph::async::use_blocked[ec]);
+  }
+  return ceph::from_error_code(ec);
 }
+
+struct StopWriter : rgwrados::shard_io::RadosWriter {
+  using RadosWriter::RadosWriter;
+  void prepare_write(int, librados::ObjectWriteOperation& op) override {
+    cls_rgw_bilog_stop(op);
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "stop bilog shards: ";
+  }
+};
 
 int RGWSI_BILog_RADOS::log_stop(const DoutPrefixProvider *dpp, optional_yield y,
                                 const RGWBucketInfo& bucket_info,
@@ -82,8 +167,25 @@ int RGWSI_BILog_RADOS::log_stop(const DoutPrefixProvider *dpp, optional_yield y,
   if (r < 0)
     return r;
 
-  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
-  return CLSRGWIssueBucketBILogStop(index_pool, bucket_objs, cct->_conf->rgw_bucket_index_max_aio)();
+  const size_t max_aio = cct->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto writer = StopWriter{*dpp, ex, index_pool};
+
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio, yield[ec]);
+  } else {
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto writer = StopWriter{*dpp, ex, index_pool};
+
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_writes(writer, bucket_objs, max_aio,
+                                     ceph::async::use_blocked[ec]);
+  }
+  return ceph::from_error_code(ec);
 }
 
 static void build_bucket_index_marker(const string& shard_id_str,
@@ -96,6 +198,62 @@ static void build_bucket_index_marker(const string& shard_id_str,
   }
 }
 
+struct LogReader : rgwrados::shard_io::RadosReader {
+  const BucketIndexShardsManager& start;
+  uint32_t max;
+  std::map<int, cls_rgw_bi_log_list_ret>& logs;
+
+  LogReader(const DoutPrefixProvider& dpp, boost::asio::any_io_executor ex,
+            librados::IoCtx& ioctx, const BucketIndexShardsManager& start,
+            uint32_t max, std::map<int, cls_rgw_bi_log_list_ret>& logs)
+    : RadosReader(dpp, std::move(ex), ioctx),
+      start(start), max(max), logs(logs)
+  {}
+  void prepare_read(int shard, librados::ObjectReadOperation& op) override {
+    auto& result = logs[shard];
+    cls_rgw_bilog_list(op, start.get(shard, ""), max, &result, nullptr);
+  }
+  void add_prefix(std::ostream& out) const override {
+    out << "list bilog shards: ";
+  }
+};
+
+static int bilog_list(const DoutPrefixProvider* dpp, optional_yield y,
+                      RGWSI_BucketIndex_RADOS* svc_bi,
+                      const RGWBucketInfo& bucket_info,
+                      const rgw::bucket_log_layout_generation& log_layout,
+                      const BucketIndexShardsManager& start,
+                      int shard_id, uint32_t max,
+                      std::map<int, cls_rgw_bi_log_list_ret>& logs)
+{
+  librados::IoCtx index_pool;
+  map<int, string> oids;
+  const auto& current_index = rgw::log_to_index_layout(log_layout);
+  int r = svc_bi->open_bucket_index(dpp, bucket_info, shard_id, current_index, &index_pool, &oids, nullptr);
+  if (r < 0)
+    return r;
+
+  const size_t max_aio = dpp->get_cct()->_conf->rgw_bucket_index_max_aio;
+  boost::system::error_code ec;
+  if (y) {
+    // run on the coroutine's executor and suspend until completion
+    auto yield = y.get_yield_context();
+    auto ex = yield.get_executor();
+    auto reader = LogReader{*dpp, ex, index_pool, start, max, logs};
+
+    rgwrados::shard_io::async_reads(reader, oids, max_aio, yield[ec]);
+  } else {
+    // run a strand on the system executor and block on a condition variable
+    auto ex = boost::asio::make_strand(boost::asio::system_executor{});
+    auto reader = LogReader{*dpp, ex, index_pool, start, max, logs};
+
+    maybe_warn_about_blocking(dpp);
+    rgwrados::shard_io::async_reads(reader, oids, max_aio,
+                                    ceph::async::use_blocked[ec]);
+  }
+  return ceph::from_error_code(ec);
+}
+
 int RGWSI_BILog_RADOS::log_list(const DoutPrefixProvider *dpp, optional_yield y,
 				const RGWBucketInfo& bucket_info,
 				const rgw::bucket_log_layout_generation& log_layout,
@@ -105,26 +263,19 @@ int RGWSI_BILog_RADOS::log_list(const DoutPrefixProvider *dpp, optional_yield y,
   ldpp_dout(dpp, 20) << __func__ << ": " << bucket_info.bucket << " marker " << marker << " shard_id=" << shard_id << " max " << max << dendl;
   result.clear();
 
-  librados::IoCtx index_pool;
-  map<int, string> oids;
-  map<int, cls_rgw_bi_log_list_ret> bi_log_lists;
-  const auto& current_index = rgw::log_to_index_layout(log_layout);
-  int r = svc.bi->open_bucket_index(dpp, bucket_info, shard_id, current_index, &index_pool, &oids, nullptr);
-  if (r < 0)
-    return r;
-
   BucketIndexShardsManager marker_mgr;
-  bool has_shards = (oids.size() > 1 || shard_id >= 0);
+  const bool has_shards = (shard_id >= 0);
   // If there are multiple shards for the bucket index object, the marker
   // should have the pattern '{shard_id_1}#{shard_marker_1},{shard_id_2}#
   // {shard_marker_2}...', if there is no sharding, the bi_log_list should
   // only contain one record, and the key is the bucket instance id.
-  r = marker_mgr.from_string(marker, shard_id);
+  int r = marker_mgr.from_string(marker, shard_id);
   if (r < 0)
     return r;
 
-  maybe_warn_about_blocking(dpp); // TODO: use AioTrottle
-  r = CLSRGWIssueBILogList(index_pool, marker_mgr, max, oids, bi_log_lists, cct->_conf->rgw_bucket_index_max_aio)();
+  std::map<int, cls_rgw_bi_log_list_ret> bi_log_lists;
+  r = bilog_list(dpp, y, svc.bi, bucket_info, log_layout, marker_mgr,
+                 shard_id, max, bi_log_lists);
   if (r < 0)
     return r;
 

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -20,7 +20,7 @@ void RGWSI_BILog_RADOS::init(RGWSI_BucketIndex_RADOS *bi_rados_svc)
   svc.bi = bi_rados_svc;
 }
 
-int RGWSI_BILog_RADOS::log_trim(const DoutPrefixProvider *dpp,
+int RGWSI_BILog_RADOS::log_trim(const DoutPrefixProvider *dpp, optional_yield y,
 				const RGWBucketInfo& bucket_info,
 				const rgw::bucket_log_layout_generation& log_layout,
 				int shard_id,
@@ -54,7 +54,10 @@ int RGWSI_BILog_RADOS::log_trim(const DoutPrefixProvider *dpp,
 			      cct->_conf->rgw_bucket_index_max_aio)();
 }
 
-int RGWSI_BILog_RADOS::log_start(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw::bucket_log_layout_generation& log_layout, int shard_id)
+int RGWSI_BILog_RADOS::log_start(const DoutPrefixProvider *dpp, optional_yield y,
+                                 const RGWBucketInfo& bucket_info,
+                                 const rgw::bucket_log_layout_generation& log_layout,
+                                 int shard_id)
 {
   librados::IoCtx index_pool;
   map<int, string> bucket_objs;
@@ -67,7 +70,10 @@ int RGWSI_BILog_RADOS::log_start(const DoutPrefixProvider *dpp, const RGWBucketI
   return CLSRGWIssueResyncBucketBILog(index_pool, bucket_objs, cct->_conf->rgw_bucket_index_max_aio)();
 }
 
-int RGWSI_BILog_RADOS::log_stop(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw::bucket_log_layout_generation& log_layout, int shard_id)
+int RGWSI_BILog_RADOS::log_stop(const DoutPrefixProvider *dpp, optional_yield y,
+                                const RGWBucketInfo& bucket_info,
+                                const rgw::bucket_log_layout_generation& log_layout,
+                                int shard_id)
 {
   librados::IoCtx index_pool;
   map<int, string> bucket_objs;
@@ -90,7 +96,7 @@ static void build_bucket_index_marker(const string& shard_id_str,
   }
 }
 
-int RGWSI_BILog_RADOS::log_list(const DoutPrefixProvider *dpp,
+int RGWSI_BILog_RADOS::log_list(const DoutPrefixProvider *dpp, optional_yield y,
 				const RGWBucketInfo& bucket_info,
 				const rgw::bucket_log_layout_generation& log_layout,
 				int shard_id, string& marker, uint32_t max,

--- a/src/rgw/services/svc_bilog_rados.h
+++ b/src/rgw/services/svc_bilog_rados.h
@@ -29,15 +29,23 @@ public:
 
   void init(RGWSI_BucketIndex_RADOS *bi_rados_svc);
 
-  int log_start(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw::bucket_log_layout_generation& log_layout, int shard_id);
-  int log_stop(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, const rgw::bucket_log_layout_generation& log_layout, int shard_id);
+  int log_start(const DoutPrefixProvider *dpp, optional_yield y,
+                const RGWBucketInfo& bucket_info,
+                const rgw::bucket_log_layout_generation& log_layout,
+                int shard_id);
+  int log_stop(const DoutPrefixProvider *dpp, optional_yield y,
+               const RGWBucketInfo& bucket_info,
+               const rgw::bucket_log_layout_generation& log_layout,
+               int shard_id);
 
-  int log_trim(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
+  int log_trim(const DoutPrefixProvider *dpp, optional_yield y,
+               const RGWBucketInfo& bucket_info,
                const rgw::bucket_log_layout_generation& log_layout,
                int shard_id,
                std::string_view start_marker,
                std::string_view end_marker);
-  int log_list(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
+  int log_list(const DoutPrefixProvider *dpp, optional_yield y,
+               const RGWBucketInfo& bucket_info,
                const rgw::bucket_log_layout_generation& log_layout,
                int shard_id,
                std::string& marker,

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -52,22 +52,27 @@ string str_int(string s, int i)
   return s;
 }
 
+static int read_header(librados::IoCtx& ioctx, const string& oid,
+                       rgw_bucket_dir_header& header)
+{
+  bufferlist bl;
+  librados::ObjectReadOperation op;
+  op.omap_get_header(&bl, nullptr);
+  int r = ioctx.operate(oid, &op, nullptr);
+  if (r < 0) {
+    return r;
+  }
+  auto p = bl.cbegin();
+  decode(header, p);
+  return r;
+}
+
 void test_stats(librados::IoCtx& ioctx, const string& oid, RGWObjCategory category, uint64_t num_entries, uint64_t total_size)
 {
-  map<int, struct rgw_cls_list_ret> results;
-  map<int, string> oids;
-  oids[0] = oid;
-  ASSERT_EQ(0, CLSRGWIssueGetDirHeader(ioctx, oids, results, 8)());
-
-  uint64_t entries = 0;
-  uint64_t size = 0;
-  map<int, struct rgw_cls_list_ret>::iterator iter = results.begin();
-  for (; iter != results.end(); ++iter) {
-    entries += (iter->second).dir.header.stats[category].num_entries;
-    size += (iter->second).dir.header.stats[category].total_size;
-  }
-  ASSERT_EQ(total_size, size);
-  ASSERT_EQ(num_entries, entries);
+  rgw_bucket_dir_header header;
+  ASSERT_EQ(0, read_header(ioctx, oid, header));
+  ASSERT_EQ(total_size, header.stats[category].total_size);
+  ASSERT_EQ(num_entries, header.stats[category].num_entries);
 }
 
 void index_prepare(librados::IoCtx& ioctx, const string& oid, RGWModifyOp index_op,
@@ -343,10 +348,11 @@ TEST_F(cls_rgw, index_suggest)
     cls_rgw_encode_suggestion(suggest_op, dirent, updates);
   }
 
-  map<int, string> bucket_objs;
-  bucket_objs[0] = bucket_oid;
-  int r = CLSRGWIssueSetTagTimeout(ioctx, bucket_objs, 8 /* max aio */, 1)();
-  ASSERT_EQ(0, r);
+  {
+    librados::ObjectWriteOperation op;
+    cls_rgw_bucket_set_tag_timeout(op, 1);
+    ASSERT_EQ(0, ioctx.operate(bucket_oid, &op));
+  }
 
   sleep(1);
 
@@ -368,15 +374,17 @@ TEST_F(cls_rgw, index_suggest)
 static void list_entries(librados::IoCtx& ioctx,
                          const std::string& oid,
                          uint32_t num_entries,
-                         std::map<int, rgw_cls_list_ret>& results)
+                         rgw_cls_list_ret& result,
+                         const cls_rgw_obj_key& start_key = {},
+                         const std::string& delimiter = "")
 {
   std::map<int, std::string> oids = { {0, oid} };
-  cls_rgw_obj_key start_key;
   string empty_prefix;
-  string empty_delimiter;
-  ASSERT_EQ(0, CLSRGWIssueBucketList(ioctx, start_key, empty_prefix,
-                                     empty_delimiter, num_entries,
-                                     true, oids, results, 1)());
+  constexpr bool list_versions = true;
+  librados::ObjectReadOperation op;
+  cls_rgw_bucket_list_op(op, start_key, empty_prefix, delimiter,
+                         num_entries, list_versions, &result);
+  ASSERT_EQ(0, ioctx.operate(oid, &op, nullptr));
 }
 
 TEST_F(cls_rgw, index_suggest_complete)
@@ -398,10 +406,9 @@ TEST_F(cls_rgw, index_suggest_complete)
   // list entry before completion
   rgw_bucket_dir_entry dirent;
   {
-    std::map<int, rgw_cls_list_ret> listing;
+    rgw_cls_list_ret listing;
     list_entries(ioctx, bucket_oid, 1, listing);
-    ASSERT_EQ(1, listing.size());
-    const auto& entries = listing.begin()->second.dir.m;
+    const auto& entries = listing.dir.m;
     ASSERT_EQ(1, entries.size());
     dirent = entries.begin()->second;
     ASSERT_EQ(obj, dirent.key);
@@ -422,10 +429,9 @@ TEST_F(cls_rgw, index_suggest_complete)
   }
   // list entry again, verify that suggested removal was not applied
   {
-    std::map<int, rgw_cls_list_ret> listing;
+    rgw_cls_list_ret listing;
     list_entries(ioctx, bucket_oid, 1, listing);
-    ASSERT_EQ(1, listing.size());
-    const auto& entries = listing.begin()->second.dir.m;
+    const auto& entries = listing.dir.m;
     ASSERT_EQ(1, entries.size());
     EXPECT_TRUE(entries.begin()->second.exists);
   }
@@ -485,19 +491,9 @@ TEST_F(cls_rgw, index_list)
   test_stats(ioctx, bucket_oid, RGWObjCategory::None,
 	     num_objs, obj_size * num_objs);
 
-  map<int, string> oids = { {0, bucket_oid} };
-  map<int, struct rgw_cls_list_ret> list_results;
-  cls_rgw_obj_key start_key("", "");
-  string empty_prefix;
-  string empty_delimiter;
-  int r = CLSRGWIssueBucketList(ioctx, start_key,
-				empty_prefix, empty_delimiter,
-				1000, true, oids, list_results, 1)();
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(1u, list_results.size());
-
-  auto it = list_results.begin();
-  auto m = (it->second).dir.m;
+  rgw_cls_list_ret listing;
+  list_entries(ioctx, bucket_oid, 1000, listing);
+  const auto& m = listing.dir.m;
 
   ASSERT_EQ(4u, m.size());
   int i = 0;
@@ -561,22 +557,11 @@ TEST_F(cls_rgw, index_list_delimited)
     }
   }
 
-  map<int, string> oids = { {0, bucket_oid} };
-  map<int, struct rgw_cls_list_ret> list_results;
+  rgw_cls_list_ret listing;
   cls_rgw_obj_key start_key("", "");
-  const string empty_prefix;
   const string delimiter = "/";
-  int r = CLSRGWIssueBucketList(ioctx, start_key,
-				empty_prefix, delimiter,
-				1000, true, oids, list_results, 1)();
-  ASSERT_EQ(r, 0);
-  ASSERT_EQ(1u, list_results.size()) <<
-    "Because we only have one bucket index shard, we should "
-    "only get one list_result.";
-
-  auto it = list_results.begin();
-  auto id_entry_map = it->second.dir.m;
-  bool truncated = it->second.is_truncated;
+  list_entries(ioctx, bucket_oid, 1000, listing, start_key, delimiter);
+  auto id_entry_map = listing.dir.m;
 
   // the cls code will make 4 tries to get 1000 entries; however
   // because each of the subdirectories is so large, each attempt will
@@ -584,28 +569,21 @@ TEST_F(cls_rgw, index_list_delimited)
 
   ASSERT_EQ(48u, id_entry_map.size()) <<
     "We should get 40 top-level entries and the tops of 8 \"subdirectories\".";
-  ASSERT_EQ(true, truncated) << "We did not get all entries.";
+  ASSERT_EQ(true, listing.is_truncated) << "We did not get all entries.";
 
   ASSERT_EQ("a-0", id_entry_map.cbegin()->first);
   ASSERT_EQ("p/", id_entry_map.crbegin()->first);
 
   // now let's get the rest of the entries
 
-  list_results.clear();
-  
+  listing = {};
   cls_rgw_obj_key start_key2("p/", "");
-  r = CLSRGWIssueBucketList(ioctx, start_key2,
-			    empty_prefix, delimiter,
-			    1000, true, oids, list_results, 1)();
-  ASSERT_EQ(r, 0);
-
-  it = list_results.begin();
-  id_entry_map = it->second.dir.m;
-  truncated = it->second.is_truncated;
+  list_entries(ioctx, bucket_oid, 1000, listing, start_key2, delimiter);
+  id_entry_map = listing.dir.m;
 
   ASSERT_EQ(17u, id_entry_map.size()) <<
     "We should get 15 top-level entries and the tops of 2 \"subdirectories\".";
-  ASSERT_EQ(false, truncated) << "We now have all entries.";
+  ASSERT_EQ(false, listing.is_truncated) << "We now have all entries.";
 
   ASSERT_EQ("q-0", id_entry_map.cbegin()->first);
   ASSERT_EQ("u-4", id_entry_map.crbegin()->first);
@@ -1283,10 +1261,9 @@ TEST_F(cls_rgw, index_racing_removes)
 
   // list to verify no pending ops
   {
-    std::map<int, rgw_cls_list_ret> results;
-    list_entries(ioctx, bucket_oid, 1, results);
-    ASSERT_EQ(1, results.size());
-    const auto& entries = results.begin()->second.dir.m;
+    rgw_cls_list_ret listing;
+    list_entries(ioctx, bucket_oid, 1, listing);
+    const auto& entries = listing.dir.m;
     ASSERT_EQ(1, entries.size());
     dirent = std::move(entries.begin()->second);
     ASSERT_EQ(obj, dirent.key);
@@ -1307,10 +1284,9 @@ TEST_F(cls_rgw, index_racing_removes)
   // complete on tag2
   index_complete(ioctx, bucket_oid, CLS_RGW_OP_DEL, tag2, ++epoch, obj, meta);
   {
-    std::map<int, rgw_cls_list_ret> results;
-    list_entries(ioctx, bucket_oid, 1, results);
-    ASSERT_EQ(1, results.size());
-    const auto& entries = results.begin()->second.dir.m;
+    rgw_cls_list_ret listing;
+    list_entries(ioctx, bucket_oid, 1, listing);
+    const auto& entries = listing.dir.m;
     ASSERT_EQ(1, entries.size());
     dirent = std::move(entries.begin()->second);
     ASSERT_EQ(obj, dirent.key);
@@ -1321,10 +1297,9 @@ TEST_F(cls_rgw, index_racing_removes)
   // cancel on tag1
   index_complete(ioctx, bucket_oid, CLS_RGW_OP_CANCEL, tag1, ++epoch, obj, meta);
   {
-    std::map<int, rgw_cls_list_ret> results;
-    list_entries(ioctx, bucket_oid, 1, results);
-    ASSERT_EQ(1, results.size());
-    const auto& entries = results.begin()->second.dir.m;
+    rgw_cls_list_ret listing;
+    list_entries(ioctx, bucket_oid, 1, listing);
+    const auto& entries = listing.dir.m;
     ASSERT_EQ(1, entries.size());
     dirent = std::move(entries.begin()->second);
     ASSERT_EQ(obj, dirent.key);
@@ -1337,10 +1312,9 @@ TEST_F(cls_rgw, index_racing_removes)
 
   // verify that the key was removed
   {
-    std::map<int, rgw_cls_list_ret> results;
-    list_entries(ioctx, bucket_oid, 1, results);
-    EXPECT_EQ(1, results.size());
-    const auto& entries = results.begin()->second.dir.m;
+    rgw_cls_list_ret listing;
+    list_entries(ioctx, bucket_oid, 1, listing);
+    const auto& entries = listing.dir.m;
     ASSERT_EQ(0, entries.size());
   }
 
@@ -1350,11 +1324,9 @@ TEST_F(cls_rgw, index_racing_removes)
 void set_reshard_status(librados::IoCtx& ioctx, const std::string& oid,
                         cls_rgw_reshard_status status)
 {
-  map<int, string> bucket_objs;
-  bucket_objs[0] = oid;
-  const auto entry = cls_rgw_bucket_instance_entry{.reshard_status = status};
-  int r = CLSRGWIssueSetBucketResharding(ioctx, bucket_objs, entry, 1)();
-  ASSERT_EQ(0, r);
+  librados::ObjectWriteOperation op;
+  cls_rgw_set_bucket_resharding(op, status);
+  ASSERT_EQ(0, ioctx.operate(oid, &op));
 }
 
 static int reshardlog_list(librados::IoCtx& ioctx, const std::string& oid,
@@ -1426,17 +1398,9 @@ TEST_F(cls_rgw, reshardlog_list)
 
 void reshardlog_entries(librados::IoCtx& ioctx, const std::string& oid, uint32_t num_entries)
 {
-  map<int, struct rgw_cls_list_ret> results;
-  map<int, string> oids;
-  oids[0] = oid;
-  ASSERT_EQ(0, CLSRGWIssueGetDirHeader(ioctx, oids, results, 8)());
-
-  uint32_t entries = 0;
-  map<int, struct rgw_cls_list_ret>::iterator iter = results.begin();
-  for (; iter != results.end(); ++iter) {
-    entries += (iter->second).dir.header.reshardlog_entries;
-  }
-  ASSERT_EQ(entries, num_entries);
+  rgw_bucket_dir_header header;
+  ASSERT_EQ(0, read_header(ioctx, oid, header));
+  ASSERT_EQ(num_entries, header.reshardlog_entries);
 }
 
 TEST_F(cls_rgw, reshardlog_num)

--- a/src/test/cls_rgw/test_cls_rgw_stats.cc
+++ b/src/test/cls_rgw/test_cls_rgw_stats.cc
@@ -110,11 +110,16 @@ int index_complete(librados::IoCtx& ioctx, const std::string& oid,
 void read_stats(librados::IoCtx& ioctx, const std::string& oid,
                 rgw_bucket_dir_stats& stats)
 {
-  auto oids = std::map<int, std::string>{{0, oid}};
-  std::map<int, rgw_cls_list_ret> results;
-  ASSERT_EQ(0, CLSRGWIssueGetDirHeader(ioctx, oids, results, 8)());
-  ASSERT_EQ(1, results.size());
-  stats = std::move(results.begin()->second.dir.header.stats);
+  bufferlist bl;
+  librados::ObjectReadOperation op;
+  op.omap_get_header(&bl, nullptr);
+  ASSERT_EQ(0, ioctx.operate(oid, &op, nullptr));
+
+  rgw_bucket_dir_header header;
+  auto p = bl.cbegin();
+  decode(header, p);
+
+  stats = std::move(header.stats);
 }
 
 static void account_entry(rgw_bucket_dir_stats& stats,

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -303,6 +303,10 @@ target_include_directories(ceph_test_rgw_gc_log
 target_link_libraries(ceph_test_rgw_gc_log ${rgw_libs} radostest-cxx)
 install(TARGETS ceph_test_rgw_gc_log DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+add_executable(unittest_rgw_shard_io test_rgw_shard_io.cc)
+add_ceph_unittest(unittest_rgw_shard_io)
+target_link_libraries(unittest_rgw_shard_io ${rgw_libs} unit-main ${UNITTEST_LIBS})
+
 add_ceph_test(test-ceph-diff-sorted.sh
   ${CMAKE_CURRENT_SOURCE_DIR}/test-ceph-diff-sorted.sh)
 

--- a/src/test/rgw/test_rgw_shard_io.cc
+++ b/src/test/rgw/test_rgw_shard_io.cc
@@ -1,0 +1,1973 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "driver/rados/shard_io.h"
+
+#include <optional>
+#include <limits>
+
+#include <boost/asio/append.hpp>
+#include <boost/asio/associated_cancellation_slot.hpp>
+#include <boost/asio/bind_cancellation_slot.hpp>
+#include <boost/asio/cancellation_signal.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/intrusive/list.hpp>
+#include <boost/system/errc.hpp>
+
+#include <gtest/gtest.h>
+
+#include "global/global_context.h"
+
+#define dout_subsys ceph_subsys_rgw
+#define dout_context g_ceph_context
+
+using boost::system::error_code;
+using boost::system::errc::io_error;
+using boost::system::errc::no_such_file_or_directory;
+using boost::system::errc::operation_canceled;
+using boost::system::errc::resource_unavailable_try_again;
+
+constexpr size_t infinite_aio = std::numeric_limits<size_t>::max();
+
+template <typename T>
+auto capture(std::optional<T>& opt)
+{
+  return [&opt] (T value) { opt = std::move(value); };
+}
+
+template <typename T>
+auto capture(boost::asio::cancellation_signal& signal, std::optional<T>& opt)
+{
+  return boost::asio::bind_cancellation_slot(signal.slot(), capture(opt));
+}
+
+// handler wrapper that removes itself from a list on cancellation
+template <typename Handler>
+struct MockHandler :
+    boost::intrusive::list_base_hook<
+        boost::intrusive::link_mode<
+            boost::intrusive::auto_unlink>> {
+  Handler handler;
+
+  struct Cancel {
+    MockHandler* self;
+    explicit Cancel(MockHandler* self) : self(self) {}
+
+    void operator()(boost::asio::cancellation_type type) {
+      if (!!(type & boost::asio::cancellation_type::terminal)) {
+        auto tmp = std::move(self->handler);
+        delete self; // auto unlink
+        auto ec = make_error_code(operation_canceled);
+        boost::asio::dispatch(boost::asio::append(std::move(tmp), ec));
+      }
+    }
+  };
+
+  MockHandler(Handler&& h) : handler(std::move(h)) {
+    auto slot = boost::asio::get_associated_cancellation_slot(handler);
+    if (slot.is_connected()) {
+      slot.template emplace<Cancel>(this);
+    }
+  }
+
+  void operator()(error_code ec) {
+    auto slot = boost::asio::get_associated_cancellation_slot(handler);
+    slot.clear();
+    std::move(handler)(ec);
+  }
+
+  const Handler* operator->() const { return &handler; }
+};
+
+namespace boost::asio {
+
+// forward wrapped handler's associations
+template <template <typename, typename> class Associator,
+    typename Handler, typename DefaultCandidate>
+struct associator<Associator, MockHandler<Handler>, DefaultCandidate>
+  : Associator<Handler, DefaultCandidate>
+{
+  static auto get(const MockHandler<Handler>& h) noexcept {
+    return Associator<Handler, DefaultCandidate>::get(h.handler);
+  }
+  static auto get(const MockHandler<Handler>& h,
+                  const DefaultCandidate& c) noexcept {
+    return Associator<Handler, DefaultCandidate>::get(h.handler, c);
+  }
+};
+
+} // namespace boost::asio
+
+template <typename Handler>
+using MockHandlerList = boost::intrusive::list<MockHandler<Handler>,
+      boost::intrusive::constant_time_size<false>>; // required by auto_unlink
+
+template <typename Handler>
+static void complete_at(MockHandlerList<Handler>& handlers,
+                        size_t index, error_code ec)
+{
+  auto i = std::next(handlers.begin(), index);
+  auto h = std::move(*i);
+  handlers.erase_and_dispose(i, std::default_delete<MockHandler<Handler>>{});
+  boost::asio::dispatch(boost::asio::append(std::move(h), ec));
+}
+
+namespace rgwrados::shard_io {
+
+struct MockRevertibleWriter : RevertibleWriter {
+  MockHandlerList<detail::RevertibleWriteHandler> writes;
+  MockHandlerList<detail::RevertHandler> reverts;
+
+  using RevertibleWriter::RevertibleWriter;
+
+  ~MockRevertibleWriter() {
+    writes.clear_and_dispose(std::default_delete<
+        MockHandler<detail::RevertibleWriteHandler>>{});
+    reverts.clear_and_dispose(std::default_delete<
+        MockHandler<detail::RevertHandler>>{});
+  }
+
+  void write(int shard, const std::string& object,
+             detail::RevertibleWriteHandler&& handler) override {
+    auto h = new MockHandler<detail::RevertibleWriteHandler>(std::move(handler));
+    writes.push_back(*h);
+  }
+  void revert(int shard, const std::string& object,
+              detail::RevertHandler&& handler) override {
+    auto h = new MockHandler<detail::RevertHandler>(std::move(handler));
+    reverts.push_back(*h);
+  }
+  Result on_complete(int, error_code ec) override {
+    if (ec == resource_unavailable_try_again) {
+      return Result::Retry;
+    } else if (ec) {
+      return Result::Error;
+    } else {
+      return Result::Success;
+    }
+  }
+};
+
+TEST(RevertibleWriter, empty)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{}; // no objects
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, writer.writes.size());
+  EXPECT_EQ(0, writer.reverts.size());
+}
+
+TEST(RevertibleWriter, co_spawn)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{}; // no objects
+
+  std::optional<std::exception_ptr> eptr;
+  boost::asio::co_spawn(ex,
+                        async_writes(writer, objects, infinite_aio,
+                                     boost::asio::use_awaitable),
+                        capture(eptr));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(eptr);
+  EXPECT_FALSE(*eptr);
+  EXPECT_EQ(0, writer.writes.size());
+  EXPECT_EQ(0, writer.reverts.size());
+}
+
+TEST(RevertibleWriter, spawn)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{}; // no objects
+
+  std::optional<std::exception_ptr> eptr;
+  boost::asio::spawn(ex, [&] (boost::asio::yield_context yield) {
+        async_writes(writer, objects, infinite_aio, yield);
+      }, capture(eptr));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(eptr);
+  EXPECT_FALSE(*eptr);
+  EXPECT_EQ(0, writer.writes.size());
+  EXPECT_EQ(0, writer.reverts.size());
+}
+
+TEST(RevertibleWriter, throttle)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, max_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(1, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 1, error_code{}); // complete shard 1
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(2, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 1, error_code{}); // complete shard 2
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(3, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 1, error_code{}); // complete shard 3
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+
+  complete_at(writer.writes, 0, error_code{}); // complete shard 0
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, writer.writes.size());
+  EXPECT_EQ(0, writer.reverts.size());
+}
+
+TEST(RevertibleWriter, retry_success)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{{0, "obj0"}, {1, "obj1"}};
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(1, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 0, make_error_code(resource_unavailable_try_again));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(1, writer.writes.front()->shard.id());
+  EXPECT_EQ(0, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(RevertibleWriter, retry_error)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{{0, "obj0"}, {1, "obj1"}};
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(1, writer.writes.back()->shard.id());
+  ASSERT_EQ(0, writer.reverts.size());
+
+  complete_at(writer.writes, 0, make_error_code(resource_unavailable_try_again));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(1, writer.writes.front()->shard.id());
+  EXPECT_EQ(0, writer.writes.back()->shard.id());
+  ASSERT_EQ(0, writer.reverts.size());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  ASSERT_EQ(0, writer.reverts.size());
+
+  // retry error on shard 0 triggers revert of shard 1
+  complete_at(writer.writes, 0, make_error_code(no_such_file_or_directory));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(0, writer.writes.size());
+  ASSERT_EQ(1, writer.reverts.size());
+  EXPECT_EQ(1, writer.reverts.front()->shard.id());
+
+  complete_at(writer.reverts, 0, error_code{});
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(no_such_file_or_directory, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(RevertibleWriter, retry_success_other_error)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{{0, "obj0"}, {1, "obj1"}};
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(1, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 0, make_error_code(resource_unavailable_try_again));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(1, writer.writes.front()->shard.id());
+  EXPECT_EQ(0, writer.writes.back()->shard.id());
+  ASSERT_EQ(0, writer.reverts.size());
+
+  complete_at(writer.writes, 0, make_error_code(no_such_file_or_directory));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  ASSERT_EQ(0, writer.reverts.size());
+
+  // successful retry of shard 0 triggers revert due to error from shard 1
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(0, writer.writes.size());
+  ASSERT_EQ(1, writer.reverts.size());
+  EXPECT_EQ(0, writer.reverts.front()->shard.id());
+
+  complete_at(writer.reverts, 0, error_code{});
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(no_such_file_or_directory, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(RevertibleWriter, retry_throttle)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, max_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(1, writer.writes.back()->shard.id());
+  ASSERT_EQ(0, writer.reverts.size());
+
+  complete_at(writer.writes, 0, error_code{});
+  complete_at(writer.writes, 0, make_error_code(resource_unavailable_try_again));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(2, writer.writes.front()->shard.id());
+  EXPECT_EQ(3, writer.writes.back()->shard.id());
+  ASSERT_EQ(0, writer.reverts.size());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(3, writer.writes.front()->shard.id());
+  EXPECT_EQ(1, writer.writes.back()->shard.id());
+  ASSERT_EQ(0, writer.reverts.size());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, writer.writes.size());
+  EXPECT_EQ(1, writer.writes.front()->shard.id());
+  ASSERT_EQ(0, writer.reverts.size());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, writer.writes.size());
+  ASSERT_EQ(0, writer.reverts.size());
+}
+
+TEST(RevertibleWriter, revert)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, writer.writes.size());
+
+  // complete shards 2 and 0
+  complete_at(writer.writes, 2, error_code{});
+  complete_at(writer.writes, 0, error_code{});
+  // fail shard 1
+  complete_at(writer.writes, 0, make_error_code(no_such_file_or_directory));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, writer.writes.size());
+  EXPECT_EQ(3, writer.writes.front()->shard.id());
+  ASSERT_EQ(2, writer.reverts.size());
+  EXPECT_EQ(2, writer.reverts.front()->shard.id());
+  EXPECT_EQ(0, writer.reverts.back()->shard.id());
+
+  complete_at(writer.writes, 0, error_code{}); // complete shard 3
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(0, writer.writes.size());
+  ASSERT_EQ(3, writer.reverts.size());
+  EXPECT_EQ(2, writer.reverts.front()->shard.id());
+  EXPECT_EQ(3, writer.reverts.back()->shard.id());
+
+  complete_at(writer.reverts, 2, error_code{});
+  complete_at(writer.reverts, 1, make_error_code(io_error));
+  complete_at(writer.reverts, 0, error_code{});
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(no_such_file_or_directory, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+  EXPECT_EQ(0, writer.reverts.size());
+}
+
+TEST(RevertibleWriter, throttle_all_fail)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, max_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+
+  complete_at(writer.writes, 0, make_error_code(no_such_file_or_directory));
+  complete_at(writer.writes, 0, make_error_code(io_error));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(no_such_file_or_directory, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+  EXPECT_EQ(0, writer.reverts.size());
+}
+
+TEST(RevertibleWriter, drain_all_fail)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, writer.writes.size());
+
+  complete_at(writer.writes, 0, make_error_code(no_such_file_or_directory));
+  complete_at(writer.writes, 0, make_error_code(io_error));
+  complete_at(writer.writes, 0, make_error_code(io_error));
+  complete_at(writer.writes, 0, make_error_code(io_error));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(no_such_file_or_directory, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+  EXPECT_EQ(0, writer.reverts.size());
+}
+
+TEST(RevertibleWriter, throttle_cancel_total)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_writes(writer, objects, max_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+
+  signal.emit(boost::asio::cancellation_type::total);
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, writer.writes.size());
+  ASSERT_EQ(1, writer.reverts.size());
+
+  // write completions after cancellation still get reverted
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(0, writer.writes.size());
+  ASSERT_EQ(2, writer.reverts.size());
+
+  complete_at(writer.reverts, 0, error_code{});
+  complete_at(writer.reverts, 0, error_code{});
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(operation_canceled, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+  EXPECT_EQ(0, writer.reverts.size());
+}
+
+TEST(RevertibleWriter, throttle_cancel_total_then_terminal)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_writes(writer, objects, max_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+
+  // total cancellation triggers reverts
+  signal.emit(boost::asio::cancellation_type::total);
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+
+  complete_at(writer.writes, 0, error_code{});
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(0, writer.writes.size());
+  ASSERT_EQ(2, writer.reverts.size());
+
+  // terminal cancellation cancels reverts
+  signal.emit(boost::asio::cancellation_type::terminal);
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(operation_canceled, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+  EXPECT_EQ(0, writer.reverts.size());
+}
+
+TEST(RevertibleWriter, throttle_cancel_terminal)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_writes(writer, objects, max_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+
+  signal.emit(boost::asio::cancellation_type::terminal);
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(operation_canceled, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+  EXPECT_EQ(0, writer.reverts.size());
+}
+
+TEST(RevertibleWriter, drain_cancel_total)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, writer.writes.size());
+
+  signal.emit(boost::asio::cancellation_type::total);
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, writer.writes.size());
+
+  complete_at(writer.writes, 0, error_code{});
+  complete_at(writer.writes, 0, error_code{});
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, writer.writes.size());
+  ASSERT_EQ(3, writer.reverts.size());
+
+  // write completions after cancellation still get reverted
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(0, writer.writes.size());
+  ASSERT_EQ(4, writer.reverts.size());
+
+  complete_at(writer.reverts, 0, error_code{});
+  complete_at(writer.reverts, 0, error_code{});
+  complete_at(writer.reverts, 0, error_code{});
+  complete_at(writer.reverts, 0, error_code{});
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(operation_canceled, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+  EXPECT_EQ(0, writer.reverts.size());
+}
+
+TEST(RevertibleWriter, drain_cancel_total_then_terminal)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, writer.writes.size());
+
+  // total cancellation triggers reverts
+  signal.emit(boost::asio::cancellation_type::total);
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, writer.writes.size());
+
+  complete_at(writer.writes, 0, error_code{});
+  complete_at(writer.writes, 0, error_code{});
+  complete_at(writer.writes, 0, error_code{});
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(0, writer.writes.size());
+  ASSERT_EQ(4, writer.reverts.size());
+
+  // terminal cancellation cancels reverts
+  signal.emit(boost::asio::cancellation_type::terminal);
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(operation_canceled, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+  EXPECT_EQ(0, writer.reverts.size());
+}
+
+TEST(RevertibleWriter, drain_cancel_terminal)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockRevertibleWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, writer.writes.size());
+
+  signal.emit(boost::asio::cancellation_type::terminal);
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(operation_canceled, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+  EXPECT_EQ(0, writer.reverts.size());
+}
+
+
+struct MockWriter : Writer {
+  MockHandlerList<detail::WriteHandler> writes;
+
+  using Writer::Writer;
+
+  ~MockWriter() {
+    writes.clear_and_dispose(std::default_delete<
+        MockHandler<detail::WriteHandler>>{});
+  }
+
+  void write(int shard, const std::string& object,
+             detail::WriteHandler&& handler) override {
+    auto h = new MockHandler<detail::WriteHandler>(std::move(handler));
+    writes.push_back(*h);
+  }
+  Result on_complete(int, error_code ec) override {
+    if (ec == resource_unavailable_try_again) {
+      return Result::Retry;
+    } else if (ec) {
+      return Result::Error;
+    } else {
+      return Result::Success;
+    }
+  }
+};
+
+TEST(Writer, empty)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{}; // no objects
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(Writer, co_spawn)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{}; // no objects
+
+  std::optional<std::exception_ptr> eptr;
+  boost::asio::co_spawn(ex,
+                        async_writes(writer, objects, infinite_aio,
+                                     boost::asio::use_awaitable),
+                        capture(eptr));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(eptr);
+  EXPECT_FALSE(*eptr);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(Writer, spawn)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{}; // no objects
+
+  std::optional<std::exception_ptr> eptr;
+  boost::asio::spawn(ex, [&] (boost::asio::yield_context yield) {
+        async_writes(writer, objects, infinite_aio, yield);
+      }, capture(eptr));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(eptr);
+  EXPECT_FALSE(*eptr);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(Writer, throttle)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, max_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(1, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 1, error_code{}); // complete shard 1
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(2, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 1, error_code{}); // complete shard 2
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(3, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 1, error_code{}); // complete shard 3
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+
+  complete_at(writer.writes, 0, error_code{}); // complete shard 0
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(Writer, retry_success)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{{0, "obj0"}, {1, "obj1"}};
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(1, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 0, make_error_code(resource_unavailable_try_again));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(1, writer.writes.front()->shard.id());
+  EXPECT_EQ(0, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(Writer, retry_error)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{{0, "obj0"}, {1, "obj1"}};
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(1, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 0, make_error_code(resource_unavailable_try_again));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(1, writer.writes.front()->shard.id());
+  EXPECT_EQ(0, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+
+  complete_at(writer.writes, 0, make_error_code(no_such_file_or_directory));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(no_such_file_or_directory, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(Writer, retry_success_other_error)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{{0, "obj0"}, {1, "obj1"}};
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(1, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 0, make_error_code(resource_unavailable_try_again));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(1, writer.writes.front()->shard.id());
+  EXPECT_EQ(0, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 0, make_error_code(no_such_file_or_directory));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(no_such_file_or_directory, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(Writer, retry_throttle)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, max_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(0, writer.writes.front()->shard.id());
+  EXPECT_EQ(1, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 0, error_code{});
+  complete_at(writer.writes, 0, make_error_code(resource_unavailable_try_again));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(2, writer.writes.front()->shard.id());
+  EXPECT_EQ(3, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+  EXPECT_EQ(3, writer.writes.front()->shard.id());
+  EXPECT_EQ(1, writer.writes.back()->shard.id());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, writer.writes.size());
+  EXPECT_EQ(1, writer.writes.front()->shard.id());
+
+  complete_at(writer.writes, 0, error_code{});
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(Writer, throttle_errors)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, max_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+
+  complete_at(writer.writes, 0, error_code{});
+  complete_at(writer.writes, 0, make_error_code(no_such_file_or_directory));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+
+  complete_at(writer.writes, 0, error_code{});
+  complete_at(writer.writes, 0, make_error_code(io_error));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(no_such_file_or_directory, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(Writer, drain_errors)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, writer.writes.size());
+
+  complete_at(writer.writes, 0, error_code{});
+  complete_at(writer.writes, 0, make_error_code(no_such_file_or_directory));
+  complete_at(writer.writes, 0, error_code{});
+  complete_at(writer.writes, 0, make_error_code(io_error));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(no_such_file_or_directory, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(Writer, throttle_cancel_total)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_writes(writer, objects, max_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+
+  signal.emit(boost::asio::cancellation_type::total); // noop
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+
+  complete_at(writer.writes, 0, error_code{}); // shard 0
+  complete_at(writer.writes, 0, error_code{}); // shard 1
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+
+  complete_at(writer.writes, 0, error_code{}); // shard 2
+  complete_at(writer.writes, 0, error_code{}); // shard 3
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(Writer, throttle_cancel_terminal)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_writes(writer, objects, max_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+
+  signal.emit(boost::asio::cancellation_type::terminal);
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(operation_canceled, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(Writer, drain_cancel_total)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, writer.writes.size());
+
+  signal.emit(boost::asio::cancellation_type::total); // noop
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, writer.writes.size());
+
+  complete_at(writer.writes, 0, error_code{}); // shard 0
+  complete_at(writer.writes, 0, error_code{}); // shard 1
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, writer.writes.size());
+
+  complete_at(writer.writes, 0, error_code{}); // shard 2
+  complete_at(writer.writes, 0, error_code{}); // shard 3
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+TEST(Writer, drain_cancel_terminal)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto writer = MockWriter{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_writes(writer, objects, infinite_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, writer.writes.size());
+
+  signal.emit(boost::asio::cancellation_type::terminal);
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(operation_canceled, *ec);
+  EXPECT_EQ(0, writer.writes.size());
+}
+
+
+struct MockReader : Reader {
+  MockHandlerList<detail::ReadHandler> reads;
+
+  using Reader::Reader;
+
+  ~MockReader() {
+    reads.clear_and_dispose(std::default_delete<
+        MockHandler<detail::ReadHandler>>{});
+  }
+
+  void read(int shard, const std::string& object,
+            detail::ReadHandler&& handler) override {
+    auto h = new MockHandler<detail::ReadHandler>(std::move(handler));
+    reads.push_back(*h);
+  }
+  Result on_complete(int, error_code ec) override {
+    if (ec == resource_unavailable_try_again) {
+      return Result::Retry;
+    } else if (ec) {
+      return Result::Error;
+    } else {
+      return Result::Success;
+    }
+  }
+};
+
+TEST(Reader, empty)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{}; // no objects
+
+  std::optional<error_code> ec;
+  async_reads(reader, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+TEST(Reader, co_spawn)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{}; // no objects
+
+  std::optional<std::exception_ptr> eptr;
+  boost::asio::co_spawn(ex,
+                        async_reads(reader, objects, infinite_aio,
+                                    boost::asio::use_awaitable),
+                        capture(eptr));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(eptr);
+  EXPECT_FALSE(*eptr);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+TEST(Reader, spawn)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{}; // no objects
+
+  std::optional<std::exception_ptr> eptr;
+  boost::asio::spawn(ex, [&] (boost::asio::yield_context yield) {
+        async_reads(reader, objects, infinite_aio, yield);
+      }, capture(eptr));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(eptr);
+  EXPECT_FALSE(*eptr);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+TEST(Reader, throttle)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  std::optional<error_code> ec;
+  async_reads(reader, objects, max_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+  EXPECT_EQ(0, reader.reads.front()->shard.id());
+  EXPECT_EQ(1, reader.reads.back()->shard.id());
+
+  complete_at(reader.reads, 1, error_code{}); // complete shard 1
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+  EXPECT_EQ(0, reader.reads.front()->shard.id());
+  EXPECT_EQ(2, reader.reads.back()->shard.id());
+
+  complete_at(reader.reads, 1, error_code{}); // complete shard 2
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+  EXPECT_EQ(0, reader.reads.front()->shard.id());
+  EXPECT_EQ(3, reader.reads.back()->shard.id());
+
+  complete_at(reader.reads, 1, error_code{}); // complete shard 3
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, reader.reads.size());
+  EXPECT_EQ(0, reader.reads.front()->shard.id());
+
+  complete_at(reader.reads, 0, error_code{}); // complete shard 0
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+TEST(Reader, retry_success)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{{0, "obj0"}, {1, "obj1"}};
+
+  std::optional<error_code> ec;
+  async_reads(reader, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+  EXPECT_EQ(0, reader.reads.front()->shard.id());
+  EXPECT_EQ(1, reader.reads.back()->shard.id());
+
+  complete_at(reader.reads, 0, make_error_code(resource_unavailable_try_again));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+  EXPECT_EQ(1, reader.reads.front()->shard.id());
+  EXPECT_EQ(0, reader.reads.back()->shard.id());
+
+  complete_at(reader.reads, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, reader.reads.size());
+  EXPECT_EQ(0, reader.reads.front()->shard.id());
+
+  complete_at(reader.reads, 0, error_code{});
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+TEST(Reader, retry_error)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{{0, "obj0"}, {1, "obj1"}};
+
+  std::optional<error_code> ec;
+  async_reads(reader, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+  EXPECT_EQ(0, reader.reads.front()->shard.id());
+  EXPECT_EQ(1, reader.reads.back()->shard.id());
+
+  complete_at(reader.reads, 0, make_error_code(resource_unavailable_try_again));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+  EXPECT_EQ(1, reader.reads.front()->shard.id());
+  EXPECT_EQ(0, reader.reads.back()->shard.id());
+
+  complete_at(reader.reads, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, reader.reads.size());
+  EXPECT_EQ(0, reader.reads.front()->shard.id());
+
+  complete_at(reader.reads, 0, make_error_code(no_such_file_or_directory));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(no_such_file_or_directory, *ec);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+TEST(Reader, retry_then_error)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{{0, "obj0"}, {1, "obj1"}};
+
+  std::optional<error_code> ec;
+  async_reads(reader, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+  EXPECT_EQ(0, reader.reads.front()->shard.id());
+  EXPECT_EQ(1, reader.reads.back()->shard.id());
+
+  complete_at(reader.reads, 0, make_error_code(resource_unavailable_try_again));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+  EXPECT_EQ(1, reader.reads.front()->shard.id());
+  EXPECT_EQ(0, reader.reads.back()->shard.id());
+
+  complete_at(reader.reads, 0, make_error_code(no_such_file_or_directory));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(no_such_file_or_directory, *ec);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+TEST(Reader, retry_throttle)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  std::optional<error_code> ec;
+  async_reads(reader, objects, max_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+  EXPECT_EQ(0, reader.reads.front()->shard.id());
+  EXPECT_EQ(1, reader.reads.back()->shard.id());
+
+  complete_at(reader.reads, 0, error_code{});
+  complete_at(reader.reads, 0, make_error_code(resource_unavailable_try_again));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+  EXPECT_EQ(2, reader.reads.front()->shard.id());
+  EXPECT_EQ(3, reader.reads.back()->shard.id());
+
+  complete_at(reader.reads, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+  EXPECT_EQ(3, reader.reads.front()->shard.id());
+  EXPECT_EQ(1, reader.reads.back()->shard.id());
+
+  complete_at(reader.reads, 0, error_code{});
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(1, reader.reads.size());
+  EXPECT_EQ(1, reader.reads.front()->shard.id());
+
+  complete_at(reader.reads, 0, error_code{});
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+TEST(Reader, throttle_errors)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  std::optional<error_code> ec;
+  async_reads(reader, objects, max_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+
+  complete_at(reader.reads, 0, error_code{});
+  complete_at(reader.reads, 0, make_error_code(no_such_file_or_directory));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(no_such_file_or_directory, *ec);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+TEST(Reader, drain_errors)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+
+  std::optional<error_code> ec;
+  async_reads(reader, objects, infinite_aio, capture(ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, reader.reads.size());
+
+  complete_at(reader.reads, 0, error_code{});
+  complete_at(reader.reads, 0, make_error_code(no_such_file_or_directory));
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(no_such_file_or_directory, *ec);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+TEST(Reader, throttle_cancel_total)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_reads(reader, objects, max_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+
+  signal.emit(boost::asio::cancellation_type::total); // noop
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+
+  complete_at(reader.reads, 0, error_code{}); // shard 0
+  complete_at(reader.reads, 0, error_code{}); // shard 1
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+
+  complete_at(reader.reads, 0, error_code{}); // shard 2
+  complete_at(reader.reads, 0, error_code{}); // shard 3
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+TEST(Reader, throttle_cancel_terminal)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+  constexpr size_t max_aio = 2;
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_reads(reader, objects, max_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+
+  signal.emit(boost::asio::cancellation_type::terminal);
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(operation_canceled, *ec);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+TEST(Reader, drain_cancel_total)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_reads(reader, objects, infinite_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, reader.reads.size());
+
+  signal.emit(boost::asio::cancellation_type::total); // noop
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, reader.reads.size());
+
+  complete_at(reader.reads, 0, error_code{}); // shard 0
+  complete_at(reader.reads, 0, error_code{}); // shard 1
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(2, reader.reads.size());
+
+  complete_at(reader.reads, 0, error_code{}); // shard 2
+  complete_at(reader.reads, 0, error_code{}); // shard 3
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_FALSE(*ec);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+TEST(Reader, drain_cancel_terminal)
+{
+  const auto dpp = NoDoutPrefix{dout_context, dout_subsys};
+  boost::asio::io_context service;
+  auto ex = service.get_executor();
+
+  auto reader = MockReader{dpp, ex};
+  const auto objects = std::map<int, std::string>{
+    {0, "obj0"}, {1, "obj1"}, {2, "obj2"}, {3, "obj3"}};
+
+  boost::asio::cancellation_signal signal;
+  std::optional<error_code> ec;
+  async_reads(reader, objects, infinite_aio, capture(signal, ec));
+
+  service.poll();
+  ASSERT_FALSE(service.stopped());
+  ASSERT_FALSE(ec);
+  ASSERT_EQ(4, reader.reads.size());
+
+  signal.emit(boost::asio::cancellation_type::terminal);
+
+  service.poll();
+  ASSERT_TRUE(service.stopped());
+  ASSERT_TRUE(ec);
+  EXPECT_EQ(operation_canceled, *ec);
+  EXPECT_EQ(0, reader.reads.size());
+}
+
+} // namespace rgwrados::shard_io


### PR DESCRIPTION
cls/rgw provides the base class CLSRGWConcurrentIO as a swiss army knife for bucket index operations that visit every shard object. while it uses asynchronous librados requests to perform the io, it blocks on a condition variable when waiting for the AioCompletions.

for use in coroutines, we need a version of this that suspends instead of blocking. and to support both stackful and stackless coroutines, we want a fully-generic async inferface templated on CompletionToken.

while the CLSRGWConcurrentIO algorithm works for all current uses (reads and writes, with/without retries, with/without cleanup), i chose to break this into 3 algorithms with well-defined semantics:

1. reads: to produce a successful result, all shard operations must succeed. so any shard's failure causes the rest to be cancelled or skipped. supports retries for ListBucket (RGWBIAdvanceAndRetryError).
2. writes: even if some shards fail, we still want to visit every shard before returning the error. supports retries for log trimming operations (repeat until ENODATA).
3. revertible writes: similar to reads, requires all shard operations to succeed. on any failure, the side effects of any successful writes must be reverted before returning. only used by IndexInit (any created shards are removed on failure).

each algorithm provides a pure virtual base class that must be implemented for each type of operation, similar to how existing operations inherit from CLSRGWConcurrentIO.

---

additional commits add an example of each to services/svc_bi_rados.cc

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
