### PR TITLE
client: refactor `add_update_inode` for enhanced clarity and modularity

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -843,6 +843,16 @@ public:
 
   Inode *add_update_inode(InodeStat *st, utime_t ttl, MetaSession *session,
 			  const UserPerm& request_perms);
+  Inode* create_new_inode(InodeStat* st);
+  void update_inode_common_attributes(Inode* in, InodeStat* st);
+  bool should_update_inode_version(Inode* in, InodeStat* st, int& issued, int& new_issued, bool& need_snapdir_attr_refresh);
+  void update_inode_auth_attributes(Inode* in, InodeStat* st);
+  void update_inode_attributes(Inode* in, InodeStat* st, bool new_version, int issued, int new_issued, bool& need_snapdir_attr_refresh);
+  void update_inode_directory_attributes(Inode* in, InodeStat* st);
+  void update_xattr_and_inline_data(Inode* in, InodeStat* st, bool& need_snapdir_attr_refresh, int issued);
+  void update_change_attr(Inode* in, InodeStat* st);
+  void handle_snap_and_caps(Inode* in, InodeStat* st, MetaSession* session, const UserPerm& request_perms, int issued);
+  void refresh_snapdir_attrs_for_directory(Inode* in);
   Dentry *insert_dentry_inode(Dir *dir, const std::string& dname, LeaseStat *dlease,
 			      Inode *in, utime_t from, MetaSession *session,
 			      Dentry *old_dentry = NULL);


### PR DESCRIPTION
- Simplified the `add_update_inode` function by breaking it into smaller, descriptive helper functions.
- Improved code readability and maintainability without altering functionality.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
