### PR TITLE
rgw/notification: Fix segmentation fault in RGWPSListTopicsOp::execute() and correct topic listing to use get_topics_v2

### DIFF
--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -494,11 +494,11 @@ void RGWPSListTopicsOp::execute(optional_yield y) {
 
   const RGWPubSub ps(driver, get_account_or_tenant(s->owner.id), *s->penv.site);
   if (rgw::all_zonegroups_support(*s->penv.site, rgw::zone_features::notification_v2) &&
-      driver->stat_topics_v1(s->bucket->get_tenant(), null_yield, this) == -ENOENT) {
-    op_ret = ps.get_topics_v1(this, result, y);
-  } else {
+      driver->stat_topics_v1(get_account_or_tenant(s->owner.id), null_yield, this) == -ENOENT) {
     constexpr int max_items = 100;
     op_ret = ps.get_topics_v2(this, start_token, max_items, result, next_token, y);
+  } else {
+    op_ret = ps.get_topics_v1(this, result, y);
   }
   // if there are no topics it is not considered an error
   op_ret = op_ret == -ENOENT ? 0 : op_ret;


### PR DESCRIPTION
This PR resolves two issues in `RGWPSListTopicsOp::execute()`:

1. **Segmentation Fault:** Resolved a segmentation fault caused by dereferencing a null bucket pointer. Updated the code to use `get_account_or_tenant(s->owner.id)` to handle the bucket owner safely and prevent crashes.

2. **Fix for Topic Listing Logic:** Fixed an issue where v2 notifications were not retrieved when v2 support was enabled. The logic now uses `get_topics_v2` when available, and falls back to `get_topics_v1` in cases v1 system or migration.

Fixes: https://tracker.ceph.com/issues/68756

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
