### PR TITLE
include/types.h, tools/cephfs: remove _BACKWARD_BACKWARD_WARNING_H

### DIFF
--- a/src/include/types.h
+++ b/src/include/types.h
@@ -28,12 +28,6 @@
 #include "ceph_frag.h"
 #include "rbd_types.h"
 
-#ifdef __cplusplus
-#ifndef _BACKWARD_BACKWARD_WARNING_H
-#define _BACKWARD_BACKWARD_WARNING_H   // make gcc 4.3 shut up about hash_*
-#endif
-#endif
-
 extern "C" {
 #include <stdint.h>
 #include <sys/types.h>

--- a/src/journal/Entry.cc
+++ b/src/journal/Entry.cc
@@ -5,7 +5,8 @@
 #include "include/encoding.h"
 #include "include/stringify.h"
 #include "common/Formatter.h"
-#include <strstream>
+
+#include <sstream>
 
 #define dout_subsys ceph_subsys_journaler
 #undef dout_prefix

--- a/src/tools/cephfs/Dumper.cc
+++ b/src/tools/cephfs/Dumper.cc
@@ -12,10 +12,6 @@
  * 
  */
 
-#ifndef _BACKWARD_BACKWARD_WARNING_H
-#define _BACKWARD_BACKWARD_WARNING_H   // make gcc 4.3 shut up about hash_*
-#endif
-
 #include "include/compat.h"
 #include "include/fs_types.h"
 #include "common/entity_name.h"


### PR DESCRIPTION
This kludge has been obsolete for a long time and GCC 4.3 cannot compile Ceph anymore these days.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
