### PR TITLE
src/test: remove tier_flush test

### DIFF
--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -405,11 +405,6 @@ private:
       cout << m_op << ": " << "tier_promote oid " << oid << std::endl;
       return new TierPromoteOp(m_op, &context, oid, m_stats);
 
-    case TEST_OP_TIER_FLUSH:
-      oid = *(rand_choose(context.oid_not_in_use));
-      cout << m_op << ": " << "tier_flush oid " << oid << std::endl;
-      return new TierFlushOp(m_op, &context, oid, m_stats);
-
     case TEST_OP_SET_REDIRECT:
       oid = *(rand_choose(context.oid_not_in_use));
       oid2 = *(rand_choose(context.oid_redirect_not_in_use));
@@ -500,7 +495,6 @@ int main(int argc, char **argv)
     { TEST_OP_UNSET_REDIRECT, "unset_redirect", true },
     { TEST_OP_CHUNK_READ, "chunk_read", true },
     { TEST_OP_TIER_PROMOTE, "tier_promote", true },
-    { TEST_OP_TIER_FLUSH, "tier_flush", true },
     { TEST_OP_SET_CHUNK, "set_chunk", true },
     { TEST_OP_TIER_EVICT, "tier_evict", true },
     { TEST_OP_READ /* grr */, NULL },


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/68518

Cache Tiering feature has been [deprecated](https://docs.ceph.com/en/reef/rados/operations/cache-tiering/). The test related to this feature is causing errors in our test runs. This PR removes the `TIER_FLUSH` test from the src/test directory. For reference, this test was added as part of this commit: https://github.com/ceph/ceph/pull/28778/commits/f1acdf3f2e5272e7011a6929d320ae47792efa39


<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
