### PR TITLE
rgw: consider multi zonegroup for is_syncing_bucket_meta

### DIFF
--- a/src/rgw/driver/rados/rgw_datalog.cc
+++ b/src/rgw/driver/rados/rgw_datalog.cc
@@ -576,7 +576,7 @@ int RGWDataChangesLog::renew_entries(const DoutPrefixProvider *dpp)
     if (ret < 0) {
       /* we don't really need to have a special handling for failed cases here,
        * as this is just an optimization. */
-      ldpp_dout(dpp, -1) << "ERROR: svc.cls->timelog.add() returned " << ret << dendl;
+      ldpp_dout(dpp, -1) << "ERROR: be->push() returned " << ret << dendl;
       return ret;
     }
 

--- a/src/rgw/driver/rados/rgw_rados.cc
+++ b/src/rgw/driver/rados/rgw_rados.cc
@@ -5445,7 +5445,7 @@ int RGWRados::delete_bucket(RGWBucketInfo& bucket_info, RGWObjVersionTracker& ob
   }
 
   /* if the bucket is not synced we can remove the meta file */
-  if (!svc.zone->is_syncing_bucket_meta(bucket)) {
+  if (!svc.zone->is_syncing_bucket_meta()) {
     RGWObjVersionTracker objv_tracker;
     r = ctl.bucket->remove_bucket_instance_info(bucket, bucket_info, y, dpp);
     if (r < 0) {

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -743,8 +743,7 @@ bool RGWSI_Zone::is_meta_master() const
 
 bool RGWSI_Zone::need_to_log_metadata() const
 {
-  return is_meta_master() &&
-    (zonegroup->zones.size() > 1 || current_period->is_multi_zonegroups_with_zones());
+  return is_meta_master() && is_syncing_bucket_meta();
 }
 
 bool RGWSI_Zone::can_reshard() const
@@ -761,33 +760,16 @@ bool RGWSI_Zone::can_reshard() const
 
 /**
   * Check to see if the bucket metadata could be synced
-  * bucket: the bucket to check
   * Returns false is the bucket is not synced
   */
-bool RGWSI_Zone::is_syncing_bucket_meta(const rgw_bucket& bucket)
+bool RGWSI_Zone::is_syncing_bucket_meta() const
 {
-
   /* no current period  */
   if (current_period->get_id().empty()) {
     return false;
   }
 
-  /* zonegroup is not master zonegroup */
-  if (!zonegroup->is_master_zonegroup()) {
-    return false;
-  }
-
-  /* single zonegroup and a single zone */
-  if (current_period->is_single_zonegroup() && zonegroup->zones.size() == 1) {
-    return false;
-  }
-
-  /* zone is not master */
-  if (zonegroup->master_zone != zone_public_config->id) {
-    return false;
-  }
-
-  return true;
+  return zonegroup->zones.size() > 1 || current_period->is_multi_zonegroups_with_zones();
 }
 
 

--- a/src/rgw/services/svc_zone.h
+++ b/src/rgw/services/svc_zone.h
@@ -146,7 +146,7 @@ public:
   bool need_to_log_data() const;
   bool need_to_log_metadata() const;
   bool can_reshard() const;
-  bool is_syncing_bucket_meta(const rgw_bucket& bucket);
+  bool is_syncing_bucket_meta() const;
 
   int list_zonegroups(const DoutPrefixProvider *dpp, std::list<std::string>& zonegroups);
   int list_regions(const DoutPrefixProvider *dpp, std::list<std::string>& regions);


### PR DESCRIPTION
Updated is_syncing_bucket_meta() to account for multi-zone and multi-zonegroup scenarios during this check.

Fixes: https://tracker.ceph.com/issues/69049