### PR TITLE
osd/scrub: show reservation status in 'pg dump' output

### DIFF
--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2223,6 +2223,13 @@ struct pg_scrubbing_status_t {
   bool m_is_active{false};
   scrub_level_t m_is_deep{scrub_level_t::shallow};
   bool m_is_periodic{true};
+  // the following are only relevant when we are reserving replicas:
+  uint16_t m_osd_to_respond{0};
+  /// this is the n'th replica we are reserving (out of m_num_to_reserve)
+  uint8_t m_ordinal_of_requested_replica{0};
+  /// the number of replicas we are reserving for scrubbing. 0 means we are not
+  /// in the process of reserving replicas.
+  uint8_t m_num_to_reserve{0};
 };
 
 bool operator==(const pg_scrubbing_status_t& l, const pg_scrubbing_status_t& r);

--- a/src/osd/scrubber/scrub_machine.h
+++ b/src/osd/scrubber/scrub_machine.h
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include <boost/statechart/custom_reaction.hpp>
@@ -289,8 +290,11 @@ class ScrubMachine : public sc::state_machine<ScrubMachine, NotActive> {
   [[nodiscard]] bool is_accepting_updates() const;
   [[nodiscard]] bool is_primary_idle() const;
 
-  // elapsed time for the currently active scrub.session
+  /// elapsed time for the currently active scrub.session
   ceph::timespan get_time_scrubbing() const;
+
+  /// replica reservation process status
+  std::optional<pg_scrubbing_status_t> get_reservation_status() const;
 
 // ///////////////// aux declarations & functions //////////////////////// //
 
@@ -555,6 +559,9 @@ struct Session : sc::state<Session, PrimaryActive, ReservingReplicas>,
   /// abort reason - if known. Determines the delay time imposed on the
   /// failed scrub target.
   std::optional<Scrub::delay_cause_t> m_abort_reason{std::nullopt};
+
+  /// when reserving replicas: fetch the reservation status
+  std::optional<pg_scrubbing_status_t> get_reservation_status() const;
 };
 
 struct ReservingReplicas : sc::state<ReservingReplicas, Session>, NamedSimply {

--- a/src/osd/scrubber/scrub_reservations.h
+++ b/src/osd/scrubber/scrub_reservations.h
@@ -157,12 +157,12 @@ class ReplicaReservations {
   // note: 'public', as accessed via the 'standard' dout_prefix() macro
   std::ostream& gen_prefix(std::ostream& out, std::string fn) const;
 
+  /// The number of requests that have been sent (and not rejected) so far.
+  size_t active_requests_cnt() const;
+
  private:
   /// send 'release' messages to all replicas we have managed to reserve
   void release_all();
-
-  /// The number of requests that have been sent (and not rejected) so far.
-  size_t active_requests_cnt() const;
 
   /**
    * Send a reservation request to the next replica.


### PR DESCRIPTION
Whenever a PG is selected for scrubbing, and is waiting for remote reservations, the 'pg dump' output will include the following text (under the 'SCRUB_SCHEDULING' column):

Reserving. Waiting Ns for OSD.k (n/m)
