### PR TITLE
qa/rgw: bump keystone/barbican from 2023.1 to 2024.1

### DIFF
--- a/qa/suites/rgw/crypt/2-kms/barbican.yaml
+++ b/qa/suites/rgw/crypt/2-kms/barbican.yaml
@@ -27,7 +27,7 @@ tasks:
 - tox: [ client.0 ]
 - keystone:
     client.0:
-      force-branch: stable/2023.1
+      force-branch: stable/2024.1
       services:
         - name: swift
           type: object-store
@@ -68,7 +68,7 @@ tasks:
           project: s3
 - barbican:
     client.0:
-      force-branch: stable/2023.1
+      force-branch: stable/2024.1
       use-keystone-role: client.0
       keystone_authtoken:
         auth_plugin: password

--- a/qa/suites/rgw/tempest/0-install.yaml
+++ b/qa/suites/rgw/tempest/0-install.yaml
@@ -4,7 +4,7 @@ tasks:
 - tox: [ client.0 ]
 - keystone:
     client.0:
-      force-branch: stable/2023.1
+      force-branch: stable/2024.1
       services:
         - name: swift
           type: object-store


### PR DESCRIPTION
the openstack branches that the rgw suite depends on disappeared again:
> Remote branch stable/2023.1 not found in upstream origin

Fixes: https://tracker.ceph.com/issues/69134

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
