### PR TITLE
rgw: control full sync on bucket replication enable

### DIFF
--- a/doc/radosgw/zone-features.rst
+++ b/doc/radosgw/zone-features.rst
@@ -9,15 +9,17 @@ On creation of new zones and zonegroups, all known features are supported and so
 Supported Features
 ------------------
 
-+-----------------------------------+---------+----------+
-| Feature                           | Release | Default  |
-+===================================+=========+==========+
-| :ref:`feature_resharding`         | Reef    | Enabled  |
-+-----------------------------------+---------+----------+
-| :ref:`feature_compress_encrypted` | Reef    | Disabled |
-+-----------------------------------+---------+----------+
-| :ref:`feature_notification_v2`    | Squid   | Enabled  |
-+-----------------------------------+---------+----------+
++--------------------------------------------------------+----------+----------+
+| Feature                                                | Release  | Default  |
++========================================================+==========+==========+
+| :ref:`feature_resharding`                              | Reef     | Enabled  |
++--------------------------------------------------------+----------+----------+
+| :ref:`feature_compress_encrypted`                      | Reef     | Disabled |
++--------------------------------------------------------+----------+----------+
+| :ref:`feature_notification_v2`                         | Squid    | Enabled  |
++--------------------------------------------------------+----------+----------+
+| :ref:`feature_skip_existing_object_replication_policy` | Tentacle | Enabled  |
++--------------------------------------------------------+----------+----------+
 
 .. _feature_resharding:
 
@@ -63,6 +65,25 @@ scale to many topics.
 
 Once this feature is enabled on all zonegroups in the realm, a background process
 will convert existing v1 topics and bucket notifications into their v2 format.
+
+
+.. _feature_skip_existing_object_replication_policy:
+
+skip-existing-object-replication-policy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This feature enables bucket replication to start incrementally, applying only to
+changes and new objects created after replication is enabled, rather than performing
+a full sync of existing objects. This behavior applies to bucket replication policies
+in general, whether they operate within the same zonegroup or across different zonegroups.
+
+AWS has set this as the default behavior for bucket replication policies following the
+deprecation of their ExistingObjectReplication feature. As a result, this feature is enabled
+by default for new deployments but requires existing deployments to opt-in manually.
+
+In cases where the source and destination buckets are the same, symmetry is enforced, and the
+zonegroup feature is ignored, relying instead on whether a full sync is needed. If the source
+and destination buckets differ, the zonegroup feature and full sync logic come into play.
 
 
 Commands

--- a/src/rgw/driver/rados/rgw_data_sync.h
+++ b/src/rgw/driver/rados/rgw_data_sync.h
@@ -58,6 +58,10 @@ struct rgw_bucket_sync_pair_info {
   RGWBucketSyncFlowManager::pipe_handler handler; /* responsible for sync filters */
   rgw_bucket_shard source_bs;
   rgw_bucket dest_bucket;
+
+  bool is_symmetric_pair() const {
+    return source_bs.bucket.match(dest_bucket);
+  }
 };
 
 inline std::ostream& operator<<(std::ostream& out, const rgw_bucket_sync_pair_info& p) {
@@ -858,7 +862,7 @@ public:
   RGWDefaultSyncModule() {}
   bool supports_writes() override { return true; }
   bool supports_data_export() override { return true; }
-  int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) override;
+  int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, const RGWZoneGroup& zonegroup, RGWSyncModuleInstanceRef *instance) override;
 };
 
 class RGWArchiveSyncModule : public RGWDefaultSyncModule {
@@ -866,5 +870,5 @@ public:
   RGWArchiveSyncModule() {}
   bool supports_writes() override { return true; }
   bool supports_data_export() override { return false; }
-  int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) override;
+  int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, const RGWZoneGroup& zonegroup, RGWSyncModuleInstanceRef *instance) override;
 };

--- a/src/rgw/driver/rados/rgw_sync_module.h
+++ b/src/rgw/driver/rados/rgw_sync_module.h
@@ -73,7 +73,7 @@ public:
   // indication whether the sync module start with full sync (default behavior)
   // incremental sync would follow anyway
   virtual bool should_full_sync() const {
-      return true;
+    return true;
   }
 };
 
@@ -91,7 +91,7 @@ public:
     return false;
   }
   virtual bool supports_data_export() = 0;
-  virtual int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) = 0;
+  virtual int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, const RGWZoneGroup& zonegroup, RGWSyncModuleInstanceRef *instance) = 0;
 };
 
 typedef std::shared_ptr<RGWSyncModule> RGWSyncModuleRef;
@@ -134,13 +134,13 @@ public:
     return module->supports_data_export();
   }
 
-  int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const std::string& name, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) {
+  int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const std::string& name, const JSONFormattable& config, const RGWZoneGroup& zonegroup, RGWSyncModuleInstanceRef *instance) {
     RGWSyncModuleRef module;
     if (!get_module(name, &module)) {
       return -ENOENT;
     }
 
-    return module.get()->create_instance(dpp, cct, config, instance);
+    return module.get()->create_instance(dpp, cct, config, zonegroup, instance);
   }
 
   std::vector<std::string> get_registered_module_names() const {

--- a/src/rgw/driver/rados/rgw_sync_module_aws.cc
+++ b/src/rgw/driver/rados/rgw_sync_module_aws.cc
@@ -1814,7 +1814,7 @@ public:
   }
 };
 
