### PR TITLE
squid: radosgw-admin: allow 'sync group pipe modify' with existing user

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -10316,7 +10316,8 @@ next:
 
     if (!rgw::sal::User::empty(user)) {
       pipe->params.user = user->get_id();
-    } else if (pipe->params.mode == rgw_sync_pipe_params::MODE_USER) {
+    } else if (pipe->params.mode == rgw_sync_pipe_params::MODE_USER &&
+               pipe->params.user.empty()) {
       cerr << "ERROR: missing --uid for --mode=user" << std::endl;
       return EINVAL;
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69146

---

backport of https://github.com/ceph/ceph/pull/60415
parent tracker: https://tracker.ceph.com/issues/68645

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh