### PR TITLE
osd/scrub: remove the 'has_deep_errors' scheduling flag

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1278,7 +1278,6 @@ Scrub::schedule_result_t PG::start_scrubbing(
   pg_cond.allow_deep =
       !(get_osdmap()->test_flag(CEPH_OSDMAP_NODEEP_SCRUB) ||
 	pool.info.has_flag(pg_pool_t::FLAG_NODEEP_SCRUB));
-  pg_cond.has_deep_errors = (info.stats.stats.sum.num_deep_scrub_errors > 0);
   pg_cond.can_autorepair =
       (cct->_conf->osd_scrub_auto_repair &&
        get_pgbackend()->auto_repair_supported());

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -109,7 +109,6 @@ static_assert(sizeof(Scrub::OSDRestrictions) <= sizeof(uint32_t));
 struct ScrubPGPreconds {
   bool allow_shallow{true};
   bool allow_deep{true};
-  bool has_deep_errors{false};
   bool can_autorepair{false};
 };
 static_assert(sizeof(Scrub::ScrubPGPreconds) <= sizeof(uint32_t));
@@ -181,9 +180,8 @@ struct formatter<Scrub::ScrubPGPreconds> {
   auto format(const Scrub::ScrubPGPreconds& conds, FormatContext& ctx) const
   {
     return fmt::format_to(
-	ctx.out(), "allowed(shallow/deep):{:1}/{:1},deep-err:{:1},can-autorepair:{:1}",
-	conds.allow_shallow, conds.allow_deep, conds.has_deep_errors,
-	conds.can_autorepair);
+	ctx.out(), "allowed(shallow/deep):{:1}/{:1},can-autorepair:{:1}",
+	conds.allow_shallow, conds.allow_deep, conds.can_autorepair);
   }
 };
 


### PR DESCRIPTION
Following https://github.com/ceph/ceph/pull/59942
("osd/scrub: separate shallow vs deep errors storage"), the ScrubStore
now holds two separate error databases, one for the shallow
errors and one for the deep errors.

There is no longer a need to prevent (or warn about) shallow scrubs
being performed when deep errors are present.