-int RGWAWSSyncModule::create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config,  RGWSyncModuleInstanceRef *instance){
+int RGWAWSSyncModule::create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, const RGWZoneGroup& zonegroup, RGWSyncModuleInstanceRef *instance){
   AWSSyncConfig conf;
 
   int r = conf.init(dpp, cct, config);

--- a/src/rgw/driver/rados/rgw_sync_module_aws.h
+++ b/src/rgw/driver/rados/rgw_sync_module_aws.h
@@ -104,5 +104,5 @@ class RGWAWSSyncModule : public RGWSyncModule {
  public:
   RGWAWSSyncModule() {}
   bool supports_data_export() override { return false;}
-  int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) override;
+  int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, const RGWZoneGroup& zonegroup, RGWSyncModuleInstanceRef *instance) override;
 };

--- a/src/rgw/driver/rados/rgw_sync_module_es.cc
+++ b/src/rgw/driver/rados/rgw_sync_module_es.cc
@@ -951,7 +951,7 @@ RGWRESTMgr *RGWElasticSyncModuleInstance::get_rest_filter(int dialect, RGWRESTMg
   return new RGWRESTMgr_MDSearch_S3();
 }
 
-int RGWElasticSyncModule::create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) {
+int RGWElasticSyncModule::create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, const RGWZoneGroup& zonegroup, RGWSyncModuleInstanceRef *instance) {
   string endpoint = config["endpoint"];
   instance->reset(new RGWElasticSyncModuleInstance(dpp, cct, config));
   return 0;

--- a/src/rgw/driver/rados/rgw_sync_module_es.h
+++ b/src/rgw/driver/rados/rgw_sync_module_es.h
@@ -38,7 +38,7 @@ public:
   bool supports_data_export() override {
     return false;
   }
-  int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) override;
+  int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, const RGWZoneGroup& zonegroup, RGWSyncModuleInstanceRef *instance) override;
 };
 
 class RGWElasticDataSyncModule;

--- a/src/rgw/driver/rados/rgw_sync_module_log.cc
+++ b/src/rgw/driver/rados/rgw_sync_module_log.cc
@@ -68,7 +68,7 @@ public:
   }
 };
 
-int RGWLogSyncModule::create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) {
+int RGWLogSyncModule::create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, const RGWZoneGroup& zonegroup, RGWSyncModuleInstanceRef *instance) {
   string prefix = config["prefix"];
   instance->reset(new RGWLogSyncModuleInstance(prefix));
   return 0;

--- a/src/rgw/driver/rados/rgw_sync_module_log.h
+++ b/src/rgw/driver/rados/rgw_sync_module_log.h
@@ -11,5 +11,5 @@ public:
   bool supports_data_export() override {
     return false;
   }
-  int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) override;
+  int create_instance(const DoutPrefixProvider *dpp, CephContext *cct, const JSONFormattable& config, const RGWZoneGroup& zonegroup, RGWSyncModuleInstanceRef *instance) override;
 };

--- a/src/rgw/radosgw-admin/radosgw-admin.cc
+++ b/src/rgw/radosgw-admin/radosgw-admin.cc
@@ -9910,7 +9910,7 @@ next:
 
     RGWSyncModuleInstanceRef sync_module;
     int ret = static_cast<rgw::sal::RadosStore*>(driver)->svc()->sync_modules->get_manager()->create_instance(dpp(), g_ceph_context, static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->get_zone().tier_type,
-        static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->get_zone_params().tier_config, &sync_module);
+        static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->get_zone_params().tier_config, static_cast<rgw::sal::RadosStore*>(driver)->svc()->zone->get_zonegroup(), &sync_module);
     if (ret < 0) {
       ldpp_dout(dpp(), -1) << "ERROR: failed to init sync module instance, ret=" << ret << dendl;
       return ret;

--- a/src/rgw/rgw_zone_features.h
+++ b/src/rgw/rgw_zone_features.h
@@ -16,12 +16,14 @@ namespace rgw::zone_features {
 inline constexpr std::string_view resharding = "resharding";
 inline constexpr std::string_view compress_encrypted = "compress-encrypted";
 inline constexpr std::string_view notification_v2 = "notification_v2";
+inline constexpr std::string_view skip_existing_object_replication_policy = "skip-existing-object-replication-policy";
 
 // static list of features supported by this release
 inline constexpr std::initializer_list<std::string_view> supported = {
     resharding,
     compress_encrypted,
     notification_v2,
+    skip_existing_object_replication_policy,
 };
 
 inline constexpr bool supports(std::string_view feature) {
@@ -37,6 +39,7 @@ inline constexpr bool supports(std::string_view feature) {
 inline constexpr std::initializer_list<std::string_view> enabled = {
     resharding,
     notification_v2,
+    skip_existing_object_replication_policy,
 };
 
 

--- a/src/rgw/services/svc_sync_modules.cc
+++ b/src/rgw/services/svc_sync_modules.cc
@@ -20,7 +20,7 @@ int RGWSI_SyncModules::do_start(optional_yield, const DoutPrefixProvider *dpp)
 {
   auto& zone_public_config = svc.zone->get_zone();
 
-  int ret = sync_modules_manager->create_instance(dpp, cct, zone_public_config.tier_type, svc.zone->get_zone_params().tier_config, &sync_module);
+  int ret = sync_modules_manager->create_instance(dpp, cct, zone_public_config.tier_type, svc.zone->get_zone_params().tier_config, svc.zone->get_zonegroup(), &sync_module);
   if (ret < 0) {
     ldpp_dout(dpp, -1) << "ERROR: failed to start sync module instance, ret=" << ret << dendl;
     if (ret == -ENOENT) {


### PR DESCRIPTION
Introduced a "skip-existing-object-replication-policy" feature, allowing bucket replication to start incrementally for new changes and objects, bypassing a full sync of existing objects. The feature applies to both intra- and cross-zonegroup replication policies, aligning with AWS behavior after the deprecation of their ExistingObjectReplication option.

Fixes: https://tracker.ceph.com/issues/69159