### PR TITLE
squid: qa/tasks/ceph: wait the osds down before start check the logs

### DIFF
--- a/qa/suites/upgrade/quincy-x/filestore-remove-check/0-cluster/start.yaml
+++ b/qa/suites/upgrade/quincy-x/filestore-remove-check/0-cluster/start.yaml
@@ -19,6 +19,20 @@ overrides:
       - \(MGR_DOWN\)
       - slow request
       - \(MON_MSGR2_NOT_ENABLED\)
+      - \(OSD_DOWN\)
+      - \(OSD_HOST_DOWN\)
+      - \(POOL_APP_NOT_ENABLED\)
+      - OSD_DOWN
+      - mons down
+      - mon down
+      - MON_DOWN
+      - out of quorum
+      - PG_DEGRADED
+      - Reduced data availability
+      - Degraded data redundancy
+      - OSDMAP_FLAGS
+      - OSD_ROOT_DOWN
+
     conf:
       global:
         enable experimental unrecoverable data corrupting features: "*"

--- a/qa/suites/upgrade/quincy-x/filestore-remove-check/0-cluster/start.yaml
+++ b/qa/suites/upgrade/quincy-x/filestore-remove-check/0-cluster/start.yaml
@@ -44,4 +44,3 @@ roles:
   - mgr.x
   - osd.0
   - osd.1
-  - osd.2

--- a/qa/suites/upgrade/quincy-x/filestore-remove-check/1-ceph-install/quincy.yaml
+++ b/qa/suites/upgrade/quincy-x/filestore-remove-check/1-ceph-install/quincy.yaml
@@ -18,9 +18,6 @@ tasks:
       mon:
         mon_warn_on_insecure_global_id_reclaim: false
         mon_warn_on_insecure_global_id_reclaim_allowed: false
-    log-ignorelist:
-      - Not found or unloadable
-      - evicting unresponsive client
 - exec:
     osd.0:
       - ceph osd require-osd-release quincy

--- a/qa/suites/upgrade/quincy-x/filestore-remove-check/2 - upgrade.yaml
+++ b/qa/suites/upgrade/quincy-x/filestore-remove-check/2 - upgrade.yaml
@@ -3,14 +3,13 @@ meta:
    install upgrade ceph/-x on cluster
    restart : mons, osd.*
 tasks:
+- print: "**** start install.upgrade of nodes"
 - install.upgrade:
-    mon.a:
-- exec:
-    osd.0:
-      - ceph osd require-osd-release quincy
+    all:
 - print: "**** done install.upgrade of nodes"
+- print: "**** start ceph.restart of all osds"
 - ceph.restart:
-    daemons: [mon.a,mgr.x,osd.0,osd.1,osd.2]
+    daemons: [osd.0,osd.1,osd.2]
     mon-health-to-clog: false
     wait-for-healthy: false
     wait-for-osds-up: false


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68950

---

backport of https://github.com/ceph/ceph/pull/59855
parent tracker: https://tracker.ceph.com/issues/67999

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh