### PR TITLE
squid: test/rgw/multisite: add meta checkpoint after bucket creation

### DIFF
--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -573,6 +573,7 @@ def create_bucket_per_zone_in_realm():
         b, z = create_bucket_per_zone(zg_conn)
         buckets.extend(b)
         zone_bucket.extend(z)
+    realm_meta_checkpoint(realm)
     return buckets, zone_bucket
 
 def test_bucket_create():


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69148

---

backport of https://github.com/ceph/ceph/pull/60129
parent tracker: https://tracker.ceph.com/issues/68396

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh