### PR TITLE
osd: fix C++20 atomic deprecation warnings

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1670,13 +1670,12 @@ protected:
  protected:
 
   // -- osd map --
-  // TODO: switch to std::atomic<OSDMapRef> when C++20 will be available.
   OSDMapRef       _osdmap;
   void set_osdmap(OSDMapRef osdmap) {
-    std::atomic_store(&_osdmap, osdmap);
+    _osdmap = osdmap;
   }
   OSDMapRef get_osdmap() const {
-    return std::atomic_load(&_osdmap);
+    return _osdmap;
   }
   epoch_t get_osdmap_epoch() const {
     // XXX: performance?

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -3291,7 +3291,7 @@ class PastIntervals {
 #ifdef WITH_SEASTAR
   using OSDMapRef = boost::local_shared_ptr<const OSDMap>;
 #else
-  using OSDMapRef = std::shared_ptr<const OSDMap>;
+  using OSDMapRef = std::atomic<std::shared_ptr<const OSDMap>>;
 #endif
 public:
   struct pg_interval_t {
@@ -3497,7 +3497,7 @@ public:
       old_up_primary, new_up_primary,
       old_up, new_up,
       same_interval_since, last_epoch_clean,
-      osdmap.get(), lastmap.get(),
+      osdmap.load(), lastmap.load(),
       pgid,
       could_have_gone_active,
       past_intervals,


### PR DESCRIPTION

gcc14 issues warnings about C++11 atomic features that were deprecated in C++20. This
patch migrates the types involved to atomic<shared_ptr<>> to resolve this.

note:
Does NOT patch for WITH_SEASTAR=ON.

refer-to:
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2869r0.pdf

Fixes: https://tracker.ceph.com/issues/69026

Signed-off-by: Jesse F. Williamson <nerd.cpp@gmail.com>


- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [x] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
