### PR TITLE
tools/ceph-dencoder/sstring.h: use `char8_t` instead of `unsigned char`

### DIFF
--- a/src/common/sstring.hh
+++ b/src/common/sstring.hh
@@ -44,6 +44,7 @@ template <typename char_type, typename Size, Size max_size>
 class basic_sstring {
     static_assert(
             (std::is_same<char_type, char>::value
+             || std::is_same<char_type, char8_t>::value
              || std::is_same<char_type, signed char>::value
              || std::is_same<char_type, unsigned char>::value),
             "basic_sstring only supports single byte char types");

--- a/src/tools/ceph-dencoder/sstring.h
+++ b/src/tools/ceph-dencoder/sstring.h
@@ -7,7 +7,7 @@
 class sstring_wrapper {
   using sstring16 = basic_sstring<char, uint32_t, 16>;
   sstring16 s1;
-  using sstring24 = basic_sstring<unsigned char, uint16_t, 24>;
+  using sstring24 = basic_sstring<char8_t, uint16_t, 24>;
   sstring24 s2;
  public:
   sstring_wrapper() = default;


### PR DESCRIPTION
This fixes a build failure with libc++ (clang/LLVM).  This build failure is correct: there exists no specialization for `std::char_traits<unsigned char>`.  The standards-compliant way to use unsigned chars in strings is to use `char8_t`.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
