### PR TITLE
squid: mds: Implement remove for ceph vxattrs 

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -193,6 +193,10 @@ CephFS: Disallow delegating preallocated inode ranges to clients. Config
   without this feature will trigger the MDS to raise a HEALTH_ERR on the
   cluster, MDS_CLIENTS_BROKEN_ROOTSQUASH. See the documentation on this warning
   and the new feature bit for more information.
+* CephFS: Expanded removexattr support for cephfs virtual extended attributes.
+  Previously one had to use setxattr to restore the default in order to "remove".
+  You may now properly use removexattr to remove. You can also now remove layout
+  on root inode, which then will restore layout to default layout.
 
 * cls_cxx_gather is marked as deprecated.
 * CephFS: cephfs-journal-tool is guarded against running on an online file system.

--- a/doc/cephfs/quota.rst
+++ b/doc/cephfs/quota.rst
@@ -45,15 +45,28 @@ To view quota limit::
    system call. Instead, a specific CephFS extended attribute can be viewed by
    running ``getfattr /some/dir -n ceph.<some-xattr>``.
 
-To remove a quota, set the value of extended attribute to ``0``::
+To remove or disable a quota, remove the respective extended attribute or set
+the value to ``0``.
+
+Utilizing remove::
+
+  $ setfattr -x ceph.quota.max_bytes /some/dir
+  $ getfattr /some/dir -n ceph.quota.max_bytes
+  /some/dir/: ceph.quota.max_bytes: No such attribute
+  $
+  $ setfattr -x ceph.quota.max_files /some/dir
+  $ getfattr /some/dir/ -n ceph.quota.max_files
+  /some/dir/: ceph.quota.max_files: No such attribute
+
+Remove by setting value to zero::
 
   $ setfattr -n ceph.quota.max_bytes -v 0 /some/dir
   $ getfattr /some/dir -n ceph.quota.max_bytes
-  dir1/: ceph.quota.max_bytes: No such attribute
+  /some/dir/: ceph.quota.max_bytes: No such attribute
   $
   $ setfattr -n ceph.quota.max_files -v 0 /some/dir
-  $ getfattr dir1/ -n ceph.quota.max_files
-  dir1/: ceph.quota.max_files: No such attribute
+  $ getfattr /some/dir/ -n ceph.quota.max_files
+  /some/dir/: ceph.quota.max_files: No such attribute
 
 Space Usage Reporting and CephFS Quotas
 ---------------------------------------

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -1557,6 +1557,20 @@ class CephFSMountBase(object):
             # gives you [''] instead of []
             return []
 
+    def removexattr(self, path, key, **kwargs):
+        """
+        Wrap setfattr removal.
+
+        :param path: relative to mount point
+        :param key: xattr name
+        :return: None
+        """
+        kwargs['args'] = ["setfattr", "-x", key, path]
+        if kwargs.pop('sudo', False):
+            kwargs['args'].insert(0, 'sudo')
+            kwargs['omit_sudo'] = False
+        self.run_shell(**kwargs)
+
     def setfattr(self, path, key, val, **kwargs):
         """
         Wrap setfattr.

--- a/qa/tasks/cephfs/test_subvolume.py
+++ b/qa/tasks/cephfs/test_subvolume.py
@@ -133,6 +133,33 @@ class TestSubvolume(CephFSTestCase):
             self.mount_a.run_shell(['ln', 'group/subvol2/file1',
                                     'group/subvol3/file1'])
 
+    def test_subvolume_setfattr_empty_value(self):
+        """
+        To verify that an empty value fails on subvolume xattr
+        """
+
+        # create subvol
+        self.mount_a.run_shell(['mkdir', 'group/subvol4'])
+
+        try:
+            self.mount_a.setfattr('group/subvol4', 'ceph.dir.subvolume', '')
+        except CommandFailedError:
+            pass
+        else:
+            self.fail("run_shell should raise CommandFailedError")
+
+    def test_subvolume_rmattr(self):
+        """
+        To verify that rmattr can be used to reset subvolume xattr
+        """
+
+        # create subvol
+        self.mount_a.run_shell(['mkdir', 'group/subvol4'])
+        self.mount_a.setfattr('group/subvol4', 'ceph.dir.subvolume', '1')
+
+        # clear subvolume flag
+        self.mount_a.removexattr('group/subvol4', 'ceph.dir.subvolume')
+
     def test_subvolume_create_subvolume_inside_subvolume(self):
         """
         To verify that subvolume can't be created inside a subvolume

