### PR TITLE
squid: Modify container/ software to support release containers and the promotion of prerelease containers

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -65,25 +65,25 @@ RUN \
     echo "enabled=1" >> /etc/yum.repos.d/ganesha.repo
 
 # ISCSI repo
-RUN set -x && \
+RUN set -ex && \
     curl -s -L https://shaman.ceph.com/api/repos/tcmu-runner/main/latest/centos/9/repo?arch=$(arch) -o /etc/yum.repos.d/tcmu-runner.repo && \
     case "${CEPH_REF}" in \
         quincy|reef) \
-            curl -s -L https://download.ceph.com/ceph-iscsi/3/rpm/el9/ceph-iscsi.repo -o /etc/yum.repos.d/ceph-iscsi.repo ;\
+            curl -fs -L https://download.ceph.com/ceph-iscsi/3/rpm/el9/ceph-iscsi.repo -o /etc/yum.repos.d/ceph-iscsi.repo ;\
             ;;\
         main|*) \
-            curl -s -L https://shaman.ceph.com/api/repos/ceph-iscsi/main/latest/centos/9/repo -o /etc/yum.repos.d/ceph-iscsi.repo ;\
+            curl -fs -L https://shaman.ceph.com/api/repos/ceph-iscsi/main/latest/centos/9/repo -o /etc/yum.repos.d/ceph-iscsi.repo ;\
             ;;\
     esac
 
 # Ceph repo
-RUN set -x && \
+RUN set -ex && \
     rpm --import 'https://download.ceph.com/keys/release.asc' && \
     ARCH=$(arch); if [ "${ARCH}" == "aarch64" ]; then ARCH="arm64"; fi ;\
     IS_RELEASE=0 ;\
     if [[ "${CI_CONTAINER}" == "true" ]] ; then \
         # TODO: this can return different ceph builds (SHA1) for x86 vs. arm runs. is it important to fix?
-        REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/${ARCH}&flavor=${OSD_FLAVOR}&ref=${CEPH_REF}&sha1=latest" | jq -r .[0].url) ;\
+        REPO_URL=$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/${ARCH}&flavor=${OSD_FLAVOR}&ref=${CEPH_REF}&sha1=latest" | jq -r .[0].url) ;\
     else \
         IS_RELEASE=1 ;\
         REPO_URL="https://${PRERELEASE_USERNAME}:${PRERELEASE_PASSWORD}@download.ceph.com/prerelease/ceph/rpm-${CEPH_REF}/el9/" ;\
@@ -195,7 +195,7 @@ RUN \
     grep -sqo "obtain_device_list_from_udev = 0" /etc/lvm/lvm.conf
 
 # CLEAN UP!
