### PR TITLE
objclass: don't do costly string formatting when not needed

### DIFF
--- a/src/osd/objclass.cc
+++ b/src/osd/objclass.cc
@@ -765,6 +765,11 @@ int cls_cxx_get_gathered_data(cls_method_context_t hctx, std::map<std::string, b
 // crimson-osd, it's different b/c of how the dout macro expands.
 int cls_log(int level, const char *format, ...)
 {
+   if (!ClassHandler::get_instance().cct->_conf->subsys.should_gather(dout_subsys, level)) {
+     // if this early exit becomes visible in profiling, switch to
+     // the static, compile-time check as the dout does.
+     return 0;
+   }
    size_t size = 256;
    va_list ap;
    while (1) {


### PR DESCRIPTION
Special thanks and credits to Mark Kogan for profiling ceph-osd under the RGW list workload.

In this particular workload the change is worth around 4.2% of CPU cycles [1]. However, it's not restricted to RGW's bucket listing nor `cls_rgw`; I think it affects every cls plugin in the system.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

[1]: https://github.com/ceph/ceph/pull/60278#issuecomment-2416582108





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
