### PR TITLE
doc/dev: update link to backporter manual

### DIFF
--- a/doc/dev/development-workflow.rst
+++ b/doc/dev/development-workflow.rst
@@ -108,12 +108,12 @@ status of an open issue can be:
 * ``Pending Backport``: the fix needs to be backported to the stable
   releases listed in the backport field
 
-For each ``Pending Backport`` issue, there exists at least one issue
-in the ``Backport`` tracker to record the work done to cherry pick the
-necessary commits from the master branch to the target stable branch.
-See `the backporter manual
-<http://tracker.ceph.com/projects/ceph-releases/wiki/HOWTO>`_ for more
-information.
+For each ``Pending Backport`` issue, there exists at least one issue in the
+``Backport`` tracker to record the work done to cherry pick the necessary
+commits from the master branch to the target stable branch. See `the backporter
+manual
+<https://github.com/ceph/ceph/blob/main/SubmittingPatches-backports.rst>`_ for
+more information.
 
 Running and interpreting teuthology integration tests
 =====================================================
@@ -244,5 +244,5 @@ differences:
   reference the original commit
 
 See `the backporter manual
-<http://tracker.ceph.com/projects/ceph-releases/wiki/HOWTO>`_ for more
-information.
+<https://github.com/ceph/ceph/blob/main/SubmittingPatches-backports.rst>`_ for
+more information.


### PR DESCRIPTION
Update the link to the backporter manual, in
doc/dev/development-workflow.rst. Laura Flores requested this change on 04 Dec 2024.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
