### PR TITLE
reef: mgr/dashboard: add cephfs rename REST API

### DIFF
--- a/qa/tasks/mgr/dashboard/test_cephfs.py
+++ b/qa/tasks/mgr/dashboard/test_cephfs.py
@@ -74,6 +74,12 @@ class CephfsTest(DashboardTestCase):
         yield 1
         self.rm_dir(self.QUOTA_PATH)
 
+    def rename_path(self, src_path, dst_path):
+        params = {'src_path': src_path, 'dst_path': dst_path}
+        self._put(f"/api/cephfs/{self.get_fs_id()}/rename-path",
+                  data=params)
+        self.assertStatus(200)
+
     @DashboardTestCase.RunAs('test', 'test', ['block-manager'])
     def test_access_permissions(self):
         fs_id = self.get_fs_id()
@@ -304,3 +310,9 @@ class CephfsTest(DashboardTestCase):
         self.fs.set_joinable()
         self._get(f"/api/cephfs/{fs_id}/clients")
         self.assertStatus(200)
+
+    def test_rename_path(self):
+        self.mk_dirs('/apple')
+        self.rename_path('/apple', '/orange')
+        self.ls_dir('/orange', 0)
+        self.rm_dir('/orange')

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -639,6 +639,17 @@ class CephFS(RESTController):
         cfs = self._cephfs_instance(fs_id)
         cfs.rm_snapshot(path, name)
 
+    @RESTController.Resource('PUT', path='/rename-path')
+    def rename_path(self, fs_id, src_path, dst_path) -> None:
+        """
+        Rename a file or directory.
+        :param fs_id: The filesystem identifier.
+        :param src_path: The path to the existing file or directory.
+        :param dst_path: The new name of the file or directory.
+        """
+        cfs = self._cephfs_instance(fs_id)
+        cfs.rename_path(src_path, dst_path)
+
 
 class CephFSClients(object):
     def __init__(self, module_inst, fscid):

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -3050,6 +3050,55 @@ paths:
       - jwt: []
       tags:
       - Cephfs
+  /api/cephfs/{fs_id}/rename-path:
+    put:
+      description: "\n        Rename a file or directory.\n        :param fs_id: The\
+        \ filesystem identifier.\n        :param src_path: The path to the existing\
+        \ file or directory.\n        :param dst_path: The new name of the file or\
+        \ directory.\n        "
+      parameters:
+      - in: path
+        name: fs_id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                dst_path:
+                  type: string
+                src_path:
+                  type: string
+              required:
+              - src_path
+              - dst_path
+              type: object
+      responses:
+        '200':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Resource updated.
+        '202':
+          content:
+            application/vnd.ceph.api.v1.0+json:
+              type: object
+          description: Operation is still executing. Please check the task queue.
+        '400':
+          description: Operation exception. Please check the response body for details.
+        '401':
+          description: Unauthenticated access. Please login first.
+        '403':
+          description: Unauthorized access. Please check your permissions.
+        '500':
+          description: Unexpected error. Please check the response body for the stack
+            trace.
+      security:
+      - jwt: []
+      tags:
+      - Cephfs
   /api/cephfs/{fs_id}/snapshot:
     delete:
       description: "\n        Remove a snapshot.\n        :param fs_id: The filesystem\

--- a/src/pybind/mgr/dashboard/services/cephfs.py
+++ b/src/pybind/mgr/dashboard/services/cephfs.py
@@ -260,3 +260,12 @@ class CephFS(object):
         if max_files is not None:
             self.cfs.setxattr(path, 'ceph.quota.max_files',
                               str(max_files).encode(), 0)
+
+    def rename_path(self, src_path, dst_path) -> None:
+        """
+        Rename a file or directory.
+        :param src: the path to the existing file or directory.
+        :param dst: the new name of the file or directory.
+        """
+        logger.info("Renaming: from %s to %s", src_path, dst_path)
+        self.cfs.rename(src_path, dst_path)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68935

---

backport of https://github.com/ceph/ceph/pull/58386
parent tracker: https://tracker.ceph.com/issues/66797

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh