### PR TITLE
examples/rgw: register boto extension for HeadBucket stats

### DIFF
--- a/examples/rgw/boto3/head_bucket_stats.py
+++ b/examples/rgw/boto3/head_bucket_stats.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+
+import boto3
+import sys
+
+if len(sys.argv) != 2:
+    print('Usage: ' + sys.argv[0] + ' <bucket>')
+    sys.exit(1)
+
+# bucket name as first argument
+bucketname = sys.argv[1]
+
+# endpoint and keys from vstart
+endpoint = 'http://127.0.0.1:8000'
+access_key='0555b35654ad1656d804'
+secret_key='h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=='
+
+client = boto3.client('s3',
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key)
+
+# reading bucket stats via HeadBucket
+
+response = client.head_bucket(Bucket=bucketname, ReadStats=True)
+
+print('Objects:', response['ObjectCount'], 'Bytes:', response['BytesUsed'])

--- a/examples/rgw/boto3/service-2.sdk-extras.json
+++ b/examples/rgw/boto3/service-2.sdk-extras.json
@@ -379,7 +379,36 @@
             },
             "documentation":"<p>A filter for all log object. Filter for the object by its key (prefix, suffix and regex).</p>",
             "locationName":"Filter"
-        }
+        },
+        "HeadBucketRequest": {
+            "members": {
+                "ReadStats":{
+                    "shape":"ReadStats",
+                    "documentation":"<p>Read additional usage statistics for <code>ObjectCount</code> and <code>BytesUsed</code> in the response.</p> <note> <p>This request parameter is a Ceph RGW extension.</p> </note>",
+                    "location":"querystring",
+                    "locationName":"read-stats"
+                }
+            }
+        },
+        "HeadBucketOutput":{
+            "members":{
+                "ObjectCount":{
+                    "shape":"ObjectCount",
+                    "documentation": "<p>Total number of objects/versions in the bucket.</p>",
+                    "location": "header",
+                    "locationName": "x-rgw-object-count"
+                },
+                "BytesUsed":{
+                    "shape":"BytesUsed",
+                    "documentation": "<p>Total size in bytes of all objects/versions in the bucket.</p>",
+                    "location": "header",
+                    "locationName": "x-rgw-bytes-used"
+                }
+            }
+        },
+        "ReadStats":{"type":"boolean"},
+        "ObjectCount":{"type":"integer"},
+        "BytesUsed":{"type":"integer"}
     },
     "documentation":"<p/>"
 }


### PR DESCRIPTION
```
$ aws s3api head-bucket help
...
OPTIONS
...
       --read-stats | --no-read-stats (boolean)
          Read  additional  usage  statistics for ObjectCount and BytesUsed in
          the response.

          NOTE:
              This request parameter is a Ceph RGW extension.
...
OUTPUT
...
       ObjectCount -> (integer)
          Total number of objects/versions in the bucket.

       BytesUsed -> (integer)
          Total size in bytes of all objects/versions in the bucket.
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
