### PR TITLE
cephadm: Add pre_remove and ensure deployment values are reset and API settings are updated when  removing Prometheus or Alertmanager daemons

### DIFF
--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -4,6 +4,8 @@ import os
 import socket
 from typing import List, Any, Tuple, Dict, Optional, cast, TYPE_CHECKING
 import ipaddress
+import time
+import requests
 
 from mgr_module import HandleCommandResult
 
@@ -442,6 +444,36 @@ class AlertmanagerService(CephadmService):
                 service_url
             )
 
+    def pre_remove(self, daemon: DaemonDescription) -> None:
+        """
+        Called before Alertmanager is removed
+        """
+        if daemon.hostname is None:
+            return
+        try:
+            current_api_host = self.mgr.check_mon_command({"prefix": "dashboard get-alertmanager-api-host"}).stdout.strip()
+            daemon_addr = daemon.ip if daemon.ip else self.mgr.get_fqdn(daemon.hostname)
+            daemon_port = daemon.ports[0] if daemon.ports else self.DEFAULT_SERVICE_PORT
+            service_url = build_url(scheme='http', host=daemon_addr, port=daemon_port)
+
+            if current_api_host == service_url:
+                # This is the active daemon, update or reset the settings
+                remaining_daemons = [
+                    d for d in self.mgr.cache.get_daemons_by_service(self.TYPE)
+                    if d.name() != daemon.name()
+                ]
+                if remaining_daemons:
+                    self.config_dashboard(remaining_daemons)
+                    logger.info("Updated dashboard API settings to point to a remaining Alertmanager daemon")
+                else:
+                    self.mgr.check_mon_command({"prefix": "dashboard reset-alertmanager-api-host"})
+                    self.mgr.check_mon_command({"prefix": "dashboard reset-alertmanager-api-ssl-verify"})
+                    logger.info("Reset dashboard API settings as no Alertmnager daemons are remaining")
+            else:
+                logger.info(f"Alertmanager {daemon.name()} removed; no changes to dashboard API settings")
+        except Exception as e:
+            logger.error(f"Error in Alertmanager pre_remove: {str(e)}")
+
     def ok_to_stop(self,
                    daemon_ids: List[str],
                    force: bool = False,
@@ -715,6 +747,48 @@ class PrometheusService(CephadmService):
                 'dashboard set-prometheus-api-host',
                 service_url
             )
