### PR TITLE
reef: rgw: fix the Content-Length in response header of static website

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -607,6 +607,7 @@ void end_header(req_state* s, RGWOp* op, const char *content_type,
   if (!force_no_error && s->is_err()) {
     dump_start(s);
     dump(s);
+    s->formatter->output_footer();
     dump_content_length(s, s->formatter->get_len());
   } else {
     if (proposed_content_length == CHUNKED_TRANSFER_ENCODING) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/62255

---

backport of https://github.com/ceph/ceph/pull/52341
parent tracker: https://tracker.ceph.com/issues/52363

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh