### PR TITLE
Add resource limits to nvmeof configuration

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nvmeof/ceph-nvmeof.conf.j2
@@ -22,6 +22,10 @@ ping_spdk_under_lock = {{ spec.ping_spdk_under_lock }}
 enable_monitor_client = {{ spec.enable_monitor_client }}
 max_hosts_per_namespace = {{ spec.max_hosts_per_namespace }}
 max_namespaces_with_netmask = {{ spec.max_namespaces_with_netmask }}
+max_subsystems = {{ spec.max_subsystems }}
+max_namespaces = {{ spec.max_namespaces }}
+max_namespaces_per_subsystem = {{ spec.max_namespaces_per_subsystem }}
+max_hosts_per_subsystem = {{ spec.max_hosts_per_subsystem }}
 
 [gateway-logs]
 log_level = {{ spec.log_level }}

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -411,6 +411,10 @@ ping_spdk_under_lock = False
 enable_monitor_client = True
 max_hosts_per_namespace = 1
 max_namespaces_with_netmask = 1000
+max_subsystems = 128
+max_namespaces = 1024
+max_namespaces_per_subsystem = 256
+max_hosts_per_subsystem = 32
 
 [gateway-logs]
 log_level = INFO

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -1342,6 +1342,10 @@ class NvmeofServiceSpec(ServiceSpec):
                  ping_spdk_under_lock: Optional[bool] = False,
                  max_hosts_per_namespace: Optional[int] = 1,
                  max_namespaces_with_netmask: Optional[int] = 1000,
+                 max_subsystems: Optional[int] = 128,
+                 max_namespaces: Optional[int] = 1024,
+                 max_namespaces_per_subsystem: Optional[int] = 256,
+                 max_hosts_per_subsystem: Optional[int] = 32,
                  server_key: Optional[str] = None,
                  server_cert: Optional[str] = None,
                  client_key: Optional[str] = None,
@@ -1425,6 +1429,14 @@ class NvmeofServiceSpec(ServiceSpec):
         self.max_hosts_per_namespace = max_hosts_per_namespace
         #: ``max_namespaces_with_netmask`` max number of namespaces which are not auto visible
         self.max_namespaces_with_netmask = max_namespaces_with_netmask
+        #: ``max_subsystems`` max number of subsystems
+        self.max_subsystems = max_subsystems
+        #: ``max_namespaces`` max number of namespaces on all subsystems
+        self.max_namespaces = max_namespaces
+        #: ``max_namespaces_per_subsystem`` max number of namespaces per one subsystem
+        self.max_namespaces_per_subsystem = max_namespaces_per_subsystem
+        #: ``max_hosts_per_subsystem`` max number of hosts per subsystems
+        self.max_hosts_per_subsystem = max_hosts_per_subsystem
         #: ``allowed_consecutive_spdk_ping_failures`` # of ping failures before aborting gateway
         self.allowed_consecutive_spdk_ping_failures = allowed_consecutive_spdk_ping_failures
         #: ``spdk_ping_interval_in_seconds`` sleep interval in seconds between SPDK pings
@@ -1612,6 +1624,36 @@ class NvmeofServiceSpec(ServiceSpec):
             and self.max_log_directory_backups < 0
         ):
             raise SpecValidationError("Log file directory backups can't be negative")
+
+        if (self.max_hosts_per_namespace and self.max_hosts_per_namespace < 0):
+            raise SpecValidationError("Max hosts per namespace can't be negative")
+
+        if (self.max_namespaces_with_netmask and self.max_namespaces_with_netmask < 0):
+            raise SpecValidationError("Max namespaces with netmask can't be negative")
+
+        if type(self.max_subsystems) != int:
+            raise SpecValidationError("Max subsystems must be an integer")
+
+        if self.max_subsystems <= 0:
+            raise SpecValidationError("Max subsystems must be greater than zero")
+
+        if type(self.max_namespaces) != int:
+            raise SpecValidationError("Max namespaces must be an integer")
+
+        if self.max_namespaces <= 0:
+            raise SpecValidationError("Max namespaces must be greater than zero")
+
+        if type(self.max_namespaces_per_subsystem) != int:
+            raise SpecValidationError("Max namespaces per subsystem must be an integer")
+
+        if self.max_namespaces_per_subsystem <= 0:
+            raise SpecValidationError("Max namespaces per subsystem must be greater than zero")
+
+        if type(self.max_hosts_per_subsystem) != int:
+            raise SpecValidationError("Max hosts per subsystem must be an integer")
+
+        if self.max_hosts_per_subsystem <= 0:
+            raise SpecValidationError("Max hosts per subsystem must be greater than zero")
 
         if (
             self.monitor_timeout


### PR DESCRIPTION
<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->
mgr/cephadm: Add resource limits to nvmeof configuration
python-common/ceph/deployment: Add resource limits to nvmeof configuration

    Fixes https://tracker.ceph.com/issues/68967

    Signed-off-by: Gil Bregman <gbregman@il.ibm.com>

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [x] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>