### PR TITLE
qa/rgw/multisite: add yaml option to disable user accounts

### DIFF
--- a/qa/tasks/rgw_multisite_tests.py
+++ b/qa/tasks/rgw_multisite_tests.py
@@ -71,10 +71,15 @@ class RGWMultisiteTests(Task):
 
         # create test account/user
         log.info('creating test user..')
-        user = multisite.User('rgw-multisite-test-user', account='RGW11111111111111111')
-        arg = ['--account-id', user.account]
-        arg += master_zone.zone_args()
-        master_zone.cluster.admin(['account', 'create'] + arg)
+        if self.config.get('with-accounts', True):
+            user = multisite.User('rgw-multisite-test-user', account='RGW11111111111111111')
+            arg = ['--account-id', user.account]
+            arg += master_zone.zone_args()
+            master_zone.cluster.admin(['account', 'create'] + arg)
+        else:
+            # upgrade tests from reef won't support account users
+            user = multisite.User('rgw-multisite-test-user')
+
         user.create(master_zone, ['--display-name', 'TestUser',
                                   '--gen-access-key', '--gen-secret'])
 


### PR DESCRIPTION
related to https://github.com/ceph/ceph/pull/60717 which tries to revive multisite upgrade tests. the reef-x tests are failing due to lack of account support:
> User.__init__() got an unexpected keyword argument 'account'

gates the account creation on a yaml option which the reef-x suite can override with `with-accounts: false`

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
