### PR TITLE
mgr/dashboard: Automate system user creation and restart of rgw daemons on Migrate to Multisite

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -106,13 +106,11 @@ class RgwMultisiteStatus(RESTController):
     @allow_empty_body
     # pylint: disable=W0102,W0613
     def migrate(self, daemon_name=None, realm_name=None, zonegroup_name=None, zone_name=None,
-                zonegroup_endpoints=None, zone_endpoints=None, access_key=None,
-                secret_key=None):
+                zonegroup_endpoints=None, zone_endpoints=None, username=None):
         multisite_instance = RgwMultisite()
         result = multisite_instance.migrate_to_multisite(realm_name, zonegroup_name,
                                                          zone_name, zonegroup_endpoints,
-                                                         zone_endpoints, access_key,
-                                                         secret_key)
+                                                         zone_endpoints, username)
         return result
 
     @RESTController.Collection(method='POST', path='/multisite-replications')

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-migrate/rgw-multisite-migrate.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-multisite-migrate/rgw-multisite-migrate.component.html
@@ -111,36 +111,21 @@
       </div>
       <div class="form-group row">
         <label class="cd-col-form-label required"
-               for="access_key"
-               i18n>S3 access key
-          <cd-helper>
-            <span>To see or copy your S3 access key, go to <b>Object Gateway > Users</b> and click on your user name. In <b>Keys</b>, click <b>Show</b>. View the access key by clicking Show and copy the key by clicking <b>Copy to Clipboard</b>.</span>
-          </cd-helper>
-        </label>
+               for="username"
+               i18n>Username</label>
         <div class="cd-col-form-input">
           <input class="form-control"
                  type="text"
-                 placeholder="e.g."
-                 id="access_key"
-                 name="access_key"
-                 formControlName="access_key">
-        </div>
-      </div>
-      <div class="form-group row">
-        <label class="cd-col-form-label required"
-               for="access_key"
-               i18n>S3 secret key
-          <cd-helper>
-            <span>To see or copy your S3 access key, go to <b>Object Gateway > Users</b> and click on your user name. In <b>Keys</b>, click <b>Show</b>. View the secret key by clicking Show and copy the key by clicking <b>Copy to Clipboard</b>.</span>
-          </cd-helper>
-        </label>
-        <div class="cd-col-form-input">
-          <input class="form-control"
-                 type="text"
-                 placeholder="e.g."
-                 id="secret_key"
-                 name="secret_key"
-                 formControlName="secret_key">
+                 placeholder="username"
+                 id="username"
+                 name="username"
+                 formControlName="username">
+          <cd-help-text>
+            <span i18n>Specify the username for the system user. This user will be created automatically as part of the process.</span>
+          </cd-help-text>
+          <span class="invalid-feedback"
+                *ngIf="multisiteMigrateForm.showError('username', formDir, 'required')"
+                i18n>This field is required.</span>
         </div>
       </div>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-multisite.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-multisite.service.ts
@@ -16,7 +16,7 @@ export class RgwMultisiteService {
 
   constructor(private http: HttpClient, public rgwDaemonService: RgwDaemonService) {}
 
-  migrate(realm: RgwRealm, zonegroup: RgwZonegroup, zone: RgwZone) {
+  migrate(realm: RgwRealm, zonegroup: RgwZonegroup, zone: RgwZone, username: string) {
     return this.rgwDaemonService.request((params: HttpParams) => {
       params = params.appendAll({
         realm_name: realm.name,
@@ -24,8 +24,7 @@ export class RgwMultisiteService {
         zone_name: zone.name,
         zonegroup_endpoints: zonegroup.endpoints,
         zone_endpoints: zone.endpoints,
-        access_key: zone.system_key.access_key,
-        secret_key: zone.system_key.secret_key
+        username: username
       });
       return this.http.put(`${this.uiUrl}/migrate`, null, { params: params });
     });


### PR DESCRIPTION
1. Automate the process of replication user creation during single site to multi-site migration
2. Provide a support for automatic restart post creation of default realm/zone group/zone as a part of multisite migrate

Fixes: https://tracker.ceph.com/issues/69052

Signed-off-by: Aashish Sharma <aasharma@redhat.com>


https://github.com/user-attachments/assets/be7b9256-db32-402a-b830-2541cda73083







<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
