### PR TITLE
squid: radosgw-admin: 'user create' rejects uids matching the account id format

### DIFF
--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -1749,7 +1749,11 @@ int RGWUser::execute_add(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_
   user_info.display_name = display_name;
   user_info.type = TYPE_RGW;
 
-  // tenant must not look like a valid account id
+  // user/tenant must not look like a valid account id
+  if (rgw::account::validate_id(uid.id)) {
+    set_err_msg(err_msg, "uid must not be formatted as an account id");
+    return -EINVAL;
+  }
   if (rgw::account::validate_id(uid.tenant)) {
     set_err_msg(err_msg, "tenant must not be formatted as an account id");
     return -EINVAL;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/69145

---

backport of https://github.com/ceph/ceph/pull/60830
parent tracker: https://tracker.ceph.com/issues/69043

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/main/src/script/ceph-backport.sh