--- a/qa/workunits/fs/misc/general_vxattrs.sh
+++ b/qa/workunits/fs/misc/general_vxattrs.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# test setfattr remove, and check values of vxattr
+# after remove for vxattr, where possible.
+
+set -ex
+
+mkdir -p dir
+
+#ceph.dir.pin test, def val -1, reset val -1
+getfattr -n ceph.dir.pin dir | grep 'ceph.dir.pin="-1"'
+setfattr -n ceph.dir.pin dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -n ceph.dir.pin -v 1 dir
+getfattr -n ceph.dir.pin dir | grep 'ceph.dir.pin="1"'
+setfattr -x ceph.dir.pin dir
+getfattr -n ceph.dir.pin dir | grep 'ceph.dir.pin="-1"'
+
+#TODO: Once test machines support getfattr for vxattr, uncomment getfattr below
+#see: https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/thread/EZL3POLMQLMMNBPAJ2QQ2BAKH44VUNJU/#JJNRRYLUKUAUN5HIL5A7Q4N63OCLWQXF
+#for further detail
+
+#ceph.dir.pin.distributed, def val 0, reset val 0
+#getfattr -n ceph.dir.pin.distributed dir | grep 'ceph.dir.pin.distributed="0"'
+setfattr -n ceph.dir.pin.distributed dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -n ceph.dir.pin.distributed -v 1 dir
+#getfattr -n ceph.dir.pin.distributed dir | grep 'ceph.dir.pin.distributed="1"'
+setfattr -x ceph.dir.pin.distributed dir
+#getfattr -n ceph.dir.pin.distributed dir | grep 'ceph.dir.pin.distributed="0"'
+
+#ceph.dir.pin.random def val 0, reset val 0
+#getfattr -n ceph.dir.pin.random dir | grep 'ceph.dir.pin.random="0"'
+setfattr -n ceph.dir.pin.random dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -n ceph.dir.pin.random -v 0.01 dir
+#getfattr -n ceph.dir.pin.random dir | grep 'ceph.dir.pin.random="0.01"'
+setfattr -x ceph.dir.pin.random dir
+#getfattr -n ceph.dir.pin.random dir | grep 'ceph.dir.pin.random="0"'
+
+#ceph.quota, def value 0, reset val 0
+setfattr -n ceph.quota.max_bytes dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -n ceph.quota.max_bytes -v 100000000 dir
+#getfattr -n ceph.quota.max_bytes dir | grep 'ceph.quota.max_bytes="100000000"'
+setfattr -x ceph.quota.max_bytes dir
+setfattr -n ceph.quota.max_files dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -n ceph.quota.max_files -v 10000 dir
+#getfattr -n ceph.quota.max_files dir | grep 'ceph.quota.max_files="10000"'
+setfattr -x ceph.quota.max_files dir
+
+rmdir dir
+
+echo OK
+

--- a/qa/workunits/fs/misc/layout_vxattrs.sh
+++ b/qa/workunits/fs/misc/layout_vxattrs.sh
@@ -105,6 +105,23 @@ getfattr -n ceph.file.layout.stripe_count dir/file | grep -q 8
 getfattr -n ceph.file.layout.object_size dir/file | grep -q 10485760
 getfattr -n ceph.file.layout.pool_namespace dir/file | grep -q dirns
 
