### PR TITLE
mgr/cephadm: Command to upgrade non-ceph image services with custom image

### DIFF
--- a/doc/cephadm/upgrade.rst
+++ b/doc/cephadm/upgrade.rst
@@ -307,3 +307,19 @@ upgrading:
 
 You should now have all your Manager daemons on the new version and be able to
 specify the limiting parameters for the rest of the upgrade.
+
+
+Updating a non-Ceph image service with custom image
+====================================================
+
+To update a non-Ceph image service, run a command of the following form:
+
+.. prompt:: bash #
+
+  ceph orch update service <service_type> <image>
+
+For example:
+
+.. prompt:: bash #
+
+  ceph orch update service prometheus quay.io/prometheus/prometheus:v2.55.1

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -522,6 +522,13 @@ class SpecStore():
         else:
             self.mgr.log.warning(f'Attempted to mark unknown service "{name}" as having been configured')
 
+    def get_specs_by_type(self, service_type: str) -> Mapping[str, ServiceSpec]:
+        return {
+            service_name: spec
+            for service_name, spec in self._specs.items()
+            if service_type == spec.service_type
+        }
+
 
 class ClientKeyringSpec(object):
     """

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2458,22 +2458,26 @@ Then run the following:
                 result.append(dd)
         return result
 
-    @handle_orch_error
-    def service_action(self, action: str, service_name: str) -> List[str]:
-        if service_name not in self.spec_store.all_specs.keys() and service_name != 'osd':
-            raise OrchestratorError(f'Invalid service name "{service_name}".'
-                                    + ' View currently running services using "ceph orch ls"')
+    def perform_service_action(self, action: str, service_name: str) -> List[str]:
         dds: List[DaemonDescription] = self.cache.get_daemons_by_service(service_name)
         if not dds:
             raise OrchestratorError(f'No daemons exist under service name "{service_name}".'
                                     + ' View currently running services using "ceph orch ls"')
-        if action == 'stop' and service_name.split('.')[0].lower() in ['mgr', 'mon', 'osd']:
-            return [f'Stopping entire {service_name} service is prohibited.']
         self.log.info('%s service %s' % (action.capitalize(), service_name))
         return [
             self._schedule_daemon_action(dd.name(), action)
             for dd in dds
         ]
+
+    @handle_orch_error
+    def service_action(self, action: str, service_name: str) -> List[str]:
+        if service_name not in self.spec_store.all_specs.keys():
+            raise OrchestratorError(f'Invalid service name "{service_name}".'
+                                    + ' View currently running services using "ceph orch ls"')
+        if action == 'stop' and service_name.split('.')[0].lower() in ['mgr', 'mon', 'osd']:
+            return [f'Stopping entire {service_name} service is prohibited.']
+
+        return self.perform_service_action(action, service_name)
 
     def _rotate_daemon_key(self, daemon_spec: CephadmDaemonDeploySpec) -> str:
         self.log.info(f'Rotating authentication key for {daemon_spec.name()}')
@@ -3809,6 +3813,10 @@ Then run the following:
     @handle_orch_error
     def upgrade_stop(self) -> str:
         return self.upgrade.upgrade_stop()
+
+    @handle_orch_error
+    def update_service(self, service_type: str, service_image: str, image: str) -> List[str]:
+        return self.upgrade.update_service(service_type, service_image, image)
 
     @handle_orch_error
     def replace_device(self,

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -945,6 +945,9 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def update_service(self, service_type: str, service_image: str, image: str) -> OrchResult:
+        raise NotImplementedError()
+
     @_hide_in_features
     def upgrade_available(self) -> OrchResult:
         """

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -21,7 +21,7 @@ from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, service_spe
 from ceph.deployment.hostspec import SpecValidationError
 from ceph.deployment.utils import unwrap_ipv6
 from ceph.utils import datetime_now
-
+from ceph.cephadm.images import NonCephImageServiceTypes
 from mgr_util import to_pretty_timedelta, format_bytes
 from mgr_module import MgrModule, HandleCommandResult, Option
 from object_format import Format
@@ -2418,5 +2418,12 @@ Usage:
     def _upgrade_stop(self) -> HandleCommandResult:
         """Stop an in-progress upgrade"""
         completion = self.upgrade_stop()
+        raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
+    @_cli_write_command('orch update service')
+    def _update_service(self, service_type: NonCephImageServiceTypes, image: str) -> HandleCommandResult:
+        """Update image for non-ceph image daemon"""
+        completion = self.update_service(service_type.value, service_type.name, image)
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())

--- a/src/python-common/ceph/cephadm/images.py
+++ b/src/python-common/ceph/cephadm/images.py
@@ -55,3 +55,20 @@ class DefaultImages(Enum):
     @property
     def desc(self) -> str:
         return self.value.desc
+
+
+class NonCephImageServiceTypes(Enum):
+    prometheus = 'prometheus'
+    loki = 'loki'
+    promtail = 'promtail'
+    node_exporter = 'node-exporter'
+    alertmanager = 'alertmanager'
+    grafana = 'grafana'
+    nvmeof = 'nvmeof'
+    snmp_gateway = 'snmp-gateway'
+    elasticsearch = 'elasticsearch'
+    jaeger_collector = 'jaeger-collector'
+    jaeger_query = 'jaeger-query'
+    jaeger_agent = 'jaeger-agent'
+    samba = 'smb'
+    oauth2_proxy = 'oauth2-proxy'


### PR DESCRIPTION
mgr/cephadm: Command to upgrade non-ceph image services with custom image

Added a command to upgrade non-ceph image services, it will combine 'ceph config set mgr/cephadm/container_image_<daemon-type>' and 'ceph orch redeploy <service-of-that-daemon-type>' functionality.

Fixes: https://tracker.ceph.com/issues/68979
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>
 
Testing logs:
```
[ceph: root@ceph-node-0 /]# ceph orch upgrade-image smb quay.io/samba.org/samba-server:latest 
Processing "smb.test1" service
Scheduled to redeploy smb.test1.ceph-node-0.xeffdz on host 'ceph-node-0'
Processing "smb.test2" service
Scheduled to redeploy smb.test2.ceph-node-0.hioiam on host 'ceph-node-0'
[ceph: root@ceph-node-0 /]# 

[ceph: root@ceph-node-0 /]# ceph orch upgrade-image prometheus quay.io/prometheus/prometheus:v2.55.1 
Processing "prometheus" service
Scheduled to redeploy prometheus.ceph-node-0 on host 'ceph-node-0'
Scheduled to redeploy prometheus.ceph-node-1 on host 'ceph-node-1'
Scheduled to redeploy prometheus.ceph-node-2 on host 'ceph-node-2'
[ceph: root@ceph-node-0 /]#
```




## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [X] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
