### PR TITLE
squid: tools/rados: Fix extra NL in getxattr

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2774,7 +2774,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     }
     else {
       string s(bl.c_str(), bl.length());
-      cout << s << std::endl;
+      cout << s;
     }
   } else if (strcmp(nargs[0], "rmxattr") == 0) {
     if (!pool_name || nargs.size() < (obj_name ? 2 : 3)) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67532

---

backport of https://github.com/ceph/ceph/pull/59025
parent tracker: https://tracker.ceph.com/issues/67336

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh