### PR TITLE
fix issue 67831 of cephfs: when dir updates, the change_attr should always be increased by 1

### DIFF
--- a/src/include/cephfs/types.h
+++ b/src/include/cephfs/types.h
@@ -94,12 +94,14 @@ struct frag_info_t : public scatter_info_t {
     if (cur.mtime > mtime) {
       mtime = cur.mtime;
       if (touched_mtime)
-	*touched_mtime = true;
+        *touched_mtime = true;
+      if (touched_chattr)
+        *touched_chattr = true;
     }
     if (cur.change_attr > change_attr) {
       change_attr = cur.change_attr;
       if (touched_chattr)
-	*touched_chattr = true;
+        *touched_chattr = true;
     }
     nfiles += cur.nfiles - acc.nfiles;
     nsubdirs += cur.nsubdirs - acc.nsubdirs;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -2211,8 +2211,12 @@ void MDCache::predirty_journal_parents(MutationRef mut, EMetaBlob *blob,
 
       if (do_parent_mtime) {
 	pf->fragstat.mtime = mut->get_op_stamp();
-	pf->fragstat.change_attr++;
-	dout(10) << "predirty_journal_parents bumping fragstat change_attr to " << pf->fragstat.change_attr << " on " << parent << dendl;
+
+        uint64_t dirstat_change_attr = pin->get_inode()->dirstat.change_attr;
+        /* If a dentry is added or deleted in any dir frag, the change_attr of the directory should be increased */
+        pf->fragstat.change_attr = (pf->fragstat.change_attr >= dirstat_change_attr) ? pf->fragstat.change_attr + 1 : dirstat_change_attr + 1;
+
+        dout(10) << "predirty_journal_parents bumping fragstat change_attr to " << pf->fragstat.change_attr << " on " << parent << dendl;
 	if (pf->fragstat.mtime > pf->rstat.rctime) {
 	  dout(10) << "predirty_journal_parents updating mtime on " << *parent << dendl;
 	  pf->rstat.rctime = pf->fragstat.mtime;
@@ -2337,8 +2341,10 @@ void MDCache::predirty_journal_parents(MutationRef mut, EMetaBlob *blob,
       pf->accounted_fragstat = pf->fragstat;
       if (touched_mtime)
 	pi.inode->mtime = pi.inode->ctime = pi.inode->dirstat.mtime;
+
+      // if mtime or linkunlink changed, just increment change_attr
       if (touched_chattr)
-	pi.inode->change_attr++;
+        pi.inode->change_attr++;
       dout(20) << "predirty_journal_parents     gives " << pi.inode->dirstat << " on " << *pin << dendl;
 
       if (parent->get_frag() == frag_t()) { // i.e., we are the only frag


### PR DESCRIPTION


cephfs: when dir updates, the change_attr should always be increased by 1

Now, if a new dentry created under a dir frag whose change_attr is smaller than the dirstat's change_attr, the inode and  inode->dirstat's change_attr will not increased, so the client will not be aware of updates of the directory by a getattr request.
So We should make sure that when a dentry is created or deleted in any directory fragment, the change_attr of the frag should be larger than the directory dirstat.

Fixes: https://tracker.ceph.com/issues/67831