### PR TITLE
qa/workunits/mon: ensure election strategy is "connectivity" for stretch mode

### DIFF
--- a/qa/suites/rados/singleton/all/stretch-mode-5-mons-8-osds.yaml
+++ b/qa/suites/rados/singleton/all/stretch-mode-5-mons-8-osds.yaml
@@ -26,7 +26,6 @@ overrides:
   ceph:
     conf:
       global:
-        mon election default strategy: 3
         osd pool default size: 3
         osd pool default min size: 2
       mon:

--- a/qa/workunits/mon/mon-stretch-mode-5-mons-8-osds.sh
+++ b/qa/workunits/mon/mon-stretch-mode-5-mons-8-osds.sh
@@ -9,6 +9,10 @@ if [ $NUM_OSDS_UP -lt 8 ]; then
     exit 1
 fi
 
+# ensure election strategy is set to "connectivity"
+# See https://tracker.ceph.com/issues/69107
+ceph mon set election_strategy connectivity
+
 for dc in dc1 dc2
     do
       ceph osd crush add-bucket $dc datacenter


### PR DESCRIPTION
The election strategy is randomly chosen for this type of test. Sometimes, the test passes if the "connectivity" election strategy happens to be picked. But if a different strategy, i.e. "classic", is picked, then the test will fail.

We can ensure that the election strategy is "connectivity" by setting it in the workunit with the ceph CLI command. Although connectivity was specified in `stretch-mode-5-mons-8-osds.yaml`, that config ultimately gets overridden by the "qa/mon_config" yaml.

Fixes: https://tracker.ceph.com/issues/69107





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [x] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
