### PR TITLE
rgw: respect policies in data sync in user mode

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -313,7 +313,8 @@ static auto transform_old_authinfo(const RGWUserInfo& user,
 auto transform_old_authinfo(const DoutPrefixProvider* dpp,
                             optional_yield y,
                             sal::Driver* driver,
-                            sal::User* user)
+                            sal::User* user,
+                            std::vector<IAM::Policy>* policies_)
   -> tl::expected<std::unique_ptr<Identity>, int>
 {
   const RGWUserInfo& info = user->get_info();
@@ -328,6 +329,9 @@ auto transform_old_authinfo(const DoutPrefixProvider* dpp,
     return tl::unexpected(r);
   }
 
+  if (policies_) { // return policies to caller if requested
+    *policies_ = policies;
+  }
   return transform_old_authinfo(info, std::move(account), std::move(policies));
 }
 

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -105,7 +105,8 @@ inline std::ostream& operator<<(std::ostream& out,
 auto transform_old_authinfo(const DoutPrefixProvider* dpp,
                             optional_yield y,
                             sal::Driver* driver,
-                            sal::User* user)
+                            sal::User* user,
+                            std::vector<IAM::Policy>* policies_ = nullptr)
   -> tl::expected<std::unique_ptr<Identity>, int>;
 
 // Load the user account and all user/group policies. May throw

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -3204,3 +3204,14 @@ void RGWObjVersionTracker::generate_new_write_ver(CephContext *cct)
   append_rand_alpha(cct, write_version.tag, write_version.tag, TAG_LEN);
 }
 
+boost::optional<rgw::IAM::Policy>
+get_iam_policy_from_attr(CephContext* cct,
+                         const std::map<std::string, bufferlist>& attrs,
+                         const std::string& tenant)
+{
+  if (auto i = attrs.find(RGW_ATTR_IAM_POLICY); i != attrs.end()) {
+    return Policy(cct, &tenant, i->second.to_str(), false);
+  } else {
+    return boost::none;
+  }
+}

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1746,24 +1746,22 @@ rgw::IAM::Effect evaluate_iam_policies(
 
 bool verify_user_permission(const DoutPrefixProvider* dpp,
                             req_state * const s,
-                            const RGWAccessControlPolicy& user_acl,
-                            const std::vector<rgw::IAM::Policy>& user_policies,
-                            const std::vector<rgw::IAM::Policy>& session_policies,
-                            const rgw::ARN& res,
-                            const uint64_t op,
-                            bool mandatory_policy=true);
-bool verify_user_permission_no_policy(const DoutPrefixProvider* dpp,
-                                      req_state * const s,
-                                      const RGWAccessControlPolicy& user_acl,
-                                      const int perm);
-bool verify_user_permission(const DoutPrefixProvider* dpp,
-                            req_state * const s,
                             const rgw::ARN& res,
                             const uint64_t op,
                             bool mandatory_policy=true);
 bool verify_user_permission_no_policy(const DoutPrefixProvider* dpp,
                                       req_state * const s,
                                       int perm);
+bool verify_bucket_permission(const DoutPrefixProvider* dpp,
+                              struct perm_state_base * const s,
+                              const rgw::ARN& arn,
+                              bool account_root,
+                              const RGWAccessControlPolicy& user_acl,
+                              const RGWAccessControlPolicy& bucket_acl,
+			      const boost::optional<rgw::IAM::Policy>& bucket_policy,
+                              const std::vector<rgw::IAM::Policy>& identity_policies,
+                              const std::vector<rgw::IAM::Policy>& session_policies,
+                              const uint64_t op);
 bool verify_bucket_permission(
   const DoutPrefixProvider* dpp,
   req_state * const s,
@@ -2011,3 +2009,8 @@ struct AioCompletionDeleter {
   void operator()(librados::AioCompletion* c) { c->release(); }
 };
 using aio_completion_ptr = std::unique_ptr<librados::AioCompletion, AioCompletionDeleter>;
+
+extern boost::optional<rgw::IAM::Policy>
+get_iam_policy_from_attr(CephContext* cct,
+                         const std::map<std::string, bufferlist>& attrs,
+                         const std::string& tenant);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -330,19 +330,6 @@ static int get_obj_policy_from_attr(const DoutPrefixProvider *dpp,
   return ret;
 }
 
-
-static boost::optional<Policy>
-get_iam_policy_from_attr(CephContext* cct,
-                         const map<string, bufferlist>& attrs,
-                         const string& tenant)
-{
-  if (auto i = attrs.find(RGW_ATTR_IAM_POLICY); i != attrs.end()) {
-    return Policy(cct, &tenant, i->second.to_str(), false);
-  } else {
-    return none;
-  }
-}
-
 static boost::optional<PublicAccessBlockConfiguration>
 get_public_access_conf_from_attr(const map<string, bufferlist>& attrs)
 {


### PR DESCRIPTION
In the data sync phase, both source and destination object permissions are evaluated locally on the destination zone, leading to two issues:
1. Source object policies aren't evaluated, causing access to be denied when the uid is bound to an account or IAM policies are involved. This can be fixed by passing the UID as `rgwx-uid`, allowing the source zone to handle policy evaluation.
2. Destination object policies are skipped, resulting in access denial when IAM policies grant access to the UID. This can be resolved by using `verify_bucket_permission()` instead of `verify_bucket_permission_no_policy()`.

Fixes: https://tracker.ceph.com/issues/68884