### PR TITLE
rgw: handle EINVAL translation in forward_request

### DIFF
--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -453,9 +453,9 @@ int RGWRESTSimpleRequest::forward_request(const DoutPrefixProvider *dpp, const R
   url = new_url;
 
   int r = process(dpp, y);
-  if (r < 0){
-    if (r == -EINVAL){
-      // curl_easy has errored, generally means the service is not available
+  if (r < 0) {
+    if (http_status == 0) {
+      // no http status, generally means the service is not available
       r = -ERR_SERVICE_UNAVAILABLE;
     }
     return r;


### PR DESCRIPTION
RGWRESTSimpleRequest::forward_request() translates EINVAL to a 503 status code to reflect connection errors as internal errors rather than client errors. However, if the master is explicitly returning EINVAL (which corresponds to an HTTP 400 status code), this translation incorrectly converts it to 503, hiding the true client error.

To address this, we now check the HTTP status code to ensure the error originates from easy_curl and not from a valid HTTP response, preserving the intended 400 status when appropriate.

Fixes: https://tracker.ceph.com/issues/69084