### PR TITLE
rados/test_crash.sh: add PG_DEGRADED to ignorelist

### DIFF
--- a/qa/suites/rados/singleton/all/test-crash.yaml
+++ b/qa/suites/rados/singleton/all/test-crash.yaml
@@ -11,6 +11,7 @@ tasks:
         - OSD_.*DOWN
         - \(RECENT_CRASH\)
         - \(POOL_APP_NOT_ENABLED\)
+        - \(PG_DEGRADED\)
   - workunit:
       clients:
          client.0:


### PR DESCRIPTION
Issue: rados/test_crash.sh is failing due to PG_DEGRADED state.

Cause: This is expected as we are intentionally killing OSDs and testing for crashes. Adding the PG_DEGRADED warning to the ignorelist will prevent the test from failing when this warning is raised.

Fixes: https://tracker.ceph.com/issues/69010

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
