### PR TITLE
cephadm: ceph orch upgrade status - Display easily understandable message

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2361,7 +2361,10 @@ Usage:
             'is_paused': status.is_paused,
         }
         out = json.dumps(r, indent=4)
-        return HandleCommandResult(stdout=out)
+        if r.get('in_progress'):
+            return HandleCommandResult(stdout=out)
+        else:
+            return HandleCommandResult(stdout="There are no upgrades in progress currently.")
 
     @_cli_write_command('orch upgrade start')
     def _upgrade_start(self,

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -2363,8 +2363,7 @@ Usage:
         out = json.dumps(r, indent=4)
         if r.get('in_progress'):
             return HandleCommandResult(stdout=out)
-        else:
-            return HandleCommandResult(stdout="There are no upgrades in progress currently.")
+        return HandleCommandResult(stdout="There are no upgrades in progress currently.")
 
     @_cli_write_command('orch upgrade start')
     def _upgrade_start(self,


### PR DESCRIPTION
cephadm: ceph orch upgrade status - Display easily understandable message

Tracker: https://tracker.ceph.com/issues/68999
Test logs:

```
[ceph: root@ceph-node-0 ~]# ceph orch upgrade start --image quay.io/kdeb/ceph:upgrade_status-2 --daemon_types mgr
Initiating upgrade to quay.io/kdeb/ceph:upgrade_status-2
[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS  RUNNING  REFRESHED  AGE   PLACEMENT  
crash                                 3/3  8m ago     103m  *          
mgr                                   2/2  8m ago     103m  count:2    
mon                                   3/5  8m ago     103m  count:5    
osd.all-available-devices               3  8m ago     101m  *          
[ceph: root@ceph-node-0 ~]# ceph orch upgrade status
{
    "target_image": "quay.io/kdeb/ceph@sha256:8a8fe1ff96ddc4fbd2c2232a55819a5e7161342400c8c0a61813fa72afa92a59",
    "in_progress": true,
    "which": "Upgrading daemons of type(s) mgr",
    "services_complete": [],
    "progress": "0/2 daemons upgraded",
    "message": "Currently upgrading mgr daemons",
    "is_paused": false
}

[ceph: root@ceph-node-0 ~]# ceph orch upgrade status
{
    "target_image": "quay.io/kdeb/ceph@sha256:8a8fe1ff96ddc4fbd2c2232a55819a5e7161342400c8c0a61813fa72afa92a59",
    "in_progress": true,
    "which": "Upgrading daemons of type(s) mgr",
    "services_complete": [
        "mgr"
    ],
    "progress": "2/2 daemons upgraded",
    "message": "Currently upgrading mgr daemons",
    "is_paused": false
}

[ceph: root@ceph-node-0 ~]# ceph -s
  cluster:
    id:     b57dc2ea-ab0a-11ef-9fb7-525400d205fb
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum ceph-node-0,ceph-node-1,ceph-node-2 (age 10m)
    mgr: ceph-node-0.fwhltk(active, since 45s), standbys: ceph-node-1.ustczw
    osd: 3 osds: 3 up (since 10m), 3 in (since 96m)
 
  data:
    pools:   1 pools, 1 pgs
    objects: 2 objects, 449 KiB
    usage:   81 MiB used, 30 GiB / 30 GiB avail
    pgs:     1 active+clean
 

[ceph: root@ceph-node-0 ~]# ceph orch upgrade status
There are no upgrades in progress currently.

```

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
