### PR TITLE
crimson: Set device class during spawn of a crimson osd

### DIFF
--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -590,6 +590,19 @@ seastar::future<struct stat> AlienStore::stat(
   });
 }
 
+seastar::future<std::string> AlienStore::get_default_device_class()
+{
+  logger().debug("{}", __func__);
+  assert(tp);
+  return op_gates.simple_dispatch("get_default_device_class", [=, this] {
+    return tp->submit([=, this] {
+      return store->get_default_device_class();
+    }).then([] (std::string device_class) {
+      return seastar::make_ready_future<std::string>(device_class);
+    });
+  });
+}
+
 auto AlienStore::omap_get_header(CollectionRef ch,
                                  const ghobject_t& oid)
   -> get_attr_errorator::future<ceph::bufferlist>

--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -98,6 +98,7 @@ public:
   seastar::future<struct stat> stat(
     CollectionRef,
     const ghobject_t&) final;
+  seastar::future<std::string> get_default_device_class() final;
   get_attr_errorator::future<ceph::bufferlist> omap_get_header(
     CollectionRef,
     const ghobject_t&) final;

--- a/src/crimson/os/cyanstore/cyan_store.cc
+++ b/src/crimson/os/cyanstore/cyan_store.cc
@@ -143,6 +143,12 @@ CyanStore::list_collections()
   });
 }
 
+seastar::future<std::string>
+CyanStore::get_default_device_class()
+{
+  return seastar::make_ready_future<std::string>("");
+}
+
 CyanStore::mount_ertr::future<> CyanStore::Shard::mount()
 {
   static const char read_file_errmsg[]{"read_file"};

--- a/src/crimson/os/cyanstore/cyan_store.h
+++ b/src/crimson/os/cyanstore/cyan_store.h
@@ -221,6 +221,8 @@ public:
 
   seastar::future<std::vector<coll_core_t>> list_collections() final;
 
+  seastar::future<std::string> get_default_device_class() final;
+
 private:
   seastar::sharded<CyanStore::Shard> shard_stores;
   const std::string path;

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -203,6 +203,7 @@ public:
   using coll_core_t = std::pair<coll_t, core_id_t>;
   virtual seastar::future<std::vector<coll_core_t>> list_collections() = 0;
 
+  virtual seastar::future<std::string> get_default_device_class() = 0;
 protected:
   const core_id_t primary_core;
 };

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -2721,6 +2721,13 @@ SeaStore::read_meta(const std::string& key)
   );
 }
 
+seastar::future<std::string> SeaStore::get_default_device_class()
+{
+  using crimson::common::get_conf;
+  std::string type = get_conf<std::string>("seastore_main_device_type");
+  return seastar::make_ready_future<std::string>(type);
+}
+
 uuid_d SeaStore::Shard::get_fsid() const
 {
   return device->get_meta().seastore_id;

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -191,6 +191,8 @@ public:
     seastar::future<> write_meta(const std::string& key,
                                  const std::string& value);
 
+    seastar::future<std::string> get_default_device_class();
+
     store_statfs_t stat() const;
 
     uuid_d get_fsid() const;
@@ -566,6 +568,8 @@ public:
   seastar::future<std::tuple<int, std::string>> read_meta(const std::string& key) final;
 
   seastar::future<std::vector<coll_core_t>> list_collections() final;
+
+  seastar::future<std::string> get_default_device_class() final;
 
   FuturizedStore::Shard& get_sharded_store() final {
     return shard_stores.local();

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -188,6 +188,7 @@ private:
   seastar::future<> _preboot(version_t oldest_osdmap, version_t newest_osdmap);
   seastar::future<> _send_boot();
   seastar::future<> _add_me_to_crush();
+  seastar::future<> _add_device_class();
 
   seastar::future<> osdmap_subscribe(version_t epoch, bool force_request);
 


### PR DESCRIPTION
Implement a wrapper for different backend storage to set device_class during spawn of a process

Fixes: https://tracker.ceph.com/issues/66627





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
