### PR TITLE
container: avoid hard-coding CEPH_REF in Containerfile

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -5,7 +5,7 @@ FROM $FROM_IMAGE
 ARG FROM_IMAGE
 
 # Ceph branch name
-ARG CEPH_REF="main"
+ARG CEPH_REF
 
 # Ceph SHA1
 ARG CEPH_SHA1


### PR DESCRIPTION
The `build.sh` script already defaults to setting `CEPH_REF=main`. It's confusing to see this set here in the non-`main` branches, so we might as well remove it to match what we do with `CEPH_SHA1`.
