### PR TITLE
doc/radosgw: update rgw_dns_name doc

### DIFF
--- a/doc/radosgw/s3/commons.rst
+++ b/doc/radosgw/s3/commons.rst
@@ -7,22 +7,47 @@
 
 Bucket and Host Name
 --------------------
-There are two different modes of accessing the buckets. The first (preferred) method
-identifies the bucket as the top-level directory in the URI. ::
+There are two different modes of accessing buckets. The first method identifies
+the bucket as the top-level directory in the URI::
 
 	GET /mybucket HTTP/1.1
 	Host: cname.domain.com
 
-The second method identifies the bucket via a virtual bucket host name. For example::
+Most S3 clients nowadays rely on vhost-style access. The desired bucket is
+indicated by a DNS FQDN. For example::
 
 	GET / HTTP/1.1
 	Host: mybucket.cname.domain.com
 
-To configure virtual hosted buckets, you can either set ``rgw_dns_name = cname.domain.com`` in ceph.conf, or add ``cname.domain.com`` to the list of ``hostnames`` in your zonegroup configuration. See `Ceph Object Gateway - Multisite Configuration`_ for more on zonegroups.
+The second method is deprecated by AWS. See the `Amazon S3 Path Deprecation
+Plan`_ for more information.
 
-.. tip:: We prefer the first method, because the second method requires expensive domain certification and DNS wild cards.
+To configure virtual hosted buckets, you can either set ``rgw_dns_name =
+cname.domain.com`` in ``ceph.conf`` or add ``cname.domain.com`` to the list of
+``hostnames`` in your zonegroup configuration. See `Ceph Object Gateway -
+Multisite Configuration`_ for more on zonegroups.
 
-.. tip:: You can define multiple hostname directly with the :confval:`rgw_dns_name` parameter.
+Here is an example of a ``ceph config set`` comamnd that sets ``rgw_dns_name``
+to ``cname.domain.com``:
+
+.. prompt:: bash $
+
+   ceph config set client.rgw.<ceph authx client for rgw> rgw_dns_name cname.domain.dom
+
+.. tip:: You can define multiple hostnames directly with the
+   :confval:`rgw_dns_name` parameter.
+
+.. tip:: When SSL is enabled, the certificates must use a wildcard in the
+   domain name in order to match the bucket subdomains.
+
+.. note:: When Ceph Object Gateways are behind a proxy, use the proxy's DNS
+   name instead. Then you can use ``ceph config set client.rgw`` to set the DNS
+   name for all instances.
+   
+.. note:: The static website view for the `s3website` API must be served under
+   a different domain name. This is configured separately from
+   :confval:`rgw_dns_name`, in :confval:`rgw_dns_s3website_name`.
+
 
 Common Request Headers
 ----------------------
@@ -111,3 +136,4 @@ Common Response Status
 +---------------+-----------------------------------+
 
 .. _`Ceph Object Gateway - Multisite Configuration`: ../../multisite
+.. _`Amazon S3 Path Deprecation Plan`: https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/


### PR DESCRIPTION
Update doc/radosgw/s3/commons.rst with the changes made by Jiffin Tony Thottan in https://github.com/ceph/ceph/pull/54524 and the suggestions made in that same PR by Anthony D'Atri.

Explain how to set rgw_dns_name to a domain name in order to configure access to virtual hosted buckets.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
