### PR TITLE
rgw/abortmp: Race condition on AbortMultipartUpload

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7040,6 +7040,9 @@ void RGWAbortMultipart::execute(optional_yield y)
   auto serializer = meta_obj->get_serializer(this, "RGWCompleteMultipart");
   op_ret = serializer->try_lock(this, dur, y);
   if (op_ret < 0) {
+    if (op_ret == -ENOENT) {
+      op_ret = -ERR_NO_SUCH_UPLOAD;
+    }
     return;
   }
   op_ret = upload->abort(this, s->cct, y);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7023,17 +7023,27 @@ void RGWAbortMultipart::execute(optional_yield y)
     return;
 
   upload = s->bucket->get_multipart_upload(s->object->get_name(), upload_id);
+  meta_obj = upload->get_meta_obj();
+  meta_obj->set_in_extra_data(true);
+  meta_obj->get_obj_attrs(s->yield, this);
+
   jspan_context trace_ctx(false, false);
   if (tracing::rgw::tracer.is_enabled()) {
     // read meta object attributes for trace info
-    meta_obj = upload->get_meta_obj();
-    meta_obj->set_in_extra_data(true);
-    meta_obj->get_obj_attrs(s->yield, this);
     extract_span_context(meta_obj->get_attrs(), trace_ctx);
   }
   multipart_trace = tracing::rgw::tracer.add_span(name(), trace_ctx);
 
+  int max_lock_secs_mp =
+    s->cct->_conf.get_val<int64_t>("rgw_mp_lock_max_time");
+  utime_t dur(max_lock_secs_mp, 0);
+  auto serializer = meta_obj->get_serializer(this, "RGWCompleteMultipart");
+  op_ret = serializer->try_lock(this, dur, y);
+  if (op_ret < 0) {
+    return;
+  }
   op_ret = upload->abort(this, s->cct, y);
+  serializer->unlock();
 }
 
 int RGWListMultipart::verify_permission(optional_yield y)


### PR DESCRIPTION
Hi, We have encountered a bug related to object metadata. Here is how this issue appears from the user’s perspective:

- The object can be listed.
- The head object operation returns the metadata.
- The get object request returns a 404 (NoSuchKey) error.

I can confirm that this issue is present in **v17.2.8**.

```
parallels@ubuntu-linux-22-04-desktop:~$ ./s3-multipart-fuzzer --rgw2 http://localhost:8000 
Found object: fuzzobject_000016

parallels@ubuntu-linux-22-04-desktop:~$ s3cmd get s3://test/fuzzobject_000016
download: 's3://test/fuzzobject_000016' -> './fuzzobject_000016'  [1 of 1]
ERROR: Download of './fuzzobject_000016' failed (Reason: 404 (NoSuchKey))
ERROR: S3 error: 404 (NoSuchKey)

parallels@ubuntu-linux-22-04-desktop:~$ s3cmd info s3://test/fuzzobject_000016
s3://test/fuzzobject_000016 (object):
   File size: 5242880
   Last mod:  Mon, 18 Nov 2024 14:38:48 GMT
   MIME type: binary/octet-stream
   Storage:   STANDARD
   MD5 sum:   81485c0e873d222199469076b60f30e9-1
   SSE:       none
   Policy:    none
   CORS:      none
   ACL:       M. Tester: FULL_CONTROL
```

This bug was identified during the following sequence of events:

1. The user initiated a multipart upload.
2. The user uploaded a part.
3. The user called CompleteMultipart, which took 6 seconds due to slow operations on the OSD.
4. The SDK (official Java SDK) retried CompleteMultipart two additional times during these 6 seconds, receiving an HTTP status code 500 both times.
5. The user called AbortMultipart because the SDK reported an error and received an HTTP status code 204.
6. The first CompleteMultipart call eventually finished successfully (reporting a status code 200).
## How to reproduce
I was able to reliably reproduce this bug using a small [fuzzer](https://gist.github.com/YaZasnyal/0a4462d1789dcb83a147cbd99e51494a) on a development cluster. This program initiates a multipart upload, uploads a part, and then sends CompleteMultipart while simultaneously calling AbortMultipart.

```
# start the cluster
MDS=0 MON=1 MGR=1 OSD=2 RGW=1 ../src/vstart.sh --without-dashboard -n
# run the fuzzer for several seconds and press Ctrl+C
./s3-multipart-fuzzer
```

Now you can use s3cmd to get the data:
```
mkdir -p fuzz && rm -rf fuzz/* && s3cmd sync s3://test ./fuzz/ -f
```

At this point, no errors will occur for the files that can be listed. However, you will need to wait for the garbage collector to remove the aborted multiparts, or you can manually trigger that action:
```
radosgw-admin gc process --include-all
```

After this process, some objects may be missing, even though they were present in the listing and the HeadObject operation could be successfully executed on them. 

Despite the user explicitly canceling the upload and receiving a successful response, I still classify this as data loss because the object remained accessible for some time afterward.

## How to fix
I can confirm that I am not able to reproduce this bug if the lock is added. 

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
