### PR TITLE
mgr/dashboard: add feature toggle for nvmeof

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -200,6 +200,7 @@
                             [useRouter]="true"
                             title="NVMe/TCP"
                             i18n-title
+                            *ngIf="permissions.nvmeof.read && enabledFeature.nvmeof"
                             class="tc_submenuitem tc_submenuitem_block_nvme"><span i18n>NVMe/TCP</span></cds-sidenav-item>
         </cds-sidenav-menu>
         <!-- Object Storage -->

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/feature-toggles.service.ts
@@ -13,6 +13,7 @@ export class FeatureTogglesMap {
   rgw = true;
   nfs = true;
   dashboard = true;
+  nvmeof = true;
 }
 export type Features = keyof FeatureTogglesMap;
 export type FeatureTogglesMap$ = Observable<FeatureTogglesMap>;

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -31,7 +31,6 @@ from mgr_util import ServerConfigException, build_url, \
 
 from . import mgr
 from .cli import DBCLICommand
-from .controllers import nvmeof  # noqa # pylint: disable=unused-import
 from .controllers import Router, json_error_page
 from .grafana import push_local_dashboards
 from .services import nvmeof_cli  # noqa # pylint: disable=unused-import

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -6925,6 +6925,9 @@ paths:
                   nfs:
                     description: ''
                     type: boolean
+                  nvmeof:
+                    description: ''
+                    type: boolean
                   rbd:
                     description: ''
                     type: boolean
@@ -6939,6 +6942,7 @@ paths:
                 - rgw
                 - nfs
                 - dashboard
+                - nvmeof
                 type: object
             application/vnd.ceph.api.v1.0+json:
               schema:
@@ -6956,6 +6960,9 @@ paths:
                     description: ''
                     type: boolean
                   nfs:
+                    description: ''
+                    type: boolean
+                  nvmeof:
                     description: ''
                     type: boolean
                   rbd:

--- a/src/pybind/mgr/dashboard/plugins/feature_toggles.py
+++ b/src/pybind/mgr/dashboard/plugins/feature_toggles.py
@@ -8,6 +8,7 @@ from mgr_module import Option
 from mgr_util import CLIWarning
 
 from ..cli import DBCLICommand
+from ..controllers import nvmeof  # noqa # pylint: disable=unused-import
 from ..controllers.cephfs import CephFS
 from ..controllers.iscsi import Iscsi, IscsiTarget
 from ..controllers.nfs import NFSGaneshaExports, NFSGaneshaUi
@@ -28,6 +29,7 @@ class Features(Enum):
     RGW = 'rgw'
     NFS = 'nfs'
     DASHBOARD = 'dashboard'
+    NVMEOF = 'nvmeof'
 
     # if we want to add any custom warning message when enabling a feature
     # we can add it here as key-value pair in warn_msg.
@@ -152,7 +154,8 @@ class FeatureToggles(I.CanMgr, I.Setupable, I.HasOptions,
             "cephfs": (bool, ''),
             "rgw": (bool, ''),
             "nfs": (bool, ''),
-            "dashboard": (bool, '')
+            "dashboard": (bool, ''),
+            "nvmeof": (bool, ''),
         }
 
         @APIRouter('/feature_toggles')

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -226,7 +226,8 @@ READ_ONLY_ROLE = Role(
 
 # block manager role provides all permission for block related scopes
 BLOCK_MGR_ROLE = Role(
-    'block-manager', 'allows full permissions for rbd-image, rbd-mirroring, and iscsi scopes', {
+    'block-manager',
+    'allows full permissions for rbd-image, rbd-mirroring, iscsi and nvmeof scopes', {
         Scope.RBD_IMAGE: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.POOL: [_P.READ],
         Scope.ISCSI: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],


### PR DESCRIPTION
i saw that the feature toggle was missing for nvmeof, so adding it here. also the scope was not added in the navigation which is also being fixed here

Fixes: https://tracker.ceph.com/issues/68970





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
