### PR TITLE
script: ceph-backport no longer launches firefox

### DIFF
--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -1741,7 +1741,6 @@ fi
 
 if [ "$PR_PHASE" ] || [ "$EXISTING_PR" ] ; then
     maybe_update_pr_milestone_labels
-    pgrep firefox >/dev/null && firefox "${backport_pr_url}"
 fi
 
 if [ "$TRACKER_PHASE" ] ; then
@@ -1792,12 +1791,10 @@ if [ "$TRACKER_PHASE" ] ; then
     if [ "$tracker_is_in_desired_state" ] ; then
         [ "$tracker_was_updated" ] && info "Backport tracker ${redmine_url} was updated"
         info "Backport tracker ${redmine_url} is in the desired state"
-        pgrep firefox >/dev/null && firefox "${redmine_url}"
         exit 0
     fi
     if [ "$tracker_was_updated" ] ; then
         warning "backport tracker ${redmine_url} was updated, but is not in the desired state. Please check it."
-        pgrep firefox >/dev/null && firefox "${redmine_url}"
         exit 1
     else
         data_binary="{\"issue\":{\"notes\":\"please link this Backport tracker issue with GitHub PR ${desc_should_be}\nceph-backport.sh version ${SCRIPT_VERSION}\"}}"


### PR DESCRIPTION
this script uses `pgrep firefox` to determine whether a browser is open, and will pause the ceph-backport script waiting for the commands `firefox "${backport_pr_url}` and `firefox "${redmine_url}"` to exit

on Fedora release 41 with Mozilla Firefox 133.0, `pgrep firefox` always finds a process even if no browser window is open:

> /usr/lib64/firefox/firefox --dbus-service /usr/bin/firefox

the ceph-backport script prints these URLs as output, so it's easy enough to open them in a browser where desired

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
