### PR TITLE
cephadm: Updated list-networks command to list loopback interface ip

### DIFF
--- a/src/cephadm/tests/test_networks.py
+++ b/src/cephadm/tests/test_networks.py
@@ -137,6 +137,9 @@ class TestCommandListNetworks:
                    valid_lft forever preferred_lft forever
             """),
             {
+                "::1/128": {
+                    "lo": {"::1"},
+                },
                 "fe80::/64": {
                     "eno1": {"fe80::225:90ff:fee5:26e8"},
                     "br-3d443496454c": {"fe80::42:23ff:fe9d:ee4"},
@@ -180,6 +183,9 @@ class TestCommandListNetworks:
                    valid_lft forever preferred_lft forever
             """),
             {
+                "::1/128": {
+                    "lo": {"::1"},
+                },
                 '2001:1458:301:eb::100:1a/128': {
                     'ens20f0': {
                         '2001:1458:301:eb::100:1a'
@@ -217,6 +223,9 @@ class TestCommandListNetworks:
                    valid_lft forever preferred_lft forever
             """),
             {
+                "::1/128": {
+                    "lo": {"::1"},
+                },
                 'fe80::/64': {
                     'brx.0': {'fe80::a4cb:54ff:fecc:f2a2'},
                     'ceph-brx': {'fe80::d8a1:69ff:fede:8f58'}


### PR DESCRIPTION
cephadm: Updated list-networks command to list loopback interface ip

Fixes: https://tracker.ceph.com/issues/69108
Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>

Testing logs:
```
[root@ceph-node-0 ~]# cephadm list-networks
{
    "192.168.100.0/24": {
        "eth0": [
            "192.168.100.100"
        ]
    },
    "127.0.0.0/8": {
        "lo": [
            "127.0.0.1"
        ]
    },
    "fd12:3456:789a::/64": {
        "lo": [
            "fd12:3456:789a::1f"
        ]
    },
    "fe80::/64": {
        "eth0": [
            "fe80::5054:ff:fe8c:b395"
        ]
    }
}
[root@ceph-node-0 ~]# 

```
```
[ceph: root@ceph-node-0 /]# cat ingress.yml 
service_type: ingress
service_id: rgw.test1
placement:
  count: 2
spec:
  backend_service: rgw.test1
  virtual_ip: 127.1.1.100/8
  frontend_port: 443
  monitor_port: 1967
  ssl_cert: |


[ceph: root@ceph-node-0 /]# ceph orch ls
NAME                       PORTS                 RUNNING  REFRESHED  AGE  PLACEMENT  
crash                                                2/2  6m ago     14m  *          
ingress.rgw.test1          127.1.1.100:443,1967      4/4  6m ago     6m   count:2    
mgr                                                  2/2  6m ago     14m  count:2    
mon                                                  2/5  6m ago     14m  count:5    
osd.all-available-devices                              6  6m ago     13m  *          
rgw.test1                  ?:80                      2/2  6m ago     11m  count:2    
[ceph: root@ceph-node-0 /]# 

```


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
