### PR TITLE
 os/bluestore: add disk io request diversion strategy

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5020,6 +5020,11 @@ std::vector<Option> get_global_options() {
     .set_min_max(0_K, 128_K)
     .set_description("Under the hybrid allocator, use the bitmap allocator for io sizes smaller than bluestore_hybrid_bitmap_boundary(such as 0,8_K,24_K,...,0 means use the original logic), and use the avl allocator for the rest."),
 
+    Option("bluestore_hybrid_avl_boundary", Option::TYPE_UINT, Option::LEVEL_DEV)
+    .set_default(0)
+    .set_min_max(0_K, 128_K)
+    .set_description("Under the hybrid allocator, the minimum size of the space managed by the avl allocator.If space managed by avl is less than bluestore_hybrid_avl_boundary(0 means use the original logic), avl will release the space to bitmap."),
+
     Option("bluestore_volume_selection_policy", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("use_some_extra")
     .set_enum_allowed({ "rocksdb_original", "use_some_extra", "fit_to_fast" })

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5015,6 +5015,11 @@ std::vector<Option> get_global_options() {
     .set_default(64_M)
     .set_description("Maximum RAM hybrid allocator should use before enabling bitmap supplement"),
 
+    Option("bluestore_hybrid_bitmap_boundary", Option::TYPE_UINT, Option::LEVEL_DEV)
+    .set_default(0)
+    .set_min_max(0_K, 128_K)
+    .set_description("Under the hybrid allocator, use the bitmap allocator for io sizes smaller than bluestore_hybrid_bitmap_boundary(such as 0,8_K,24_K,...,0 means use the original logic), and use the avl allocator for the rest."),
+
     Option("bluestore_volume_selection_policy", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("use_some_extra")
     .set_enum_allowed({ "rocksdb_original", "use_some_extra", "fit_to_fast" })

--- a/src/os/bluestore/AvlAllocator.h
+++ b/src/os/bluestore/AvlAllocator.h
@@ -176,6 +176,8 @@ private:
   */
   uint64_t range_count_cap = 0;
 
+  uint64_t avl_min_boundary = 0;
+
   void _range_size_tree_rm(range_seg_t& r) {
     ceph_assert(num_free >= r.length());
     num_free -= r.length();
@@ -261,6 +263,9 @@ protected:
   void _shutdown();
 
   void _process_range_removal(uint64_t start, uint64_t end, range_tree_t::iterator& rs);
+  // _process_range_removal_v2 is used to implement the io diversion strategy, 
+  // and release the small segment space managed by the avl allocator to the bitmap allocator.
+  void _process_range_removal_v2(uint64_t start, uint64_t end, range_tree_t::iterator& rs);
   void _remove_from_tree(uint64_t start, uint64_t size);
   void _try_remove_from_tree(uint64_t start, uint64_t size,
     std::function<void(uint64_t offset, uint64_t length, bool found)> cb);

--- a/src/os/bluestore/HybridAllocator.cc
+++ b/src/os/bluestore/HybridAllocator.cc
@@ -50,10 +50,15 @@ int64_t HybridAllocator::allocate(
     --orig_pos;
   }
 
+  bool use_bitmap = true;
+  if (bitmap_boundary_value != 0 && want > bitmap_boundary_value) {
+    use_bitmap = false;
+  }
+
   // try bitmap first to avoid unneeded contiguous extents split if
   // desired amount is less than shortes range in AVL
   if (bmap_alloc && bmap_alloc->get_free() &&
-    want < _lowest_size_available()) {
+    want < _lowest_size_available() && use_bitmap) {
     res = bmap_alloc->allocate(want, unit, max_alloc_size, hint, extents);
     if (res < 0) {
       // got a failure, release already allocated and

--- a/src/os/bluestore/HybridAllocator.h
+++ b/src/os/bluestore/HybridAllocator.h
@@ -15,6 +15,7 @@ public:
                   uint64_t max_mem,
 	          const std::string& name) :
       AvlAllocator(cct, device_size, _block_size, max_mem, name) {
+    bitmap_boundary_value = cct->_conf.get_val<uint64_t>("bluestore_hybrid_bitmap_boundary");
   }
   const char* get_type() const override
   {
@@ -50,4 +51,6 @@ private:
 
   // called when extent to be released/marked free
   void _add_to_tree(uint64_t start, uint64_t size) override;
+      
+  uint64_t bitmap_boundary_value;
 };


### PR DESCRIPTION
When the business load is:
- Business that is deleted regularly, such as video surveillance
- Objects of different sizes.

As the life cycle expires, a large amount of space fragmentation will be released. At this time, the allocator of Bluestore will inevitably switch to bitmap, and it is very likely that it will not switch to avl again. If this continues for a long time, space fragmentation will be more serious, larger objects may require multiple disk io, and HDD disk utilization may increase to 100%.

As shown in the figure below, this is the situation I simulated under a serious space debris scenario
![image](https://github.com/user-attachments/assets/894cbd70-d168-40f1-976a-a35a126018bc)

The figure below shows the disk performance after using the new strategy under the same circumstances, and all indicators are obviously more stable.
![image](https://github.com/user-attachments/assets/6d4b341a-748c-4e4f-a215-9e4445b9b1e8)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
