### PR TITLE
cls/rbd: fix mirror_image_map_list object

### DIFF
--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -2538,7 +2538,7 @@ int mirror_image_map_list(
   mirror_image_map_list_start(&op, start_after, max_read);
 
   bufferlist out_bl;
-  int r = ioctx->operate(RBD_MIRRORING, &op, &out_bl);
+  int r = ioctx->operate(RBD_MIRROR_LEADER, &op, &out_bl);
   if (r < 0) {
     return r;
   }

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -2156,7 +2156,7 @@ TEST_F(TestClsRbd, mirror_image_map)
 {
   librados::IoCtx ioctx;
   ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
-  ioctx.remove(RBD_MIRRORING);
+  ioctx.remove(RBD_MIRROR_LEADER);
 
   std::map<std::string, cls::rbd::MirrorImageMap> image_mapping;
   ASSERT_EQ(-ENOENT, mirror_image_map_list(&ioctx, "", 0, &image_mapping));
@@ -2177,7 +2177,7 @@ TEST_F(TestClsRbd, mirror_image_map)
 
       mirror_image_map_update(&op, global_image_id, mirror_image_map);
     }
-    ASSERT_EQ(0, ioctx.operate(RBD_MIRRORING, &op));
+    ASSERT_EQ(0, ioctx.operate(RBD_MIRROR_LEADER, &op));
   }
 
   ASSERT_EQ(0, mirror_image_map_list(&ioctx, "", 1000, &image_mapping));
@@ -2203,7 +2203,7 @@ TEST_F(TestClsRbd, mirror_image_map)
   librados::ObjectWriteOperation op;
   mirror_image_map_remove(&op, "1");
   mirror_image_map_update(&op, "10", expected_mirror_image_map);
-  ASSERT_EQ(0, ioctx.operate(RBD_MIRRORING, &op));
+  ASSERT_EQ(0, ioctx.operate(RBD_MIRROR_LEADER, &op));
 
   ASSERT_EQ(0, mirror_image_map_list(&ioctx, "0", 1, &image_mapping));
   ASSERT_EQ(1U, image_mapping.size());


### PR DESCRIPTION
The rbd-mirror image map is stored in the rbd_mirror_leader object. Fixed mirror_image_map_list() to operate on the correct object.

Fixes: [69112](https://tracker.ceph.com/issues/69112)



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [x] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
