### PR TITLE
reef: client: fixed a bug that read operation hung

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3627,6 +3627,9 @@ void Client::put_cap_ref(Inode *in, int cap)
     if (last & CEPH_CAP_FILE_CACHE) {
       ldout(cct, 5) << __func__ << " dropped last FILE_CACHE ref on " << *in << dendl;
       ++put_nref;
+
+      ldout(cct, 10) << __func__ << " calling signal_caps_inode" << dendl;
+      signal_cond_list(in->waitfor_caps);
     }
     if (drop)
       check_caps(in, 0);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68693

---

backport of https://github.com/ceph/ceph/pull/59027
parent tracker: https://tracker.ceph.com/issues/65971

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh