### PR TITLE
rgw: respect rgw_graceful_stop on realm reload

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -1194,8 +1194,11 @@ void AsioFrontend::pause()
     l.signal.emit(boost::asio::cancellation_type::terminal);
   }
 
-  // close all connections so outstanding requests fail quickly
-  connections.close(ec);
+  const bool graceful_stop{ g_ceph_context->_conf->rgw_graceful_stop };
+  if (!graceful_stop) {
+    // close all connections so outstanding requests fail quickly
+    connections.close(ec);
+  }
 
   // pause and wait until outstanding requests complete
   pause_mutex.lock(ec);


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/68352

continuing the work https://github.com/ceph/ceph/pull/57659#issuecomment-2388021917

below are screen recordings with this PR of realm-reloads and
`rgw_graceful_stop=[false/true]` 

on left side of the split terminal is the realm reload operation triggered by:
```
sudo ./bin/radosgw-admin zonegroup modify --rgw-zonegroup=us --[enable/disable]-feature=resharding | jq
sudo ./bin/radosgw-admin period update --rgw-realm=gold --commit | jq
```
executed while an `s3cmd put` of an 4GB objects is performed in the right terminal


1. `rgw_graceful_stop=false` note that the `s3cmd` transfer is interrupted as it would be before this PR:
![Peek 2024-12-03 14-49 rgc=false](https://github.com/user-attachments/assets/13afe958-4524-4096-8770-d11c9f5b59ce)

2. `rgw_graceful_stop=true` note that the `s3cmd` transfer is NOT interrupted:
![Peek 2024-12-03 14-53 rgc=true](https://github.com/user-attachments/assets/fc893f7f-1c77-4521-9aa1-5857b0a6dcca)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
