### PR TITLE
mgr/nfs: Show ingress mode in output of 'ceph nfs cluster info' command

### DIFF
--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -236,6 +236,14 @@ class NFSCluster:
                     r['port'] = i.ports[0]
                     if len(i.ports) > 1:
                         r['monitor_port'] = i.ports[1]
+                if spec.keepalive_only:
+                    ingress_mode = IngressType.keepalive_only
+                elif spec.enable_haproxy_protocol:
+                    ingress_mode = IngressType.haproxy_protocol
+                else:
+                    ingress_mode = IngressType.haproxy_standard
+                r['ingress_mode'] = ingress_mode.value
+
         log.debug("Successfully fetched %s info: %s", cluster_id, r)
         return r
 


### PR DESCRIPTION
Show ingress mode in output of 'ceph nfs cluster info' command

Fixes: https://tracker.ceph.com/issues/69153

Signed-off-by: Shweta Bhosale <Shweta.Bhosale1@ibm.com>

Testing logs:
```
[ceph: root@ceph-node-0 /]# ceph nfs cluster info
{
  "mynfs": {
    "backend": [
      {
        "hostname": "ceph-node-0",
        "ip": "192.168.100.100",
        "port": 12345
      },
      {
        "hostname": "ceph-node-1",
        "ip": "192.168.100.101",
        "port": 12345
      },
      {
        "hostname": "ceph-node-2",
        "ip": "192.168.100.102",
        "port": 12345
      }
    ],
    "ingress_mode": "haproxy-standard",
    "monitor_port": 9000,
    "port": 2049,
    "virtual_ip": "192.168.100.123"
  },
  "mynfs1": {
    "backend": [
      {
        "hostname": "ceph-node-0",
        "ip": "192.168.100.100",
        "port": 12345
      },
      {
        "hostname": "ceph-node-1",
        "ip": "192.168.100.101",
        "port": 12345
      },
      {
        "hostname": "ceph-node-2",
        "ip": "192.168.100.102",
        "port": 12345
      }
    ],
    "virtual_ip": null
  }
}


[ceph: root@ceph-node-0 /]# ceph nfs cluster info mynfs1
{
  "mynfs1": {
    "backend": [
      {
        "hostname": "ceph-node-0",
        "ip": "192.168.100.100",
        "port": 12345
      },
      {
        "hostname": "ceph-node-1",
        "ip": "192.168.100.101",
        "port": 12345
      },
      {
        "hostname": "ceph-node-2",
        "ip": "192.168.100.102",
        "port": 12345
      }
    ],
    "ingress_mode": "keepalive-only",
    "monitor_port": 9000,
    "port": 2049,
    "virtual_ip": "192.168.100.123"
  }
}

```


## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [x] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
- `jenkins test rook e2e`
</details>
