### PR TITLE
radosgw-admin: 'user create' rejects uids matching the account id format

### DIFF
--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -1755,7 +1755,11 @@ int RGWUser::execute_add(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_
   user_info.display_name = display_name;
   user_info.type = TYPE_RGW;
 
-  // tenant must not look like a valid account id
+  // user/tenant must not look like a valid account id
+  if (rgw::account::validate_id(uid.id)) {
+    set_err_msg(err_msg, "uid must not be formatted as an account id");
+    return -EINVAL;
+  }
   if (rgw::account::validate_id(uid.tenant)) {
     set_err_msg(err_msg, "tenant must not be formatted as an account id");
     return -EINVAL;


### PR DESCRIPTION
`parse_owner()` relies on `rgw::account::validate_id()` to disambiguate between user ids and account ids. reject attempts to create a user with an ambiguous user id

Fixes: https://tracker.ceph.com/issues/69043

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
