### PR TITLE
mgr/PyModule: disable `BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS`

### DIFF
--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -36,6 +36,11 @@ std::string PyModule::mgr_store_prefix = "mgr/";
 
 // Courtesy of http://stackoverflow.com/questions/1418015/how-to-get-python-exception-text
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
+// Fix instances of "'BOOST_PP_ITERATION_02' was not declared in this scope; did you mean 'BOOST_PP_ITERATION_05'"
+// and related macro error bullshit that spans 300 lines of errors
+//
+// Apparently you can't include boost/python stuff _and_ have this header defined
+#undef BOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
 // Boost apparently can't be bothered to fix its own usage of its own
 // deprecated features.
 #include <boost/python/extract.hpp>


### PR DESCRIPTION
Imported from
https://aur.archlinux.org/cgit/aur.git/tree/ceph-18.2.4-boost-1.86-fixes.patch?h=ceph

This fixes CI build failures like this one:

```
 FAILED: src/mgr/CMakeFiles/ceph-mgr.dir/PyModule.cc.o
 /usr/bin/ccache /usr/bin/clang++-14 [...]
 In file included from /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/mgr/PyModule.cc:41:
 In file included from /opt/ceph/include/boost/python/extract.hpp:16:
 In file included from /opt/ceph/include/boost/python/object_core.hpp:14:
 In file included from /opt/ceph/include/boost/python/call.hpp:15:
 In file included from /opt/ceph/include/boost/python/converter/arg_to_python.hpp:19:
 In file included from /opt/ceph/include/boost/python/object/function_handle.hpp:11:
 In file included from /opt/ceph/include/boost/python/signature.hpp:26:
 In file included from /opt/ceph/include/boost/python/detail/type_list.hpp:28:
 In file included from /opt/ceph/include/boost/mpl/vector/vector20.hpp:18:
 In file included from /opt/ceph/include/boost/mpl/vector/vector10.hpp:18:
 In file included from /opt/ceph/include/boost/mpl/vector/vector0.hpp:24:
 In file included from /opt/ceph/include/boost/mpl/vector/aux_/clear.hpp:18:
 In file included from /opt/ceph/include/boost/mpl/vector/aux_/vector0.hpp:22:
 In file included from /opt/ceph/include/boost/mpl/vector/aux_/iterator.hpp:20:
 In file included from /opt/ceph/include/boost/mpl/minus.hpp:19:
 In file included from /opt/ceph/include/boost/mpl/aux_/arithmetic_op.hpp:26:
 /opt/ceph/include/boost/mpl/aux_/numeric_op.hpp:177:7: error: use of undeclared identifier 'BOOST_PP_ITERATION_02'
     : AUX778076_OP_N_CALLS(AUX778076_OP_ARITY, N)
       ^
 /opt/ceph/include/boost/mpl/aux_/numeric_op.hpp:168:53: note: expanded from macro 'AUX778076_OP_N_CALLS'
     N1 BOOST_MPL_PP_REPEAT( BOOST_MPL_PP_SUB(i, 1), AUX778076_OP_RIGHT_OPERAND, N ) \
                                                     ^
```

I have no idea what this means and I don't know the author of this patch, but it fixes the build failure for me.


## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [X] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [X] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [X] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [X] No tests