+#Per https://docs.ceph.com/en/latest/cephfs/file-layouts/#clearing-layouts, pool_namespace
+#can be individually removed, while other layout xattrs must be cleared together.
+setfattr -x ceph.dir.layout.pool dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -x ceph.dir.layout.pool_id dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -x ceph.dir.layout.pool_name dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -x ceph.dir.layout.stripe_unit dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -x ceph.dir.layout.stripe_count dir 2>&1 | grep "setfattr: dir: Invalid argument"
+setfattr -x ceph.dir.layout.object_size dir 2>&1 | grep "setfattr: dir: Invalid argument"
+
+setfattr -x ceph.file.layout.pool dir/file 2>&1 | grep "setfattr: dir/file: Invalid argument"
+setfattr -x ceph.file.layout.pool_id dir/file 2>&1 | grep "setfattr: dir/file: Invalid argument"
+setfattr -x ceph.file.layout.pool_name dir/file 2>&1 | grep "setfattr: dir/file: Invalid argument"
+setfattr -x ceph.file.layout.stripe_unit dir/file 2>&1 | grep "setfattr: dir/file: Invalid argument"
+setfattr -x ceph.file.layout.stripe_count dir/file 2>&1 | grep "setfattr: dir/file: Invalid argument"
+setfattr -x ceph.file.layout.object_size dir/file 2>&1 | grep "setfattr: dir/file: Invalid argument"
+setfattr -x ceph.file.layout.pool_namespace dir/file
+
 setfattr -x ceph.dir.layout.pool_namespace dir
 getfattr -n ceph.dir.layout dir | grep -q -v pool_namespace=dirns
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -6001,6 +6001,7 @@ int Server::check_layout_vxattr(const MDRequestRef& mdr,
                                 file_layout_t *layout)
 {
   const cref_t<MClientRequest> &req = mdr->client_request;
+  bool is_rmxattr = (req->get_op() == CEPH_MDS_OP_RMXATTR);
   epoch_t epoch;
   int r;
 
@@ -6010,7 +6011,12 @@ int Server::check_layout_vxattr(const MDRequestRef& mdr,
     });
 
   if (r == -CEPHFS_ENOENT) {
+    if (is_rmxattr) {
+      r = -CEPHFS_EINVAL;
 
+      respond_to_request(mdr, r);
+      return r;
+    }
     // we don't have the specified pool, make sure our map
     // is newer than or as new as the client.
     epoch_t req_epoch = req->get_osdmap_epoch();
@@ -6050,14 +6056,15 @@ int Server::check_layout_vxattr(const MDRequestRef& mdr,
   return 0;
 }
 
-void Server::handle_set_vxattr(const MDRequestRef& mdr, CInode *cur)
+void Server::handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur)
 {
   const cref_t<MClientRequest> &req = mdr->client_request;
+  bool is_rmxattr = (req->get_op() == CEPH_MDS_OP_RMXATTR);
   MutationImpl::LockOpVec lov;
   string name(req->get_path2());
   bufferlist bl = req->get_data();
   string value (bl.c_str(), bl.length());
-  dout(10) << "handle_set_vxattr " << name
+  dout(10) << "handle_client_setvxattr " << name
            << " val " << value.length()
            << " bytes on " << *cur
            << dendl;
@@ -6099,17 +6106,42 @@ void Server::handle_set_vxattr(const MDRequestRef& mdr, CInode *cur)
     else
       layout = mdcache->default_file_layout;
 
-    rest = name.substr(name.find("layout"));
-    if (check_layout_vxattr(mdr, rest, value, &layout) < 0)
-      return;
+    if (is_rmxattr && name == "ceph.dir.layout") {
+      lov.add_xlock(&cur->policylock);
+      if (!mds->locker->acquire_locks(mdr, lov)) {
+        return;
+      }
+      if (!cur->get_projected_inode()->has_layout()) {
+        respond_to_request(mdr, 0);
+        return;
+      }
+      auto pi = cur->project_inode(mdr);
 
-    auto pi = cur->project_inode(mdr);
-    pi.inode->layout = layout;
+      if (cur->is_root()) {
+	  pi.inode->layout = mdcache->default_file_layout;
+      } else {
+	pi.inode->clear_layout();
+	pi.inode->version = cur->pre_dirty();
+      }
+      pip = pi.inode.get();
+    } else {
+      rest = name.substr(name.find("layout"));
+      if (check_layout_vxattr(mdr, rest, value, &layout) < 0)
+	return;
+
+      auto pi = cur->project_inode(mdr);
+      pi.inode->layout = layout;
+      pip = pi.inode.get();
+    }
+
     mdr->no_early_reply = true;
-    pip = pi.inode.get();
   } else if (name.compare(0, 16, "ceph.file.layout") == 0) {
     if (!cur->is_file()) {
       respond_to_request(mdr, -CEPHFS_EINVAL);
+      return;
+    }
+    if (!cur->get_projected_inode()->has_layout()) {
+      respond_to_request(mdr, 0);
       return;
     }
     if (cur->get_projected_inode()->size ||
@@ -6144,6 +6176,13 @@ void Server::handle_set_vxattr(const MDRequestRef& mdr, CInode *cur)
     }
 
     quota_info_t quota = cur->get_projected_inode()->quota;
+    if (is_rmxattr) {
+      if (!quota.is_enabled()) {
+        respond_to_request(mdr, 0);
+        return;
+      }
+      value = "0";
+    }
 
     rest = name.substr(name.find("quota"));
     int r = parse_quota_vxattr(rest, value, &quota);
@@ -6229,6 +6268,14 @@ void Server::handle_set_vxattr(const MDRequestRef& mdr, CInode *cur)
 
     bool val;
     try {
+      if (is_rmxattr) {
+        const auto srnode = cur->get_projected_srnode();
+	if (!srnode->is_subvolume()) {
+	  respond_to_request(mdr, 0);
+	  return;
+	}
+        value = "0";
+      }
       val = boost::lexical_cast<bool>(value);
     } catch (boost::bad_lexical_cast const&) {
       dout(10) << "bad vxattr value, unable to parse bool for " << name << dendl;
@@ -6302,6 +6349,13 @@ void Server::handle_set_vxattr(const MDRequestRef& mdr, CInode *cur)
 
     mds_rank_t rank;
     try {
+      if (is_rmxattr) {
+	if (cur->get_projected_inode()->export_pin == -1) {
+          respond_to_request(mdr, 0);
+          return;
+	}
+        value = "-1";
+      }
       rank = boost::lexical_cast<mds_rank_t>(value);
       if (rank < 0) rank = MDS_RANK_NONE;
       else if (rank >= MAX_MDS) {
@@ -6328,6 +6382,13 @@ void Server::handle_set_vxattr(const MDRequestRef& mdr, CInode *cur)
 
     double val;
     try {
+      if (is_rmxattr) {
+	if (cur->get_projected_inode()->export_ephemeral_random_pin == 0.0) {
+	  respond_to_request(mdr, 0);
+          return;
+	}
+        value = "0";
+      }
       val = boost::lexical_cast<double>(value);
     } catch (boost::bad_lexical_cast const&) {
       dout(10) << "bad vxattr value, unable to parse float for " << name << dendl;
@@ -6357,6 +6418,13 @@ void Server::handle_set_vxattr(const MDRequestRef& mdr, CInode *cur)
 
     bool val;
     try {
+      if (is_rmxattr) {
+	if (cur->get_projected_inode()->get_ephemeral_distributed_pin() == 0) {
+          respond_to_request(mdr, 0);
+          return;
+	}
+        value = "0";
+      }
       val = boost::lexical_cast<bool>(value);
     } catch (boost::bad_lexical_cast const&) {
       dout(10) << "bad vxattr value, unable to parse bool for " << name << dendl;
@@ -6394,61 +6462,6 @@ void Server::handle_set_vxattr(const MDRequestRef& mdr, CInode *cur)
   journal_and_reply(mdr, cur, 0, le, new C_MDS_inode_update_finish(this, mdr, cur,
 								   false, false, adjust_realm));
   return;
-}
-
-void Server::handle_remove_vxattr(const MDRequestRef& mdr, CInode *cur)
-{
-  const cref_t<MClientRequest> &req = mdr->client_request;
-  string name(req->get_path2());
-
-  dout(10) << __func__ << " " << name << " on " << *cur << dendl;
-
-  if (name == "ceph.dir.layout") {
-    if (!cur->is_dir()) {
-      respond_to_request(mdr, -CEPHFS_ENODATA);
-      return;
-    }
-    if (cur->is_root()) {
-      dout(10) << "can't remove layout policy on the root directory" << dendl;
-      respond_to_request(mdr, -CEPHFS_EINVAL);
-      return;
-    }
-
-    if (!cur->get_projected_inode()->has_layout()) {
-      respond_to_request(mdr, -CEPHFS_ENODATA);
-      return;
-    }
-
-    MutationImpl::LockOpVec lov;
-    lov.add_xlock(&cur->policylock);
-    if (!mds->locker->acquire_locks(mdr, lov))
-      return;
-
-    auto pi = cur->project_inode(mdr);
-    pi.inode->clear_layout();
-    pi.inode->version = cur->pre_dirty();
-
-    // log + wait
-    mdr->ls = mdlog->get_current_segment();
-    EUpdate *le = new EUpdate(mdlog, "remove dir layout vxattr");
-    le->metablob.add_client_req(req->get_reqid(), req->get_oldest_client_tid());
-    mdcache->predirty_journal_parents(mdr, &le->metablob, cur, 0, PREDIRTY_PRIMARY);
-    mdcache->journal_dirty_inode(mdr.get(), &le->metablob, cur);
-
-    mdr->no_early_reply = true;
-    journal_and_reply(mdr, cur, 0, le, new C_MDS_inode_update_finish(this, mdr, cur));
-    return;
-  } else if (name == "ceph.dir.layout.pool_namespace"
-          || name == "ceph.file.layout.pool_namespace") {
-    // Namespace is the only layout field that has a meaningful
-    // null/none value (empty string, means default layout).  Is equivalent
-    // to a setxattr with empty string: pass through the empty payload of
-    // the rmxattr request to do this.
-    handle_set_vxattr(mdr, cur);
-    return;
-  }
-
-  respond_to_request(mdr, -CEPHFS_ENODATA);
 }
 
 const Server::XattrHandler Server::xattr_handlers[] = {
@@ -6646,7 +6659,7 @@ void Server::handle_client_setxattr(const MDRequestRef& mdr)
     if (!cur)
       return;
 
-    handle_set_vxattr(mdr, cur);
+    handle_client_setvxattr(mdr, cur);
     return;
   }
 
@@ -6743,7 +6756,7 @@ void Server::handle_client_removexattr(const MDRequestRef& mdr)
     if (!cur)
       return;
 
-    handle_remove_vxattr(mdr, cur);
+    handle_client_setvxattr(mdr, cur);
     return;
   }
 

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -233,8 +233,7 @@ public:
                           std::string name,
                           std::string value,
                           file_layout_t *layout);
-  void handle_set_vxattr(const MDRequestRef& mdr, CInode *cur);
-  void handle_remove_vxattr(const MDRequestRef& mdr, CInode *cur);
+  void handle_client_setvxattr(const MDRequestRef& mdr, CInode *cur);
   void handle_client_getvxattr(const MDRequestRef& mdr);
   void handle_client_setxattr(const MDRequestRef& mdr);
   void handle_client_removexattr(const MDRequestRef& mdr);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68942

---

backport of https://github.com/ceph/ceph/pull/53755
parent tracker: https://tracker.ceph.com/issues/62793

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh