### PR TITLE
osd/scrub: list additional information when dumping the queue

### DIFF
--- a/src/osd/scrubber/osd_scrub_sched.cc
+++ b/src/osd/scrubber/osd_scrub_sched.cc
@@ -140,9 +140,10 @@ bool ScrubQueue::remove_entry_unlocked(spg_t pgid, scrub_level_t s_or_d)
 void ScrubQueue::dump_scrubs(ceph::Formatter* f) const
 {
   ceph_assert(f != nullptr);
+  const auto query_time = ceph_clock_now();
   f->open_array_section("scrubs");
   for_each_job(
-      [&f](const Scrub::SchedEntry& e) {
+      [&f, query_time](const Scrub::SchedEntry& e) {
 	f->open_object_section("scrub");
 	f->dump_stream("pgid") << e.pgid;
 	f->dump_stream("sched_time") << e.schedule.not_before;
@@ -151,6 +152,15 @@ void ScrubQueue::dump_scrubs(ceph::Formatter* f) const
 	f->dump_bool(
 	    "forced",
 	    e.schedule.scheduled_at == PgScrubber::scrub_must_stamp());
+
+        f->dump_stream("level") << (e.level == scrub_level_t::shallow
+                                       ? "shallow"
+                                       : "deep");
+        f->dump_stream("urgency") << fmt::format("{}", e.urgency);
+        f->dump_bool("eligible", e.schedule.not_before <= query_time);
+        f->dump_bool("overdue", e.schedule.deadline < query_time);
+        f->dump_stream("last_issue") << fmt::format("{}", e.last_issue);
+
 	f->close_section();
       },
       std::numeric_limits<int>::max());


### PR DESCRIPTION
Extend the information provided for operator dump commands, to include the basic identity and scheduling information of the entries in the scrub queue.

This change mostly benefits automatic QA and our internal testing.

