### PR TITLE
.github/workflows: Do not exempt PRs with milestone

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -47,9 +47,6 @@ jobs:
           # Labels on PRs exempted from stale
           exempt-pr-labels: 'pinned,security'
           
-          # Exempt all PRs with milestones from stale (also exempts Issues)
-          exempt-all-pr-milestones: true
-          
           # Max number of operations per run
           operations-per-run: 100
 


### PR DESCRIPTION
The stale bot doesn't close certain PRs, even if they have been inactive for several years, because almost all of these PRs have a milestone
