### PR TITLE
osd/scrub: remove config option osd_repair_during_recovery

### DIFF
--- a/src/common/options/osd.yaml.in
+++ b/src/common/options/osd.yaml.in
@@ -214,7 +214,7 @@ options:
 - name: osd_repair_during_recovery
   type: bool
   level: advanced
-  desc: Allow requested repairing when PGs on the OSD are undergoing recovery
+  desc: not in use
   default: false
   with_legacy: true
 - name: osd_scrub_begin_hour

--- a/src/osd/scrubber/osd_scrub.cc
+++ b/src/osd/scrubber/osd_scrub.cc
@@ -202,18 +202,9 @@ Scrub::OSDRestrictions OsdScrub::restrictions_on_scrubbing(
     env_conditions.random_backoff_active = true;
 
   } else if (is_recovery_active && !conf->osd_scrub_during_recovery) {
-    if (conf->osd_repair_during_recovery) {
-      dout(15)
-	  << "will only schedule explicitly requested repair due to active "
-	     "recovery"
-	  << dendl;
-      env_conditions.allow_requested_repair_only = true;
-
-    } else {
-      dout(15) << "recovery in progress. Operator-initiated scrubs only."
-	       << dendl;
-      env_conditions.recovery_in_progress = true;
-    }
+    dout(15) << "recovery in progress. Operator-initiated scrubs only."
+	     << dendl;
+    env_conditions.recovery_in_progress = true;
   } else {
 
     // regular, i.e. non-high-priority scrubs are allowed

--- a/src/osd/scrubber/pg_scrubber.cc
+++ b/src/osd/scrubber/pg_scrubber.cc
@@ -2319,20 +2319,6 @@ Scrub::schedule_result_t PgScrubber::start_scrub_session(
     }
   }
 
-  // if only explicitly requested repairing is allowed - skip other types
-  // of scrubbing
-  if (osd_restrictions.allow_requested_repair_only &&
-      ScrubJob::observes_recovery(trgt.urgency())) {
-    dout(10) << __func__
-	     << ": skipping this PG as repairing was not explicitly "
-		"requested for it"
-	     << dendl;
-    requeue_penalized(
-	s_or_d, delay_both_targets_t::yes, delay_cause_t::scrub_params,
-	clock_now);
-    return schedule_result_t::target_specific_failure;
-  }
-
   // try to reserve the local OSD resources. If failing: no harm. We will
   // be retried by the OSD later on.
   if (!reserve_local(trgt)) {

--- a/src/osd/scrubber_common.h
+++ b/src/osd/scrubber_common.h
@@ -89,17 +89,13 @@ struct OSDRestrictions {
   /// rolled a dice, and decided not to scrub in this tick
   bool random_backoff_active{false};
 
-  /// the OSD is performing recovery & osd_repair_during_recovery is 'true'
-  bool allow_requested_repair_only:1{false};
-
   /// the CPU load is high. No regular scrubs are allowed.
   bool cpu_overloaded:1{false};
 
   /// outside of allowed scrubbing hours/days
   bool restricted_time:1{false};
 
-  /// the OSD is performing a recovery, osd_scrub_during_recovery is 'false',
-  /// and so is osd_repair_during_recovery
+  /// the OSD is performing a recovery & osd_scrub_during_recovery is 'false'
   bool recovery_in_progress:1{false};
 };
 static_assert(sizeof(Scrub::OSDRestrictions) <= sizeof(uint32_t));
@@ -195,13 +191,12 @@ struct formatter<Scrub::OSDRestrictions> {
   auto format(const Scrub::OSDRestrictions& conds, FormatContext& ctx) const
   {
     return fmt::format_to(
-	ctx.out(), "<{}.{}.{}.{}.{}.{}>",
+	ctx.out(), "<{}.{}.{}.{}.{}>",
 	conds.max_concurrency_reached ? "max-scrubs" : "",
 	conds.random_backoff_active ? "backoff" : "",
 	conds.cpu_overloaded ? "high-load" : "",
 	conds.restricted_time ? "time-restrict" : "",
-	conds.recovery_in_progress ? "recovery" : "",
-	conds.allow_requested_repair_only ? "repair-only" : "");
+	conds.recovery_in_progress ? "recovery" : "");
   }
 };
 


### PR DESCRIPTION
Here is the 'scrub-type vs restrictions' table (as implemented in 'main'(*)). When the OSD
is handling an ongoing recovery, the following holds:

image.png - TO BE EDITED IN

In other words:

Usually - both 'scrub' and 'repair' operator commands are allowed to go through.
But there is one (unfortunate) exception:

when osd_repair_during_recovery is set - the operator 'scrub' command would not
result in an actual scrub.

This is wrong: it's surprising to the operator; it's against our goal of always allowing
operator-initiated scrubs to go on, and - it does not match the original intent.
See https://tracker.ceph.com/issues/40620:
when this was added to the code, the operator did not have the option of initiating any scrub -
repair scrub or not - when a recovery took place. But this is no longer true, as today -
operator-initiated scrubs are (almost) always honoured.

Setting osd_repair_during_recovery now *removes* capabilities from the operator,
not allowing her to do more (See, BTW, the description of this configuration
option. If we are to decide to keep existing functionality - that description must
be changed.).