### PR TITLE
mgr/cephadm:  ceph orch <start/stop/restart> commands should work for service name osd  and command to updated service name for osd

### DIFF
--- a/doc/cephadm/services/osd.rst
+++ b/doc/cephadm/services/osd.rst
@@ -198,6 +198,18 @@ There are a few ways to create new OSDs:
 
 .. warning:: When deploying new OSDs with ``cephadm``, ensure that the ``ceph-osd`` package is not already installed on the target host. If it is installed, conflicts may arise in the management and control of the OSD that may lead to errors or unexpected behavior.
 
+* OSDs created via ``ceph orch daemon add`` are by default not added to the orchestrator's OSD service, they get added to 'osd' service. To attach an OSD to a different, existing OSD service, issue a command of the following form:
+
+  .. prompt:: bash *
+
+    ceph orch osd set-spec-affinity <service_name> <osd_id(s)>
+
+  For example:
+
+  .. prompt:: bash #
+
+    ceph orch osd set-spec-affinity osd.default_drive_group 0 1
+
 Dry Run
 -------
 

--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -13,7 +13,7 @@ Synopsis
 |               [--log-dir LOG_DIR] [--logrotate-dir LOGROTATE_DIR]
 |               [--unit-dir UNIT_DIR] [--verbose] [--timeout TIMEOUT]
 |               [--retry RETRY] [--no-container-init]
-|               {version,pull,inspect-image,ls,list-networks,adopt,rm-daemon,rm-cluster,run,shell,enter,ceph-volume,unit,logs,bootstrap,deploy,check-host,prepare-host,add-repo,rm-repo,install,list-images}
+|               {version,pull,inspect-image,ls,list-networks,adopt,rm-daemon,rm-cluster,run,shell,enter,ceph-volume,unit,logs,bootstrap,deploy,check-host,prepare-host,add-repo,rm-repo,install,list-images,update-osd-service}
 |               ...
 
 
@@ -106,6 +106,7 @@ Synopsis
 
 | **cephadm** **list-images**
 
+| **cephadm** **update-osd-service** [-h] [--fsid FSID] --osd-ids OSD_IDS --service-name SERVICE_NAME
 
 
 Description
@@ -533,6 +534,18 @@ list-images
 -----------
 
 List the default container images for all services in ini format. The output can be modified with custom images and passed to --config flag during bootstrap.
+
+
+update-osd-service
+------------------
+
+Update the OSD service for specific OSDs
+
+Arguments:
+
+* [--fsid FSID]                 cluster FSID
+* --osd-ids OSD_IDS             Comma-separated OSD IDs
+* --service-name SERVICE_NAME   OSD service name
 
 
 Availability

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -747,6 +747,10 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def set_osd_spec(self, service_name: str, osd_ids: List[str]) -> OrchResult:
+        """ set service of osd """
+        raise NotImplementedError()
+
     def blink_device_light(self, ident_fault: str, on: bool, locations: List['DeviceLightLoc']) -> OrchResult[List[str]]:
         """
         Instructs the orchestrator to enable or disable either the ident or the fault LED.

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1472,6 +1472,14 @@ Usage:
 
         return HandleCommandResult(stdout=out)
 
+    @_cli_write_command('orch osd set-spec-affinity')
+    def _osd_set_spec(self, service_name: str, osd_id: List[str]) -> HandleCommandResult:
+        """Set service spec affinity for osd"""
+        completion = self.set_osd_spec(service_name, osd_id)
+        res = raise_if_exception(completion)
+
+        return HandleCommandResult(stdout=res)
+
     @_cli_write_command('orch daemon add')
     def daemon_add_misc(self,
                         daemon_type: Optional[ServiceType] = None,


### PR DESCRIPTION
Issue: ceph orch <start/stop/restart> does not work for OSDs when deployment name is "osd", It fails with error Error EINVAL: Invalid service name "osd".

Solution: 
1. To fix this just added exception when service name is 'osd'
2. Added ceph command to make osd tied with certain service, by updating service name in unit.meta file. The 'ceph orch osd set-spec-affinity <service_name> <osd_id>...' command will call below cephadm command on respective host with all osd's of that host.
```
root@ceph-node-0 ~]# cephadm update-osd-service -h
usage: cephadm update-osd-service [-h] [--fsid FSID] --name NAME --service_name SERVICE_NAME

options:
  -h, --help            show this help message and exit
  --fsid FSID           cluster FSID
  --name NAME           Comma seperated daemon name (type.id1,type.id2)
  --service_name SERVICE_NAME
                        new service name for daemon
[root@ceph-node-0 ~]#
```
Fixes: https://tracker.ceph.com/issues/68695

Signed-off-by: Shweta Bhosale [Shweta.Bhosale1@ibm.com](mailto:Shweta.Bhosale1@ibm.com)

Testing logs:
```
[root@ceph-node-0 ~]# cephadm update-osd-service --name osd.0,osd.1,osd.10 --service_name osd.all-available-devices
Inferring fsid 4c36f136-a0d2-11ef-9141-52540073f970
Successfully updated daemon osd.0 with service osd.all-available-devices
Successfully updated daemon osd.1 with service osd.all-available-devices
Daemon osd.10 does not exists
[root@ceph-node-0 ~]# 


[ceph: root@ceph-node-0 /]# ceph orch osd s
no valid command found; 1 closest matches:
orch osd set-spec-affinity <service_name> <osd_id>...
Error EINVAL: invalid command
[ceph: root@ceph-node-0 /]# 

[ceph: root@ceph-node-0 /]# ceph orch daemon add osd ceph-node-0:/dev/vde
Created osd(s) 9 on host 'ceph-node-0'
[ceph: root@ceph-node-0 /]# ceph orch daemon add osd ceph-node-1:/dev/vde
Created osd(s) 10 on host 'ceph-node-1'
[ceph: root@ceph-node-0 /]# ceph orch daemon add osd ceph-node-2:/dev/vde
Created osd(s) 11 on host 'ceph-node-2'
[ceph: root@ceph-node-0 /]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT    
crash                                 3/3  4m ago     54m  *            
mgr                                   2/2  4m ago     54m  count:2      
mon                                   3/5  4m ago     54m  count:5      
osd                                     3  4m ago     -    <unmanaged>  
osd.all-available-devices               9  4m ago     53m  *            
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph orch osd set-spec-affinity osd.all-available-devices 9 10 11
Updated service for osd ['osd.9', 'osd.10', 'osd.11'] and failed for []
[ceph: root@ceph-node-0 /]# 
[ceph: root@ceph-node-0 /]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT    
crash                                 3/3  6m ago     55m  *            
mgr                                   2/2  6m ago     55m  count:2      
mon                                   3/5  6m ago     55m  count:5      
osd                                     3  6m ago     -    <unmanaged>  
osd.all-available-devices               9  6m ago     55m  *            
[ceph: root@ceph-node-0 /]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT  
crash                                 3/3  13s ago    56m  *          
mgr                                   2/2  13s ago    56m  count:2    
mon                                   3/5  13s ago    56m  count:5    
osd.all-available-devices              12  13s ago    55m  *          
[ceph: root@ceph-node-0 /]# 

```



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