-RUN set -x && \
+RUN set -ex && \
     dnf clean all && \
     rm -rf /var/cache/dnf/* && \
     rm -rf /var/lib/dnf/* && \

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -203,7 +203,8 @@ RUN set -x && \
     # remove unnecessary files with big impact
     rm -rf /etc/selinux /usr/share/{doc,man,selinux} && \
     # don't keep compiled python binaries
-    find / -xdev \( -name "*.pyc" -o -name "*.pyo" \) -delete
+    find / -xdev \( -name "*.pyc" -o -name "*.pyo" \) -delete && \
+    rm -f /etc/yum.repos.d/{ceph,ganesha,tcmu-runner,ceph-iscsi}.repo
 
 # Verify that the packages installed haven't been accidentally cleaned, then
 # clean the package list and re-clean unnecessary RPM database files

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -22,6 +22,10 @@ ARG OSD_FLAVOR="default"
 # (optional) Should be 'true' for CI builds (pull from shaman, etc.)
 ARG CI_CONTAINER="true"
 
+# creds for accessing prerelease packages on download.ceph.com for release builds
+ARG PRERELEASE_USERNAME ""
+ARG PRERELEASE_PASSWORD ""
+
 RUN /bin/echo -e "\
 FROM_IMAGE: ${FROM_IMAGE}\n\
 CEPH_REF: ${CEPH_REF}\n\
@@ -82,9 +86,14 @@ RUN set -x && \
         REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/${ARCH}&flavor=${OSD_FLAVOR}&ref=${CEPH_REF}&sha1=latest" | jq -r .[0].url) ;\
     else \
         IS_RELEASE=1 ;\
-        REPO_URL="http://download.ceph.com/rpm-${CEPH_REF}/el9/" ;\
+        REPO_URL="https://${PRERELEASE_USERNAME}:${PRERELEASE_PASSWORD}@download.ceph.com/prerelease/ceph/rpm-${CEPH_REF}/el9/" ;\
     fi && \
-    rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${IS_RELEASE}.el9.noarch.rpm"
+    rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${IS_RELEASE}.el9.noarch.rpm" ; \
+    if [[ IS_RELEASE ]] ; then \
+	sed -i "s;http://download.ceph.com/;https://${PRERELEASE_USERNAME}:${PRERELEASE_PASSWORD}@download.ceph.com/prerelease/ceph/;" /etc/yum.repos.d/ceph.repo ; \
+	dnf clean expire-cache ; \
+    fi
+
 
 # Copr repos
 # scikit for mgr-diskprediction-local

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -22,9 +22,6 @@ ARG OSD_FLAVOR="default"
 # (optional) Should be 'true' for CI builds (pull from shaman, etc.)
 ARG CI_CONTAINER="true"
 
-# creds for accessing prerelease packages on download.ceph.com for release builds
-ARG PRERELEASE_USERNAME ""
-ARG PRERELEASE_PASSWORD ""
 
 RUN /bin/echo -e "\
 FROM_IMAGE: ${FROM_IMAGE}\n\
@@ -77,7 +74,7 @@ RUN set -ex && \
     esac
 
 # Ceph repo
-RUN set -ex && \
+RUN --mount=type=secret,id=prerelease_creds set -ex && \
     rpm --import 'https://download.ceph.com/keys/release.asc' && \
     ARCH=$(arch); if [ "${ARCH}" == "aarch64" ]; then ARCH="arm64"; fi ;\
     IS_RELEASE=0 ;\
@@ -86,12 +83,13 @@ RUN set -ex && \
         REPO_URL=$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/${ARCH}&flavor=${OSD_FLAVOR}&ref=${CEPH_REF}&sha1=latest" | jq -r .[0].url) ;\
     else \
         IS_RELEASE=1 ;\
+        source /run/secrets/prerelease_creds; \
         REPO_URL="https://${PRERELEASE_USERNAME}:${PRERELEASE_PASSWORD}@download.ceph.com/prerelease/ceph/rpm-${CEPH_REF}/el9/" ;\
     fi && \
     rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${IS_RELEASE}.el9.noarch.rpm" ; \
     if [[ "$IS_RELEASE" == 1 ]] ; then \
-	sed -i "s;http://download.ceph.com/;https://${PRERELEASE_USERNAME}:${PRERELEASE_PASSWORD}@download.ceph.com/prerelease/ceph/;" /etc/yum.repos.d/ceph.repo ; \
-	dnf clean expire-cache ; \
+        sed -i "s;http://download.ceph.com/;https://${PRERELEASE_USERNAME}:${PRERELEASE_PASSWORD}@download.ceph.com/prerelease/ceph/;" /etc/yum.repos.d/ceph.repo ; \
+        dnf clean expire-cache ; \
     fi
 
 

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -89,7 +89,7 @@ RUN set -x && \
         REPO_URL="https://${PRERELEASE_USERNAME}:${PRERELEASE_PASSWORD}@download.ceph.com/prerelease/ceph/rpm-${CEPH_REF}/el9/" ;\
     fi && \
     rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${IS_RELEASE}.el9.noarch.rpm" ; \
-    if [[ IS_RELEASE ]] ; then \
+    if [[ "$IS_RELEASE" == 1 ]] ; then \
 	sed -i "s;http://download.ceph.com/;https://${PRERELEASE_USERNAME}:${PRERELEASE_PASSWORD}@download.ceph.com/prerelease/ceph/;" /etc/yum.repos.d/ceph.repo ; \
 	dnf clean expire-cache ; \
     fi

--- a/container/build.sh
+++ b/container/build.sh
@@ -22,6 +22,8 @@ CONTAINER_REPO_HOSTNAME (quay.ceph.io, for CI, for instance)
 CONTAINER_REPO_ORGANIZATION (ceph-ci, for CI, for instance)
 CONTAINER_REPO_USERNAME
 CONTAINER_REPO_PASSWORD
+PRERELEASE_USERNAME for download.ceph.com:/prerelease/ceph
+PRERELEASE_PASSWORD
 
 For a release build: (from ceph.git, built and pushed to download.ceph.com)
 CI_CONTAINER: must be 'false'
@@ -99,6 +101,8 @@ podman build --pull=newer --squash -f $CFILE -t build.sh.output \
     --build-arg CEPH_REF=${BRANCH:-main} \
     --build-arg OSD_FLAVOR=${FLAVOR:-default} \
     --build-arg CI_CONTAINER=${CI_CONTAINER:-default} \
+    --build-arg PRERELEASE_USERNAME=${PRERELEASE_USERNAME} \
+    --build-arg PRERELEASE_PASSWORD=${PRERELEASE_PASSWORD} \
     2>&1 
 
 image_id=$(podman image ls localhost/build.sh.output --format '{{.ID}}')

--- a/container/make-manifest-list.py
+++ b/container/make-manifest-list.py
@@ -186,8 +186,8 @@ def build_prerelease(sysargs):
 
     # create manifest list image with the standard list of tags
     # ignore failure on manifest rm
-    run_command(f'podman manifest rm localhost/m')
-    run_command_show_failure(f'podman manifest create localhost/m')
+    run_command(f'podman manifest rm {LOCALMANIFEST}')
+    run_command_show_failure(f'podman manifest create {LOCALMANIFEST}')
     for p in paths_with_tags:
         run_command_show_failure(f'podman manifest add m {p}')
     base = f'{manifest_host}/{manifest_repo}'
@@ -201,7 +201,7 @@ def build_prerelease(sysargs):
             print(f'skipping podman manifest push {LOCALMANIFEST} {base}:{t}')
         else:
             run_command_show_failure(
-              f'podman manifest push localhost/m {base}:{t}')
+              f'podman manifest push {LOCALMANIFEST} {base}:{t}')
 
 def promote(sysargs):
     manifest_host = os.environ.get('MANIFEST_HOST', 'quay.ceph.io')

--- a/container/make-manifest-list.py
+++ b/container/make-manifest-list.py
@@ -1,11 +1,32 @@
 #!/usr/bin/python3
 #
+# in default mode:
 # make a combined "manifest-list" container out of two arch-specific containers
 # searches for latest tags on HOST/{AMD,ARM}64_REPO, makes sure they refer
 # to the same Ceph SHA1, and creates a manifest-list ("fat") image on
-# MANIFEST_HOST/MANIFEST_REPO with the 'standard' set of tags.
+# MANIFEST_HOST/MANIFEST_REPO with the 'standard' set of tags:
+# v<major>
+# v<major>.<minor>
+# v<major>.<minor>.<micro>
+# v<major>.<minor>.<micro>-<YYYYMMDD>
 #
-# uses scratch local manifest LOCALMANIFEST, will be destroyed if present
+# uses scratch local manifest LOCALMANIFEST, defined here; will be destroyed if present
+#
+# in promote mode (by adding the --promote argument):
+# instead of building the manifest-list container, copy it
+# (and all of its tags) from the prerelease repo to the release repo
+#
+# Assumes valid logins to the necessary hosts/repos with permission to write images
+#
+# Environment variables to set:
+# ARCH_SPECIFIC_HOST (default 'quay.ceph.io'): host of prerelease repos
+# AMD64_REPO (default 'ceph/prerelease-amd64') prerelease amd64 repo
+# ARM64_REPO (default 'ceph/prerelease-arm64') prerelease arm64 repo
+# MANIFEST_HOST (default 'quay.ceph.io') prerelease manifest-list host
+# MANIFEST_REPO (default 'ceph/prerelease') prerelease manifest-list repo
+# RELEASE_MANIFEST_HOST (default 'quay.io') release host
+# RELEASE_MANIFEST_REPO (default 'ceph/ceph') release repo
+
 
 import argparse
 from datetime import datetime
@@ -15,16 +36,6 @@ import os
 import re
 import subprocess
 import sys
-
-# optional env vars (will default if not set)
-
-OPTIONAL_VARS = (
-    'ARCH_SPECIFIC_HOST',
-    'AMD64_REPO',
-    'ARM64_REPO',
-    'MANIFEST_HOST',
-    'MANIFEST_REPO',
-)
 
 # Manifest image.  Will be destroyed if already present.
 LOCALMANIFEST = 'localhost/m'
@@ -66,10 +77,14 @@ def run_command_show_failure(args):
 
 
 @functools.lru_cache
+def get_tags(path):
+    cmdout = get_command_output(f'skopeo list-tags docker://{path}')
+    return json.loads(cmdout)['Tags']
+
+
 def get_latest_tag(path):
     try:
-        cmdout = get_command_output(f'skopeo list-tags docker://{path}')
-        latest_tag = json.loads(cmdout)['Tags'][-1]
+        latest_tag = get_tags(path)[-1]
     except IndexError:
         return None
     return latest_tag
@@ -90,19 +105,36 @@ def get_sha1(info):
     return labels.get('CEPH_SHA1', None)
 
 
+@functools.lru_cache
+def get_all_matching_digest_tags(path, tag):
+
+    matching_tags = list()
+    digest = get_image_inspect(f'{path}:{tag}')['Digest']
+
+    for t in get_tags(path):
+        this_digest = get_image_inspect(f'{path}:{t}')['Digest']
+        if this_digest == digest:
+            matching_tags.append(t)
+
+    return matching_tags
+
+
 def parse_args():
     ap = argparse.ArgumentParser()
-    ap.add_argument('-n', '--dry-run', action='store_true', help='do all local manipulations but do not push final containers to MANIFEST_HOST')
+    ap.add_argument('-n', '--dry-run', action='store_true', help='do all local manipulations but do not push final containers to MANIFEST_HOST, or in --promote, calculate but do not copy images to release host')
+    ap.add_argument('-P', '--promote', action='store_true', help='promote newest prerelease manifest container to released (move from MANIFEST_HOST to RELEASE_MANIFEST_HOST')
     args = ap.parse_args()
     return args
 
-def main():
-    args = parse_args()
+def build_prerelease(sysargs):
+    global args
+
     arch_specific_host = os.environ.get('ARCH_SPECIFIC_HOST', 'quay.ceph.io')
     amd64_repo = os.environ.get('AMD64_REPO', 'ceph/prerelease-amd64')
     arm64_repo = os.environ.get('ARM64_REPO', 'ceph/prerelease-arm64')
-    manifest_host = os.environ.get('MANIFEST_HOST', arch_specific_host)
+    manifest_host = os.environ.get('MANIFEST_HOST', 'quay.ceph.io')
     manifest_repo = os.environ.get('MANIFEST_REPO', 'ceph/prerelease')
+
     dump_vars(
         ('arch_specific_host',
          'amd64_repo',
@@ -111,7 +143,6 @@ def main():
          'manifest_repo',
          ),
         locals())
-
     repopaths = (
         f'{arch_specific_host}/{amd64_repo}',
         f'{arch_specific_host}/{arm64_repo}',
@@ -166,11 +197,55 @@ def main():
             f'v{major}.{minor}.{micro}',
             f'v{major}.{minor}.{micro}-{datetime.today().strftime("%Y%m%d")}',
         ):
-        if args.dry_run:
-            print(f'skipping podman manifest push localhost/m {base}:{t}')
+        if sysargs.dry_run:
+            print(f'skipping podman manifest push {LOCALMANIFEST} {base}:{t}')
         else:
             run_command_show_failure(
               f'podman manifest push localhost/m {base}:{t}')
+
+def promote(sysargs):
+    manifest_host = os.environ.get('MANIFEST_HOST', 'quay.ceph.io')
+    manifest_repo = os.environ.get('MANIFEST_REPO', 'ceph/prerelease')
+    release_manifest_host = os.environ.get('RELEASE_MANIFEST_HOST', 'quay.io')
+    release_manifest_repo = os.environ.get('RELEASE_MANIFEST_REPO', 'ceph/ceph')
+    dump_vars(
+        ('manifest_host',
+         'manifest_repo',
+         'release_manifest_host',
+         'release_manifest_repo',
+         ),
+        locals())
+
+    manifest_path = f'{manifest_host}/{manifest_repo}'
+    release_path = f'{release_manifest_host}/{release_manifest_repo}'
+    latest_tag = get_latest_tag(manifest_path)
+    all_tags = get_all_matching_digest_tags(manifest_path, latest_tag)
+
+    copypaths = list()
+    for t in all_tags:
+        from_path = f'{manifest_path}:{t}'
+        to_path = f'{release_path}:{t}'
+        copypaths.append((from_path, to_path))
+
+    if sysargs.dry_run:
+        for f, t in copypaths:
+            print(f'dry-run: Would copy: {f} -> {t}')
+        return(0)
+
+    for f, t in copypaths:
+        print(f'Will copy: {f} -> {t}')
+
+    for f, t in copypaths:
+        run_command_show_failure(f'skopeo copy --multi-arch=all docker://{f} docker://{t}')
+
+
+def main():
+    args = parse_args()
+
+    if args.promote:
+        promote(args)
+    else:
+        build_prerelease(args)
 
 
 if (__name__ == '__main__'):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69119

---

backport of https://github.com/ceph/ceph/pull/60755
parent tracker: https://tracker.ceph.com/issues/69116

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh