### PR TITLE
squid: mds/Beacon: wake up the thread in shutdown()

### DIFF
--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -60,6 +60,7 @@ void Beacon::shutdown()
   std::unique_lock<std::mutex> lock(mutex);
   if (!finished) {
     finished = true;
+    cvar.notify_all();
     lock.unlock();
     if (sender.joinable())
       sender.join();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/68915

---

backport of https://github.com/ceph/ceph/pull/60325
parent tracker: https://tracker.ceph.com/issues/68759

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh