### PR TITLE
cls/rgw: optimize RGW bucket listing

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -537,7 +537,7 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 
   auto iter = in->cbegin();
 
-  rgw_cls_list_op op(false);
+  rgw_cls_list_op op;
   try {
     decode(op, iter);
   } catch (ceph::buffer::error& err) {

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -549,10 +549,14 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   rgw_bucket_dir& new_dir = ret.dir;
   auto& name_entry_map = new_dir.m; // map of keys to entries
 
-  int rc = read_bucket_header(hctx, &new_dir.header);
-  if (rc < 0) {
-    CLS_LOG(1, "ERROR: %s: failed to read header", __func__);
-    return rc;
+  int rc = 0;
+  if (true) {
+    new_dir.header.emplace();
+    rc = read_bucket_header(hctx, &(*new_dir.header));
+    if (rc < 0) {
+      CLS_LOG(1, "ERROR: %s: failed to read header", __func__);
+      return rc;
+    }
   }
 
   // some calls just want the header and request 0 entries
@@ -837,9 +841,8 @@ int rgw_bucket_init_index(cls_method_context_t hctx, bufferlist *in, bufferlist 
     return -EINVAL;
   }
 
-  rgw_bucket_dir dir;
-
-  return write_bucket_header(hctx, &dir.header);
+  rgw_bucket_dir_header header;
+  return write_bucket_header(hctx, &header);
 }
 
 int rgw_bucket_set_tag_timeout(cls_method_context_t hctx, bufferlist *in, bufferlist *out)

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -537,7 +537,7 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 
   auto iter = in->cbegin();
 
-  rgw_cls_list_op op;
+  rgw_cls_list_op op(false);
   try {
     decode(op, iter);
   } catch (ceph::buffer::error& err) {

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -550,7 +550,7 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   auto& name_entry_map = new_dir.m; // map of keys to entries
 
   int rc = 0;
-  if (true) {
+  if (op.want_header) {
     new_dir.header.emplace();
     rc = read_bucket_header(hctx, &(*new_dir.header));
     if (rc < 0) {

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -828,7 +828,8 @@ public:
     } catch (ceph::buffer::error& err) {
       r = -EIO;
     }
-    cb->handle_response(r, ret.dir.header);
+    ceph_assert(ret.dir.header.has_value());
+    cb->handle_response(r, *ret.dir.header);
   }
 };
 

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -350,7 +350,7 @@ void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
                             rgw_cls_list_ret* result)
 {
   bufferlist in;
-  rgw_cls_list_op call(false);
+  rgw_cls_list_op call;
   call.start_obj = start_obj;
   call.filter_prefix = filter_prefix;
   call.delimiter = delimiter;
@@ -838,7 +838,7 @@ int cls_rgw_get_dir_header_async(IoCtx& io_ctx, const string& oid,
                                  boost::intrusive_ptr<RGWGetDirHeader_CB> cb)
 {
   bufferlist in, out;
-  rgw_cls_list_op call(false);
+  rgw_cls_list_op call;
   call.num_entries = 0;
   call.want_header = true;
   encode(call, in);

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -356,6 +356,7 @@ void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
   call.delimiter = delimiter;
   call.num_entries = num_entries;
   call.list_versions = list_versions;
+  call.want_header = (num_entries == 0);
   encode(call, in);
 
   op.exec(RGW_CLASS, RGW_BUCKET_LIST, in,
@@ -839,6 +840,7 @@ int cls_rgw_get_dir_header_async(IoCtx& io_ctx, const string& oid,
   bufferlist in, out;
   rgw_cls_list_op call;
   call.num_entries = 0;
+  call.want_header = true;
   encode(call, in);
   ObjectReadOperation op;
   op.exec(RGW_CLASS, RGW_BUCKET_LIST, in,

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -350,7 +350,7 @@ void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
                             rgw_cls_list_ret* result)
 {
   bufferlist in;
-  rgw_cls_list_op call;
+  rgw_cls_list_op call(false);
   call.start_obj = start_obj;
   call.filter_prefix = filter_prefix;
   call.delimiter = delimiter;
@@ -838,7 +838,7 @@ int cls_rgw_get_dir_header_async(IoCtx& io_ctx, const string& oid,
                                  boost::intrusive_ptr<RGWGetDirHeader_CB> cb)
 {
   bufferlist in, out;
-  rgw_cls_list_op call;
+  rgw_cls_list_op call(false);
   call.num_entries = 0;
   call.want_header = true;
   encode(call, in);

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -315,6 +315,7 @@ void rgw_cls_list_op::dump(Formatter *f) const
 {
   f->dump_string("start_obj", start_obj.name);
   f->dump_unsigned("num_entries", num_entries);
+  f->dump_bool("want_header", want_header);
 }
 
 void rgw_cls_list_ret::generate_test_instances(list<rgw_cls_list_ret*>& o)

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -303,12 +303,12 @@ void rgw_cls_bucket_clear_olh_op::dump(Formatter *f) const
 
 void rgw_cls_list_op::generate_test_instances(list<rgw_cls_list_op*>& o)
 {
-  rgw_cls_list_op *op = new rgw_cls_list_op(false);
+  rgw_cls_list_op *op = new rgw_cls_list_op;
   op->start_obj.name = "start_obj";
   op->num_entries = 100;
   op->filter_prefix = "filter_prefix";
   o.push_back(op);
-  o.push_back(new rgw_cls_list_op(false));
+  o.push_back(new rgw_cls_list_op);
 }
 
 void rgw_cls_list_op::dump(Formatter *f) const

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -303,12 +303,12 @@ void rgw_cls_bucket_clear_olh_op::dump(Formatter *f) const
 
 void rgw_cls_list_op::generate_test_instances(list<rgw_cls_list_op*>& o)
 {
-  rgw_cls_list_op *op = new rgw_cls_list_op;
+  rgw_cls_list_op *op = new rgw_cls_list_op(false);
   op->start_obj.name = "start_obj";
   op->num_entries = 100;
   op->filter_prefix = "filter_prefix";
   o.push_back(op);
-  o.push_back(new rgw_cls_list_op);
+  o.push_back(new rgw_cls_list_op(false));
 }
 
 void rgw_cls_list_op::dump(Formatter *f) const

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -388,7 +388,7 @@ struct rgw_cls_list_op
   bool want_header;
   std::string delimiter;
 
-  rgw_cls_list_op(bool want_header) : num_entries(0), list_versions(false), want_header(want_header) {}
+  rgw_cls_list_op() : num_entries(0), list_versions(false), want_header(false) {}
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(7, 4, bl);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -385,21 +385,23 @@ struct rgw_cls_list_op
   uint32_t num_entries;
   std::string filter_prefix;
   bool list_versions;
+  bool want_header;
   std::string delimiter;
 
-  rgw_cls_list_op() : num_entries(0), list_versions(false) {}
+  rgw_cls_list_op() : num_entries(0), list_versions(false), want_header(false) {}
 
   void encode(ceph::buffer::list &bl) const {
-    ENCODE_START(6, 4, bl);
+    ENCODE_START(7, 4, bl);
     encode(num_entries, bl);
     encode(filter_prefix, bl);
     encode(start_obj, bl);
     encode(list_versions, bl);
     encode(delimiter, bl);
+    encode(want_header, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator &bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(6, 2, 2, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(7, 2, 2, bl);
     if (struct_v < 4) {
       decode(start_obj.name, bl);
     }
@@ -415,6 +417,9 @@ struct rgw_cls_list_op
     }
     if (struct_v >= 6) {
       decode(delimiter, bl);
+    }
+    if (struct_v >= 7) {
+      decode(want_header, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -388,7 +388,7 @@ struct rgw_cls_list_op
   bool want_header;
   std::string delimiter;
 
-  rgw_cls_list_op() : num_entries(0), list_versions(false), want_header(false) {}
+  rgw_cls_list_op(bool want_header) : num_entries(0), list_versions(false), want_header(want_header) {}
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(7, 4, bl);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -455,6 +455,16 @@ struct rgw_cls_list_ret {
     encode(marker, bl);
     ENCODE_FINISH(bl);
   }
+  void encode_reusing_encoded_dir_entries(
+    std::map<std::string, ceph::bufferlist> entries,
+    ceph::buffer::list &bl
+  ) const {
+    ENCODE_START(4, 2, bl);
+    dir.encode_reusing_encoded_dir_entries(std::move(entries), bl);
+    encode(is_truncated, bl);
+    encode(marker, bl);
+    ENCODE_FINISH(bl);
+  }
   void decode(ceph::buffer::list::const_iterator &bl) {
     DECODE_START_LEGACY_COMPAT_LEN(4, 2, 2, bl);
     decode(dir, bl);

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -730,7 +730,9 @@ void rgw_bucket_dir::generate_test_instances(list<rgw_bucket_dir*>& o)
 void rgw_bucket_dir::dump(Formatter *f) const
 {
   f->open_object_section("header");
-  header.dump(f);
+  if (header) {
+    header->dump(f);
+  }
   f->close_section();
   auto iter = m.cbegin();
   f->open_array_section("map");

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -4032,6 +4032,18 @@ options:
   - rgw
   - osd
   with_legacy: true
+- name: rgw_do_osd_side_bucket_list_checks
+  type: bool
+  level: dev
+  default: false
+  desc: Perform at OSD side checks on bucket index entries.
+  long_desc: Perform at OSD side checks on bucket index entries.
+    This allows to drop some unneeded entries earlier but requires
+    OSDs to decode them first.
+  services:
+  - rgw
+  - osd
+  with_legacy: true
 - name: rgw_allow_notification_secrets_in_cleartext
   type: bool
   level: advanced

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -10456,7 +10456,8 @@ int RGWRados::cls_bucket_head(const DoutPrefixProvider *dpp, const RGWBucketInfo
 
   map<int, struct rgw_cls_list_ret>::iterator iter = list_results.begin();
   for(; iter != list_results.end(); ++iter) {
-    headers.push_back(std::move(iter->second.dir.header));
+    ceph_assert(iter->second.dir.header.has_value());
+    headers.push_back(std::move(*iter->second.dir.header));
   }
   return 0;
 }

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -348,7 +348,8 @@ int RGWSI_BucketIndex_RADOS::cls_bucket_head(const DoutPrefixProvider *dpp,
 
   map<int, struct rgw_cls_list_ret>::iterator iter = list_results.begin();
   for(; iter != list_results.end(); ++iter) {
-    headers->push_back(std::move(iter->second.dir.header));
+    ceph_assert(iter->second.dir.header.has_value());
+    headers->push_back(std::move(*iter->second.dir.header));
   }
   return 0;
 }

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -63,8 +63,9 @@ void test_stats(librados::IoCtx& ioctx, const string& oid, RGWObjCategory catego
   uint64_t size = 0;
   map<int, struct rgw_cls_list_ret>::iterator iter = results.begin();
   for (; iter != results.end(); ++iter) {
-    entries += (iter->second).dir.header.stats[category].num_entries;
-    size += (iter->second).dir.header.stats[category].total_size;
+    ASSERT_TRUE((iter->second).dir.header.has_value());
+    entries += (iter->second).dir.header->stats[category].num_entries;
+    size += (iter->second).dir.header->stats[category].total_size;
   }
   ASSERT_EQ(total_size, size);
   ASSERT_EQ(num_entries, entries);
@@ -1440,7 +1441,8 @@ void reshardlog_entries(librados::IoCtx& ioctx, const std::string& oid, uint32_t
   uint32_t entries = 0;
   map<int, struct rgw_cls_list_ret>::iterator iter = results.begin();
   for (; iter != results.end(); ++iter) {
-    entries += (iter->second).dir.header.reshardlog_entries;
+    ASSERT_TRUE((iter->second).dir.header.has_value());
+    entries += (iter->second).dir.header->reshardlog_entries;
   }
   ASSERT_EQ(entries, num_entries);
 }

--- a/src/test/cls_rgw/test_cls_rgw_stats.cc
+++ b/src/test/cls_rgw/test_cls_rgw_stats.cc
@@ -116,7 +116,8 @@ void read_stats(librados::IoCtx& ioctx, const std::string& oid,
   std::map<int, rgw_cls_list_ret> results;
   ASSERT_EQ(0, CLSRGWIssueGetDirHeader(ioctx, oids, results, 8)());
   ASSERT_EQ(1, results.size());
-  stats = std::move(results.begin()->second.dir.header.stats);
+  ASSERT_TRUE(results.begin()->second.dir.header.has_value());
+  stats = std::move(results.begin()->second.dir.header->stats);
 }
 
 static void account_entry(rgw_bucket_dir_stats& stats,


### PR DESCRIPTION
These changes have been dissected from PR https://github.com/ceph/ceph/pull/60278 that brings the `ObjectStore::omap_iterate()` as replacement of `ObjectStore::get_omap_iterator()` to optimize `GETOMAPVALS`, the RADOS operation `rgw_bucket_list` is based on. However, [profiling `ceph-osd`](https://github.com/ceph/ceph/pull/60278#issuecomment-2416582108) during bucket listing has shown other inefficiencies blurring the benefit from `omap_iterate()`. This PR tackles the `cls_rgw` part.

There are 3 main changes in `cls_rgw`:
* not retrieving the OMAP header when unnecessary,
* not reencoding of `rgw_bucket_dir_entries`,
* not decoding the entries by default.

The related flamegraphs and performance numbers:

* https://github.com/ceph/ceph/pull/60278#issuecomment-2416582108
* https://github.com/ceph/ceph/pull/60278#issuecomment-2462794137
* https://github.com/ceph/ceph/pull/60278#issuecomment-2467890024
* https://github.com/ceph/ceph/pull/60278#issuecomment-2470388682

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
