### PR TITLE
squid: rgw/lc: delete expired delete-marker when processing Expiration lc action with Days specified

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1118,22 +1118,17 @@ public:
       return false;
     }
     if (o.is_delete_marker()) {
-      if (oc.next_key_name) {
-	std::string nkn = *oc.next_key_name;
-	if (oc.next_has_same_name(o.key.name)) {
-	  ldpp_dout(dpp, 7) << __func__ << "(): dm-check SAME: key=" << o.key
-			   << " next_key_name: %%" << nkn << "%% "
-			   << oc.wq->thr_name() << dendl;
-	  return false;
-	} else {
-	  ldpp_dout(dpp, 7) << __func__ << "(): dm-check DELE: key=" << o.key
-			   << " next_key_name: %%" << nkn << "%% "
-			   << oc.wq->thr_name() << dendl;
-        *exp_time = real_clock::now();
-        return true;
-	}
+      if (oc.next_has_same_name(o.key.name)) {
+        ldpp_dout(dpp, 7) << __func__ << "(): dm-check SAME: key=" << o.key
+                          << " next_key_name: %%" << *oc.next_key_name << "%% "
+                          << oc.wq->thr_name() << dendl;
+        return false;
       }
-      return false;
+
+      ldpp_dout(dpp, 7) << __func__ << "(): dm-check DELE: key=" << o.key
+                        << " " << oc.wq->thr_name() << dendl;
+      *exp_time = real_clock::now();
+      return true;
     }
 
     auto& mtime = o.meta.mtime;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68983

---

backport of https://github.com/ceph/ceph/pull/55203
parent tracker: https://tracker.ceph.com/issues/63995

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh