### PR TITLE
doc/rados: fix sentences in health-checks (3 of x)

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1428,8 +1428,8 @@ resolution, see :ref:`storage-capacity` and :ref:`no-free-drive-space`.
 OBJECT_MISPLACED
 ________________
 
-One or more objects in the cluster are not stored on the node that CRUSH would
-prefer that they be stored on. This alert is an indication that data migration
+One or more objects in the cluster are not stored on the node that CRUSH
+prefers that they be stored on. This alert is an indication that data migration
 due to a recent cluster change has not yet completed.
 
 Misplaced data is not a dangerous condition in and of itself; data consistency
@@ -1628,9 +1628,10 @@ Stretch Mode
 INCORRECT_NUM_BUCKETS_STRETCH_MODE
 __________________________________
 
-Stretch mode currently only support 2 dividing buckets with OSDs, this warning suggests
-that the number of dividing buckets is not equal to 2 after stretch mode is enabled.
-You can expect unpredictable failures and MON assertions until the condition is fixed.
+Stretch mode currently only support 2 dividing buckets with OSDs, this warning
+suggests that the number of dividing buckets is not equal to 2 after stretch
+mode is enabled.  You can expect unpredictable failures and MON assertions
+until the condition is fixed.
 
 We encourage you to fix this by removing additional dividing buckets or bump the
 number of dividing buckets to 2.
@@ -1653,17 +1654,19 @@ NVMeoF Gateway
 NVMEOF_SINGLE_GATEWAY
 _____________________
 
-One of the gateway group has only one gateway. This is not ideal because it makes
-high availability (HA) impossible with a single gatway in a group. This can lead to 
-problems with failover and failback operations for the NVMeoF gateway.
+One of the gateway group has only one gateway. This is not ideal because it
+makes high availability (HA) impossible with a single gatway in a group. This
+can lead to problems with failover and failback operations for the NVMeoF
+gateway.
 
 It's recommended to have multiple NVMeoF gateways in a group.
 
 NVMEOF_GATEWAY_DOWN
 ___________________
 
-Some of the gateways are in the GW_UNAVAILABLE state. If a NVMeoF daemon has crashed, 
-the daemon log file (found at ``/var/log/ceph/``) may contain troubleshooting information.
+Some of the gateways are in the GW_UNAVAILABLE state. If a NVMeoF daemon has
+crashed, the daemon log file (found at ``/var/log/ceph/``) may contain
+troubleshooting information.
 
 
 Miscellaneous


### PR DESCRIPTION
Make sentences agree at the head of each section in doc/rados/operations/health-checks.rst. The sentences were sometimes in the imperative mood and sometimes in the declarative mood.

This commit edits the second third of
doc/rados/operations/health-checks.rst.

Note to (I hope soon) future Zac: There are a a couple of places near the end of this file where the sentences are ungrammatical. Update these in a separate PR (in isolation, so that the grammar and technical accuracy of these sentences can be the primary focus of the reviewers).

Zac: cf. 000228





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
