### PR TITLE
osd/scrub: fixing reservations dump format

### DIFF
--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -65,7 +65,7 @@ void OsdScrub::dump_scrubs(ceph::Formatter* f) const
 void OsdScrub::dump_scrub_reservations(ceph::Formatter* f) const
 {
   m_resource_bookkeeper.dump_scrub_reservations(f);
-  f->open_array_section("remote_scrub_reservations");
+  f->open_object_section("remote_scrub_reservations");
   m_osd_svc.get_scrub_reserver().dump(f);
   f->close_section();
 }


### PR DESCRIPTION
Headers were missing in the faulty dump output. This commit fixes the section type to 'object section'.