+
+    def pre_remove(self, daemon: DaemonDescription) -> None:
+        """
+        Called before Prometheus daemon is removed
+        """
+        MAX_RETRIES = 5
+        RETRY_INTERVAL = 5
+        if daemon.hostname is None:
+            return
+        try:
+            current_api_host = self.mgr.check_mon_command({"prefix": "dashboard get-prometheus-api-host"}).stdout.strip()
+            daemon_addr = daemon.ip if daemon.ip else self.mgr.get_fqdn(daemon.hostname)
+            daemon_port = daemon.ports[0] if daemon.ports else self.DEFAULT_SERVICE_PORT
+            service_url = build_url(scheme="http", host=daemon_addr, port=daemon_port)
+
+            if current_api_host == service_url:
+                remaining_daemons = [
+                    d for d in self.mgr.cache.get_daemons_by_service(self.TYPE)
+                    if d.name() != daemon.name()
+                ]
+                if remaining_daemons:
+                    self.config_dashboard(remaining_daemons)
+                    logger.info("Updated Dashboard Settings to point to remaining Prometheus daemons")
+                    for attempt in range(MAX_RETRIES):
+                        try:
+                            response = requests.get(f"{service_url}/api/v1/rules", timeout=5)
+                            if response.status_code == 200:
+                                logger.info(f"Prometheus daemon is ready at {service_url}.")
+                                break
+                        except Exception as e:
+                            logger.info(f"Retry {attempt + 1}: Waiting for Prometheus daemon at {service_url}: {e}")
+                        time.sleep(RETRY_INTERVAL)
+                    else:
+                        logger.warning("Prometheus daemon did not become ready after retries.")
+                else:
+                    self.mgr.check_mon_command({"prefix": "dashboard reset-prometheus-api-host"})
+                    self.mgr.check_mon_command({"prefix": "dashboard reset-prometheus-api-ssl-verify"})
+                    logger.info("Reset Prometheus API settings as no daemons are remaining")
+            else:
+                logger.info("Prometheus daemon removed; no changes to dashboard API settings")
+        except Exception as e:
+            logger.error(f"Error in Prometheus pre_remove {str(e)}")
 
     def ok_to_stop(self,
                    daemon_ids: List[str],


### PR DESCRIPTION
cephadm: Add pre_remove and ensure deployment values are reset and API settings are updated when  removing Prometheus or Alertmanager daemons

Fixes: https://tracker.ceph.com/issues/69088

Logs:

**Alertmanager Scenario 1: Removing the daemon which is not active.**

```
[ceph: root@ceph-node-0 ~]# ceph orch apply alertmanager --placement '*'
Scheduled alertmanager update...

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS        RUNNING  REFRESHED  AGE  PLACEMENT  
alertmanager               ?:9093,9094      3/3  31s ago    91s  *          
crash                                       3/3  31s ago    11m  *          
mgr                                         2/2  31s ago    11m  count:2    
mon                                         3/5  31s ago    11m  count:5    
node-exporter              ?:9100           3/3  31s ago    3m   *          
osd.all-available-devices                     3  31s ago    10m  * 

[ceph: root@ceph-node-0 ~]# ceph dashboard get-alertmanager-api-host
http://ceph-node-0.local:9093

[ceph: root@ceph-node-0 ~]# ceph orch apply alertmanager --placement="ceph-node-0,ceph-node-1"
Scheduled alertmanager update...

[ceph: root@ceph-node-0 ~]# ceph orch ls 
NAME                       PORTS        RUNNING  REFRESHED  AGE  PLACEMENT                
alertmanager               ?:9093,9094      2/2  5s ago     12s  ceph-node-0;ceph-node-1 
```

**Scanerio 2 : Removing the active daemon**

```
[ceph: root@ceph-node-0 ~]# ceph orch apply alertmanager --placement="ceph-node-1"
Scheduled alertmanager update...

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS        RUNNING  REFRESHED  AGE  PLACEMENT    
alertmanager               ?:9093,9094      1/1  5s ago     14s  ceph-node-1  

[ceph: root@ceph-node-0 ~]# ceph dashboard get-alertmanager-api-host
http://ceph-node-1.local:9093
```

**Prometheus Scenarios:**

```
[ceph: root@ceph-node-0 ~]# ceph orch apply prometheus --placement="ceph-node-0,ceph-node-1,ceph-node-2"
Scheduled prometheus update...

[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS        RUNNING  REFRESHED  AGE   PLACEMENT                                                            
prometheus                 ?:9095           3/3  8s ago     21s   ceph-node-0;ceph-node-1;ceph-node-2  

[ceph: root@ceph-node-0 ~]# ceph dashboard get-prometheus-api-host
http://ceph-node-0.local:9095

[ceph: root@ceph-node-0 ~]# ceph orch apply prometheus --placement="ceph-node-1,ceph-node-2"
Scheduled prometheus update...


[ceph: root@ceph-node-0 ~]# ceph orch ls
NAME                       PORTS        RUNNING  REFRESHED  AGE  PLACEMENT                                    
prometheus                 ?:9095           2/2  69s ago    36s  ceph-node-1;ceph-node-2  

[ceph: root@ceph-node-0 ~]# ceph dashboard get-prometheus-api-host
http://ceph-node-1.local:9095
```

```
[ceph: root@ceph-node-0 ~]# curl -i 192.168.100.101:9095/api/v1/rules
HTTP/1.1 200 OK
Content-Type: application/json
Date: Mon, 16 Dec 2024 11:56:46 GMT
Transfer-Encoding: chunked
```

Tests: 

```
 tox -e py39 -- cephadm  
=============================1243 passed, 1 skipped, 7 warnings ========================================
  py39: OK (362.94=setup[0.08]+cmd[362.86] seconds)
  congratulations :) (363.01 seconds)
```



## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [x] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
