### PR TITLE
reef: rgw/multisite: metadata polling event based on unmodified mdlog_marker

### DIFF
--- a/src/rgw/driver/rados/rgw_sync.cc
+++ b/src/rgw/driver/rados/rgw_sync.cc
@@ -1444,6 +1444,7 @@ class RGWMetaSyncShardCR : public RGWCoroutine {
   bool done_with_period = false;
 
   int total_entries = 0;
+  string old_mdlog_marker;
 
   RGWSyncTraceNodeRef tn;
 public:
@@ -1766,6 +1767,7 @@ public:
 	if (mdlog_marker <= max_marker || !truncated) {
 	  /* we're at the tip, try to bring more entries */
           ldpp_dout(sync_env->dpp, 20) << __func__ << ":" << __LINE__ << ": shard_id=" << shard_id << " syncing mdlog for shard_id=" << shard_id << dendl;
+          old_mdlog_marker = mdlog_marker;
           yield call(new RGWCloneMetaLogCoroutine(sync_env, mdlog,
                                                   period, shard_id,
                                                   mdlog_marker, &mdlog_marker));
@@ -1836,7 +1838,8 @@ public:
           tn->log(10, SSTR(*this << ": done with period"));
           break;
         }
-	if (mdlog_marker == max_marker && can_adjust_marker) {
+	if (mdlog_marker == old_mdlog_marker && can_adjust_marker) {
+          tn->log(20, SSTR("mdlog_marker=" << mdlog_marker << " old_mdlog_marker=" << old_mdlog_marker));
           tn->unset_flag(RGW_SNS_FLAG_ACTIVE);
 	  yield wait(utime_t(cct->_conf->rgw_meta_sync_poll_interval, 0));
 	}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69004

---

backport of https://github.com/ceph/ceph/pull/52568
parent tracker: https://tracker.ceph.com/issues/61743

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh