### PR TITLE
doc: fixes in doc building

### DIFF
--- a/doc/_ext/ceph_commands.py
+++ b/doc/_ext/ceph_commands.py
@@ -94,7 +94,7 @@ class CmdParam(object):
         self.goodchars = goodchars
         self.positional = positional != 'false'
 
-        assert who == None
+        assert who is None
 
     def help(self):
         advanced = []

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -76,7 +76,7 @@ html_show_sphinx = False
 html_static_path = ["_static"]
 html_sidebars = {
     '**': ['smarttoc.html', 'searchbox.html']
-    }
+}
 
 html_css_files = ['css/custom.css']
 
@@ -133,13 +133,23 @@ extensions = [
     'sphinxcontrib.mermaid',
     'sphinxcontrib.openapi',
     'sphinxcontrib.seqdiag',
-    ]
+]
 
 ditaa = shutil.which("ditaa")
 if ditaa is not None:
     # in case we don't have binfmt_misc enabled or jar is not registered
-    ditaa_args = ['-jar', ditaa]
-    ditaa = 'java'
+    _jar_paths = [
+        '/usr/share/ditaa/lib/ditaa.jar',  # Gentoo
+        '/usr/share/ditaa/ditaa.jar',  # deb
+        '/usr/share/java/ditaa.jar',  # rpm
+    ]
+    _jar_paths = [p for p in _jar_paths if os.path.exists(p)]
+    if _jar_paths:
+        ditaa = 'java'
+        ditaa_args = ['-jar', _jar_paths[0]]
+    else:
+        # keep ditaa from shutil.which
+        ditaa_args = []
     extensions += ['sphinxcontrib.ditaa']
 else:
     extensions += ['plantweb.directive']


### PR DESCRIPTION
commit a54f5710456345b797eabf2a8b6d09f8aa7e6dd5 (HEAD -> main, drunkard-fork/main)
Author: Drunkard Zhang <gongfan193@gmail.com>
Date:   Sat Dec 7 11:38:48 2024 +0800

    doc/conf.py: try to provide real jar path
    
    The path got by shutil.which is usually a hook, not real jar, so try to
    provide real jar. And fallback to the hook detected when failed.
    
    Signed-off-by: Drunkard Zhang <gongfan193@gmail.com>

commit cf48fddbc6afd43536c0cdf4c2a091287b5257ba
Author: Drunkard Zhang <gongfan193@gmail.com>
Date:   Sat Dec 7 11:32:38 2024 +0800

    doc/_ext: mute syntax check warn E711
    
    According to E711 of PEP0008:
    
    When compare to None, should use 'is' instead of '=='
    
    Signed-off-by: Drunkard Zhang <gongfan193@gmail.com>



<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
