### PR TITLE
squid: mds: getattr just waits the xlock to be released by the previous client

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4083,6 +4083,7 @@ CDir* Server::try_open_auth_dirfrag(CInode *diri, frag_t fg, const MDRequestRef&
 void Server::handle_client_getattr(const MDRequestRef& mdr, bool is_lookup)
 {
   const cref_t<MClientRequest> &req = mdr->client_request;
+  client_t client = mdr->get_client();
 
   if (req->get_filepath().depth() == 0 && is_lookup) {
     // refpath can't be empty for lookup but it can for
@@ -4103,6 +4104,17 @@ void Server::handle_client_getattr(const MDRequestRef& mdr, bool is_lookup)
 				   &mdr->dn[0], &mdr->in[0]);
     if (r > 0)
       return; // delayed
+
+    // Do not batch if any xlock is held
+    if (!r) {
+      CInode *in = mdr->in[0];
+      if (((mask & CEPH_CAP_LINK_SHARED) && (in->linklock.is_xlocked_by_client(client))) ||
+          ((mask & CEPH_CAP_AUTH_SHARED) && (in->authlock.is_xlocked_by_client(client))) ||
+          ((mask & CEPH_CAP_XATTR_SHARED) && (in->xattrlock.is_xlocked_by_client(client))) ||
+          ((mask & CEPH_CAP_FILE_SHARED) && (in->filelock.is_xlocked_by_client(client)))) {
+	r = -1;
+      }
+    }
 
     if (r < 0) {
       // fall-thru. let rdlock_path_pin_ref() check again.
@@ -4145,7 +4157,6 @@ void Server::handle_client_getattr(const MDRequestRef& mdr, bool is_lookup)
    * handling this case here is easier than weakening rdlock
    * semantics... that would cause problems elsewhere.
    */
-  client_t client = mdr->get_client();
   int issued = 0;
   Capability *cap = ref->get_client_cap(client);
   if (cap && (mdr->snapid == CEPH_NOSNAP ||


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/67693

---

backport of https://github.com/ceph/ceph/pull/56602
parent tracker: https://tracker.ceph.com/issues/63906

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh